### PR TITLE
Fix migrate import: omit locale on PATCH + select draft AppInfo

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1168,6 +1168,9 @@ func (c *Client) CreateAppStoreVersionLocalization(ctx context.Context, versionI
 
 // UpdateAppStoreVersionLocalization updates a localization for an app store version.
 func (c *Client) UpdateAppStoreVersionLocalization(ctx context.Context, localizationID string, attributes AppStoreVersionLocalizationAttributes) (*AppStoreVersionLocalizationResponse, error) {
+	// "locale" is immutable on App Store Connect; PATCH requests must not include it.
+	attributes.Locale = ""
+
 	payload := AppStoreVersionLocalizationUpdateRequest{
 		Data: AppStoreVersionLocalizationUpdateData{
 			Type:       ResourceTypeAppStoreVersionLocalizations,
@@ -1412,6 +1415,9 @@ func (c *Client) CreateAppInfoLocalization(ctx context.Context, appInfoID string
 
 // UpdateAppInfoLocalization updates a localization for an app info resource.
 func (c *Client) UpdateAppInfoLocalization(ctx context.Context, localizationID string, attributes AppInfoLocalizationAttributes) (*AppInfoLocalizationResponse, error) {
+	// "locale" is immutable on App Store Connect; PATCH requests must not include it.
+	attributes.Locale = ""
+
 	payload := AppInfoLocalizationUpdateRequest{
 		Data: AppInfoLocalizationUpdateData{
 			Type:       ResourceTypeAppInfoLocalizations,

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -2279,6 +2279,28 @@ func TestUpdateAppStoreVersionLocalization_SendsRequest(t *testing.T) {
 	}
 }
 
+func TestUpdateAppStoreVersionLocalization_OmitsLocale(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"description":"Updated"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if strings.Contains(string(body), `"locale"`) {
+			t.Fatalf("expected request body to omit locale, got: %s", string(body))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	attrs := AppStoreVersionLocalizationAttributes{
+		Locale:      "en-US",
+		Description: "Updated",
+	}
+	if _, err := client.UpdateAppStoreVersionLocalization(context.Background(), "loc-1", attrs); err != nil {
+		t.Fatalf("UpdateAppStoreVersionLocalization() error: %v", err)
+	}
+}
+
 func TestDeleteAppStoreVersionLocalization_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusNoContent, "")
 	client := newTestClient(t, func(req *http.Request) {
@@ -2674,6 +2696,28 @@ func TestUpdateAppInfoLocalization_SendsRequest(t *testing.T) {
 
 	attrs := AppInfoLocalizationAttributes{
 		Name: "Updated",
+	}
+	if _, err := client.UpdateAppInfoLocalization(context.Background(), "loc-1", attrs); err != nil {
+		t.Fatalf("UpdateAppInfoLocalization() error: %v", err)
+	}
+}
+
+func TestUpdateAppInfoLocalization_OmitsLocale(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"name":"Updated"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if strings.Contains(string(body), `"locale"`) {
+			t.Fatalf("expected request body to omit locale, got: %s", string(body))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	attrs := AppInfoLocalizationAttributes{
+		Locale: "en-US",
+		Name:   "Updated",
 	}
 	if _, err := client.UpdateAppInfoLocalization(context.Background(), "loc-1", attrs); err != nil {
 		t.Fatalf("UpdateAppInfoLocalization() error: %v", err)

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -13,6 +13,46 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
+func appInfoAttrString(attrs asc.AppInfoAttributes, key string) string {
+	if attrs == nil {
+		return ""
+	}
+	value, ok := attrs[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func pickEditableAppInfoID(appInfos *asc.AppInfosResponse) string {
+	if appInfos == nil || len(appInfos.Data) == 0 {
+		return ""
+	}
+
+	// Prefer the draft app info record. Apps commonly have both a live AppInfo
+	// (READY_FOR_DISTRIBUTION) and a draft AppInfo (PREPARE_FOR_SUBMISSION).
+	for _, info := range appInfos.Data {
+		if appInfoAttrString(info.Attributes, "appStoreState") == "PREPARE_FOR_SUBMISSION" {
+			return info.ID
+		}
+	}
+
+	// Fallback: pick the first non-live state if present.
+	for _, info := range appInfos.Data {
+		state := appInfoAttrString(info.Attributes, "appStoreState")
+		if state != "" && state != "READY_FOR_DISTRIBUTION" {
+			return info.ID
+		}
+	}
+
+	return appInfos.Data[0].ID
+}
+
 // MigrateCommand returns the migrate command with subcommands.
 func MigrateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("migrate", flag.ExitOnError)
@@ -189,7 +229,10 @@ Examples:
 				if len(appInfos.Data) == 0 {
 					return fmt.Errorf("migrate import: no app info found for app")
 				}
-				appInfoID := appInfos.Data[0].ID
+				appInfoID := pickEditableAppInfoID(appInfos)
+				if strings.TrimSpace(appInfoID) == "" {
+					return fmt.Errorf("migrate import: failed to select app info for app")
+				}
 
 				// Get existing App Info localizations
 				existingAppInfoLocs, err := client.GetAppInfoLocalizations(requestCtx, appInfoID)
@@ -333,7 +376,10 @@ Examples:
 			// Export App Info localizations (name, subtitle)
 			appInfos, err := client.GetAppInfos(requestCtx, resolvedAppID)
 			if err == nil && len(appInfos.Data) > 0 {
-				appInfoID := appInfos.Data[0].ID
+				appInfoID := pickEditableAppInfoID(appInfos)
+				if strings.TrimSpace(appInfoID) == "" {
+					return fmt.Errorf("migrate export: failed to select app info for app")
+				}
 				appInfoLocs, err := client.GetAppInfoLocalizations(requestCtx, appInfoID)
 				if err == nil {
 					for _, loc := range appInfoLocs.Data {


### PR DESCRIPTION
This fixes two issues that break `asc migrate import` for apps with multiple localizations.

1) Omit immutable `locale` on PATCH updates
- App Store Connect rejects UPDATE requests that include `locale`:
  `The attribute 'locale' can not be included in a 'UPDATE' request`
- `UpdateAppStoreVersionLocalization` and `UpdateAppInfoLocalization` now clear `attributes.Locale` before building the PATCH payload.
- Added unit tests that assert `"locale"` is not present in the JSON body for these PATCH requests.

2) Prefer the draft (editable) AppInfo during migrate import/export
- Apps can have multiple `AppInfo` records (commonly a live one in `READY_FOR_DISTRIBUTION` and a draft one in `PREPARE_FOR_SUBMISSION`).
- Updating `AppInfoLocalization.name/subtitle` against the live AppInfo fails with:
  `The field 'name' can not be modified in the current state.`
- `migrate import` and `migrate export` now select the `AppInfo` in `PREPARE_FOR_SUBMISSION` when present, otherwise fall back sensibly.

Validation
- `go test ./...`
- Manual end-to-end `migrate import` run against a real app that has both live + draft AppInfo records; confirmed the CLI targets the `PREPARE_FOR_SUBMISSION` AppInfo and completes without API errors.