### PR TITLE
Builds beta group management

### DIFF
--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// BuildsAddGroupsCommand returns the builds add-groups subcommand.
+func BuildsAddGroupsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("add-groups", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID")
+	groups := fs.String("group", "", "Comma-separated beta group IDs")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "add-groups",
+		ShortUsage: "asc builds add-groups --build BUILD_ID --group GROUP_ID[,GROUP_ID...]",
+		ShortHelp:  "Add beta groups to a build for TestFlight distribution.",
+		LongHelp: `Add beta groups to a build for TestFlight distribution.
+
+Examples:
+  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
+  asc builds add-groups --build "BUILD_ID" --group "GROUP1,GROUP2"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedBuildID := strings.TrimSpace(*buildID)
+			if trimmedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+
+			groupIDs := parseCommaSeparatedIDs(*groups)
+			if len(groupIDs) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --group is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("builds add-groups: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.AddBetaGroupsToBuild(requestCtx, trimmedBuildID, groupIDs); err != nil {
+				return fmt.Errorf("builds add-groups: failed to add groups: %w", err)
+			}
+
+			fmt.Fprintf(os.Stderr, "Successfully added %d group(s) to build %s\n", len(groupIDs), trimmedBuildID)
+			result := &asc.BuildBetaGroupsUpdateResult{
+				BuildID:  trimmedBuildID,
+				GroupIDs: groupIDs,
+				Action:   "added",
+			}
+
+			return printOutput(result, *output, *pretty)
+		},
+	}
+}
+
+// BuildsRemoveGroupsCommand returns the builds remove-groups subcommand.
+func BuildsRemoveGroupsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("remove-groups", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID")
+	groups := fs.String("group", "", "Comma-separated beta group IDs")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "remove-groups",
+		ShortUsage: "asc builds remove-groups --build BUILD_ID --group GROUP_ID[,GROUP_ID...]",
+		ShortHelp:  "Remove beta groups from a build.",
+		LongHelp: `Remove beta groups from a build.
+
+Examples:
+  asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID"
+  asc builds remove-groups --build "BUILD_ID" --group "GROUP1,GROUP2"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedBuildID := strings.TrimSpace(*buildID)
+			if trimmedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+
+			groupIDs := parseCommaSeparatedIDs(*groups)
+			if len(groupIDs) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --group is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("builds remove-groups: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.RemoveBetaGroupsFromBuild(requestCtx, trimmedBuildID, groupIDs); err != nil {
+				return fmt.Errorf("builds remove-groups: failed to remove groups: %w", err)
+			}
+
+			fmt.Fprintf(os.Stderr, "Successfully removed %d group(s) from build %s\n", len(groupIDs), trimmedBuildID)
+			result := &asc.BuildBetaGroupsUpdateResult{
+				BuildID:  trimmedBuildID,
+				GroupIDs: groupIDs,
+				Action:   "removed",
+			}
+
+			return printOutput(result, *output, *pretty)
+		},
+	}
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -674,7 +674,9 @@ Examples:
   asc builds list --app "123456789"
   asc builds info --build "BUILD_ID"
   asc builds expire --build "BUILD_ID"
-  asc builds upload --app "123456789" --ipa "app.ipa"`,
+  asc builds upload --app "123456789" --ipa "app.ipa"
+  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
+  asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID"`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -682,6 +684,8 @@ Examples:
 			BuildsInfoCommand(),
 			BuildsExpireCommand(),
 			BuildsUploadCommand(),
+			BuildsAddGroupsCommand(),
+			BuildsRemoveGroupsCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
@@ -997,6 +1001,10 @@ func contextWithTimeout(ctx context.Context) (context.Context, context.CancelFun
 		ctx = context.Background()
 	}
 	return context.WithTimeout(ctx, asc.ResolveTimeout())
+}
+
+func parseCommaSeparatedIDs(value string) []string {
+	return splitCSV(value)
 }
 
 func splitCSV(value string) []string {

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -982,6 +982,44 @@ func TestPrintMarkdown_AppStoreVersionAttachBuildResult(t *testing.T) {
 	}
 }
 
+func TestPrintTable_BuildBetaGroupsUpdateResult(t *testing.T) {
+	resp := &BuildBetaGroupsUpdateResult{
+		BuildID:  "BUILD_123",
+		GroupIDs: []string{"GROUP_1", "GROUP_2"},
+		Action:   "added",
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Group IDs") {
+		t.Fatalf("expected group IDs header, got: %s", output)
+	}
+	if !strings.Contains(output, "GROUP_1, GROUP_2") {
+		t.Fatalf("expected group IDs in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_BuildBetaGroupsUpdateResult(t *testing.T) {
+	resp := &BuildBetaGroupsUpdateResult{
+		BuildID:  "BUILD_123",
+		GroupIDs: []string{"GROUP_1", "GROUP_2"},
+		Action:   "removed",
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| Build ID | Group IDs | Action |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "GROUP_1, GROUP_2") {
+		t.Fatalf("expected group IDs in output, got: %s", output)
+	}
+}
+
 func TestPrintTable_SalesReportResult(t *testing.T) {
 	result := &SalesReportResult{
 		VendorNumber:  "12345678",


### PR DESCRIPTION
Add `asc builds add-groups` and `asc builds remove-groups` commands to manage TestFlight beta group assignments for builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-774b8e87-c568-4c28-831f-cebd69affce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-774b8e87-c568-4c28-831f-cebd69affce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

