### PR TITLE
Testflight apps commands

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -909,6 +909,7 @@ func RootCommand(version string) *ffcli.Command {
 			ReviewsCommand(),
 			AnalyticsCommand(),
 			AppsCommand(),
+			TestFlightCommand(),
 			BuildsCommand(),
 			VersionsCommand(),
 			PreReleaseVersionsCommand(),
@@ -1002,10 +1003,6 @@ func contextWithTimeout(ctx context.Context) (context.Context, context.CancelFun
 		ctx = context.Background()
 	}
 	return context.WithTimeout(ctx, asc.ResolveTimeout())
-}
-
-func parseCommaSeparatedIDs(value string) []string {
-	return splitCSV(value)
 }
 
 func splitCSV(value string) []string {

--- a/cmd/testflight.go
+++ b/cmd/testflight.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// TestFlightCommand returns the testflight command with subcommands.
+func TestFlightCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("testflight", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "testflight",
+		ShortUsage: "asc testflight <subcommand> [flags]",
+		ShortHelp:  "Manage TestFlight resources.",
+		LongHelp: `Manage TestFlight resources.
+
+Examples:
+  asc testflight apps list
+  asc testflight apps get --app "APP_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			TestFlightAppsCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// TestFlightAppsCommand returns the testflight apps command with subcommands.
+func TestFlightAppsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "apps",
+		ShortUsage: "asc testflight apps <subcommand> [flags]",
+		ShortHelp:  "List or fetch apps for TestFlight.",
+		LongHelp: `List or fetch apps for TestFlight.
+
+Examples:
+  asc testflight apps list --sort name
+  asc testflight apps get --app "APP_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			TestFlightAppsListCommand(),
+			TestFlightAppsGetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// TestFlightAppsListCommand lists TestFlight apps using the Apps API.
+func TestFlightAppsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+
+	bundleID := fs.String("bundle-id", "", "Filter by bundle ID(s), comma-separated")
+	name := fs.String("name", "", "Filter by app name(s), comma-separated")
+	sku := fs.String("sku", "", "Filter by SKU(s), comma-separated")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	sort := fs.String("sort", "", "Sort by name or -name, bundleId or -bundleId")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc testflight apps list [flags]",
+		ShortHelp:  "List apps in App Store Connect for TestFlight.",
+		LongHelp: `List apps in App Store Connect for TestFlight.
+
+Examples:
+  asc testflight apps list
+  asc testflight apps list --bundle-id "com.example.app"
+  asc testflight apps list --name "Example App"
+  asc testflight apps list --sku "SKU123"
+  asc testflight apps list --sort name --limit 10
+  asc testflight apps list --output table
+  asc testflight apps list --next "<links.next>"
+  asc testflight apps list --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("testflight apps list: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("testflight apps list: %w", err)
+			}
+			if err := validateSort(*sort, "name", "-name", "bundleId", "-bundleId"); err != nil {
+				return fmt.Errorf("testflight apps list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("testflight apps list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.AppsOption{
+				asc.WithAppsBundleIDs(splitCSV(*bundleID)),
+				asc.WithAppsNames(splitCSV(*name)),
+				asc.WithAppsSKUs(splitCSV(*sku)),
+				asc.WithAppsLimit(*limit),
+				asc.WithAppsNextURL(*next),
+			}
+			if strings.TrimSpace(*sort) != "" {
+				opts = append(opts, asc.WithAppsSort(*sort))
+			}
+
+			if *paginate {
+				// Fetch first page with limit set for consistent pagination
+				paginateOpts := append(opts, asc.WithAppsLimit(200))
+				firstPage, err := client.GetApps(requestCtx, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("testflight apps list: failed to fetch: %w", err)
+				}
+
+				// Fetch all remaining pages
+				apps, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetApps(ctx, asc.WithAppsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("testflight apps list: %w", err)
+				}
+
+				return printOutput(apps, *output, *pretty)
+			}
+
+			apps, err := client.GetApps(requestCtx, opts...)
+			if err != nil {
+				return fmt.Errorf("testflight apps list: failed to fetch: %w", err)
+			}
+
+			return printOutput(apps, *output, *pretty)
+		},
+	}
+}
+
+// TestFlightAppsGetCommand fetches a TestFlight app by ID.
+func TestFlightAppsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("get", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (required)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc testflight apps get [flags]",
+		ShortHelp:  "Fetch an app by ID for TestFlight.",
+		LongHelp: `Fetch an app by ID for TestFlight.
+
+Examples:
+  asc testflight apps get --app "APP_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedAppID := strings.TrimSpace(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("testflight apps get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			app, err := client.GetApp(requestCtx, resolvedAppID)
+			if err != nil {
+				return fmt.Errorf("testflight apps get: failed to fetch: %w", err)
+			}
+
+			return printOutput(app, *output, *pretty)
+		},
+	}
+}

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -356,6 +356,9 @@ func TestBuildAppsQuery(t *testing.T) {
 		WithAppsLimit(10),
 		WithAppsNextURL("https://api.appstoreconnect.apple.com/v1/apps?cursor=abc123"),
 		WithAppsSort("-name"),
+		WithAppsBundleIDs([]string{"com.example.app", " ", "com.example.other"}),
+		WithAppsNames([]string{"Demo", " "}),
+		WithAppsSKUs([]string{"SKU1", "SKU2"}),
 	}
 	for _, opt := range opts {
 		opt(query)
@@ -369,6 +372,15 @@ func TestBuildAppsQuery(t *testing.T) {
 	}
 	if query.sort != "-name" {
 		t.Fatalf("expected sort=-name, got %q", query.sort)
+	}
+	if len(query.bundleIDs) != 2 || query.bundleIDs[0] != "com.example.app" || query.bundleIDs[1] != "com.example.other" {
+		t.Fatalf("expected bundleIDs to be normalized, got %v", query.bundleIDs)
+	}
+	if len(query.names) != 1 || query.names[0] != "Demo" {
+		t.Fatalf("expected names to be normalized, got %v", query.names)
+	}
+	if len(query.skus) != 2 || query.skus[0] != "SKU1" || query.skus[1] != "SKU2" {
+		t.Fatalf("expected skus to be set, got %v", query.skus)
 	}
 }
 


### PR DESCRIPTION
Add `testflight apps` commands for listing and retrieving App Store Connect apps with TestFlight-specific filters.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8c65567-6c4c-4c57-b7ca-6a31a71f4619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8c65567-6c4c-4c57-b7ca-6a31a71f4619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

