### PR TITLE
Add performance metrics and diagnostics support

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -1663,6 +1663,93 @@ func TestEncryptionValidationErrors(t *testing.T) {
 	}
 }
 
+func TestPerformanceValidationErrors(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantErr  string
+		wantHelp bool
+	}{
+		{
+			name:     "performance metrics list missing app",
+			args:     []string{"performance", "metrics", "list"},
+			wantErr:  "--app is required",
+			wantHelp: true,
+		},
+		{
+			name:     "performance metrics get missing build",
+			args:     []string{"performance", "metrics", "get"},
+			wantErr:  "--build is required",
+			wantHelp: true,
+		},
+		{
+			name:     "performance diagnostics list missing build",
+			args:     []string{"performance", "diagnostics", "list"},
+			wantErr:  "--build is required",
+			wantHelp: true,
+		},
+		{
+			name:     "performance diagnostics get missing id",
+			args:     []string{"performance", "diagnostics", "get"},
+			wantErr:  "--id is required",
+			wantHelp: true,
+		},
+		{
+			name:     "performance download missing selection",
+			args:     []string{"performance", "download"},
+			wantErr:  "--app, --build, or --diagnostic-id is required",
+			wantHelp: true,
+		},
+		{
+			name:    "performance download mutually exclusive",
+			args:    []string{"performance", "download", "--app", "APP_ID", "--build", "BUILD_ID"},
+			wantErr: "mutually exclusive",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if test.wantHelp {
+					if !errors.Is(err, flag.ErrHelp) {
+						t.Fatalf("expected ErrHelp, got %v", err)
+					}
+				} else {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+					if errors.Is(err, flag.ErrHelp) {
+						t.Fatalf("expected non-help error, got %v", err)
+					}
+				}
+			})
+
+			if test.wantHelp {
+				if stdout != "" {
+					t.Fatalf("expected empty stdout, got %q", stdout)
+				}
+				if !strings.Contains(stderr, test.wantErr) {
+					t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+				}
+			}
+		})
+	}
+}
+
 func TestTestFlightBetaDetailsValidationErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/performance.go
