### PR TITLE
Align sandbox create/delete with OpenAPI v2

### DIFF
--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -24,7 +24,9 @@ Examples:
   asc sandbox get --id "SANDBOX_TESTER_ID"
   asc sandbox update --id "SANDBOX_TESTER_ID" --territory "USA"
   asc sandbox clear-history --id "SANDBOX_TESTER_ID" --confirm
-  asc sandbox delete --email "tester@example.com" --confirm`,
+  asc sandbox delete --email "tester@example.com" --confirm
+
+Note: The OpenAPI v2 snapshot does not include sandbox tester create/delete endpoints. These commands currently return errors until the API supports v2 create/delete.`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{

--- a/cmd/sandbox_create.go
+++ b/cmd/sandbox_create.go
@@ -39,7 +39,9 @@ func SandboxCreateCommand() *ffcli.Command {
 
 Examples:
   asc sandbox create --email "tester@example.com" --first-name "Test" --last-name "User" --password "Passwordtest1" --confirm-password "Passwordtest1" --secret-question "Question" --secret-answer "Answer" --birth-date "1980-03-01" --territory "USA"
-  echo "Passwordtest1" | asc sandbox create --email "tester@example.com" --first-name "Test" --last-name "User" --password-stdin --secret-question "Question" --secret-answer "Answer" --birth-date "1980-03-01" --territory "USA"`,
+  echo "Passwordtest1" | asc sandbox create --email "tester@example.com" --first-name "Test" --last-name "User" --password-stdin --secret-question "Question" --secret-answer "Answer" --birth-date "1980-03-01" --territory "USA"
+
+Note: The OpenAPI v2 snapshot does not include a sandbox tester create endpoint. This command returns an error until the API supports v2 create.`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/cmd/sandbox_manage.go
+++ b/cmd/sandbox_manage.go
@@ -84,7 +84,9 @@ func SandboxDeleteCommand() *ffcli.Command {
 
 Examples:
   asc sandbox delete --id "SANDBOX_TESTER_ID" --confirm
-  asc sandbox delete --email "tester@example.com" --confirm`,
+  asc sandbox delete --email "tester@example.com" --confirm
+
+Note: The OpenAPI v2 snapshot does not include a sandbox tester delete endpoint. This command returns an error until the API supports v2 delete.`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/asc/sandbox.go
+++ b/internal/asc/sandbox.go
@@ -280,28 +280,7 @@ func (c *Client) UpdateSandboxTester(ctx context.Context, testerID string, attri
 
 // CreateSandboxTester creates a sandbox tester.
 func (c *Client) CreateSandboxTester(ctx context.Context, attributes SandboxTesterCreateAttributes) (*SandboxTesterResponse, error) {
-	payload := SandboxTesterCreateRequest{
-		Data: SandboxTesterCreateData{
-			Type:       ResourceTypeSandboxTesters,
-			Attributes: attributes,
-		},
-	}
-	body, err := BuildRequestBody(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := c.do(ctx, "POST", "/v1/sandboxTesters", body)
-	if err != nil {
-		return nil, err
-	}
-
-	var response SandboxTesterResponse
-	if err := json.Unmarshal(data, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse sandbox tester response: %w", err)
-	}
-
-	return &response, nil
+	return nil, fmt.Errorf("sandbox tester create is not supported by OpenAPI v2")
 }
 
 // ClearSandboxTesterPurchaseHistory clears purchase history for a sandbox tester.
@@ -338,7 +317,5 @@ func (c *Client) ClearSandboxTesterPurchaseHistory(ctx context.Context, testerID
 
 // DeleteSandboxTester deletes a sandbox tester by ID.
 func (c *Client) DeleteSandboxTester(ctx context.Context, testerID string) error {
-	path := fmt.Sprintf("/v1/sandboxTesters/%s", testerID)
-	_, err := c.do(ctx, "DELETE", path, nil)
-	return err
+	return fmt.Errorf("sandbox tester delete is not supported by OpenAPI v2")
 }

--- a/internal/asc/sandbox_test.go
+++ b/internal/asc/sandbox_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -148,57 +149,17 @@ func TestUpdateSandboxTester_SendsRequest(t *testing.T) {
 	}
 }
 
-func TestCreateSandboxTester_SendsRequest(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"sandboxTesters","id":"tester-1","attributes":{"email":"tester@example.com","firstName":"Test","lastName":"User","appStoreTerritory":"USA"}}}`)
+func TestCreateSandboxTester_NotSupported(t *testing.T) {
 	client := newTestClient(t, func(req *http.Request) {
-		if req.Method != http.MethodPost {
-			t.Fatalf("expected POST, got %s", req.Method)
-		}
-		if req.URL.Path != "/v1/sandboxTesters" {
-			t.Fatalf("expected path /v1/sandboxTesters, got %s", req.URL.Path)
-		}
+		t.Fatalf("unexpected request to %s %s", req.Method, req.URL.Path)
+	}, jsonResponse(http.StatusOK, `{}`))
 
-		var body map[string]map[string]any
-		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-		data, ok := body["data"]
-		if !ok {
-			t.Fatalf("expected data in request body")
-		}
-		if data["type"] != "sandboxTesters" {
-			t.Fatalf("expected type sandboxTesters, got %v", data["type"])
-		}
-
-		attributes, ok := data["attributes"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected attributes in request body")
-		}
-		if attributes["email"] != "tester@example.com" {
-			t.Fatalf("expected email tester@example.com, got %v", attributes["email"])
-		}
-		if attributes["firstName"] != "Test" || attributes["lastName"] != "User" {
-			t.Fatalf("expected name Test User, got %v %v", attributes["firstName"], attributes["lastName"])
-		}
-		if attributes["appStoreTerritory"] != "USA" {
-			t.Fatalf("expected appStoreTerritory USA, got %v", attributes["appStoreTerritory"])
-		}
-		assertAuthorized(t, req)
-	}, response)
-
-	attrs := SandboxTesterCreateAttributes{
-		FirstName:         "Test",
-		LastName:          "User",
-		Email:             "tester@example.com",
-		Password:          "Passwordtest1",
-		ConfirmPassword:   "Passwordtest1",
-		SecretQuestion:    "Question",
-		SecretAnswer:      "Answer",
-		BirthDate:         "1980-03-01",
-		AppStoreTerritory: "USA",
+	_, err := client.CreateSandboxTester(context.Background(), SandboxTesterCreateAttributes{})
+	if err == nil {
+		t.Fatal("expected CreateSandboxTester to return error")
 	}
-	if _, err := client.CreateSandboxTester(context.Background(), attrs); err != nil {
-		t.Fatalf("CreateSandboxTester() error: %v", err)
+	if !strings.Contains(err.Error(), "not supported by OpenAPI v2") {
+		t.Fatalf("expected OpenAPI v2 unsupported error, got %v", err)
 	}
 }
 
@@ -250,19 +211,14 @@ func TestClearSandboxTesterPurchaseHistory(t *testing.T) {
 	}
 }
 
-func TestDeleteSandboxTester(t *testing.T) {
-	response := jsonResponse(http.StatusNoContent, "")
+func TestDeleteSandboxTester_NotSupported(t *testing.T) {
 	client := newTestClient(t, func(req *http.Request) {
-		if req.Method != http.MethodDelete {
-			t.Fatalf("expected DELETE, got %s", req.Method)
-		}
-		if req.URL.Path != "/v1/sandboxTesters/tester-1" {
-			t.Fatalf("expected path /v1/sandboxTesters/tester-1, got %s", req.URL.Path)
-		}
-		assertAuthorized(t, req)
-	}, response)
+		t.Fatalf("unexpected request to %s %s", req.Method, req.URL.Path)
+	}, jsonResponse(http.StatusOK, `{}`))
 
-	if err := client.DeleteSandboxTester(context.Background(), "tester-1"); err != nil {
-		t.Fatalf("DeleteSandboxTester() error: %v", err)
+	if err := client.DeleteSandboxTester(context.Background(), "tester-1"); err == nil {
+		t.Fatal("expected DeleteSandboxTester to return error")
+	} else if !strings.Contains(err.Error(), "not supported by OpenAPI v2") {
+		t.Fatalf("expected OpenAPI v2 unsupported error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Return a clear unsupported error for sandbox tester create/delete and update CLI help + tests to match the OpenAPI v2 surface.

## Research / Probe
- GET /v2/sandboxTesters?limit=1 -> 200
- POST /v2/sandboxTesters -> 403 (resource does not allow CREATE)
- DELETE /v2/sandboxTesters/{id} -> 403 (resource does not allow DELETE)
- DELETE /v1/sandboxTesters/{id} via asc sandbox delete -> resource 'v1/sandboxTesters' does not exist

## Tests
- Not run (on this branch)
