### PR TITLE
Iap offer code parity

### DIFF
--- a/internal/asc/client_iap_subresources_test.go
+++ b/internal/asc/client_iap_subresources_test.go
@@ -484,6 +484,23 @@ func TestGetInAppPurchasePriceScheduleByID(t *testing.T) {
 	}
 }
 
+func TestGetInAppPurchasePriceScheduleBaseTerritory(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"territories","id":"USA","attributes":{"currency":"USD"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchasePriceSchedules/schedule-1/baseTerritory" {
+			t.Fatalf("expected path /v1/inAppPurchasePriceSchedules/schedule-1/baseTerritory, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchasePriceScheduleBaseTerritory(context.Background(), "schedule-1"); err != nil {
+		t.Fatalf("GetInAppPurchasePriceScheduleBaseTerritory() error: %v", err)
+	}
+}
+
 func TestCreateInAppPurchasePriceSchedule(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"inAppPurchasePriceSchedules","id":"schedule-1"}}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -535,6 +552,41 @@ func TestGetInAppPurchaseOfferCodes_UsesNextURL(t *testing.T) {
 
 	if _, err := client.GetInAppPurchaseOfferCodes(context.Background(), "iap-1", WithIAPOfferCodesNextURL(next)); err != nil {
 		t.Fatalf("GetInAppPurchaseOfferCodes() error: %v", err)
+	}
+}
+
+func TestGetInAppPurchaseOfferCodePrices_WithLimit(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"inAppPurchaseOfferPrices","id":"price-1"}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchaseOfferCodes/offer-1/prices" {
+			t.Fatalf("expected path /v1/inAppPurchaseOfferCodes/offer-1/prices, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "5" {
+			t.Fatalf("expected limit=5, got %q", req.URL.Query().Get("limit"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchaseOfferCodePrices(context.Background(), "offer-1", WithIAPOfferCodePricesLimit(5)); err != nil {
+		t.Fatalf("GetInAppPurchaseOfferCodePrices() error: %v", err)
+	}
+}
+
+func TestGetInAppPurchaseOfferCodePrices_UsesNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=abc"
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.URL.String() != next {
+			t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchaseOfferCodePrices(context.Background(), "offer-1", WithIAPOfferCodePricesNextURL(next)); err != nil {
+		t.Fatalf("GetInAppPurchaseOfferCodePrices() error: %v", err)
 	}
 }
 

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -88,6 +88,8 @@ func PaginateAll(ctx context.Context, firstPage PaginatedResponse, fetchNext Pag
 		result = &InAppPurchasePricePointsResponse{Links: Links{}}
 	case *InAppPurchasePricesResponse:
 		result = &InAppPurchasePricesResponse{Links: Links{}}
+	case *InAppPurchaseOfferPricesResponse:
+		result = &InAppPurchaseOfferPricesResponse{Links: Links{}}
 	case *AppEventsResponse:
 		result = &AppEventsResponse{Links: Links{}}
 	case *AppEventLocalizationsResponse:
@@ -442,6 +444,8 @@ func typeOf(p PaginatedResponse) string {
 		return "MerchantIDsResponse"
 	case *InAppPurchasesV2Response:
 		return "InAppPurchasesV2Response"
+	case *InAppPurchaseOfferPricesResponse:
+		return "InAppPurchaseOfferPricesResponse"
 	case *AppEventsResponse:
 		return "AppEventsResponse"
 	case *AppEventLocalizationsResponse:

--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -243,6 +243,8 @@ func PrintMarkdown(data interface{}) error {
 		return printInAppPurchasePricePointsMarkdown(v)
 	case *InAppPurchasePricesResponse:
 		return printInAppPurchasePricesMarkdown(v)
+	case *InAppPurchaseOfferPricesResponse:
+		return printInAppPurchaseOfferCodePricesMarkdown(v)
 	case *InAppPurchaseOfferCodesResponse:
 		return printInAppPurchaseOfferCodesMarkdown(v)
 	case *InAppPurchaseOfferCodeResponse:
@@ -301,6 +303,8 @@ func PrintMarkdown(data interface{}) error {
 		return printSubscriptionGracePeriodMarkdown(v)
 	case *TerritoriesResponse:
 		return printTerritoriesMarkdown(v)
+	case *TerritoryResponse:
+		return printTerritoriesMarkdown(&TerritoriesResponse{Data: []Resource[TerritoryAttributes]{v.Data}})
 	case *TerritoryAgeRatingsResponse:
 		return printTerritoryAgeRatingsMarkdown(v)
 	case *OfferCodeValuesResult:
@@ -1171,6 +1175,8 @@ func PrintTable(data interface{}) error {
 		return printInAppPurchasePricePointsTable(v)
 	case *InAppPurchasePricesResponse:
 		return printInAppPurchasePricesTable(v)
+	case *InAppPurchaseOfferPricesResponse:
+		return printInAppPurchaseOfferCodePricesTable(v)
 	case *InAppPurchaseOfferCodesResponse:
 		return printInAppPurchaseOfferCodesTable(v)
 	case *InAppPurchaseOfferCodeResponse:
@@ -1229,6 +1235,8 @@ func PrintTable(data interface{}) error {
 		return printSubscriptionGracePeriodTable(v)
 	case *TerritoriesResponse:
 		return printTerritoriesTable(v)
+	case *TerritoryResponse:
+		return printTerritoriesTable(&TerritoriesResponse{Data: []Resource[TerritoryAttributes]{v.Data}})
 	case *TerritoryAgeRatingsResponse:
 		return printTerritoryAgeRatingsTable(v)
 	case *OfferCodeValuesResult:

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -511,10 +511,10 @@ func TestPrintTable_InAppPurchases(t *testing.T) {
 			{
 				ID: "iap-1",
 				Attributes: InAppPurchaseAttributes{
-					ReferenceName:   "Legacy Pro",
-					ProductID:       "com.example.legacy",
+					ReferenceName:     "Legacy Pro",
+					ProductID:         "com.example.legacy",
 					InAppPurchaseType: "CONSUMABLE",
-					State:           "APPROVED",
+					State:             "APPROVED",
 				},
 			},
 		},
@@ -535,10 +535,10 @@ func TestPrintMarkdown_InAppPurchases(t *testing.T) {
 			{
 				ID: "iap-1",
 				Attributes: InAppPurchaseAttributes{
-					ReferenceName:   "Legacy Pro",
-					ProductID:       "com.example.legacy",
+					ReferenceName:     "Legacy Pro",
+					ProductID:         "com.example.legacy",
 					InAppPurchaseType: "CONSUMABLE",
-					State:           "APPROVED",
+					State:             "APPROVED",
 				},
 			},
 		},
@@ -630,6 +630,130 @@ func TestPrintMarkdown_OfferCodePrices(t *testing.T) {
 	}
 	if !strings.Contains(output, "PRICE-1") {
 		t.Fatalf("expected price point in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_IAPOfferCodePrices(t *testing.T) {
+	relationships := InAppPurchaseOfferPriceInlineRelationships{
+		Territory: Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeTerritories,
+				ID:   "USA",
+			},
+		},
+		PricePoint: Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeInAppPurchasePricePoints,
+				ID:   "PRICE-1",
+			},
+		},
+	}
+	raw, err := json.Marshal(relationships)
+	if err != nil {
+		t.Fatalf("marshal relationships error: %v", err)
+	}
+	resp := &InAppPurchaseOfferPricesResponse{
+		Data: []Resource[InAppPurchaseOfferPriceAttributes]{
+			{
+				ID:            "price-1",
+				Relationships: raw,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Price Point") {
+		t.Fatalf("expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "PRICE-1") {
+		t.Fatalf("expected price point in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_IAPOfferCodePrices(t *testing.T) {
+	relationships := InAppPurchaseOfferPriceInlineRelationships{
+		Territory: Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeTerritories,
+				ID:   "USA",
+			},
+		},
+		PricePoint: Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeInAppPurchasePricePoints,
+				ID:   "PRICE-1",
+			},
+		},
+	}
+	raw, err := json.Marshal(relationships)
+	if err != nil {
+		t.Fatalf("marshal relationships error: %v", err)
+	}
+	resp := &InAppPurchaseOfferPricesResponse{
+		Data: []Resource[InAppPurchaseOfferPriceAttributes]{
+			{
+				ID:            "price-1",
+				Relationships: raw,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+		t.Fatalf("expected markdown header, got: %s", output)
+	}
+	if !strings.Contains(output, "PRICE-1") {
+		t.Fatalf("expected price point in output, got: %s", output)
+	}
+}
+
+func TestPrintTable_TerritoryResponse(t *testing.T) {
+	resp := &TerritoryResponse{
+		Data: Resource[TerritoryAttributes]{
+			ID: "USA",
+			Attributes: TerritoryAttributes{
+				Currency: "USD",
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Currency") {
+		t.Fatalf("expected currency header, got: %s", output)
+	}
+	if !strings.Contains(output, "USD") {
+		t.Fatalf("expected currency in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_TerritoryResponse(t *testing.T) {
+	resp := &TerritoryResponse{
+		Data: Resource[TerritoryAttributes]{
+			ID: "USA",
+			Attributes: TerritoryAttributes{
+				Currency: "USD",
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "| ID | Currency |") {
+		t.Fatalf("expected currency header, got: %s", output)
+	}
+	if !strings.Contains(output, "USD") {
+		t.Fatalf("expected currency in output, got: %s", output)
 	}
 }
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -942,6 +942,11 @@ func TestIAPValidationErrors(t *testing.T) {
 			wantErr: "--iap-id or --schedule-id is required",
 		},
 		{
+			name:    "iap price-schedules base-territory missing schedule-id",
+			args:    []string{"iap", "price-schedules", "base-territory"},
+			wantErr: "--schedule-id is required",
+		},
+		{
 			name:    "iap price-schedules create missing prices",
 			args:    []string{"iap", "price-schedules", "create", "--iap-id", "IAP_ID", "--base-territory", "USA"},
 			wantErr: "--prices is required",
@@ -1000,6 +1005,11 @@ func TestIAPValidationErrors(t *testing.T) {
 			name:    "iap offer-codes one-time-codes values missing one-time-code-id",
 			args:    []string{"iap", "offer-codes", "one-time-codes", "values"},
 			wantErr: "--one-time-code-id is required",
+		},
+		{
+			name:    "iap offer-codes prices missing offer-code-id",
+			args:    []string{"iap", "offer-codes", "prices"},
+			wantErr: "--offer-code-id is required",
 		},
 		{
 			name:    "iap promoted-purchase get missing id",
@@ -1450,8 +1460,13 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "subscriptions offer-codes one-time-codes missing offer-code-id",
-			args:    []string{"subscriptions", "offer-codes", "one-time-codes"},
+			args:    []string{"subscriptions", "offer-codes", "one-time-codes", "list"},
 			wantErr: "--offer-code-id is required",
+		},
+		{
+			name:    "subscriptions offer-codes one-time-codes get missing id",
+			args:    []string{"subscriptions", "offer-codes", "one-time-codes", "get"},
+			wantErr: "--id is required",
 		},
 		{
 			name:    "subscriptions offer-codes prices missing offer-code-id",

--- a/internal/cli/iap/offer_code_prices.go
+++ b/internal/cli/iap/offer_code_prices.go
@@ -1,0 +1,89 @@
+package iap
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// IAPOfferCodesPricesCommand returns the offer code prices subcommand.
+func IAPOfferCodesPricesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("offer-codes prices", flag.ExitOnError)
+
+	offerCodeID := fs.String("offer-code-id", "", "Offer code ID")
+	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "prices",
+		ShortUsage: "asc iap offer-codes prices --offer-code-id \"OFFER_CODE_ID\" [flags]",
+		ShortHelp:  "List prices for an offer code.",
+		LongHelp: `List prices for an offer code.
+
+Examples:
+  asc iap offer-codes prices --offer-code-id "OFFER_CODE_ID"
+  asc iap offer-codes prices --offer-code-id "OFFER_CODE_ID" --paginate`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("iap offer-codes prices: --limit must be between 1 and 200")
+			}
+			if err := validateNextURL(*next); err != nil {
+				return fmt.Errorf("iap offer-codes prices: %w", err)
+			}
+
+			id := strings.TrimSpace(*offerCodeID)
+			if id == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("iap offer-codes prices: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			opts := []asc.IAPOfferCodePricesOption{
+				asc.WithIAPOfferCodePricesLimit(*limit),
+				asc.WithIAPOfferCodePricesNextURL(*next),
+			}
+
+			if *paginate {
+				paginateOpts := append(opts, asc.WithIAPOfferCodePricesLimit(200))
+				firstPage, err := client.GetInAppPurchaseOfferCodePrices(requestCtx, id, paginateOpts...)
+				if err != nil {
+					return fmt.Errorf("iap offer-codes prices: failed to fetch: %w", err)
+				}
+
+				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetInAppPurchaseOfferCodePrices(ctx, id, asc.WithIAPOfferCodePricesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("iap offer-codes prices: %w", err)
+				}
+
+				return printOutput(resp, *output, *pretty)
+			}
+
+			resp, err := client.GetInAppPurchaseOfferCodePrices(requestCtx, id, opts...)
+			if err != nil {
+				return fmt.Errorf("iap offer-codes prices: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}

--- a/internal/cli/iap/offer_codes.go
+++ b/internal/cli/iap/offer_codes.go
@@ -43,6 +43,7 @@ Examples:
 			IAPOfferCodesUpdateCommand(),
 			IAPOfferCodesCustomCodesCommand(),
 			IAPOfferCodesOneTimeCodesCommand(),
+			IAPOfferCodesPricesCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/iap/price_schedules.go
+++ b/internal/cli/iap/price_schedules.go
@@ -30,6 +30,7 @@ Examples:
 		UsageFunc: DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			IAPPriceSchedulesGetCommand(),
+			IAPPriceSchedulesBaseTerritoryCommand(),
 			IAPPriceSchedulesCreateCommand(),
 			IAPPriceSchedulesManualPricesCommand(),
 			IAPPriceSchedulesAutomaticPricesCommand(),
@@ -92,6 +93,49 @@ Examples:
 			resp, err := client.GetInAppPurchasePriceSchedule(requestCtx, iapValue)
 			if err != nil {
 				return fmt.Errorf("iap price-schedules get: failed to fetch: %w", err)
+			}
+
+			return printOutput(resp, *output, *pretty)
+		},
+	}
+}
+
+// IAPPriceSchedulesBaseTerritoryCommand returns the price schedules base territory subcommand.
+func IAPPriceSchedulesBaseTerritoryCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("price-schedules base-territory", flag.ExitOnError)
+
+	scheduleID := fs.String("schedule-id", "", "Price schedule ID")
+	output := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "base-territory",
+		ShortUsage: "asc iap price-schedules base-territory --schedule-id \"SCHEDULE_ID\"",
+		ShortHelp:  "Get base territory for a price schedule.",
+		LongHelp: `Get base territory for a price schedule.
+
+Examples:
+  asc iap price-schedules base-territory --schedule-id "SCHEDULE_ID"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			id := strings.TrimSpace(*scheduleID)
+			if id == "" {
+				fmt.Fprintln(os.Stderr, "Error: --schedule-id is required")
+				return flag.ErrHelp
+			}
+
+			client, err := getASCClient()
+			if err != nil {
+				return fmt.Errorf("iap price-schedules base-territory: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetInAppPurchasePriceScheduleBaseTerritory(requestCtx, id)
+			if err != nil {
+				return fmt.Errorf("iap price-schedules base-territory: failed to fetch: %w", err)
 			}
 
 			return printOutput(resp, *output, *pretty)


### PR DESCRIPTION
Adds CLI commands for `iap offer-codes prices` and `iap price-schedules base-territory`, and introduces `subscriptions offer-codes one-time-codes get` to expand App Store Connect API coverage.

The `subscriptions offer-codes one-time-codes` command has been refactored from a direct listing command to a subcommand group, now including `list` and `get` operations for better organization and future extensibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-071ccab3-4c95-4a00-bcf6-62d4701056ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-071ccab3-4c95-4a00-bcf6-62d4701056ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

