### PR TITLE
Show usesNonExemptEncryption in builds list output

### DIFF
--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -16,7 +16,7 @@ type BuildAttributes struct {
 	ExpirationDate          string `json:"expirationDate,omitempty"`
 	ProcessingState         string `json:"processingState,omitempty"`
 	MinOSVersion            string `json:"minOsVersion,omitempty"`
-	UsesNonExemptEncryption bool   `json:"usesNonExemptEncryption,omitempty"`
+	UsesNonExemptEncryption *bool  `json:"usesNonExemptEncryption,omitempty"`
 	Expired                 bool   `json:"expired,omitempty"`
 }
 

--- a/internal/asc/output_builds.go
+++ b/internal/asc/output_builds.go
@@ -68,29 +68,44 @@ type BuildExpireAllResult struct {
 	Failures            []BuildExpireAllFailure `json:"failures,omitempty"`
 }
 
+// formatEncryptionStatus formats the UsesNonExemptEncryption field for display.
+// Returns "required" if true (needs encryption declaration), "exempt" if false,
+// or "n/a" if null (no information available).
+func formatEncryptionStatus(usesNonExempt *bool) string {
+	if usesNonExempt == nil {
+		return "n/a"
+	}
+	if *usesNonExempt {
+		return "required"
+	}
+	return "exempt"
+}
+
 func printBuildsTable(resp *BuildsResponse) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "Version\tUploaded\tProcessing\tExpired")
+	fmt.Fprintln(w, "Version\tUploaded\tProcessing\tExpired\tEncryption")
 	for _, item := range resp.Data {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%t\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\n",
 			item.Attributes.Version,
 			item.Attributes.UploadedDate,
 			item.Attributes.ProcessingState,
 			item.Attributes.Expired,
+			formatEncryptionStatus(item.Attributes.UsesNonExemptEncryption),
 		)
 	}
 	return w.Flush()
 }
 
 func printBuildsMarkdown(resp *BuildsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Version | Uploaded | Processing | Expired |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
+	fmt.Fprintln(os.Stdout, "| Version | Uploaded | Processing | Expired | Encryption |")
+	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
 	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %t |\n",
+		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %t | %s |\n",
 			escapeMarkdown(item.Attributes.Version),
 			escapeMarkdown(item.Attributes.UploadedDate),
 			escapeMarkdown(item.Attributes.ProcessingState),
 			item.Attributes.Expired,
+			formatEncryptionStatus(item.Attributes.UsesNonExemptEncryption),
 		)
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Add `Encryption` column to builds list table and markdown output
- Display encryption status as "required" (needs declaration), "exempt", or "n/a"
- Change `UsesNonExemptEncryption` from `bool` to `*bool` to properly handle null values from API

## Why this matters

The `usesNonExemptEncryption` field is important for App Store submissions:
- If `true` (shown as "required"): the build uses non-exempt encryption and requires an approved encryption declaration before submission
- If `false` (shown as "exempt"): the build is exempt from encryption requirements
- If `null` (shown as "n/a"): no encryption information available

This helps users quickly identify which builds need encryption declarations before they can be submitted to the App Store.

## Test plan

- [ ] Run `asc builds list --app <app-id>` and verify the new Encryption column appears
- [ ] Verify builds show appropriate values (required/exempt/n/a)
- [ ] Test with `--output markdown` to confirm markdown table also shows the column