### PR TITLE
Tester group relationships

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -225,6 +225,26 @@ func TestBetaManagementValidationErrors(t *testing.T) {
 			wantErr: "--email is required",
 		},
 		{
+			name:    "beta-testers add-groups missing id",
+			args:    []string{"beta-testers", "add-groups", "--group", "GROUP_ID"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "beta-testers add-groups missing group",
+			args:    []string{"beta-testers", "add-groups", "--id", "TESTER_ID"},
+			wantErr: "--group is required",
+		},
+		{
+			name:    "beta-testers remove-groups missing id",
+			args:    []string{"beta-testers", "remove-groups", "--group", "GROUP_ID"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "beta-testers remove-groups missing group",
+			args:    []string{"beta-testers", "remove-groups", "--id", "TESTER_ID"},
+			wantErr: "--group is required",
+		},
+		{
 			name:    "beta-testers invite missing app",
 			args:    []string{"beta-testers", "invite", "--email", "tester@example.com"},
 			wantErr: "--app is required",

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -759,6 +759,74 @@ func TestDeleteBetaTester_SendsRequest(t *testing.T) {
 	}
 }
 
+func TestAddBetaTesterToGroups_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaTesters/bt-1/relationships/betaGroups" {
+			t.Fatalf("expected path /v1/betaTesters/bt-1/relationships/betaGroups, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		var payload RelationshipList
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode body error: %v", err)
+		}
+		if len(payload.Data) != 2 {
+			t.Fatalf("expected 2 beta group relationships, got %d", len(payload.Data))
+		}
+		if payload.Data[0].Type != ResourceTypeBetaGroups {
+			t.Fatalf("expected type betaGroups, got %q", payload.Data[0].Type)
+		}
+		if payload.Data[0].ID != "group-1" {
+			t.Fatalf("expected group-1, got %q", payload.Data[0].ID)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.AddBetaTesterToGroups(context.Background(), "bt-1", []string{"group-1", "group-2"}); err != nil {
+		t.Fatalf("AddBetaTesterToGroups() error: %v", err)
+	}
+}
+
+func TestRemoveBetaTesterFromGroups_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaTesters/bt-1/relationships/betaGroups" {
+			t.Fatalf("expected path /v1/betaTesters/bt-1/relationships/betaGroups, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		var payload RelationshipList
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode body error: %v", err)
+		}
+		if len(payload.Data) != 2 {
+			t.Fatalf("expected 2 beta group relationships, got %d", len(payload.Data))
+		}
+		if payload.Data[0].Type != ResourceTypeBetaGroups {
+			t.Fatalf("expected type betaGroups, got %q", payload.Data[0].Type)
+		}
+		if payload.Data[1].ID != "group-2" {
+			t.Fatalf("expected group-2, got %q", payload.Data[1].ID)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.RemoveBetaTesterFromGroups(context.Background(), "bt-1", []string{"group-1", "group-2"}); err != nil {
+		t.Fatalf("RemoveBetaTesterFromGroups() error: %v", err)
+	}
+}
+
 func TestCreateBetaTesterInvitation_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"betaTesterInvitations","id":"invite-1"}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -1084,6 +1084,44 @@ func TestPrintTable_SandboxTesters(t *testing.T) {
 	}
 }
 
+func TestPrintTable_BetaTesterGroupsUpdateResult(t *testing.T) {
+	result := &BetaTesterGroupsUpdateResult{
+		TesterID: "tester-1",
+		GroupIDs: []string{"group-1", "group-2"},
+		Action:   "added",
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	if !strings.Contains(output, "Tester ID") || !strings.Contains(output, "Group IDs") {
+		t.Fatalf("expected table headers, got: %s", output)
+	}
+	if !strings.Contains(output, "group-1,group-2") {
+		t.Fatalf("expected group IDs in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_BetaTesterGroupsUpdateResult(t *testing.T) {
+	result := &BetaTesterGroupsUpdateResult{
+		TesterID: "tester-1",
+		GroupIDs: []string{"group-1", "group-2"},
+		Action:   "removed",
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(result)
+	})
+
+	if !strings.Contains(output, "| Tester ID | Group IDs | Action |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "group-1,group-2") {
+		t.Fatalf("expected group IDs in output, got: %s", output)
+	}
+}
+
 func TestPrintMarkdown_SandboxTesterDeleteResult(t *testing.T) {
 	result := &SandboxTesterDeleteResult{
 		ID:      "tester-1",


### PR DESCRIPTION
Add `beta-testers add-groups` and `remove-groups` commands to manage a beta tester's group memberships.

This implements the functionality to add or remove a single beta tester from multiple beta groups, mirroring the existing `beta-groups add/remove testers` commands but from the perspective of the tester.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3f92f82-9cc0-4894-8c27-1a841a9c7000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3f92f82-9cc0-4894-8c27-1a841a9c7000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

