### PR TITLE
Use default keychain and migrate legacy entries

### DIFF
--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -179,11 +179,16 @@ func writeECDSAPEM(t *testing.T, path string, mode os.FileMode, pkcs8 bool) {
 func withArrayKeyring(t *testing.T) {
 	t.Helper()
 	previous := keyringOpener
+	previousLegacy := legacyKeyringOpener
 	kr := keyring.NewArrayKeyring([]keyring.Item{})
 	keyringOpener = func() (keyring.Keyring, error) {
 		return kr, nil
 	}
 	t.Cleanup(func() {
 		keyringOpener = previous
+		legacyKeyringOpener = previousLegacy
 	})
+	legacyKeyringOpener = func() (keyring.Keyring, error) {
+		return kr, nil
+	}
 }


### PR DESCRIPTION
## Summary
- store credentials in the default login keychain (no custom keychain name)
- migrate legacy entries from the old "asc" keychain on read
- clean up legacy entries on removal

## Testing
- go test ./internal/auth