### PR TITLE
Avoid pre-stat file checks

### DIFF
--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -127,7 +128,13 @@ var legacyKeyringOpener = func() (keyring.Keyring, error) {
 
 // ValidateKeyFile validates that the private key file exists and is valid
 func ValidateKeyFile(path string) error {
-	info, err := os.Stat(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open key file: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf("failed to stat key file: %w", err)
 	}
@@ -138,7 +145,7 @@ func ValidateKeyFile(path string) error {
 		return fmt.Errorf("private key file is too permissive; run: chmod 600 %q", path)
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("failed to read key file: %w", err)
 	}

--- a/internal/cli/gamecenter/game_center_matchmaking.go
+++ b/internal/cli/gamecenter/game_center_matchmaking.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -1836,7 +1837,13 @@ func ascClient(ctx context.Context) *asc.Client {
 }
 
 func readJSONFilePayload(path string) (json.RawMessage, error) {
-	info, err := os.Stat(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
 	if err != nil {
 		return nil, err
 	}
@@ -1844,7 +1851,7 @@ func readJSONFilePayload(path string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("payload path must be a file")
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -97,21 +97,23 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			// Check if directory exists
 			metadataDir := filepath.Join(*fastlaneDir, "metadata")
-			if _, err := os.Stat(metadataDir); os.IsNotExist(err) {
-				return fmt.Errorf("migrate import: metadata directory not found: %s", metadataDir)
-			}
 
 			// Read metadata from fastlane structure
 			localizations, err := readFastlaneMetadata(metadataDir)
 			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("migrate import: metadata directory not found: %s", metadataDir)
+				}
 				return fmt.Errorf("migrate import: %w", err)
 			}
 
 			// Read App Info metadata (name, subtitle)
 			appInfoLocs, err := readFastlaneAppInfoMetadata(metadataDir)
 			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("migrate import: metadata directory not found: %s", metadataDir)
+				}
 				return fmt.Errorf("migrate import: %w", err)
 			}
 
@@ -621,21 +623,23 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			// Check if directory exists
 			metadataDir := filepath.Join(*fastlaneDir, "metadata")
-			if _, err := os.Stat(metadataDir); os.IsNotExist(err) {
-				return fmt.Errorf("migrate validate: metadata directory not found: %s", metadataDir)
-			}
 
 			// Read metadata from fastlane structure
 			localizations, err := readFastlaneMetadata(metadataDir)
 			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("migrate validate: metadata directory not found: %s", metadataDir)
+				}
 				return fmt.Errorf("migrate validate: %w", err)
 			}
 
 			// Read App Info metadata (name, subtitle)
 			appInfoLocs, err := readFastlaneAppInfoMetadata(metadataDir)
 			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("migrate validate: metadata directory not found: %s", metadataDir)
+				}
 				return fmt.Errorf("migrate validate: %w", err)
 			}
 

--- a/internal/cli/testflight/testflight_sync.go
+++ b/internal/cli/testflight/testflight_sync.go
@@ -657,10 +657,6 @@ func writeTestFlightConfigYAML(outputPath string, config *TestFlightConfig) erro
 		return fmt.Errorf("config is required")
 	}
 
-	if info, err := os.Stat(outputPath); err == nil && info.IsDir() {
-		return fmt.Errorf("output path is a directory")
-	}
-
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return err
 	}
@@ -696,6 +692,9 @@ func writeTestFlightConfigYAML(outputPath string, config *TestFlightConfig) erro
 	}
 	tempFile = nil
 	if err := os.Rename(tempName, outputPath); err != nil {
+		if info, statErr := os.Stat(outputPath); statErr == nil && info.IsDir() {
+			return fmt.Errorf("output path is a directory")
+		}
 		return err
 	}
 	committed = true

--- a/internal/cli/xcodecloud/xcode_cloud_extras.go
+++ b/internal/cli/xcodecloud/xcode_cloud_extras.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -1010,7 +1011,13 @@ func xcodeCloudXcodeVersionsList(ctx context.Context, limit int, next string, pa
 }
 
 func readJSONFilePayload(path string) (json.RawMessage, error) {
-	info, err := os.Stat(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
 	if err != nil {
 		return nil, err
 	}
@@ -1018,7 +1025,7 @@ func readJSONFilePayload(path string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("payload path must be a file")
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- switch JSON payload reads to open/stat/read to avoid TOCTOU
- validate key files using the opened fd before reading
- remove redundant metadata dir pre-checks and defer output-path dir errors to rename

## Test plan
- make format
- make lint
- make test