### PR TITLE
feat: expand xcode cloud coverage

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -2877,9 +2877,69 @@ func TestXcodeCloudValidationErrors(t *testing.T) {
 			wantErr: "--app is required",
 		},
 		{
+			name:    "xcode-cloud workflows list missing app",
+			args:    []string{"xcode-cloud", "workflows", "list"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "xcode-cloud workflows get missing id",
+			args:    []string{"xcode-cloud", "workflows", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud workflows repository missing id",
+			args:    []string{"xcode-cloud", "workflows", "repository"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud workflows create missing file",
+			args:    []string{"xcode-cloud", "workflows", "create"},
+			wantErr: "--file is required",
+		},
+		{
+			name:    "xcode-cloud workflows update missing id",
+			args:    []string{"xcode-cloud", "workflows", "update", "--file", "./workflow.json"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud workflows update missing file",
+			args:    []string{"xcode-cloud", "workflows", "update", "--id", "WF_ID"},
+			wantErr: "--file is required",
+		},
+		{
+			name:    "xcode-cloud workflows delete missing id",
+			args:    []string{"xcode-cloud", "workflows", "delete", "--confirm"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud workflows delete missing confirm",
+			args:    []string{"xcode-cloud", "workflows", "delete", "--id", "WF_ID"},
+			wantErr: "--confirm is required",
+		},
+		{
 			name:    "xcode-cloud build-runs missing workflow-id",
 			args:    []string{"xcode-cloud", "build-runs"},
 			wantErr: "--workflow-id is required",
+		},
+		{
+			name:    "xcode-cloud build-runs builds missing run-id",
+			args:    []string{"xcode-cloud", "build-runs", "builds"},
+			wantErr: "--run-id is required",
+		},
+		{
+			name:    "xcode-cloud actions missing run-id",
+			args:    []string{"xcode-cloud", "actions"},
+			wantErr: "--run-id is required",
+		},
+		{
+			name:    "xcode-cloud actions get missing id",
+			args:    []string{"xcode-cloud", "actions", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud actions build-run missing id",
+			args:    []string{"xcode-cloud", "actions", "build-run"},
+			wantErr: "--id is required",
 		},
 		{
 			name:    "xcode-cloud artifacts list missing action-id",
@@ -2919,6 +2979,66 @@ func TestXcodeCloudValidationErrors(t *testing.T) {
 		{
 			name:    "xcode-cloud issues get missing id",
 			args:    []string{"xcode-cloud", "issues", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products get missing id",
+			args:    []string{"xcode-cloud", "products", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products app missing id",
+			args:    []string{"xcode-cloud", "products", "app"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products build-runs missing id",
+			args:    []string{"xcode-cloud", "products", "build-runs"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products workflows missing id",
+			args:    []string{"xcode-cloud", "products", "workflows"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products primary-repositories missing id",
+			args:    []string{"xcode-cloud", "products", "primary-repositories"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products additional-repositories missing id",
+			args:    []string{"xcode-cloud", "products", "additional-repositories"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products delete missing id",
+			args:    []string{"xcode-cloud", "products", "delete", "--confirm"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud products delete missing confirm",
+			args:    []string{"xcode-cloud", "products", "delete", "--id", "PROD_ID"},
+			wantErr: "--confirm is required",
+		},
+		{
+			name:    "xcode-cloud macos-versions get missing id",
+			args:    []string{"xcode-cloud", "macos-versions", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud macos-versions xcode-versions missing id",
+			args:    []string{"xcode-cloud", "macos-versions", "xcode-versions"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud xcode-versions get missing id",
+			args:    []string{"xcode-cloud", "xcode-versions", "get"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "xcode-cloud xcode-versions macos-versions missing id",
+			args:    []string{"xcode-cloud", "xcode-versions", "macos-versions"},
 			wantErr: "--id is required",
 		},
 	}

--- a/cmd/xcode_cloud_extras.go
+++ b/cmd/xcode_cloud_extras.go
@@ -1,0 +1,1047 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// XcodeCloudProductsCommand returns the xcode-cloud products command with subcommands.
+func XcodeCloudProductsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("products", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "products",
+		ShortUsage: "asc xcode-cloud products [flags]",
+		ShortHelp:  "Manage Xcode Cloud products.",
+		LongHelp: `Manage Xcode Cloud products.
+
+Examples:
+  asc xcode-cloud products --app "APP_ID"
+  asc xcode-cloud products list --app "APP_ID"
+  asc xcode-cloud products get --id "PRODUCT_ID"
+  asc xcode-cloud products delete --id "PRODUCT_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			XcodeCloudProductsListCommand(),
+			XcodeCloudProductsGetCommand(),
+			XcodeCloudProductsAppCommand(),
+			XcodeCloudProductsBuildRunsCommand(),
+			XcodeCloudProductsWorkflowsCommand(),
+			XcodeCloudProductsPrimaryRepositoriesCommand(),
+			XcodeCloudProductsAdditionalRepositoriesCommand(),
+			XcodeCloudProductsDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return xcodeCloudProductsList(ctx, *appID, *limit, *next, *paginate, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc xcode-cloud products list [flags]",
+		ShortHelp:  "List Xcode Cloud products.",
+		LongHelp: `List Xcode Cloud products.
+
+Examples:
+  asc xcode-cloud products list
+  asc xcode-cloud products list --app "APP_ID"
+  asc xcode-cloud products list --limit 50
+  asc xcode-cloud products list --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			return xcodeCloudProductsList(ctx, *appID, *limit, *next, *paginate, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("get", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc xcode-cloud products get --id \"PRODUCT_ID\"",
+		ShortHelp:  "Get details for a product.",
+		LongHelp: `Get details for a product.
+
+Examples:
+  asc xcode-cloud products get --id "PRODUCT_ID"
+  asc xcode-cloud products get --id "PRODUCT_ID" --output table`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			resp, err := client.GetCiProduct(requestCtx, idValue)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsAppCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("app", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "app",
+		ShortUsage: "asc xcode-cloud products app --id \"PRODUCT_ID\"",
+		ShortHelp:  "Get the app for a product.",
+		LongHelp: `Get the app for a product.
+
+Examples:
+  asc xcode-cloud products app --id "PRODUCT_ID"
+  asc xcode-cloud products app --id "PRODUCT_ID" --output table`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products app: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			resp, err := client.GetCiProductApp(requestCtx, idValue)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products app: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsBuildRunsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("build-runs", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "build-runs",
+		ShortUsage: "asc xcode-cloud products build-runs [flags]",
+		ShortHelp:  "List build runs for a product.",
+		LongHelp: `List build runs for a product.
+
+Examples:
+  asc xcode-cloud products build-runs --id "PRODUCT_ID"
+  asc xcode-cloud products build-runs --id "PRODUCT_ID" --limit 50
+  asc xcode-cloud products build-runs --id "PRODUCT_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("xcode-cloud products build-runs: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("xcode-cloud products build-runs: %w", err)
+			}
+
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products build-runs: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			opts := []asc.CiBuildRunsOption{
+				asc.WithCiBuildRunsLimit(*limit),
+				asc.WithCiBuildRunsNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithCiBuildRunsLimit(200))
+				firstPage, err := client.GetCiProductBuildRuns(requestCtx, idValue, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products build-runs: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetCiProductBuildRuns(ctx, idValue, asc.WithCiBuildRunsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products build-runs: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetCiProductBuildRuns(requestCtx, idValue, opts...)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products build-runs: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsWorkflowsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("workflows", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "workflows",
+		ShortUsage: "asc xcode-cloud products workflows [flags]",
+		ShortHelp:  "List workflows for a product.",
+		LongHelp: `List workflows for a product.
+
+Examples:
+  asc xcode-cloud products workflows --id "PRODUCT_ID"
+  asc xcode-cloud products workflows --id "PRODUCT_ID" --limit 50
+  asc xcode-cloud products workflows --id "PRODUCT_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("xcode-cloud products workflows: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("xcode-cloud products workflows: %w", err)
+			}
+
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products workflows: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			opts := []asc.CiWorkflowsOption{
+				asc.WithCiWorkflowsLimit(*limit),
+				asc.WithCiWorkflowsNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithCiWorkflowsLimit(200))
+				firstPage, err := client.GetCiWorkflows(requestCtx, idValue, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products workflows: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetCiWorkflows(ctx, idValue, asc.WithCiWorkflowsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products workflows: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetCiWorkflows(requestCtx, idValue, opts...)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products workflows: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsPrimaryRepositoriesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("primary-repositories", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "primary-repositories",
+		ShortUsage: "asc xcode-cloud products primary-repositories [flags]",
+		ShortHelp:  "List primary repositories for a product.",
+		LongHelp: `List primary repositories for a product.
+
+Examples:
+  asc xcode-cloud products primary-repositories --id "PRODUCT_ID"
+  asc xcode-cloud products primary-repositories --id "PRODUCT_ID" --limit 50
+  asc xcode-cloud products primary-repositories --id "PRODUCT_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("xcode-cloud products primary-repositories: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("xcode-cloud products primary-repositories: %w", err)
+			}
+
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products primary-repositories: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			opts := []asc.CiProductRepositoriesOption{
+				asc.WithCiProductRepositoriesLimit(*limit),
+				asc.WithCiProductRepositoriesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithCiProductRepositoriesLimit(200))
+				firstPage, err := client.GetCiProductPrimaryRepositories(requestCtx, idValue, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products primary-repositories: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetCiProductPrimaryRepositories(ctx, idValue, asc.WithCiProductRepositoriesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products primary-repositories: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetCiProductPrimaryRepositories(requestCtx, idValue, opts...)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products primary-repositories: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsAdditionalRepositoriesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("additional-repositories", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "additional-repositories",
+		ShortUsage: "asc xcode-cloud products additional-repositories [flags]",
+		ShortHelp:  "List additional repositories for a product.",
+		LongHelp: `List additional repositories for a product.
+
+Examples:
+  asc xcode-cloud products additional-repositories --id "PRODUCT_ID"
+  asc xcode-cloud products additional-repositories --id "PRODUCT_ID" --limit 50
+  asc xcode-cloud products additional-repositories --id "PRODUCT_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("xcode-cloud products additional-repositories: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("xcode-cloud products additional-repositories: %w", err)
+			}
+
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products additional-repositories: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			opts := []asc.CiProductRepositoriesOption{
+				asc.WithCiProductRepositoriesLimit(*limit),
+				asc.WithCiProductRepositoriesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithCiProductRepositoriesLimit(200))
+				firstPage, err := client.GetCiProductAdditionalRepositories(requestCtx, idValue, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products additional-repositories: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetCiProductAdditionalRepositories(ctx, idValue, asc.WithCiProductRepositoriesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud products additional-repositories: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetCiProductAdditionalRepositories(requestCtx, idValue, opts...)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products additional-repositories: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudProductsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("delete", flag.ExitOnError)
+
+	id := fs.String("id", "", "Product ID")
+	confirm := fs.Bool("confirm", false, "Confirm deletion")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "asc xcode-cloud products delete --id \"PRODUCT_ID\" --confirm",
+		ShortHelp:  "Delete a product.",
+		LongHelp: `Delete a product.
+
+Examples:
+  asc xcode-cloud products delete --id "PRODUCT_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products delete: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			if err := client.DeleteCiProduct(requestCtx, idValue); err != nil {
+				return fmt.Errorf("xcode-cloud products delete: failed to delete: %w", err)
+			}
+
+			result := &asc.CiProductDeleteResult{ID: idValue, Deleted: true}
+			return printOutput(result, *output, *pretty)
+		},
+	}
+}
+
+func xcodeCloudProductsList(ctx context.Context, appID string, limit int, next string, paginate bool, output string, pretty bool) error {
+	if limit != 0 && (limit < 1 || limit > 200) {
+		return fmt.Errorf("xcode-cloud products: --limit must be between 1 and 200")
+	}
+	if err := validateNextURL(next); err != nil {
+		return fmt.Errorf("xcode-cloud products: %w", err)
+	}
+
+	resolvedAppID := resolveAppID(appID)
+	opts := []asc.CiProductsOption{
+		asc.WithCiProductsLimit(limit),
+		asc.WithCiProductsNextURL(next),
+	}
+	if strings.TrimSpace(next) == "" && resolvedAppID != "" {
+		opts = append(opts, asc.WithCiProductsAppID(resolvedAppID))
+	}
+
+	client, err := getASCClient()
+	if err != nil {
+		return fmt.Errorf("xcode-cloud products: %w", err)
+	}
+
+	requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+	defer cancel()
+
+	if paginate {
+		paginateOpts := append(opts, asc.WithCiProductsLimit(200))
+		firstPage, err := client.GetCiProducts(requestCtx, paginateOpts...)
+		if err != nil {
+			return fmt.Errorf("xcode-cloud products: failed to fetch: %w", err)
+		}
+
+		resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetCiProducts(ctx, asc.WithCiProductsNextURL(nextURL))
+		})
+		if err != nil {
+			return fmt.Errorf("xcode-cloud products: %w", err)
+		}
+
+		return printOutput(resp, output, pretty)
+	}
+
+	resp, err := client.GetCiProducts(requestCtx, opts...)
+	if err != nil {
+		return fmt.Errorf("xcode-cloud products: %w", err)
+	}
+
+	return printOutput(resp, output, pretty)
+}
+
+// XcodeCloudMacOSVersionsCommand returns the xcode-cloud macos-versions command.
+func XcodeCloudMacOSVersionsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("macos-versions", flag.ExitOnError)
+
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "macos-versions",
+		ShortUsage: "asc xcode-cloud macos-versions [flags]",
+		ShortHelp:  "Manage Xcode Cloud macOS versions.",
+		LongHelp: `Manage Xcode Cloud macOS versions.
+
+Examples:
+  asc xcode-cloud macos-versions
+  asc xcode-cloud macos-versions list
+  asc xcode-cloud macos-versions get --id "MACOS_VERSION_ID"
+  asc xcode-cloud macos-versions xcode-versions --id "MACOS_VERSION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			XcodeCloudMacOSVersionsListCommand(),
+			XcodeCloudMacOSVersionsGetCommand(),
+			XcodeCloudMacOSVersionsXcodeVersionsCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return xcodeCloudMacOSVersionsList(ctx, *limit, *next, *paginate, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudMacOSVersionsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc xcode-cloud macos-versions list [flags]",
+		ShortHelp:  "List Xcode Cloud macOS versions.",
+		LongHelp: `List Xcode Cloud macOS versions.
+
+Examples:
+  asc xcode-cloud macos-versions list
+  asc xcode-cloud macos-versions list --limit 50
+  asc xcode-cloud macos-versions list --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			return xcodeCloudMacOSVersionsList(ctx, *limit, *next, *paginate, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudMacOSVersionsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("get", flag.ExitOnError)
+
+	id := fs.String("id", "", "macOS version ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc xcode-cloud macos-versions get --id \"MACOS_VERSION_ID\"",
+		ShortHelp:  "Get details for a macOS version.",
+		LongHelp: `Get details for a macOS version.
+
+Examples:
+  asc xcode-cloud macos-versions get --id "MACOS_VERSION_ID"
+  asc xcode-cloud macos-versions get --id "MACOS_VERSION_ID" --output table`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud macos-versions get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			resp, err := client.GetCiMacOsVersion(requestCtx, idValue)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud macos-versions get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudMacOSVersionsXcodeVersionsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("xcode-versions", flag.ExitOnError)
+
+	id := fs.String("id", "", "macOS version ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "xcode-versions",
+		ShortUsage: "asc xcode-cloud macos-versions xcode-versions [flags]",
+		ShortHelp:  "List Xcode versions for a macOS version.",
+		LongHelp: `List Xcode versions for a macOS version.
+
+Examples:
+  asc xcode-cloud macos-versions xcode-versions --id "MACOS_VERSION_ID"
+  asc xcode-cloud macos-versions xcode-versions --id "MACOS_VERSION_ID" --limit 50
+  asc xcode-cloud macos-versions xcode-versions --id "MACOS_VERSION_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("xcode-cloud macos-versions xcode-versions: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("xcode-cloud macos-versions xcode-versions: %w", err)
+			}
+
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud macos-versions xcode-versions: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			opts := []asc.CiXcodeVersionsOption{
+				asc.WithCiXcodeVersionsLimit(*limit),
+				asc.WithCiXcodeVersionsNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithCiXcodeVersionsLimit(200))
+				firstPage, err := client.GetCiMacOsVersionXcodeVersions(requestCtx, idValue, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud macos-versions xcode-versions: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetCiMacOsVersionXcodeVersions(ctx, idValue, asc.WithCiXcodeVersionsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud macos-versions xcode-versions: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetCiMacOsVersionXcodeVersions(requestCtx, idValue, opts...)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud macos-versions xcode-versions: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func xcodeCloudMacOSVersionsList(ctx context.Context, limit int, next string, paginate bool, output string, pretty bool) error {
+	if limit != 0 && (limit < 1 || limit > 200) {
+		return fmt.Errorf("xcode-cloud macos-versions: --limit must be between 1 and 200")
+	}
+	if err := validateNextURL(next); err != nil {
+		return fmt.Errorf("xcode-cloud macos-versions: %w", err)
+	}
+
+	client, err := getASCClient()
+	if err != nil {
+		return fmt.Errorf("xcode-cloud macos-versions: %w", err)
+	}
+
+	requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+	defer cancel()
+
+	opts := []asc.CiMacOsVersionsOption{
+		asc.WithCiMacOsVersionsLimit(limit),
+		asc.WithCiMacOsVersionsNextURL(next),
+	}
+
+	if paginate {
+		paginateOpts := append(opts, asc.WithCiMacOsVersionsLimit(200))
+		firstPage, err := client.GetCiMacOsVersions(requestCtx, paginateOpts...)
+		if err != nil {
+			return fmt.Errorf("xcode-cloud macos-versions: failed to fetch: %w", err)
+		}
+
+		resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetCiMacOsVersions(ctx, asc.WithCiMacOsVersionsNextURL(nextURL))
+		})
+		if err != nil {
+			return fmt.Errorf("xcode-cloud macos-versions: %w", err)
+		}
+
+		return printOutput(resp, output, pretty)
+	}
+
+	resp, err := client.GetCiMacOsVersions(requestCtx, opts...)
+	if err != nil {
+		return fmt.Errorf("xcode-cloud macos-versions: %w", err)
+	}
+
+	return printOutput(resp, output, pretty)
+}
+
+// XcodeCloudXcodeVersionsCommand returns the xcode-cloud xcode-versions command.
+func XcodeCloudXcodeVersionsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("xcode-versions", flag.ExitOnError)
+
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "xcode-versions",
+		ShortUsage: "asc xcode-cloud xcode-versions [flags]",
+		ShortHelp:  "Manage Xcode Cloud Xcode versions.",
+		LongHelp: `Manage Xcode Cloud Xcode versions.
+
+Examples:
+  asc xcode-cloud xcode-versions
+  asc xcode-cloud xcode-versions list
+  asc xcode-cloud xcode-versions get --id \"XCODE_VERSION_ID\"
+  asc xcode-cloud xcode-versions macos-versions --id \"XCODE_VERSION_ID\"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			XcodeCloudXcodeVersionsListCommand(),
+			XcodeCloudXcodeVersionsGetCommand(),
+			XcodeCloudXcodeVersionsMacOSVersionsCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return xcodeCloudXcodeVersionsList(ctx, *limit, *next, *paginate, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudXcodeVersionsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc xcode-cloud xcode-versions list [flags]",
+		ShortHelp:  "List Xcode Cloud Xcode versions.",
+		LongHelp: `List Xcode Cloud Xcode versions.
+
+Examples:
+  asc xcode-cloud xcode-versions list
+  asc xcode-cloud xcode-versions list --limit 50
+  asc xcode-cloud xcode-versions list --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			return xcodeCloudXcodeVersionsList(ctx, *limit, *next, *paginate, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudXcodeVersionsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("get", flag.ExitOnError)
+
+	id := fs.String("id", "", "Xcode version ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc xcode-cloud xcode-versions get --id \"XCODE_VERSION_ID\"",
+		ShortHelp:  "Get details for an Xcode version.",
+		LongHelp: `Get details for an Xcode version.
+
+Examples:
+  asc xcode-cloud xcode-versions get --id "XCODE_VERSION_ID"
+  asc xcode-cloud xcode-versions get --id "XCODE_VERSION_ID" --output table`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud xcode-versions get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			resp, err := client.GetCiXcodeVersion(requestCtx, idValue)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud xcode-versions get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func XcodeCloudXcodeVersionsMacOSVersionsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("macos-versions", flag.ExitOnError)
+
+	id := fs.String("id", "", "Xcode version ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "macos-versions",
+		ShortUsage: "asc xcode-cloud xcode-versions macos-versions [flags]",
+		ShortHelp:  "List macOS versions for an Xcode version.",
+		LongHelp: `List macOS versions for an Xcode version.
+
+Examples:
+  asc xcode-cloud xcode-versions macos-versions --id \"XCODE_VERSION_ID\"
+  asc xcode-cloud xcode-versions macos-versions --id \"XCODE_VERSION_ID\" --limit 50
+  asc xcode-cloud xcode-versions macos-versions --id \"XCODE_VERSION_ID\" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("xcode-cloud xcode-versions macos-versions: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("xcode-cloud xcode-versions macos-versions: %w", err)
+			}
+
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud xcode-versions macos-versions: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			opts := []asc.CiMacOsVersionsOption{
+				asc.WithCiMacOsVersionsLimit(*limit),
+				asc.WithCiMacOsVersionsNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithCiMacOsVersionsLimit(200))
+				firstPage, err := client.GetCiXcodeVersionMacOsVersions(requestCtx, idValue, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud xcode-versions macos-versions: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetCiXcodeVersionMacOsVersions(ctx, idValue, asc.WithCiMacOsVersionsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud xcode-versions macos-versions: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetCiXcodeVersionMacOsVersions(requestCtx, idValue, opts...)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud xcode-versions macos-versions: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+func xcodeCloudXcodeVersionsList(ctx context.Context, limit int, next string, paginate bool, output string, pretty bool) error {
+	if limit != 0 && (limit < 1 || limit > 200) {
+		return fmt.Errorf("xcode-cloud xcode-versions: --limit must be between 1 and 200")
+	}
+	if err := validateNextURL(next); err != nil {
+		return fmt.Errorf("xcode-cloud xcode-versions: %w", err)
+	}
+
+	client, err := getASCClient()
+	if err != nil {
+		return fmt.Errorf("xcode-cloud xcode-versions: %w", err)
+	}
+
+	requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+	defer cancel()
+
+	opts := []asc.CiXcodeVersionsOption{
+		asc.WithCiXcodeVersionsLimit(limit),
+		asc.WithCiXcodeVersionsNextURL(next),
+	}
+
+	if paginate {
+		paginateOpts := append(opts, asc.WithCiXcodeVersionsLimit(200))
+		firstPage, err := client.GetCiXcodeVersions(requestCtx, paginateOpts...)
+		if err != nil {
+			return fmt.Errorf("xcode-cloud xcode-versions: failed to fetch: %w", err)
+		}
+
+		resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetCiXcodeVersions(ctx, asc.WithCiXcodeVersionsNextURL(nextURL))
+		})
+		if err != nil {
+			return fmt.Errorf("xcode-cloud xcode-versions: %w", err)
+		}
+
+		return printOutput(resp, output, pretty)
+	}
+
+	resp, err := client.GetCiXcodeVersions(requestCtx, opts...)
+	if err != nil {
+		return fmt.Errorf("xcode-cloud xcode-versions: %w", err)
+	}
+
+	return printOutput(resp, output, pretty)
+}
+
+func readJSONFilePayload(path string) (json.RawMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("payload path must be a file")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, fmt.Errorf("payload file is empty")
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return json.RawMessage(data), nil
+}

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -3039,6 +3039,120 @@ func TestGetCiProducts_WithAppFilterAndLimit(t *testing.T) {
 	}
 }
 
+func TestGetCiProduct(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciProducts","id":"prod-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciProducts/prod-1" {
+			t.Fatalf("expected path /v1/ciProducts/prod-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiProduct(context.Background(), "prod-1"); err != nil {
+		t.Fatalf("GetCiProduct() error: %v", err)
+	}
+}
+
+func TestGetCiProductApp(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciProducts/prod-1/app" {
+			t.Fatalf("expected path /v1/ciProducts/prod-1/app, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiProductApp(context.Background(), "prod-1"); err != nil {
+		t.Fatalf("GetCiProductApp() error: %v", err)
+	}
+}
+
+func TestGetCiProductBuildRuns_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"ciBuildRuns","id":"run-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciProducts/prod-1/buildRuns" {
+			t.Fatalf("expected path /v1/ciProducts/prod-1/buildRuns, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "50" {
+			t.Fatalf("expected limit=50, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiProductBuildRuns(context.Background(), "prod-1", WithCiBuildRunsLimit(50)); err != nil {
+		t.Fatalf("GetCiProductBuildRuns() error: %v", err)
+	}
+}
+
+func TestGetCiProductPrimaryRepositories_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"scmRepositories","id":"repo-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciProducts/prod-1/primaryRepositories" {
+			t.Fatalf("expected path /v1/ciProducts/prod-1/primaryRepositories, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "10" {
+			t.Fatalf("expected limit=10, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiProductPrimaryRepositories(context.Background(), "prod-1", WithCiProductRepositoriesLimit(10)); err != nil {
+		t.Fatalf("GetCiProductPrimaryRepositories() error: %v", err)
+	}
+}
+
+func TestGetCiProductAdditionalRepositories_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"scmRepositories","id":"repo-2"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciProducts/prod-1/additionalRepositories" {
+			t.Fatalf("expected path /v1/ciProducts/prod-1/additionalRepositories, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiProductAdditionalRepositories(context.Background(), "prod-1", WithCiProductRepositoriesLimit(5)); err != nil {
+		t.Fatalf("GetCiProductAdditionalRepositories() error: %v", err)
+	}
+}
+
+func TestDeleteCiProduct(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciProducts/prod-1" {
+			t.Fatalf("expected path /v1/ciProducts/prod-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteCiProduct(context.Background(), "prod-1"); err != nil {
+		t.Fatalf("DeleteCiProduct() error: %v", err)
+	}
+}
+
 func TestGetCiWorkflows_UsesNextURL(t *testing.T) {
 	next := "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/workflows?cursor=abc"
 	response := jsonResponse(http.StatusOK, `{"data":[]}`)
@@ -3051,6 +3165,92 @@ func TestGetCiWorkflows_UsesNextURL(t *testing.T) {
 
 	if _, err := client.GetCiWorkflows(context.Background(), "prod-1", WithCiWorkflowsNextURL(next)); err != nil {
 		t.Fatalf("GetCiWorkflows() error: %v", err)
+	}
+}
+
+func TestGetCiWorkflow(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciWorkflows","id":"wf-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciWorkflows/wf-1" {
+			t.Fatalf("expected path /v1/ciWorkflows/wf-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiWorkflow(context.Background(), "wf-1"); err != nil {
+		t.Fatalf("GetCiWorkflow() error: %v", err)
+	}
+}
+
+func TestCreateCiWorkflow(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"ciWorkflows","id":"wf-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciWorkflows" {
+			t.Fatalf("expected path /v1/ciWorkflows, got %s", req.URL.Path)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		data, ok := payload["data"].(map[string]interface{})
+		if !ok || data["type"] != "ciWorkflows" {
+			t.Fatalf("expected data.type=ciWorkflows")
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	body := json.RawMessage(`{"data":{"type":"ciWorkflows"}}`)
+	if _, err := client.CreateCiWorkflow(context.Background(), body); err != nil {
+		t.Fatalf("CreateCiWorkflow() error: %v", err)
+	}
+}
+
+func TestUpdateCiWorkflow(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciWorkflows","id":"wf-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciWorkflows/wf-1" {
+			t.Fatalf("expected path /v1/ciWorkflows/wf-1, got %s", req.URL.Path)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		data, ok := payload["data"].(map[string]interface{})
+		if !ok || data["type"] != "ciWorkflows" {
+			t.Fatalf("expected data.type=ciWorkflows")
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	body := json.RawMessage(`{"data":{"type":"ciWorkflows","id":"wf-1"}}`)
+	if _, err := client.UpdateCiWorkflow(context.Background(), "wf-1", body); err != nil {
+		t.Fatalf("UpdateCiWorkflow() error: %v", err)
+	}
+}
+
+func TestDeleteCiWorkflow(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciWorkflows/wf-1" {
+			t.Fatalf("expected path /v1/ciWorkflows/wf-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteCiWorkflow(context.Background(), "wf-1"); err != nil {
+		t.Fatalf("DeleteCiWorkflow() error: %v", err)
 	}
 }
 
@@ -3113,6 +3313,27 @@ func TestGetCiBuildRun(t *testing.T) {
 	}
 }
 
+func TestGetCiBuildRunBuilds_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildRuns/run-1/builds" {
+			t.Fatalf("expected path /v1/ciBuildRuns/run-1/builds, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "10" {
+			t.Fatalf("expected limit=10, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiBuildRunBuilds(context.Background(), "run-1", WithCiBuildRunBuildsLimit(10)); err != nil {
+		t.Fatalf("GetCiBuildRunBuilds() error: %v", err)
+	}
+}
+
 func TestCreateCiBuildRun(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":1}}}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -3150,6 +3371,40 @@ func TestCreateCiBuildRun(t *testing.T) {
 	}
 	if _, err := client.CreateCiBuildRun(context.Background(), req); err != nil {
 		t.Fatalf("CreateCiBuildRun() error: %v", err)
+	}
+}
+
+func TestGetCiBuildAction(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciBuildActions","id":"action-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildActions/action-1" {
+			t.Fatalf("expected path /v1/ciBuildActions/action-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiBuildAction(context.Background(), "action-1"); err != nil {
+		t.Fatalf("GetCiBuildAction() error: %v", err)
+	}
+}
+
+func TestGetCiBuildActionBuildRun(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciBuildRuns","id":"run-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildActions/action-1/buildRun" {
+			t.Fatalf("expected path /v1/ciBuildActions/action-1/buildRun, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiBuildActionBuildRun(context.Background(), "action-1"); err != nil {
+		t.Fatalf("GetCiBuildActionBuildRun() error: %v", err)
 	}
 }
 
@@ -3264,6 +3519,124 @@ func TestGetCiIssue(t *testing.T) {
 
 	if _, err := client.GetCiIssue(context.Background(), "issue-1"); err != nil {
 		t.Fatalf("GetCiIssue() error: %v", err)
+	}
+}
+
+func TestGetCiMacOsVersions_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"ciMacOsVersions","id":"macos-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciMacOsVersions" {
+			t.Fatalf("expected path /v1/ciMacOsVersions, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiMacOsVersions(context.Background(), WithCiMacOsVersionsLimit(5)); err != nil {
+		t.Fatalf("GetCiMacOsVersions() error: %v", err)
+	}
+}
+
+func TestGetCiMacOsVersion(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciMacOsVersions","id":"macos-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciMacOsVersions/macos-1" {
+			t.Fatalf("expected path /v1/ciMacOsVersions/macos-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiMacOsVersion(context.Background(), "macos-1"); err != nil {
+		t.Fatalf("GetCiMacOsVersion() error: %v", err)
+	}
+}
+
+func TestGetCiMacOsVersionXcodeVersions_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"ciXcodeVersions","id":"xcode-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciMacOsVersions/macos-1/xcodeVersions" {
+			t.Fatalf("expected path /v1/ciMacOsVersions/macos-1/xcodeVersions, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "20" {
+			t.Fatalf("expected limit=20, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiMacOsVersionXcodeVersions(context.Background(), "macos-1", WithCiXcodeVersionsLimit(20)); err != nil {
+		t.Fatalf("GetCiMacOsVersionXcodeVersions() error: %v", err)
+	}
+}
+
+func TestGetCiXcodeVersions_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"ciXcodeVersions","id":"xcode-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciXcodeVersions" {
+			t.Fatalf("expected path /v1/ciXcodeVersions, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "10" {
+			t.Fatalf("expected limit=10, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiXcodeVersions(context.Background(), WithCiXcodeVersionsLimit(10)); err != nil {
+		t.Fatalf("GetCiXcodeVersions() error: %v", err)
+	}
+}
+
+func TestGetCiXcodeVersion(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciXcodeVersions","id":"xcode-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciXcodeVersions/xcode-1" {
+			t.Fatalf("expected path /v1/ciXcodeVersions/xcode-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiXcodeVersion(context.Background(), "xcode-1"); err != nil {
+		t.Fatalf("GetCiXcodeVersion() error: %v", err)
+	}
+}
+
+func TestGetCiXcodeVersionMacOsVersions_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"ciMacOsVersions","id":"macos-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciXcodeVersions/xcode-1/macOsVersions" {
+			t.Fatalf("expected path /v1/ciXcodeVersions/xcode-1/macOsVersions, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("limit") != "15" {
+			t.Fatalf("expected limit=15, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiXcodeVersionMacOsVersions(context.Background(), "xcode-1", WithCiMacOsVersionsLimit(15)); err != nil {
+		t.Fatalf("GetCiXcodeVersionMacOsVersions() error: %v", err)
 	}
 }
 

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -132,6 +132,8 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &CiWorkflowsResponse{Links: Links{}}
 	case *ScmGitReferencesResponse:
 		result = &ScmGitReferencesResponse{Links: Links{}}
+	case *ScmRepositoriesResponse:
+		result = &ScmRepositoriesResponse{Links: Links{}}
 	case *CiBuildRunsResponse:
 		result = &CiBuildRunsResponse{Links: Links{}}
 	case *CiBuildActionsResponse:
@@ -142,6 +144,10 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &CiTestResultsResponse{Links: Links{}}
 	case *CiIssuesResponse:
 		result = &CiIssuesResponse{Links: Links{}}
+	case *CiMacOsVersionsResponse:
+		result = &CiMacOsVersionsResponse{Links: Links{}}
+	case *CiXcodeVersionsResponse:
+		result = &CiXcodeVersionsResponse{Links: Links{}}
 	default:
 		return nil, fmt.Errorf("unsupported response type for pagination")
 	}
@@ -295,8 +301,22 @@ func typeOf(p PaginatedResponse) string {
 		return "CiWorkflowsResponse"
 	case *ScmGitReferencesResponse:
 		return "ScmGitReferencesResponse"
+	case *ScmRepositoriesResponse:
+		return "ScmRepositoriesResponse"
 	case *CiBuildRunsResponse:
 		return "CiBuildRunsResponse"
+	case *CiBuildActionsResponse:
+		return "CiBuildActionsResponse"
+	case *CiArtifactsResponse:
+		return "CiArtifactsResponse"
+	case *CiTestResultsResponse:
+		return "CiTestResultsResponse"
+	case *CiIssuesResponse:
+		return "CiIssuesResponse"
+	case *CiMacOsVersionsResponse:
+		return "CiMacOsVersionsResponse"
+	case *CiXcodeVersionsResponse:
+		return "CiXcodeVersionsResponse"
 	default:
 		return "unknown"
 	}

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -1591,3 +1591,147 @@ func TestPaginateAll_CiIssues_ManyPages(t *testing.T) {
 		t.Fatalf("expected next link to be cleared, got %q", issues.Links.Next)
 	}
 }
+
+func TestPaginateAll_ScmRepositories_ManyPages(t *testing.T) {
+	const totalPages = 3
+	const perPage = 2
+
+	makePage := func(page int) *ScmRepositoriesResponse {
+		data := make([]ScmRepositoryResource, 0, perPage)
+		for i := 0; i < perPage; i++ {
+			data = append(data, ScmRepositoryResource{
+				Type: ResourceTypeScmRepositories,
+				ID:   fmt.Sprintf("repo-%d-%d", page, i),
+			})
+		}
+		links := Links{}
+		if page < totalPages {
+			links.Next = fmt.Sprintf("page=%d", page+1)
+		}
+		return &ScmRepositoriesResponse{
+			Data:  data,
+			Links: links,
+		}
+	}
+
+	firstPage := makePage(1)
+	response, err := PaginateAll(context.Background(), firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		pageStr := strings.TrimPrefix(nextURL, "page=")
+		page, err := strconv.Atoi(pageStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid next URL %q", nextURL)
+		}
+		return makePage(page), nil
+	})
+	if err != nil {
+		t.Fatalf("PaginateAll() error: %v", err)
+	}
+
+	repos, ok := response.(*ScmRepositoriesResponse)
+	if !ok {
+		t.Fatalf("expected ScmRepositoriesResponse, got %T", response)
+	}
+	expected := totalPages * perPage
+	if len(repos.Data) != expected {
+		t.Fatalf("expected %d repositories, got %d", expected, len(repos.Data))
+	}
+	if repos.Links.Next != "" {
+		t.Fatalf("expected next link to be cleared, got %q", repos.Links.Next)
+	}
+}
+
+func TestPaginateAll_CiMacOsVersions_ManyPages(t *testing.T) {
+	const totalPages = 4
+	const perPage = 2
+
+	makePage := func(page int) *CiMacOsVersionsResponse {
+		data := make([]CiMacOsVersionResource, 0, perPage)
+		for i := 0; i < perPage; i++ {
+			data = append(data, CiMacOsVersionResource{
+				Type: ResourceTypeCiMacOsVersions,
+				ID:   fmt.Sprintf("macos-%d-%d", page, i),
+			})
+		}
+		links := Links{}
+		if page < totalPages {
+			links.Next = fmt.Sprintf("page=%d", page+1)
+		}
+		return &CiMacOsVersionsResponse{
+			Data:  data,
+			Links: links,
+		}
+	}
+
+	firstPage := makePage(1)
+	response, err := PaginateAll(context.Background(), firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		pageStr := strings.TrimPrefix(nextURL, "page=")
+		page, err := strconv.Atoi(pageStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid next URL %q", nextURL)
+		}
+		return makePage(page), nil
+	})
+	if err != nil {
+		t.Fatalf("PaginateAll() error: %v", err)
+	}
+
+	versions, ok := response.(*CiMacOsVersionsResponse)
+	if !ok {
+		t.Fatalf("expected CiMacOsVersionsResponse, got %T", response)
+	}
+	expected := totalPages * perPage
+	if len(versions.Data) != expected {
+		t.Fatalf("expected %d macOS versions, got %d", expected, len(versions.Data))
+	}
+	if versions.Links.Next != "" {
+		t.Fatalf("expected next link to be cleared, got %q", versions.Links.Next)
+	}
+}
+
+func TestPaginateAll_CiXcodeVersions_ManyPages(t *testing.T) {
+	const totalPages = 3
+	const perPage = 3
+
+	makePage := func(page int) *CiXcodeVersionsResponse {
+		data := make([]CiXcodeVersionResource, 0, perPage)
+		for i := 0; i < perPage; i++ {
+			data = append(data, CiXcodeVersionResource{
+				Type: ResourceTypeCiXcodeVersions,
+				ID:   fmt.Sprintf("xcode-%d-%d", page, i),
+			})
+		}
+		links := Links{}
+		if page < totalPages {
+			links.Next = fmt.Sprintf("page=%d", page+1)
+		}
+		return &CiXcodeVersionsResponse{
+			Data:  data,
+			Links: links,
+		}
+	}
+
+	firstPage := makePage(1)
+	response, err := PaginateAll(context.Background(), firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		pageStr := strings.TrimPrefix(nextURL, "page=")
+		page, err := strconv.Atoi(pageStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid next URL %q", nextURL)
+		}
+		return makePage(page), nil
+	})
+	if err != nil {
+		t.Fatalf("PaginateAll() error: %v", err)
+	}
+
+	versions, ok := response.(*CiXcodeVersionsResponse)
+	if !ok {
+		t.Fatalf("expected CiXcodeVersionsResponse, got %T", response)
+	}
+	expected := totalPages * perPage
+	if len(versions.Data) != expected {
+		t.Fatalf("expected %d Xcode versions, got %d", expected, len(versions.Data))
+	}
+	if versions.Links.Next != "" {
+		t.Fatalf("expected next link to be cleared, got %q", versions.Links.Next)
+	}
+}

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -309,12 +309,30 @@ func PrintMarkdown(data interface{}) error {
 		return printXcodeCloudStatusResultMarkdown(v)
 	case *CiProductsResponse:
 		return printCiProductsMarkdown(v)
+	case *CiProductResponse:
+		return printCiProductsMarkdown(&CiProductsResponse{Data: []CiProductResource{v.Data}})
 	case *CiWorkflowsResponse:
 		return printCiWorkflowsMarkdown(v)
+	case *CiWorkflowResponse:
+		return printCiWorkflowsMarkdown(&CiWorkflowsResponse{Data: []CiWorkflowResource{v.Data}})
+	case *ScmRepositoriesResponse:
+		return printScmRepositoriesMarkdown(v)
 	case *CiBuildRunsResponse:
 		return printCiBuildRunsMarkdown(v)
+	case *CiBuildRunResponse:
+		return printCiBuildRunsMarkdown(&CiBuildRunsResponse{Data: []CiBuildRunResource{v.Data}})
 	case *CiBuildActionsResponse:
 		return printCiBuildActionsMarkdown(v)
+	case *CiBuildActionResponse:
+		return printCiBuildActionsMarkdown(&CiBuildActionsResponse{Data: []CiBuildActionResource{v.Data}})
+	case *CiMacOsVersionsResponse:
+		return printCiMacOsVersionsMarkdown(v)
+	case *CiMacOsVersionResponse:
+		return printCiMacOsVersionsMarkdown(&CiMacOsVersionsResponse{Data: []CiMacOsVersionResource{v.Data}})
+	case *CiXcodeVersionsResponse:
+		return printCiXcodeVersionsMarkdown(v)
+	case *CiXcodeVersionResponse:
+		return printCiXcodeVersionsMarkdown(&CiXcodeVersionsResponse{Data: []CiXcodeVersionResource{v.Data}})
 	case *CiArtifactsResponse:
 		return printCiArtifactsMarkdown(v)
 	case *CiArtifactResponse:
@@ -329,6 +347,10 @@ func PrintMarkdown(data interface{}) error {
 		return printCiIssueMarkdown(v)
 	case *CiArtifactDownloadResult:
 		return printCiArtifactDownloadResultMarkdown(v)
+	case *CiWorkflowDeleteResult:
+		return printCiWorkflowDeleteResultMarkdown(v)
+	case *CiProductDeleteResult:
+		return printCiProductDeleteResultMarkdown(v)
 	case *EndUserLicenseAgreementResponse:
 		return printEndUserLicenseAgreementMarkdown(v)
 	case *EndUserLicenseAgreementDeleteResult:
@@ -645,12 +667,30 @@ func PrintTable(data interface{}) error {
 		return printXcodeCloudStatusResultTable(v)
 	case *CiProductsResponse:
 		return printCiProductsTable(v)
+	case *CiProductResponse:
+		return printCiProductsTable(&CiProductsResponse{Data: []CiProductResource{v.Data}})
 	case *CiWorkflowsResponse:
 		return printCiWorkflowsTable(v)
+	case *CiWorkflowResponse:
+		return printCiWorkflowsTable(&CiWorkflowsResponse{Data: []CiWorkflowResource{v.Data}})
+	case *ScmRepositoriesResponse:
+		return printScmRepositoriesTable(v)
 	case *CiBuildRunsResponse:
 		return printCiBuildRunsTable(v)
+	case *CiBuildRunResponse:
+		return printCiBuildRunsTable(&CiBuildRunsResponse{Data: []CiBuildRunResource{v.Data}})
 	case *CiBuildActionsResponse:
 		return printCiBuildActionsTable(v)
+	case *CiBuildActionResponse:
+		return printCiBuildActionsTable(&CiBuildActionsResponse{Data: []CiBuildActionResource{v.Data}})
+	case *CiMacOsVersionsResponse:
+		return printCiMacOsVersionsTable(v)
+	case *CiMacOsVersionResponse:
+		return printCiMacOsVersionsTable(&CiMacOsVersionsResponse{Data: []CiMacOsVersionResource{v.Data}})
+	case *CiXcodeVersionsResponse:
+		return printCiXcodeVersionsTable(v)
+	case *CiXcodeVersionResponse:
+		return printCiXcodeVersionsTable(&CiXcodeVersionsResponse{Data: []CiXcodeVersionResource{v.Data}})
 	case *CiArtifactsResponse:
 		return printCiArtifactsTable(v)
 	case *CiArtifactResponse:
@@ -665,6 +705,10 @@ func PrintTable(data interface{}) error {
 		return printCiIssueTable(v)
 	case *CiArtifactDownloadResult:
 		return printCiArtifactDownloadResultTable(v)
+	case *CiWorkflowDeleteResult:
+		return printCiWorkflowDeleteResultTable(v)
+	case *CiProductDeleteResult:
+		return printCiProductDeleteResultTable(v)
 	case *CustomerReviewResponseResponse:
 		return printCustomerReviewResponseTable(v)
 	case *CustomerReviewResponseDeleteResult:

--- a/internal/asc/xcode_cloud_output.go
+++ b/internal/asc/xcode_cloud_output.go
@@ -16,6 +16,18 @@ type CiArtifactDownloadResult struct {
 	BytesWritten int64  `json:"bytesWritten,omitempty"`
 }
 
+// CiWorkflowDeleteResult represents CLI output for workflow deletions.
+type CiWorkflowDeleteResult struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+// CiProductDeleteResult represents CLI output for product deletions.
+type CiProductDeleteResult struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
 func printXcodeCloudRunResultTable(result *XcodeCloudRunResult) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "Build Run ID\tBuild #\tWorkflow ID\tWorkflow Name\tGit Ref ID\tGit Ref Name\tProgress\tStatus\tStart Reason\tCreated")
@@ -141,6 +153,90 @@ func printCiWorkflowsMarkdown(resp *CiWorkflowsResponse) error {
 			escapeMarkdown(item.Attributes.Name),
 			item.Attributes.IsEnabled,
 			escapeMarkdown(item.Attributes.LastModifiedDate),
+		)
+	}
+	return nil
+}
+
+func printScmRepositoriesTable(resp *ScmRepositoriesResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tOwner\tRepository\tHTTP URL\tSSH URL\tLast Accessed")
+	for _, item := range resp.Data {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			item.ID,
+			item.Attributes.OwnerName,
+			item.Attributes.RepositoryName,
+			item.Attributes.HTTPCloneURL,
+			item.Attributes.SSHCloneURL,
+			item.Attributes.LastAccessedDate,
+		)
+	}
+	return w.Flush()
+}
+
+func printScmRepositoriesMarkdown(resp *ScmRepositoriesResponse) error {
+	fmt.Fprintln(os.Stdout, "| ID | Owner | Repository | HTTP URL | SSH URL | Last Accessed |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
+	for _, item := range resp.Data {
+		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
+			escapeMarkdown(item.ID),
+			escapeMarkdown(item.Attributes.OwnerName),
+			escapeMarkdown(item.Attributes.RepositoryName),
+			escapeMarkdown(item.Attributes.HTTPCloneURL),
+			escapeMarkdown(item.Attributes.SSHCloneURL),
+			escapeMarkdown(item.Attributes.LastAccessedDate),
+		)
+	}
+	return nil
+}
+
+func printCiMacOsVersionsTable(resp *CiMacOsVersionsResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tVersion\tName")
+	for _, item := range resp.Data {
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			item.ID,
+			item.Attributes.Version,
+			item.Attributes.Name,
+		)
+	}
+	return w.Flush()
+}
+
+func printCiMacOsVersionsMarkdown(resp *CiMacOsVersionsResponse) error {
+	fmt.Fprintln(os.Stdout, "| ID | Version | Name |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
+	for _, item := range resp.Data {
+		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
+			escapeMarkdown(item.ID),
+			escapeMarkdown(item.Attributes.Version),
+			escapeMarkdown(item.Attributes.Name),
+		)
+	}
+	return nil
+}
+
+func printCiXcodeVersionsTable(resp *CiXcodeVersionsResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tVersion\tName")
+	for _, item := range resp.Data {
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			item.ID,
+			item.Attributes.Version,
+			item.Attributes.Name,
+		)
+	}
+	return w.Flush()
+}
+
+func printCiXcodeVersionsMarkdown(resp *CiXcodeVersionsResponse) error {
+	fmt.Fprintln(os.Stdout, "| ID | Version | Name |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
+	for _, item := range resp.Data {
+		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
+			escapeMarkdown(item.ID),
+			escapeMarkdown(item.Attributes.Version),
+			escapeMarkdown(item.Attributes.Name),
 		)
 	}
 	return nil
@@ -371,6 +467,34 @@ func printCiArtifactDownloadResultMarkdown(result *CiArtifactDownloadResult) err
 		result.BytesWritten,
 		escapeMarkdown(result.OutputPath),
 	)
+	return nil
+}
+
+func printCiWorkflowDeleteResultTable(result *CiWorkflowDeleteResult) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tDeleted")
+	fmt.Fprintf(w, "%s\t%t\n", result.ID, result.Deleted)
+	return w.Flush()
+}
+
+func printCiWorkflowDeleteResultMarkdown(result *CiWorkflowDeleteResult) error {
+	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
+	fmt.Fprintln(os.Stdout, "| --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	return nil
+}
+
+func printCiProductDeleteResultTable(result *CiProductDeleteResult) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tDeleted")
+	fmt.Fprintf(w, "%s\t%t\n", result.ID, result.Deleted)
+	return w.Flush()
+}
+
+func printCiProductDeleteResultMarkdown(result *CiProductDeleteResult) error {
+	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
+	fmt.Fprintln(os.Stdout, "| --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
 	return nil
 }
 

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -544,6 +544,216 @@ func TestIsBuildRunSuccessful(t *testing.T) {
 	}
 }
 
+func TestPrintTable_ScmRepositories(t *testing.T) {
+	resp := &ScmRepositoriesResponse{
+		Data: []ScmRepositoryResource{
+			{
+				ID: "repo-1",
+				Attributes: ScmRepositoryAttributes{
+					OwnerName:      "example",
+					RepositoryName: "demo",
+				},
+			},
+		},
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Repository") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "demo") {
+		t.Fatalf("expected repository name in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_ScmRepositories(t *testing.T) {
+	resp := &ScmRepositoriesResponse{
+		Data: []ScmRepositoryResource{
+			{
+				ID: "repo-2",
+				Attributes: ScmRepositoryAttributes{
+					OwnerName:      "example",
+					RepositoryName: "demo",
+				},
+			},
+		},
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Owner | Repository |") {
+		t.Fatalf("expected markdown header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "example") {
+		t.Fatalf("expected owner name in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_CiMacOsVersions(t *testing.T) {
+	resp := &CiMacOsVersionsResponse{
+		Data: []CiMacOsVersionResource{
+			{
+				ID: "macos-1",
+				Attributes: CiMacOsVersionAttributes{
+					Version: "14.0",
+					Name:    "Sonoma",
+				},
+			},
+		},
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Version") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Sonoma") {
+		t.Fatalf("expected name in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_CiMacOsVersions(t *testing.T) {
+	resp := &CiMacOsVersionsResponse{
+		Data: []CiMacOsVersionResource{
+			{
+				ID: "macos-2",
+				Attributes: CiMacOsVersionAttributes{
+					Version: "13.0",
+					Name:    "Ventura",
+				},
+			},
+		},
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Version | Name |") {
+		t.Fatalf("expected markdown header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Ventura") {
+		t.Fatalf("expected name in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_CiXcodeVersions(t *testing.T) {
+	resp := &CiXcodeVersionsResponse{
+		Data: []CiXcodeVersionResource{
+			{
+				ID: "xcode-1",
+				Attributes: CiXcodeVersionAttributes{
+					Version: "15.0",
+					Name:    "Xcode 15",
+				},
+			},
+		},
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Version") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Xcode 15") {
+		t.Fatalf("expected name in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_CiXcodeVersions(t *testing.T) {
+	resp := &CiXcodeVersionsResponse{
+		Data: []CiXcodeVersionResource{
+			{
+				ID: "xcode-2",
+				Attributes: CiXcodeVersionAttributes{
+					Version: "14.3",
+					Name:    "Xcode 14.3",
+				},
+			},
+		},
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Version | Name |") {
+		t.Fatalf("expected markdown header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Xcode 14.3") {
+		t.Fatalf("expected name in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_CiWorkflowDeleteResult(t *testing.T) {
+	result := &CiWorkflowDeleteResult{ID: "wf-1", Deleted: true}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	if !strings.Contains(output, "Deleted") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "wf-1") {
+		t.Fatalf("expected ID in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_CiWorkflowDeleteResult(t *testing.T) {
+	result := &CiWorkflowDeleteResult{ID: "wf-2", Deleted: true}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintMarkdown(result)
+	})
+
+	if !strings.Contains(output, "| ID | Deleted |") {
+		t.Fatalf("expected markdown header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "wf-2") {
+		t.Fatalf("expected ID in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_CiProductDeleteResult(t *testing.T) {
+	result := &CiProductDeleteResult{ID: "prod-1", Deleted: true}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	if !strings.Contains(output, "Deleted") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "prod-1") {
+		t.Fatalf("expected ID in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_CiProductDeleteResult(t *testing.T) {
+	result := &CiProductDeleteResult{ID: "prod-2", Deleted: true}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintMarkdown(result)
+	})
+
+	if !strings.Contains(output, "| ID | Deleted |") {
+		t.Fatalf("expected markdown header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "prod-2") {
+		t.Fatalf("expected ID in output, got: %s", output)
+	}
+}
+
 func TestBuildCiProductsQuery(t *testing.T) {
 	query := &ciProductsQuery{}
 	WithCiProductsAppID("app-1")(query)
@@ -636,5 +846,57 @@ func TestBuildCiIssuesQuery(t *testing.T) {
 	}
 	if got := values.Get("limit"); got != "35" {
 		t.Fatalf("expected limit=35, got %q", got)
+	}
+}
+
+func TestBuildCiMacOsVersionsQuery(t *testing.T) {
+	query := &ciMacOsVersionsQuery{}
+	WithCiMacOsVersionsLimit(15)(query)
+
+	values, err := url.ParseQuery(buildCiMacOsVersionsQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("limit"); got != "15" {
+		t.Fatalf("expected limit=15, got %q", got)
+	}
+}
+
+func TestBuildCiXcodeVersionsQuery(t *testing.T) {
+	query := &ciXcodeVersionsQuery{}
+	WithCiXcodeVersionsLimit(20)(query)
+
+	values, err := url.ParseQuery(buildCiXcodeVersionsQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("limit"); got != "20" {
+		t.Fatalf("expected limit=20, got %q", got)
+	}
+}
+
+func TestBuildCiProductRepositoriesQuery(t *testing.T) {
+	query := &ciProductRepositoriesQuery{}
+	WithCiProductRepositoriesLimit(12)(query)
+
+	values, err := url.ParseQuery(buildCiProductRepositoriesQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("limit"); got != "12" {
+		t.Fatalf("expected limit=12, got %q", got)
+	}
+}
+
+func TestBuildCiBuildRunBuildsQuery(t *testing.T) {
+	query := &ciBuildRunBuildsQuery{}
+	WithCiBuildRunBuildsLimit(8)(query)
+
+	values, err := url.ParseQuery(buildCiBuildRunBuildsQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("limit"); got != "8" {
+		t.Fatalf("expected limit=8, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add Xcode Cloud product, workflow, action/build-run, and macOS/Xcode version commands
- extend client models, pagination, and output formatting for new CI resources
- add tests for new endpoints, pagination, and CLI validation

## Test plan
- [x] go test ./cmd
- [x] go test ./internal/asc
- [x] Manual: verified read-only Xcode Cloud commands against live API
- [ ] Manual: workflow create/update/delete and product delete (destructive)