### PR TITLE
Build localizations commands

### DIFF
--- a/cmd/build_localizations.go
+++ b/cmd/build_localizations.go
@@ -1,0 +1,391 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+var buildLocalizationLocaleRegex = regexp.MustCompile(`^[a-zA-Z]{2,3}(-[a-zA-Z0-9]+)*$`)
+
+// BuildLocalizationsCommand returns the build-localizations command group.
+func BuildLocalizationsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("build-localizations", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "build-localizations",
+		ShortUsage: "asc build-localizations <subcommand> [flags]",
+		ShortHelp:  "Manage build release notes localizations.",
+		LongHelp: `Manage localized release notes by build.
+
+Subcommands:
+  list    List localizations for a build.
+  get     Get a localization by ID.
+  create  Create a localization for a build.
+  update  Update a localization by ID.
+  delete  Delete a localization by ID.
+
+Examples:
+  asc build-localizations list --build "BUILD_ID"
+  asc build-localizations get --id "LOCALIZATION_ID"
+  asc build-localizations create --build "BUILD_ID" --locale "en-US" --whats-new "Bug fixes"
+  asc build-localizations update --id "LOCALIZATION_ID" --whats-new "New features"
+  asc build-localizations delete --id "LOCALIZATION_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			BuildLocalizationsListCommand(),
+			BuildLocalizationsGetCommand(),
+			BuildLocalizationsCreateCommand(),
+			BuildLocalizationsUpdateCommand(),
+			BuildLocalizationsDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// BuildLocalizationsListCommand returns the list subcommand.
+func BuildLocalizationsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID")
+	locale := fs.String("locale", "", "Filter by locale(s), comma-separated")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc build-localizations list [flags]",
+		ShortHelp:  "List release note localizations for a build.",
+		LongHelp: `List release note localizations for a build.
+
+Examples:
+  asc build-localizations list --build "BUILD_ID"
+  asc build-localizations list --build "BUILD_ID" --locale "en-US,ja"
+  asc build-localizations list --build "BUILD_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("build-localizations list: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("build-localizations list: %w", err)
+			}
+
+			build := strings.TrimSpace(*buildID)
+			if build == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+
+			locales := splitCSV(*locale)
+			if err := validateBuildLocalizationLocales(locales); err != nil {
+				return fmt.Errorf("build-localizations list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("build-localizations list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			versionID, err := resolveBuildAppStoreVersion(requestCtx, client, build)
+			if err != nil {
+				return fmt.Errorf("build-localizations list: %w", err)
+			}
+
+			opts := []asc.AppStoreVersionLocalizationsOption{
+				asc.WithAppStoreVersionLocalizationsLimit(*limit),
+				asc.WithAppStoreVersionLocalizationsNextURL(*next),
+			}
+			if len(locales) > 0 {
+				opts = append(opts, asc.WithAppStoreVersionLocalizationLocales(locales))
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithAppStoreVersionLocalizationsLimit(200))
+				firstPage, err := client.GetAppStoreVersionLocalizations(requestCtx, versionID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("build-localizations list: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("build-localizations list: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppStoreVersionLocalizations(requestCtx, versionID, opts...)
+			if err != nil {
+				return fmt.Errorf("build-localizations list: failed to fetch: %w", err)
+			}
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// BuildLocalizationsGetCommand returns the get subcommand.
+func BuildLocalizationsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("get", flag.ExitOnError)
+
+	localizationID := fs.String("id", "", "Localization ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc build-localizations get [flags]",
+		ShortHelp:  "Get a localization by ID.",
+		LongHelp: `Get a localization by ID.
+
+Examples:
+  asc build-localizations get --id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			id := strings.TrimSpace(*localizationID)
+			if id == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("build-localizations get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetAppStoreVersionLocalization(requestCtx, id)
+			if err != nil {
+				return fmt.Errorf("build-localizations get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// BuildLocalizationsCreateCommand returns the create subcommand.
+func BuildLocalizationsCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("create", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID")
+	locale := fs.String("locale", "", "Locale (e.g., en-US)")
+	whatsNew := fs.String("whats-new", "", "Release notes (whats new)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "asc build-localizations create [flags]",
+		ShortHelp:  "Create a localization for a build.",
+		LongHelp: `Create a localization for a build.
+
+Examples:
+  asc build-localizations create --build "BUILD_ID" --locale "en-US"
+  asc build-localizations create --build "BUILD_ID" --locale "en-US" --whats-new "Bug fixes"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			build := strings.TrimSpace(*buildID)
+			if build == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+
+			localeValue := strings.TrimSpace(*locale)
+			if localeValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --locale is required")
+				return flag.ErrHelp
+			}
+			if err := validateBuildLocalizationLocale(localeValue); err != nil {
+				return fmt.Errorf("build-localizations create: %w", err)
+			}
+
+			whatsNewValue := strings.TrimSpace(*whatsNew)
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("build-localizations create: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			versionID, err := resolveBuildAppStoreVersion(requestCtx, client, build)
+			if err != nil {
+				return fmt.Errorf("build-localizations create: %w", err)
+			}
+
+			attrs := asc.AppStoreVersionLocalizationAttributes{
+				Locale: localeValue,
+			}
+			if whatsNewValue != "" {
+				attrs.WhatsNew = whatsNewValue
+			}
+
+			resp, err := client.CreateAppStoreVersionLocalization(requestCtx, versionID, attrs)
+			if err != nil {
+				return fmt.Errorf("build-localizations create: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// BuildLocalizationsUpdateCommand returns the update subcommand.
+func BuildLocalizationsUpdateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+
+	localizationID := fs.String("id", "", "Localization ID")
+	whatsNew := fs.String("whats-new", "", "Release notes (whats new)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "update",
+		ShortUsage: "asc build-localizations update [flags]",
+		ShortHelp:  "Update a localization by ID.",
+		LongHelp: `Update a localization by ID.
+
+Examples:
+  asc build-localizations update --id "LOCALIZATION_ID" --whats-new "New features"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			id := strings.TrimSpace(*localizationID)
+			if id == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			whatsNewValue := strings.TrimSpace(*whatsNew)
+			if whatsNewValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("build-localizations update: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			attrs := asc.AppStoreVersionLocalizationAttributes{
+				WhatsNew: whatsNewValue,
+			}
+
+			resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, id, attrs)
+			if err != nil {
+				return fmt.Errorf("build-localizations update: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// BuildLocalizationsDeleteCommand returns the delete subcommand.
+func BuildLocalizationsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("delete", flag.ExitOnError)
+
+	localizationID := fs.String("id", "", "Localization ID")
+	confirm := fs.Bool("confirm", false, "Confirm deletion")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "asc build-localizations delete [flags]",
+		ShortHelp:  "Delete a localization by ID.",
+		LongHelp: `Delete a localization by ID.
+
+Examples:
+  asc build-localizations delete --id "LOCALIZATION_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			id := strings.TrimSpace(*localizationID)
+			if id == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("build-localizations delete: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.DeleteAppStoreVersionLocalization(requestCtx, id); err != nil {
+				return fmt.Errorf("build-localizations delete: %w", err)
+			}
+
+			result := &asc.AppStoreVersionLocalizationDeleteResult{
+				ID:      id,
+				Deleted: true,
+			}
+
+			return printOutput(result, *output, *pretty)
+		},
+	}
+}
+
+func resolveBuildAppStoreVersion(ctx context.Context, client *asc.Client, buildID string) (string, error) {
+	resp, err := client.GetBuildAppStoreVersion(ctx, buildID)
+	if err != nil {
+		if asc.IsNotFound(err) {
+			return "", fmt.Errorf("build %s has no associated App Store version", buildID)
+		}
+		return "", err
+	}
+	if resp == nil || strings.TrimSpace(resp.Data.ID) == "" {
+		return "", fmt.Errorf("build %s has no associated App Store version", buildID)
+	}
+	return resp.Data.ID, nil
+}
+
+func validateBuildLocalizationLocales(locales []string) error {
+	for _, locale := range locales {
+		if err := validateBuildLocalizationLocale(locale); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBuildLocalizationLocale(locale string) error {
+	if locale == "" || !buildLocalizationLocaleRegex.MatchString(locale) {
+		return fmt.Errorf("invalid locale %q: must match pattern like en or en-US", locale)
+	}
+	return nil
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -914,6 +914,7 @@ func RootCommand(version string) *ffcli.Command {
 			VersionsCommand(),
 			PreReleaseVersionsCommand(),
 			LocalizationsCommand(),
+			BuildLocalizationsCommand(),
 			BetaGroupsCommand(),
 			BetaTestersCommand(),
 			SandboxCommand(),

--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1007,6 +1007,12 @@ type BetaTesterGroupsUpdateResult struct {
 	Action   string   `json:"action"`
 }
 
+// AppStoreVersionLocalizationDeleteResult represents CLI output for localization deletions.
+type AppStoreVersionLocalizationDeleteResult struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
 // LocalizationFileResult represents a localization file written or read.
 type LocalizationFileResult struct {
 	Locale string `json:"locale"`
@@ -2792,6 +2798,22 @@ func (c *Client) GetAppStoreVersionLocalizations(ctx context.Context, versionID 
 	return &response, nil
 }
 
+// GetAppStoreVersionLocalization retrieves a single app store version localization by ID.
+func (c *Client) GetAppStoreVersionLocalization(ctx context.Context, localizationID string) (*AppStoreVersionLocalizationResponse, error) {
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s", localizationID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionLocalizationResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // CreateAppStoreVersionLocalization creates a localization for an app store version.
 func (c *Client) CreateAppStoreVersionLocalization(ctx context.Context, versionID string, attributes AppStoreVersionLocalizationAttributes) (*AppStoreVersionLocalizationResponse, error) {
 	payload := AppStoreVersionLocalizationCreateRequest{
@@ -2854,6 +2876,15 @@ func (c *Client) UpdateAppStoreVersionLocalization(ctx context.Context, localiza
 	}
 
 	return &response, nil
+}
+
+// DeleteAppStoreVersionLocalization deletes a localization by ID.
+func (c *Client) DeleteAppStoreVersionLocalization(ctx context.Context, localizationID string) error {
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s", localizationID)
+	if _, err := c.do(ctx, "DELETE", path, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetAppInfoLocalizations retrieves localizations for an app info resource.
@@ -2976,6 +3007,22 @@ func (c *Client) GetBuild(ctx context.Context, buildID string) (*BuildResponse, 
 	}
 
 	var response BuildResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetBuildAppStoreVersion retrieves the app store version for a build.
+func (c *Client) GetBuildAppStoreVersion(ctx context.Context, buildID string) (*AppStoreVersionResponse, error) {
+	path := fmt.Sprintf("/v1/builds/%s/appStoreVersion", buildID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
@@ -3412,6 +3459,8 @@ func PrintMarkdown(data interface{}) error {
 		return printPreReleaseVersionsMarkdown(&PreReleaseVersionsResponse{Data: []PreReleaseVersion{v.Data}})
 	case *AppStoreVersionLocalizationsResponse:
 		return printAppStoreVersionLocalizationsMarkdown(v)
+	case *AppStoreVersionLocalizationResponse:
+		return printAppStoreVersionLocalizationsMarkdown(&AppStoreVersionLocalizationsResponse{Data: []Resource[AppStoreVersionLocalizationAttributes]{v.Data}})
 	case *AppInfoLocalizationsResponse:
 		return printAppInfoLocalizationsMarkdown(v)
 	case *BetaGroupsResponse:
@@ -3462,6 +3511,8 @@ func PrintMarkdown(data interface{}) error {
 		return printBetaTesterDeleteResultMarkdown(v)
 	case *BetaTesterGroupsUpdateResult:
 		return printBetaTesterGroupsUpdateResultMarkdown(v)
+	case *AppStoreVersionLocalizationDeleteResult:
+		return printAppStoreVersionLocalizationDeleteResultMarkdown(v)
 	case *BetaTesterInvitationResult:
 		return printBetaTesterInvitationResultMarkdown(v)
 	case *SandboxTesterDeleteResult:
@@ -3508,6 +3559,8 @@ func PrintTable(data interface{}) error {
 		return printPreReleaseVersionsTable(&PreReleaseVersionsResponse{Data: []PreReleaseVersion{v.Data}})
 	case *AppStoreVersionLocalizationsResponse:
 		return printAppStoreVersionLocalizationsTable(v)
+	case *AppStoreVersionLocalizationResponse:
+		return printAppStoreVersionLocalizationsTable(&AppStoreVersionLocalizationsResponse{Data: []Resource[AppStoreVersionLocalizationAttributes]{v.Data}})
 	case *AppInfoLocalizationsResponse:
 		return printAppInfoLocalizationsTable(v)
 	case *BetaGroupsResponse:
@@ -3558,6 +3611,8 @@ func PrintTable(data interface{}) error {
 		return printBetaTesterDeleteResultTable(v)
 	case *BetaTesterGroupsUpdateResult:
 		return printBetaTesterGroupsUpdateResultTable(v)
+	case *AppStoreVersionLocalizationDeleteResult:
+		return printAppStoreVersionLocalizationDeleteResultTable(v)
 	case *BetaTesterInvitationResult:
 		return printBetaTesterInvitationResultTable(v)
 	case *SandboxTesterDeleteResult:
@@ -4341,6 +4396,26 @@ func printLocalizationUploadResultMarkdown(result *LocalizationUploadResult) err
 			escapeMarkdown(item.LocalizationID),
 		)
 	}
+	return nil
+}
+
+func printAppStoreVersionLocalizationDeleteResultTable(result *AppStoreVersionLocalizationDeleteResult) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tDeleted")
+	fmt.Fprintf(w, "%s\t%t\n",
+		result.ID,
+		result.Deleted,
+	)
+	return w.Flush()
+}
+
+func printAppStoreVersionLocalizationDeleteResultMarkdown(result *AppStoreVersionLocalizationDeleteResult) error {
+	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
+	fmt.Fprintln(os.Stdout, "| --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
+		escapeMarkdown(result.ID),
+		result.Deleted,
+	)
 	return nil
 }
 

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -605,6 +605,23 @@ func TestGetApp_ByID(t *testing.T) {
 	}
 }
 
+func TestGetBuildAppStoreVersion_ByBuildID(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.0"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/builds/123/appStoreVersion" {
+			t.Fatalf("expected path /v1/builds/123/appStoreVersion, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetBuildAppStoreVersion(context.Background(), "123"); err != nil {
+		t.Fatalf("GetBuildAppStoreVersion() error: %v", err)
+	}
+}
+
 func TestExpireBuild_SendsPatch(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":{"type":"builds","id":"123","attributes":{"version":"1.0","uploadedDate":"2026-01-20T00:00:00Z","expired":true}}}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -1074,6 +1091,23 @@ func TestGetAppStoreVersionLocalizations_WithFilters(t *testing.T) {
 	}
 }
 
+func TestGetAppStoreVersionLocalization_ByID(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersionLocalization(context.Background(), "loc-1"); err != nil {
+		t.Fatalf("GetAppStoreVersionLocalization() error: %v", err)
+	}
+}
+
 func TestCreateAppStoreVersionLocalization_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -1146,6 +1180,23 @@ func TestUpdateAppStoreVersionLocalization_SendsRequest(t *testing.T) {
 	}
 	if _, err := client.UpdateAppStoreVersionLocalization(context.Background(), "loc-1", attrs); err != nil {
 		t.Fatalf("UpdateAppStoreVersionLocalization() error: %v", err)
+	}
+}
+
+func TestDeleteAppStoreVersionLocalization_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, "")
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteAppStoreVersionLocalization(context.Background(), "loc-1"); err != nil {
+		t.Fatalf("DeleteAppStoreVersionLocalization() error: %v", err)
 	}
 }
 

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -272,6 +272,26 @@ func TestPrintTable_AppStoreVersionLocalizations(t *testing.T) {
 	}
 }
 
+func TestPrintTable_AppStoreVersionLocalization(t *testing.T) {
+	resp := &AppStoreVersionLocalizationResponse{
+		Data: Resource[AppStoreVersionLocalizationAttributes]{
+			ID: "loc-1",
+			Attributes: AppStoreVersionLocalizationAttributes{
+				Locale:   "en-US",
+				WhatsNew: "Bug fixes",
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "en-US") {
+		t.Fatalf("expected locale in output, got: %s", output)
+	}
+}
+
 func TestPrintMarkdown_AppStoreVersionLocalizations(t *testing.T) {
 	resp := &AppStoreVersionLocalizationsResponse{
 		Data: []Resource[AppStoreVersionLocalizationAttributes]{
@@ -294,6 +314,65 @@ func TestPrintMarkdown_AppStoreVersionLocalizations(t *testing.T) {
 	}
 	if !strings.Contains(output, "en-US") {
 		t.Fatalf("expected locale in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_AppStoreVersionLocalization(t *testing.T) {
+	resp := &AppStoreVersionLocalizationResponse{
+		Data: Resource[AppStoreVersionLocalizationAttributes]{
+			ID: "loc-1",
+			Attributes: AppStoreVersionLocalizationAttributes{
+				Locale:   "en-US",
+				WhatsNew: "Bug fixes",
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| Locale | Whats New |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "en-US") {
+		t.Fatalf("expected locale in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_AppStoreVersionLocalizationDeleteResult(t *testing.T) {
+	result := &AppStoreVersionLocalizationDeleteResult{
+		ID:      "loc-1",
+		Deleted: true,
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	if !strings.Contains(output, "Deleted") {
+		t.Fatalf("expected deleted header, got: %s", output)
+	}
+	if !strings.Contains(output, "loc-1") {
+		t.Fatalf("expected id in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_AppStoreVersionLocalizationDeleteResult(t *testing.T) {
+	result := &AppStoreVersionLocalizationDeleteResult{
+		ID:      "loc-1",
+		Deleted: true,
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(result)
+	})
+
+	if !strings.Contains(output, "| ID | Deleted |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "loc-1") {
+		t.Fatalf("expected id in output, got: %s", output)
 	}
 }
 


### PR DESCRIPTION
Implements the `asc build-localizations` command group to manage App Store Version Localizations (release notes) by resolving them via a build ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b6bdf6a-fa6b-432c-888e-f56ac30ffa6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b6bdf6a-fa6b-432c-888e-f56ac30ffa6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

