### PR TITLE
audit: minor code quality improvements

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -494,6 +494,7 @@ func TestUsersValidationErrors(t *testing.T) {
 }
 
 func TestTestFlightAppsValidationErrors(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_KEY_ID", "")
 	t.Setenv("ASC_ISSUER_ID", "")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", "")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/99designs/keyring v1.2.2
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/peterbourgon/ff/v3 v3.4.0
+	golang.org/x/sys v0.3.0
+	golang.org/x/term v0.3.0
+	gopkg.in/yaml.v3 v3.0.1
 	howett.net/plist v1.0.1
 )
 
@@ -16,7 +19,4 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
-	golang.org/x/sys v0.3.0 // indirect
-	golang.org/x/term v0.3.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLF
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=

--- a/internal/asc/client_core.go
+++ b/internal/asc/client_core.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"os"
@@ -32,6 +33,16 @@ const (
 	DefaultBaseDelay  = 1 * time.Second
 	DefaultMaxDelay   = 30 * time.Second
 )
+
+var retryLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	Level: slog.LevelInfo,
+	ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+		if attr.Key == slog.TimeKey {
+			return slog.Attr{}
+		}
+		return attr
+	},
+}))
 
 func loadConfig() *config.Config {
 	cfg, err := config.Load()
@@ -198,7 +209,7 @@ func WithRetry[T any](ctx context.Context, fn func() (T, error), opts RetryOptio
 		}
 
 		if shouldLogRetries() {
-			fmt.Fprintf(os.Stderr, "retrying in %s (attempt %d/%d): %v\n", delay, retryCount+1, opts.MaxRetries, err)
+			logRetry(delay, retryCount+1, opts.MaxRetries, err)
 		}
 
 		retryCount++
@@ -224,6 +235,10 @@ func shouldLogRetries() bool {
 	return strings.TrimSpace(cfg.RetryLog) != ""
 }
 
+func logRetry(delay time.Duration, attempt, maxRetries int, err error) {
+	retryLogger.Info("retrying request", "delay", delay.String(), "attempt", attempt, "maxRetries", maxRetries, "error", err)
+}
+
 // ResolveTimeout returns the request timeout, optionally overridden by config/env.
 func ResolveTimeout() time.Duration {
 	return ResolveTimeoutWithDefault(DefaultTimeout)
@@ -232,8 +247,8 @@ func ResolveTimeout() time.Duration {
 // ResolveUploadTimeout returns the upload timeout, optionally overridden by config/env.
 func ResolveUploadTimeout() time.Duration {
 	cfg := loadConfig()
-	uploadTimeout := ""
-	uploadTimeoutSeconds := ""
+	var uploadTimeout config.DurationValue
+	var uploadTimeoutSeconds config.DurationValue
 	if cfg != nil {
 		uploadTimeout = cfg.UploadTimeout
 		uploadTimeoutSeconds = cfg.UploadTimeoutSeconds
@@ -245,8 +260,8 @@ func ResolveUploadTimeout() time.Duration {
 // ASC_TIMEOUT and ASC_TIMEOUT_SECONDS override the default when set.
 func ResolveTimeoutWithDefault(defaultTimeout time.Duration) time.Duration {
 	cfg := loadConfig()
-	timeout := ""
-	timeoutSeconds := ""
+	var timeout config.DurationValue
+	var timeoutSeconds config.DurationValue
 	if cfg != nil {
 		timeout = cfg.Timeout
 		timeoutSeconds = cfg.TimeoutSeconds
@@ -254,7 +269,7 @@ func ResolveTimeoutWithDefault(defaultTimeout time.Duration) time.Duration {
 	return resolveTimeoutWithDefaultAndEnv(defaultTimeout, "ASC_TIMEOUT", "ASC_TIMEOUT_SECONDS", timeout, timeoutSeconds)
 }
 
-func resolveTimeoutWithDefaultAndEnv(defaultTimeout time.Duration, durationEnv, secondsEnv, durationConfig, secondsConfig string) time.Duration {
+func resolveTimeoutWithDefaultAndEnv(defaultTimeout time.Duration, durationEnv, secondsEnv string, durationConfig, secondsConfig config.DurationValue) time.Duration {
 	timeout := defaultTimeout
 	if override, ok := envValue(durationEnv); ok {
 		if override != "" {
@@ -272,14 +287,10 @@ func resolveTimeoutWithDefaultAndEnv(defaultTimeout time.Duration, durationEnv, 
 		}
 		return timeout
 	}
-	if override := strings.TrimSpace(durationConfig); override != "" {
-		if parsed, err := time.ParseDuration(override); err == nil && parsed > 0 {
-			timeout = parsed
-		}
-	} else if override := strings.TrimSpace(secondsConfig); override != "" {
-		if parsed, err := strconv.Atoi(override); err == nil && parsed > 0 {
-			timeout = time.Duration(parsed) * time.Second
-		}
+	if override, ok := durationConfig.Value(); ok {
+		timeout = override
+	} else if override, ok := secondsConfig.Value(); ok {
+		timeout = override
 	}
 	return timeout
 }

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -251,7 +251,13 @@ func TestIntegrationAuthConfig(t *testing.T) {
 			DefaultKeyName: "LogoutTestKey",
 			AppID:          "12345",
 			VendorNumber:   "67890",
-			Timeout:        "60s",
+			Timeout: func() config.DurationValue {
+				value, err := config.ParseDurationValue("60s")
+				if err != nil {
+					t.Fatalf("ParseDurationValue(\"60s\") error: %v", err)
+				}
+				return value
+			}(),
 		}
 		if err := config.SaveAt(configPath, cfg); err != nil {
 			t.Fatalf("failed to save config: %v", err)
@@ -289,8 +295,8 @@ func TestIntegrationAuthConfig(t *testing.T) {
 		if loadedCfg.VendorNumber != "67890" {
 			t.Fatalf("VendorNumber should be preserved, got %q", loadedCfg.VendorNumber)
 		}
-		if loadedCfg.Timeout != "60s" {
-			t.Fatalf("Timeout should be preserved, got %q", loadedCfg.Timeout)
+		if loadedCfg.Timeout.String() != "60s" {
+			t.Fatalf("Timeout should be preserved, got %q", loadedCfg.Timeout.String())
 		}
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func mustDurationValue(t *testing.T, raw string) DurationValue {
+	t.Helper()
+	value, err := ParseDurationValue(raw)
+	if err != nil {
+		t.Fatalf("ParseDurationValue(%q) error: %v", raw, err)
+	}
+	return value
+}
+
 func TestConfigSaveLoadRemove(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
@@ -19,10 +28,10 @@ func TestConfigSaveLoadRemove(t *testing.T) {
 		AppID:                 "APP123",
 		VendorNumber:          "VENDOR123",
 		AnalyticsVendorNumber: "ANALYTICS456",
-		Timeout:               "90s",
-		TimeoutSeconds:        "120",
-		UploadTimeout:         "60s",
-		UploadTimeoutSeconds:  "180",
+		Timeout:               mustDurationValue(t, "90s"),
+		TimeoutSeconds:        mustDurationValue(t, "120"),
+		UploadTimeout:         mustDurationValue(t, "60s"),
+		UploadTimeoutSeconds:  mustDurationValue(t, "180"),
 		MaxRetries:            "5",
 		BaseDelay:             "2s",
 		MaxDelay:              "45s",
@@ -59,17 +68,17 @@ func TestConfigSaveLoadRemove(t *testing.T) {
 	if loaded.AnalyticsVendorNumber != cfg.AnalyticsVendorNumber {
 		t.Fatalf("AnalyticsVendorNumber mismatch: got %q want %q", loaded.AnalyticsVendorNumber, cfg.AnalyticsVendorNumber)
 	}
-	if loaded.Timeout != cfg.Timeout {
-		t.Fatalf("Timeout mismatch: got %q want %q", loaded.Timeout, cfg.Timeout)
+	if loaded.Timeout.String() != cfg.Timeout.String() {
+		t.Fatalf("Timeout mismatch: got %q want %q", loaded.Timeout.String(), cfg.Timeout.String())
 	}
-	if loaded.TimeoutSeconds != cfg.TimeoutSeconds {
-		t.Fatalf("TimeoutSeconds mismatch: got %q want %q", loaded.TimeoutSeconds, cfg.TimeoutSeconds)
+	if loaded.TimeoutSeconds.String() != cfg.TimeoutSeconds.String() {
+		t.Fatalf("TimeoutSeconds mismatch: got %q want %q", loaded.TimeoutSeconds.String(), cfg.TimeoutSeconds.String())
 	}
-	if loaded.UploadTimeout != cfg.UploadTimeout {
-		t.Fatalf("UploadTimeout mismatch: got %q want %q", loaded.UploadTimeout, cfg.UploadTimeout)
+	if loaded.UploadTimeout.String() != cfg.UploadTimeout.String() {
+		t.Fatalf("UploadTimeout mismatch: got %q want %q", loaded.UploadTimeout.String(), cfg.UploadTimeout.String())
 	}
-	if loaded.UploadTimeoutSeconds != cfg.UploadTimeoutSeconds {
-		t.Fatalf("UploadTimeoutSeconds mismatch: got %q want %q", loaded.UploadTimeoutSeconds, cfg.UploadTimeoutSeconds)
+	if loaded.UploadTimeoutSeconds.String() != cfg.UploadTimeoutSeconds.String() {
+		t.Fatalf("UploadTimeoutSeconds mismatch: got %q want %q", loaded.UploadTimeoutSeconds.String(), cfg.UploadTimeoutSeconds.String())
 	}
 	if loaded.MaxRetries != cfg.MaxRetries {
 		t.Fatalf("MaxRetries mismatch: got %q want %q", loaded.MaxRetries, cfg.MaxRetries)


### PR DESCRIPTION
## Summary
- skip ANSI styling when the terminal doesn’t support it (NO_COLOR/dumb/TTY)
- switch retry logging to slog for structured output
- use typed duration values in config while preserving JSON string format
- allow bypassing keychain via ASC_BYPASS_KEYCHAIN for deterministic auth tests

## Testing
- make test
- make lint

Fixes #166