### PR TITLE
Document finance report type mapping (UI vs API)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -250,9 +250,25 @@ Analytics & sales env:
 - Vendor number comes from Sales and Trends → Reports URL (`vendorNumber=...`)
 - Use `--paginate` with `asc analytics get --date` to avoid missing instances on later pages
 - Long analytics runs can require raising `ASC_TIMEOUT`
-- Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months
-- `FINANCE_DETAIL` reports require region code `Z1` (financial detail consolidated)
+
+## Finance Reports Notes
+
+Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
+
+**API Report Types (mapping to App Store Connect UI):**
+
+| API `--report-type` | UI Option                               | `--region` Code(s)      |
+|---------------------|-----------------------------------------|-------------------------|
+| `FINANCIAL`         | All Countries or Regions (Single File)  | `ZZ` (consolidated)     |
+| `FINANCIAL`         | All Countries or Regions (Multiple Files) | `US`, `EU`, `JP`, etc. |
+| `FINANCE_DETAIL`    | All Countries or Regions (Detailed)     | `Z1` (required)         |
+| Not available       | Transaction Tax (Single File)           | N/A                     |
+
+**Important:**
+- `FINANCE_DETAIL` reports require region code `Z1` (the only valid region for detailed reports)
+- Transaction Tax reports are NOT available via API; download manually from App Store Connect
 - Region codes reference: https://developer.apple.com/help/app-store-connect/reference/financial-report-regions-and-currencies/
+- Use `asc finance regions` to see all available region codes
 
 ## Sandbox Testers Notes
 

--- a/README.md
+++ b/README.md
@@ -230,23 +230,37 @@ Notes:
 ### Finance Reports
 
 ```bash
-# Download monthly finance report (writes .tsv.gz)
+# Download consolidated report (all regions in one file)
+asc finance reports --vendor "12345678" --report-type FINANCIAL --region "ZZ" --date "2025-12"
+
+# Download US-only monthly report
 asc finance reports --vendor "12345678" --report-type FINANCIAL --region "US" --date "2025-12"
 
-# Download detailed finance report and decompress
+# Download detailed report (transaction-level data) and decompress
 asc finance reports --vendor "12345678" --report-type FINANCE_DETAIL --region "Z1" --date "2025-12" --decompress
 
 # List finance report region codes and currencies
 asc finance regions --output table
 ```
 
-Notes:
+**Report Types (API to UI mapping):**
+
+| API Report Type  | UI Option                              | Region Code(s)          |
+|------------------|----------------------------------------|-------------------------|
+| `FINANCIAL`      | All Countries or Regions (Single File) | `ZZ` (consolidated)     |
+| `FINANCIAL`      | All Countries or Regions (Multiple Files) | `US`, `EU`, `JP`, etc. |
+| `FINANCE_DETAIL` | All Countries or Regions (Detailed)    | `Z1` (required)         |
+| Not available    | Transaction Tax (Single File)          | N/A - manual download   |
+
+**Notes:**
 - Report date format: `YYYY-MM` (Apple fiscal month)
 - Reports typically appear the first Friday of the following fiscal month
-- Region codes are listed by Apple: https://developer.apple.com/help/app-store-connect/reference/financial-report-regions-and-currencies/
-- `FINANCE_DETAIL` reports require region code `Z1` (financial detail consolidated)
-- Use `asc finance regions` to list valid region codes and currencies
+- `FINANCE_DETAIL` requires region code `Z1` (the only valid region for detailed reports)
+- Transaction Tax reports are not available via API - download manually from App Store Connect
+- Use `asc finance regions` to list all valid region codes and currencies
 - Requires Account Holder, Admin, or Finance role
+
+**Region codes reference:** https://developer.apple.com/help/app-store-connect/reference/financial-report-regions-and-currencies/
 
 ### Sandbox Testers
 

--- a/internal/asc/finance.go
+++ b/internal/asc/finance.go
@@ -6,11 +6,29 @@ import (
 	"strings"
 )
 
-// FinanceReportType represents the finance report type.
+// FinanceReportType represents the finance report type for the App Store Connect API.
+//
+// The API supports two report types that map to UI options as follows:
+//
+//   - FINANCIAL: Aggregated monthly financial report.
+//     Maps to UI options "All Countries or Regions (Single File)" with region ZZ,
+//     or "All Countries or Regions (Multiple Files)" with individual region codes.
+//
+//   - FINANCE_DETAIL: Detailed report with transaction and settlement dates.
+//     Maps to UI option "All Countries or Regions (Detailed)".
+//     Requires region code Z1.
+//
+// Note: Transaction Tax reports shown in the App Store Connect UI are NOT available
+// via the API. They must be downloaded manually from the web interface.
 type FinanceReportType string
 
 const (
-	FinanceReportTypeFinancial     FinanceReportType = "FINANCIAL"
+	// FinanceReportTypeFinancial is for aggregated monthly financial reports.
+	// Use with region codes: US, EU, ZZ (consolidated), or other individual/regional codes.
+	FinanceReportTypeFinancial FinanceReportType = "FINANCIAL"
+
+	// FinanceReportTypeFinanceDetail is for detailed reports with transaction dates.
+	// Must be used with region code Z1 only.
 	FinanceReportTypeFinanceDetail FinanceReportType = "FINANCE_DETAIL"
 )
 

--- a/internal/asc/finance_regions.go
+++ b/internal/asc/finance_regions.go
@@ -1,6 +1,15 @@
 package asc
 
 // FinanceRegion describes a finance report region code and currency.
+//
+// Region codes are used with the --region flag for 'asc finance reports'.
+// Special region codes:
+//   - ZZ: Consolidated Financial Reports (all regions, use with FINANCIAL)
+//   - Z1: Financial Detail Reports (all regions, required for FINANCE_DETAIL)
+//   - EU, LL, AP, WW: Regional aggregates (use with FINANCIAL)
+//   - US, AU, JP, etc.: Individual country reports (use with FINANCIAL)
+//
+// Reference: https://developer.apple.com/help/app-store-connect/reference/financial-report-regions-and-currencies/
 type FinanceRegion struct {
 	ReportRegion       string `json:"reportRegion"`
 	ReportCurrency     string `json:"reportCurrency"`


### PR DESCRIPTION
## Summary

Clarifies and documents how App Store Connect UI financial report types map to API `financeReports` `reportType` values.

Closes #77

## Key Findings

| API `--report-type` | UI Option | `--region` Code(s) |
|---------------------|-----------------------------------------|-------------------------|
| `FINANCIAL` | All Countries or Regions (Single File) | `ZZ` (consolidated) |
| `FINANCIAL` | All Countries or Regions (Multiple Files) | `US`, `EU`, `JP`, etc. |
| `FINANCE_DETAIL` | All Countries or Regions (Detailed) | `Z1` (required) |
| Not available | Transaction Tax (Single File) | N/A |

**Important:** Transaction Tax reports are NOT available via the API - users must download them manually from App Store Connect.

## Changes

- **cmd/finance.go**: Enhanced CLI help text with detailed report type explanations, region codes, and examples
- **internal/asc/finance.go**: Added comprehensive Go doc comments for `FinanceReportType`
- **internal/asc/finance_regions.go**: Documented special region codes (ZZ, Z1, EU, LL, AP, WW)
- **README.md**: Added report type mapping table and updated examples
- **Agents.md**: Added "Finance Reports Notes" section

## Test plan

- [ ] Verify `asc finance reports --help` shows the new documentation
- [ ] Verify `asc finance regions --help` shows region code guidance
- [ ] Confirm `make test` and `make lint` pass