### PR TITLE
Certificate activation toggle

### DIFF
--- a/internal/asc/client_signing.go
+++ b/internal/asc/client_signing.go
@@ -281,6 +281,35 @@ func (c *Client) CreateCertificate(ctx context.Context, csrContent string, certT
 	return &response, nil
 }
 
+// UpdateCertificate updates a certificate's attributes.
+func (c *Client) UpdateCertificate(ctx context.Context, id string, attrs CertificateUpdateAttributes) (*CertificateResponse, error) {
+	id = strings.TrimSpace(id)
+	request := CertificateUpdateRequest{
+		Data: CertificateUpdateData{
+			Type:       ResourceTypeCertificates,
+			ID:         id,
+			Attributes: &attrs,
+		},
+	}
+
+	body, err := BuildRequestBody(request)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := c.do(ctx, "PATCH", fmt.Sprintf("/v1/certificates/%s", id), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CertificateResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // RevokeCertificate revokes a certificate by ID.
 func (c *Client) RevokeCertificate(ctx context.Context, id string) error {
 	id = strings.TrimSpace(id)

--- a/internal/asc/signing.go
+++ b/internal/asc/signing.go
@@ -108,6 +108,7 @@ type CertificateAttributes struct {
 	Platform           string `json:"platform,omitempty"`
 	ExpirationDate     string `json:"expirationDate,omitempty"`
 	CertificateContent string `json:"certificateContent,omitempty"`
+	Activated          *bool  `json:"activated,omitempty"`
 }
 
 // CertificateCreateAttributes describes attributes for creating a certificate.
@@ -125,6 +126,23 @@ type CertificateCreateData struct {
 // CertificateCreateRequest is a request to create a certificate.
 type CertificateCreateRequest struct {
 	Data CertificateCreateData `json:"data"`
+}
+
+// CertificateUpdateAttributes describes attributes for updating a certificate.
+type CertificateUpdateAttributes struct {
+	Activated *bool `json:"activated,omitempty"`
+}
+
+// CertificateUpdateData is the data portion of a certificate update request.
+type CertificateUpdateData struct {
+	Type       ResourceType                 `json:"type"`
+	ID         string                       `json:"id"`
+	Attributes *CertificateUpdateAttributes `json:"attributes,omitempty"`
+}
+
+// CertificateUpdateRequest is a request to update a certificate.
+type CertificateUpdateRequest struct {
+	Data CertificateUpdateData `json:"data"`
 }
 
 // CertificatesResponse is the response from certificates list endpoint.

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -54,6 +54,30 @@ func TestCertificatesRevokeCommand_MissingConfirm(t *testing.T) {
 	}
 }
 
+func TestCertificatesUpdateCommand_MissingID(t *testing.T) {
+	cmd := CertificatesUpdateCommand()
+
+	if err := cmd.FlagSet.Parse([]string{"--activated", "true"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
+	}
+}
+
+func TestCertificatesUpdateCommand_MissingActivated(t *testing.T) {
+	cmd := CertificatesUpdateCommand()
+
+	if err := cmd.FlagSet.Parse([]string{"--id", "CERT_ID"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+		t.Fatalf("expected flag.ErrHelp when --activated is missing, got %v", err)
+	}
+}
+
 func TestCertificatesGetCommand_MissingID(t *testing.T) {
 	cmd := CertificatesGetCommand()
 

--- a/internal/cli/certificates/shared_wrappers.go
+++ b/internal/cli/certificates/shared_wrappers.go
@@ -36,3 +36,7 @@ func splitCSVUpper(value string) []string {
 func splitCSV(value string) []string {
 	return shared.SplitCSV(value)
 }
+
+func parseOptionalBoolFlag(name, value string) (*bool, error) {
+	return shared.ParseOptionalBoolFlag(name, value)
+}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1688,6 +1688,49 @@ func TestDevicesValidationErrors(t *testing.T) {
 	}
 }
 
+func TestCertificatesValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "certificates update missing id",
+			args:    []string{"certificates", "update", "--activated", "true"},
+			wantErr: "Error: --id is required",
+		},
+		{
+			name:    "certificates update missing activated",
+			args:    []string{"certificates", "update", "--id", "CERT_ID"},
+			wantErr: "Error: --activated is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
 func TestDevicesListLimitValidation(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)


### PR DESCRIPTION
Add `UpdateCertificate` client method and `asc certificates update` CLI command to toggle the `activated` flag for certificates.

---
<a href="https://cursor.com/background-agent?bcId=bc-8acf3543-86c9-4d60-8596-f002871d50eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8acf3543-86c9-4d60-8596-f002871d50eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

