### PR TITLE
Fix users command: required name flags for invite, role filter for list

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -422,22 +422,32 @@ func TestUsersValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "users invite missing email",
-			args:    []string{"users", "invite", "--roles", "ADMIN", "--all-apps"},
+			args:    []string{"users", "invite", "--first-name", "Jane", "--last-name", "Doe", "--roles", "ADMIN", "--all-apps"},
 			wantErr: "--email is required",
 		},
 		{
+			name:    "users invite missing first name",
+			args:    []string{"users", "invite", "--email", "user@example.com", "--last-name", "Doe", "--roles", "ADMIN", "--all-apps"},
+			wantErr: "--first-name is required",
+		},
+		{
+			name:    "users invite missing last name",
+			args:    []string{"users", "invite", "--email", "user@example.com", "--first-name", "Jane", "--roles", "ADMIN", "--all-apps"},
+			wantErr: "--last-name is required",
+		},
+		{
 			name:    "users invite missing roles",
-			args:    []string{"users", "invite", "--email", "user@example.com", "--all-apps"},
+			args:    []string{"users", "invite", "--email", "user@example.com", "--first-name", "Jane", "--last-name", "Doe", "--all-apps"},
 			wantErr: "--roles is required",
 		},
 		{
 			name:    "users invite missing access",
-			args:    []string{"users", "invite", "--email", "user@example.com", "--roles", "ADMIN"},
+			args:    []string{"users", "invite", "--email", "user@example.com", "--first-name", "Jane", "--last-name", "Doe", "--roles", "ADMIN"},
 			wantErr: "--all-apps or --visible-app is required",
 		},
 		{
 			name:    "users invite conflicting access",
-			args:    []string{"users", "invite", "--email", "user@example.com", "--roles", "ADMIN", "--all-apps", "--visible-app", "APP_ID"},
+			args:    []string{"users", "invite", "--email", "user@example.com", "--first-name", "Jane", "--last-name", "Doe", "--roles", "ADMIN", "--all-apps", "--visible-app", "APP_ID"},
 			wantErr: "--all-apps and --visible-app cannot be used together",
 		},
 		{

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -536,6 +536,13 @@ func WithUsersEmail(email string) UsersOption {
 	}
 }
 
+// WithUsersRoles filters users by roles.
+func WithUsersRoles(roles []string) UsersOption {
+	return func(q *usersQuery) {
+		q.roles = normalizeList(roles)
+	}
+}
+
 // WithUserInvitationsLimit sets the max number of invitations to return.
 func WithUserInvitationsLimit(limit int) UserInvitationsOption {
 	return func(q *userInvitationsQuery) {

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -102,6 +102,7 @@ type betaTestersQuery struct {
 type usersQuery struct {
 	listQuery
 	email string
+	roles []string
 }
 
 type userInvitationsQuery struct {
@@ -116,6 +117,7 @@ type pricePointsQuery struct {
 	listQuery
 	territory string
 }
+
 func buildReviewQuery(opts []ReviewOption) string {
 	query := &reviewQuery{}
 	for _, opt := range opts {
@@ -232,6 +234,7 @@ func buildUsersQuery(query *usersQuery) string {
 	if strings.TrimSpace(query.email) != "" {
 		values.Set("filter[username]", strings.TrimSpace(query.email))
 	}
+	addCSV(values, "filter[roles]", query.roles)
 	addLimit(values, query.limit)
 	return values.Encode()
 }


### PR DESCRIPTION
## Summary
Fixes critical issues found during code review and end-to-end testing of PR #101.

## Changes
- **Add `--first-name` and `--last-name` required flags to `users invite`** - The App Store Connect API requires `firstName` attribute, without which invitations fail
- **Add `--role` filter flag to `users list`** - Allows filtering users by role (e.g., `--role "ADMIN"` or `--role "DEVELOPER,APP_MANAGER"`)
- **Improve error message** in `users update` when visible apps operation fails after roles update succeeds
- **Remove dead validation code** that was unreachable due to `parseCommaSeparatedIDs` already handling empty strings

## Testing Performed

### Automated Tests
- All user validation tests pass (`go test -run "Users" ./cmd/`)
- Added new test cases for `--first-name` and `--last-name` validation

### End-to-End Tests (against real App Store Connect API)
| Command | Result |
|---------|--------|
| `asc users list --role "ADMIN"` | ✅ Filters correctly |
| `asc users invite --email "..." --first-name "..." --last-name "..." --roles "DEVELOPER" --visible-app "..."` | ✅ Creates invitation |
| `asc users invites list` | ✅ Lists invitations |
| `asc users invites get --id "..."` | ✅ Retrieves invitation |
| `asc users invites revoke --id "..." --confirm` | ✅ Revokes invitation |
| Error handling for missing `--first-name` | ✅ Shows clear error |
| Error handling for missing `--last-name` | ✅ Shows clear error |

## Manual Testing Recommended
Before merging PR #101 to main, recommend testing:
1. **Invite a real user** to App Store Connect (not just test emails) and verify they receive the invitation
2. **Accept an invitation** and verify the user appears in `users list`
3. **Test `users delete`** with an actual user (carefully, in a test account if possible)
4. **Test `users update --roles`** to change a user's role and verify with `users get`