### PR TITLE
Add --pkg flag to builds upload for macOS apps

### DIFF
--- a/internal/asc/client_types.go
+++ b/internal/asc/client_types.go
@@ -262,6 +262,7 @@ type UTI string
 
 const (
 	UTIIPA UTI = "com.apple.ipa"
+	UTIPKG UTI = "com.apple.installer-package-archive"
 )
 
 // Relationship represents a generic API relationship.

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -2912,9 +2912,14 @@ func TestBuildsUploadValidationErrors(t *testing.T) {
 			wantErr: "Error: --app is required",
 		},
 		{
-			name:    "missing ipa",
+			name:    "missing ipa or pkg",
 			args:    []string{"builds", "upload", "--app", "APP_123", "--version", "1.0.0", "--build-number", "123"},
-			wantErr: "Error: --ipa is required",
+			wantErr: "Error: --ipa or --pkg is required",
+		},
+		{
+			name:    "ipa and pkg mutually exclusive",
+			args:    []string{"builds", "upload", "--app", "APP_123", "--ipa", "app.ipa", "--pkg", "app.pkg", "--version", "1.0.0", "--build-number", "123"},
+			wantErr: "Error: --ipa and --pkg are mutually exclusive",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add `--pkg` flag to `asc builds upload` command for uploading macOS .pkg installer files
- When using `--pkg`, the platform is automatically set to `MAC_OS`
- Validate that `--ipa` and `--pkg` flags are mutually exclusive
- Require explicit `--version` and `--build-number` flags for PKG uploads (IPA files can auto-extract these from Info.plist)

## Changes

- `internal/asc/client_types.go`: Add `UTIPKG` constant for macOS installer package UTI (`com.apple.installer-package-archive`)
- `internal/cli/builds/builds_commands.go`: Add `--pkg` flag with validation logic and platform auto-detection
- `internal/cli/cmdtest/commands_test.go`: Add test cases for new validation behavior

## Usage Examples

```bash
# Upload a macOS .pkg file
asc builds upload --app "123456789" --pkg "app.pkg" --version "1.0.0" --build-number "1"

# Upload an iOS .ipa file (unchanged)
asc builds upload --app "123456789" --ipa "app.ipa"
```

## Test plan

- [x] `go build .` compiles successfully
- [x] `go test ./...` passes all tests
- [x] New validation error messages work correctly:
  - `--ipa or --pkg is required` when neither is provided
  - `--ipa and --pkg are mutually exclusive` when both are provided
  - `--pkg requires --platform MAC_OS` when conflicting platform is specified
  - `--version and --build-number required for PKG uploads` when missing