### PR TITLE
fix: prioritize keychain over env vars for credentials

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -924,26 +924,25 @@ func RootCommand(version string) *ffcli.Command {
 }
 
 func getASCClient() (*asc.Client, error) {
-	actualKeyID := os.Getenv("ASC_KEY_ID")
-	actualIssuerID := os.Getenv("ASC_ISSUER_ID")
-	actualKeyPath := os.Getenv("ASC_PRIVATE_KEY_PATH")
+	var actualKeyID, actualIssuerID, actualKeyPath string
 
-	if actualKeyID == "" || actualIssuerID == "" || actualKeyPath == "" {
-		cfg, err := auth.GetDefaultCredentials()
-		if err != nil && actualKeyID == "" && actualIssuerID == "" && actualKeyPath == "" {
-			return nil, err
-		}
-		if cfg != nil {
-			if actualKeyID == "" {
-				actualKeyID = cfg.KeyID
-			}
-			if actualIssuerID == "" {
-				actualIssuerID = cfg.IssuerID
-			}
-			if actualKeyPath == "" {
-				actualKeyPath = cfg.PrivateKeyPath
-			}
-		}
+	// Priority 1: Keychain credentials (explicit user setup via 'asc auth login')
+	cfg, err := auth.GetDefaultCredentials()
+	if err == nil && cfg != nil {
+		actualKeyID = cfg.KeyID
+		actualIssuerID = cfg.IssuerID
+		actualKeyPath = cfg.PrivateKeyPath
+	}
+
+	// Priority 2: Environment variables (fallback for CI/CD or when keychain unavailable)
+	if actualKeyID == "" {
+		actualKeyID = os.Getenv("ASC_KEY_ID")
+	}
+	if actualIssuerID == "" {
+		actualIssuerID = os.Getenv("ASC_ISSUER_ID")
+	}
+	if actualKeyPath == "" {
+		actualKeyPath = os.Getenv("ASC_PRIVATE_KEY_PATH")
 	}
 
 	if actualKeyID == "" || actualIssuerID == "" || actualKeyPath == "" {


### PR DESCRIPTION
## Summary

The credential resolution in `getASCClient()` was incorrectly checking environment variables first and only falling back to keychain when env vars were missing. This violated the documented behavior in AGENTS.md where credentials set via `asc auth login` should take precedence.

**Problem**: Users who authenticated with `asc auth login` (storing credentials in keychain) were unexpectedly using credentials from stale `ASC_*` env vars in their `.zshrc`/`.bashrc`.

**Fix**: Swap the credential resolution order:
1. **Priority 1**: Keychain credentials (explicit user setup via `asc auth login`)
2. **Priority 2**: Environment variables (fallback for CI/CD or when keychain unavailable)

## Test Plan

- [x] `make test` passes (all 58 tests)
- [x] `go fmt ./...` clean
- [x] Manual testing: verified keychain credentials now take precedence over env vars

## Breaking Change?

No. Users relying on env var overrides can still use them by clearing their keychain credentials (`asc auth logout`). The new behavior matches the documented intent in AGENTS.md.