### PR TITLE
Fix subscription create relationship name from subscriptionGroup to group

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -3018,11 +3018,11 @@ func TestCreateSubscription(t *testing.T) {
 		if payload.Data.Attributes.Name != "Monthly" || payload.Data.Attributes.ProductID != "com.example.sub.monthly" {
 			t.Fatalf("unexpected attributes: %+v", payload.Data.Attributes)
 		}
-		if payload.Data.Relationships == nil || payload.Data.Relationships.SubscriptionGroup == nil {
-			t.Fatalf("expected subscriptionGroup relationship")
+		if payload.Data.Relationships == nil || payload.Data.Relationships.Group == nil {
+			t.Fatalf("expected group relationship")
 		}
-		if payload.Data.Relationships.SubscriptionGroup.Data.Type != ResourceTypeSubscriptionGroups || payload.Data.Relationships.SubscriptionGroup.Data.ID != "group-1" {
-			t.Fatalf("unexpected relationship: %+v", payload.Data.Relationships.SubscriptionGroup.Data)
+		if payload.Data.Relationships.Group.Data.Type != ResourceTypeSubscriptionGroups || payload.Data.Relationships.Group.Data.ID != "group-1" {
+			t.Fatalf("unexpected relationship: %+v", payload.Data.Relationships.Group.Data)
 		}
 		assertAuthorized(t, req)
 	}, response)

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -162,7 +162,7 @@ func (c *Client) CreateSubscription(ctx context.Context, groupID string, attrs S
 			Type:       ResourceTypeSubscriptions,
 			Attributes: attrs,
 			Relationships: &SubscriptionRelationships{
-				SubscriptionGroup: &Relationship{
+				Group: &Relationship{
 					Data: ResourceData{
 						Type: ResourceTypeSubscriptionGroups,
 						ID:   strings.TrimSpace(groupID),

--- a/internal/asc/subscriptions.go
+++ b/internal/asc/subscriptions.go
@@ -84,7 +84,7 @@ type SubscriptionUpdateAttributes struct {
 
 // SubscriptionRelationships describes relationships for subscriptions.
 type SubscriptionRelationships struct {
-	SubscriptionGroup *Relationship `json:"subscriptionGroup"`
+	Group *Relationship `json:"group"`
 }
 
 // SubscriptionCreateData is the data portion of a subscription create request.


### PR DESCRIPTION
## Summary

Fixes a critical bug in PR #118 where `subscriptions create` fails with:
```
'subscriptionGroup' is not a relationship on the resource 'subscriptions'
```

## The Problem

The Apple App Store Connect API expects the relationship to be named `group`, not `subscriptionGroup`, when creating subscriptions. The API documentation at [sosumi.ai](https://sosumi.ai/documentation/appstoreconnectapi/post-v1-subscriptions) shows the correct format.

## The Fix

- Changed JSON tag in `SubscriptionCreateRequestDataRelationships` from `json:"subscriptionGroup"` to `json:"group"`
- Updated corresponding struct field name from `SubscriptionGroup` to `Group`
- Updated unit tests to match

## Files Changed

- `internal/asc/subscriptions.go:87` - Fixed JSON tag
- `internal/asc/client_subscriptions.go:165` - Updated field reference
- `internal/asc/client_http_test.go:3021-3025` - Updated test

## Testing

Tested against live App Store Connect API on RetroBudget (app ID 6743363764):

```bash
# Before fix - FAILED
$ asc subscriptions create --group b]"2.99" --duration ONE_MONTH
Error: 'subscriptionGroup' is not a relationship on the resource 'subscriptions'

# After fix - WORKS
$ asc subscriptions create --group 2a7c18d5-xxxx --name "Test Sub" --product-id "com.test.sub" --duration ONE_MONTH
{"data":{"type":"subscriptions","id":"...",...}}
```

All subscription commands verified working:
- `subscriptions groups list/get/create/update/delete` ✅
- `subscriptions list/get/create/update/delete` ✅

## Related

- Fixes bug found during testing of #118
- This branch is based on `cursor/in-app-purchases-and-subscriptions-5fad`