### PR TITLE
Add build info/expire commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@
 *.dll
 *.so
 *.dylib
-asc
-asc-debug
+/asc
+/asc-debug
 
 # Test binary, built with `go test -c`
 *.test

--- a/Agents.md
+++ b/Agents.md
@@ -74,6 +74,8 @@ asc apps --json
 asc apps --sort name --json
 asc builds --app "123456789" --json
 asc builds --app "123456789" --sort -uploadedDate --json
+asc builds info --build "BUILD_ID" --json
+asc builds expire --build "BUILD_ID" --json
 
 # Utilities
 asc version

--- a/PLAN.md
+++ b/PLAN.md
@@ -24,6 +24,11 @@ A fast, AI-agent-friendly CLI for App Store Connect that enables developers to s
 - Feedback/crash/review endpoints aligned to ASC OpenAPI spec
 - Code compiles and unit tests run
 - Live API validation: feedback/crashes return data; reviews may be empty if no reviews exist
+- Apps/builds list commands working with manual pagination
+- Sorting supported for apps/builds/reviews/feedback/crashes
+- Build info and build expiration commands available
+- Installer script available for latest release downloads
+- HTTP-level client tests and CLI/output tests added
 
 ### What Doesn't Work Yet
 
@@ -175,37 +180,35 @@ asc reviews --app "123456789" --json
 
 **Goal:** Add commands for managing apps and builds
 
-#### Features
+#### Features (Current + Remaining)
 
-1. **List Apps**
+1. **List Apps** ✅
    ```bash
-   asc apps list
-   asc apps list --json
+   asc apps --json
    ```
 
-2. **List Builds**
+2. **List Builds** ✅
    ```bash
-   asc builds list --app "APP_ID"
-   asc builds list --app "APP_ID" --json
+   asc builds --app "APP_ID" --json
    ```
 
-3. **Build Details**
+3. **Build Details** ✅
    ```bash
    asc builds info --build "BUILD_ID"
    ```
 
-4. **Expire Build**
+4. **Expire Build** ✅
    ```bash
-   asc builds expire --build "BUILD_ID" --app "APP_ID"
+   asc builds expire --build "BUILD_ID"
    ```
 
 #### Technical Tasks
 
-- [ ] Implement `GET /v1/apps`
-- [ ] Implement `GET /v1/apps/{id}/builds`
-- [ ] Implement `PATCH /v1/builds/{id}`
+- [x] Implement `GET /v1/apps`
+- [x] Implement `GET /v1/apps/{id}/builds`
+- [x] Implement `GET /v1/builds/{id}`
+- [x] Implement `PATCH /v1/builds/{id}`
 - [ ] Add build expiration workflow
-- [ ] Add pagination support
 
 ---
 
@@ -410,7 +413,7 @@ github.com/goreleaser/nfpm/v2     - Packaging via `go run` (optional)
 
 **Phase 1: Foundation - IMPLEMENTED** (validated locally)
 
-Next: Add auto-pagination, more filters (build/tester/platform), and mockable integration tests
+Next: Add auto-pagination and beta management commands
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ asc builds --app "123456789" --sort -uploadedDate --json
 # Fetch next page
 asc apps --next "<links.next>" --json
 asc builds --next "<links.next>" --json
+
+# Build details
+asc builds info --build "BUILD_ID" --json
+
+# Expire a build (irreversible)
+asc builds expire --build "BUILD_ID" --json
 ```
 
 ### Utilities

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -128,3 +128,45 @@ func TestUnknownCommandPrintsHelpError(t *testing.T) {
 		t.Fatalf("expected unknown command message, got %q", stderr)
 	}
 }
+
+func TestBuildsInfoRequiresBuildID(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "info"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--build is required") {
+		t.Fatalf("expected missing build error, got %q", stderr)
+	}
+}
+
+func TestBuildsExpireRequiresBuildID(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "expire"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--build is required") {
+		t.Fatalf("expected missing build error, got %q", stderr)
+	}
+}

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -195,6 +195,56 @@ func TestPrintMarkdown_Builds(t *testing.T) {
 	}
 }
 
+func TestPrintTable_BuildInfo(t *testing.T) {
+	resp := &BuildResponse{
+		Data: Resource[BuildAttributes]{
+			ID: "1",
+			Attributes: BuildAttributes{
+				Version:         "2.0.0",
+				UploadedDate:    "2026-01-20T00:00:00Z",
+				ProcessingState: "VALID",
+				Expired:         true,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Processing") {
+		t.Fatalf("expected build info header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "2.0.0") {
+		t.Fatalf("expected build version in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_BuildInfo(t *testing.T) {
+	resp := &BuildResponse{
+		Data: Resource[BuildAttributes]{
+			ID: "1",
+			Attributes: BuildAttributes{
+				Version:         "2.0.0",
+				UploadedDate:    "2026-01-20T00:00:00Z",
+				ProcessingState: "VALID",
+				Expired:         true,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| Version | Uploaded | Processing | Expired |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "2.0.0") {
+		t.Fatalf("expected build version in output, got: %s", output)
+	}
+}
+
 func TestPrintPrettyJSON(t *testing.T) {
 	resp := &ReviewsResponse{
 		Data: []Resource[ReviewAttributes]{


### PR DESCRIPTION
## Summary
- add build detail and expiration API methods with CLI subcommands
- route builds listing through /v1/builds with app filtering to allow sorting
- extend output handling for single-build responses and add HTTP/integration tests
- update docs and plan notes for new commands

## Test plan
- [x] go test ./...
- [x] make test-integration (reviews subtest skipped: no review data)