### PR TITLE
Add routing coverage CLI support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ func RootCommand(version string) *ffcli.Command {
 			BuildsCommand(),
 			PublishCommand(),
 			VersionsCommand(),
+			RoutingCoverageCommand(),
 			AppInfoCommand(),
 			EULACommand(),
 			PricingCommand(),

--- a/cmd/routing_coverage.go
+++ b/cmd/routing_coverage.go
@@ -1,0 +1,270 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// RoutingCoverageCommand returns the routing coverage command group.
+func RoutingCoverageCommand() *ffcli.Command {
+	return &ffcli.Command{
+		Name:       "routing-coverage",
+		ShortUsage: "asc routing-coverage <subcommand> [flags]",
+		ShortHelp:  "Manage routing app coverage files.",
+		LongHelp: `Manage routing app coverage files required for routing apps.
+
+Examples:
+  asc routing-coverage get --version-id "VERSION_ID"
+  asc routing-coverage info --id "COVERAGE_ID"
+  asc routing-coverage create --version-id "VERSION_ID" --file ./coverage.geojson
+  asc routing-coverage delete --id "COVERAGE_ID" --confirm`,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			RoutingCoverageGetCommand(),
+			RoutingCoverageInfoCommand(),
+			RoutingCoverageCreateCommand(),
+			RoutingCoverageDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// RoutingCoverageGetCommand returns the routing coverage get subcommand.
+func RoutingCoverageGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("routing-coverage get", flag.ExitOnError)
+
+	versionID := fs.String("version-id", "", "App Store version ID (required)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc routing-coverage get --version-id \"VERSION_ID\"",
+		ShortHelp:  "Get routing app coverage for a version.",
+		LongHelp: `Get routing app coverage for an App Store version.
+
+Examples:
+  asc routing-coverage get --version-id "VERSION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			versionValue := strings.TrimSpace(*versionID)
+			if versionValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("routing-coverage get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetRoutingAppCoverageForVersion(requestCtx, versionValue)
+			if err != nil {
+				return fmt.Errorf("routing-coverage get: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// RoutingCoverageInfoCommand returns the routing coverage info subcommand.
+func RoutingCoverageInfoCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("routing-coverage info", flag.ExitOnError)
+
+	coverageID := fs.String("id", "", "Routing app coverage ID (required)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "info",
+		ShortUsage: "asc routing-coverage info --id \"COVERAGE_ID\"",
+		ShortHelp:  "Get routing app coverage by ID.",
+		LongHelp: `Get routing app coverage by ID.
+
+Examples:
+  asc routing-coverage info --id "COVERAGE_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			coverageValue := strings.TrimSpace(*coverageID)
+			if coverageValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("routing-coverage info: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetRoutingAppCoverage(requestCtx, coverageValue)
+			if err != nil {
+				return fmt.Errorf("routing-coverage info: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// RoutingCoverageCreateCommand returns the routing coverage create subcommand.
+func RoutingCoverageCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("routing-coverage create", flag.ExitOnError)
+
+	versionID := fs.String("version-id", "", "App Store version ID (required)")
+	filePath := fs.String("file", "", "Path to routing coverage file (required)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "asc routing-coverage create --version-id \"VERSION_ID\" --file ./coverage.geojson",
+		ShortHelp:  "Upload routing app coverage for a version.",
+		LongHelp: `Upload routing app coverage for an App Store version.
+
+Examples:
+  asc routing-coverage create --version-id "VERSION_ID" --file ./coverage.geojson`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			versionValue := strings.TrimSpace(*versionID)
+			if versionValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
+				return flag.ErrHelp
+			}
+
+			pathValue := strings.TrimSpace(*filePath)
+			if pathValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --file is required")
+				return flag.ErrHelp
+			}
+
+			info, err := os.Lstat(pathValue)
+			if err != nil {
+				return fmt.Errorf("routing-coverage create: %w", err)
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("routing-coverage create: refusing to read symlink %q", pathValue)
+			}
+			if info.IsDir() {
+				return fmt.Errorf("routing-coverage create: %q is a directory", pathValue)
+			}
+			if info.Size() <= 0 {
+				return fmt.Errorf("routing-coverage create: file size must be greater than 0")
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("routing-coverage create: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.CreateRoutingAppCoverage(requestCtx, versionValue, filepath.Base(pathValue), info.Size())
+			if err != nil {
+				return fmt.Errorf("routing-coverage create: failed to create: %w", err)
+			}
+			if resp == nil || len(resp.Data.Attributes.UploadOperations) == 0 {
+				return fmt.Errorf("routing-coverage create: no upload operations returned")
+			}
+
+			uploadCtx, uploadCancel := contextWithUploadTimeout(ctx)
+			err = asc.ExecuteUploadOperations(uploadCtx, pathValue, resp.Data.Attributes.UploadOperations)
+			uploadCancel()
+			if err != nil {
+				return fmt.Errorf("routing-coverage create: upload failed: %w", err)
+			}
+
+			checksum, err := asc.ComputeFileChecksum(pathValue, asc.ChecksumAlgorithmMD5)
+			if err != nil {
+				return fmt.Errorf("routing-coverage create: checksum failed: %w", err)
+			}
+
+			uploaded := true
+			updateAttrs := asc.RoutingAppCoverageUpdateAttributes{
+				SourceFileChecksum: &checksum.Hash,
+				Uploaded:           &uploaded,
+			}
+
+			commitCtx, commitCancel := contextWithUploadTimeout(ctx)
+			commitResp, err := client.UpdateRoutingAppCoverage(commitCtx, resp.Data.ID, updateAttrs)
+			commitCancel()
+			if err != nil {
+				return fmt.Errorf("routing-coverage create: failed to commit upload: %w", err)
+			}
+
+			return printOutput(commitResp, *output, *pretty)
+		},
+	}
+}
+
+// RoutingCoverageDeleteCommand returns the routing coverage delete subcommand.
+func RoutingCoverageDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("routing-coverage delete", flag.ExitOnError)
+
+	coverageID := fs.String("id", "", "Routing app coverage ID (required)")
+	confirm := fs.Bool("confirm", false, "Confirm deletion")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "asc routing-coverage delete --id \"COVERAGE_ID\" --confirm",
+		ShortHelp:  "Delete routing app coverage.",
+		LongHelp: `Delete routing app coverage.
+
+Examples:
+  asc routing-coverage delete --id "COVERAGE_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			coverageValue := strings.TrimSpace(*coverageID)
+			if coverageValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("routing-coverage delete: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.DeleteRoutingAppCoverage(requestCtx, coverageValue); err != nil {
+				return fmt.Errorf("routing-coverage delete: failed to delete: %w", err)
+			}
+
+			result := &asc.RoutingAppCoverageDeleteResult{
+				ID:      coverageValue,
+				Deleted: true,
+			}
+
+			return printOutput(result, *output, *pretty)
+		},
+	}
+}

--- a/internal/asc/client_types.go
+++ b/internal/asc/client_types.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypeBuildUploadFiles                     ResourceType = "buildUploadFiles"
 	ResourceTypeCertificates                         ResourceType = "certificates"
 	ResourceTypeAppStoreVersions                     ResourceType = "appStoreVersions"
+	ResourceTypeRoutingAppCoverages                  ResourceType = "routingAppCoverages"
 	ResourceTypeAppStoreVersionPromotions            ResourceType = "appStoreVersionPromotions"
 	ResourceTypeAppStoreVersionExperimentTreatments  ResourceType = "appStoreVersionExperimentTreatments"
 	ResourceTypePreReleaseVersions                   ResourceType = "preReleaseVersions"

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -171,6 +171,8 @@ func PrintMarkdown(data interface{}) error {
 		return printAppStoreReviewAttachmentsMarkdown(v)
 	case *AppStoreReviewAttachmentResponse:
 		return printAppStoreReviewAttachmentMarkdown(v)
+	case *RoutingAppCoverageResponse:
+		return printRoutingAppCoverageMarkdown(v)
 	case *BetaRecruitmentCriterionOptionsResponse:
 		return printBetaRecruitmentCriterionOptionsMarkdown(v)
 	case *BetaRecruitmentCriteriaResponse:
@@ -311,6 +313,8 @@ func PrintMarkdown(data interface{}) error {
 		return printAccessibilityDeclarationDeleteResultMarkdown(v)
 	case *AppStoreReviewAttachmentDeleteResult:
 		return printAppStoreReviewAttachmentDeleteResultMarkdown(v)
+	case *RoutingAppCoverageDeleteResult:
+		return printRoutingAppCoverageDeleteResultMarkdown(v)
 	default:
 		return PrintJSON(data)
 	}
@@ -469,6 +473,8 @@ func PrintTable(data interface{}) error {
 		return printAppStoreReviewAttachmentsTable(v)
 	case *AppStoreReviewAttachmentResponse:
 		return printAppStoreReviewAttachmentTable(v)
+	case *RoutingAppCoverageResponse:
+		return printRoutingAppCoverageTable(v)
 	case *BetaRecruitmentCriterionOptionsResponse:
 		return printBetaRecruitmentCriterionOptionsTable(v)
 	case *BetaRecruitmentCriteriaResponse:
@@ -609,6 +615,8 @@ func PrintTable(data interface{}) error {
 		return printAccessibilityDeclarationDeleteResultTable(v)
 	case *AppStoreReviewAttachmentDeleteResult:
 		return printAppStoreReviewAttachmentDeleteResultTable(v)
+	case *RoutingAppCoverageDeleteResult:
+		return printRoutingAppCoverageDeleteResultTable(v)
 	default:
 		return PrintJSON(data)
 	}

--- a/internal/asc/output_routing_coverage.go
+++ b/internal/asc/output_routing_coverage.go
@@ -1,0 +1,61 @@
+package asc
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+type routingAppCoverageField struct {
+	Name  string
+	Value string
+}
+
+func printRoutingAppCoverageTable(resp *RoutingAppCoverageResponse) error {
+	fields := routingAppCoverageFields(resp)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Field\tValue")
+	for _, field := range fields {
+		fmt.Fprintf(w, "%s\t%s\n", field.Name, field.Value)
+	}
+	return w.Flush()
+}
+
+func printRoutingAppCoverageMarkdown(resp *RoutingAppCoverageResponse) error {
+	fields := routingAppCoverageFields(resp)
+	fmt.Fprintln(os.Stdout, "| Field | Value |")
+	fmt.Fprintln(os.Stdout, "| --- | --- |")
+	for _, field := range fields {
+		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
+	}
+	return nil
+}
+
+func routingAppCoverageFields(resp *RoutingAppCoverageResponse) []routingAppCoverageField {
+	if resp == nil {
+		return nil
+	}
+	attrs := resp.Data.Attributes
+	return []routingAppCoverageField{
+		{Name: "ID", Value: fallbackValue(resp.Data.ID)},
+		{Name: "Type", Value: fallbackValue(string(resp.Data.Type))},
+		{Name: "File Name", Value: fallbackValue(attrs.FileName)},
+		{Name: "File Size", Value: formatAttachmentFileSize(attrs.FileSize)},
+		{Name: "Source File Checksum", Value: fallbackValue(attrs.SourceFileChecksum)},
+		{Name: "Delivery State", Value: formatAssetDeliveryState(attrs.AssetDeliveryState)},
+	}
+}
+
+func printRoutingAppCoverageDeleteResultTable(result *RoutingAppCoverageDeleteResult) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tDeleted")
+	fmt.Fprintf(w, "%s\t%t\n", result.ID, result.Deleted)
+	return w.Flush()
+}
+
+func printRoutingAppCoverageDeleteResultMarkdown(result *RoutingAppCoverageDeleteResult) error {
+	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
+	fmt.Fprintln(os.Stdout, "| --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	return nil
+}

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -2239,3 +2239,75 @@ func TestPrintTable_AppStoreReviewAttachmentDeleteResult(t *testing.T) {
 		t.Fatalf("expected id in output, got: %s", output)
 	}
 }
+
+func TestPrintTable_RoutingAppCoverage(t *testing.T) {
+	state := "COMPLETE"
+	resp := &RoutingAppCoverageResponse{
+		Data: Resource[RoutingAppCoverageAttributes]{
+			ID:   "cover-1",
+			Type: ResourceTypeRoutingAppCoverages,
+			Attributes: RoutingAppCoverageAttributes{
+				FileName:           "coverage.geojson",
+				FileSize:           2048,
+				SourceFileChecksum: "abcd1234",
+				AssetDeliveryState: &AppMediaAssetState{State: &state},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "File Name") {
+		t.Fatalf("expected file name header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "coverage.geojson") {
+		t.Fatalf("expected file name in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_RoutingAppCoverage(t *testing.T) {
+	state := "COMPLETE"
+	resp := &RoutingAppCoverageResponse{
+		Data: Resource[RoutingAppCoverageAttributes]{
+			ID:   "cover-1",
+			Type: ResourceTypeRoutingAppCoverages,
+			Attributes: RoutingAppCoverageAttributes{
+				FileName:           "coverage.geojson",
+				FileSize:           2048,
+				SourceFileChecksum: "abcd1234",
+				AssetDeliveryState: &AppMediaAssetState{State: &state},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| Field | Value |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "File Name") {
+		t.Fatalf("expected file name field in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_RoutingAppCoverageDeleteResult(t *testing.T) {
+	result := &RoutingAppCoverageDeleteResult{
+		ID:      "cover-1",
+		Deleted: true,
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	if !strings.Contains(output, "Deleted") {
+		t.Fatalf("expected Deleted header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "cover-1") {
+		t.Fatalf("expected id in output, got: %s", output)
+	}
+}

--- a/internal/asc/routing_coverage.go
+++ b/internal/asc/routing_coverage.go
@@ -1,0 +1,206 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// RoutingAppCoverageAttributes describes routing app coverage attributes.
+type RoutingAppCoverageAttributes struct {
+	FileSize           int64               `json:"fileSize,omitempty"`
+	FileName           string              `json:"fileName,omitempty"`
+	SourceFileChecksum string              `json:"sourceFileChecksum,omitempty"`
+	UploadOperations   []UploadOperation   `json:"uploadOperations,omitempty"`
+	AssetDeliveryState *AppMediaAssetState `json:"assetDeliveryState,omitempty"`
+}
+
+// RoutingAppCoverageResponse is the response for routing app coverage endpoints.
+type RoutingAppCoverageResponse = SingleResponse[RoutingAppCoverageAttributes]
+
+// RoutingAppCoverageCreateAttributes describes create attributes.
+type RoutingAppCoverageCreateAttributes struct {
+	FileSize int64  `json:"fileSize"`
+	FileName string `json:"fileName"`
+}
+
+// RoutingAppCoverageRelationships describes routing app coverage relationships.
+type RoutingAppCoverageRelationships struct {
+	AppStoreVersion *Relationship `json:"appStoreVersion"`
+}
+
+// RoutingAppCoverageCreateData is the data portion of a create request.
+type RoutingAppCoverageCreateData struct {
+	Type          ResourceType                       `json:"type"`
+	Attributes    RoutingAppCoverageCreateAttributes `json:"attributes"`
+	Relationships *RoutingAppCoverageRelationships   `json:"relationships"`
+}
+
+// RoutingAppCoverageCreateRequest is a request to create routing app coverage.
+type RoutingAppCoverageCreateRequest struct {
+	Data RoutingAppCoverageCreateData `json:"data"`
+}
+
+// RoutingAppCoverageUpdateAttributes describes update attributes.
+type RoutingAppCoverageUpdateAttributes struct {
+	SourceFileChecksum *string `json:"sourceFileChecksum,omitempty"`
+	Uploaded           *bool   `json:"uploaded,omitempty"`
+}
+
+// RoutingAppCoverageUpdateData is the data portion of an update request.
+type RoutingAppCoverageUpdateData struct {
+	Type       ResourceType                        `json:"type"`
+	ID         string                              `json:"id"`
+	Attributes *RoutingAppCoverageUpdateAttributes `json:"attributes,omitempty"`
+}
+
+// RoutingAppCoverageUpdateRequest is a request to update routing app coverage.
+type RoutingAppCoverageUpdateRequest struct {
+	Data RoutingAppCoverageUpdateData `json:"data"`
+}
+
+// RoutingAppCoverageDeleteResult represents CLI output for deletions.
+type RoutingAppCoverageDeleteResult struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+// GetRoutingAppCoverage retrieves routing app coverage by ID.
+func (c *Client) GetRoutingAppCoverage(ctx context.Context, coverageID string) (*RoutingAppCoverageResponse, error) {
+	coverageID = strings.TrimSpace(coverageID)
+	if coverageID == "" {
+		return nil, fmt.Errorf("coverageID is required")
+	}
+
+	path := fmt.Sprintf("/v1/routingAppCoverages/%s", coverageID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response RoutingAppCoverageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetRoutingAppCoverageForVersion retrieves routing app coverage for an app store version.
+func (c *Client) GetRoutingAppCoverageForVersion(ctx context.Context, versionID string) (*RoutingAppCoverageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/routingAppCoverage", versionID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response RoutingAppCoverageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// CreateRoutingAppCoverage creates a routing app coverage upload reservation.
+func (c *Client) CreateRoutingAppCoverage(ctx context.Context, versionID, fileName string, fileSize int64) (*RoutingAppCoverageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	fileName = strings.TrimSpace(fileName)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+	if fileName == "" {
+		return nil, fmt.Errorf("fileName is required")
+	}
+	if fileSize <= 0 {
+		return nil, fmt.Errorf("fileSize is required")
+	}
+
+	payload := RoutingAppCoverageCreateRequest{
+		Data: RoutingAppCoverageCreateData{
+			Type: ResourceTypeRoutingAppCoverages,
+			Attributes: RoutingAppCoverageCreateAttributes{
+				FileName: fileName,
+				FileSize: fileSize,
+			},
+			Relationships: &RoutingAppCoverageRelationships{
+				AppStoreVersion: &Relationship{
+					Data: ResourceData{
+						Type: ResourceTypeAppStoreVersions,
+						ID:   versionID,
+					},
+				},
+			},
+		},
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := c.do(ctx, http.MethodPost, "/v1/routingAppCoverages", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response RoutingAppCoverageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// UpdateRoutingAppCoverage updates routing app coverage by ID.
+func (c *Client) UpdateRoutingAppCoverage(ctx context.Context, coverageID string, attrs RoutingAppCoverageUpdateAttributes) (*RoutingAppCoverageResponse, error) {
+	coverageID = strings.TrimSpace(coverageID)
+	if coverageID == "" {
+		return nil, fmt.Errorf("coverageID is required")
+	}
+
+	payload := RoutingAppCoverageUpdateRequest{
+		Data: RoutingAppCoverageUpdateData{
+			Type: ResourceTypeRoutingAppCoverages,
+			ID:   coverageID,
+		},
+	}
+	if attrs.SourceFileChecksum != nil || attrs.Uploaded != nil {
+		payload.Data.Attributes = &attrs
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/v1/routingAppCoverages/%s", coverageID), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response RoutingAppCoverageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// DeleteRoutingAppCoverage deletes routing app coverage by ID.
+func (c *Client) DeleteRoutingAppCoverage(ctx context.Context, coverageID string) error {
+	coverageID = strings.TrimSpace(coverageID)
+	if coverageID == "" {
+		return fmt.Errorf("coverageID is required")
+	}
+
+	_, err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/v1/routingAppCoverages/%s", coverageID), nil)
+	return err
+}


### PR DESCRIPTION
## Summary
- add routing coverage client types and output formatting
- add routing-coverage CLI commands for get/info/create/delete with upload commit flow
- add command validation and HTTP/output tests

## Test plan
- [x] make build
- [x] make test
- [x] make lint
- [x] ASC_BYPASS_KEYCHAIN=1 go run . routing-coverage get --version-id 2a668936-a90d-4dc1-9103-5809ad0c88f5 --output json