### PR TITLE
Handle missing submission lookups

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -174,8 +174,14 @@ Examples:
 			resolvedVersionID := strings.TrimSpace(*versionID)
 			if strings.TrimSpace(*submissionID) != "" {
 				submissionResp, err = client.GetAppStoreVersionSubmissionResource(requestCtx, strings.TrimSpace(*submissionID))
+				if err != nil && asc.IsNotFound(err) {
+					return fmt.Errorf("submit status: no submission found for ID %q", strings.TrimSpace(*submissionID))
+				}
 			} else {
 				submissionResp, err = client.GetAppStoreVersionSubmissionForVersion(requestCtx, resolvedVersionID)
+				if err != nil && asc.IsNotFound(err) {
+					return fmt.Errorf("submit status: no submission found for version %q", resolvedVersionID)
+				}
 			}
 			if err != nil {
 				return fmt.Errorf("submit status: %w", err)
@@ -252,12 +258,18 @@ Examples:
 			if resolvedSubmissionID == "" {
 				submissionResp, err := client.GetAppStoreVersionSubmissionForVersion(requestCtx, strings.TrimSpace(*versionID))
 				if err != nil {
+					if asc.IsNotFound(err) {
+						return fmt.Errorf("submit cancel: no submission found for version %q", strings.TrimSpace(*versionID))
+					}
 					return fmt.Errorf("submit cancel: %w", err)
 				}
 				resolvedSubmissionID = submissionResp.Data.ID
 			}
 
 			if err := client.DeleteAppStoreVersionSubmission(requestCtx, resolvedSubmissionID); err != nil {
+				if asc.IsNotFound(err) {
+					return fmt.Errorf("submit cancel: no submission found for ID %q", resolvedSubmissionID)
+				}
 				return fmt.Errorf("submit cancel: %w", err)
 			}
 

--- a/cmd/versions_test.go
+++ b/cmd/versions_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestFetchOptionalBuild_NotFound(t *testing.T) {
+	resp, err := fetchOptionalBuild(context.Background(), "VERSION_ID", func(ctx context.Context, versionID string) (*asc.BuildResponse, error) {
+		return nil, fmt.Errorf("NOT_FOUND: missing")
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+}
+
+func TestFetchOptionalBuild_Error(t *testing.T) {
+	expected := errors.New("boom")
+	_, err := fetchOptionalBuild(context.Background(), "VERSION_ID", func(ctx context.Context, versionID string) (*asc.BuildResponse, error) {
+		return nil, expected
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("expected error %v, got %v", expected, err)
+	}
+}
+
+func TestFetchOptionalBuild_Success(t *testing.T) {
+	resp, err := fetchOptionalBuild(context.Background(), "VERSION_ID", func(ctx context.Context, versionID string) (*asc.BuildResponse, error) {
+		return &asc.BuildResponse{
+			Data: asc.Resource[asc.BuildAttributes]{
+				ID: "BUILD_ID",
+				Attributes: asc.BuildAttributes{
+					Version: "1.0",
+				},
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp == nil || resp.Data.ID != "BUILD_ID" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestFetchOptionalSubmission_NotFound(t *testing.T) {
+	resp, err := fetchOptionalSubmission(context.Background(), "VERSION_ID", func(ctx context.Context, versionID string) (*asc.AppStoreVersionSubmissionResourceResponse, error) {
+		return nil, fmt.Errorf("NOT_FOUND: missing")
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+}
+
+func TestFetchOptionalSubmission_Error(t *testing.T) {
+	expected := errors.New("boom")
+	_, err := fetchOptionalSubmission(context.Background(), "VERSION_ID", func(ctx context.Context, versionID string) (*asc.AppStoreVersionSubmissionResourceResponse, error) {
+		return nil, expected
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("expected error %v, got %v", expected, err)
+	}
+}
+
+func TestFetchOptionalSubmission_Success(t *testing.T) {
+	resp, err := fetchOptionalSubmission(context.Background(), "VERSION_ID", func(ctx context.Context, versionID string) (*asc.AppStoreVersionSubmissionResourceResponse, error) {
+		return &asc.AppStoreVersionSubmissionResourceResponse{
+			Data: asc.AppStoreVersionSubmissionResource{
+				Type: asc.ResourceTypeAppStoreVersionSubmissions,
+				ID:   "SUBMIT_ID",
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp == nil || resp.Data.ID != "SUBMIT_ID" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -2425,7 +2425,13 @@ func ParseError(body []byte) error {
 
 // IsNotFound checks if the error is a "not found" error
 func IsNotFound(err error) bool {
-	return strings.Contains(err.Error(), "NOT_FOUND")
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not_found") ||
+		strings.Contains(message, "not found") ||
+		strings.Contains(message, "resource does not exist")
 }
 
 // IsUnauthorized checks if the error is an "unauthorized" error

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -1064,6 +1064,9 @@ func TestIsNotFoundAndUnauthorized(t *testing.T) {
 	if !IsNotFound(fmt.Errorf("NOT_FOUND: missing")) {
 		t.Fatal("expected IsNotFound to return true")
 	}
+	if !IsNotFound(fmt.Errorf("The specified resource does not exist")) {
+		t.Fatal("expected IsNotFound to return true for resource does not exist")
+	}
 	if IsNotFound(fmt.Errorf("something else")) {
 		t.Fatal("expected IsNotFound to return false")
 	}


### PR DESCRIPTION
## Summary
- Treat missing build/submission relationships as optional in `versions get` includes
- Improve submit status/cancel not-found messaging and make not-found detection more robust
- Add unit coverage for optional fetch helpers and not-found detection

## Test plan
- `PATH="$(go env GOPATH)/bin:$PATH" make format`
- `go test ./...`
- `make clean build`
- `./asc versions get --version-id <VERSION_ID> --include-submission`
- `./asc submit status --version-id <VERSION_ID>`