### PR TITLE
Fix performance pretty output and downloads

### DIFF
--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -1,7 +1,9 @@
 package asc
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -13,9 +15,31 @@ func PrintJSON(data interface{}) error {
 
 // PrintPrettyJSON prints data as indented JSON (best for debugging).
 func PrintPrettyJSON(data interface{}) error {
+	switch v := data.(type) {
+	case *PerfPowerMetricsResponse:
+		return printPrettyRawJSON(v.Data)
+	case *DiagnosticLogsResponse:
+		return printPrettyRawJSON(v.Data)
+	}
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(data)
+}
+
+func printPrettyRawJSON(data json.RawMessage) error {
+	if len(data) == 0 {
+		_, err := os.Stdout.Write([]byte("null\n"))
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, data, "", "  "); err != nil {
+		return fmt.Errorf("pretty-print json: %w", err)
+	}
+	buf.WriteByte('\n')
+	_, err := os.Stdout.Write(buf.Bytes())
+	return err
 }
 
 // PrintMarkdown prints data as Markdown table


### PR DESCRIPTION
## Summary
- pretty-print raw performance metrics and diagnostic logs JSON when using `--pretty`
- skip gzip decompression when downloads are not gzip, so `--decompress` doesn’t error
- keep download output paths consistent with actual compression

## Test plan
- [x] make test