### PR TITLE
Per-territory pricing commands

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6027,10 +6027,10 @@ func TestCreateSubscriptionPrice(t *testing.T) {
 		if payload.Data.Type != ResourceTypeSubscriptionPrices {
 			t.Fatalf("expected type subscriptionPrices, got %q", payload.Data.Type)
 		}
-		if payload.Data.Relationships == nil || payload.Data.Relationships.Subscription == nil || payload.Data.Relationships.SubscriptionPricePoint == nil {
-			t.Fatalf("expected subscription and price point relationships")
+		if payload.Data.Relationships == nil || payload.Data.Relationships.Subscription == nil || payload.Data.Relationships.SubscriptionPricePoint == nil || payload.Data.Relationships.Territory == nil {
+			t.Fatalf("expected subscription, price point, and territory relationships")
 		}
-		if payload.Data.Relationships.Subscription.Data.ID != "sub-1" || payload.Data.Relationships.SubscriptionPricePoint.Data.ID != "price-point-1" {
+		if payload.Data.Relationships.Subscription.Data.ID != "sub-1" || payload.Data.Relationships.SubscriptionPricePoint.Data.ID != "price-point-1" || payload.Data.Relationships.Territory.Data.ID != "USA" {
 			t.Fatalf("unexpected relationships: %+v", payload.Data.Relationships)
 		}
 		assertAuthorized(t, req)
@@ -6041,7 +6041,7 @@ func TestCreateSubscriptionPrice(t *testing.T) {
 		StartDate: "2026-01-01",
 		Preserved: &preserved,
 	}
-	if _, err := client.CreateSubscriptionPrice(context.Background(), "sub-1", "price-point-1", priceAttrs); err != nil {
+	if _, err := client.CreateSubscriptionPrice(context.Background(), "sub-1", "price-point-1", "USA", priceAttrs); err != nil {
 		t.Fatalf("CreateSubscriptionPrice() error: %v", err)
 	}
 }

--- a/internal/asc/client_iap_subresources_test.go
+++ b/internal/asc/client_iap_subresources_test.go
@@ -336,6 +336,26 @@ func TestGetInAppPurchaseContent(t *testing.T) {
 	}
 }
 
+func TestGetInAppPurchasePricePoints_WithTerritory(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v2/inAppPurchases/iap-1/pricePoints" {
+			t.Fatalf("expected path /v2/inAppPurchases/iap-1/pricePoints, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("filter[territory]") != "USA" {
+			t.Fatalf("expected territory filter USA, got %q", req.URL.Query().Get("filter[territory]"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchasePricePoints(context.Background(), "iap-1", WithIAPPricePointsTerritory("USA")); err != nil {
+		t.Fatalf("GetInAppPurchasePricePoints() error: %v", err)
+	}
+}
+
 func TestGetInAppPurchasePricePointEqualizations(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[]}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -350,6 +370,46 @@ func TestGetInAppPurchasePricePointEqualizations(t *testing.T) {
 
 	if _, err := client.GetInAppPurchasePricePointEqualizations(context.Background(), "price-1"); err != nil {
 		t.Fatalf("GetInAppPurchasePricePointEqualizations() error: %v", err)
+	}
+}
+
+func TestGetInAppPurchasePriceScheduleManualPrices_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchasePriceSchedules/schedule-1/manualPrices" {
+			t.Fatalf("expected path /v1/inAppPurchasePriceSchedules/schedule-1/manualPrices, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", req.URL.Query().Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchasePriceScheduleManualPrices(context.Background(), "schedule-1", WithIAPPriceSchedulePricesLimit(5)); err != nil {
+		t.Fatalf("GetInAppPurchasePriceScheduleManualPrices() error: %v", err)
+	}
+}
+
+func TestGetInAppPurchasePriceScheduleAutomaticPrices_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchasePriceSchedules/schedule-1/automaticPrices" {
+			t.Fatalf("expected path /v1/inAppPurchasePriceSchedules/schedule-1/automaticPrices, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", req.URL.Query().Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchasePriceScheduleAutomaticPrices(context.Background(), "schedule-1", WithIAPPriceSchedulePricesLimit(5)); err != nil {
+		t.Fatalf("GetInAppPurchasePriceScheduleAutomaticPrices() error: %v", err)
 	}
 }
 

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -82,6 +82,10 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &PassTypeIDsResponse{Links: Links{}}
 	case *InAppPurchasesV2Response:
 		result = &InAppPurchasesV2Response{Links: Links{}}
+	case *InAppPurchasePricePointsResponse:
+		result = &InAppPurchasePricePointsResponse{Links: Links{}}
+	case *InAppPurchasePricesResponse:
+		result = &InAppPurchasePricesResponse{Links: Links{}}
 	case *AppEventsResponse:
 		result = &AppEventsResponse{Links: Links{}}
 	case *AppEventLocalizationsResponse:
@@ -126,6 +130,8 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &SubscriptionOfferCodeCustomCodesResponse{Links: Links{}}
 	case *SubscriptionOfferCodePricesResponse:
 		result = &SubscriptionOfferCodePricesResponse{Links: Links{}}
+	case *SubscriptionPricesResponse:
+		result = &SubscriptionPricesResponse{Links: Links{}}
 	case *SubscriptionPricePointsResponse:
 		result = &SubscriptionPricePointsResponse{Links: Links{}}
 	case *SubscriptionGroupLocalizationsResponse:

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -773,6 +773,35 @@ func (c *Client) GetSubscriptionOfferCodePrices(ctx context.Context, offerCodeID
 	return &response, nil
 }
 
+// GetSubscriptionPrices retrieves prices for a subscription.
+func (c *Client) GetSubscriptionPrices(ctx context.Context, subscriptionID string, opts ...SubscriptionPricesOption) (*SubscriptionPricesResponse, error) {
+	query := &subscriptionPricesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/prices", strings.TrimSpace(subscriptionID))
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPrices: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildSubscriptionPricesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionPricesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
 // GetSubscriptionPricePoints retrieves price points for a subscription.
 func (c *Client) GetSubscriptionPricePoints(ctx context.Context, subscriptionID string, opts ...SubscriptionPricePointsOption) (*SubscriptionPricePointsResponse, error) {
 	query := &subscriptionPricePointsQuery{}

--- a/internal/asc/iap_output_test.go
+++ b/internal/asc/iap_output_test.go
@@ -1,6 +1,7 @@
 package asc
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -152,6 +153,62 @@ func TestPrintMarkdown_InAppPurchasePricePoints(t *testing.T) {
 	}
 	if !strings.Contains(output, "1.40") {
 		t.Fatalf("expected proceeds in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_InAppPurchasePrices(t *testing.T) {
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"inAppPurchasePricePoint":{"data":{"type":"inAppPurchasePricePoints","id":"PRICE_POINT_1"}}}`)
+	resp := &InAppPurchasePricesResponse{
+		Data: []Resource[InAppPurchasePriceAttributes]{
+			{
+				ID:            "price-1",
+				Relationships: relationships,
+				Attributes: InAppPurchasePriceAttributes{
+					StartDate: "2026-01-01",
+					EndDate:   "2026-02-01",
+					Manual:    true,
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Territory") || !strings.Contains(output, "Price Point") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "USA") {
+		t.Fatalf("expected territory in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_InAppPurchasePrices(t *testing.T) {
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"inAppPurchasePricePoint":{"data":{"type":"inAppPurchasePricePoints","id":"PRICE_POINT_1"}}}`)
+	resp := &InAppPurchasePricesResponse{
+		Data: []Resource[InAppPurchasePriceAttributes]{
+			{
+				ID:            "price-1",
+				Relationships: relationships,
+				Attributes: InAppPurchasePriceAttributes{
+					StartDate: "2026-01-01",
+					EndDate:   "2026-02-01",
+					Manual:    true,
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "PRICE_POINT_1") {
+		t.Fatalf("expected price point in output, got: %s", output)
 	}
 }
 

--- a/internal/asc/iap_queries.go
+++ b/internal/asc/iap_queries.go
@@ -24,6 +24,7 @@ type iapOfferCodesQuery struct {
 
 type iapPricePointsQuery struct {
 	listQuery
+	territory string
 }
 
 type iapOfferCodeCustomCodesQuery struct {
@@ -90,6 +91,14 @@ func WithIAPPricePointsNextURL(next string) IAPPricePointsOption {
 	return func(q *iapPricePointsQuery) {
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+func WithIAPPricePointsTerritory(territory string) IAPPricePointsOption {
+	return func(q *iapPricePointsQuery) {
+		if strings.TrimSpace(territory) != "" {
+			q.territory = strings.TrimSpace(territory)
 		}
 	}
 }
@@ -188,6 +197,9 @@ func buildIAPOfferCodesQuery(query *iapOfferCodesQuery) string {
 
 func buildIAPPricePointsQuery(query *iapPricePointsQuery) string {
 	values := url.Values{}
+	if strings.TrimSpace(query.territory) != "" {
+		values.Set("filter[territory]", strings.TrimSpace(query.territory))
+	}
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -223,6 +223,8 @@ func PrintMarkdown(data interface{}) error {
 		return printInAppPurchaseImagesMarkdown(&InAppPurchaseImagesResponse{Data: []Resource[InAppPurchaseImageAttributes]{v.Data}})
 	case *InAppPurchasePricePointsResponse:
 		return printInAppPurchasePricePointsMarkdown(v)
+	case *InAppPurchasePricesResponse:
+		return printInAppPurchasePricesMarkdown(v)
 	case *InAppPurchaseOfferCodesResponse:
 		return printInAppPurchaseOfferCodesMarkdown(v)
 	case *InAppPurchaseOfferCodeResponse:
@@ -263,6 +265,8 @@ func PrintMarkdown(data interface{}) error {
 		return printPromotedPurchasesMarkdown(v)
 	case *PromotedPurchaseResponse:
 		return printPromotedPurchasesMarkdown(&PromotedPurchasesResponse{Data: []Resource[PromotedPurchaseAttributes]{v.Data}})
+	case *SubscriptionPricesResponse:
+		return printSubscriptionPricesMarkdown(v)
 	case *SubscriptionPriceResponse:
 		return printSubscriptionPriceMarkdown(v)
 	case *SubscriptionAvailabilityResponse:
@@ -323,6 +327,8 @@ func PrintMarkdown(data interface{}) error {
 		return printOfferCodeCustomCodesMarkdown(&SubscriptionOfferCodeCustomCodesResponse{Data: []Resource[SubscriptionOfferCodeCustomCodeAttributes]{v.Data}})
 	case *WinBackOfferDeleteResult:
 		return printWinBackOfferDeleteResultMarkdown(v)
+	case *SubscriptionPriceDeleteResult:
+		return printSubscriptionPriceDeleteResultMarkdown(v)
 	case *SubscriptionOfferCodePricesResponse:
 		return printOfferCodePricesMarkdown(v)
 	case *AppAvailabilityV2Response:
@@ -1077,6 +1083,8 @@ func PrintTable(data interface{}) error {
 		return printInAppPurchaseImagesTable(&InAppPurchaseImagesResponse{Data: []Resource[InAppPurchaseImageAttributes]{v.Data}})
 	case *InAppPurchasePricePointsResponse:
 		return printInAppPurchasePricePointsTable(v)
+	case *InAppPurchasePricesResponse:
+		return printInAppPurchasePricesTable(v)
 	case *InAppPurchaseOfferCodesResponse:
 		return printInAppPurchaseOfferCodesTable(v)
 	case *InAppPurchaseOfferCodeResponse:
@@ -1117,6 +1125,8 @@ func PrintTable(data interface{}) error {
 		return printPromotedPurchasesTable(v)
 	case *PromotedPurchaseResponse:
 		return printPromotedPurchasesTable(&PromotedPurchasesResponse{Data: []Resource[PromotedPurchaseAttributes]{v.Data}})
+	case *SubscriptionPricesResponse:
+		return printSubscriptionPricesTable(v)
 	case *SubscriptionPriceResponse:
 		return printSubscriptionPriceTable(v)
 	case *SubscriptionAvailabilityResponse:
@@ -1177,6 +1187,8 @@ func PrintTable(data interface{}) error {
 		return printOfferCodeCustomCodesTable(&SubscriptionOfferCodeCustomCodesResponse{Data: []Resource[SubscriptionOfferCodeCustomCodeAttributes]{v.Data}})
 	case *WinBackOfferDeleteResult:
 		return printWinBackOfferDeleteResultTable(v)
+	case *SubscriptionPriceDeleteResult:
+		return printSubscriptionPriceDeleteResultTable(v)
 	case *SubscriptionOfferCodePricesResponse:
 		return printOfferCodePricesTable(v)
 	case *AppAvailabilityV2Response:

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -32,6 +32,9 @@ type SubscriptionOfferCodePricesOption func(*subscriptionOfferCodePricesQuery)
 // SubscriptionPricePointsOption is a functional option for subscription price point list endpoints.
 type SubscriptionPricePointsOption func(*subscriptionPricePointsQuery)
 
+// SubscriptionPricesOption is a functional option for subscription price list endpoints.
+type SubscriptionPricesOption func(*subscriptionPricesQuery)
+
 // SubscriptionGroupLocalizationsOption is a functional option for subscription group localization list endpoints.
 type SubscriptionGroupLocalizationsOption func(*subscriptionGroupLocalizationsQuery)
 
@@ -68,6 +71,10 @@ type subscriptionOfferCodePricesQuery struct {
 }
 
 type subscriptionPricePointsQuery struct {
+	listQuery
+}
+
+type subscriptionPricesQuery struct {
 	listQuery
 }
 
@@ -237,6 +244,24 @@ func WithSubscriptionPricePointsNextURL(next string) SubscriptionPricePointsOpti
 	}
 }
 
+// WithSubscriptionPricesLimit sets the max number of prices to return.
+func WithSubscriptionPricesLimit(limit int) SubscriptionPricesOption {
+	return func(q *subscriptionPricesQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithSubscriptionPricesNextURL uses a next page URL directly.
+func WithSubscriptionPricesNextURL(next string) SubscriptionPricesOption {
+	return func(q *subscriptionPricesQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
 // WithSubscriptionGroupLocalizationsLimit sets the max number of group localizations to return.
 func WithSubscriptionGroupLocalizationsLimit(limit int) SubscriptionGroupLocalizationsOption {
 	return func(q *subscriptionGroupLocalizationsQuery) {
@@ -304,6 +329,12 @@ func buildSubscriptionOfferCodePricesQuery(query *subscriptionOfferCodePricesQue
 }
 
 func buildSubscriptionPricePointsQuery(query *subscriptionPricePointsQuery) string {
+	values := url.Values{}
+	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildSubscriptionPricesQuery(query *subscriptionPricesQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
 	return values.Encode()

--- a/internal/asc/subscriptions.go
+++ b/internal/asc/subscriptions.go
@@ -127,6 +127,7 @@ type SubscriptionPriceCreateAttributes struct {
 type SubscriptionPriceRelationships struct {
 	Subscription           *Relationship `json:"subscription"`
 	SubscriptionPricePoint *Relationship `json:"subscriptionPricePoint"`
+	Territory              *Relationship `json:"territory,omitempty"`
 }
 
 // SubscriptionPriceCreateData is the data portion of a price create request.

--- a/internal/asc/subscriptions_output_test.go
+++ b/internal/asc/subscriptions_output_test.go
@@ -1,0 +1,85 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPrintTable_SubscriptionPrices(t *testing.T) {
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"PRICE_POINT_1"}}}`)
+	resp := &SubscriptionPricesResponse{
+		Data: []Resource[SubscriptionPriceAttributes]{
+			{
+				ID:            "price-1",
+				Relationships: relationships,
+				Attributes: SubscriptionPriceAttributes{
+					StartDate: "2026-01-01",
+					Preserved: true,
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Territory") || !strings.Contains(output, "Price Point") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "USA") {
+		t.Fatalf("expected territory in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_SubscriptionPrices(t *testing.T) {
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"PRICE_POINT_1"}}}`)
+	resp := &SubscriptionPricesResponse{
+		Data: []Resource[SubscriptionPriceAttributes]{
+			{
+				ID:            "price-1",
+				Relationships: relationships,
+				Attributes: SubscriptionPriceAttributes{
+					StartDate: "2026-01-01",
+					Preserved: true,
+				},
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "PRICE_POINT_1") {
+		t.Fatalf("expected price point in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_SubscriptionPriceDeleteResult(t *testing.T) {
+	result := &SubscriptionPriceDeleteResult{ID: "price-1", Deleted: true}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	if !strings.Contains(output, "Deleted") {
+		t.Fatalf("expected deleted column in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_SubscriptionPriceDeleteResult(t *testing.T) {
+	result := &SubscriptionPriceDeleteResult{ID: "price-1", Deleted: true}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(result)
+	})
+
+	if !strings.Contains(output, "| ID | Deleted |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -826,6 +826,11 @@ func TestIAPValidationErrors(t *testing.T) {
 			wantErr: "--iap-id is required",
 		},
 		{
+			name:    "iap price-points equalizations missing id",
+			args:    []string{"iap", "price-points", "equalizations"},
+			wantErr: "--id is required",
+		},
+		{
 			name:    "iap price-schedules get missing iap-id",
 			args:    []string{"iap", "price-schedules", "get"},
 			wantErr: "--iap-id is required",
@@ -834,6 +839,16 @@ func TestIAPValidationErrors(t *testing.T) {
 			name:    "iap price-schedules create missing prices",
 			args:    []string{"iap", "price-schedules", "create", "--iap-id", "IAP_ID", "--base-territory", "USA"},
 			wantErr: "--prices is required",
+		},
+		{
+			name:    "iap price-schedules manual-prices missing schedule-id",
+			args:    []string{"iap", "price-schedules", "manual-prices"},
+			wantErr: "--schedule-id is required",
+		},
+		{
+			name:    "iap price-schedules automatic-prices missing schedule-id",
+			args:    []string{"iap", "price-schedules", "automatic-prices"},
+			wantErr: "--schedule-id is required",
 		},
 		{
 			name:    "iap offer-codes list missing iap-id",
@@ -1106,6 +1121,21 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 			name:    "subscriptions prices add missing price-point",
 			args:    []string{"subscriptions", "prices", "add", "--id", "SUB_ID"},
 			wantErr: "--price-point is required",
+		},
+		{
+			name:    "subscriptions prices list missing id",
+			args:    []string{"subscriptions", "prices", "list"},
+			wantErr: "--id is required",
+		},
+		{
+			name:    "subscriptions prices delete missing price-id",
+			args:    []string{"subscriptions", "prices", "delete", "--confirm"},
+			wantErr: "--price-id is required",
+		},
+		{
+			name:    "subscriptions prices delete missing confirm",
+			args:    []string{"subscriptions", "prices", "delete", "--price-id", "PRICE_ID"},
+			wantErr: "--confirm is required",
 		},
 		{
 			name:    "subscriptions availability set missing id",


### PR DESCRIPTION
Implement subscription pricing commands (add with `--territory`, list, delete) and enhance IAP pricing commands (territory filtering, price equalizations, manual/automatic price listings) as requested.

The changes introduce new CLI commands and client-side logic to manage subscription and in-app purchase pricing, including territory-specific pricing, listing existing prices, and deleting them, fulfilling a feature request to expand pricing management capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-1aaea42b-3821-49c6-b300-4e98cd7de2ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1aaea42b-3821-49c6-b300-4e98cd7de2ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

