### PR TITLE
Add categories management commands (list and set)

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,18 @@ asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
 asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID"
 ```
 
+### Categories
+
+```bash
+# List all App Store categories
+asc categories list
+asc categories list --output table
+
+# Set primary and secondary categories for an app
+asc categories set --app "123456789" --primary GAMES
+asc categories set --app "123456789" --primary GAMES --secondary ENTERTAINMENT
+```
+
 ### Versions
 
 ```bash

--- a/cmd/categories.go
+++ b/cmd/categories.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// CategoriesCommand returns the categories command with subcommands.
+func CategoriesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("categories", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "categories",
+		ShortUsage: "asc categories <subcommand> [flags]",
+		ShortHelp:  "Manage App Store categories.",
+		LongHelp: `Manage App Store categories.
+
+Examples:
+  asc categories list
+  asc categories set --app APP_ID --primary GAMES`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			CategoriesListCommand(),
+			CategoriesSetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// CategoriesListCommand returns the categories list subcommand.
+func CategoriesListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("categories list", flag.ExitOnError)
+
+	limit := fs.Int("limit", 200, "Maximum results to fetch (1-200)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc categories list [flags]",
+		ShortHelp:  "List available App Store categories.",
+		LongHelp: `List available App Store categories.
+
+Category IDs can be used when updating app information to set primary
+and secondary categories.
+
+Examples:
+  asc categories list
+  asc categories list --output table`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit < 1 || *limit > 200 {
+				return fmt.Errorf("categories list: --limit must be between 1 and 200")
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("categories list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			categories, err := client.GetAppCategories(requestCtx, asc.WithAppCategoriesLimit(*limit))
+			if err != nil {
+				return fmt.Errorf("categories list: %w", err)
+			}
+
+			return printOutput(categories, *output, *pretty)
+		},
+	}
+}
+
+// CategoriesSetCommand returns the categories set subcommand.
+func CategoriesSetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("categories set", flag.ExitOnError)
+
+	appID := fs.String("app", os.Getenv("ASC_APP_ID"), "App ID (required)")
+	primary := fs.String("primary", "", "Primary category ID (required)")
+	secondary := fs.String("secondary", "", "Secondary category ID (optional)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "set",
+		ShortUsage: "asc categories set --app APP_ID --primary CATEGORY_ID [--secondary CATEGORY_ID]",
+		ShortHelp:  "Set primary and secondary categories for an app.",
+		LongHelp: `Set the primary and secondary categories for an app.
+
+Use 'asc categories list' to find valid category IDs.
+
+Note: The app must have an editable version in PREPARE_FOR_SUBMISSION state.
+
+Examples:
+  asc categories set --app 123456789 --primary GAMES
+  asc categories set --app 123456789 --primary GAMES --secondary ENTERTAINMENT
+  asc categories set --app 123456789 --primary PHOTO_AND_VIDEO`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			appIDValue := strings.TrimSpace(*appID)
+			primaryValue := strings.TrimSpace(*primary)
+			secondaryValue := strings.TrimSpace(*secondary)
+
+			if appIDValue == "" {
+				return fmt.Errorf("categories set: --app is required")
+			}
+			if primaryValue == "" {
+				return fmt.Errorf("categories set: --primary is required")
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("categories set: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			// Get the current app info ID
+			appInfos, err := client.GetAppInfos(requestCtx, appIDValue)
+			if err != nil {
+				return fmt.Errorf("categories set: failed to get app info: %w", err)
+			}
+
+			if len(appInfos.Data) == 0 {
+				return fmt.Errorf("categories set: no app info found for app %s", appIDValue)
+			}
+
+			// Use the first (most recent) app info
+			appInfoID := appInfos.Data[0].ID
+
+			// Update categories
+			resp, err := client.UpdateAppInfoCategories(requestCtx, appInfoID, primaryValue, secondaryValue)
+			if err != nil {
+				return fmt.Errorf("categories set: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func RootCommand(version string) *ffcli.Command {
 			SandboxCommand(),
 			SubmitCommand(),
 			XcodeCloudCommand(),
+			CategoriesCommand(),
 			VersionCommand(version),
 		},
 	}

--- a/internal/asc/categories.go
+++ b/internal/asc/categories.go
@@ -1,0 +1,144 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// AppCategoryAttributes describes app category metadata.
+type AppCategoryAttributes struct {
+	Platforms []Platform `json:"platforms,omitempty"`
+}
+
+// AppCategory represents an app category resource.
+type AppCategory struct {
+	Type       ResourceType          `json:"type"`
+	ID         string                `json:"id"`
+	Attributes AppCategoryAttributes `json:"attributes,omitempty"`
+}
+
+// AppCategoriesResponse is the response from app categories endpoint.
+type AppCategoriesResponse struct {
+	Data  []AppCategory `json:"data"`
+	Links Links         `json:"links,omitempty"`
+}
+
+// GetAppCategories retrieves all app categories.
+func (c *Client) GetAppCategories(ctx context.Context, opts ...AppCategoriesOption) (*AppCategoriesResponse, error) {
+	query := &appCategoriesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	path := "/v1/appCategories"
+	if query.limit > 0 {
+		path += fmt.Sprintf("?limit=%d", query.limit)
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppCategoriesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// appCategoriesQuery holds query parameters for app categories.
+type appCategoriesQuery struct {
+	limit int
+}
+
+// AppCategoriesOption configures app categories queries.
+type AppCategoriesOption func(*appCategoriesQuery)
+
+// WithAppCategoriesLimit sets the limit for app categories queries.
+func WithAppCategoriesLimit(limit int) AppCategoriesOption {
+	return func(q *appCategoriesQuery) {
+		q.limit = limit
+	}
+}
+
+// AppInfoUpdateCategoriesRelationships describes relationships for updating categories.
+type AppInfoUpdateCategoriesRelationships struct {
+	PrimaryCategory             *Relationship `json:"primaryCategory,omitempty"`
+	SecondaryCategory           *Relationship `json:"secondaryCategory,omitempty"`
+	PrimarySubcategoryOne       *Relationship `json:"primarySubcategoryOne,omitempty"`
+	PrimarySubcategoryTwo       *Relationship `json:"primarySubcategoryTwo,omitempty"`
+	SecondarySubcategoryOne     *Relationship `json:"secondarySubcategoryOne,omitempty"`
+	SecondarySubcategoryTwo     *Relationship `json:"secondarySubcategoryTwo,omitempty"`
+}
+
+// AppInfoUpdateCategoriesData is the data for updating app info categories.
+type AppInfoUpdateCategoriesData struct {
+	Type          ResourceType                          `json:"type"`
+	ID            string                                `json:"id"`
+	Relationships *AppInfoUpdateCategoriesRelationships `json:"relationships,omitempty"`
+}
+
+// AppInfoUpdateCategoriesRequest is a request to update app info categories.
+type AppInfoUpdateCategoriesRequest struct {
+	Data AppInfoUpdateCategoriesData `json:"data"`
+}
+
+// AppInfoResponse is the response from updating app info.
+type AppInfoResponse struct {
+	Data struct {
+		Type       ResourceType       `json:"type"`
+		ID         string             `json:"id"`
+		Attributes AppInfoAttributes  `json:"attributes,omitempty"`
+	} `json:"data"`
+}
+
+// UpdateAppInfoCategories updates the categories for an app info resource.
+func (c *Client) UpdateAppInfoCategories(ctx context.Context, appInfoID string, primaryCategoryID, secondaryCategoryID string) (*AppInfoResponse, error) {
+	relationships := &AppInfoUpdateCategoriesRelationships{}
+
+	if primaryCategoryID != "" {
+		relationships.PrimaryCategory = &Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeAppCategories,
+				ID:   primaryCategoryID,
+			},
+		}
+	}
+
+	if secondaryCategoryID != "" {
+		relationships.SecondaryCategory = &Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeAppCategories,
+				ID:   secondaryCategoryID,
+			},
+		}
+	}
+
+	request := AppInfoUpdateCategoriesRequest{
+		Data: AppInfoUpdateCategoriesData{
+			Type:          ResourceTypeAppInfos,
+			ID:            appInfoID,
+			Relationships: relationships,
+		},
+	}
+
+	body, err := BuildRequestBody(request)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := c.do(ctx, "PATCH", fmt.Sprintf("/v1/appInfos/%s", appInfoID), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/categories_output.go
+++ b/internal/asc/categories_output.go
@@ -1,0 +1,35 @@
+package asc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+// formatPlatforms converts a slice of Platform to a comma-separated string.
+func formatPlatforms(platforms []Platform) string {
+	strs := make([]string, len(platforms))
+	for i, p := range platforms {
+		strs[i] = string(p)
+	}
+	return strings.Join(strs, ", ")
+}
+
+func printAppCategoriesMarkdown(resp *AppCategoriesResponse) error {
+	fmt.Println("| ID | Platforms |")
+	fmt.Println("|---|---|")
+	for _, cat := range resp.Data {
+		fmt.Printf("| %s | %s |\n", cat.ID, formatPlatforms(cat.Attributes.Platforms))
+	}
+	return nil
+}
+
+func printAppCategoriesTable(resp *AppCategoriesResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tPLATFORMS")
+	for _, cat := range resp.Data {
+		fmt.Fprintf(w, "%s\t%s\n", cat.ID, formatPlatforms(cat.Attributes.Platforms))
+	}
+	return w.Flush()
+}

--- a/internal/asc/client_types.go
+++ b/internal/asc/client_types.go
@@ -5,6 +5,7 @@ type ResourceType string
 
 const (
 	ResourceTypeApps                         ResourceType = "apps"
+	ResourceTypeAppCategories                ResourceType = "appCategories"
 	ResourceTypeAppAvailabilities            ResourceType = "appAvailabilities"
 	ResourceTypeAppPricePoints               ResourceType = "appPricePoints"
 	ResourceTypeAppPriceSchedules            ResourceType = "appPriceSchedules"

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -29,6 +29,8 @@ func PrintMarkdown(data interface{}) error {
 		return printReviewsMarkdown(v)
 	case *AppsResponse:
 		return printAppsMarkdown(v)
+	case *AppCategoriesResponse:
+		return printAppCategoriesMarkdown(v)
 	case *AppResponse:
 		return printAppsMarkdown(&AppsResponse{Data: []Resource[AppAttributes]{v.Data}})
 	case *TerritoriesResponse:
@@ -157,6 +159,8 @@ func PrintTable(data interface{}) error {
 		return printReviewsTable(v)
 	case *AppsResponse:
 		return printAppsTable(v)
+	case *AppCategoriesResponse:
+		return printAppCategoriesTable(v)
 	case *AppResponse:
 		return printAppsTable(&AppsResponse{Data: []Resource[AppAttributes]{v.Data}})
 	case *TerritoriesResponse:


### PR DESCRIPTION
## Summary

Adds `asc categories` command with two subcommands for managing App Store categories.

### Commands Added

```bash
# List all App Store categories
asc categories list
asc categories list --output table

# Set primary and secondary categories for an app
asc categories set --app APP_ID --primary GAMES
asc categories set --app APP_ID --primary GAMES --secondary ENTERTAINMENT
```

---

## Production Testing ✅

```
$ asc categories list --limit 5 --output table
ID                              PLATFORMS
STICKERS_EMOJI_AND_EXPRESSIONS  IOS
GAMES_ACTION                    IOS, MAC_OS, TV_OS, VISION_OS
BUSINESS                        IOS, MAC_OS, TV_OS, VISION_OS
WEATHER                         IOS, MAC_OS, TV_OS, VISION_OS
UTILITIES                       IOS, MAC_OS, TV_OS, VISION_OS
```

---

## Files Changed

| File | Purpose |
|------|---------|
| `cmd/categories.go` | CLI commands for list and set |
| `cmd/root.go` | Register CategoriesCommand |
| `internal/asc/categories.go` | API client for categories |
| `internal/asc/categories_output.go` | Table and markdown formatters |
| `internal/asc/client_types.go` | Add ResourceTypeAppCategories |
| `internal/asc/output_core.go` | Register output formatters |
| `README.md` | Documentation |

---

## Use Cases

1. **Discover category IDs** - List all valid categories before setting them
2. **Automate category updates** - Set categories programmatically in CI/CD
3. **Bulk updates** - Script category changes across multiple apps

---

## Breaking Changes

None. This is an additive feature.

---

🤖 Generated with [Claude Code](https://claude.ai/code)