### PR TITLE
Pre-release versions commands

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -911,6 +911,7 @@ func RootCommand(version string) *ffcli.Command {
 			AppsCommand(),
 			BuildsCommand(),
 			VersionsCommand(),
+			PreReleaseVersionsCommand(),
 			LocalizationsCommand(),
 			BetaGroupsCommand(),
 			BetaTestersCommand(),

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -687,6 +687,51 @@ func TestVersionsValidationErrors(t *testing.T) {
 	}
 }
 
+func TestPreReleaseVersionsValidationErrors(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "pre-release-versions list missing app",
+			args:    []string{"pre-release-versions", "list"},
+			wantErr: "Error: --app is required",
+		},
+		{
+			name:    "pre-release-versions get missing id",
+			args:    []string{"pre-release-versions", "get"},
+			wantErr: "Error: --id is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
 func TestXcodeCloudValidationErrors(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 

--- a/cmd/prerelease.go
+++ b/cmd/prerelease.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// PreReleaseVersionsCommand returns the pre-release-versions command.
+func PreReleaseVersionsCommand() *ffcli.Command {
+	return &ffcli.Command{
+		Name:       "pre-release-versions",
+		ShortUsage: "asc pre-release-versions <subcommand> [flags]",
+		ShortHelp:  "Manage TestFlight pre-release versions.",
+		LongHelp: `Manage TestFlight pre-release versions.
+
+Subcommands:
+  list  List pre-release versions for an app.
+  get   Get a pre-release version by ID.`,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			PreReleaseVersionsListCommand(),
+			PreReleaseVersionsGetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// PreReleaseVersionsListCommand returns the pre-release versions list subcommand.
+func PreReleaseVersionsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("pre-release-versions list", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	platform := fs.String("platform", "", "Filter by platform: IOS, MAC_OS, TV_OS, VISION_OS")
+	version := fs.String("version", "", "Filter by version string")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Next page URL from a previous response")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc pre-release-versions list [flags]",
+		ShortHelp:  "List TestFlight pre-release versions for an app.",
+		LongHelp: `List TestFlight pre-release versions for an app.
+
+Examples:
+  asc pre-release-versions list --app "APP_ID"
+  asc pre-release-versions list --app "APP_ID" --platform IOS
+  asc pre-release-versions list --app "APP_ID" --version "1.0.0"
+  asc pre-release-versions list --app "APP_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("pre-release-versions list: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("pre-release-versions list: %w", err)
+			}
+
+			platforms, err := normalizeAppStoreVersionPlatforms(splitCSVUpper(*platform))
+			if err != nil {
+				return fmt.Errorf("pre-release-versions list: %w", err)
+			}
+
+			resolvedAppID := strings.TrimSpace(resolveAppID(strings.TrimSpace(*appID)))
+			nextValue := strings.TrimSpace(*next)
+			if resolvedAppID == "" && nextValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("pre-release-versions list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.PreReleaseVersionsOption{
+				asc.WithPreReleaseVersionsLimit(*limit),
+				asc.WithPreReleaseVersionsNextURL(nextValue),
+			}
+
+			if len(platforms) > 0 {
+				opts = append(opts, asc.WithPreReleaseVersionsPlatform(strings.Join(platforms, ",")))
+			}
+			if versions := splitCSV(*version); len(versions) > 0 {
+				opts = append(opts, asc.WithPreReleaseVersionsVersion(strings.Join(versions, ",")))
+			}
+
+			if *paginate {
+				// Fetch first page with limit set for consistent pagination
+				paginateOpts := append(opts, asc.WithPreReleaseVersionsLimit(200))
+				firstPage, err := client.GetPreReleaseVersions(requestCtx, resolvedAppID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("pre-release-versions list: failed to fetch: %w", err)
+				}
+
+				// Fetch all remaining pages
+				versions, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetPreReleaseVersions(ctx, resolvedAppID, asc.WithPreReleaseVersionsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("pre-release-versions list: %w", err)
+				}
+
+				return printOutput(versions, *output, *pretty)
+			}
+
+			versions, err := client.GetPreReleaseVersions(requestCtx, resolvedAppID, opts...)
+			if err != nil {
+				return fmt.Errorf("pre-release-versions list: failed to fetch: %w", err)
+			}
+
+			return printOutput(versions, *output, *pretty)
+		},
+	}
+}
+
+// PreReleaseVersionsGetCommand returns the pre-release versions get subcommand.
+func PreReleaseVersionsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("pre-release-versions get", flag.ExitOnError)
+
+	id := fs.String("id", "", "Pre-release version ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc pre-release-versions get [flags]",
+		ShortHelp:  "Get a TestFlight pre-release version by ID.",
+		LongHelp: `Get a TestFlight pre-release version by ID.
+
+Examples:
+  asc pre-release-versions get --id "PR_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("pre-release-versions get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			version, err := client.GetPreReleaseVersion(requestCtx, idValue)
+			if err != nil {
+				return fmt.Errorf("pre-release-versions get: failed to fetch: %w", err)
+			}
+
+			return printOutput(version, *output, *pretty)
+		},
+	}
+}

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -246,6 +246,35 @@ func TestBuildAppStoreVersionsQuery(t *testing.T) {
 	}
 }
 
+func TestBuildPreReleaseVersionsQuery(t *testing.T) {
+	query := &preReleaseVersionsQuery{}
+	opts := []PreReleaseVersionsOption{
+		WithPreReleaseVersionsLimit(15),
+		WithPreReleaseVersionsPlatform(" ios, MAC_OS "),
+		WithPreReleaseVersionsVersion("1.0.0, 1.1.0"),
+	}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	values, err := url.ParseQuery(buildPreReleaseVersionsQuery("APP_ID", query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("filter[app]"); got != "APP_ID" {
+		t.Fatalf("expected filter[app]=APP_ID, got %q", got)
+	}
+	if got := values.Get("filter[platform]"); got != "IOS,MAC_OS" {
+		t.Fatalf("expected filter[platform]=IOS,MAC_OS, got %q", got)
+	}
+	if got := values.Get("filter[version]"); got != "1.0.0,1.1.0" {
+		t.Fatalf("expected filter[version]=1.0.0,1.1.0, got %q", got)
+	}
+	if got := values.Get("limit"); got != "15" {
+		t.Fatalf("expected limit=15, got %q", got)
+	}
+}
+
 func TestBuildAppStoreVersionLocalizationsQuery(t *testing.T) {
 	query := &appStoreVersionLocalizationsQuery{}
 	opts := []AppStoreVersionLocalizationsOption{


### PR DESCRIPTION
Add `asc pre-release-versions` command to manage TestFlight pre-release versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ce3b526-4e86-4918-86e3-c5ae34999e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ce3b526-4e86-4918-86e3-c5ae34999e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

