### PR TITLE
feat: app metadata keywords and relationships

### DIFF
--- a/internal/asc/client_alternative_distribution.go
+++ b/internal/asc/client_alternative_distribution.go
@@ -237,6 +237,27 @@ func (c *Client) GetAlternativeDistributionPackage(ctx context.Context, packageI
 	return &response, nil
 }
 
+// GetAlternativeDistributionPackageForVersion retrieves a package for an app store version.
+func (c *Client) GetAlternativeDistributionPackageForVersion(ctx context.Context, versionID string) (*AlternativeDistributionPackageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/alternativeDistributionPackage", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AlternativeDistributionPackageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse alternative distribution package response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // CreateAlternativeDistributionPackage creates an alternative distribution package.
 func (c *Client) CreateAlternativeDistributionPackage(ctx context.Context, appStoreVersionID string) (*AlternativeDistributionPackageResponse, error) {
 	appStoreVersionID = strings.TrimSpace(appStoreVersionID)

--- a/internal/asc/client_app_info_relationships.go
+++ b/internal/asc/client_app_info_relationships.go
@@ -1,0 +1,232 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// AppInfoAgeRatingDeclarationLinkageResponse is the response for age rating relationships.
+type AppInfoAgeRatingDeclarationLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppInfoPrimaryCategoryLinkageResponse is the response for primary category relationships.
+type AppInfoPrimaryCategoryLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppInfoPrimarySubcategoryOneLinkageResponse is the response for primary subcategory one relationships.
+type AppInfoPrimarySubcategoryOneLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppInfoPrimarySubcategoryTwoLinkageResponse is the response for primary subcategory two relationships.
+type AppInfoPrimarySubcategoryTwoLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppInfoSecondaryCategoryLinkageResponse is the response for secondary category relationships.
+type AppInfoSecondaryCategoryLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppInfoSecondarySubcategoryOneLinkageResponse is the response for secondary subcategory one relationships.
+type AppInfoSecondarySubcategoryOneLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppInfoSecondarySubcategoryTwoLinkageResponse is the response for secondary subcategory two relationships.
+type AppInfoSecondarySubcategoryTwoLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// GetAppInfoAgeRatingDeclarationRelationship retrieves the age rating linkage for an app info.
+func (c *Client) GetAppInfoAgeRatingDeclarationRelationship(ctx context.Context, appInfoID string) (*AppInfoAgeRatingDeclarationLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/ageRatingDeclaration", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoAgeRatingDeclarationLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoPrimaryCategoryRelationship retrieves the primary category linkage for an app info.
+func (c *Client) GetAppInfoPrimaryCategoryRelationship(ctx context.Context, appInfoID string) (*AppInfoPrimaryCategoryLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/primaryCategory", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoPrimaryCategoryLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoPrimarySubcategoryOneRelationship retrieves the primary subcategory one linkage.
+func (c *Client) GetAppInfoPrimarySubcategoryOneRelationship(ctx context.Context, appInfoID string) (*AppInfoPrimarySubcategoryOneLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/primarySubcategoryOne", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoPrimarySubcategoryOneLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoPrimarySubcategoryTwoRelationship retrieves the primary subcategory two linkage.
+func (c *Client) GetAppInfoPrimarySubcategoryTwoRelationship(ctx context.Context, appInfoID string) (*AppInfoPrimarySubcategoryTwoLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/primarySubcategoryTwo", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoPrimarySubcategoryTwoLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoSecondaryCategoryRelationship retrieves the secondary category linkage.
+func (c *Client) GetAppInfoSecondaryCategoryRelationship(ctx context.Context, appInfoID string) (*AppInfoSecondaryCategoryLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/secondaryCategory", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoSecondaryCategoryLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoSecondarySubcategoryOneRelationship retrieves the secondary subcategory one linkage.
+func (c *Client) GetAppInfoSecondarySubcategoryOneRelationship(ctx context.Context, appInfoID string) (*AppInfoSecondarySubcategoryOneLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/secondarySubcategoryOne", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoSecondarySubcategoryOneLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoSecondarySubcategoryTwoRelationship retrieves the secondary subcategory two linkage.
+func (c *Client) GetAppInfoSecondarySubcategoryTwoRelationship(ctx context.Context, appInfoID string) (*AppInfoSecondarySubcategoryTwoLinkageResponse, error) {
+	appInfoID = strings.TrimSpace(appInfoID)
+	if appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/secondarySubcategoryTwo", appInfoID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoSecondarySubcategoryTwoLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppInfoTerritoryAgeRatingsRelationships retrieves territory age rating linkages.
+func (c *Client) GetAppInfoTerritoryAgeRatingsRelationships(ctx context.Context, appInfoID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	appInfoID = strings.TrimSpace(appInfoID)
+	if query.nextURL == "" && appInfoID == "" {
+		return nil, fmt.Errorf("appInfoID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfos/%s/relationships/territoryAgeRatings", appInfoID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("territoryAgeRatingsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/client_app_metadata_test.go
+++ b/internal/asc/client_app_metadata_test.go
@@ -1,0 +1,562 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestGetAppSearchKeywords_SendsRequestWithFilters(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"appKeywords","id":"keyword-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/searchKeywords" {
+			t.Fatalf("expected path /v1/apps/app-1/searchKeywords, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("filter[platform]") != "IOS,MAC_OS" {
+			t.Fatalf("expected filter[platform]=IOS,MAC_OS, got %q", values.Get("filter[platform]"))
+		}
+		if values.Get("filter[locale]") != "en-US,ja" {
+			t.Fatalf("expected filter[locale]=en-US,ja, got %q", values.Get("filter[locale]"))
+		}
+		if values.Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", values.Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	_, err := client.GetAppSearchKeywords(
+		context.Background(),
+		"app-1",
+		WithAppSearchKeywordsPlatforms([]string{"ios", "MAC_OS"}),
+		WithAppSearchKeywordsLocales([]string{"en-US", "ja"}),
+		WithAppSearchKeywordsLimit(5),
+	)
+	if err != nil {
+		t.Fatalf("GetAppSearchKeywords() error: %v", err)
+	}
+}
+
+func TestGetAppSearchKeywords_UsesNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/apps/app-1/searchKeywords?cursor=abc"
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.URL.String() != next {
+			t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppSearchKeywords(context.Background(), "", WithAppSearchKeywordsNextURL(next)); err != nil {
+		t.Fatalf("GetAppSearchKeywords() error: %v", err)
+	}
+}
+
+func TestGetAppSearchKeywords_RequiresAppID(t *testing.T) {
+	client := newTestClient(t, nil, jsonResponse(http.StatusOK, `{"data":[]}`))
+	if _, err := client.GetAppSearchKeywords(context.Background(), ""); err == nil {
+		t.Fatal("expected error for missing app ID")
+	}
+}
+
+func TestSetAppSearchKeywords_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, `{}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/relationships/searchKeywords" {
+			t.Fatalf("expected path /v1/apps/app-1/relationships/searchKeywords, got %s", req.URL.Path)
+		}
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		var payload RelationshipRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		if len(payload.Data) != 2 {
+			t.Fatalf("expected 2 keywords, got %d", len(payload.Data))
+		}
+		if payload.Data[0].Type != ResourceTypeAppKeywords {
+			t.Fatalf("expected appKeywords type, got %q", payload.Data[0].Type)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.SetAppSearchKeywords(context.Background(), "app-1", []string{"kw-1", "kw-2"}); err != nil {
+		t.Fatalf("SetAppSearchKeywords() error: %v", err)
+	}
+}
+
+func TestSetAppSearchKeywords_ValidationErrors(t *testing.T) {
+	client := newTestClient(t, nil, jsonResponse(http.StatusNoContent, `{}`))
+	if err := client.SetAppSearchKeywords(context.Background(), "", []string{"kw-1"}); err == nil {
+		t.Fatal("expected error for missing app ID")
+	}
+	if err := client.SetAppSearchKeywords(context.Background(), "app-1", nil); err == nil {
+		t.Fatal("expected error for missing keywords")
+	}
+}
+
+func TestGetAppStoreVersionLocalizationSearchKeywords_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"appKeywords","id":"keyword-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1/searchKeywords" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1/searchKeywords, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersionLocalizationSearchKeywords(context.Background(), "loc-1"); err != nil {
+		t.Fatalf("GetAppStoreVersionLocalizationSearchKeywords() error: %v", err)
+	}
+}
+
+func TestAddAppStoreVersionLocalizationSearchKeywords_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, `{}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1/relationships/searchKeywords" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1/relationships/searchKeywords, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		var payload RelationshipRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		if len(payload.Data) != 2 {
+			t.Fatalf("expected 2 keywords, got %d", len(payload.Data))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.AddAppStoreVersionLocalizationSearchKeywords(context.Background(), "loc-1", []string{"kw-1", "kw-2"}); err != nil {
+		t.Fatalf("AddAppStoreVersionLocalizationSearchKeywords() error: %v", err)
+	}
+}
+
+func TestDeleteAppStoreVersionLocalizationSearchKeywords_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, `{}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1/relationships/searchKeywords" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1/relationships/searchKeywords, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		var payload RelationshipRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		if len(payload.Data) != 1 {
+			t.Fatalf("expected 1 keyword, got %d", len(payload.Data))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteAppStoreVersionLocalizationSearchKeywords(context.Background(), "loc-1", []string{"kw-1"}); err != nil {
+		t.Fatalf("DeleteAppStoreVersionLocalizationSearchKeywords() error: %v", err)
+	}
+}
+
+func TestGetAppStoreVersionLocalizationPreviewSets_SendsRequestWithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1/appPreviewSets" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1/appPreviewSets, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "10" {
+			t.Fatalf("expected limit=10, got %q", req.URL.Query().Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersionLocalizationPreviewSets(context.Background(), "loc-1", WithAppStoreVersionLocalizationPreviewSetsLimit(10)); err != nil {
+		t.Fatalf("GetAppStoreVersionLocalizationPreviewSets() error: %v", err)
+	}
+}
+
+func TestGetAppStoreVersionLocalizationPreviewSetsRelationships_UsesNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/loc-1/relationships/appPreviewSets?cursor=abc"
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.URL.String() != next {
+			t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersionLocalizationPreviewSetsRelationships(context.Background(), "", WithLinkagesNextURL(next)); err != nil {
+		t.Fatalf("GetAppStoreVersionLocalizationPreviewSetsRelationships() error: %v", err)
+	}
+}
+
+func TestGetAppStoreVersionLocalizationScreenshotSets_SendsRequestWithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1/appScreenshotSets" {
+			t.Fatalf("expected path /v1/appStoreVersionLocalizations/loc-1/appScreenshotSets, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", req.URL.Query().Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersionLocalizationScreenshotSets(context.Background(), "loc-1", WithAppStoreVersionLocalizationScreenshotSetsLimit(5)); err != nil {
+		t.Fatalf("GetAppStoreVersionLocalizationScreenshotSets() error: %v", err)
+	}
+}
+
+func TestGetAppStoreVersionLocalizationScreenshotSetsRelationships_UsesNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/loc-1/relationships/appScreenshotSets?cursor=abc"
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.URL.String() != next {
+			t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersionLocalizationScreenshotSetsRelationships(context.Background(), "", WithLinkagesNextURL(next)); err != nil {
+		t.Fatalf("GetAppStoreVersionLocalizationScreenshotSetsRelationships() error: %v", err)
+	}
+}
+
+func TestGetAppStoreVersionRelationships_SendsRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(ctx context.Context, client *Client) error
+		path string
+	}{
+		{
+			name: "age rating",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionAgeRatingDeclarationRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/ageRatingDeclaration",
+		},
+		{
+			name: "review detail",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionReviewDetailRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/appStoreReviewDetail",
+		},
+		{
+			name: "app clip default experience",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionAppClipDefaultExperienceRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/appClipDefaultExperience",
+		},
+		{
+			name: "submission",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionSubmissionRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/appStoreVersionSubmission",
+		},
+		{
+			name: "routing app coverage",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionRoutingAppCoverageRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/routingAppCoverage",
+		},
+		{
+			name: "alternative distribution package",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionAlternativeDistributionPackageRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/alternativeDistributionPackage",
+		},
+		{
+			name: "game center app version",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionGameCenterAppVersionRelationship(ctx, "version-1")
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/gameCenterAppVersion",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"rel-1"}}`)
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != test.path {
+					t.Fatalf("expected path %s, got %s", test.path, req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			}, response)
+
+			if err := test.call(context.Background(), client); err != nil {
+				t.Fatalf("call error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetAppStoreVersionRelationshipLists_SendsRequestWithLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(ctx context.Context, client *Client) error
+		path string
+	}{
+		{
+			name: "experiments v1",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionExperimentsRelationships(ctx, "version-1", WithLinkagesLimit(20))
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/appStoreVersionExperiments",
+		},
+		{
+			name: "experiments v2",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionExperimentsV2Relationships(ctx, "version-1", WithLinkagesLimit(20))
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/appStoreVersionExperimentsV2",
+		},
+		{
+			name: "customer reviews",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppStoreVersionCustomerReviewsRelationships(ctx, "version-1", WithLinkagesLimit(20))
+				return err
+			},
+			path: "/v1/appStoreVersions/version-1/relationships/customerReviews",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := jsonResponse(http.StatusOK, `{"data":[{"type":"apps","id":"rel-1"}]}`)
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != test.path {
+					t.Fatalf("expected path %s, got %s", test.path, req.URL.Path)
+				}
+				if req.URL.Query().Get("limit") != "20" {
+					t.Fatalf("expected limit=20, got %q", req.URL.Query().Get("limit"))
+				}
+				assertAuthorized(t, req)
+			}, response)
+
+			if err := test.call(context.Background(), client); err != nil {
+				t.Fatalf("call error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetAppCategory_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appCategories","id":"GAMES","attributes":{"platforms":["IOS"]}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appCategories/GAMES" {
+			t.Fatalf("expected path /v1/appCategories/GAMES, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppCategory(context.Background(), "GAMES"); err != nil {
+		t.Fatalf("GetAppCategory() error: %v", err)
+	}
+}
+
+func TestGetAppCategoryParent_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appCategories","id":"PARENT"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appCategories/GAMES/parent" {
+			t.Fatalf("expected path /v1/appCategories/GAMES/parent, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppCategoryParent(context.Background(), "GAMES"); err != nil {
+		t.Fatalf("GetAppCategoryParent() error: %v", err)
+	}
+}
+
+func TestGetAppCategorySubcategories_SendsRequestWithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appCategories/GAMES/subcategories" {
+			t.Fatalf("expected path /v1/appCategories/GAMES/subcategories, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "50" {
+			t.Fatalf("expected limit=50, got %q", req.URL.Query().Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppCategorySubcategories(context.Background(), "GAMES", WithAppCategoriesLimit(50)); err != nil {
+		t.Fatalf("GetAppCategorySubcategories() error: %v", err)
+	}
+}
+
+func TestGetAppCategorySubcategories_UsesNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appCategories/GAMES/subcategories?cursor=abc"
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.URL.String() != next {
+			t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppCategorySubcategories(context.Background(), "", WithAppCategoriesNextURL(next)); err != nil {
+		t.Fatalf("GetAppCategorySubcategories() error: %v", err)
+	}
+}
+
+func TestGetAlternativeDistributionPackageForVersion_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"alternativeDistributionPackages","id":"pkg-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersions/version-1/alternativeDistributionPackage" {
+			t.Fatalf("expected path /v1/appStoreVersions/version-1/alternativeDistributionPackage, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAlternativeDistributionPackageForVersion(context.Background(), "version-1"); err != nil {
+		t.Fatalf("GetAlternativeDistributionPackageForVersion() error: %v", err)
+	}
+}
+
+func TestGetAppInfo_SendsRequestWithInclude(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appInfos","id":"info-1","attributes":{"state":"READY"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appInfos/info-1" {
+			t.Fatalf("expected path /v1/appInfos/info-1, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("include") != "ageRatingDeclaration" {
+			t.Fatalf("expected include=ageRatingDeclaration, got %q", req.URL.Query().Get("include"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppInfo(context.Background(), "info-1", WithAppInfoInclude([]string{"ageRatingDeclaration"})); err != nil {
+		t.Fatalf("GetAppInfo() error: %v", err)
+	}
+}
+
+func TestGetAppInfoRelationships_SendsRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(ctx context.Context, client *Client) error
+		path string
+	}{
+		{
+			name: "age rating",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppInfoAgeRatingDeclarationRelationship(ctx, "info-1")
+				return err
+			},
+			path: "/v1/appInfos/info-1/relationships/ageRatingDeclaration",
+		},
+		{
+			name: "primary category",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppInfoPrimaryCategoryRelationship(ctx, "info-1")
+				return err
+			},
+			path: "/v1/appInfos/info-1/relationships/primaryCategory",
+		},
+		{
+			name: "secondary subcategory two",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppInfoSecondarySubcategoryTwoRelationship(ctx, "info-1")
+				return err
+			},
+			path: "/v1/appInfos/info-1/relationships/secondarySubcategoryTwo",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := jsonResponse(http.StatusOK, `{"data":{"type":"appCategories","id":"cat-1"}}`)
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != test.path {
+					t.Fatalf("expected path %s, got %s", test.path, req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			}, response)
+
+			if err := test.call(context.Background(), client); err != nil {
+				t.Fatalf("call error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetAppInfoTerritoryAgeRatingsRelationships_UsesNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appInfos/info-1/relationships/territoryAgeRatings?cursor=abc"
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.URL.String() != next {
+			t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppInfoTerritoryAgeRatingsRelationships(context.Background(), "", WithLinkagesNextURL(next)); err != nil {
+		t.Fatalf("GetAppInfoTerritoryAgeRatingsRelationships() error: %v", err)
+	}
+}

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -14,6 +14,9 @@ type ReviewOption func(*reviewQuery)
 // AppsOption is a functional option for GetApps.
 type AppsOption func(*appsQuery)
 
+// AppSearchKeywordsOption is a functional option for GetAppSearchKeywords.
+type AppSearchKeywordsOption func(*appSearchKeywordsQuery)
+
 // AppClipsOption is a functional option for GetAppClips.
 type AppClipsOption func(*appClipsQuery)
 
@@ -61,6 +64,9 @@ type WinBackOfferPricesOption func(*winBackOfferPricesQuery)
 
 // AppStoreVersionsOption is a functional option for GetAppStoreVersions.
 type AppStoreVersionsOption func(*appStoreVersionsQuery)
+
+// AppStoreVersionOption is a functional option for GetAppStoreVersion.
+type AppStoreVersionOption func(*appStoreVersionQuery)
 
 // ReviewSubmissionsOption is a functional option for GetReviewSubmissions.
 type ReviewSubmissionsOption func(*reviewSubmissionsQuery)
@@ -155,6 +161,9 @@ type BetaBuildLocalizationsOption func(*betaBuildLocalizationsQuery)
 // AppInfoLocalizationsOption is a functional option for app info localizations.
 type AppInfoLocalizationsOption func(*appInfoLocalizationsQuery)
 
+// AppInfoOption is a functional option for GetAppInfo.
+type AppInfoOption func(*appInfoQuery)
+
 // AppCustomProductPagesOption is a functional option for custom product page list endpoints.
 type AppCustomProductPagesOption func(*appCustomProductPagesQuery)
 
@@ -169,6 +178,12 @@ type AppCustomProductPageLocalizationPreviewSetsOption func(*appCustomProductPag
 
 // AppCustomProductPageLocalizationScreenshotSetsOption is a functional option for screenshot set list endpoints.
 type AppCustomProductPageLocalizationScreenshotSetsOption func(*appCustomProductPageLocalizationScreenshotSetsQuery)
+
+// AppStoreVersionLocalizationPreviewSetsOption is a functional option for app store version preview sets list endpoints.
+type AppStoreVersionLocalizationPreviewSetsOption func(*appStoreVersionLocalizationPreviewSetsQuery)
+
+// AppStoreVersionLocalizationScreenshotSetsOption is a functional option for app store version screenshot sets list endpoints.
+type AppStoreVersionLocalizationScreenshotSetsOption func(*appStoreVersionLocalizationScreenshotSetsQuery)
 
 // AppStoreVersionExperimentsOption is a functional option for app store version experiment list endpoints (v1).
 type AppStoreVersionExperimentsOption func(*appStoreVersionExperimentsQuery)
@@ -1034,6 +1049,38 @@ func WithAppsSKUs(skus []string) AppsOption {
 	}
 }
 
+// WithAppSearchKeywordsLimit sets the max number of app keywords to return.
+func WithAppSearchKeywordsLimit(limit int) AppSearchKeywordsOption {
+	return func(q *appSearchKeywordsQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithAppSearchKeywordsNextURL uses a next page URL directly.
+func WithAppSearchKeywordsNextURL(next string) AppSearchKeywordsOption {
+	return func(q *appSearchKeywordsQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+// WithAppSearchKeywordsPlatforms filters app keywords by platform(s).
+func WithAppSearchKeywordsPlatforms(platforms []string) AppSearchKeywordsOption {
+	return func(q *appSearchKeywordsQuery) {
+		q.platforms = normalizeUpperList(platforms)
+	}
+}
+
+// WithAppSearchKeywordsLocales filters app keywords by locale(s).
+func WithAppSearchKeywordsLocales(locales []string) AppSearchKeywordsOption {
+	return func(q *appSearchKeywordsQuery) {
+		q.locales = normalizeList(locales)
+	}
+}
+
 // WithAppClipsLimit sets the max number of App Clips to return.
 func WithAppClipsLimit(limit int) AppClipsOption {
 	return func(q *appClipsQuery) {
@@ -1441,6 +1488,20 @@ func WithAppStoreVersionsVersionStrings(versions []string) AppStoreVersionsOptio
 func WithAppStoreVersionsStates(states []string) AppStoreVersionsOption {
 	return func(q *appStoreVersionsQuery) {
 		q.states = normalizeUpperList(states)
+	}
+}
+
+// WithAppStoreVersionsInclude includes related resources for versions.
+func WithAppStoreVersionsInclude(include []string) AppStoreVersionsOption {
+	return func(q *appStoreVersionsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithAppStoreVersionInclude includes related resources for a version.
+func WithAppStoreVersionInclude(include []string) AppStoreVersionOption {
+	return func(q *appStoreVersionQuery) {
+		q.include = normalizeList(include)
 	}
 }
 
@@ -2553,6 +2614,13 @@ func WithAppInfoLocalizationLocales(locales []string) AppInfoLocalizationsOption
 	}
 }
 
+// WithAppInfoInclude includes related resources for an app info.
+func WithAppInfoInclude(include []string) AppInfoOption {
+	return func(q *appInfoQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
 // WithTerritoriesLimit sets the max number of territories to return.
 func WithTerritoriesLimit(limit int) TerritoriesOption {
 	return func(q *territoriesQuery) {
@@ -2812,6 +2880,42 @@ func WithAppCustomProductPageLocalizationScreenshotSetsLimit(limit int) AppCusto
 // WithAppCustomProductPageLocalizationScreenshotSetsNextURL uses a next page URL directly.
 func WithAppCustomProductPageLocalizationScreenshotSetsNextURL(next string) AppCustomProductPageLocalizationScreenshotSetsOption {
 	return func(q *appCustomProductPageLocalizationScreenshotSetsQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+// WithAppStoreVersionLocalizationPreviewSetsLimit sets the max number of preview sets to return.
+func WithAppStoreVersionLocalizationPreviewSetsLimit(limit int) AppStoreVersionLocalizationPreviewSetsOption {
+	return func(q *appStoreVersionLocalizationPreviewSetsQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithAppStoreVersionLocalizationPreviewSetsNextURL uses a next page URL directly.
+func WithAppStoreVersionLocalizationPreviewSetsNextURL(next string) AppStoreVersionLocalizationPreviewSetsOption {
+	return func(q *appStoreVersionLocalizationPreviewSetsQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+// WithAppStoreVersionLocalizationScreenshotSetsLimit sets the max number of screenshot sets to return.
+func WithAppStoreVersionLocalizationScreenshotSetsLimit(limit int) AppStoreVersionLocalizationScreenshotSetsOption {
+	return func(q *appStoreVersionLocalizationScreenshotSetsQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithAppStoreVersionLocalizationScreenshotSetsNextURL uses a next page URL directly.
+func WithAppStoreVersionLocalizationScreenshotSetsNextURL(next string) AppStoreVersionLocalizationScreenshotSetsOption {
+	return func(q *appStoreVersionLocalizationScreenshotSetsQuery) {
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -122,6 +122,14 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &AppCustomProductPageVersionsResponse{Links: Links{}}
 	case *AppCustomProductPageLocalizationsResponse:
 		result = &AppCustomProductPageLocalizationsResponse{Links: Links{}}
+	case *AppKeywordsResponse:
+		result = &AppKeywordsResponse{Links: Links{}}
+	case *AppPreviewSetsResponse:
+		result = &AppPreviewSetsResponse{Links: Links{}}
+	case *AppScreenshotSetsResponse:
+		result = &AppScreenshotSetsResponse{Links: Links{}}
+	case *AppCategoriesResponse:
+		result = &AppCategoriesResponse{Links: Links{}}
 	case *AppStoreVersionExperimentsResponse:
 		result = &AppStoreVersionExperimentsResponse{Links: Links{}}
 	case *AppStoreVersionExperimentsV2Response:
@@ -366,6 +374,14 @@ func typeOf(p PaginatedResponse) string {
 		return "AppCustomProductPageVersionsResponse"
 	case *AppCustomProductPageLocalizationsResponse:
 		return "AppCustomProductPageLocalizationsResponse"
+	case *AppKeywordsResponse:
+		return "AppKeywordsResponse"
+	case *AppPreviewSetsResponse:
+		return "AppPreviewSetsResponse"
+	case *AppScreenshotSetsResponse:
+		return "AppScreenshotSetsResponse"
+	case *AppCategoriesResponse:
+		return "AppCategoriesResponse"
 	case *AppStoreVersionExperimentsResponse:
 		return "AppStoreVersionExperimentsResponse"
 	case *AppStoreVersionExperimentsV2Response:

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -52,6 +52,12 @@ type appsQuery struct {
 	skus      []string
 }
 
+type appSearchKeywordsQuery struct {
+	listQuery
+	platforms []string
+	locales   []string
+}
+
 type appClipsQuery struct {
 	listQuery
 	bundleIDs []string
@@ -210,6 +216,11 @@ type appStoreVersionsQuery struct {
 	platforms      []string
 	versionStrings []string
 	states         []string
+	include        []string
+}
+
+type appStoreVersionQuery struct {
+	include []string
 }
 
 type reviewSubmissionsQuery struct {
@@ -243,6 +254,10 @@ type appInfoLocalizationsQuery struct {
 	locales []string
 }
 
+type appInfoQuery struct {
+	include []string
+}
+
 type appCustomProductPagesQuery struct {
 	listQuery
 }
@@ -260,6 +275,14 @@ type appCustomProductPageLocalizationPreviewSetsQuery struct {
 }
 
 type appCustomProductPageLocalizationScreenshotSetsQuery struct {
+	listQuery
+}
+
+type appStoreVersionLocalizationPreviewSetsQuery struct {
+	listQuery
+}
+
+type appStoreVersionLocalizationScreenshotSetsQuery struct {
 	listQuery
 }
 
@@ -1137,12 +1160,27 @@ func buildWinBackOfferPricesQuery(query *winBackOfferPricesQuery) string {
 	return values.Encode()
 }
 
+func buildAppSearchKeywordsQuery(query *appSearchKeywordsQuery) string {
+	values := url.Values{}
+	addCSV(values, "filter[platform]", query.platforms)
+	addCSV(values, "filter[locale]", query.locales)
+	addLimit(values, query.limit)
+	return values.Encode()
+}
+
 func buildAppStoreVersionsQuery(query *appStoreVersionsQuery) string {
 	values := url.Values{}
 	addCSV(values, "filter[platform]", query.platforms)
 	addCSV(values, "filter[versionString]", query.versionStrings)
 	addCSV(values, "filter[appStoreState]", query.states)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildAppStoreVersionQuery(query *appStoreVersionQuery) string {
+	values := url.Values{}
+	addCSV(values, "include", query.include)
 	return values.Encode()
 }
 
@@ -1196,6 +1234,12 @@ func buildAppInfoLocalizationsQuery(query *appInfoLocalizationsQuery) string {
 	return values.Encode()
 }
 
+func buildAppInfoQuery(query *appInfoQuery) string {
+	values := url.Values{}
+	addCSV(values, "include", query.include)
+	return values.Encode()
+}
+
 func buildAppCustomProductPagesQuery(query *appCustomProductPagesQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
@@ -1221,6 +1265,18 @@ func buildAppCustomProductPageLocalizationPreviewSetsQuery(query *appCustomProdu
 }
 
 func buildAppCustomProductPageLocalizationScreenshotSetsQuery(query *appCustomProductPageLocalizationScreenshotSetsQuery) string {
+	values := url.Values{}
+	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildAppStoreVersionLocalizationPreviewSetsQuery(query *appStoreVersionLocalizationPreviewSetsQuery) string {
+	values := url.Values{}
+	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildAppStoreVersionLocalizationScreenshotSetsQuery(query *appStoreVersionLocalizationScreenshotSetsQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
 	return values.Encode()

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -720,6 +720,7 @@ func TestBuildAppStoreVersionsQuery(t *testing.T) {
 		WithAppStoreVersionsPlatforms([]string{"ios", "MAC_OS"}),
 		WithAppStoreVersionsVersionStrings([]string{"1.0.0", "1.1.0"}),
 		WithAppStoreVersionsStates([]string{"ready_for_review"}),
+		WithAppStoreVersionsInclude([]string{"appStoreReviewDetail"}),
 	}
 	for _, opt := range opts {
 		opt(query)
@@ -738,8 +739,63 @@ func TestBuildAppStoreVersionsQuery(t *testing.T) {
 	if got := values.Get("filter[appStoreState]"); got != "READY_FOR_REVIEW" {
 		t.Fatalf("expected filter[appStoreState]=READY_FOR_REVIEW, got %q", got)
 	}
+	if got := values.Get("include"); got != "appStoreReviewDetail" {
+		t.Fatalf("expected include=appStoreReviewDetail, got %q", got)
+	}
 	if got := values.Get("limit"); got != "20" {
 		t.Fatalf("expected limit=20, got %q", got)
+	}
+}
+
+func TestBuildAppSearchKeywordsQuery(t *testing.T) {
+	query := &appSearchKeywordsQuery{}
+	opts := []AppSearchKeywordsOption{
+		WithAppSearchKeywordsLimit(15),
+		WithAppSearchKeywordsPlatforms([]string{"ios", "MAC_OS"}),
+		WithAppSearchKeywordsLocales([]string{"en-US", "ja"}),
+	}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	values, err := url.ParseQuery(buildAppSearchKeywordsQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("filter[platform]"); got != "IOS,MAC_OS" {
+		t.Fatalf("expected filter[platform]=IOS,MAC_OS, got %q", got)
+	}
+	if got := values.Get("filter[locale]"); got != "en-US,ja" {
+		t.Fatalf("expected filter[locale]=en-US,ja, got %q", got)
+	}
+	if got := values.Get("limit"); got != "15" {
+		t.Fatalf("expected limit=15, got %q", got)
+	}
+}
+
+func TestBuildAppStoreVersionQuery(t *testing.T) {
+	query := &appStoreVersionQuery{}
+	WithAppStoreVersionInclude([]string{"appStoreReviewDetail", "ageRatingDeclaration"})(query)
+
+	values, err := url.ParseQuery(buildAppStoreVersionQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("include"); got != "appStoreReviewDetail,ageRatingDeclaration" {
+		t.Fatalf("expected include=appStoreReviewDetail,ageRatingDeclaration, got %q", got)
+	}
+}
+
+func TestBuildAppInfoQuery(t *testing.T) {
+	query := &appInfoQuery{}
+	WithAppInfoInclude([]string{"ageRatingDeclaration", "territoryAgeRatings"})(query)
+
+	values, err := url.ParseQuery(buildAppInfoQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("include"); got != "ageRatingDeclaration,territoryAgeRatings" {
+		t.Fatalf("expected include=ageRatingDeclaration,territoryAgeRatings, got %q", got)
 	}
 }
 

--- a/internal/asc/client_version_localizations.go
+++ b/internal/asc/client_version_localizations.go
@@ -1,0 +1,266 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// GetAppStoreVersionLocalizationSearchKeywords retrieves search keywords for a localization.
+func (c *Client) GetAppStoreVersionLocalizationSearchKeywords(ctx context.Context, localizationID string) (*AppKeywordsResponse, error) {
+	localizationID = strings.TrimSpace(localizationID)
+	if localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/searchKeywords", localizationID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppKeywordsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionLocalizationSearchKeywordsRelationships retrieves search keyword relationships.
+func (c *Client) GetAppStoreVersionLocalizationSearchKeywordsRelationships(ctx context.Context, localizationID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	localizationID = strings.TrimSpace(localizationID)
+	if query.nextURL == "" && localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/relationships/searchKeywords", localizationID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("searchKeywordsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// AddAppStoreVersionLocalizationSearchKeywords adds search keywords to a localization.
+func (c *Client) AddAppStoreVersionLocalizationSearchKeywords(ctx context.Context, localizationID string, keywords []string) error {
+	localizationID = strings.TrimSpace(localizationID)
+	keywords = normalizeList(keywords)
+	if localizationID == "" {
+		return fmt.Errorf("localizationID is required")
+	}
+	if len(keywords) == 0 {
+		return fmt.Errorf("keywords are required")
+	}
+
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, 0, len(keywords)),
+	}
+	for _, keyword := range keywords {
+		payload.Data = append(payload.Data, RelationshipData{
+			Type: ResourceTypeAppKeywords,
+			ID:   keyword,
+		})
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/relationships/searchKeywords", localizationID)
+	_, err = c.do(ctx, "POST", path, body)
+	return err
+}
+
+// DeleteAppStoreVersionLocalizationSearchKeywords removes search keywords from a localization.
+func (c *Client) DeleteAppStoreVersionLocalizationSearchKeywords(ctx context.Context, localizationID string, keywords []string) error {
+	localizationID = strings.TrimSpace(localizationID)
+	keywords = normalizeList(keywords)
+	if localizationID == "" {
+		return fmt.Errorf("localizationID is required")
+	}
+	if len(keywords) == 0 {
+		return fmt.Errorf("keywords are required")
+	}
+
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, 0, len(keywords)),
+	}
+	for _, keyword := range keywords {
+		payload.Data = append(payload.Data, RelationshipData{
+			Type: ResourceTypeAppKeywords,
+			ID:   keyword,
+		})
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/relationships/searchKeywords", localizationID)
+	_, err = c.do(ctx, "DELETE", path, body)
+	return err
+}
+
+// GetAppStoreVersionLocalizationPreviewSets retrieves preview sets for a localization.
+func (c *Client) GetAppStoreVersionLocalizationPreviewSets(ctx context.Context, localizationID string, opts ...AppStoreVersionLocalizationPreviewSetsOption) (*AppPreviewSetsResponse, error) {
+	query := &appStoreVersionLocalizationPreviewSetsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	localizationID = strings.TrimSpace(localizationID)
+	if query.nextURL == "" && localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/appPreviewSets", localizationID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appPreviewSets: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildAppStoreVersionLocalizationPreviewSetsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppPreviewSetsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionLocalizationPreviewSetsRelationships retrieves preview set relationships.
+func (c *Client) GetAppStoreVersionLocalizationPreviewSetsRelationships(ctx context.Context, localizationID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	localizationID = strings.TrimSpace(localizationID)
+	if query.nextURL == "" && localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/relationships/appPreviewSets", localizationID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appPreviewSetsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionLocalizationScreenshotSets retrieves screenshot sets for a localization.
+func (c *Client) GetAppStoreVersionLocalizationScreenshotSets(ctx context.Context, localizationID string, opts ...AppStoreVersionLocalizationScreenshotSetsOption) (*AppScreenshotSetsResponse, error) {
+	query := &appStoreVersionLocalizationScreenshotSetsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	localizationID = strings.TrimSpace(localizationID)
+	if query.nextURL == "" && localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/appScreenshotSets", localizationID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appScreenshotSets: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildAppStoreVersionLocalizationScreenshotSetsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppScreenshotSetsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionLocalizationScreenshotSetsRelationships retrieves screenshot set relationships.
+func (c *Client) GetAppStoreVersionLocalizationScreenshotSetsRelationships(ctx context.Context, localizationID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	localizationID = strings.TrimSpace(localizationID)
+	if query.nextURL == "" && localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s/relationships/appScreenshotSets", localizationID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appScreenshotSetsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/client_version_relationships.go
+++ b/internal/asc/client_version_relationships.go
@@ -1,0 +1,275 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// AppStoreVersionAgeRatingDeclarationLinkageResponse is the response for age rating relationships.
+type AppStoreVersionAgeRatingDeclarationLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppStoreVersionReviewDetailLinkageResponse is the response for review detail relationships.
+type AppStoreVersionReviewDetailLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppStoreVersionAppClipDefaultExperienceLinkageResponse is the response for app clip default experience relationships.
+type AppStoreVersionAppClipDefaultExperienceLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppStoreVersionSubmissionLinkageResponse is the response for submission relationships.
+type AppStoreVersionSubmissionLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppStoreVersionRoutingAppCoverageLinkageResponse is the response for routing coverage relationships.
+type AppStoreVersionRoutingAppCoverageLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// AppStoreVersionGameCenterAppVersionLinkageResponse is the response for Game Center app version relationships.
+type AppStoreVersionGameCenterAppVersionLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links,omitempty"`
+}
+
+// GetAppStoreVersionAgeRatingDeclarationRelationship retrieves the age rating linkage for a version.
+func (c *Client) GetAppStoreVersionAgeRatingDeclarationRelationship(ctx context.Context, versionID string) (*AppStoreVersionAgeRatingDeclarationLinkageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/ageRatingDeclaration", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionAgeRatingDeclarationLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionReviewDetailRelationship retrieves the review detail linkage for a version.
+func (c *Client) GetAppStoreVersionReviewDetailRelationship(ctx context.Context, versionID string) (*AppStoreVersionReviewDetailLinkageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/appStoreReviewDetail", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionReviewDetailLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionAppClipDefaultExperienceRelationship retrieves the app clip default experience linkage.
+func (c *Client) GetAppStoreVersionAppClipDefaultExperienceRelationship(ctx context.Context, versionID string) (*AppStoreVersionAppClipDefaultExperienceLinkageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/appClipDefaultExperience", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionAppClipDefaultExperienceLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionExperimentsRelationships retrieves experiment linkages for a version (v1).
+func (c *Client) GetAppStoreVersionExperimentsRelationships(ctx context.Context, versionID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	versionID = strings.TrimSpace(versionID)
+	if query.nextURL == "" && versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/appStoreVersionExperiments", versionID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appStoreVersionExperimentsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionExperimentsV2Relationships retrieves experiment linkages for a version (v2).
+func (c *Client) GetAppStoreVersionExperimentsV2Relationships(ctx context.Context, versionID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	versionID = strings.TrimSpace(versionID)
+	if query.nextURL == "" && versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/appStoreVersionExperimentsV2", versionID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appStoreVersionExperimentsV2Relationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionSubmissionRelationship retrieves the submission linkage for a version.
+func (c *Client) GetAppStoreVersionSubmissionRelationship(ctx context.Context, versionID string) (*AppStoreVersionSubmissionLinkageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/appStoreVersionSubmission", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionSubmissionLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionCustomerReviewsRelationships retrieves customer review linkages for a version.
+func (c *Client) GetAppStoreVersionCustomerReviewsRelationships(ctx context.Context, versionID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	versionID = strings.TrimSpace(versionID)
+	if query.nextURL == "" && versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/customerReviews", versionID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("customerReviewsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionRoutingAppCoverageRelationship retrieves routing coverage linkage for a version.
+func (c *Client) GetAppStoreVersionRoutingAppCoverageRelationship(ctx context.Context, versionID string) (*AppStoreVersionRoutingAppCoverageLinkageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/routingAppCoverage", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionRoutingAppCoverageLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppStoreVersionGameCenterAppVersionRelationship retrieves Game Center app version linkage.
+func (c *Client) GetAppStoreVersionGameCenterAppVersionRelationship(ctx context.Context, versionID string) (*AppStoreVersionGameCenterAppVersionLinkageResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("versionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appStoreVersions/%s/relationships/gameCenterAppVersion", versionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppStoreVersionGameCenterAppVersionLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/client_versions.go
+++ b/internal/asc/client_versions.go
@@ -219,8 +219,17 @@ func (c *Client) GetPreReleaseVersion(ctx context.Context, id string) (*PreRelea
 }
 
 // GetAppStoreVersion retrieves an app store version by ID.
-func (c *Client) GetAppStoreVersion(ctx context.Context, versionID string) (*AppStoreVersionResponse, error) {
+func (c *Client) GetAppStoreVersion(ctx context.Context, versionID string, opts ...AppStoreVersionOption) (*AppStoreVersionResponse, error) {
+	query := &appStoreVersionQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	path := fmt.Sprintf("/v1/appStoreVersions/%s", versionID)
+	if queryString := buildAppStoreVersionQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/output_app_info.go
+++ b/internal/asc/output_app_info.go
@@ -1,0 +1,59 @@
+package asc
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+func printAppInfosTable(resp *AppInfosResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tApp Store State\tState\tAge Rating\tKids Age Band")
+	for _, info := range resp.Data {
+		attrs := info.Attributes
+		fmt.Fprintf(
+			w,
+			"%s\t%s\t%s\t%s\t%s\n",
+			info.ID,
+			appInfoAttrString(attrs, "appStoreState"),
+			appInfoAttrString(attrs, "state"),
+			appInfoAttrString(attrs, "appStoreAgeRating"),
+			appInfoAttrString(attrs, "kidsAgeBand"),
+		)
+	}
+	return w.Flush()
+}
+
+func printAppInfosMarkdown(resp *AppInfosResponse) error {
+	fmt.Fprintln(os.Stdout, "| ID | App Store State | State | Age Rating | Kids Age Band |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
+	for _, info := range resp.Data {
+		attrs := info.Attributes
+		fmt.Fprintf(
+			os.Stdout,
+			"| %s | %s | %s | %s | %s |\n",
+			escapeMarkdown(info.ID),
+			escapeMarkdown(appInfoAttrString(attrs, "appStoreState")),
+			escapeMarkdown(appInfoAttrString(attrs, "state")),
+			escapeMarkdown(appInfoAttrString(attrs, "appStoreAgeRating")),
+			escapeMarkdown(appInfoAttrString(attrs, "kidsAgeBand")),
+		)
+	}
+	return nil
+}
+
+func appInfoAttrString(attrs AppInfoAttributes, key string) string {
+	if attrs == nil {
+		return ""
+	}
+	value, ok := attrs[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}

--- a/internal/asc/output_app_info_test.go
+++ b/internal/asc/output_app_info_test.go
@@ -1,0 +1,58 @@
+package asc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrintTable_AppInfos(t *testing.T) {
+	resp := &AppInfosResponse{
+		Data: []Resource[AppInfoAttributes]{
+			{
+				ID: "info-1",
+				Attributes: AppInfoAttributes{
+					"appStoreState":     "READY_FOR_REVIEW",
+					"state":             "READY",
+					"appStoreAgeRating": "12+",
+					"kidsAgeBand":       "NINE_TO_ELEVEN",
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "App Store State") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "READY_FOR_REVIEW") {
+		t.Fatalf("expected app store state in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_AppInfos(t *testing.T) {
+	resp := &AppInfosResponse{
+		Data: []Resource[AppInfoAttributes]{
+			{
+				ID: "info-1",
+				Attributes: AppInfoAttributes{
+					"appStoreState": "READY_FOR_REVIEW",
+					"state":         "READY",
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "info-1") {
+		t.Fatalf("expected app info ID in output, got: %s", output)
+	}
+}

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -57,6 +57,12 @@ func PrintMarkdown(data interface{}) error {
 		return printAppClipsMarkdown(v)
 	case *AppCategoriesResponse:
 		return printAppCategoriesMarkdown(v)
+	case *AppCategoryResponse:
+		return printAppCategoriesMarkdown(&AppCategoriesResponse{Data: []AppCategory{v.Data}})
+	case *AppInfosResponse:
+		return printAppInfosMarkdown(v)
+	case *AppInfoResponse:
+		return printAppInfosMarkdown(&AppInfosResponse{Data: []Resource[AppInfoAttributes]{v.Data}})
 	case *AppResponse:
 		return printAppsMarkdown(&AppsResponse{Data: []Resource[AppAttributes]{v.Data}})
 	case *AppClipResponse:
@@ -140,6 +146,34 @@ func PrintMarkdown(data interface{}) error {
 	case *AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse:
 		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
 	case *AppClipDefaultExperienceLocalizationHeaderImageLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionAgeRatingDeclarationLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionReviewDetailLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionAppClipDefaultExperienceLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionSubmissionLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionRoutingAppCoverageLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionAlternativeDistributionPackageLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionGameCenterAppVersionLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoAgeRatingDeclarationLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoPrimaryCategoryLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoPrimarySubcategoryOneLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoPrimarySubcategoryTwoLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoSecondaryCategoryLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoSecondarySubcategoryOneLinkageResponse:
+		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoSecondarySubcategoryTwoLinkageResponse:
 		return printLinkagesMarkdown(&LinkagesResponse{Data: []ResourceData{v.Data}})
 	case *BundleIDsResponse:
 		return printBundleIDsMarkdown(v)
@@ -703,6 +737,12 @@ func PrintTable(data interface{}) error {
 		return printAppClipsTable(v)
 	case *AppCategoriesResponse:
 		return printAppCategoriesTable(v)
+	case *AppCategoryResponse:
+		return printAppCategoriesTable(&AppCategoriesResponse{Data: []AppCategory{v.Data}})
+	case *AppInfosResponse:
+		return printAppInfosTable(v)
+	case *AppInfoResponse:
+		return printAppInfosTable(&AppInfosResponse{Data: []Resource[AppInfoAttributes]{v.Data}})
 	case *AppResponse:
 		return printAppsTable(&AppsResponse{Data: []Resource[AppAttributes]{v.Data}})
 	case *AppClipResponse:
@@ -786,6 +826,34 @@ func PrintTable(data interface{}) error {
 	case *AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse:
 		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
 	case *AppClipDefaultExperienceLocalizationHeaderImageLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionAgeRatingDeclarationLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionReviewDetailLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionAppClipDefaultExperienceLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionSubmissionLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionRoutingAppCoverageLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionAlternativeDistributionPackageLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppStoreVersionGameCenterAppVersionLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoAgeRatingDeclarationLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoPrimaryCategoryLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoPrimarySubcategoryOneLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoPrimarySubcategoryTwoLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoSecondaryCategoryLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoSecondarySubcategoryOneLinkageResponse:
+		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
+	case *AppInfoSecondarySubcategoryTwoLinkageResponse:
 		return printLinkagesTable(&LinkagesResponse{Data: []ResourceData{v.Data}})
 	case *BundleIDsResponse:
 		return printBundleIDsTable(v)

--- a/internal/cli/apps/app_info_include.go
+++ b/internal/cli/apps/app_info_include.go
@@ -1,0 +1,40 @@
+package apps
+
+import (
+	"fmt"
+	"strings"
+)
+
+func normalizeAppInfoInclude(value string) ([]string, error) {
+	return normalizeInclude(value, appInfoIncludeList(), "--include")
+}
+
+func normalizeInclude(value string, allowed []string, flagName string) ([]string, error) {
+	include := splitCSV(value)
+	if len(include) == 0 {
+		return nil, nil
+	}
+	allowedMap := map[string]struct{}{}
+	for _, option := range allowed {
+		allowedMap[option] = struct{}{}
+	}
+	for _, option := range include {
+		if _, ok := allowedMap[option]; !ok {
+			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(allowed, ", "))
+		}
+	}
+	return include, nil
+}
+
+func appInfoIncludeList() []string {
+	return []string{
+		"ageRatingDeclaration",
+		"territoryAgeRatings",
+		"primaryCategory",
+		"primarySubcategoryOne",
+		"primarySubcategoryTwo",
+		"secondaryCategory",
+		"secondarySubcategoryOne",
+		"secondarySubcategoryTwo",
+	}
+}

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -54,6 +54,7 @@ Examples:
 			AppsListCommand(),
 			AppsGetCommand(),
 			AppsUpdateCommand(),
+			AppsSearchKeywordsCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return appsList(ctx, *output, *pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate)

--- a/internal/cli/apps/search_keywords.go
+++ b/internal/cli/apps/search_keywords.go
@@ -1,0 +1,201 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// AppsSearchKeywordsCommand returns the search keywords command group.
+func AppsSearchKeywordsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("search-keywords", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "search-keywords",
+		ShortUsage: "asc apps search-keywords <subcommand> [flags]",
+		ShortHelp:  "Manage search keywords for an app.",
+		LongHelp: `Manage search keywords for an app.
+
+Examples:
+  asc apps search-keywords list --app "APP_ID"
+  asc apps search-keywords list --app "APP_ID" --platform IOS --locale "en-US"
+  asc apps search-keywords set --app "APP_ID" --keywords "kw1,kw2" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AppsSearchKeywordsListCommand(),
+			AppsSearchKeywordsSetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// AppsSearchKeywordsListCommand returns the search keywords list subcommand.
+func AppsSearchKeywordsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps search-keywords list", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	platform := fs.String("platform", "", "Filter by platform: IOS, MAC_OS, TV_OS, VISION_OS (comma-separated)")
+	locale := fs.String("locale", "", "Filter by locale(s), comma-separated")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc apps search-keywords list --app \"APP_ID\"",
+		ShortHelp:  "List search keywords for an app.",
+		LongHelp: `List search keywords for an app.
+
+Examples:
+  asc apps search-keywords list --app "APP_ID"
+  asc apps search-keywords list --app "APP_ID" --platform IOS --locale "en-US"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("apps search-keywords list: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("apps search-keywords list: %w", err)
+			}
+
+			resolvedAppID := resolveAppID(*appID)
+			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+
+			platforms, err := shared.NormalizeAppStoreVersionPlatforms(splitCSVUpper(*platform))
+			if err != nil {
+				return fmt.Errorf("apps search-keywords list: %w", err)
+			}
+
+			locales := splitCSV(*locale)
+			if err := shared.ValidateBuildLocalizationLocales(locales); err != nil {
+				return fmt.Errorf("apps search-keywords list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("apps search-keywords list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.AppSearchKeywordsOption{
+				asc.WithAppSearchKeywordsLimit(*limit),
+				asc.WithAppSearchKeywordsNextURL(*next),
+			}
+			if len(platforms) > 0 {
+				opts = append(opts, asc.WithAppSearchKeywordsPlatforms(platforms))
+			}
+			if len(locales) > 0 {
+				opts = append(opts, asc.WithAppSearchKeywordsLocales(locales))
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithAppSearchKeywordsLimit(200))
+				firstPage, err := client.GetAppSearchKeywords(requestCtx, resolvedAppID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("apps search-keywords list: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppSearchKeywords(ctx, resolvedAppID, asc.WithAppSearchKeywordsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("apps search-keywords list: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppSearchKeywords(requestCtx, resolvedAppID, opts...)
+			if err != nil {
+				return fmt.Errorf("apps search-keywords list: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// AppsSearchKeywordsSetCommand returns the search keywords set subcommand.
+func AppsSearchKeywordsSetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps search-keywords set", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	keywords := fs.String("keywords", "", "Keywords (comma-separated)")
+	confirm := fs.Bool("confirm", false, "Confirm replacing all keywords")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "set",
+		ShortUsage: "asc apps search-keywords set --app \"APP_ID\" --keywords \"kw1,kw2\" --confirm",
+		ShortHelp:  "Replace search keywords for an app.",
+		LongHelp: `Replace search keywords for an app.
+
+Examples:
+  asc apps search-keywords set --app "APP_ID" --keywords "kw1,kw2" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedAppID := resolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return flag.ErrHelp
+			}
+
+			keywordValues := splitCSV(*keywords)
+			if len(keywordValues) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("apps search-keywords set: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.SetAppSearchKeywords(requestCtx, resolvedAppID, keywordValues); err != nil {
+				return fmt.Errorf("apps search-keywords set: failed to update: %w", err)
+			}
+
+			return printOutput(buildAppKeywordsResponse(keywordValues), *output, *pretty)
+		},
+	}
+}
+
+func buildAppKeywordsResponse(keywords []string) *asc.AppKeywordsResponse {
+	resp := &asc.AppKeywordsResponse{
+		Data: make([]asc.Resource[asc.AppKeywordAttributes], 0, len(keywords)),
+	}
+	for _, keyword := range keywords {
+		resp.Data = append(resp.Data, asc.Resource[asc.AppKeywordAttributes]{
+			Type:       asc.ResourceTypeAppKeywords,
+			ID:         keyword,
+			Attributes: asc.AppKeywordAttributes{},
+		})
+	}
+	return resp
+}

--- a/internal/cli/categories/categories.go
+++ b/internal/cli/categories/categories.go
@@ -23,11 +23,17 @@ func CategoriesCommand() *ffcli.Command {
 
 Examples:
   asc categories list
+  asc categories get --category-id "GAMES"
+  asc categories parent --category-id "GAMES"
+  asc categories subcategories --category-id "GAMES"
   asc categories set --app APP_ID --primary GAMES`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			CategoriesListCommand(),
+			CategoriesGetCommand(),
+			CategoriesParentCommand(),
+			CategoriesSubcategoriesCommand(),
 			CategoriesSetCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/categories/category_detail.go
+++ b/internal/cli/categories/category_detail.go
@@ -1,0 +1,175 @@
+package categories
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// CategoriesGetCommand returns the category get subcommand.
+func CategoriesGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("categories get", flag.ExitOnError)
+
+	categoryID := fs.String("category-id", "", "App category ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc categories get --category-id \"CATEGORY_ID\"",
+		ShortHelp:  "Get an App Store category by ID.",
+		LongHelp: `Get an App Store category by ID.
+
+Examples:
+  asc categories get --category-id "GAMES"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*categoryID)
+			if trimmedID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --category-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("categories get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetAppCategory(requestCtx, trimmedID)
+			if err != nil {
+				return fmt.Errorf("categories get: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// CategoriesParentCommand returns the category parent subcommand.
+func CategoriesParentCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("categories parent", flag.ExitOnError)
+
+	categoryID := fs.String("category-id", "", "App category ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "parent",
+		ShortUsage: "asc categories parent --category-id \"CATEGORY_ID\"",
+		ShortHelp:  "Get the parent category for a category.",
+		LongHelp: `Get the parent category for a category.
+
+Examples:
+  asc categories parent --category-id "GAMES"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*categoryID)
+			if trimmedID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --category-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("categories parent: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetAppCategoryParent(requestCtx, trimmedID)
+			if err != nil {
+				return fmt.Errorf("categories parent: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// CategoriesSubcategoriesCommand returns the category subcategories subcommand.
+func CategoriesSubcategoriesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("categories subcategories", flag.ExitOnError)
+
+	categoryID := fs.String("category-id", "", "App category ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "subcategories",
+		ShortUsage: "asc categories subcategories --category-id \"CATEGORY_ID\"",
+		ShortHelp:  "List subcategories for a category.",
+		LongHelp: `List subcategories for a category.
+
+Examples:
+  asc categories subcategories --category-id "GAMES"
+  asc categories subcategories --category-id "GAMES" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				fmt.Fprintln(os.Stderr, "Error: --limit must be between 1 and 200")
+				return flag.ErrHelp
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("categories subcategories: %w", err)
+			}
+
+			trimmedID := strings.TrimSpace(*categoryID)
+			trimmedNext := strings.TrimSpace(*next)
+			if trimmedID == "" && trimmedNext == "" {
+				fmt.Fprintln(os.Stderr, "Error: --category-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("categories subcategories: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.AppCategoriesOption{
+				asc.WithAppCategoriesLimit(*limit),
+				asc.WithAppCategoriesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithAppCategoriesLimit(200))
+				firstPage, err := client.GetAppCategorySubcategories(requestCtx, trimmedID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("categories subcategories: failed to fetch: %w", err)
+				}
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppCategorySubcategories(ctx, trimmedID, asc.WithAppCategoriesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("categories subcategories: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppCategorySubcategories(requestCtx, trimmedID, opts...)
+			if err != nil {
+				return fmt.Errorf("categories subcategories: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}

--- a/internal/cli/categories/shared_wrappers.go
+++ b/internal/cli/categories/shared_wrappers.go
@@ -24,3 +24,7 @@ func contextWithTimeout(ctx context.Context) (context.Context, context.CancelFun
 func printOutput(data interface{}, format string, pretty bool) error {
 	return shared.PrintOutput(data, format, pretty)
 }
+
+func validateNextURL(next string) error {
+	return shared.ValidateNextURL(next)
+}

--- a/internal/cli/cmdtest/app_metadata_test.go
+++ b/internal/cli/cmdtest/app_metadata_test.go
@@ -1,0 +1,322 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestAppsSearchKeywordsValidationErrors(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "apps search-keywords list missing app",
+			args:    []string{"apps", "search-keywords", "list"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "apps search-keywords set missing app",
+			args:    []string{"apps", "search-keywords", "set", "--keywords", "kw1", "--confirm"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "apps search-keywords set missing confirm",
+			args:    []string{"apps", "search-keywords", "set", "--app", "123", "--keywords", "kw1"},
+			wantErr: "--confirm is required",
+		},
+		{
+			name:    "apps search-keywords set missing keywords",
+			args:    []string{"apps", "search-keywords", "set", "--app", "123", "--confirm"},
+			wantErr: "--keywords is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestLocalizationsSearchKeywordsValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "localizations search-keywords list missing localization",
+			args:    []string{"localizations", "search-keywords", "list"},
+			wantErr: "--localization-id is required",
+		},
+		{
+			name:    "localizations search-keywords add missing keywords",
+			args:    []string{"localizations", "search-keywords", "add", "--localization-id", "loc-1"},
+			wantErr: "--keywords is required",
+		},
+		{
+			name:    "localizations search-keywords delete missing confirm",
+			args:    []string{"localizations", "search-keywords", "delete", "--localization-id", "loc-1", "--keywords", "kw1"},
+			wantErr: "--confirm is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestLocalizationsMediaSetsValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "preview sets list missing localization",
+			args:    []string{"localizations", "preview-sets", "list"},
+			wantErr: "--localization-id is required",
+		},
+		{
+			name:    "preview sets relationships missing localization",
+			args:    []string{"localizations", "preview-sets", "relationships"},
+			wantErr: "--localization-id is required",
+		},
+		{
+			name:    "screenshot sets list missing localization",
+			args:    []string{"localizations", "screenshot-sets", "list"},
+			wantErr: "--localization-id is required",
+		},
+		{
+			name:    "screenshot sets relationships missing localization",
+			args:    []string{"localizations", "screenshot-sets", "relationships"},
+			wantErr: "--localization-id is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestVersionsRelationshipsValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "versions relationships missing type",
+			args:    []string{"versions", "relationships", "--version-id", "id-1"},
+			wantErr: "--type is required",
+		},
+		{
+			name:    "versions relationships missing version id",
+			args:    []string{"versions", "relationships", "--type", "appStoreReviewDetail"},
+			wantErr: "--version-id is required",
+		},
+		{
+			name:    "versions relationships invalid type",
+			args:    []string{"versions", "relationships", "--version-id", "id-1", "--type", "nope"},
+			wantErr: "--type must be one of",
+		},
+		{
+			name:    "versions relationships invalid limit for single",
+			args:    []string{"versions", "relationships", "--version-id", "id-1", "--type", "appStoreReviewDetail", "--limit", "10"},
+			wantErr: "--limit, --next, and --paginate are only valid for to-many relationships",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestCategoriesValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "categories get missing id",
+			args:    []string{"categories", "get"},
+			wantErr: "--category-id is required",
+		},
+		{
+			name:    "categories parent missing id",
+			args:    []string{"categories", "parent"},
+			wantErr: "--category-id is required",
+		},
+		{
+			name:    "categories subcategories missing id",
+			args:    []string{"categories", "subcategories"},
+			wantErr: "--category-id is required",
+		},
+		{
+			name:    "categories subcategories invalid limit",
+			args:    []string{"categories", "subcategories", "--category-id", "GAMES", "--limit", "201"},
+			wantErr: "--limit must be between 1 and 200",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestAppInfoIncludeValidationErrors(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "app-info id without include",
+			args:    []string{"app-info", "get", "--app-info", "info-1"},
+			wantErr: "--app-info requires --include",
+		},
+		{
+			name:    "app-info include missing app",
+			args:    []string{"app-info", "get", "--include", "ageRatingDeclaration"},
+			wantErr: "--app or --app-info is required",
+		},
+		{
+			name:    "app-info include with version flags",
+			args:    []string{"app-info", "get", "--include", "ageRatingDeclaration", "--app", "123", "--version", "1.2.3", "--platform", "IOS"},
+			wantErr: "--include cannot be used with version localization flags",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -2734,7 +2734,7 @@ func TestAppInfoValidationErrors(t *testing.T) {
 		{
 			name:    "app-info get missing app",
 			args:    []string{"app-info", "get"},
-			wantErr: "--app is required",
+			wantErr: "--app or --app-info is required",
 		},
 		{
 			name:    "app-info get version missing platform",

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -25,12 +25,17 @@ func LocalizationsCommand() *ffcli.Command {
 
 Examples:
   asc localizations list --version "VERSION_ID"
+  asc localizations search-keywords list --localization-id "LOCALIZATION_ID"
+  asc localizations preview-sets list --localization-id "LOCALIZATION_ID"
   asc localizations download --version "VERSION_ID" --path "./localizations"
   asc localizations upload --version "VERSION_ID" --path "./localizations"`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			LocalizationsListCommand(),
+			LocalizationsSearchKeywordsCommand(),
+			LocalizationsPreviewSetsCommand(),
+			LocalizationsScreenshotSetsCommand(),
 			LocalizationsDownloadCommand(),
 			LocalizationsUploadCommand(),
 		},

--- a/internal/cli/localizations/media_sets.go
+++ b/internal/cli/localizations/media_sets.go
@@ -1,0 +1,355 @@
+package localizations
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// LocalizationsPreviewSetsCommand returns the preview sets command group.
+func LocalizationsPreviewSetsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("preview-sets", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "preview-sets",
+		ShortUsage: "asc localizations preview-sets <subcommand> [flags]",
+		ShortHelp:  "Manage preview sets for an App Store localization.",
+		LongHelp: `Manage preview sets for an App Store localization.
+
+Examples:
+  asc localizations preview-sets list --localization-id "LOCALIZATION_ID"
+  asc localizations preview-sets relationships --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			LocalizationsPreviewSetsListCommand(),
+			LocalizationsPreviewSetsRelationshipsCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// LocalizationsPreviewSetsListCommand returns the preview sets list subcommand.
+func LocalizationsPreviewSetsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations preview-sets list", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc localizations preview-sets list --localization-id \"LOCALIZATION_ID\"",
+		ShortHelp:  "List preview sets for an App Store localization.",
+		LongHelp: `List preview sets for an App Store localization.
+
+Examples:
+  asc localizations preview-sets list --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			trimmedNext := strings.TrimSpace(*next)
+			if trimmedID == "" && trimmedNext == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("localizations preview-sets list: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("localizations preview-sets list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations preview-sets list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.AppStoreVersionLocalizationPreviewSetsOption{
+				asc.WithAppStoreVersionLocalizationPreviewSetsLimit(*limit),
+				asc.WithAppStoreVersionLocalizationPreviewSetsNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithAppStoreVersionLocalizationPreviewSetsLimit(200))
+				firstPage, err := client.GetAppStoreVersionLocalizationPreviewSets(requestCtx, trimmedID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("localizations preview-sets list: failed to fetch: %w", err)
+				}
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppStoreVersionLocalizationPreviewSets(ctx, trimmedID, asc.WithAppStoreVersionLocalizationPreviewSetsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("localizations preview-sets list: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppStoreVersionLocalizationPreviewSets(requestCtx, trimmedID, opts...)
+			if err != nil {
+				return fmt.Errorf("localizations preview-sets list: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// LocalizationsPreviewSetsRelationshipsCommand returns the preview sets relationships subcommand.
+func LocalizationsPreviewSetsRelationshipsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations preview-sets relationships", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "relationships",
+		ShortUsage: "asc localizations preview-sets relationships --localization-id \"LOCALIZATION_ID\"",
+		ShortHelp:  "List preview set relationships for an App Store localization.",
+		LongHelp: `List preview set relationships for an App Store localization.
+
+Examples:
+  asc localizations preview-sets relationships --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			trimmedNext := strings.TrimSpace(*next)
+			if trimmedID == "" && trimmedNext == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("localizations preview-sets relationships: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("localizations preview-sets relationships: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations preview-sets relationships: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.LinkagesOption{
+				asc.WithLinkagesLimit(*limit),
+				asc.WithLinkagesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
+				firstPage, err := client.GetAppStoreVersionLocalizationPreviewSetsRelationships(requestCtx, trimmedID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("localizations preview-sets relationships: failed to fetch: %w", err)
+				}
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppStoreVersionLocalizationPreviewSetsRelationships(ctx, trimmedID, asc.WithLinkagesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("localizations preview-sets relationships: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppStoreVersionLocalizationPreviewSetsRelationships(requestCtx, trimmedID, opts...)
+			if err != nil {
+				return fmt.Errorf("localizations preview-sets relationships: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// LocalizationsScreenshotSetsCommand returns the screenshot sets command group.
+func LocalizationsScreenshotSetsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("screenshot-sets", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "screenshot-sets",
+		ShortUsage: "asc localizations screenshot-sets <subcommand> [flags]",
+		ShortHelp:  "Manage screenshot sets for an App Store localization.",
+		LongHelp: `Manage screenshot sets for an App Store localization.
+
+Examples:
+  asc localizations screenshot-sets list --localization-id "LOCALIZATION_ID"
+  asc localizations screenshot-sets relationships --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			LocalizationsScreenshotSetsListCommand(),
+			LocalizationsScreenshotSetsRelationshipsCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// LocalizationsScreenshotSetsListCommand returns the screenshot sets list subcommand.
+func LocalizationsScreenshotSetsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations screenshot-sets list", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc localizations screenshot-sets list --localization-id \"LOCALIZATION_ID\"",
+		ShortHelp:  "List screenshot sets for an App Store localization.",
+		LongHelp: `List screenshot sets for an App Store localization.
+
+Examples:
+  asc localizations screenshot-sets list --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			trimmedNext := strings.TrimSpace(*next)
+			if trimmedID == "" && trimmedNext == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("localizations screenshot-sets list: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("localizations screenshot-sets list: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations screenshot-sets list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.AppStoreVersionLocalizationScreenshotSetsOption{
+				asc.WithAppStoreVersionLocalizationScreenshotSetsLimit(*limit),
+				asc.WithAppStoreVersionLocalizationScreenshotSetsNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithAppStoreVersionLocalizationScreenshotSetsLimit(200))
+				firstPage, err := client.GetAppStoreVersionLocalizationScreenshotSets(requestCtx, trimmedID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("localizations screenshot-sets list: failed to fetch: %w", err)
+				}
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppStoreVersionLocalizationScreenshotSets(ctx, trimmedID, asc.WithAppStoreVersionLocalizationScreenshotSetsNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("localizations screenshot-sets list: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppStoreVersionLocalizationScreenshotSets(requestCtx, trimmedID, opts...)
+			if err != nil {
+				return fmt.Errorf("localizations screenshot-sets list: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// LocalizationsScreenshotSetsRelationshipsCommand returns the screenshot sets relationships subcommand.
+func LocalizationsScreenshotSetsRelationshipsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations screenshot-sets relationships", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "relationships",
+		ShortUsage: "asc localizations screenshot-sets relationships --localization-id \"LOCALIZATION_ID\"",
+		ShortHelp:  "List screenshot set relationships for an App Store localization.",
+		LongHelp: `List screenshot set relationships for an App Store localization.
+
+Examples:
+  asc localizations screenshot-sets relationships --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			trimmedNext := strings.TrimSpace(*next)
+			if trimmedID == "" && trimmedNext == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("localizations screenshot-sets relationships: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("localizations screenshot-sets relationships: %w", err)
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations screenshot-sets relationships: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.LinkagesOption{
+				asc.WithLinkagesLimit(*limit),
+				asc.WithLinkagesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
+				firstPage, err := client.GetAppStoreVersionLocalizationScreenshotSetsRelationships(requestCtx, trimmedID, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("localizations screenshot-sets relationships: failed to fetch: %w", err)
+				}
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppStoreVersionLocalizationScreenshotSetsRelationships(ctx, trimmedID, asc.WithLinkagesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("localizations screenshot-sets relationships: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetAppStoreVersionLocalizationScreenshotSetsRelationships(requestCtx, trimmedID, opts...)
+			if err != nil {
+				return fmt.Errorf("localizations screenshot-sets relationships: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}

--- a/internal/cli/localizations/search_keywords.go
+++ b/internal/cli/localizations/search_keywords.go
@@ -1,0 +1,200 @@
+package localizations
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// LocalizationsSearchKeywordsCommand returns the search keywords command group.
+func LocalizationsSearchKeywordsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("search-keywords", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "search-keywords",
+		ShortUsage: "asc localizations search-keywords <subcommand> [flags]",
+		ShortHelp:  "Manage search keywords for an App Store localization.",
+		LongHelp: `Manage search keywords for an App Store localization.
+
+Examples:
+  asc localizations search-keywords list --localization-id "LOCALIZATION_ID"
+  asc localizations search-keywords add --localization-id "LOCALIZATION_ID" --keywords "kw1,kw2"
+  asc localizations search-keywords delete --localization-id "LOCALIZATION_ID" --keywords "kw1,kw2" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			LocalizationsSearchKeywordsListCommand(),
+			LocalizationsSearchKeywordsAddCommand(),
+			LocalizationsSearchKeywordsDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// LocalizationsSearchKeywordsListCommand returns the search keywords list subcommand.
+func LocalizationsSearchKeywordsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations search-keywords list", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc localizations search-keywords list --localization-id \"LOCALIZATION_ID\"",
+		ShortHelp:  "List search keywords for an App Store localization.",
+		LongHelp: `List search keywords for an App Store localization.
+
+Examples:
+  asc localizations search-keywords list --localization-id "LOCALIZATION_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			if trimmedID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations search-keywords list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetAppStoreVersionLocalizationSearchKeywords(requestCtx, trimmedID)
+			if err != nil {
+				return fmt.Errorf("localizations search-keywords list: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// LocalizationsSearchKeywordsAddCommand returns the search keywords add subcommand.
+func LocalizationsSearchKeywordsAddCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations search-keywords add", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	keywords := fs.String("keywords", "", "Keywords (comma-separated)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "add",
+		ShortUsage: "asc localizations search-keywords add --localization-id \"LOCALIZATION_ID\" --keywords \"kw1,kw2\"",
+		ShortHelp:  "Add search keywords to an App Store localization.",
+		LongHelp: `Add search keywords to an App Store localization.
+
+Examples:
+  asc localizations search-keywords add --localization-id "LOCALIZATION_ID" --keywords "kw1,kw2"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			if trimmedID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+
+			keywordValues := splitCSV(*keywords)
+			if len(keywordValues) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations search-keywords add: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.AddAppStoreVersionLocalizationSearchKeywords(requestCtx, trimmedID, keywordValues); err != nil {
+				return fmt.Errorf("localizations search-keywords add: failed to add: %w", err)
+			}
+
+			return printOutput(buildAppKeywordsResponse(keywordValues), *output, *pretty)
+		},
+	}
+}
+
+// LocalizationsSearchKeywordsDeleteCommand returns the search keywords delete subcommand.
+func LocalizationsSearchKeywordsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations search-keywords delete", flag.ExitOnError)
+
+	localizationID := fs.String("localization-id", "", "App Store version localization ID")
+	keywords := fs.String("keywords", "", "Keywords (comma-separated)")
+	confirm := fs.Bool("confirm", false, "Confirm deletion")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "asc localizations search-keywords delete --localization-id \"LOCALIZATION_ID\" --keywords \"kw1,kw2\" --confirm",
+		ShortHelp:  "Delete search keywords from an App Store localization.",
+		LongHelp: `Delete search keywords from an App Store localization.
+
+Examples:
+  asc localizations search-keywords delete --localization-id "LOCALIZATION_ID" --keywords "kw1,kw2" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedID := strings.TrimSpace(*localizationID)
+			if trimmedID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
+				return flag.ErrHelp
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return flag.ErrHelp
+			}
+
+			keywordValues := splitCSV(*keywords)
+			if len(keywordValues) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("localizations search-keywords delete: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			if err := client.DeleteAppStoreVersionLocalizationSearchKeywords(requestCtx, trimmedID, keywordValues); err != nil {
+				return fmt.Errorf("localizations search-keywords delete: failed to delete: %w", err)
+			}
+
+			return printOutput(buildAppKeywordsResponse(keywordValues), *output, *pretty)
+		},
+	}
+}
+
+func buildAppKeywordsResponse(keywords []string) *asc.AppKeywordsResponse {
+	resp := &asc.AppKeywordsResponse{
+		Data: make([]asc.Resource[asc.AppKeywordAttributes], 0, len(keywords)),
+	}
+	for _, keyword := range keywords {
+		resp.Data = append(resp.Data, asc.Resource[asc.AppKeywordAttributes]{
+			Type:       asc.ResourceTypeAppKeywords,
+			ID:         keyword,
+			Attributes: asc.AppKeywordAttributes{},
+		})
+	}
+	return resp
+}

--- a/internal/cli/versions/include_helpers.go
+++ b/internal/cli/versions/include_helpers.go
@@ -1,0 +1,42 @@
+package versions
+
+import (
+	"fmt"
+	"strings"
+)
+
+func normalizeAppStoreVersionInclude(value string) ([]string, error) {
+	return normalizeInclude(value, appStoreVersionIncludeList(), "--include")
+}
+
+func normalizeInclude(value string, allowed []string, flagName string) ([]string, error) {
+	include := splitCSV(value)
+	if len(include) == 0 {
+		return nil, nil
+	}
+	allowedMap := map[string]struct{}{}
+	for _, option := range allowed {
+		allowedMap[option] = struct{}{}
+	}
+	for _, option := range include {
+		if _, ok := allowedMap[option]; !ok {
+			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(allowed, ", "))
+		}
+	}
+	return include, nil
+}
+
+func appStoreVersionIncludeList() []string {
+	return []string{
+		"ageRatingDeclaration",
+		"appStoreReviewDetail",
+		"appClipDefaultExperience",
+		"appStoreVersionExperiments",
+		"appStoreVersionExperimentsV2",
+		"appStoreVersionSubmission",
+		"customerReviews",
+		"routingAppCoverage",
+		"alternativeDistributionPackage",
+		"gameCenterAppVersion",
+	}
+}

--- a/internal/cli/versions/relationships.go
+++ b/internal/cli/versions/relationships.go
@@ -1,0 +1,180 @@
+package versions
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type relationshipKind int
+
+const (
+	relationshipSingle relationshipKind = iota
+	relationshipList
+)
+
+var appStoreVersionRelationshipKinds = map[string]relationshipKind{
+	"ageRatingDeclaration":           relationshipSingle,
+	"appStoreReviewDetail":           relationshipSingle,
+	"appClipDefaultExperience":       relationshipSingle,
+	"appStoreVersionExperiments":     relationshipList,
+	"appStoreVersionExperimentsV2":   relationshipList,
+	"appStoreVersionSubmission":      relationshipSingle,
+	"customerReviews":                relationshipList,
+	"routingAppCoverage":             relationshipSingle,
+	"alternativeDistributionPackage": relationshipSingle,
+	"gameCenterAppVersion":           relationshipSingle,
+}
+
+// VersionsRelationshipsCommand returns the relationships subcommand.
+func VersionsRelationshipsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("versions relationships", flag.ExitOnError)
+
+	versionID := fs.String("version-id", "", "App Store version ID")
+	relType := fs.String("type", "", "Relationship type: "+strings.Join(appStoreVersionRelationshipList(), ", "))
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "relationships",
+		ShortUsage: "asc versions relationships --version-id \"VERSION_ID\" --type \"RELATIONSHIP\" [flags]",
+		ShortHelp:  "List relationship linkages for an app store version.",
+		LongHelp: `List relationship linkages for an app store version.
+
+Examples:
+  asc versions relationships --version-id "VERSION_ID" --type "appStoreReviewDetail"
+  asc versions relationships --version-id "VERSION_ID" --type "appStoreVersionExperiments" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("versions relationships: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("versions relationships: %w", err)
+			}
+
+			relationshipType := strings.TrimSpace(*relType)
+			if relationshipType == "" {
+				fmt.Fprintln(os.Stderr, "Error: --type is required")
+				return flag.ErrHelp
+			}
+
+			kind, ok := appStoreVersionRelationshipKinds[relationshipType]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "Error: --type must be one of: %s\n", strings.Join(appStoreVersionRelationshipList(), ", "))
+				return flag.ErrHelp
+			}
+
+			trimmedID := strings.TrimSpace(*versionID)
+			trimmedNext := strings.TrimSpace(*next)
+			if trimmedID == "" && trimmedNext == "" {
+				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
+				return flag.ErrHelp
+			}
+
+			if kind == relationshipSingle && (trimmedNext != "" || *paginate || *limit != 0) {
+				fmt.Fprintln(os.Stderr, "Error: --limit, --next, and --paginate are only valid for to-many relationships")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("versions relationships: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			switch kind {
+			case relationshipSingle:
+				resp, err := getAppStoreVersionRelationship(requestCtx, client, relationshipType, trimmedID)
+				if err != nil {
+					return fmt.Errorf("versions relationships: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			case relationshipList:
+				opts := []asc.LinkagesOption{
+					asc.WithLinkagesLimit(*limit),
+					asc.WithLinkagesNextURL(*next),
+				}
+
+				if *paginate {
+					paginateOpts := append(opts, asc.WithLinkagesLimit(200))
+					firstPage, err := getAppStoreVersionRelationshipList(requestCtx, client, relationshipType, trimmedID, paginateOpts...)
+					if err != nil {
+						return fmt.Errorf("versions relationships: failed to fetch: %w", err)
+					}
+					resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+						return getAppStoreVersionRelationshipList(ctx, client, relationshipType, trimmedID, asc.WithLinkagesNextURL(nextURL))
+					})
+					if err != nil {
+						return fmt.Errorf("versions relationships: %w", err)
+					}
+					return printOutput(resp, *output, *pretty)
+				}
+
+				resp, err := getAppStoreVersionRelationshipList(requestCtx, client, relationshipType, trimmedID, opts...)
+				if err != nil {
+					return fmt.Errorf("versions relationships: %w", err)
+				}
+				return printOutput(resp, *output, *pretty)
+			default:
+				return fmt.Errorf("versions relationships: unsupported relationship type %q", relationshipType)
+			}
+		},
+	}
+}
+
+func getAppStoreVersionRelationship(ctx context.Context, client *asc.Client, relationshipType, versionID string) (interface{}, error) {
+	switch relationshipType {
+	case "ageRatingDeclaration":
+		return client.GetAppStoreVersionAgeRatingDeclarationRelationship(ctx, versionID)
+	case "appStoreReviewDetail":
+		return client.GetAppStoreVersionReviewDetailRelationship(ctx, versionID)
+	case "appClipDefaultExperience":
+		return client.GetAppStoreVersionAppClipDefaultExperienceRelationship(ctx, versionID)
+	case "appStoreVersionSubmission":
+		return client.GetAppStoreVersionSubmissionRelationship(ctx, versionID)
+	case "routingAppCoverage":
+		return client.GetAppStoreVersionRoutingAppCoverageRelationship(ctx, versionID)
+	case "alternativeDistributionPackage":
+		return client.GetAppStoreVersionAlternativeDistributionPackageRelationship(ctx, versionID)
+	case "gameCenterAppVersion":
+		return client.GetAppStoreVersionGameCenterAppVersionRelationship(ctx, versionID)
+	default:
+		return nil, fmt.Errorf("unsupported relationship type %q", relationshipType)
+	}
+}
+
+func getAppStoreVersionRelationshipList(ctx context.Context, client *asc.Client, relationshipType, versionID string, opts ...asc.LinkagesOption) (asc.PaginatedResponse, error) {
+	switch relationshipType {
+	case "appStoreVersionExperiments":
+		return client.GetAppStoreVersionExperimentsRelationships(ctx, versionID, opts...)
+	case "appStoreVersionExperimentsV2":
+		return client.GetAppStoreVersionExperimentsV2Relationships(ctx, versionID, opts...)
+	case "customerReviews":
+		return client.GetAppStoreVersionCustomerReviewsRelationships(ctx, versionID, opts...)
+	default:
+		return nil, fmt.Errorf("unsupported relationship type %q", relationshipType)
+	}
+}
+
+func appStoreVersionRelationshipList() []string {
+	relationships := make([]string, 0, len(appStoreVersionRelationshipKinds))
+	for key := range appStoreVersionRelationshipKinds {
+		relationships = append(relationships, key)
+	}
+	sort.Strings(relationships)
+	return relationships
+}


### PR DESCRIPTION
## Summary
- add app search keywords commands plus localization keywords/media set relationships
- support version relationship listing and app-info includes, plus category detail endpoints
- extend client pagination/output handling and add cmdtest/unit coverage

## Test plan
- make test
- make test-integration (requires ASC_* env vars)
- Manual live smoke:
  - asc apps search-keywords list --app 1479784361 --platform VISION_OS --locale en-GB
  - asc versions get --version-id 823375e0-919d-450c-a5b3-9d7e9cde6e32 --include "ageRatingDeclaration,appStoreReviewDetail"
  - asc versions relationships --version-id 823375e0-919d-450c-a5b3-9d7e9cde6e32 --type appStoreReviewDetail
  - asc localizations search-keywords list --localization-id c84271d4-7162-45f8-86ab-a3ce7512f58e
  - asc localizations preview-sets list --localization-id c84271d4-7162-45f8-86ab-a3ce7512f58e
  - asc localizations screenshot-sets list --localization-id c84271d4-7162-45f8-86ab-a3ce7512f58e
  - asc categories get --category-id GAMES
  - asc categories subcategories --category-id GAMES --limit 1

@cursor FYI: integration tests require live ASC_* credentials; the manual smoke steps above are safe read-only except for localization keyword add/delete behavior (API rejects deleting the last remaining keyword).