### PR TITLE
Add cmdtest coverage for TestFlight commands

### DIFF
--- a/internal/cli/cmdtest/testflight_beta_crash_logs_notifications_test.go
+++ b/internal/cli/cmdtest/testflight_beta_crash_logs_notifications_test.go
@@ -1,0 +1,105 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTestFlightBetaCrashLogsGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaCrashLogs/log-1" {
+			t.Fatalf("expected path /v1/betaCrashLogs/log-1, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"betaCrashLogs","id":"log-1"}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-crash-logs", "get", "--id", "log-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"log-1"`) {
+		t.Fatalf("expected crash log id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaNotificationsCreateOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/buildBetaNotifications" {
+			t.Fatalf("expected path /v1/buildBetaNotifications, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"id":"build-1"`) {
+			t.Fatalf("expected build id in body, got %s", string(payload))
+		}
+		body := `{"data":{"type":"buildBetaNotifications","id":"notif-1"}}`
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-notifications", "create", "--build", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"notif-1"`) {
+		t.Fatalf("expected notification id in output, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
+++ b/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
@@ -1,0 +1,396 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTestFlightBetaDetailsGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/buildBetaDetails" {
+			t.Fatalf("expected path /v1/buildBetaDetails, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if query.Get("filter[build]") != "build-1" {
+			t.Fatalf("expected build filter build-1, got %q", query.Get("filter[build]"))
+		}
+		if query.Get("limit") != "1" {
+			t.Fatalf("expected limit 1, got %q", query.Get("limit"))
+		}
+		body := `{"data":[{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true}}],"links":{"next":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-details", "get", "--build", "build-1", "--limit", "1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"detail-1"`) {
+		t.Fatalf("expected detail id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaDetailsBuildGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/buildBetaDetails/detail-1/build" {
+			t.Fatalf("expected path /v1/buildBetaDetails/detail-1/build, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"builds","id":"build-1","attributes":{"version":"1.0"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-details", "build", "get", "--id", "detail-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"build-1"`) {
+		t.Fatalf("expected build id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaDetailsUpdateOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/buildBetaDetails/detail-1" {
+			t.Fatalf("expected path /v1/buildBetaDetails/detail-1, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"autoNotifyEnabled":true`) {
+			t.Fatalf("expected autoNotifyEnabled in body, got %s", string(payload))
+		}
+		body := `{"data":{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-details", "update", "--id", "detail-1", "--auto-notify"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"detail-1"`) {
+		t.Fatalf("expected detail id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightRecruitmentOptionsOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaRecruitmentCriterionOptions" {
+			t.Fatalf("expected path /v1/betaRecruitmentCriterionOptions, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if query.Get("fields[betaRecruitmentCriterionOptions]") != "deviceFamilyOsVersions" {
+			t.Fatalf("expected fields deviceFamilyOsVersions, got %q", query.Get("fields[betaRecruitmentCriterionOptions]"))
+		}
+		if query.Get("limit") != "1" {
+			t.Fatalf("expected limit 1, got %q", query.Get("limit"))
+		}
+		body := `{"data":[{"type":"betaRecruitmentCriterionOptions","id":"opt-1","attributes":{"deviceFamilyOsVersions":[{"deviceFamily":"IPHONE","osVersions":["26"]}]}}],"links":{"next":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "recruitment", "options", "--fields", "deviceFamilyOsVersions", "--limit", "1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"opt-1"`) {
+		t.Fatalf("expected option id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightRecruitmentSetUpdatesExisting(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaGroups/group-1/betaRecruitmentCriteria" {
+				t.Fatalf("expected path /v1/betaGroups/group-1/betaRecruitmentCriteria, got %s", req.URL.Path)
+			}
+			body := `{"data":{"type":"betaRecruitmentCriteria","id":"criteria-1","attributes":{"deviceFamilyOsVersionFilters":[{"deviceFamily":"IPHONE","minimumOsInclusive":"26"}]}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaRecruitmentCriteria/criteria-1" {
+				t.Fatalf("expected path /v1/betaRecruitmentCriteria/criteria-1, got %s", req.URL.Path)
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			if !strings.Contains(string(payload), `"deviceFamilyOsVersionFilters"`) {
+				t.Fatalf("expected filters in body, got %s", string(payload))
+			}
+			body := `{"data":{"type":"betaRecruitmentCriteria","id":"criteria-1","attributes":{"deviceFamilyOsVersionFilters":[{"deviceFamily":"IPHONE","minimumOsInclusive":"26"}]}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "recruitment", "set", "--group", "group-1", "--os-version-filter", "IPHONE=26"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"criteria-1"`) {
+		t.Fatalf("expected criteria id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightRecruitmentSetCreatesWhenMissing(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaGroups/group-2/betaRecruitmentCriteria" {
+				t.Fatalf("expected path /v1/betaGroups/group-2/betaRecruitmentCriteria, got %s", req.URL.Path)
+			}
+			body := `{"errors":[{"code":"NOT_FOUND","title":"Not Found"}]}`
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaRecruitmentCriteria" {
+				t.Fatalf("expected path /v1/betaRecruitmentCriteria, got %s", req.URL.Path)
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			if !strings.Contains(string(payload), `"id":"group-2"`) {
+				t.Fatalf("expected group id in body, got %s", string(payload))
+			}
+			body := `{"data":{"type":"betaRecruitmentCriteria","id":"criteria-2","attributes":{"deviceFamilyOsVersionFilters":[{"deviceFamily":"IPHONE","minimumOsInclusive":"26"}]}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "recruitment", "set", "--group", "group-2", "--os-version-filter", "IPHONE=26"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"criteria-2"`) {
+		t.Fatalf("expected criteria id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightRecruitmentSetReturnsErrorOnFetchFailure(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"errors":[{"code":"FORBIDDEN","title":"Forbidden"}]}`
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "recruitment", "set", "--group", "group-3", "--os-version-filter", "IPHONE=26"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected non-help error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(runErr.Error(), "failed to fetch existing criteria") {
+		t.Fatalf("expected fetch error, got %v (stderr: %q)", runErr, stderr)
+	}
+}

--- a/internal/cli/cmdtest/testflight_beta_feedback_get_test.go
+++ b/internal/cli/cmdtest/testflight_beta_feedback_get_test.go
@@ -1,0 +1,142 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTestFlightBetaFeedbackCrashSubmissionsGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaFeedbackCrashSubmissions/sub-1" {
+			t.Fatalf("expected path /v1/betaFeedbackCrashSubmissions/sub-1, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"betaFeedbackCrashSubmissions","id":"sub-1"}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-feedback", "crash-submissions", "get", "--id", "sub-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-1"`) {
+		t.Fatalf("expected submission id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaFeedbackScreenshotSubmissionsGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaFeedbackScreenshotSubmissions/sub-2" {
+			t.Fatalf("expected path /v1/betaFeedbackScreenshotSubmissions/sub-2, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"betaFeedbackScreenshotSubmissions","id":"sub-2"}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-feedback", "screenshot-submissions", "get", "--id", "sub-2"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-2"`) {
+		t.Fatalf("expected submission id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaFeedbackCrashLogGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaFeedbackCrashSubmissions/sub-1/crashLog" {
+			t.Fatalf("expected path /v1/betaFeedbackCrashSubmissions/sub-1/crashLog, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"betaCrashLogs","id":"log-1"}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-feedback", "crash-log", "get", "--id", "sub-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"log-1"`) {
+		t.Fatalf("expected crash log id in output, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/testflight_beta_license_agreements_test.go
+++ b/internal/cli/cmdtest/testflight_beta_license_agreements_test.go
@@ -5,8 +5,207 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestTestFlightBetaLicenseAgreementsListOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaLicenseAgreements" {
+			t.Fatalf("expected path /v1/betaLicenseAgreements, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if query.Get("filter[app]") != "app-1" {
+			t.Fatalf("expected app filter app-1, got %q", query.Get("filter[app]"))
+		}
+		if query.Get("limit") != "2" {
+			t.Fatalf("expected limit 2, got %q", query.Get("limit"))
+		}
+		body := `{"data":[{"type":"betaLicenseAgreements","id":"agree-1","attributes":{"agreementText":"Terms"}}],"links":{"next":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-license-agreements", "list", "--app", "app-1", "--limit", "2"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"agree-1"`) {
+		t.Fatalf("expected agreement id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaLicenseAgreementsGetByIDOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaLicenseAgreements/agree-1" {
+			t.Fatalf("expected path /v1/betaLicenseAgreements/agree-1, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("fields[betaLicenseAgreements]") != "agreementText" {
+			t.Fatalf("expected fields agreementText, got %q", req.URL.Query().Get("fields[betaLicenseAgreements]"))
+		}
+		body := `{"data":{"type":"betaLicenseAgreements","id":"agree-1","attributes":{"agreementText":"Terms"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-license-agreements", "get", "--id", "agree-1", "--fields", "agreementText"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"agree-1"`) {
+		t.Fatalf("expected agreement id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaLicenseAgreementsGetByAppOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/betaLicenseAgreement" {
+			t.Fatalf("expected path /v1/apps/app-1/betaLicenseAgreement, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("fields[betaLicenseAgreements]") != "agreementText" {
+			t.Fatalf("expected fields agreementText, got %q", req.URL.Query().Get("fields[betaLicenseAgreements]"))
+		}
+		body := `{"data":{"type":"betaLicenseAgreements","id":"agree-2","attributes":{"agreementText":"Terms"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-license-agreements", "get", "--app", "app-1", "--fields", "agreementText"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"agree-2"`) {
+		t.Fatalf("expected agreement id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaLicenseAgreementsUpdateOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaLicenseAgreements/agree-1" {
+			t.Fatalf("expected path /v1/betaLicenseAgreements/agree-1, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"agreementText":"Updated terms"`) {
+			t.Fatalf("expected agreement text in body, got %s", string(payload))
+		}
+		body := `{"data":{"type":"betaLicenseAgreements","id":"agree-1","attributes":{"agreementText":"Updated terms"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-license-agreements", "update", "--id", "agree-1", "--agreement-text", "Updated terms"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"agree-1"`) {
+		t.Fatalf("expected agreement id in output, got %q", stdout)
+	}
+}
 
 func TestTestFlightBetaLicenseAgreementsGetValidationErrors(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")

--- a/internal/cli/cmdtest/testflight_beta_testers_commands_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_commands_test.go
@@ -1,0 +1,363 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTestFlightBetaTestersAddOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("expected path /v1/apps/app-1/betaGroups, got %s", req.URL.Path)
+			}
+			if req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("expected limit 200, got %q", req.URL.Query().Get("limit"))
+			}
+			body := `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"Beta"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("expected path /v1/betaTesters, got %s", req.URL.Path)
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			if !strings.Contains(string(payload), `"email":"tester@example.com"`) {
+				t.Fatalf("expected email in body, got %s", string(payload))
+			}
+			if !strings.Contains(string(payload), `"id":"group-1"`) {
+				t.Fatalf("expected group id in body, got %s", string(payload))
+			}
+			body := `{"data":{"type":"betaTesters","id":"tester-1","attributes":{"email":"tester@example.com"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-testers", "add", "--app", "app-1", "--email", "tester@example.com", "--group", "Beta"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"tester-1"`) {
+		t.Fatalf("expected tester id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaTestersRemoveOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("expected path /v1/betaTesters, got %s", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if query.Get("filter[apps]") != "app-1" {
+				t.Fatalf("expected app filter app-1, got %q", query.Get("filter[apps]"))
+			}
+			if query.Get("filter[email]") != "tester@example.com" {
+				t.Fatalf("expected email filter tester@example.com, got %q", query.Get("filter[email]"))
+			}
+			body := `{"data":[{"type":"betaTesters","id":"tester-2","attributes":{"email":"tester@example.com"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodDelete {
+				t.Fatalf("expected DELETE, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesters/tester-2" {
+				t.Fatalf("expected path /v1/betaTesters/tester-2, got %s", req.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-testers", "remove", "--app", "app-1", "--email", "tester@example.com"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"deleted":true`) {
+		t.Fatalf("expected deleted true in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaTestersAddGroupsOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaTesters/tester-1/relationships/betaGroups" {
+			t.Fatalf("expected path /v1/betaTesters/tester-1/relationships/betaGroups, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"id":"group-1"`) {
+			t.Fatalf("expected group id in body, got %s", string(payload))
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-testers", "add-groups", "--id", "tester-1", "--group", "group-1,group-2"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "Successfully added tester tester-1") {
+		t.Fatalf("expected success message, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"action":"added"`) {
+		t.Fatalf("expected action added in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaTestersRemoveGroupsOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaTesters/tester-2/relationships/betaGroups" {
+			t.Fatalf("expected path /v1/betaTesters/tester-2/relationships/betaGroups, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"id":"group-3"`) {
+			t.Fatalf("expected group id in body, got %s", string(payload))
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-testers", "remove-groups", "--id", "tester-2", "--group", "group-3", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "Successfully removed tester tester-2") {
+		t.Fatalf("expected success message, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"action":"removed"`) {
+		t.Fatalf("expected action removed in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaTestersInviteOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("expected path /v1/betaTesters, got %s", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if query.Get("filter[apps]") != "app-1" {
+				t.Fatalf("expected app filter app-1, got %q", query.Get("filter[apps]"))
+			}
+			if query.Get("filter[email]") != "tester@example.com" {
+				t.Fatalf("expected email filter tester@example.com, got %q", query.Get("filter[email]"))
+			}
+			body := `{"data":[]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("expected path /v1/apps/app-1/betaGroups, got %s", req.URL.Path)
+			}
+			body := `{"data":[{"type":"betaGroups","id":"group-9","attributes":{"name":"Beta"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 3:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("expected path /v1/betaTesters, got %s", req.URL.Path)
+			}
+			body := `{"data":{"type":"betaTesters","id":"tester-9","attributes":{"email":"tester@example.com"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 4:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesterInvitations" {
+				t.Fatalf("expected path /v1/betaTesterInvitations, got %s", req.URL.Path)
+			}
+			body := `{"data":{"type":"betaTesterInvitations","id":"invite-1"}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "beta-testers", "invite", "--app", "app-1", "--email", "tester@example.com", "--group", "Beta"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"invitationId":"invite-1"`) {
+		t.Fatalf("expected invitation id in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"testerId":"tester-9"`) {
+		t.Fatalf("expected tester id in output, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/testflight_review_commands_test.go
+++ b/internal/cli/cmdtest/testflight_review_commands_test.go
@@ -1,0 +1,296 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTestFlightReviewGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewDetails" {
+			t.Fatalf("expected path /v1/betaAppReviewDetails, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if query.Get("filter[app]") != "app-1" {
+			t.Fatalf("expected filter app app-1, got %q", query.Get("filter[app]"))
+		}
+		if query.Get("limit") != "2" {
+			t.Fatalf("expected limit 2, got %q", query.Get("limit"))
+		}
+		body := `{"data":[{"type":"betaAppReviewDetails","id":"detail-1","attributes":{"contactEmail":"dev@example.com"}}],"links":{"next":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "get", "--app", "app-1", "--limit", "2"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"detail-1"`) {
+		t.Fatalf("expected detail id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightReviewUpdateOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewDetails/detail-1" {
+			t.Fatalf("expected path /v1/betaAppReviewDetails/detail-1, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"contactEmail":"dev@example.com"`) {
+			t.Fatalf("expected contactEmail in body, got %s", string(payload))
+		}
+		body := `{"data":{"type":"betaAppReviewDetails","id":"detail-1","attributes":{"contactEmail":"dev@example.com"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "update", "--id", "detail-1", "--contact-email", "dev@example.com"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"detail-1"`) {
+		t.Fatalf("expected detail id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightReviewSubmitOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewSubmissions" {
+			t.Fatalf("expected path /v1/betaAppReviewSubmissions, got %s", req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if !strings.Contains(string(payload), `"id":"build-1"`) {
+			t.Fatalf("expected build id in body, got %s", string(payload))
+		}
+		body := `{"data":{"type":"betaAppReviewSubmissions","id":"submission-1"}}`
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "submit", "--build", "build-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"submission-1"`) {
+		t.Fatalf("expected submission id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightReviewAppGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewDetails/detail-1/app" {
+			t.Fatalf("expected path /v1/betaAppReviewDetails/detail-1/app, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"apps","id":"app-1","attributes":{"name":"App"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "app", "get", "--id", "detail-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"app-1"`) {
+		t.Fatalf("expected app id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightReviewSubmissionsGetOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewSubmissions/submission-1" {
+			t.Fatalf("expected path /v1/betaAppReviewSubmissions/submission-1, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"betaAppReviewSubmissions","id":"submission-1","attributes":{"betaReviewState":"WAITING_FOR_REVIEW"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "submissions", "get", "--id", "submission-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"submission-1"`) {
+		t.Fatalf("expected submission id in output, got %q", stdout)
+	}
+}
+
+func TestTestFlightReviewSubmissionsBuildOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewSubmissions/submission-1/build" {
+			t.Fatalf("expected path /v1/betaAppReviewSubmissions/submission-1/build, got %s", req.URL.Path)
+		}
+		body := `{"data":{"type":"builds","id":"build-1","attributes":{"version":"1.0"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "submissions", "build", "--id", "submission-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"build-1"`) {
+		t.Fatalf("expected build id in output, got %q", stdout)
+	}
+}

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -922,6 +922,8 @@ Examples:
 					return fmt.Errorf("testflight recruitment set: failed to update: %w", err)
 				}
 				return printOutput(criteria, *output, *pretty)
+			} else if !asc.IsNotFound(err) {
+				return fmt.Errorf("testflight recruitment set: failed to fetch existing criteria: %w", err)
 			}
 
 			criteria, createErr := client.CreateBetaRecruitmentCriteria(requestCtx, trimmedGroupID, filterValues)


### PR DESCRIPTION
## Summary
- guard recruitment set create path to only run on not-found errors
- add cmdtests for TestFlight review, beta details, testers, feedback, crash logs, notifications, and license agreements
- expand recruitment tests for update, create, and error handling cases

## Test plan
- make test
- make test-integration (skips when ASC_* env vars/assets unavailable)