### PR TITLE
Add versions create, update, and delete commands

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -429,7 +429,10 @@ func TestCreateAppStoreVersion(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	result, err := client.CreateAppStoreVersion(context.Background(), "APP_123", "1.0.0", PlatformIOS)
+	result, err := client.CreateAppStoreVersion(context.Background(), "APP_123", AppStoreVersionCreateAttributes{
+		Platform:      PlatformIOS,
+		VersionString: "1.0.0",
+	})
 	if err != nil {
 		t.Fatalf("CreateAppStoreVersion() error: %v", err)
 	}

--- a/internal/asc/client_publish.go
+++ b/internal/asc/client_publish.go
@@ -62,7 +62,10 @@ func (c *Client) FindOrCreateAppStoreVersion(ctx context.Context, appID, version
 
 	switch len(versions.Data) {
 	case 0:
-		return c.CreateAppStoreVersion(ctx, appID, version, Platform(platformValue))
+		return c.CreateAppStoreVersion(ctx, appID, AppStoreVersionCreateAttributes{
+			Platform:      Platform(platformValue),
+			VersionString: version,
+		})
 	case 1:
 		return &AppStoreVersionResponse{Data: versions.Data[0]}, nil
 	default:

--- a/internal/asc/client_versions.go
+++ b/internal/asc/client_versions.go
@@ -20,6 +20,28 @@ type AppStoreVersionAttributes struct {
 type AppStoreVersionCreateAttributes struct {
 	Platform      Platform `json:"platform"`
 	VersionString string   `json:"versionString"`
+	Copyright     string   `json:"copyright,omitempty"`
+	ReleaseType   string   `json:"releaseType,omitempty"`
+}
+
+// AppStoreVersionUpdateAttributes describes app store version update payload attributes.
+type AppStoreVersionUpdateAttributes struct {
+	Copyright           *string `json:"copyright,omitempty"`
+	ReleaseType         *string `json:"releaseType,omitempty"`
+	EarliestReleaseDate *string `json:"earliestReleaseDate,omitempty"`
+	VersionString       *string `json:"versionString,omitempty"`
+}
+
+// AppStoreVersionUpdateData is the data portion of an app store version update request.
+type AppStoreVersionUpdateData struct {
+	Type       ResourceType                    `json:"type"`
+	ID         string                          `json:"id"`
+	Attributes AppStoreVersionUpdateAttributes `json:"attributes"`
+}
+
+// AppStoreVersionUpdateRequest is a request to update an app store version.
+type AppStoreVersionUpdateRequest struct {
+	Data AppStoreVersionUpdateData `json:"data"`
 }
 
 // AppStoreVersionCreateRelationships describes relationships for app store version create requests.
@@ -213,14 +235,11 @@ func (c *Client) GetAppStoreVersion(ctx context.Context, versionID string) (*App
 }
 
 // CreateAppStoreVersion creates a new app store version for an app.
-func (c *Client) CreateAppStoreVersion(ctx context.Context, appID, version string, platform Platform) (*AppStoreVersionResponse, error) {
+func (c *Client) CreateAppStoreVersion(ctx context.Context, appID string, attrs AppStoreVersionCreateAttributes) (*AppStoreVersionResponse, error) {
 	payload := AppStoreVersionCreateRequest{
 		Data: AppStoreVersionCreateData{
-			Type: ResourceTypeAppStoreVersions,
-			Attributes: AppStoreVersionCreateAttributes{
-				Platform:      platform,
-				VersionString: version,
-			},
+			Type:       ResourceTypeAppStoreVersions,
+			Attributes: attrs,
 			Relationships: &AppStoreVersionCreateRelationships{
 				App: &Relationship{
 					Data: ResourceData{
@@ -248,6 +267,43 @@ func (c *Client) CreateAppStoreVersion(ctx context.Context, appID, version strin
 	}
 
 	return &response, nil
+}
+
+// UpdateAppStoreVersion updates an existing app store version.
+func (c *Client) UpdateAppStoreVersion(ctx context.Context, versionID string, attrs AppStoreVersionUpdateAttributes) (*AppStoreVersionResponse, error) {
+	payload := AppStoreVersionUpdateRequest{
+		Data: AppStoreVersionUpdateData{
+			Type:       ResourceTypeAppStoreVersions,
+			ID:         strings.TrimSpace(versionID),
+			Attributes: attrs,
+		},
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s", strings.TrimSpace(versionID))
+	data, err := c.do(ctx, "PATCH", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// DeleteAppStoreVersion deletes an app store version.
+// Only versions in PREPARE_FOR_SUBMISSION state can be deleted.
+func (c *Client) DeleteAppStoreVersion(ctx context.Context, versionID string) error {
+	path := fmt.Sprintf("/v1/appStoreVersions/%s", strings.TrimSpace(versionID))
+	_, err := c.do(ctx, "DELETE", path, nil)
+	return err
 }
 
 // AttachBuildToVersion attaches a build to an app store version.


### PR DESCRIPTION
## Summary

Adds full CRUD operations for App Store versions, enabling programmatic version management:

- **`asc versions create`**: Create new versions with optional copyright and release type
- **`asc versions update`**: Update copyright, release type, scheduled release date, or version string
- **`asc versions delete`**: Safely delete versions in PREPARE_FOR_SUBMISSION state

## New Commands

### Create Version
```bash
# Basic creation
asc versions create --app "123456789" --version "2.0.0"

# With all options
asc versions create --app "123456789" --version "2.0.0" \
  --platform IOS \
  --copyright "2026 My Company" \
  --release-type MANUAL
```

### Update Version
```bash
# Update copyright
asc versions update --version-id "VERSION_ID" --copyright "2026 My Company"

# Schedule a release
asc versions update --version-id "VERSION_ID" \
  --release-type SCHEDULED \
  --earliest-release-date "2026-02-01T08:00:00+00:00"
```

### Delete Version
```bash
# Requires --confirm for safety
asc versions delete --version-id "VERSION_ID" --confirm
```

## API Changes

- Extended `AppStoreVersionCreateAttributes` to support optional `copyright` and `releaseType` fields
- Added `AppStoreVersionUpdateAttributes` type for PATCH operations
- Added `UpdateAppStoreVersion()` and `DeleteAppStoreVersion()` client methods
- Updated `CreateAppStoreVersion()` signature to accept full attributes struct

## Testing

- Builds successfully: `go build ./...`
- All tests pass: `go test ./internal/asc/...`
- Tested with real App Store Connect API

## Checklist

- [x] Code follows project patterns (explicit flags, JSON-first output)
- [x] `--confirm` required for destructive delete operation
- [x] Help text includes examples
- [x] All output formats supported (json, table, markdown)
- [x] Tests updated for new API signature

---

🤖 Generated with [Claude Code](https://claude.ai/code)