### PR TITLE
Beta group tester management

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -255,6 +255,26 @@ func TestBetaManagementValidationErrors(t *testing.T) {
 			wantErr: "--public-link-limit must be between 1 and 10000",
 		},
 		{
+			name:    "beta-groups add-testers missing group",
+			args:    []string{"beta-groups", "add-testers"},
+			wantErr: "--group is required",
+		},
+		{
+			name:    "beta-groups add-testers missing tester",
+			args:    []string{"beta-groups", "add-testers", "--group", "GROUP_ID"},
+			wantErr: "--tester is required",
+		},
+		{
+			name:    "beta-groups remove-testers missing group",
+			args:    []string{"beta-groups", "remove-testers"},
+			wantErr: "--group is required",
+		},
+		{
+			name:    "beta-groups remove-testers missing tester",
+			args:    []string{"beta-groups", "remove-testers", "--group", "GROUP_ID"},
+			wantErr: "--tester is required",
+		},
+		{
 			name:    "beta-groups delete missing id",
 			args:    []string{"beta-groups", "delete"},
 			wantErr: "--id is required",
@@ -286,6 +306,49 @@ func TestBetaManagementValidationErrors(t *testing.T) {
 			}
 			if !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestParseCommaSeparatedIDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  []string{},
+		},
+		{
+			name:  "single id",
+			input: "tester-1",
+			want:  []string{"tester-1"},
+		},
+		{
+			name:  "comma separated",
+			input: "tester-1, tester-2, tester-3",
+			want:  []string{"tester-1", "tester-2", "tester-3"},
+		},
+		{
+			name:  "drops empty entries",
+			input: "tester-1,, ,tester-2",
+			want:  []string{"tester-1", "tester-2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parseCommaSeparatedIDs(test.input)
+			if len(got) != len(test.want) {
+				t.Fatalf("expected %d ids, got %d", len(test.want), len(got))
+			}
+			for i, want := range test.want {
+				if got[i] != want {
+					t.Fatalf("expected %q at index %d, got %q", want, i, got[i])
+				}
 			}
 		})
 	}

--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -552,6 +552,17 @@ type RelationshipList struct {
 	Data []ResourceData `json:"data"`
 }
 
+// RelationshipRequest represents a relationship list payload.
+type RelationshipRequest struct {
+	Data []RelationshipData `json:"data"`
+}
+
+// RelationshipData represents data in a relationship payload.
+type RelationshipData struct {
+	Type ResourceType `json:"type"`
+	ID   string       `json:"id"`
+}
+
 // ResourceData represents the data portion of a resource.
 type ResourceData struct {
 	Type ResourceType `json:"type"`
@@ -2265,6 +2276,52 @@ func (c *Client) UpdateBetaGroup(ctx context.Context, groupID string, req BetaGr
 func (c *Client) DeleteBetaGroup(ctx context.Context, groupID string) error {
 	path := fmt.Sprintf("/v1/betaGroups/%s", groupID)
 	_, err := c.do(ctx, "DELETE", path, nil)
+	return err
+}
+
+// AddBetaTestersToGroup adds testers to a beta group.
+func (c *Client) AddBetaTestersToGroup(ctx context.Context, groupID string, testerIDs []string) error {
+	testerIDs = normalizeList(testerIDs)
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, 0, len(testerIDs)),
+	}
+	for _, testerID := range testerIDs {
+		payload.Data = append(payload.Data, RelationshipData{
+			Type: ResourceTypeBetaTesters,
+			ID:   testerID,
+		})
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/betaTesters", groupID)
+	_, err = c.do(ctx, "POST", path, body)
+	return err
+}
+
+// RemoveBetaTestersFromGroup removes testers from a beta group.
+func (c *Client) RemoveBetaTestersFromGroup(ctx context.Context, groupID string, testerIDs []string) error {
+	testerIDs = normalizeList(testerIDs)
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, 0, len(testerIDs)),
+	}
+	for _, testerID := range testerIDs {
+		payload.Data = append(payload.Data, RelationshipData{
+			Type: ResourceTypeBetaTesters,
+			ID:   testerID,
+		})
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/betaTesters", groupID)
+	_, err = c.do(ctx, "DELETE", path, body)
 	return err
 }
 


### PR DESCRIPTION
Adds `beta-groups add-testers` and `beta-groups remove-testers` commands to manage beta testers within groups.

---
<a href="https://cursor.com/background-agent?bcId=bc-06447577-d440-4feb-a487-a482f6f6e4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06447577-d440-4feb-a487-a482f6f6e4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

