### PR TITLE
Add App Clip image get commands

### DIFF
--- a/internal/asc/output_app_clips.go
+++ b/internal/asc/output_app_clips.go
@@ -163,6 +163,38 @@ func printAppClipAdvancedExperienceImageUploadResultMarkdown(result *AppClipAdva
 	return nil
 }
 
+func printAppClipAdvancedExperienceImageTable(resp *AppClipAdvancedExperienceImageResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tFile Name\tFile Size\tState")
+	state := ""
+	if resp.Data.Attributes.AssetDeliveryState != nil {
+		state = resp.Data.Attributes.AssetDeliveryState.State
+	}
+	fmt.Fprintf(w, "%s\t%s\t%d\t%s\n",
+		resp.Data.ID,
+		resp.Data.Attributes.FileName,
+		resp.Data.Attributes.FileSize,
+		state,
+	)
+	return w.Flush()
+}
+
+func printAppClipAdvancedExperienceImageMarkdown(resp *AppClipAdvancedExperienceImageResponse) error {
+	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | State |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
+	state := ""
+	if resp.Data.Attributes.AssetDeliveryState != nil {
+		state = resp.Data.Attributes.AssetDeliveryState.State
+	}
+	fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
+		escapeMarkdown(resp.Data.ID),
+		escapeMarkdown(resp.Data.Attributes.FileName),
+		resp.Data.Attributes.FileSize,
+		escapeMarkdown(state),
+	)
+	return nil
+}
+
 func printAppClipHeaderImageUploadResultTable(result *AppClipHeaderImageUploadResult) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tLocalization ID\tFile Name\tFile Size\tState\tUploaded")

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -85,6 +85,8 @@ func PrintMarkdown(data interface{}) error {
 		return printAppClipDefaultExperienceLocalizationsMarkdown(&AppClipDefaultExperienceLocalizationsResponse{Data: []Resource[AppClipDefaultExperienceLocalizationAttributes]{v.Data}})
 	case *AppClipHeaderImageResponse:
 		return printAppClipHeaderImageMarkdown(v)
+	case *AppClipAdvancedExperienceImageResponse:
+		return printAppClipAdvancedExperienceImageMarkdown(v)
 	case *AppClipAdvancedExperiencesResponse:
 		return printAppClipAdvancedExperiencesMarkdown(v)
 	case *AppClipAdvancedExperienceResponse:
@@ -1011,6 +1013,8 @@ func PrintTable(data interface{}) error {
 		return printAppClipDefaultExperienceLocalizationsTable(&AppClipDefaultExperienceLocalizationsResponse{Data: []Resource[AppClipDefaultExperienceLocalizationAttributes]{v.Data}})
 	case *AppClipHeaderImageResponse:
 		return printAppClipHeaderImageTable(v)
+	case *AppClipAdvancedExperienceImageResponse:
+		return printAppClipAdvancedExperienceImageTable(v)
 	case *AppClipAdvancedExperiencesResponse:
 		return printAppClipAdvancedExperiencesTable(v)
 	case *AppClipAdvancedExperienceResponse:

--- a/internal/cli/appclips/advanced_experience_images.go
+++ b/internal/cli/appclips/advanced_experience_images.go
@@ -23,16 +23,61 @@ func AppClipAdvancedExperienceImagesCommand() *ffcli.Command {
 		LongHelp: `Manage App Clip advanced experience images.
 
 Examples:
+  asc app-clips advanced-experiences images get --id "IMAGE_ID"
   asc app-clips advanced-experiences images create --experience-id "EXP_ID" --file path/to/image.png
   asc app-clips advanced-experiences images delete --id "IMAGE_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			AppClipAdvancedExperienceImagesGetCommand(),
 			AppClipAdvancedExperienceImagesCreateCommand(),
 			AppClipAdvancedExperienceImagesDeleteCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
+		},
+	}
+}
+
+// AppClipAdvancedExperienceImagesGetCommand retrieves an image by ID.
+func AppClipAdvancedExperienceImagesGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("get", flag.ExitOnError)
+
+	imageID := fs.String("id", "", "Image ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "asc app-clips advanced-experiences images get --id \"IMAGE_ID\"",
+		ShortHelp:  "Get an advanced experience image by ID.",
+		LongHelp: `Get an advanced experience image by ID.
+
+Examples:
+  asc app-clips advanced-experiences images get --id "IMAGE_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*imageID)
+			if idValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("app-clips advanced-experiences images get: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetAppClipAdvancedExperienceImage(requestCtx, idValue)
+			if err != nil {
+				return fmt.Errorf("app-clips advanced-experiences images get: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
 		},
 	}
 }

--- a/internal/cli/cmdtest/app_clips_images_test.go
+++ b/internal/cli/cmdtest/app_clips_images_test.go
@@ -1,0 +1,47 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"testing"
+)
+
+func TestAppClipsHeaderImagesGetValidationErrors(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"app-clips", "header-images", "get"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestAppClipsAdvancedExperienceImagesGetValidationErrors(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"app-clips", "advanced-experiences", "images", "get"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}


### PR DESCRIPTION
## Summary
- add get subcommands for App Clip header images and advanced experience images
- add table/markdown output support for advanced experience image responses
- add cmdtest validation coverage for new App Clip image commands

## Test plan
- [x] go test ./internal/cli/...