### PR TITLE
migrate: follow-up hardening for appInfo selection

### DIFF
--- a/internal/cli/migrate/migrate_test.go
+++ b/internal/cli/migrate/migrate_test.go
@@ -274,6 +274,39 @@ func TestSelectBestAppInfoID_FallsBackToNonReadyForSale(t *testing.T) {
 	}
 }
 
+func TestSelectBestAppInfoID_EmptyInput(t *testing.T) {
+	if got := selectBestAppInfoID(nil); got != "" {
+		t.Fatalf("expected empty appInfoID for nil input, got %q", got)
+	}
+
+	if got := selectBestAppInfoID(&asc.AppInfosResponse{}); got != "" {
+		t.Fatalf("expected empty appInfoID for empty input, got %q", got)
+	}
+}
+
+func TestSelectBestAppInfoID_UsesStateWhenAppStoreStateMissing(t *testing.T) {
+	appInfos := &asc.AppInfosResponse{
+		Data: []types.Resource[asc.AppInfoAttributes]{
+			{
+				ID: "live",
+				Attributes: asc.AppInfoAttributes{
+					"state": "READY_FOR_DISTRIBUTION",
+				},
+			},
+			{
+				ID: "editable",
+				Attributes: asc.AppInfoAttributes{
+					"state": "IN_REVIEW",
+				},
+			},
+		},
+	}
+
+	if got := selectBestAppInfoID(appInfos); got != "editable" {
+		t.Fatalf("expected appInfoID %q, got %q", "editable", got)
+	}
+}
+
 func TestReadFastlaneMetadata_EmptyDirectory(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
Follow-up PR after #434 and #435 to harden `migrate` appInfo selection and remove drift between import/export paths.

## The 5 follow-up changes
1. **Unify selector usage**: `migrate export` now uses `selectBestAppInfoID` (same as `migrate import`) instead of a separate helper.
2. **Remove duplicate selector path**: deleted `pickEditableAppInfoID` to avoid divergent logic over time.
3. **Nil/empty safety**: `selectBestAppInfoID` now safely handles `nil` and empty responses.
4. **State fallback hardening**: fallback selection now considers both `state` and `appStoreState` and treats live states (`READY_FOR_DISTRIBUTION`, `READY_FOR_SALE`) as non-editable.
5. **Regression coverage**: added tests for nil/empty selector input and state-only selection behavior when `appStoreState` is missing.

## Validation
- `go test ./internal/cli/migrate -run "TestSelectBestAppInfoID" -count=1`
- `make test`
- `make build`

## Notes
- `make format` was attempted but `gofumpt` is not installed in this environment; files were formatted with `gofmt`.
