### PR TITLE
Fix subscription offer code price payload

### DIFF
--- a/internal/asc/subscription_resources.go
+++ b/internal/asc/subscription_resources.go
@@ -238,6 +238,11 @@ type SubscriptionOfferCodeCreateAttributes struct {
 	AutoRenewEnabled      *bool                             `json:"autoRenewEnabled,omitempty"`
 }
 
+type SubscriptionOfferCodePrice struct {
+	TerritoryID  string
+	PricePointID string
+}
+
 // SubscriptionOfferCodeUpdateAttributes describes attributes for updating an offer code.
 type SubscriptionOfferCodeUpdateAttributes struct {
 	Active *bool `json:"active,omitempty"`
@@ -258,7 +263,8 @@ type SubscriptionOfferCodeCreateData struct {
 
 // SubscriptionOfferCodeCreateRequest is a request to create an offer code.
 type SubscriptionOfferCodeCreateRequest struct {
-	Data SubscriptionOfferCodeCreateData `json:"data"`
+	Data     SubscriptionOfferCodeCreateData          `json:"data"`
+	Included []SubscriptionOfferCodePriceInlineCreate `json:"included,omitempty"`
 }
 
 // SubscriptionOfferCodeUpdateData is the data portion of an offer code update request.

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -582,8 +582,17 @@ func TestCreateSubscriptionOfferCode(t *testing.T) {
 		if payload.Data.Relationships.Subscription.Data.ID != "sub-1" {
 			t.Fatalf("unexpected subscription relationship: %+v", payload.Data.Relationships.Subscription.Data)
 		}
-		if len(payload.Data.Relationships.Prices.Data) != 1 || payload.Data.Relationships.Prices.Data[0].ID != "price-1" {
+		if len(payload.Data.Relationships.Prices.Data) != 1 || payload.Data.Relationships.Prices.Data[0].ID != "${local-price-1}" {
 			t.Fatalf("unexpected price relationships: %+v", payload.Data.Relationships.Prices.Data)
+		}
+		if len(payload.Included) != 1 {
+			t.Fatalf("expected one included price, got %d", len(payload.Included))
+		}
+		if payload.Included[0].Relationships.Territory.Data.ID != "USA" {
+			t.Fatalf("expected territory USA, got %q", payload.Included[0].Relationships.Territory.Data.ID)
+		}
+		if payload.Included[0].Relationships.SubscriptionPricePoint.Data.ID != "price-1" {
+			t.Fatalf("expected price point price-1, got %q", payload.Included[0].Relationships.SubscriptionPricePoint.Data.ID)
 		}
 		assertAuthorized(t, req)
 	}, response)
@@ -596,7 +605,13 @@ func TestCreateSubscriptionOfferCode(t *testing.T) {
 		OfferMode:             SubscriptionOfferModeFreeTrial,
 		NumberOfPeriods:       1,
 	}
-	if _, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, []string{"price-1"}); err != nil {
+	prices := []SubscriptionOfferCodePrice{
+		{
+			TerritoryID:  "USA",
+			PricePointID: "price-1",
+		},
+	}
+	if _, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, prices); err != nil {
 		t.Fatalf("CreateSubscriptionOfferCode() error: %v", err)
 	}
 }

--- a/internal/cli/offercodes/offer_codes.go
+++ b/internal/cli/offercodes/offer_codes.go
@@ -29,7 +29,7 @@ func OfferCodesCommand() *ffcli.Command {
 
 Examples:
   asc offer-codes get --offer-code-id "OFFER_CODE_ID"
-  asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --price-id "PRICE_ID"
+  asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "USA:PRICE_POINT_ID"
   asc offer-codes update --offer-code-id "OFFER_CODE_ID" --active true
   asc offer-codes custom-codes list --offer-code-id "OFFER_CODE_ID"
   asc offer-codes prices list --offer-code-id "OFFER_CODE_ID"

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -127,6 +127,32 @@ func normalizeSubscriptionCustomerEligibilities(value string, required bool) ([]
 	return eligibilities, nil
 }
 
+func parseSubscriptionOfferCodePrices(value string) ([]asc.SubscriptionOfferCodePrice, error) {
+	entries := splitCSV(value)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	prices := make([]asc.SubscriptionOfferCodePrice, 0, len(entries))
+	for _, entry := range entries {
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("--prices must use TERRITORY:PRICE_POINT_ID entries")
+		}
+		territoryID := strings.ToUpper(strings.TrimSpace(parts[0]))
+		pricePointID := strings.TrimSpace(parts[1])
+		if territoryID == "" || pricePointID == "" {
+			return nil, fmt.Errorf("--prices must use TERRITORY:PRICE_POINT_ID entries")
+		}
+		prices = append(prices, asc.SubscriptionOfferCodePrice{
+			TerritoryID:  territoryID,
+			PricePointID: pricePointID,
+		})
+	}
+
+	return prices, nil
+}
+
 func openSubscriptionImageFile(path string) (*os.File, os.FileInfo, error) {
 	if err := asc.ValidateImageFile(path); err != nil {
 		return nil, nil, err
@@ -142,4 +168,3 @@ func openSubscriptionImageFile(path string) (*os.File, os.FileInfo, error) {
 	}
 	return file, info, nil
 }
-


### PR DESCRIPTION
## Summary
- include inline price relationships when creating subscription offer codes
- accept TERRITORY:PRICE_POINT_ID inputs for offer-code create commands (deprecated --price-id fallback)
- update tests and examples to match the new price format

## Test plan
- [x] make build
- [x] make lint
- [x] make test
- [x] asc offer-codes create --subscription-id "6670453472" --prices "USA:PRICE_POINT_ID" (plus get/prices/update)