### PR TITLE
Add content rights declaration support to apps update command

### DIFF
--- a/internal/asc/client_apps.go
+++ b/internal/asc/client_apps.go
@@ -9,16 +9,18 @@ import (
 
 // AppAttributes describes an app resource.
 type AppAttributes struct {
-	Name          string `json:"name"`
-	BundleID      string `json:"bundleId"`
-	SKU           string `json:"sku"`
-	PrimaryLocale string `json:"primaryLocale,omitempty"`
+	Name                      string `json:"name"`
+	BundleID                  string `json:"bundleId"`
+	SKU                       string `json:"sku"`
+	PrimaryLocale             string `json:"primaryLocale,omitempty"`
+	ContentRightsDeclaration  string `json:"contentRightsDeclaration,omitempty"`
 }
 
 // AppUpdateAttributes describes fields for updating an app.
 type AppUpdateAttributes struct {
-	BundleID      *string `json:"bundleId,omitempty"`
-	PrimaryLocale *string `json:"primaryLocale,omitempty"`
+	BundleID                 *string `json:"bundleId,omitempty"`
+	PrimaryLocale            *string `json:"primaryLocale,omitempty"`
+	ContentRightsDeclaration *string `json:"contentRightsDeclaration,omitempty"`
 }
 
 // AppUpdateData is the data portion of an app update request.
@@ -243,7 +245,7 @@ func (c *Client) UpdateApp(ctx context.Context, appID string, attrs AppUpdateAtt
 			ID:   appID,
 		},
 	}
-	if attrs.BundleID != nil || attrs.PrimaryLocale != nil {
+	if attrs.BundleID != nil || attrs.PrimaryLocale != nil || attrs.ContentRightsDeclaration != nil {
 		payload.Data.Attributes = &attrs
 	}
 


### PR DESCRIPTION
## Summary

- Add `--content-rights` flag to `asc apps update` command
- Support setting `contentRightsDeclaration` field on apps via CLI
- This field is required for App Store submission and was previously only settable via the web UI

## Changes

- `internal/asc/client_apps.go`: Add `ContentRightsDeclaration` field to `AppAttributes` and `AppUpdateAttributes`
- `internal/cli/apps/apps.go`: Add `--content-rights` flag with validation for valid values

## Usage

```bash
# Set content rights to indicate app does not use third-party content
asc apps update --id "APP_ID" --content-rights "DOES_NOT_USE_THIRD_PARTY_CONTENT"

# Set content rights to indicate app uses third-party content
asc apps update --id "APP_ID" --content-rights "USES_THIRD_PARTY_CONTENT"
```

## Valid Values

- `DOES_NOT_USE_THIRD_PARTY_CONTENT` - App does not contain, show, or access third-party content
- `USES_THIRD_PARTY_CONTENT` - App contains, shows, or accesses third-party content

## Test plan

- [x] Verified flag is accepted and validated
- [x] Tested updating an app's content rights declaration successfully
- [x] Confirmed the field appears in app response after update