### PR TITLE
Add review submissions-cancel command to cancel draft submissions

### DIFF
--- a/internal/cli/reviews/review.go
+++ b/internal/cli/reviews/review.go
@@ -46,6 +46,7 @@ Examples:
 			ReviewSubmissionsGetCommand(),
 			ReviewSubmissionsCreateCommand(),
 			ReviewSubmissionsSubmitCommand(),
+			ReviewSubmissionsCancelCommand(),
 			ReviewSubmissionsUpdateCommand(),
 			ReviewSubmissionsItemsIDsCommand(),
 			ReviewItemsGetCommand(),


### PR DESCRIPTION
## Summary
- Add `submissions-cancel` subcommand to the `asc review` command group
- Requires `--id` flag for the submission ID and `--confirm` flag to prevent accidental cancellation
- Calls the existing `CancelReviewSubmission` client function

## Test plan
- [ ] Run `asc review submissions-cancel --help` to verify command is registered
- [ ] Test with a valid submission ID using `asc review submissions-cancel --id "SUBMISSION_ID" --confirm`
- [ ] Verify error message when `--confirm` is missing
- [ ] Verify error message when `--id` is missing