### PR TITLE
feat: support headless private key env

### DIFF
--- a/.agent/skills/asc-cli-usage/SKILL.md
+++ b/.agent/skills/asc-cli-usage/SKILL.md
@@ -25,7 +25,7 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 
 ## Authentication and defaults
 - Prefer keychain auth via `asc auth login`.
-- Fallback env vars: `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`.
+- Fallback env vars: `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64`.
 - `ASC_APP_ID` can provide a default app ID.
 
 ## Timeouts

--- a/Agents.md
+++ b/Agents.md
@@ -43,7 +43,7 @@ API keys are generated at https://appstoreconnect.apple.com/access/integrations/
 
 | Variable | Purpose |
 |----------|---------|
-| `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH` | Auth fallback |
+| `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64` | Auth fallback |
 | `ASC_BYPASS_KEYCHAIN` | Ignore keychain and use config/env auth |
 | `ASC_APP_ID` | Default app ID |
 | `ASC_VENDOR_NUMBER` | Sales/finance reports |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,11 @@ export ASC_APP_ID="YOUR_APP_ID"
 make test-integration
 ```
 
+Headless alternative (write the key to a temp file at runtime):
+```bash
+export ASC_PRIVATE_KEY_B64="BASE64_KEY"
+```
+
 ## Local API Testing (Optional)
 
 If you have App Store Connect API credentials, you can run real API calls locally:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Environment variable fallback:
 - `ASC_KEY_ID`
 - `ASC_ISSUER_ID`
 - `ASC_PRIVATE_KEY_PATH`
+- `ASC_PRIVATE_KEY` (raw key content; CLI writes a temp key file)
+- `ASC_PRIVATE_KEY_B64` (base64 key content; CLI writes a temp key file)
 - `ASC_CONFIG_PATH`
 - `ASC_BYPASS_KEYCHAIN` (ignore keychain and use config/env auth)
 

--- a/cmd/shared_test.go
+++ b/cmd/shared_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestResolvePrivateKeyPathPrefersPath(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+	t.Setenv("ASC_PRIVATE_KEY_B64", base64.StdEncoding.EncodeToString([]byte("ignored")))
+	t.Setenv("ASC_PRIVATE_KEY", "ignored")
+
+	path, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() error: %v", err)
+	}
+	if path != "/tmp/AuthKey.p8" {
+		t.Fatalf("expected path /tmp/AuthKey.p8, got %q", path)
+	}
+}
+
+func TestResolvePrivateKeyPathFromBase64(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("key-data"))
+	t.Setenv("ASC_PRIVATE_KEY_B64", encoded)
+
+	path, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "key-data" {
+		t.Fatalf("expected key data %q, got %q", "key-data", string(data))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected 0600 permissions, got %v", info.Mode().Perm())
+	}
+}
+
+func TestResolvePrivateKeyPathFromRawValue(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	t.Setenv("ASC_PRIVATE_KEY", "line1\\nline2")
+	path, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "line1\nline2" {
+		t.Fatalf("expected newline expansion, got %q", string(data))
+	}
+}
+
+func TestResolvePrivateKeyPathInvalidBase64(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "not-base64")
+
+	if _, err := resolvePrivateKeyPath(); err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func resetPrivateKeyTemp(t *testing.T) {
+	t.Helper()
+	if privateKeyTempPath != "" {
+		_ = os.Remove(privateKeyTempPath)
+		privateKeyTempPath = ""
+	}
+	t.Cleanup(func() {
+		if privateKeyTempPath != "" {
+			_ = os.Remove(privateKeyTempPath)
+			privateKeyTempPath = ""
+		}
+	})
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", os.TempDir()+string(os.PathSeparator)+strings.ReplaceAll(t.Name(), " ", "_"))
+}


### PR DESCRIPTION
## Summary
- allow `ASC_PRIVATE_KEY`/`ASC_PRIVATE_KEY_B64` by writing a temp key file
- add unit coverage for env-based key resolution
- document new env vars for headless usage

## Test plan
- [x] go test ./...