### PR TITLE
feat: add auth init --open helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ asc auth login \
 
 Generate API keys at: https://appstoreconnect.apple.com/access/integrations/api
 
+Open the API keys page in your browser:
+```bash
+asc auth init --open
+```
+
 Credentials are stored in the system keychain when available, with a config fallback
 at `~/.asc/config.json` (restricted permissions). A repo-local `./.asc/config.json`
 takes precedence when present. Override with `ASC_CONFIG_PATH`.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
 )
 
+const authKeysURL = "https://appstoreconnect.apple.com/access/integrations/api"
+
 // Auth command factory
 func AuthCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("auth", flag.ExitOnError)
@@ -51,6 +53,7 @@ func AuthInitCommand() *ffcli.Command {
 
 	force := fs.Bool("force", false, "Overwrite existing config.json")
 	local := fs.Bool("local", false, "Write config.json to ./.asc in the current repo")
+	open := fs.Bool("open", false, "Open the App Store Connect API keys page in your browser")
 
 	return &ffcli.Command{
 		Name:       "init",
@@ -64,7 +67,8 @@ Use --local to write ./.asc/config.json in the current repo instead.
 Examples:
   asc auth init
   asc auth init --local
-  asc auth init --force`,
+  asc auth init --force
+  asc auth init --open`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -90,6 +94,12 @@ Examples:
 			template := &config.Config{}
 			if err := config.SaveAt(path, template); err != nil {
 				return fmt.Errorf("auth init: %w", err)
+			}
+
+			if *open {
+				if err := openURL(authKeysURL); err != nil {
+					return fmt.Errorf("auth init: %w", err)
+				}
 			}
 
 			result := struct {

--- a/cmd/open_url.go
+++ b/cmd/open_url.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func openURL(target string) error {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return fmt.Errorf("empty URL")
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("open URL: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add `asc auth init --open` to launch the App Store Connect API keys page
- document the new shortcut in the README auth section

## Test plan
- [ ] Not run (docs + small helper)