### PR TITLE
Add finance CLI validation tests

### DIFF
--- a/cmd/finance_helpers_test.go
+++ b/cmd/finance_helpers_test.go
@@ -1,56 +1,108 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
 
 func TestNormalizeFinanceReportType(t *testing.T) {
-	reportType, err := normalizeFinanceReportType("financial")
-	if err != nil {
-		t.Fatalf("expected report type to parse, got %v", err)
-	}
-	if string(reportType) != "FINANCIAL" {
-		t.Fatalf("expected FINANCIAL, got %q", reportType)
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"financial", "financial", "FINANCIAL", false},
+		{"finance detail", "finance_detail", "FINANCE_DETAIL", false},
+		{"trimmed", " FINANCIAL ", "FINANCIAL", false},
+		{"invalid", "invalid", "", true},
 	}
 
-	_, err = normalizeFinanceReportType("invalid")
-	if err == nil {
-		t.Fatal("expected error for invalid report type")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reportType, err := normalizeFinanceReportType(test.input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", test.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected report type to parse, got %v", err)
+			}
+			if string(reportType) != test.want {
+				t.Fatalf("expected %s, got %q", test.want, reportType)
+			}
+		})
 	}
 }
 
 func TestNormalizeFinanceReportDate(t *testing.T) {
-	date, err := normalizeFinanceReportDate("2025-12")
-	if err != nil {
-		t.Fatalf("expected date to parse, got %v", err)
-	}
-	if date != "2025-12" {
-		t.Fatalf("expected date to be 2025-12, got %q", date)
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"valid", "2025-12", "2025-12", false},
+		{"trimmed", " 2025-01 ", "2025-01", false},
+		{"month zero", "2025-00", "", true},
+		{"month overflow", "2025-13", "", true},
+		{"wrong separator", "2025/12", "", true},
+		{"with day", "2025-12-01", "", true},
+		{"short year", "25-12", "", true},
 	}
 
-	_, err = normalizeFinanceReportDate("2025-13")
-	if err == nil {
-		t.Fatal("expected error for invalid date")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			date, err := normalizeFinanceReportDate(test.input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", test.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected date to parse, got %v", err)
+			}
+			if date != test.want {
+				t.Fatalf("expected date to be %s, got %q", test.want, date)
+			}
+		})
 	}
 }
 
 func TestNormalizeFinanceReportRegion(t *testing.T) {
-	region, err := normalizeFinanceReportRegion("FINANCIAL", "us")
-	if err != nil {
-		t.Fatalf("expected region to parse, got %v", err)
-	}
-	if region != "US" {
-		t.Fatalf("expected region to be US, got %q", region)
-	}
-
-	region, err = normalizeFinanceReportRegion("FINANCE_DETAIL", "z1")
-	if err != nil {
-		t.Fatalf("expected Z1 to parse, got %v", err)
-	}
-	if region != "Z1" {
-		t.Fatalf("expected region to be Z1, got %q", region)
+	tests := []struct {
+		name       string
+		reportType asc.FinanceReportType
+		input      string
+		want       string
+		wantErr    bool
+	}{
+		{"financial uppercases", asc.FinanceReportTypeFinancial, "us", "US", false},
+		{"financial trimmed", asc.FinanceReportTypeFinancial, " eu ", "EU", false},
+		{"finance detail z1", asc.FinanceReportTypeFinanceDetail, "z1", "Z1", false},
+		{"finance detail invalid", asc.FinanceReportTypeFinanceDetail, "US", "", true},
+		{"missing region", asc.FinanceReportTypeFinancial, " ", "", true},
 	}
 
-	_, err = normalizeFinanceReportRegion("FINANCE_DETAIL", "US")
-	if err == nil {
-		t.Fatal("expected error for non-Z1 FINANCE_DETAIL region")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			region, err := normalizeFinanceReportRegion(test.reportType, test.input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", test.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected region to parse, got %v", err)
+			}
+			if region != test.want {
+				t.Fatalf("expected region to be %s, got %q", test.want, region)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- expand finance helper validation coverage (types, dates, regions)
- add CLI-level JSON output test for `asc finance regions`

## Test plan
- [x] `make test`
- [x] `make lint`