### PR TITLE
Add app-infos list command to show app info IDs

### DIFF
--- a/internal/cli/apps/app_infos.go
+++ b/internal/cli/apps/app_infos.go
@@ -1,0 +1,88 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+// AppInfosCommand returns the app-infos command group.
+func AppInfosCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("app-infos", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "app-infos",
+		ShortUsage: "asc app-infos <subcommand> [flags]",
+		ShortHelp:  "List app info records for an app.",
+		LongHelp: `List app info records for an app.
+
+An app can have multiple app info records (one per platform or state). This command
+helps you find the specific app info ID you need when commands report "multiple app
+infos found" errors.
+
+Examples:
+  asc app-infos list --app "APP_ID"
+  asc app-infos list --app "APP_ID" --output table`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AppInfosListCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// AppInfosListCommand returns the list subcommand for app-infos.
+func AppInfosListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("app-infos list", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc app-infos list [flags]",
+		ShortHelp:  "List all app info records for an app.",
+		LongHelp: `List all app info records for an app.
+
+An app can have multiple app info records (one per platform or state). Use this
+command to find the specific app info ID when you encounter "multiple app infos
+found" errors in other commands.
+
+Examples:
+  asc app-infos list --app "APP_ID"
+  asc app-infos list --app "APP_ID" --output table
+  asc app-infos list --app "APP_ID" --output markdown`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedAppID := resolveAppID(*appID)
+			if strings.TrimSpace(resolvedAppID) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("app-infos list: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetAppInfos(requestCtx, resolvedAppID)
+			if err != nil {
+				return fmt.Errorf("app-infos list: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -121,6 +121,7 @@ func Subcommands(version string) []*ffcli.Command {
 		productpages.ProductPagesCommand(),
 		routingcoverage.RoutingCoverageCommand(),
 		apps.AppInfoCommand(),
+		apps.AppInfosCommand(),
 		eula.EULACommand(),
 		agreements.AgreementsCommand(),
 		pricing.PricingCommand(),


### PR DESCRIPTION
## Summary

- Adds a new `app-infos` command group with a `list` subcommand
- Lists all app info records for an app, showing ID, state, age rating, and other attributes
- Supports `--app` flag (or `ASC_APP_ID` env) and `--output` format (json, table, markdown)

## Why

When an app has multiple app info records (e.g., different platforms or states), commands like `app-info get --include` fail with "multiple app infos found" errors. Users need a way to discover the specific app info ID they need. This command solves that by listing all app info records with their IDs and states.

## Usage

```bash
# List all app info records for an app
asc app-infos list --app "APP_ID"

# Output as table for easier reading
asc app-infos list --app "APP_ID" --output table

# Use environment variable
ASC_APP_ID=123456 asc app-infos list
```

## Test plan

- [ ] Verify `go build .` succeeds
- [ ] Test `asc app-infos list --app <id>` returns app info records
- [ ] Test `--output table` and `--output markdown` formats work
- [ ] Test error handling when `--app` is missing