### PR TITLE
Security hardening and beta group fixes

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -234,6 +234,36 @@ func TestBetaManagementValidationErrors(t *testing.T) {
 			args:    []string{"beta-testers", "invite", "--app", "APP_ID"},
 			wantErr: "--email is required",
 		},
+		{
+			name:    "beta-groups get missing id",
+			args:    []string{"beta-groups", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "beta-groups update missing id",
+			args:    []string{"beta-groups", "update"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "beta-groups update missing update flags",
+			args:    []string{"beta-groups", "update", "--id", "GROUP_ID"},
+			wantErr: "at least one update flag is required",
+		},
+		{
+			name:    "beta-groups update public-link-limit out of range",
+			args:    []string{"beta-groups", "update", "--id", "GROUP_ID", "--public-link-limit", "50000"},
+			wantErr: "--public-link-limit must be between 1 and 10000",
+		},
+		{
+			name:    "beta-groups delete missing id",
+			args:    []string{"beta-groups", "delete"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "beta-groups delete missing confirm",
+			args:    []string{"beta-groups", "delete", "--id", "GROUP_ID"},
+			wantErr: "--confirm is required to delete",
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/localizations_test.go
+++ b/cmd/localizations_test.go
@@ -66,3 +66,23 @@ func TestReadLocalizationStrings_FileLocale(t *testing.T) {
 		t.Fatalf("expected description Hello, got %q", values["en-US"]["description"])
 	}
 }
+
+func TestReadLocalizationStrings_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.strings")
+	if err := os.WriteFile(target, []byte("\"description\" = \"Hello\";\n"), 0o644); err != nil {
+		t.Fatalf("write file error: %v", err)
+	}
+	link := filepath.Join(dir, "en-US.strings")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := readLocalizationStrings(dir, nil)
+	if err == nil {
+		t.Fatal("expected error for symlinked strings file")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}

--- a/cmd/sandbox_test.go
+++ b/cmd/sandbox_test.go
@@ -87,6 +87,39 @@ func TestSandboxCreateValidationErrors(t *testing.T) {
 	}
 }
 
+func TestSandboxCreateStdinFlagsMutuallyExclusive(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	args := []string{
+		"sandbox", "create",
+		"--email", "tester@example.com",
+		"--first-name", "Test",
+		"--last-name", "User",
+		"--password-stdin",
+		"--secret-answer-stdin",
+		"--secret-question", "Question",
+		"--birth-date", "1980-03-01",
+		"--territory", "USA",
+	}
+
+	if err := root.Parse(args); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	_, _ = captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error for mutually exclusive stdin flags")
+	}
+	if !strings.Contains(runErr.Error(), "cannot both be set") {
+		t.Fatalf("expected mutual exclusion error, got %v", runErr)
+	}
+}
+
 func TestSandboxGetValidationErrors(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -469,6 +469,84 @@ func TestCreateBetaGroup_SendsRequest(t *testing.T) {
 	}
 }
 
+func TestGetBetaGroup_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"betaGroups","id":"bg1","attributes":{"name":"Beta Testers","isInternalGroup":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaGroups/bg1" {
+			t.Fatalf("expected path /v1/betaGroups/bg1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetBetaGroup(context.Background(), "bg1"); err != nil {
+		t.Fatalf("GetBetaGroup() error: %v", err)
+	}
+}
+
+func TestUpdateBetaGroup_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"betaGroups","id":"bg1","attributes":{"name":"Updated Beta Testers","publicLinkEnabled":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaGroups/bg1" {
+			t.Fatalf("expected path /v1/betaGroups/bg1, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		var payload BetaGroupUpdateRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode body error: %v", err)
+		}
+		if payload.Data.Type != ResourceTypeBetaGroups {
+			t.Fatalf("expected type betaGroups, got %q", payload.Data.Type)
+		}
+		if payload.Data.ID != "bg1" {
+			t.Fatalf("expected id bg1, got %q", payload.Data.ID)
+		}
+		if payload.Data.Attributes == nil {
+			t.Fatalf("expected attributes to be set")
+		}
+		if payload.Data.Attributes.Name != "Updated Beta Testers" {
+			t.Fatalf("expected name Updated Beta Testers, got %q", payload.Data.Attributes.Name)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	req := BetaGroupUpdateRequest{
+		Data: BetaGroupUpdateData{
+			Type:       ResourceTypeBetaGroups,
+			ID:         "bg1",
+			Attributes: &BetaGroupUpdateAttributes{Name: "Updated Beta Testers"},
+		},
+	}
+	if _, err := client.UpdateBetaGroup(context.Background(), "bg1", req); err != nil {
+		t.Fatalf("UpdateBetaGroup() error: %v", err)
+	}
+}
+
+func TestDeleteBetaGroup_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, "")
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaGroups/bg1" {
+			t.Fatalf("expected path /v1/betaGroups/bg1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteBetaGroup(context.Background(), "bg1"); err != nil {
+		t.Fatalf("DeleteBetaGroup() error: %v", err)
+	}
+}
+
 func TestCreateBetaTester_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"betaTesters","id":"bt1","attributes":{"email":"tester@example.com"}}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -91,6 +91,29 @@ func TestPrintTable_FeedbackWithScreenshots(t *testing.T) {
 	}
 }
 
+func TestPrintTable_Feedback_StripsControlChars(t *testing.T) {
+	resp := &FeedbackResponse{
+		Data: []Resource[FeedbackAttributes]{
+			{
+				ID: "1",
+				Attributes: FeedbackAttributes{
+					CreatedDate: "2026-01-20T00:00:00Z",
+					Email:       "test\x1b[2J@example.com",
+					Comment:     "ok\x1b[31mRED\x1b[0m",
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if strings.Contains(output, "\x1b") {
+		t.Fatalf("expected control characters to be stripped, got: %q", output)
+	}
+}
+
 func TestPrintMarkdown_FeedbackWithScreenshots(t *testing.T) {
 	resp := &FeedbackResponse{
 		Data: []Resource[FeedbackAttributes]{
@@ -144,6 +167,30 @@ func TestPrintMarkdown_Reviews(t *testing.T) {
 	}
 	if !strings.Contains(output, "Great app") {
 		t.Fatalf("expected title in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_Reviews_StripsControlChars(t *testing.T) {
+	resp := &ReviewsResponse{
+		Data: []Resource[ReviewAttributes]{
+			{
+				ID: "1",
+				Attributes: ReviewAttributes{
+					CreatedDate: "2026-01-20T00:00:00Z",
+					Rating:      5,
+					Title:       "Nice\x1b[31mTitle\x1b[0m",
+					Territory:   "US",
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if strings.Contains(output, "\x1b") {
+		t.Fatalf("expected control characters to be stripped, got: %q", output)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- sanitize terminal output for feedback/review/crash table + markdown rendering\n- allow analytics downloads from CDN hosts only when URLs are signed\n- reject symlink/non-regular .strings inputs during localization uploads\n- add stdin-based secrets for sandbox tester creation\n- validate --public-link-limit via flag presence in beta group updates\n\n## Testing\n- make test\n- go test -race ./... (ld warnings about malformed LC_DYSYMTAB on macOS)\n- make lint