### PR TITLE
Add --sort flag to apps and builds commands

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -303,6 +303,7 @@ func AppsCommand() *ffcli.Command {
 	output := fs.String("output", "json", "Output format: json (default), table, markdown")
 	jsonFlag := fs.Bool("json", false, "Output in JSON format (shorthand)")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	sort := fs.String("sort", "", "Sort by uploadedDate or -uploadedDate")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 
@@ -319,6 +320,7 @@ Examples:
   asc apps
   asc apps --json
   asc apps --limit 10 --json
+  asc apps --sort -uploadedDate --json
   asc apps --output table
   asc apps --next "<links.next>" --json`,
 		FlagSet: fs,
@@ -333,6 +335,9 @@ Examples:
 			if err := validateNextURL(*next); err != nil {
 				return err
 			}
+			if err := validateSort(*sort, "uploadedDate", "-uploadedDate"); err != nil {
+				return err
+			}
 
 			client, err := getASCClient()
 			if err != nil {
@@ -345,6 +350,9 @@ Examples:
 			opts := []asc.AppsOption{
 				asc.WithAppsLimit(*limit),
 				asc.WithAppsNextURL(*next),
+			}
+			if strings.TrimSpace(*sort) != "" {
+				opts = append(opts, asc.WithAppsSort(*sort))
 			}
 
 			apps, err := client.GetApps(requestCtx, opts...)
@@ -370,6 +378,7 @@ func BuildsCommand() *ffcli.Command {
 	output := fs.String("output", "json", "Output format: json (default), table, markdown")
 	jsonFlag := fs.Bool("json", false, "Output in JSON format (shorthand)")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	sort := fs.String("sort", "", "Sort by uploadedDate or -uploadedDate")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 
@@ -386,6 +395,7 @@ Examples:
   asc builds --app "123456789"
   asc builds --app "123456789" --json
   asc builds --app "123456789" --limit 10 --json
+  asc builds --app "123456789" --sort -uploadedDate --json
   asc builds --app "123456789" --output table
   asc builds --next "<links.next>" --json`,
 		FlagSet: fs,
@@ -398,6 +408,9 @@ Examples:
 				return fmt.Errorf("--limit must be between 1 and 200")
 			}
 			if err := validateNextURL(*next); err != nil {
+				return err
+			}
+			if err := validateSort(*sort, "uploadedDate", "-uploadedDate"); err != nil {
 				return err
 			}
 
@@ -418,6 +431,9 @@ Examples:
 			opts := []asc.BuildsOption{
 				asc.WithBuildsLimit(*limit),
 				asc.WithBuildsNextURL(*next),
+			}
+			if strings.TrimSpace(*sort) != "" {
+				opts = append(opts, asc.WithBuildsSort(*sort))
 			}
 
 			builds, err := client.GetBuilds(requestCtx, resolvedAppID, opts...)

--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -135,11 +135,13 @@ type reviewQuery struct {
 
 type appsQuery struct {
 	listQuery
+	sort string
 }
 
 type buildsQuery struct {
 	listQuery
 	appID string
+	sort string
 }
 
 // AppAttributes describes an app resource.
@@ -391,6 +393,15 @@ func WithAppsNextURL(next string) AppsOption {
 	}
 }
 
+// WithAppsSort sets the sort order for apps.
+func WithAppsSort(sort string) AppsOption {
+	return func(q *appsQuery) {
+		if strings.TrimSpace(sort) != "" {
+			q.sort = strings.TrimSpace(sort)
+		}
+	}
+}
+
 // WithBuildsLimit sets the max number of builds to return.
 func WithBuildsLimit(limit int) BuildsOption {
 	return func(q *buildsQuery) {
@@ -412,6 +423,15 @@ func WithBuildsNextURL(next string) BuildsOption {
 	return func(q *buildsQuery) {
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+// WithBuildsSort sets the sort order for builds.
+func WithBuildsSort(sort string) BuildsOption {
+	return func(q *buildsQuery) {
+		if strings.TrimSpace(sort) != "" {
+			q.sort = strings.TrimSpace(sort)
 		}
 	}
 }
@@ -695,8 +715,17 @@ func (c *Client) GetApps(ctx context.Context, opts ...AppsOption) (*AppsResponse
 	path := "/v1/apps"
 	if query.nextURL != "" {
 		path = query.nextURL
-	} else if query.limit > 0 {
-		path += "?limit=" + strconv.Itoa(query.limit)
+	} else {
+		values := url.Values{}
+		if query.sort != "" {
+			values.Set("sort", query.sort)
+		}
+		if query.limit > 0 {
+			values.Set("limit", strconv.Itoa(query.limit))
+		}
+		if queryString := values.Encode(); queryString != "" {
+			path += "?" + queryString
+		}
 	}
 
 	data, err := c.do(ctx, "GET", path, nil)
@@ -724,6 +753,9 @@ func (c *Client) GetBuilds(ctx context.Context, appID string, opts ...BuildsOpti
 		path = query.nextURL
 	} else {
 		values := url.Values{}
+		if query.sort != "" {
+			values.Set("sort", query.sort)
+		}
 		if query.limit > 0 {
 			values.Set("limit", strconv.Itoa(query.limit))
 		}

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -186,6 +186,7 @@ func TestBuildAppsQuery(t *testing.T) {
 	opts := []AppsOption{
 		WithAppsLimit(10),
 		WithAppsNextURL("https://api.appstoreconnect.apple.com/v1/apps?cursor=abc123"),
+		WithAppsSort("-uploadedDate"),
 	}
 	for _, opt := range opts {
 		opt(query)
@@ -197,6 +198,9 @@ func TestBuildAppsQuery(t *testing.T) {
 	if query.nextURL != "https://api.appstoreconnect.apple.com/v1/apps?cursor=abc123" {
 		t.Fatalf("expected nextURL, got %q", query.nextURL)
 	}
+	if query.sort != "-uploadedDate" {
+		t.Fatalf("expected sort=-uploadedDate, got %q", query.sort)
+	}
 }
 
 func TestBuildBuildsQuery(t *testing.T) {
@@ -204,6 +208,7 @@ func TestBuildBuildsQuery(t *testing.T) {
 	opts := []BuildsOption{
 		WithBuildsLimit(25),
 		WithBuildsApp("1234567890"),
+		WithBuildsSort("uploadedDate"),
 	}
 	for _, opt := range opts {
 		opt(query)
@@ -214,5 +219,8 @@ func TestBuildBuildsQuery(t *testing.T) {
 	}
 	if query.appID != "1234567890" {
 		t.Fatalf("expected appID=1234567890, got %q", query.appID)
+	}
+	if query.sort != "uploadedDate" {
+		t.Fatalf("expected sort=uploadedDate, got %q", query.sort)
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds `--sort` support to the `apps` and `builds` commands for sorting results by upload date.

### Changes

- **cmd/commands.go**: Added `--sort` flag to `apps` and `builds` commands with validation
- **internal/asc/client.go**: Added `sort` field to query structs and `WithAppsSort`/`WithBuildsSort` options
- **internal/asc/client_test.go**: Added unit tests for new sort functionality

### Usage

```bash
# Sort apps by uploaded date (descending)
asc apps --sort -uploadedDate --json

# Sort builds by uploaded date (ascending)
asc builds --app "123456789" --sort uploadedDate --json
```

## Test plan

- ✅ All unit tests pass
- ✅ Integration tests pass with real App Store Connect API

🤖 Generated with [Claude Code](https://claude.com/claude-code)