+++ b/cmd/performance.go
@@ -1,0 +1,653 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// PerformanceCommand returns the performance command group.
+func PerformanceCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("performance", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "performance",
+		ShortUsage: "asc performance <subcommand> [flags]",
+		ShortHelp:  "Access performance metrics and diagnostic logs.",
+		LongHelp: `Access performance metrics and diagnostic logs.
+
+Examples:
+  asc performance metrics list --app "APP_ID"
+  asc performance metrics get --build "BUILD_ID"
+  asc performance diagnostics list --build "BUILD_ID"
+  asc performance diagnostics get --id "SIGNATURE_ID"
+  asc performance download --build "BUILD_ID" --output ./metrics.json`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			PerformanceMetricsCommand(),
+			PerformanceDiagnosticsCommand(),
+			PerformanceDownloadCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// PerformanceMetricsCommand returns the metrics subcommand group.
+func PerformanceMetricsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metrics", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "metrics",
+		ShortUsage: "asc performance metrics <subcommand> [flags]",
+		ShortHelp:  "Work with performance/power metrics.",
+		LongHelp: `Work with performance/power metrics.
+
+Examples:
+  asc performance metrics list --app "APP_ID"
+  asc performance metrics get --build "BUILD_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			PerformanceMetricsListCommand(),
+			PerformanceMetricsGetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// PerformanceMetricsListCommand returns the metrics list subcommand.
+func PerformanceMetricsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metrics list", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	platform := fs.String("platform", "", "Platform filter (IOS)")
+	metricType := fs.String("metric-type", "", "Metric types (comma-separated: "+strings.Join(perfPowerMetricTypeList(), ", ")+")")
+	deviceType := fs.String("device-type", "", "Device types (comma-separated, e.g., iPhone15,2)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc performance metrics list --app \"APP_ID\"",
+		ShortHelp:  "List performance/power metrics for an app.",
+		LongHelp: `List performance/power metrics for an app.
+
+Examples:
+  asc performance metrics list --app "APP_ID"
+  asc performance metrics list --app "APP_ID" --metric-type "MEMORY,DISK" --device-type "iPhone15,2"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedAppID := resolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+
+			platforms, err := normalizePerfPowerMetricPlatforms(splitCSVUpper(*platform), "--platform")
+			if err != nil {
+				return fmt.Errorf("performance metrics list: %w", err)
+			}
+			metricTypes, err := normalizePerfPowerMetricTypes(splitCSVUpper(*metricType))
+			if err != nil {
+				return fmt.Errorf("performance metrics list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("performance metrics list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetPerfPowerMetricsForApp(requestCtx, resolvedAppID,
+				asc.WithPerfPowerMetricsPlatforms(platforms),
+				asc.WithPerfPowerMetricsMetricTypes(metricTypes),
+				asc.WithPerfPowerMetricsDeviceTypes(splitCSV(*deviceType)),
+			)
+			if err != nil {
+				return fmt.Errorf("performance metrics list: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// PerformanceMetricsGetCommand returns the metrics get subcommand.
+func PerformanceMetricsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metrics get", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID to fetch metrics for")
+	platform := fs.String("platform", "", "Platform filter (IOS)")
+	metricType := fs.String("metric-type", "", "Metric types (comma-separated: "+strings.Join(perfPowerMetricTypeList(), ", ")+")")
+	deviceType := fs.String("device-type", "", "Device types (comma-separated, e.g., iPhone15,2)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc performance metrics get --build \"BUILD_ID\"",
+		ShortHelp:  "Get performance/power metrics for a build.",
+		LongHelp: `Get performance/power metrics for a build.
+
+Examples:
+  asc performance metrics get --build "BUILD_ID"
+  asc performance metrics get --build "BUILD_ID" --metric-type "MEMORY" --device-type "iPhone15,2"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedBuildID := strings.TrimSpace(*buildID)
+			if trimmedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+
+			platforms, err := normalizePerfPowerMetricPlatforms(splitCSVUpper(*platform), "--platform")
+			if err != nil {
+				return fmt.Errorf("performance metrics get: %w", err)
+			}
+			metricTypes, err := normalizePerfPowerMetricTypes(splitCSVUpper(*metricType))
+			if err != nil {
+				return fmt.Errorf("performance metrics get: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("performance metrics get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetPerfPowerMetricsForBuild(requestCtx, trimmedBuildID,
+				asc.WithPerfPowerMetricsPlatforms(platforms),
+				asc.WithPerfPowerMetricsMetricTypes(metricTypes),
+				asc.WithPerfPowerMetricsDeviceTypes(splitCSV(*deviceType)),
+			)
+			if err != nil {
+				return fmt.Errorf("performance metrics get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// PerformanceDiagnosticsCommand returns the diagnostics subcommand group.
+func PerformanceDiagnosticsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("diagnostics", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "diagnostics",
+		ShortUsage: "asc performance diagnostics <subcommand> [flags]",
+		ShortHelp:  "Work with diagnostic signatures and logs.",
+		LongHelp: `Work with diagnostic signatures and logs.
+
+Examples:
+  asc performance diagnostics list --build "BUILD_ID"
+  asc performance diagnostics get --id "SIGNATURE_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			PerformanceDiagnosticsListCommand(),
+			PerformanceDiagnosticsGetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// PerformanceDiagnosticsListCommand returns the diagnostics list subcommand.
+func PerformanceDiagnosticsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("diagnostics list", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID to list diagnostics for")
+	diagnosticType := fs.String("diagnostic-type", "", "Diagnostic type filter (comma-separated: "+strings.Join(diagnosticSignatureTypeList(), ", ")+")")
+	fields := fs.String("fields", "", "Fields to return (comma-separated: "+strings.Join(diagnosticSignatureFieldList(), ", ")+")")
+	limit := fs.Int("limit", 0, "Limit number of signatures (max 200)")
+	next := fs.String("next", "", "Next page URL")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc performance diagnostics list --build \"BUILD_ID\"",
+		ShortHelp:  "List diagnostic signatures for a build.",
+		LongHelp: `List diagnostic signatures for a build.
+
+Examples:
+  asc performance diagnostics list --build "BUILD_ID"
+  asc performance diagnostics list --build "BUILD_ID" --diagnostic-type "HANGS" --limit 50`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedBuildID := strings.TrimSpace(*buildID)
+			if trimmedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("performance diagnostics list: --limit must be between 1 and 200")
+			}
+
+			diagnosticTypes, err := normalizeDiagnosticSignatureTypes(splitCSVUpper(*diagnosticType))
+			if err != nil {
+				return fmt.Errorf("performance diagnostics list: %w", err)
+			}
+			fieldValues, err := normalizeDiagnosticSignatureFields(*fields)
+			if err != nil {
+				return fmt.Errorf("performance diagnostics list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("performance diagnostics list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.DiagnosticSignaturesOption{
+				asc.WithDiagnosticSignaturesDiagnosticTypes(diagnosticTypes),
+				asc.WithDiagnosticSignaturesFields(fieldValues),
+				asc.WithDiagnosticSignaturesLimit(*limit),
+				asc.WithDiagnosticSignaturesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithDiagnosticSignaturesLimit(200))
+				firstPage, err := client.GetDiagnosticSignaturesForBuild(requestCtx, trimmedBuildID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("performance diagnostics list: failed to fetch: %w", err)
+				}
+
+				paginated, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetDiagnosticSignaturesForBuild(ctx, trimmedBuildID, asc.WithDiagnosticSignaturesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("performance diagnostics list: %w", err)
+				}
+
+				return printOutput(paginated, *output, *pretty)
+			}
+
+			resp, err := client.GetDiagnosticSignaturesForBuild(requestCtx, trimmedBuildID, opts...)
+			if err != nil {
+				return fmt.Errorf("performance diagnostics list: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// PerformanceDiagnosticsGetCommand returns the diagnostics get subcommand.
+func PerformanceDiagnosticsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("diagnostics get", flag.ExitOnError)
+
+	signatureID := fs.String("id", "", "Diagnostic signature ID")
+	limit := fs.Int("limit", 0, "Limit number of logs (max 200)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc performance diagnostics get --id \"SIGNATURE_ID\"",
+		ShortHelp:  "Get diagnostic logs for a signature.",
+		LongHelp: `Get diagnostic logs for a signature.
+
+Examples:
+  asc performance diagnostics get --id "SIGNATURE_ID"
+  asc performance diagnostics get --id "SIGNATURE_ID" --limit 50`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*signatureID)
+			if trimmedID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("performance diagnostics get: --limit must be between 1 and 200")
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("performance diagnostics get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetDiagnosticSignatureLogs(requestCtx, trimmedID, asc.WithDiagnosticLogsLimit(*limit))
+			if err != nil {
+				return fmt.Errorf("performance diagnostics get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// PerformanceDownloadCommand returns the download subcommand.
+func PerformanceDownloadCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("download", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	buildID := fs.String("build", "", "Build ID to download metrics for")
+	diagnosticID := fs.String("diagnostic-id", "", "Diagnostic signature ID to download logs for")
+	platform := fs.String("platform", "", "Platform filter (IOS)")
+	metricType := fs.String("metric-type", "", "Metric types (comma-separated: "+strings.Join(perfPowerMetricTypeList(), ", ")+")")
+	deviceType := fs.String("device-type", "", "Device types (comma-separated, e.g., iPhone15,2)")
+	limit := fs.Int("limit", 0, "Limit number of logs (max 200, diagnostic logs only)")
+	output := fs.String("output", "", "Output file path (default: metrics/diagnostic file name)")
+	decompress := fs.Bool("decompress", false, "Decompress gzip output (if compressed)")
+	outputFormat := fs.String("output-format", "json", "Output format for metadata: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "download",
+		ShortUsage: "asc performance download [flags]",
+		ShortHelp:  "Download metrics or diagnostic logs.",
+		LongHelp: `Download metrics or diagnostic logs.
+
+Examples:
+  asc performance download --app "APP_ID" --output ./metrics.json
+  asc performance download --build "BUILD_ID" --output ./metrics.json
+  asc performance download --diagnostic-id "SIGNATURE_ID" --output ./diagnostic.json --decompress`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			appFlag := strings.TrimSpace(*appID)
+			trimmedBuildID := strings.TrimSpace(*buildID)
+			trimmedDiagnosticID := strings.TrimSpace(*diagnosticID)
+
+			selectionCount := 0
+			if appFlag != "" {
+				selectionCount++
+			}
+			if trimmedBuildID != "" {
+				selectionCount++
+			}
+			if trimmedDiagnosticID != "" {
+				selectionCount++
+			}
+			if selectionCount == 0 {
+				appFlag = resolveAppID(*appID)
+				if appFlag == "" {
+					fmt.Fprintln(os.Stderr, "Error: --app, --build, or --diagnostic-id is required")
+					return flag.ErrHelp
+				}
+				selectionCount = 1
+			}
+			if selectionCount > 1 {
+				return fmt.Errorf("performance download: --app, --build, and --diagnostic-id are mutually exclusive")
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("performance download: --limit must be between 1 and 200")
+			}
+			if trimmedDiagnosticID != "" && (strings.TrimSpace(*platform) != "" || strings.TrimSpace(*metricType) != "" || strings.TrimSpace(*deviceType) != "") {
+				return fmt.Errorf("performance download: metric filters are not valid with --diagnostic-id")
+			}
+			if trimmedDiagnosticID == "" && *limit > 0 {
+				return fmt.Errorf("performance download: --limit is only valid with --diagnostic-id")
+			}
+
+			platforms, err := normalizePerfPowerMetricPlatforms(splitCSVUpper(*platform), "--platform")
+			if err != nil {
+				return fmt.Errorf("performance download: %w", err)
+			}
+			metricTypes, err := normalizePerfPowerMetricTypes(splitCSVUpper(*metricType))
+			if err != nil {
+				return fmt.Errorf("performance download: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("performance download: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			switch {
+			case trimmedDiagnosticID != "":
+				defaultOutput := fmt.Sprintf("diagnostic_logs_%s.json", trimmedDiagnosticID)
+				compressedPath, decompressedPath := resolveReportOutputPaths(*output, defaultOutput, ".json", *decompress)
+
+				download, err := client.DownloadDiagnosticSignatureLogs(requestCtx, trimmedDiagnosticID, asc.WithDiagnosticLogsLimit(*limit))
+				if err != nil {
+					return fmt.Errorf("performance download: %w", err)
+				}
+				defer download.Body.Close()
+
+				compressedSize, err := writeStreamToFile(compressedPath, download.Body)
+				if err != nil {
+					return fmt.Errorf("performance download: %w", err)
+				}
+
+				var decompressedSize int64
+				if *decompress {
+					decompressedSize, err = decompressGzipFile(compressedPath, decompressedPath)
+					if err != nil {
+						return fmt.Errorf("performance download: %w", err)
+					}
+				}
+
+				result := &asc.PerformanceDownloadResult{
+					DownloadType:          "diagnostic-logs",
+					DiagnosticSignatureID: trimmedDiagnosticID,
+					FilePath:              compressedPath,
+					FileSize:              compressedSize,
+					Decompressed:          *decompress,
+					DecompressedPath:      decompressedPath,
+					DecompressedSize:      decompressedSize,
+				}
+
+				return printOutput(result, *outputFormat, *pretty)
+			case trimmedBuildID != "":
+				defaultOutput := fmt.Sprintf("perf_power_metrics_%s.json", trimmedBuildID)
+				compressedPath, decompressedPath := resolveReportOutputPaths(*output, defaultOutput, ".json", *decompress)
+
+				download, err := client.DownloadPerfPowerMetricsForBuild(requestCtx, trimmedBuildID,
+					asc.WithPerfPowerMetricsPlatforms(platforms),
+					asc.WithPerfPowerMetricsMetricTypes(metricTypes),
+					asc.WithPerfPowerMetricsDeviceTypes(splitCSV(*deviceType)),
+				)
+				if err != nil {
+					return fmt.Errorf("performance download: %w", err)
+				}
+				defer download.Body.Close()
+
+				compressedSize, err := writeStreamToFile(compressedPath, download.Body)
+				if err != nil {
+					return fmt.Errorf("performance download: %w", err)
+				}
+
+				var decompressedSize int64
+				if *decompress {
+					decompressedSize, err = decompressGzipFile(compressedPath, decompressedPath)
+					if err != nil {
+						return fmt.Errorf("performance download: %w", err)
+					}
+				}
+
+				result := &asc.PerformanceDownloadResult{
+					DownloadType:     "metrics",
+					BuildID:          trimmedBuildID,
+					FilePath:         compressedPath,
+					FileSize:         compressedSize,
+					Decompressed:     *decompress,
+					DecompressedPath: decompressedPath,
+					DecompressedSize: decompressedSize,
+				}
+
+				return printOutput(result, *outputFormat, *pretty)
+			default:
+				defaultOutput := fmt.Sprintf("perf_power_metrics_%s.json", appFlag)
+				compressedPath, decompressedPath := resolveReportOutputPaths(*output, defaultOutput, ".json", *decompress)
+
+				download, err := client.DownloadPerfPowerMetricsForApp(requestCtx, appFlag,
+					asc.WithPerfPowerMetricsPlatforms(platforms),
+					asc.WithPerfPowerMetricsMetricTypes(metricTypes),
+					asc.WithPerfPowerMetricsDeviceTypes(splitCSV(*deviceType)),
+				)
+				if err != nil {
+					return fmt.Errorf("performance download: %w", err)
+				}
+				defer download.Body.Close()
+
+				compressedSize, err := writeStreamToFile(compressedPath, download.Body)
+				if err != nil {
+					return fmt.Errorf("performance download: %w", err)
+				}
+
+				var decompressedSize int64
+				if *decompress {
+					decompressedSize, err = decompressGzipFile(compressedPath, decompressedPath)
+					if err != nil {
+						return fmt.Errorf("performance download: %w", err)
+					}
+				}
+
+				result := &asc.PerformanceDownloadResult{
+					DownloadType:     "metrics",
+					AppID:            appFlag,
+					FilePath:         compressedPath,
+					FileSize:         compressedSize,
+					Decompressed:     *decompress,
+					DecompressedPath: decompressedPath,
+					DecompressedSize: decompressedSize,
+				}
+
+				return printOutput(result, *outputFormat, *pretty)
+			}
+		},
+	}
+}
+
+var perfPowerMetricTypes = map[string]struct{}{
+	string(asc.PerfPowerMetricTypeDisk):        {},
+	string(asc.PerfPowerMetricTypeHang):        {},
+	string(asc.PerfPowerMetricTypeBattery):     {},
+	string(asc.PerfPowerMetricTypeLaunch):      {},
+	string(asc.PerfPowerMetricTypeMemory):      {},
+	string(asc.PerfPowerMetricTypeAnimation):   {},
+	string(asc.PerfPowerMetricTypeTermination): {},
+}
+
+func perfPowerMetricTypeList() []string {
+	return []string{
+		string(asc.PerfPowerMetricTypeAnimation),
+		string(asc.PerfPowerMetricTypeBattery),
+		string(asc.PerfPowerMetricTypeDisk),
+		string(asc.PerfPowerMetricTypeHang),
+		string(asc.PerfPowerMetricTypeLaunch),
+		string(asc.PerfPowerMetricTypeMemory),
+		string(asc.PerfPowerMetricTypeTermination),
+	}
+}
+
+func normalizePerfPowerMetricTypes(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	for _, value := range values {
+		if _, ok := perfPowerMetricTypes[value]; !ok {
+			return nil, fmt.Errorf("--metric-type must be one of: %s", strings.Join(perfPowerMetricTypeList(), ", "))
+		}
+	}
+	return values, nil
+}
+
+var perfPowerMetricPlatforms = map[string]struct{}{
+	string(asc.PlatformIOS): {},
+}
+
+func perfPowerMetricPlatformList() []string {
+	return []string{
+		string(asc.PlatformIOS),
+	}
+}
+
+func normalizePerfPowerMetricPlatforms(values []string, flagName string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	for _, value := range values {
+		if _, ok := perfPowerMetricPlatforms[value]; !ok {
+			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(perfPowerMetricPlatformList(), ", "))
+		}
+	}
+	return values, nil
+}
+
+var diagnosticSignatureTypes = map[string]struct{}{
+	string(asc.DiagnosticSignatureTypeDiskWrites): {},
+	string(asc.DiagnosticSignatureTypeHangs):      {},
+	string(asc.DiagnosticSignatureTypeLaunches):   {},
+}
+
+func diagnosticSignatureTypeList() []string {
+	return []string{
+		string(asc.DiagnosticSignatureTypeDiskWrites),
+		string(asc.DiagnosticSignatureTypeHangs),
+		string(asc.DiagnosticSignatureTypeLaunches),
+	}
+}
+
+func normalizeDiagnosticSignatureTypes(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	for _, value := range values {
+		if _, ok := diagnosticSignatureTypes[value]; !ok {
+			return nil, fmt.Errorf("--diagnostic-type must be one of: %s", strings.Join(diagnosticSignatureTypeList(), ", "))
+		}
+	}
+	return values, nil
+}
+
+func diagnosticSignatureFieldList() []string {
+	return []string{
+		"diagnosticType",
+		"signature",
+		"weight",
+		"insight",
+		"logs",
+	}
+}
+
+func normalizeDiagnosticSignatureFields(value string) ([]string, error) {
+	fields := splitCSV(value)
+	if len(fields) == 0 {
+		return nil, nil
+	}
+
+	allowed := map[string]struct{}{}
+	for _, field := range diagnosticSignatureFieldList() {
+		allowed[field] = struct{}{}
+	}
+	for _, field := range fields {
+		if _, ok := allowed[field]; !ok {
+			return nil, fmt.Errorf("--fields must be one of: %s", strings.Join(diagnosticSignatureFieldList(), ", "))
+		}
+	}
+
+	return fields, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ func RootCommand(version string) *ffcli.Command {
 			ReviewsCommand(),
 			ReviewCommand(),
 			AnalyticsCommand(),
+			PerformanceCommand(),
 			FinanceCommand(),
 			AppsCommand(),
 			AppSetupCommand(),

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -104,6 +104,15 @@ type AppInfoLocalizationsOption func(*appInfoLocalizationsQuery)
 // TerritoriesOption is a functional option for GetTerritories.
 type TerritoriesOption func(*territoriesQuery)
 
+// PerfPowerMetricsOption is a functional option for performance/power metrics.
+type PerfPowerMetricsOption func(*perfPowerMetricsQuery)
+
+// DiagnosticSignaturesOption is a functional option for diagnostic signatures.
+type DiagnosticSignaturesOption func(*diagnosticSignaturesQuery)
+
+// DiagnosticLogsOption is a functional option for diagnostic logs.
+type DiagnosticLogsOption func(*diagnosticLogsQuery)
+
 // TerritoryAvailabilitiesOption is a functional option for GetTerritoryAvailabilities.
 type TerritoryAvailabilitiesOption func(*territoryAvailabilitiesQuery)
 
@@ -1446,6 +1455,68 @@ func WithTerritoriesNextURL(next string) TerritoriesOption {
 func WithTerritoriesFields(fields []string) TerritoriesOption {
 	return func(q *territoriesQuery) {
 		q.fields = normalizeList(fields)
+	}
+}
+
+// WithPerfPowerMetricsPlatforms filters metrics by platform(s).
+func WithPerfPowerMetricsPlatforms(platforms []string) PerfPowerMetricsOption {
+	return func(q *perfPowerMetricsQuery) {
+		q.platforms = normalizeUpperList(platforms)
+	}
+}
+
+// WithPerfPowerMetricsMetricTypes filters metrics by metric type(s).
+func WithPerfPowerMetricsMetricTypes(types []string) PerfPowerMetricsOption {
+	return func(q *perfPowerMetricsQuery) {
+		q.metricTypes = normalizeUpperList(types)
+	}
+}
+
+// WithPerfPowerMetricsDeviceTypes filters metrics by device type(s).
+func WithPerfPowerMetricsDeviceTypes(types []string) PerfPowerMetricsOption {
+	return func(q *perfPowerMetricsQuery) {
+		q.deviceTypes = normalizeList(types)
+	}
+}
+
+// WithDiagnosticSignaturesLimit sets the max number of diagnostic signatures to return.
+func WithDiagnosticSignaturesLimit(limit int) DiagnosticSignaturesOption {
+	return func(q *diagnosticSignaturesQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithDiagnosticSignaturesNextURL uses a next page URL directly.
+func WithDiagnosticSignaturesNextURL(next string) DiagnosticSignaturesOption {
+	return func(q *diagnosticSignaturesQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+// WithDiagnosticSignaturesDiagnosticTypes filters diagnostic signatures by type.
+func WithDiagnosticSignaturesDiagnosticTypes(types []string) DiagnosticSignaturesOption {
+	return func(q *diagnosticSignaturesQuery) {
+		q.diagnosticTypes = normalizeUpperList(types)
+	}
+}
+
+// WithDiagnosticSignaturesFields sets fields[diagnosticSignatures] for diagnostic signatures.
+func WithDiagnosticSignaturesFields(fields []string) DiagnosticSignaturesOption {
+	return func(q *diagnosticSignaturesQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
+// WithDiagnosticLogsLimit sets the max number of diagnostic logs to return.
+func WithDiagnosticLogsLimit(limit int) DiagnosticLogsOption {
+	return func(q *diagnosticLogsQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
 	}
 }
 

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -72,6 +72,8 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &InAppPurchasesV2Response{Links: Links{}}
 	case *TerritoriesResponse:
 		result = &TerritoriesResponse{Links: Links{}}
+	case *DiagnosticSignaturesResponse:
+		result = &DiagnosticSignaturesResponse{Links: Links{}}
 	case *TerritoryAvailabilitiesResponse:
 		result = &TerritoryAvailabilitiesResponse{Links: Links{}}
 	case *AppPricePointsV3Response:
@@ -247,6 +249,8 @@ func typeOf(p PaginatedResponse) string {
 		return "InAppPurchasesV2Response"
 	case *TerritoriesResponse:
 		return "TerritoriesResponse"
+	case *DiagnosticSignaturesResponse:
+		return "DiagnosticSignaturesResponse"
 	case *TerritoryAvailabilitiesResponse:
 		return "TerritoryAvailabilitiesResponse"
 	case *AppPricePointsV3Response:

--- a/internal/asc/client_performance.go
+++ b/internal/asc/client_performance.go
@@ -1,0 +1,206 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	perfPowerMetricsAcceptHeader = "application/vnd.apple.xcode-metrics+json"
+	diagnosticLogsAcceptHeader   = "application/vnd.apple.diagnostic-logs+json"
+)
+
+// GetPerfPowerMetricsForApp retrieves performance/power metrics for an app.
+func (c *Client) GetPerfPowerMetricsForApp(ctx context.Context, appID string, opts ...PerfPowerMetricsOption) (*PerfPowerMetricsResponse, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, fmt.Errorf("app ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/apps/%s/perfPowerMetrics", appID)
+	query := &perfPowerMetricsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+	if queryString := buildPerfPowerMetricsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	return c.fetchPerfPowerMetrics(ctx, path)
+}
+
+// GetPerfPowerMetricsForBuild retrieves performance/power metrics for a build.
+func (c *Client) GetPerfPowerMetricsForBuild(ctx context.Context, buildID string, opts ...PerfPowerMetricsOption) (*PerfPowerMetricsResponse, error) {
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("build ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s/perfPowerMetrics", buildID)
+	query := &perfPowerMetricsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+	if queryString := buildPerfPowerMetricsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	return c.fetchPerfPowerMetrics(ctx, path)
+}
+
+// DownloadPerfPowerMetricsForApp streams performance/power metrics for an app.
+func (c *Client) DownloadPerfPowerMetricsForApp(ctx context.Context, appID string, opts ...PerfPowerMetricsOption) (*ReportDownload, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, fmt.Errorf("app ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/apps/%s/perfPowerMetrics", appID)
+	query := &perfPowerMetricsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+	if queryString := buildPerfPowerMetricsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	resp, err := c.doStream(ctx, "GET", path, nil, perfPowerMetricsAcceptHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReportDownload{Body: resp.Body, ContentLength: resp.ContentLength}, nil
+}
+
+// DownloadPerfPowerMetricsForBuild streams performance/power metrics for a build.
+func (c *Client) DownloadPerfPowerMetricsForBuild(ctx context.Context, buildID string, opts ...PerfPowerMetricsOption) (*ReportDownload, error) {
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("build ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s/perfPowerMetrics", buildID)
+	query := &perfPowerMetricsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+	if queryString := buildPerfPowerMetricsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	resp, err := c.doStream(ctx, "GET", path, nil, perfPowerMetricsAcceptHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReportDownload{Body: resp.Body, ContentLength: resp.ContentLength}, nil
+}
+
+func (c *Client) fetchPerfPowerMetrics(ctx context.Context, path string) (*PerfPowerMetricsResponse, error) {
+	resp, err := c.doStream(ctx, "GET", path, nil, perfPowerMetricsAcceptHeader)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read perf power metrics: %w", err)
+	}
+
+	return &PerfPowerMetricsResponse{Data: data}, nil
+}
+
+// GetDiagnosticSignaturesForBuild retrieves diagnostic signatures for a build.
+func (c *Client) GetDiagnosticSignaturesForBuild(ctx context.Context, buildID string, opts ...DiagnosticSignaturesOption) (*DiagnosticSignaturesResponse, error) {
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("build ID is required")
+	}
+
+	query := &diagnosticSignaturesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s/diagnosticSignatures", buildID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("diagnosticSignatures: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildDiagnosticSignaturesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DiagnosticSignaturesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse diagnostic signatures response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetDiagnosticSignatureLogs retrieves diagnostic logs for a signature.
+func (c *Client) GetDiagnosticSignatureLogs(ctx context.Context, signatureID string, opts ...DiagnosticLogsOption) (*DiagnosticLogsResponse, error) {
+	signatureID = strings.TrimSpace(signatureID)
+	if signatureID == "" {
+		return nil, fmt.Errorf("diagnostic signature ID is required")
+	}
+
+	query := &diagnosticLogsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	path := fmt.Sprintf("/v1/diagnosticSignatures/%s/logs", signatureID)
+	if queryString := buildDiagnosticLogsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	resp, err := c.doStream(ctx, "GET", path, nil, diagnosticLogsAcceptHeader)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read diagnostic logs: %w", err)
+	}
+
+	return &DiagnosticLogsResponse{Data: data}, nil
+}
+
+// DownloadDiagnosticSignatureLogs streams diagnostic logs for a signature.
+func (c *Client) DownloadDiagnosticSignatureLogs(ctx context.Context, signatureID string, opts ...DiagnosticLogsOption) (*ReportDownload, error) {
+	signatureID = strings.TrimSpace(signatureID)
+	if signatureID == "" {
+		return nil, fmt.Errorf("diagnostic signature ID is required")
+	}
+
+	query := &diagnosticLogsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	path := fmt.Sprintf("/v1/diagnosticSignatures/%s/logs", signatureID)
+	if queryString := buildDiagnosticLogsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	resp, err := c.doStream(ctx, "GET", path, nil, diagnosticLogsAcceptHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReportDownload{Body: resp.Body, ContentLength: resp.ContentLength}, nil
+}

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -200,6 +200,22 @@ type territoriesQuery struct {
 	fields []string
 }
 
+type perfPowerMetricsQuery struct {
+	platforms   []string
+	metricTypes []string
+	deviceTypes []string
+}
+
+type diagnosticSignaturesQuery struct {
+	listQuery
+	diagnosticTypes []string
+	fields          []string
+}
+
+type diagnosticLogsQuery struct {
+	listQuery
+}
+
 type territoryAvailabilitiesQuery struct {
 	listQuery
 }
@@ -655,6 +671,28 @@ func buildAppInfoLocalizationsQuery(query *appInfoLocalizationsQuery) string {
 func buildTerritoriesQuery(query *territoriesQuery) string {
 	values := url.Values{}
 	addCSV(values, "fields[territories]", query.fields)
+	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildPerfPowerMetricsQuery(query *perfPowerMetricsQuery) string {
+	values := url.Values{}
+	addCSV(values, "filter[platform]", query.platforms)
+	addCSV(values, "filter[metricType]", query.metricTypes)
+	addCSV(values, "filter[deviceType]", query.deviceTypes)
+	return values.Encode()
+}
+
+func buildDiagnosticSignaturesQuery(query *diagnosticSignaturesQuery) string {
+	values := url.Values{}
+	addCSV(values, "filter[diagnosticType]", query.diagnosticTypes)
+	addCSV(values, "fields[diagnosticSignatures]", query.fields)
+	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildDiagnosticLogsQuery(query *diagnosticLogsQuery) string {
+	values := url.Values{}
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -955,6 +955,59 @@ func TestBuildSubscriptionOfferCodeOneTimeUseCodesQuery(t *testing.T) {
 	}
 }
 
+func TestBuildPerfPowerMetricsQuery(t *testing.T) {
+	query := &perfPowerMetricsQuery{
+		platforms:   []string{"IOS"},
+		metricTypes: []string{"DISK", "HANG"},
+		deviceTypes: []string{"iPhone15,2"},
+	}
+	values, err := url.ParseQuery(buildPerfPowerMetricsQuery(query))
+	if err != nil {
+		t.Fatalf("ParseQuery() error: %v", err)
+	}
+	if values.Get("filter[platform]") != "IOS" {
+		t.Fatalf("expected platform filter, got %q", values.Get("filter[platform]"))
+	}
+	if values.Get("filter[metricType]") != "DISK,HANG" {
+		t.Fatalf("expected metricType filter, got %q", values.Get("filter[metricType]"))
+	}
+	if values.Get("filter[deviceType]") != "iPhone15,2" {
+		t.Fatalf("expected deviceType filter, got %q", values.Get("filter[deviceType]"))
+	}
+}
+
+func TestBuildDiagnosticSignaturesQuery(t *testing.T) {
+	query := &diagnosticSignaturesQuery{
+		listQuery:       listQuery{limit: 25},
+		diagnosticTypes: []string{"HANGS"},
+		fields:          []string{"diagnosticType", "signature"},
+	}
+	values, err := url.ParseQuery(buildDiagnosticSignaturesQuery(query))
+	if err != nil {
+		t.Fatalf("ParseQuery() error: %v", err)
+	}
+	if values.Get("filter[diagnosticType]") != "HANGS" {
+		t.Fatalf("expected diagnosticType filter, got %q", values.Get("filter[diagnosticType]"))
+	}
+	if values.Get("fields[diagnosticSignatures]") != "diagnosticType,signature" {
+		t.Fatalf("expected fields, got %q", values.Get("fields[diagnosticSignatures]"))
+	}
+	if values.Get("limit") != "25" {
+		t.Fatalf("expected limit=25, got %q", values.Get("limit"))
+	}
+}
+
+func TestBuildDiagnosticLogsQuery(t *testing.T) {
+	query := &diagnosticLogsQuery{listQuery: listQuery{limit: 50}}
+	values, err := url.ParseQuery(buildDiagnosticLogsQuery(query))
+	if err != nil {
+		t.Fatalf("ParseQuery() error: %v", err)
+	}
+	if values.Get("limit") != "50" {
+		t.Fatalf("expected limit=50, got %q", values.Get("limit"))
+	}
+}
+
 func TestBuildUploadCreateRequest_JSON(t *testing.T) {
 	req := BuildUploadCreateRequest{
 		Data: BuildUploadCreateData{

--- a/internal/asc/client_types.go
+++ b/internal/asc/client_types.go
@@ -57,6 +57,7 @@ const (
 	ResourceTypeAppInfos                             ResourceType = "appInfos"
 	ResourceTypeAgeRatingDeclarations                ResourceType = "ageRatingDeclarations"
 	ResourceTypeAccessibilityDeclarations            ResourceType = "accessibilityDeclarations"
+	ResourceTypeDiagnosticSignatures                 ResourceType = "diagnosticSignatures"
 	ResourceTypeAnalyticsReportRequests              ResourceType = "analyticsReportRequests"
 	ResourceTypeAnalyticsReports                     ResourceType = "analyticsReports"
 	ResourceTypeAnalyticsReportInstances             ResourceType = "analyticsReportInstances"

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -377,6 +377,14 @@ func PrintMarkdown(data interface{}) error {
 		return printNominationDeleteResultMarkdown(v)
 	case *AppEncryptionDeclarationBuildsUpdateResult:
 		return printAppEncryptionDeclarationBuildsUpdateResultMarkdown(v)
+	case *PerfPowerMetricsResponse:
+		return printPerfPowerMetricsMarkdown(v)
+	case *DiagnosticSignaturesResponse:
+		return printDiagnosticSignaturesMarkdown(v)
+	case *DiagnosticLogsResponse:
+		return printDiagnosticLogsMarkdown(v)
+	case *PerformanceDownloadResult:
+		return printPerformanceDownloadResultMarkdown(v)
 	default:
 		return PrintJSON(data)
 	}
@@ -741,6 +749,14 @@ func PrintTable(data interface{}) error {
 		return printNominationDeleteResultTable(v)
 	case *AppEncryptionDeclarationBuildsUpdateResult:
 		return printAppEncryptionDeclarationBuildsUpdateResultTable(v)
+	case *PerfPowerMetricsResponse:
+		return printPerfPowerMetricsTable(v)
+	case *DiagnosticSignaturesResponse:
+		return printDiagnosticSignaturesTable(v)
+	case *DiagnosticLogsResponse:
+		return printDiagnosticLogsTable(v)
+	case *PerformanceDownloadResult:
+		return printPerformanceDownloadResultTable(v)
 	default:
 		return PrintJSON(data)
 	}

--- a/internal/asc/output_performance.go
+++ b/internal/asc/output_performance.go
@@ -1,0 +1,235 @@
+package asc
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+// PerformanceDownloadResult represents CLI output for performance downloads.
+type PerformanceDownloadResult struct {
+	DownloadType          string `json:"downloadType"`
+	AppID                 string `json:"appId,omitempty"`
+	BuildID               string `json:"buildId,omitempty"`
+	DiagnosticSignatureID string `json:"diagnosticSignatureId,omitempty"`
+	FilePath              string `json:"filePath"`
+	FileSize              int64  `json:"fileSize"`
+	Decompressed          bool   `json:"decompressed"`
+	DecompressedPath      string `json:"decompressedPath,omitempty"`
+	DecompressedSize      int64  `json:"decompressedSize,omitempty"`
+}
+
+type perfPowerMetricsSummary struct {
+	Version         string
+	ProductCount    int
+	TrendingUpCount int
+	RegressionCount int
+}
+
+type diagnosticLogsSummary struct {
+	Version      string
+	ProductCount int
+	LogCount     int
+	InsightCount int
+}
+
+func summarizePerfPowerMetrics(resp *PerfPowerMetricsResponse) (perfPowerMetricsSummary, error) {
+	if resp == nil {
+		return perfPowerMetricsSummary{}, fmt.Errorf("perf power metrics response is nil")
+	}
+	if len(resp.Data) == 0 {
+		return perfPowerMetricsSummary{}, fmt.Errorf("perf power metrics response is empty")
+	}
+
+	var payload struct {
+		Version  string `json:"version"`
+		Insights struct {
+			TrendingUp  []json.RawMessage `json:"trendingUp"`
+			Regressions []json.RawMessage `json:"regressions"`
+		} `json:"insights"`
+		ProductData []json.RawMessage `json:"productData"`
+	}
+	if err := json.Unmarshal(resp.Data, &payload); err != nil {
+		return perfPowerMetricsSummary{}, fmt.Errorf("decode perf power metrics: %w", err)
+	}
+
+	return perfPowerMetricsSummary{
+		Version:         payload.Version,
+		ProductCount:    len(payload.ProductData),
+		TrendingUpCount: len(payload.Insights.TrendingUp),
+		RegressionCount: len(payload.Insights.Regressions),
+	}, nil
+}
+
+func summarizeDiagnosticLogs(resp *DiagnosticLogsResponse) (diagnosticLogsSummary, error) {
+	if resp == nil {
+		return diagnosticLogsSummary{}, fmt.Errorf("diagnostic logs response is nil")
+	}
+	if len(resp.Data) == 0 {
+		return diagnosticLogsSummary{}, fmt.Errorf("diagnostic logs response is empty")
+	}
+
+	var payload struct {
+		Version     string `json:"version"`
+		ProductData []struct {
+			DiagnosticLogs     []json.RawMessage `json:"diagnosticLogs"`
+			DiagnosticInsights []json.RawMessage `json:"diagnosticInsights"`
+		} `json:"productData"`
+	}
+	if err := json.Unmarshal(resp.Data, &payload); err != nil {
+		return diagnosticLogsSummary{}, fmt.Errorf("decode diagnostic logs: %w", err)
+	}
+
+	logCount := 0
+	insightCount := 0
+	for _, item := range payload.ProductData {
+		logCount += len(item.DiagnosticLogs)
+		insightCount += len(item.DiagnosticInsights)
+	}
+
+	return diagnosticLogsSummary{
+		Version:      payload.Version,
+		ProductCount: len(payload.ProductData),
+		LogCount:     logCount,
+		InsightCount: insightCount,
+	}, nil
+}
+
+func printPerfPowerMetricsTable(resp *PerfPowerMetricsResponse) error {
+	summary, err := summarizePerfPowerMetrics(resp)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Version\tProducts\tTrending Up\tRegressions")
+	fmt.Fprintf(w, "%s\t%d\t%d\t%d\n",
+		summary.Version,
+		summary.ProductCount,
+		summary.TrendingUpCount,
+		summary.RegressionCount,
+	)
+	return w.Flush()
+}
+
+func printPerfPowerMetricsMarkdown(resp *PerfPowerMetricsResponse) error {
+	summary, err := summarizePerfPowerMetrics(resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stdout, "| Version | Products | Trending Up | Regressions |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %d | %d | %d |\n",
+		escapeMarkdown(summary.Version),
+		summary.ProductCount,
+		summary.TrendingUpCount,
+		summary.RegressionCount,
+	)
+	return nil
+}
+
+func printDiagnosticSignaturesTable(resp *DiagnosticSignaturesResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tType\tWeight\tInsight\tSignature")
+	for _, item := range resp.Data {
+		insight := ""
+		if item.Attributes.Insight != nil {
+			insight = string(item.Attributes.Insight.Direction)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%.2f\t%s\t%s\n",
+			item.ID,
+			item.Attributes.DiagnosticType,
+			item.Attributes.Weight,
+			insight,
+			item.Attributes.Signature,
+		)
+	}
+	return w.Flush()
+}
+
+func printDiagnosticSignaturesMarkdown(resp *DiagnosticSignaturesResponse) error {
+	fmt.Fprintln(os.Stdout, "| ID | Type | Weight | Insight | Signature |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
+	for _, item := range resp.Data {
+		insight := ""
+		if item.Attributes.Insight != nil {
+			insight = string(item.Attributes.Insight.Direction)
+		}
+		fmt.Fprintf(os.Stdout, "| %s | %s | %.2f | %s | %s |\n",
+			escapeMarkdown(item.ID),
+			escapeMarkdown(string(item.Attributes.DiagnosticType)),
+			item.Attributes.Weight,
+			escapeMarkdown(insight),
+			escapeMarkdown(item.Attributes.Signature),
+		)
+	}
+	return nil
+}
+
+func printDiagnosticLogsTable(resp *DiagnosticLogsResponse) error {
+	summary, err := summarizeDiagnosticLogs(resp)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Version\tProducts\tLogs\tInsights")
+	fmt.Fprintf(w, "%s\t%d\t%d\t%d\n",
+		summary.Version,
+		summary.ProductCount,
+		summary.LogCount,
+		summary.InsightCount,
+	)
+	return w.Flush()
+}
+
+func printDiagnosticLogsMarkdown(resp *DiagnosticLogsResponse) error {
+	summary, err := summarizeDiagnosticLogs(resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stdout, "| Version | Products | Logs | Insights |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %d | %d | %d |\n",
+		escapeMarkdown(summary.Version),
+		summary.ProductCount,
+		summary.LogCount,
+		summary.InsightCount,
+	)
+	return nil
+}
+
+func printPerformanceDownloadResultTable(result *PerformanceDownloadResult) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Type\tApp ID\tBuild ID\tDiagnostic ID\tCompressed File\tCompressed Size\tDecompressed File\tDecompressed Size")
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%d\n",
+		result.DownloadType,
+		result.AppID,
+		result.BuildID,
+		result.DiagnosticSignatureID,
+		result.FilePath,
+		result.FileSize,
+		result.DecompressedPath,
+		result.DecompressedSize,
+	)
+	return w.Flush()
+}
+
+func printPerformanceDownloadResultMarkdown(result *PerformanceDownloadResult) error {
+	fmt.Fprintln(os.Stdout, "| Type | App ID | Build ID | Diagnostic ID | Compressed File | Compressed Size | Decompressed File | Decompressed Size |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
+	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %d | %s | %d |\n",
+		escapeMarkdown(result.DownloadType),
+		escapeMarkdown(result.AppID),
+		escapeMarkdown(result.BuildID),
+		escapeMarkdown(result.DiagnosticSignatureID),
+		escapeMarkdown(result.FilePath),
+		result.FileSize,
+		escapeMarkdown(result.DecompressedPath),
+		result.DecompressedSize,
+	)
+	return nil
+}

--- a/internal/asc/performance.go
+++ b/internal/asc/performance.go
@@ -1,0 +1,91 @@
+package asc
+
+import "encoding/json"
+
+// PerfPowerMetricType represents a performance/power metric category.
+type PerfPowerMetricType string
+
+const (
+	PerfPowerMetricTypeDisk        PerfPowerMetricType = "DISK"
+	PerfPowerMetricTypeHang        PerfPowerMetricType = "HANG"
+	PerfPowerMetricTypeBattery     PerfPowerMetricType = "BATTERY"
+	PerfPowerMetricTypeLaunch      PerfPowerMetricType = "LAUNCH"
+	PerfPowerMetricTypeMemory      PerfPowerMetricType = "MEMORY"
+	PerfPowerMetricTypeAnimation   PerfPowerMetricType = "ANIMATION"
+	PerfPowerMetricTypeTermination PerfPowerMetricType = "TERMINATION"
+)
+
+// DiagnosticSignatureType represents a diagnostic signature category.
+type DiagnosticSignatureType string
+
+const (
+	DiagnosticSignatureTypeDiskWrites DiagnosticSignatureType = "DISK_WRITES"
+	DiagnosticSignatureTypeHangs      DiagnosticSignatureType = "HANGS"
+	DiagnosticSignatureTypeLaunches   DiagnosticSignatureType = "LAUNCHES"
+)
+
+// DiagnosticInsightDirection describes diagnostic insight direction.
+type DiagnosticInsightDirection string
+
+const (
+	DiagnosticInsightDirectionUp        DiagnosticInsightDirection = "UP"
+	DiagnosticInsightDirectionDown      DiagnosticInsightDirection = "DOWN"
+	DiagnosticInsightDirectionUndefined DiagnosticInsightDirection = "UNDEFINED"
+)
+
+// DiagnosticInsightType describes the insight category.
+type DiagnosticInsightType string
+
+const (
+	DiagnosticInsightTypeTrend DiagnosticInsightType = "TREND"
+)
+
+// DiagnosticInsightReferenceVersion describes a reference version for insight.
+type DiagnosticInsightReferenceVersion struct {
+	Version string  `json:"version,omitempty"`
+	Value   float64 `json:"value,omitempty"`
+}
+
+// DiagnosticInsight describes insight details for diagnostic signatures.
+type DiagnosticInsight struct {
+	InsightType       DiagnosticInsightType               `json:"insightType,omitempty"`
+	Direction         DiagnosticInsightDirection          `json:"direction,omitempty"`
+	ReferenceVersions []DiagnosticInsightReferenceVersion `json:"referenceVersions,omitempty"`
+}
+
+// DiagnosticSignatureAttributes describes diagnostic signature metadata.
+type DiagnosticSignatureAttributes struct {
+	DiagnosticType DiagnosticSignatureType `json:"diagnosticType,omitempty"`
+	Signature      string                  `json:"signature,omitempty"`
+	Weight         float64                 `json:"weight,omitempty"`
+	Insight        *DiagnosticInsight      `json:"insight,omitempty"`
+}
+
+// DiagnosticSignaturesResponse is the response from diagnostic signatures endpoints.
+type DiagnosticSignaturesResponse = Response[DiagnosticSignatureAttributes]
+
+// PerfPowerMetricsResponse wraps raw Xcode metrics JSON.
+type PerfPowerMetricsResponse struct {
+	Data json.RawMessage `json:"-"`
+}
+
+// MarshalJSON preserves raw API JSON for metrics responses.
+func (r PerfPowerMetricsResponse) MarshalJSON() ([]byte, error) {
+	if len(r.Data) == 0 {
+		return []byte("null"), nil
+	}
+	return r.Data, nil
+}
+
+// DiagnosticLogsResponse wraps raw diagnostic logs JSON.
+type DiagnosticLogsResponse struct {
+	Data json.RawMessage `json:"-"`
+}
+
+// MarshalJSON preserves raw API JSON for diagnostic logs responses.
+func (r DiagnosticLogsResponse) MarshalJSON() ([]byte, error) {
+	if len(r.Data) == 0 {
+		return []byte("null"), nil
+	}
+	return r.Data, nil
+}


### PR DESCRIPTION
## Summary
- add `asc performance` command group with metrics, diagnostics, and download subcommands
- add ASC client support for perf power metrics and diagnostic signatures/logs
- add output summaries plus tests for queries, HTTP requests, outputs, and validation

## Test plan
- [x] make build
- [x] make test
- [x] make lint
- [x] ASC_BYPASS_KEYCHAIN=1 go run . performance metrics list --app "1500196580"
- [x] ASC_BYPASS_KEYCHAIN=1 go run . performance metrics get --build "9c065f3d-f897-43a0-82da-f04b1c057173"
- [x] ASC_BYPASS_KEYCHAIN=1 go run . performance diagnostics list --build "9c065f3d-f897-43a0-82da-f04b1c057173" --limit 10 --output json
- [ ] ASC_BYPASS_KEYCHAIN=1 go run . performance diagnostics get --id "DIAGNOSTIC_ID" --limit 1 (no signatures available)

Fixes #157