### PR TITLE
Fix build upload State type and handle empty checksums

### DIFF
--- a/cmd/builds_commands.go
+++ b/cmd/builds_commands.go
@@ -194,16 +194,18 @@ Examples:
 				var verifiedChecksums *asc.Checksums
 				var checksumVerified *bool
 				if *verifyChecksum {
-					if fileResp.Data.Attributes.SourceFileChecksums == nil {
-						return fmt.Errorf("builds upload: --checksum requested but no source file checksums were provided")
+					src := fileResp.Data.Attributes.SourceFileChecksums
+					if src == nil || (src.File == nil && src.Composite == nil) {
+						fmt.Fprintln(os.Stderr, "Warning: --checksum requested but API provided no checksums to verify; skipping")
+					} else {
+						checksums, err := asc.VerifySourceFileChecksums(*ipaPath, src)
+						if err != nil {
+							return fmt.Errorf("builds upload: checksum verification failed: %w", err)
+						}
+						verifiedChecksums = checksums
+						verified := true
+						checksumVerified = &verified
 					}
-					checksums, err := asc.VerifySourceFileChecksums(*ipaPath, fileResp.Data.Attributes.SourceFileChecksums)
-					if err != nil {
-						return fmt.Errorf("builds upload: checksum verification failed: %w", err)
-					}
-					verifiedChecksums = checksums
-					verified := true
-					checksumVerified = &verified
 				}
 
 				uploaded := true

--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -27,11 +27,11 @@ type BuildResponse = SingleResponse[BuildAttributes]
 
 // BuildUploadAttributes describes a build upload resource.
 type BuildUploadAttributes struct {
-	CFBundleShortVersionString string   `json:"cfBundleShortVersionString"`
-	CFBundleVersion            string   `json:"cfBundleVersion"`
-	Platform                   Platform `json:"platform"`
-	CreatedDate                *string  `json:"createdDate,omitempty"`
-	State                      *string  `json:"state,omitempty"`
+	CFBundleShortVersionString string              `json:"cfBundleShortVersionString"`
+	CFBundleVersion            string              `json:"cfBundleVersion"`
+	Platform                   Platform            `json:"platform"`
+	CreatedDate                *string             `json:"createdDate,omitempty"`
+	State                      *AppMediaAssetState `json:"state,omitempty"`
 }
 
 // BuildUploadRelationships describes the relationships for a build upload.


### PR DESCRIPTION
## Summary

Fixes two issues found during end-to-end testing of #100 with a real IPA upload to App Store Connect.

- **Fix `BuildUploadAttributes.State` type** — The API returns `state` as an object (with `state`, `errors`, `warnings` fields), not a plain string. Changed from `*string` to `*AppMediaAssetState` so the response can be deserialized. Without this fix, every upload attempt fails with a JSON unmarshal error.

- **Handle empty checksums gracefully** — When `--checksum` is requested but the API returns a `sourceFileChecksums` object with no actual algorithms populated, the command now prints a warning to stderr and continues instead of failing. This matches real-world API behavior where checksums aren't always provided.