### PR TITLE
fix: merge credentials from keychain and config in auth status

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -41,6 +41,13 @@ make lint       # Lint code
 make format     # Format code
 ```
 
+## Testing Discipline
+
+- Use TDD for everything: bugs, refactors, and new features.
+- Start with a failing test that captures the expected behavior and edge cases.
+- For new features, begin with CLI-level tests (flags, output, errors) and add unit tests for core logic.
+- Verify the test fails for the right reason before implementing; keep tests green incrementally.
+
 ## Authentication
 
 API keys are generated at https://appstoreconnect.apple.com/access/integrations/api and stored in the system keychain (with local config fallback). Never commit keys to version control.


### PR DESCRIPTION
## Summary

- Fix `asc auth status` to show credentials from both keychain and config file
- Previously, if any keychain credentials existed, config-stored credentials were completely ignored
- This caused credentials added with `--bypass-keychain` to be invisible
- Also fixed test isolation bug where `TestStoreCredentialsFallbackToConfig` was writing to user's actual config

## Problem

When running:
```bash
asc auth login --bypass-keychain --name client --key-id XXX --issuer-id YYY --private-key ~/.asc/AuthKey.p8
```

The credential was stored in config, but `asc auth status` only showed keychain credentials:
```
Stored credentials:
  - key-b5d62zk8ww (Key ID: B5D62ZK8WW) (stored in keychain)
```

## Root Cause

`ListCredentials()` would return ONLY keychain credentials when any existed:
```go
credentials, err := listFromKeychain()
if err == nil {
    if len(credentials) > 0 {
        return credentials, nil  // BUG: Never checks config
    }
}
```

Additionally, `TestStoreCredentialsFallbackToConfig` set `HOME` but not `ASC_CONFIG_PATH`, causing it to write test data to the local repo's `.asc/config.json` due to config path resolution order.

## Solution

1. Modified `ListCredentials()` to merge credentials from both keychain and config
2. Keychain credentials take precedence when the same name exists in both
3. Fixed test to use `ASC_CONFIG_PATH` for proper isolation

## Test plan

- [x] Added `TestListCredentials_MergesKeychainAndConfig` test
- [x] Fixed `TestStoreCredentialsFallbackToConfig` to use `ASC_CONFIG_PATH`
- [x] All existing tests pass
- [x] Manual verification: `asc auth status` now shows both keychain and config credentials