### PR TITLE
AGENTS.md skill references

### DIFF
--- a/.agent/skills/asc-cli-usage/SKILL.md
+++ b/.agent/skills/asc-cli-usage/SKILL.md
@@ -31,10 +31,3 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 ## Timeouts
 - `ASC_TIMEOUT` / `ASC_TIMEOUT_SECONDS` control request timeouts.
 - `ASC_UPLOAD_TIMEOUT` / `ASC_UPLOAD_TIMEOUT_SECONDS` control upload timeouts.
-
-## References
-- `AGENTS.md`
-- `docs/TESTING.md`
-- `docs/GO_STANDARDS.md`
-- `docs/API_NOTES.md`
-- `CONTRIBUTING.md`

--- a/Agents.md
+++ b/Agents.md
@@ -52,7 +52,7 @@ API keys are generated at https://appstoreconnect.apple.com/access/integrations/
 | `ASC_UPLOAD_TIMEOUT` | Upload timeout (e.g., `60s`, `2m`) |
 | `ASC_UPLOAD_TIMEOUT_SECONDS` | Upload timeout in seconds (alternative) |
 
-## Further Reading
+## References
 
 Detailed guidance on specific topics (only read when needed):
 


### PR DESCRIPTION
Move references from `asc-cli-usage` skill to `Agents.md` to centralize documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb7b22d6-40ca-440b-b58f-a26651480a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb7b22d6-40ca-440b-b58f-a26651480a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

