### PR TITLE
Add xcode-cloud actions command

### DIFF
--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -137,6 +137,8 @@ func PrintMarkdown(data interface{}) error {
 		return printCiWorkflowsMarkdown(v)
 	case *CiBuildRunsResponse:
 		return printCiBuildRunsMarkdown(v)
+	case *CiBuildActionsResponse:
+		return printCiBuildActionsMarkdown(v)
 	case *CustomerReviewResponseResponse:
 		return printCustomerReviewResponseMarkdown(v)
 	case *CustomerReviewResponseDeleteResult:
@@ -265,6 +267,8 @@ func PrintTable(data interface{}) error {
 		return printCiWorkflowsTable(v)
 	case *CiBuildRunsResponse:
 		return printCiBuildRunsTable(v)
+	case *CiBuildActionsResponse:
+		return printCiBuildActionsTable(v)
 	case *CustomerReviewResponseResponse:
 		return printCustomerReviewResponseTable(v)
 	case *CustomerReviewResponseDeleteResult:

--- a/internal/asc/xcode_cloud_output.go
+++ b/internal/asc/xcode_cloud_output.go
@@ -171,3 +171,51 @@ func printCiBuildRunsMarkdown(resp *CiBuildRunsResponse) error {
 	}
 	return nil
 }
+
+func printCiBuildActionsTable(resp *CiBuildActionsResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Name\tType\tProgress\tStatus\tErrors\tWarnings\tStarted\tFinished")
+	for _, item := range resp.Data {
+		errors := 0
+		warnings := 0
+		if item.Attributes.IssueCounts != nil {
+			errors = item.Attributes.IssueCounts.Errors
+			warnings = item.Attributes.IssueCounts.Warnings
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+			item.Attributes.Name,
+			item.Attributes.ActionType,
+			string(item.Attributes.ExecutionProgress),
+			string(item.Attributes.CompletionStatus),
+			errors,
+			warnings,
+			item.Attributes.StartedDate,
+			item.Attributes.FinishedDate,
+		)
+	}
+	return w.Flush()
+}
+
+func printCiBuildActionsMarkdown(resp *CiBuildActionsResponse) error {
+	fmt.Fprintln(os.Stdout, "| Name | Type | Progress | Status | Errors | Warnings | Started | Finished |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
+	for _, item := range resp.Data {
+		errors := 0
+		warnings := 0
+		if item.Attributes.IssueCounts != nil {
+			errors = item.Attributes.IssueCounts.Errors
+			warnings = item.Attributes.IssueCounts.Warnings
+		}
+		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %d | %s | %s |\n",
+			escapeMarkdown(item.Attributes.Name),
+			escapeMarkdown(item.Attributes.ActionType),
+			escapeMarkdown(string(item.Attributes.ExecutionProgress)),
+			escapeMarkdown(string(item.Attributes.CompletionStatus)),
+			errors,
+			warnings,
+			escapeMarkdown(item.Attributes.StartedDate),
+			escapeMarkdown(item.Attributes.FinishedDate),
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds `asc xcode-cloud actions --run-id BUILD_RUN_ID` to list the individual build actions (steps) within a build run. Useful for diagnosing why builds failed by seeing which specific action (Build, Test, Archive, etc.) failed.

## New Command

```bash
# List all actions for a build run
asc xcode-cloud actions --run-id "abc123"

# Table format
asc xcode-cloud actions --run-id "abc123" --output table

# Paginate through all results
asc xcode-cloud actions --run-id "abc123" --paginate
```

## Example Output

```
$ asc xcode-cloud actions --run-id "abc123" --output table
Name         Type   Progress  Status     Errors  Warnings
Build - iOS  BUILD  COMPLETE  SUCCEEDED  0       0
Test - iOS   TEST   COMPLETE  SUCCEEDED  0       2
```

## Features

- List all actions for a build run with progress and status
- Show error/warning counts per action
- Table and markdown output formats
- Pagination support (`--limit`, `--next`, `--paginate`)

## Files Changed

| File | Purpose |
|------|---------|
| `cmd/xcode_cloud.go` | Added XcodeCloudActionsCommand |
| `internal/asc/xcode_cloud.go` | Added CiBuildActionsResponse and GetCiBuildActions |
| `internal/asc/xcode_cloud_output.go` | Added table/markdown formatters |
| `internal/asc/output_core.go` | Added CiBuildActionsResponse cases |

## Testing

- Builds successfully
- All tests pass
- Tested with real Xcode Cloud build runs

## Checklist

- [x] Code follows project patterns
- [x] All output formats supported (json, table, markdown)
- [x] Pagination support included
- [x] Help text includes examples

---

🤖 Generated with [Claude Code](https://claude.ai/code)