### PR TITLE
Unify markdown output with tablewriter's built-in renderer

### DIFF
--- a/internal/asc/actors_output.go
+++ b/internal/asc/actors_output.go
@@ -1,11 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
-func printActorsTable(resp *ActorsResponse) error {
+func actorsRows(resp *ActorsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Type", "Name", "Email", "API Key ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -18,22 +13,17 @@ func printActorsTable(resp *ActorsResponse) error {
 			compactWhitespace(attr.APIKeyID),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printActorsTable(resp *ActorsResponse) error {
+	h, r := actorsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printActorsMarkdown(resp *ActorsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Type | Name | Email | API Key ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attr := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attr.ActorType),
-			escapeMarkdown(formatPersonName(attr.UserFirstName, attr.UserLastName)),
-			escapeMarkdown(attr.UserEmail),
-			escapeMarkdown(attr.APIKeyID),
-		)
-	}
+	h, r := actorsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/analytics_output.go
+++ b/internal/asc/analytics_output.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // SalesReportResult represents CLI output for sales report downloads.
 type SalesReportResult struct {
@@ -83,7 +80,7 @@ type AnalyticsReportGetSegment struct {
 	URLExpirationDate string `json:"urlExpirationDate,omitempty"`
 }
 
-func printSalesReportResultTable(result *SalesReportResult) error {
+func salesReportResultRows(result *SalesReportResult) ([]string, [][]string) {
 	headers := []string{"Vendor", "Type", "Subtype", "Frequency", "Date", "Version", "Compressed File", "Compressed Size", "Decompressed File", "Decompressed Size"}
 	rows := [][]string{{
 		result.VendorNumber,
@@ -97,66 +94,58 @@ func printSalesReportResultTable(result *SalesReportResult) error {
 		result.DecompressedPath,
 		fmt.Sprintf("%d", result.DecompressedSize),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printSalesReportResultTable(result *SalesReportResult) error {
+	h, r := salesReportResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printSalesReportResultMarkdown(result *SalesReportResult) error {
-	fmt.Fprintln(os.Stdout, "| Vendor | Type | Subtype | Frequency | Date | Version | Compressed File | Compressed Size | Decompressed File | Decompressed Size |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s | %d | %s | %d |\n",
-		escapeMarkdown(result.VendorNumber),
-		escapeMarkdown(result.ReportType),
-		escapeMarkdown(result.ReportSubType),
-		escapeMarkdown(result.Frequency),
-		escapeMarkdown(result.ReportDate),
-		escapeMarkdown(result.Version),
-		escapeMarkdown(result.FilePath),
-		result.FileSize,
-		escapeMarkdown(result.DecompressedPath),
-		result.DecompressedSize,
-	)
+	h, r := salesReportResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportRequestResultTable(result *AnalyticsReportRequestResult) error {
+func analyticsReportRequestResultRows(result *AnalyticsReportRequestResult) ([]string, [][]string) {
 	headers := []string{"Request ID", "App ID", "Access Type", "State", "Created Date"}
 	rows := [][]string{{result.RequestID, result.AppID, result.AccessType, result.State, result.CreatedDate}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportRequestResultTable(result *AnalyticsReportRequestResult) error {
+	h, r := analyticsReportRequestResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportRequestResultMarkdown(result *AnalyticsReportRequestResult) error {
-	fmt.Fprintln(os.Stdout, "| Request ID | App ID | Access Type | State | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(result.RequestID),
-		escapeMarkdown(result.AppID),
-		escapeMarkdown(result.AccessType),
-		escapeMarkdown(result.State),
-		escapeMarkdown(result.CreatedDate),
-	)
+	h, r := analyticsReportRequestResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportRequestDeleteResultTable(result *AnalyticsReportRequestDeleteResult) error {
+func analyticsReportRequestDeleteResultRows(result *AnalyticsReportRequestDeleteResult) ([]string, [][]string) {
 	headers := []string{"Request ID", "Deleted"}
 	rows := [][]string{{result.RequestID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportRequestDeleteResultTable(result *AnalyticsReportRequestDeleteResult) error {
+	h, r := analyticsReportRequestDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportRequestDeleteResultMarkdown(result *AnalyticsReportRequestDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| Request ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.RequestID),
-		result.Deleted,
-	)
+	h, r := analyticsReportRequestDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportRequestsTable(resp *AnalyticsReportRequestsResponse) error {
+func analyticsReportRequestsRows(resp *AnalyticsReportRequestsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Access Type", "State", "Created Date", "App ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -172,30 +161,22 @@ func printAnalyticsReportRequestsTable(resp *AnalyticsReportRequestsResponse) er
 			appID,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportRequestsTable(resp *AnalyticsReportRequestsResponse) error {
+	h, r := analyticsReportRequestsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportRequestsMarkdown(resp *AnalyticsReportRequestsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Access Type | State | Created Date | App ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		appID := ""
-		if item.Relationships != nil && item.Relationships.App != nil {
-			appID = item.Relationships.App.Data.ID
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.AccessType)),
-			escapeMarkdown(string(item.Attributes.State)),
-			escapeMarkdown(item.Attributes.CreatedDate),
-			escapeMarkdown(appID),
-		)
-	}
+	h, r := analyticsReportRequestsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportDownloadResultTable(result *AnalyticsReportDownloadResult) error {
+func analyticsReportDownloadResultRows(result *AnalyticsReportDownloadResult) ([]string, [][]string) {
 	headers := []string{"Request ID", "Instance ID", "Segment ID", "Compressed File", "Compressed Size", "Decompressed File", "Decompressed Size"}
 	rows := [][]string{{
 		result.RequestID,
@@ -206,26 +187,22 @@ func printAnalyticsReportDownloadResultTable(result *AnalyticsReportDownloadResu
 		result.DecompressedPath,
 		fmt.Sprintf("%d", result.DecompressedSize),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportDownloadResultTable(result *AnalyticsReportDownloadResult) error {
+	h, r := analyticsReportDownloadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportDownloadResultMarkdown(result *AnalyticsReportDownloadResult) error {
-	fmt.Fprintln(os.Stdout, "| Request ID | Instance ID | Segment ID | Compressed File | Compressed Size | Decompressed File | Decompressed Size |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %s | %d |\n",
-		escapeMarkdown(result.RequestID),
-		escapeMarkdown(result.InstanceID),
-		escapeMarkdown(result.SegmentID),
-		escapeMarkdown(result.FilePath),
-		result.FileSize,
-		escapeMarkdown(result.DecompressedPath),
-		result.DecompressedSize,
-	)
+	h, r := analyticsReportDownloadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportGetResultTable(result *AnalyticsReportGetResult) error {
+func analyticsReportGetResultRows(result *AnalyticsReportGetResult) ([]string, [][]string) {
 	headers := []string{"Report ID", "Name", "Category", "Granularity", "Instances", "Segments"}
 	rows := make([][]string, 0, len(result.Data))
 	for _, report := range result.Data {
@@ -243,32 +220,22 @@ func printAnalyticsReportGetResultTable(result *AnalyticsReportGetResult) error 
 			fmt.Sprintf("%d", segments),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportGetResultTable(result *AnalyticsReportGetResult) error {
+	h, r := analyticsReportGetResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportGetResultMarkdown(result *AnalyticsReportGetResult) error {
-	fmt.Fprintln(os.Stdout, "| Report ID | Name | Category | Granularity | Instances | Segments |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, report := range result.Data {
-		name := report.Name
-		if name == "" {
-			name = report.ReportType
-		}
-		segments := countSegments(report.Instances)
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %d |\n",
-			escapeMarkdown(report.ID),
-			escapeMarkdown(name),
-			escapeMarkdown(report.Category),
-			escapeMarkdown(report.Granularity),
-			len(report.Instances),
-			segments,
-		)
-	}
+	h, r := analyticsReportGetResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportsTable(resp *AnalyticsReportsResponse) error {
+func analyticsReportsRows(resp *AnalyticsReportsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Report Type", "Category", "Subcategory", "Granularity"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -281,27 +248,22 @@ func printAnalyticsReportsTable(resp *AnalyticsReportsResponse) error {
 			item.Attributes.Granularity,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportsTable(resp *AnalyticsReportsResponse) error {
+	h, r := analyticsReportsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportsMarkdown(resp *AnalyticsReportsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Report Type | Category | Subcategory | Granularity |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.ReportType),
-			escapeMarkdown(item.Attributes.Category),
-			escapeMarkdown(item.Attributes.SubCategory),
-			escapeMarkdown(item.Attributes.Granularity),
-		)
-	}
+	h, r := analyticsReportsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportInstancesTable(resp *AnalyticsReportInstancesResponse) error {
+func analyticsReportInstancesRows(resp *AnalyticsReportInstancesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Report Date", "Processing Date", "Granularity", "Version"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -313,26 +275,22 @@ func printAnalyticsReportInstancesTable(resp *AnalyticsReportInstancesResponse) 
 			item.Attributes.Version,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportInstancesTable(resp *AnalyticsReportInstancesResponse) error {
+	h, r := analyticsReportInstancesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportInstancesMarkdown(resp *AnalyticsReportInstancesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Report Date | Processing Date | Granularity | Version |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReportDate),
-			escapeMarkdown(item.Attributes.ProcessingDate),
-			escapeMarkdown(item.Attributes.Granularity),
-			escapeMarkdown(item.Attributes.Version),
-		)
-	}
+	h, r := analyticsReportInstancesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAnalyticsReportSegmentsTable(resp *AnalyticsReportSegmentsResponse) error {
+func analyticsReportSegmentsRows(resp *AnalyticsReportSegmentsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Download URL", "Checksum", "Size (bytes)", "URL Expires"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -344,22 +302,18 @@ func printAnalyticsReportSegmentsTable(resp *AnalyticsReportSegmentsResponse) er
 			item.Attributes.URLExpirationDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAnalyticsReportSegmentsTable(resp *AnalyticsReportSegmentsResponse) error {
+	h, r := analyticsReportSegmentsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAnalyticsReportSegmentsMarkdown(resp *AnalyticsReportSegmentsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Download URL | Checksum | Size (bytes) | URL Expires |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.URL),
-			escapeMarkdown(item.Attributes.Checksum),
-			item.Attributes.SizeInBytes,
-			escapeMarkdown(item.Attributes.URLExpirationDate),
-		)
-	}
+	h, r := analyticsReportSegmentsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/assets_output.go
+++ b/internal/asc/assets_output.go
@@ -59,29 +59,28 @@ type AssetDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printAppScreenshotSetsTable(resp *AppScreenshotSetsResponse) error {
+func appScreenshotSetsRows(resp *AppScreenshotSetsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Display Type"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, item.Attributes.ScreenshotDisplayType})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppScreenshotSetsTable(resp *AppScreenshotSetsResponse) error {
+	h, r := appScreenshotSetsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppScreenshotSetsMarkdown(resp *AppScreenshotSetsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Display Type |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ScreenshotDisplayType),
-		)
-	}
+	h, r := appScreenshotSetsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppScreenshotsTable(resp *AppScreenshotsResponse) error {
+func appScreenshotsRows(resp *AppScreenshotsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -96,51 +95,43 @@ func printAppScreenshotsTable(resp *AppScreenshotsResponse) error {
 			state,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppScreenshotsTable(resp *AppScreenshotsResponse) error {
+	h, r := appScreenshotsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppScreenshotsMarkdown(resp *AppScreenshotsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil {
-			state = item.Attributes.AssetDeliveryState.State
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			item.Attributes.FileSize,
-			escapeMarkdown(state),
-		)
-	}
+	h, r := appScreenshotsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPreviewSetsTable(resp *AppPreviewSetsResponse) error {
+func appPreviewSetsRows(resp *AppPreviewSetsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Preview Type"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, item.Attributes.PreviewType})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPreviewSetsTable(resp *AppPreviewSetsResponse) error {
+	h, r := appPreviewSetsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPreviewSetsMarkdown(resp *AppPreviewSetsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Preview Type |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.PreviewType),
-		)
-	}
+	h, r := appPreviewSetsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPreviewsTable(resp *AppPreviewsResponse) error {
+func appPreviewsRows(resp *AppPreviewsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -155,29 +146,22 @@ func printAppPreviewsTable(resp *AppPreviewsResponse) error {
 			state,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPreviewsTable(resp *AppPreviewsResponse) error {
+	h, r := appPreviewsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPreviewsMarkdown(resp *AppPreviewsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil {
-			state = item.Attributes.AssetDeliveryState.State
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			item.Attributes.FileSize,
-			escapeMarkdown(state),
-		)
-	}
+	h, r := appPreviewsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppScreenshotListResultTable(result *AppScreenshotListResult) error {
+func appScreenshotListResultRows(result *AppScreenshotListResult) ([]string, [][]string) {
 	headers := []string{"Set ID", "Display Type", "Screenshot ID", "File Name", "File Size", "State"}
 	var rows [][]string
 	for _, set := range result.Sets {
@@ -201,41 +185,22 @@ func printAppScreenshotListResultTable(result *AppScreenshotListResult) error {
 			})
 		}
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppScreenshotListResultTable(result *AppScreenshotListResult) error {
+	h, r := appScreenshotListResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppScreenshotListResultMarkdown(result *AppScreenshotListResult) error {
-	fmt.Fprintln(os.Stdout, "| Set ID | Display Type | Screenshot ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, set := range result.Sets {
-		displayType := set.Set.Attributes.ScreenshotDisplayType
-		if len(set.Screenshots) == 0 {
-			fmt.Fprintf(os.Stdout, "| %s | %s |  |  |  |  |\n",
-				escapeMarkdown(set.Set.ID),
-				escapeMarkdown(displayType),
-			)
-			continue
-		}
-		for _, item := range set.Screenshots {
-			state := ""
-			if item.Attributes.AssetDeliveryState != nil {
-				state = item.Attributes.AssetDeliveryState.State
-			}
-			fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %s |\n",
-				escapeMarkdown(set.Set.ID),
-				escapeMarkdown(displayType),
-				escapeMarkdown(item.ID),
-				escapeMarkdown(item.Attributes.FileName),
-				item.Attributes.FileSize,
-				escapeMarkdown(state),
-			)
-		}
-	}
+	h, r := appScreenshotListResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPreviewListResultTable(result *AppPreviewListResult) error {
+func appPreviewListResultRows(result *AppPreviewListResult) ([]string, [][]string) {
 	headers := []string{"Set ID", "Preview Type", "Preview ID", "File Name", "File Size", "State"}
 	var rows [][]string
 	for _, set := range result.Sets {
@@ -259,130 +224,104 @@ func printAppPreviewListResultTable(result *AppPreviewListResult) error {
 			})
 		}
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPreviewListResultTable(result *AppPreviewListResult) error {
+	h, r := appPreviewListResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPreviewListResultMarkdown(result *AppPreviewListResult) error {
-	fmt.Fprintln(os.Stdout, "| Set ID | Preview Type | Preview ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, set := range result.Sets {
-		previewType := set.Set.Attributes.PreviewType
-		if len(set.Previews) == 0 {
-			fmt.Fprintf(os.Stdout, "| %s | %s |  |  |  |  |\n",
-				escapeMarkdown(set.Set.ID),
-				escapeMarkdown(previewType),
-			)
-			continue
-		}
-		for _, item := range set.Previews {
-			state := ""
-			if item.Attributes.AssetDeliveryState != nil {
-				state = item.Attributes.AssetDeliveryState.State
-			}
-			fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %s |\n",
-				escapeMarkdown(set.Set.ID),
-				escapeMarkdown(previewType),
-				escapeMarkdown(item.ID),
-				escapeMarkdown(item.Attributes.FileName),
-				item.Attributes.FileSize,
-				escapeMarkdown(state),
-			)
-		}
-	}
+	h, r := appPreviewListResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppScreenshotUploadResultTable(result *AppScreenshotUploadResult) error {
+func appScreenshotUploadResultMainRows(result *AppScreenshotUploadResult) ([]string, [][]string) {
 	headers := []string{"Localization ID", "Set ID", "Display Type"}
 	rows := [][]string{{result.VersionLocalizationID, result.SetID, result.DisplayType}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func appPreviewUploadResultMainRows(result *AppPreviewUploadResult) ([]string, [][]string) {
+	headers := []string{"Localization ID", "Set ID", "Preview Type"}
+	rows := [][]string{{result.VersionLocalizationID, result.SetID, result.PreviewType}}
+	return headers, rows
+}
+
+func assetUploadResultItemRows(results []AssetUploadResultItem) ([]string, [][]string) {
+	headers := []string{"File Name", "Asset ID", "State"}
+	rows := make([][]string, 0, len(results))
+	for _, item := range results {
+		rows = append(rows, []string{item.FileName, item.AssetID, item.State})
+	}
+	return headers, rows
+}
+
+func printAppScreenshotUploadResultTable(result *AppScreenshotUploadResult) error {
+	h, r := appScreenshotUploadResultMainRows(result)
+	RenderTable(h, r)
 	if len(result.Results) == 0 {
 		return nil
 	}
 	fmt.Fprintln(os.Stdout, "\nScreenshots")
-	itemHeaders := []string{"File Name", "Asset ID", "State"}
-	itemRows := make([][]string, 0, len(result.Results))
-	for _, item := range result.Results {
-		itemRows = append(itemRows, []string{item.FileName, item.AssetID, item.State})
-	}
-	RenderTable(itemHeaders, itemRows)
+	ih, ir := assetUploadResultItemRows(result.Results)
+	RenderTable(ih, ir)
 	return nil
 }
 
 func printAppScreenshotUploadResultMarkdown(result *AppScreenshotUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| Localization ID | Set ID | Display Type |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.VersionLocalizationID),
-		escapeMarkdown(result.SetID),
-		escapeMarkdown(result.DisplayType),
-	)
+	h, r := appScreenshotUploadResultMainRows(result)
+	RenderMarkdown(h, r)
 	if len(result.Results) == 0 {
 		return nil
 	}
-	fmt.Fprintln(os.Stdout, "\n| File Name | Asset ID | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range result.Results {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.FileName),
-			escapeMarkdown(item.AssetID),
-			escapeMarkdown(item.State),
-		)
-	}
+	fmt.Fprintln(os.Stdout)
+	ih, ir := assetUploadResultItemRows(result.Results)
+	RenderMarkdown(ih, ir)
 	return nil
 }
 
 func printAppPreviewUploadResultTable(result *AppPreviewUploadResult) error {
-	headers := []string{"Localization ID", "Set ID", "Preview Type"}
-	rows := [][]string{{result.VersionLocalizationID, result.SetID, result.PreviewType}}
-	RenderTable(headers, rows)
+	h, r := appPreviewUploadResultMainRows(result)
+	RenderTable(h, r)
 	if len(result.Results) == 0 {
 		return nil
 	}
 	fmt.Fprintln(os.Stdout, "\nPreviews")
-	itemHeaders := []string{"File Name", "Asset ID", "State"}
-	itemRows := make([][]string, 0, len(result.Results))
-	for _, item := range result.Results {
-		itemRows = append(itemRows, []string{item.FileName, item.AssetID, item.State})
-	}
-	RenderTable(itemHeaders, itemRows)
+	ih, ir := assetUploadResultItemRows(result.Results)
+	RenderTable(ih, ir)
 	return nil
 }
 
 func printAppPreviewUploadResultMarkdown(result *AppPreviewUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| Localization ID | Set ID | Preview Type |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.VersionLocalizationID),
-		escapeMarkdown(result.SetID),
-		escapeMarkdown(result.PreviewType),
-	)
+	h, r := appPreviewUploadResultMainRows(result)
+	RenderMarkdown(h, r)
 	if len(result.Results) == 0 {
 		return nil
 	}
-	fmt.Fprintln(os.Stdout, "\n| File Name | Asset ID | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range result.Results {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.FileName),
-			escapeMarkdown(item.AssetID),
-			escapeMarkdown(item.State),
-		)
-	}
+	fmt.Fprintln(os.Stdout)
+	ih, ir := assetUploadResultItemRows(result.Results)
+	RenderMarkdown(ih, ir)
 	return nil
 }
 
-func printAssetDeleteResultTable(result *AssetDeleteResult) error {
+func assetDeleteResultRows(result *AssetDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAssetDeleteResultTable(result *AssetDeleteResult) error {
+	h, r := assetDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAssetDeleteResultMarkdown(result *AssetDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := assetDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/build_bundles_output.go
+++ b/internal/asc/build_bundles_output.go
@@ -33,7 +33,7 @@ func buildBundleTypeValue(value *BuildBundleType) string {
 	return string(*value)
 }
 
-func printBuildBundlesTable(resp *BuildBundlesResponse) error {
+func buildBundlesRows(resp *BuildBundlesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Bundle ID", "Type", "File Name", "SDK Build", "Platform Build"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -47,28 +47,22 @@ func printBuildBundlesTable(resp *BuildBundlesResponse) error {
 			stringValue(attrs.PlatformBuild),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildBundlesTable(resp *BuildBundlesResponse) error {
+	h, r := buildBundlesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildBundlesMarkdown(resp *BuildBundlesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Bundle ID | Type | File Name | SDK Build | Platform Build |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(stringValue(attrs.BundleID)),
-			escapeMarkdown(buildBundleTypeValue(attrs.BundleType)),
-			escapeMarkdown(stringValue(attrs.FileName)),
-			escapeMarkdown(stringValue(attrs.SDKBuild)),
-			escapeMarkdown(stringValue(attrs.PlatformBuild)),
-		)
-	}
+	h, r := buildBundlesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBuildBundleFileSizesTable(resp *BuildBundleFileSizesResponse) error {
+func buildBundleFileSizesRows(resp *BuildBundleFileSizesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Device Model", "OS Version", "Download Bytes", "Install Bytes"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -81,49 +75,43 @@ func printBuildBundleFileSizesTable(resp *BuildBundleFileSizesResponse) error {
 			int64Value(attrs.InstallBytes),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildBundleFileSizesTable(resp *BuildBundleFileSizesResponse) error {
+	h, r := buildBundleFileSizesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildBundleFileSizesMarkdown(resp *BuildBundleFileSizesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Device Model | OS Version | Download Bytes | Install Bytes |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(stringValue(attrs.DeviceModel)),
-			escapeMarkdown(stringValue(attrs.OSVersion)),
-			escapeMarkdown(int64Value(attrs.DownloadBytes)),
-			escapeMarkdown(int64Value(attrs.InstallBytes)),
-		)
-	}
+	h, r := buildBundleFileSizesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaAppClipInvocationsTable(resp *BetaAppClipInvocationsResponse) error {
+func betaAppClipInvocationsRows(resp *BetaAppClipInvocationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, stringValue(item.Attributes.URL)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppClipInvocationsTable(resp *BetaAppClipInvocationsResponse) error {
+	h, r := betaAppClipInvocationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaAppClipInvocationsMarkdown(resp *BetaAppClipInvocationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(stringValue(item.Attributes.URL)),
-		)
-	}
+	h, r := betaAppClipInvocationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipDomainStatusResultTable(result *AppClipDomainStatusResult) error {
+func appClipDomainStatusMainRows(result *AppClipDomainStatusResult) ([]string, [][]string) {
 	headers := []string{"Build Bundle ID", "Available", "Status ID", "Last Updated"}
 	rows := [][]string{{
 		result.BuildBundleID,
@@ -131,46 +119,43 @@ func printAppClipDomainStatusResultTable(result *AppClipDomainStatusResult) erro
 		result.StatusID,
 		stringValue(result.LastUpdatedDate),
 	}}
-	RenderTable(headers, rows)
-	if len(result.Domains) == 0 {
-		return nil
-	}
-	fmt.Fprintln(os.Stdout, "\nDomains")
-	domainHeaders := []string{"Domain", "Valid", "Last Updated", "Error"}
-	domainRows := make([][]string, 0, len(result.Domains))
+	return headers, rows
+}
+
+func appClipDomainStatusDomainRows(result *AppClipDomainStatusResult) ([]string, [][]string) {
+	headers := []string{"Domain", "Valid", "Last Updated", "Error"}
+	rows := make([][]string, 0, len(result.Domains))
 	for _, domain := range result.Domains {
-		domainRows = append(domainRows, []string{
+		rows = append(rows, []string{
 			stringValue(domain.Domain),
 			boolValue(domain.IsValid),
 			stringValue(domain.LastUpdatedDate),
 			stringValue(domain.ErrorCode),
 		})
 	}
-	RenderTable(domainHeaders, domainRows)
+	return headers, rows
+}
+
+func printAppClipDomainStatusResultTable(result *AppClipDomainStatusResult) error {
+	h, r := appClipDomainStatusMainRows(result)
+	RenderTable(h, r)
+	if len(result.Domains) == 0 {
+		return nil
+	}
+	fmt.Fprintln(os.Stdout, "\nDomains")
+	dh, dr := appClipDomainStatusDomainRows(result)
+	RenderTable(dh, dr)
 	return nil
 }
 
 func printAppClipDomainStatusResultMarkdown(result *AppClipDomainStatusResult) error {
-	fmt.Fprintln(os.Stdout, "| Build Bundle ID | Available | Status ID | Last Updated |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t | %s | %s |\n",
-		escapeMarkdown(result.BuildBundleID),
-		result.Available,
-		escapeMarkdown(result.StatusID),
-		escapeMarkdown(stringValue(result.LastUpdatedDate)),
-	)
+	h, r := appClipDomainStatusMainRows(result)
+	RenderMarkdown(h, r)
 	if len(result.Domains) == 0 {
 		return nil
 	}
-	fmt.Fprintln(os.Stdout, "\n| Domain | Valid | Last Updated | Error |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, domain := range result.Domains {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(stringValue(domain.Domain)),
-			boolValue(domain.IsValid),
-			escapeMarkdown(stringValue(domain.LastUpdatedDate)),
-			escapeMarkdown(stringValue(domain.ErrorCode)),
-		)
-	}
+	fmt.Fprintln(os.Stdout)
+	dh, dr := appClipDomainStatusDomainRows(result)
+	RenderMarkdown(dh, dr)
 	return nil
 }

--- a/internal/asc/categories_output.go
+++ b/internal/asc/categories_output.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 // formatPlatforms converts a slice of Platform to a comma-separated string.
 func formatPlatforms(platforms []Platform) string {
@@ -14,21 +11,23 @@ func formatPlatforms(platforms []Platform) string {
 	return strings.Join(strs, ", ")
 }
 
-func printAppCategoriesMarkdown(resp *AppCategoriesResponse) error {
-	fmt.Println("| ID | Platforms |")
-	fmt.Println("|---|---|")
-	for _, cat := range resp.Data {
-		fmt.Printf("| %s | %s |\n", cat.ID, formatPlatforms(cat.Attributes.Platforms))
-	}
-	return nil
-}
-
-func printAppCategoriesTable(resp *AppCategoriesResponse) error {
-	headers := []string{"ID", "PLATFORMS"}
+func appCategoriesRows(resp *AppCategoriesResponse) ([]string, [][]string) {
+	headers := []string{"ID", "Platforms"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, cat := range resp.Data {
 		rows = append(rows, []string{cat.ID, formatPlatforms(cat.Attributes.Platforms)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppCategoriesTable(resp *AppCategoriesResponse) error {
+	h, r := appCategoriesRows(resp)
+	RenderTable(h, r)
+	return nil
+}
+
+func printAppCategoriesMarkdown(resp *AppCategoriesResponse) error {
+	h, r := appCategoriesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/devices_output.go
+++ b/internal/asc/devices_output.go
@@ -1,34 +1,30 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
 // DeviceLocalUDIDResult represents CLI output for local device UDID lookup.
 type DeviceLocalUDIDResult struct {
 	UDID     string `json:"udid"`
 	Platform string `json:"platform"`
 }
 
-func printDeviceLocalUDIDTable(result *DeviceLocalUDIDResult) error {
+func deviceLocalUDIDRows(result *DeviceLocalUDIDResult) ([]string, [][]string) {
 	headers := []string{"UDID", "Platform"}
 	rows := [][]string{{result.UDID, result.Platform}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printDeviceLocalUDIDTable(result *DeviceLocalUDIDResult) error {
+	h, r := deviceLocalUDIDRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printDeviceLocalUDIDMarkdown(result *DeviceLocalUDIDResult) error {
-	fmt.Fprintln(os.Stdout, "| UDID | Platform |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-		escapeMarkdown(result.UDID),
-		escapeMarkdown(result.Platform),
-	)
+	h, r := deviceLocalUDIDRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printDevicesTable(resp *DevicesResponse) error {
+func devicesRows(resp *DevicesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "UDID", "Platform", "Status", "Class", "Model", "Added"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -43,24 +39,17 @@ func printDevicesTable(resp *DevicesResponse) error {
 			compactWhitespace(item.Attributes.AddedDate),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printDevicesTable(resp *DevicesResponse) error {
+	h, r := devicesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printDevicesMarkdown(resp *DevicesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | UDID | Platform | Status | Class | Model | Added |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.UDID),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(string(item.Attributes.Status)),
-			escapeMarkdown(string(item.Attributes.DeviceClass)),
-			escapeMarkdown(item.Attributes.Model),
-			escapeMarkdown(item.Attributes.AddedDate),
-		)
-	}
+	h, r := devicesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/eula_output.go
+++ b/internal/asc/eula_output.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -34,7 +33,7 @@ func formatEndUserLicenseAgreementTerritories(resource EndUserLicenseAgreementRe
 	return strings.Join(ids, ",")
 }
 
-func printEndUserLicenseAgreementTable(resp *EndUserLicenseAgreementResponse) error {
+func endUserLicenseAgreementRows(resp *EndUserLicenseAgreementResponse) ([]string, [][]string) {
 	headers := []string{"ID", "App ID", "Territories", "Agreement Text"}
 	rows := [][]string{{
 		resp.Data.ID,
@@ -42,35 +41,35 @@ func printEndUserLicenseAgreementTable(resp *EndUserLicenseAgreementResponse) er
 		compactWhitespace(formatEndUserLicenseAgreementTerritories(resp.Data)),
 		compactWhitespace(resp.Data.Attributes.AgreementText),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printEndUserLicenseAgreementTable(resp *EndUserLicenseAgreementResponse) error {
+	h, r := endUserLicenseAgreementRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printEndUserLicenseAgreementMarkdown(resp *EndUserLicenseAgreementResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | App ID | Territories | Agreement Text |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(endUserLicenseAgreementAppID(resp.Data)),
-		escapeMarkdown(formatEndUserLicenseAgreementTerritories(resp.Data)),
-		escapeMarkdown(resp.Data.Attributes.AgreementText),
-	)
+	h, r := endUserLicenseAgreementRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printEndUserLicenseAgreementDeleteResultTable(result *EndUserLicenseAgreementDeleteResult) error {
+func endUserLicenseAgreementDeleteResultRows(result *EndUserLicenseAgreementDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printEndUserLicenseAgreementDeleteResultTable(result *EndUserLicenseAgreementDeleteResult) error {
+	h, r := endUserLicenseAgreementDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printEndUserLicenseAgreementDeleteResultMarkdown(result *EndUserLicenseAgreementDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := endUserLicenseAgreementDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/eula_output_test.go
+++ b/internal/asc/eula_output_test.go
@@ -58,7 +58,7 @@ func TestPrintMarkdown_EndUserLicenseAgreement(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Agreement Text |") {
+	if !strings.Contains(output, "Agreement Text") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "eula-2") {

--- a/internal/asc/finance_output.go
+++ b/internal/asc/finance_output.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // FinanceReportResult represents CLI output for finance report downloads.
 type FinanceReportResult struct {
@@ -18,7 +15,7 @@ type FinanceReportResult struct {
 	DecompressedBytes int64  `json:"decompressedSize,omitempty"`
 }
 
-func printFinanceReportResultTable(result *FinanceReportResult) error {
+func financeReportResultRows(result *FinanceReportResult) ([]string, [][]string) {
 	headers := []string{"Vendor", "Type", "Region", "Date", "Compressed File", "Compressed Size", "Decompressed File", "Decompressed Size"}
 	rows := [][]string{{
 		result.VendorNumber,
@@ -30,27 +27,22 @@ func printFinanceReportResultTable(result *FinanceReportResult) error {
 		result.DecompressedPath,
 		fmt.Sprintf("%d", result.DecompressedBytes),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printFinanceReportResultTable(result *FinanceReportResult) error {
+	h, r := financeReportResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printFinanceReportResultMarkdown(result *FinanceReportResult) error {
-	fmt.Fprintln(os.Stdout, "| Vendor | Type | Region | Date | Compressed File | Compressed Size | Decompressed File | Decompressed Size |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %d | %s | %d |\n",
-		escapeMarkdown(result.VendorNumber),
-		escapeMarkdown(result.ReportType),
-		escapeMarkdown(result.RegionCode),
-		escapeMarkdown(result.ReportDate),
-		escapeMarkdown(result.FilePath),
-		result.Bytes,
-		escapeMarkdown(result.DecompressedPath),
-		result.DecompressedBytes,
-	)
+	h, r := financeReportResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printFinanceRegionsTable(result *FinanceRegionsResult) error {
+func financeRegionsRows(result *FinanceRegionsResult) ([]string, [][]string) {
 	headers := []string{"Region", "Currency", "Code", "Countries or Regions"}
 	rows := make([][]string, 0, len(result.Regions))
 	for _, region := range result.Regions {
@@ -61,20 +53,17 @@ func printFinanceRegionsTable(result *FinanceRegionsResult) error {
 			region.CountriesOrRegions,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printFinanceRegionsTable(result *FinanceRegionsResult) error {
+	h, r := financeRegionsRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printFinanceRegionsMarkdown(result *FinanceRegionsResult) error {
-	fmt.Fprintln(os.Stdout, "| Region | Currency | Code | Countries or Regions |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, region := range result.Regions {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(region.ReportRegion),
-			escapeMarkdown(region.ReportCurrency),
-			escapeMarkdown(region.RegionCode),
-			escapeMarkdown(region.CountriesOrRegions),
-		)
-	}
+	h, r := financeRegionsRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/iap_output.go
+++ b/internal/asc/iap_output.go
@@ -3,7 +3,6 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
 // InAppPurchaseDeleteResult represents CLI output for IAP deletions.
@@ -12,7 +11,7 @@ type InAppPurchaseDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printInAppPurchasesTable(resp *InAppPurchasesV2Response) error {
+func inAppPurchasesRows(resp *InAppPurchasesV2Response) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Product ID", "Type", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -24,26 +23,22 @@ func printInAppPurchasesTable(resp *InAppPurchasesV2Response) error {
 			item.Attributes.State,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchasesTable(resp *InAppPurchasesV2Response) error {
+	h, r := inAppPurchasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchasesMarkdown(resp *InAppPurchasesV2Response) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Product ID | Type | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.ProductID),
-			escapeMarkdown(item.Attributes.InAppPurchaseType),
-			escapeMarkdown(item.Attributes.State),
-		)
-	}
+	h, r := inAppPurchasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printLegacyInAppPurchasesTable(resp *InAppPurchasesResponse) error {
+func legacyInAppPurchasesRows(resp *InAppPurchasesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Product ID", "Type", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -55,26 +50,22 @@ func printLegacyInAppPurchasesTable(resp *InAppPurchasesResponse) error {
 			item.Attributes.State,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printLegacyInAppPurchasesTable(resp *InAppPurchasesResponse) error {
+	h, r := legacyInAppPurchasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printLegacyInAppPurchasesMarkdown(resp *InAppPurchasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Product ID | Type | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.ProductID),
-			escapeMarkdown(item.Attributes.InAppPurchaseType),
-			escapeMarkdown(item.Attributes.State),
-		)
-	}
+	h, r := legacyInAppPurchasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseLocalizationsTable(resp *InAppPurchaseLocalizationsResponse) error {
+func inAppPurchaseLocalizationsRows(resp *InAppPurchaseLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name", "Description"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -85,42 +76,40 @@ func printInAppPurchaseLocalizationsTable(resp *InAppPurchaseLocalizationsRespon
 			compactWhitespace(item.Attributes.Description),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseLocalizationsTable(resp *InAppPurchaseLocalizationsResponse) error {
+	h, r := inAppPurchaseLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseLocalizationsMarkdown(resp *InAppPurchaseLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name | Description |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Description),
-		)
-	}
+	h, r := inAppPurchaseLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseDeleteResultTable(result *InAppPurchaseDeleteResult) error {
+func inAppPurchaseDeleteResultRows(result *InAppPurchaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseDeleteResultTable(result *InAppPurchaseDeleteResult) error {
+	h, r := inAppPurchaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseDeleteResultMarkdown(result *InAppPurchaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := inAppPurchaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseImagesTable(resp *InAppPurchaseImagesResponse) error {
+func inAppPurchaseImagesRows(resp *InAppPurchaseImagesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -131,25 +120,22 @@ func printInAppPurchaseImagesTable(resp *InAppPurchaseImagesResponse) error {
 			item.Attributes.State,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseImagesTable(resp *InAppPurchaseImagesResponse) error {
+	h, r := inAppPurchaseImagesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseImagesMarkdown(resp *InAppPurchaseImagesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			item.Attributes.FileSize,
-			escapeMarkdown(item.Attributes.State),
-		)
-	}
+	h, r := inAppPurchaseImagesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchasePricePointsTable(resp *InAppPurchasePricePointsResponse) error {
+func inAppPurchasePricePointsRows(resp *InAppPurchasePricePointsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Customer Price", "Proceeds"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -159,30 +145,28 @@ func printInAppPurchasePricePointsTable(resp *InAppPurchasePricePointsResponse) 
 			item.Attributes.Proceeds,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchasePricePointsTable(resp *InAppPurchasePricePointsResponse) error {
+	h, r := inAppPurchasePricePointsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchasePricePointsMarkdown(resp *InAppPurchasePricePointsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Customer Price | Proceeds |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.CustomerPrice),
-			escapeMarkdown(item.Attributes.Proceeds),
-		)
-	}
+	h, r := inAppPurchasePricePointsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchasePricesTable(resp *InAppPurchasePricesResponse) error {
+func inAppPurchasePricesRows(resp *InAppPurchasePricesResponse) ([]string, [][]string, error) {
 	headers := []string{"ID", "Territory", "Price Point", "Start Date", "End Date", "Manual"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		territoryID, pricePointID, err := inAppPurchasePriceRelationshipIDs(item.Relationships)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		rows = append(rows, []string{
 			item.ID,
@@ -193,37 +177,34 @@ func printInAppPurchasePricesTable(resp *InAppPurchasePricesResponse) error {
 			fmt.Sprintf("%t", item.Attributes.Manual),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printInAppPurchasePricesTable(resp *InAppPurchasePricesResponse) error {
+	h, r, err := inAppPurchasePricesRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchasePricesMarkdown(resp *InAppPurchasePricesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Territory | Price Point | Start Date | End Date | Manual |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		territoryID, pricePointID, err := inAppPurchasePriceRelationshipIDs(item.Relationships)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(territoryID),
-			escapeMarkdown(pricePointID),
-			escapeMarkdown(item.Attributes.StartDate),
-			escapeMarkdown(item.Attributes.EndDate),
-			item.Attributes.Manual,
-		)
+	h, r, err := inAppPurchasePricesRows(resp)
+	if err != nil {
+		return err
 	}
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseOfferCodePricesTable(resp *InAppPurchaseOfferPricesResponse) error {
+func inAppPurchaseOfferCodePricesRows(resp *InAppPurchaseOfferPricesResponse) ([]string, [][]string, error) {
 	headers := []string{"ID", "Territory", "Price Point"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		territoryID, pricePointID, err := inAppPurchaseOfferPriceRelationshipIDs(item.Relationships)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		rows = append(rows, []string{
 			sanitizeTerminal(item.ID),
@@ -231,28 +212,28 @@ func printInAppPurchaseOfferCodePricesTable(resp *InAppPurchaseOfferPricesRespon
 			sanitizeTerminal(pricePointID),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printInAppPurchaseOfferCodePricesTable(resp *InAppPurchaseOfferPricesResponse) error {
+	h, r, err := inAppPurchaseOfferCodePricesRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseOfferCodePricesMarkdown(resp *InAppPurchaseOfferPricesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Territory | Price Point |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		territoryID, pricePointID, err := inAppPurchaseOfferPriceRelationshipIDs(item.Relationships)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(territoryID),
-			escapeMarkdown(pricePointID),
-		)
+	h, r, err := inAppPurchaseOfferCodePricesRows(resp)
+	if err != nil {
+		return err
 	}
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseOfferCodesTable(resp *InAppPurchaseOfferCodesResponse) error {
+func inAppPurchaseOfferCodesRows(resp *InAppPurchaseOfferCodesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Active", "Prod Codes", "Sandbox Codes"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -264,26 +245,22 @@ func printInAppPurchaseOfferCodesTable(resp *InAppPurchaseOfferCodesResponse) er
 			fmt.Sprintf("%d", item.Attributes.SandboxCodeCount),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseOfferCodesTable(resp *InAppPurchaseOfferCodesResponse) error {
+	h, r := inAppPurchaseOfferCodesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseOfferCodesMarkdown(resp *InAppPurchaseOfferCodesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Active | Prod Codes | Sandbox Codes |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %t | %d | %d |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			item.Attributes.Active,
-			item.Attributes.ProductionCodeCount,
-			item.Attributes.SandboxCodeCount,
-		)
-	}
+	h, r := inAppPurchaseOfferCodesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseOfferCodeCustomCodesTable(resp *InAppPurchaseOfferCodeCustomCodesResponse) error {
+func inAppPurchaseOfferCodeCustomCodesRows(resp *InAppPurchaseOfferCodeCustomCodesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Custom Code", "Codes", "Expires", "Created", "Active"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -297,28 +274,22 @@ func printInAppPurchaseOfferCodeCustomCodesTable(resp *InAppPurchaseOfferCodeCus
 			fmt.Sprintf("%t", attrs.Active),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseOfferCodeCustomCodesTable(resp *InAppPurchaseOfferCodeCustomCodesResponse) error {
+	h, r := inAppPurchaseOfferCodeCustomCodesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseOfferCodeCustomCodesMarkdown(resp *InAppPurchaseOfferCodeCustomCodesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Custom Code | Codes | Expires | Created | Active |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.CustomCode),
-			attrs.NumberOfCodes,
-			escapeMarkdown(attrs.ExpirationDate),
-			escapeMarkdown(attrs.CreatedDate),
-			attrs.Active,
-		)
-	}
+	h, r := inAppPurchaseOfferCodeCustomCodesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseOfferCodeOneTimeUseCodesTable(resp *InAppPurchaseOfferCodeOneTimeUseCodesResponse) error {
+func inAppPurchaseOfferCodeOneTimeUseCodesRows(resp *InAppPurchaseOfferCodeOneTimeUseCodesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Codes", "Expires", "Created", "Active", "Environment"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -332,45 +303,40 @@ func printInAppPurchaseOfferCodeOneTimeUseCodesTable(resp *InAppPurchaseOfferCod
 			sanitizeTerminal(attrs.Environment),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseOfferCodeOneTimeUseCodesTable(resp *InAppPurchaseOfferCodeOneTimeUseCodesResponse) error {
+	h, r := inAppPurchaseOfferCodeOneTimeUseCodesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseOfferCodeOneTimeUseCodesMarkdown(resp *InAppPurchaseOfferCodeOneTimeUseCodesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Codes | Expires | Created | Active | Environment |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			attrs.NumberOfCodes,
-			escapeMarkdown(attrs.ExpirationDate),
-			escapeMarkdown(attrs.CreatedDate),
-			attrs.Active,
-			escapeMarkdown(attrs.Environment),
-		)
-	}
+	h, r := inAppPurchaseOfferCodeOneTimeUseCodesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseAvailabilityTable(resp *InAppPurchaseAvailabilityResponse) error {
+func inAppPurchaseAvailabilityRows(resp *InAppPurchaseAvailabilityResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Available In New Territories"}
 	rows := [][]string{{resp.Data.ID, fmt.Sprintf("%t", resp.Data.Attributes.AvailableInNewTerritories)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseAvailabilityTable(resp *InAppPurchaseAvailabilityResponse) error {
+	h, r := inAppPurchaseAvailabilityRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseAvailabilityMarkdown(resp *InAppPurchaseAvailabilityResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Available In New Territories |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(resp.Data.ID),
-		resp.Data.Attributes.AvailableInNewTerritories,
-	)
+	h, r := inAppPurchaseAvailabilityRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchaseContentTable(resp *InAppPurchaseContentResponse) error {
+func inAppPurchaseContentRows(resp *InAppPurchaseContentResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Last Modified", "URL"}
 	rows := [][]string{{
 		resp.Data.ID,
@@ -379,34 +345,36 @@ func printInAppPurchaseContentTable(resp *InAppPurchaseContentResponse) error {
 		resp.Data.Attributes.LastModifiedDate,
 		resp.Data.Attributes.URL,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseContentTable(resp *InAppPurchaseContentResponse) error {
+	h, r := inAppPurchaseContentRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseContentMarkdown(resp *InAppPurchaseContentResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Last Modified | URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.FileName),
-		resp.Data.Attributes.FileSize,
-		escapeMarkdown(resp.Data.Attributes.LastModifiedDate),
-		escapeMarkdown(resp.Data.Attributes.URL),
-	)
+	h, r := inAppPurchaseContentRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printInAppPurchasePriceScheduleTable(resp *InAppPurchasePriceScheduleResponse) error {
+func inAppPurchasePriceScheduleRows(resp *InAppPurchasePriceScheduleResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := [][]string{{resp.Data.ID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchasePriceScheduleTable(resp *InAppPurchasePriceScheduleResponse) error {
+	h, r := inAppPurchasePriceScheduleRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchasePriceScheduleMarkdown(resp *InAppPurchasePriceScheduleResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(resp.Data.ID))
+	h, r := inAppPurchasePriceScheduleRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -443,7 +411,7 @@ func inAppPurchaseOfferPriceRelationshipIDs(raw json.RawMessage) (string, string
 	return relationships.Territory.Data.ID, relationships.PricePoint.Data.ID, nil
 }
 
-func printInAppPurchaseReviewScreenshotTable(resp *InAppPurchaseAppStoreReviewScreenshotResponse) error {
+func inAppPurchaseReviewScreenshotRows(resp *InAppPurchaseAppStoreReviewScreenshotResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Asset Type"}
 	rows := [][]string{{
 		resp.Data.ID,
@@ -451,18 +419,17 @@ func printInAppPurchaseReviewScreenshotTable(resp *InAppPurchaseAppStoreReviewSc
 		fmt.Sprintf("%d", resp.Data.Attributes.FileSize),
 		resp.Data.Attributes.AssetType,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printInAppPurchaseReviewScreenshotTable(resp *InAppPurchaseAppStoreReviewScreenshotResponse) error {
+	h, r := inAppPurchaseReviewScreenshotRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printInAppPurchaseReviewScreenshotMarkdown(resp *InAppPurchaseAppStoreReviewScreenshotResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Asset Type |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.FileName),
-		resp.Data.Attributes.FileSize,
-		escapeMarkdown(resp.Data.Attributes.AssetType),
-	)
+	h, r := inAppPurchaseReviewScreenshotRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/iap_output_test.go
+++ b/internal/asc/iap_output_test.go
@@ -50,7 +50,7 @@ func TestPrintMarkdown_InAppPurchaseImages(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | File Name | File Size | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "File Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "UPLOAD_COMPLETE") {
@@ -98,7 +98,7 @@ func TestPrintMarkdown_InAppPurchaseLocalization(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale | Name | Description |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Locale") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Premium coins") {
@@ -148,7 +148,7 @@ func TestPrintMarkdown_InAppPurchasePricePoints(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Customer Price | Proceeds |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Customer Price") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "1.40") {
@@ -204,7 +204,7 @@ func TestPrintMarkdown_InAppPurchasePrices(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Territory") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "PRICE_POINT_1") {
@@ -258,7 +258,7 @@ func TestPrintMarkdown_InAppPurchaseOfferCodes(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Active | Prod Codes | Sandbox Codes |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Prod Codes") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "SPRING") {

--- a/internal/asc/nominations_output.go
+++ b/internal/asc/nominations_output.go
@@ -1,11 +1,8 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
-func printNominationsTable(resp *NominationsResponse) error {
+func nominationsRows(resp *NominationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Type", "State", "Publish Start", "Publish End"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -19,37 +16,35 @@ func printNominationsTable(resp *NominationsResponse) error {
 			sanitizeTerminal(fallbackValue(attrs.PublishEndDate)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printNominationsTable(resp *NominationsResponse) error {
+	h, r := nominationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printNominationsMarkdown(resp *NominationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Type | State | Publish Start | Publish End |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(fallbackValue(attrs.Name)),
-			escapeMarkdown(fallbackValue(string(attrs.Type))),
-			escapeMarkdown(fallbackValue(string(attrs.State))),
-			escapeMarkdown(fallbackValue(attrs.PublishStartDate)),
-			escapeMarkdown(fallbackValue(attrs.PublishEndDate)),
-		)
-	}
+	h, r := nominationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printNominationDeleteResultTable(result *NominationDeleteResult) error {
+func nominationDeleteResultRows(result *NominationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printNominationDeleteResultTable(result *NominationDeleteResult) error {
+	h, r := nominationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printNominationDeleteResultMarkdown(result *NominationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := nominationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/offer_codes_custom_output.go
+++ b/internal/asc/offer_codes_custom_output.go
@@ -3,10 +3,9 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
-func printOfferCodeCustomCodesTable(resp *SubscriptionOfferCodeCustomCodesResponse) error {
+func offerCodeCustomCodesRows(resp *SubscriptionOfferCodeCustomCodesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Custom Code", "Codes", "Expires", "Created", "Active"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -20,55 +19,49 @@ func printOfferCodeCustomCodesTable(resp *SubscriptionOfferCodeCustomCodesRespon
 			fmt.Sprintf("%t", attrs.Active),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printOfferCodeCustomCodesTable(resp *SubscriptionOfferCodeCustomCodesResponse) error {
+	h, r := offerCodeCustomCodesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printOfferCodeCustomCodesMarkdown(resp *SubscriptionOfferCodeCustomCodesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Custom Code | Codes | Expires | Created | Active |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.CustomCode),
-			attrs.NumberOfCodes,
-			escapeMarkdown(attrs.ExpirationDate),
-			escapeMarkdown(attrs.CreatedDate),
-			attrs.Active,
-		)
-	}
+	h, r := offerCodeCustomCodesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printOfferCodePricesTable(resp *SubscriptionOfferCodePricesResponse) error {
+func offerCodePricesRows(resp *SubscriptionOfferCodePricesResponse) ([]string, [][]string, error) {
 	headers := []string{"ID", "Territory", "Price Point"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		territoryID, pricePointID, err := offerCodePriceRelationshipIDs(item.Relationships)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		rows = append(rows, []string{sanitizeTerminal(item.ID), sanitizeTerminal(territoryID), sanitizeTerminal(pricePointID)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printOfferCodePricesTable(resp *SubscriptionOfferCodePricesResponse) error {
+	h, r, err := offerCodePricesRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printOfferCodePricesMarkdown(resp *SubscriptionOfferCodePricesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Territory | Price Point |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		territoryID, pricePointID, err := offerCodePriceRelationshipIDs(item.Relationships)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(territoryID),
-			escapeMarkdown(pricePointID),
-		)
+	h, r, err := offerCodePricesRows(resp)
+	if err != nil {
+		return err
 	}
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -83,21 +76,23 @@ func offerCodePriceRelationshipIDs(raw json.RawMessage) (string, string, error) 
 	return relationships.Territory.Data.ID, relationships.SubscriptionPricePoint.Data.ID, nil
 }
 
-func printOfferCodeValuesTable(result *OfferCodeValuesResult) error {
+func offerCodeValuesRows(result *OfferCodeValuesResult) ([]string, [][]string) {
 	headers := []string{"Code"}
 	rows := make([][]string, 0, len(result.Codes))
 	for _, code := range result.Codes {
 		rows = append(rows, []string{sanitizeTerminal(code)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printOfferCodeValuesTable(result *OfferCodeValuesResult) error {
+	h, r := offerCodeValuesRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printOfferCodeValuesMarkdown(result *OfferCodeValuesResult) error {
-	fmt.Fprintln(os.Stdout, "| Code |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	for _, code := range result.Codes {
-		fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(code))
-	}
+	h, r := offerCodeValuesRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/offer_codes_output.go
+++ b/internal/asc/offer_codes_output.go
@@ -2,11 +2,10 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
-func printOfferCodesTable(resp *SubscriptionOfferCodeOneTimeUseCodesResponse) error {
+func offerCodesRows(resp *SubscriptionOfferCodeOneTimeUseCodesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Codes", "Expires", "Created", "Active"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -19,27 +18,22 @@ func printOfferCodesTable(resp *SubscriptionOfferCodeOneTimeUseCodesResponse) er
 			fmt.Sprintf("%t", attrs.Active),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printOfferCodesTable(resp *SubscriptionOfferCodeOneTimeUseCodesResponse) error {
+	h, r := offerCodesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printOfferCodesMarkdown(resp *SubscriptionOfferCodeOneTimeUseCodesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Codes | Expires | Created | Active |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			attrs.NumberOfCodes,
-			escapeMarkdown(attrs.ExpirationDate),
-			escapeMarkdown(attrs.CreatedDate),
-			attrs.Active,
-		)
-	}
+	h, r := offerCodesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printSubscriptionOfferCodeTable(resp *SubscriptionOfferCodeResponse) error {
+func subscriptionOfferCodeRows(resp *SubscriptionOfferCodeResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Customer Eligibilities", "Offer Eligibility", "Duration", "Mode", "Periods", "Total Codes", "Production Codes", "Sandbox Codes", "Active", "Auto Renew"}
 	attrs := resp.Data.Attributes
 	rows := [][]string{{
@@ -56,28 +50,18 @@ func printSubscriptionOfferCodeTable(resp *SubscriptionOfferCodeResponse) error 
 		fmt.Sprintf("%t", attrs.Active),
 		formatOptionalBool(attrs.AutoRenewEnabled),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printSubscriptionOfferCodeTable(resp *SubscriptionOfferCodeResponse) error {
+	h, r := subscriptionOfferCodeRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printSubscriptionOfferCodeMarkdown(resp *SubscriptionOfferCodeResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Customer Eligibilities | Offer Eligibility | Duration | Mode | Periods | Total Codes | Production Codes | Sandbox Codes | Active | Auto Renew |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-	attrs := resp.Data.Attributes
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %d | %d | %d | %d | %t | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(attrs.Name),
-		escapeMarkdown(formatOfferCodeCustomerEligibilities(attrs.CustomerEligibilities)),
-		escapeMarkdown(string(attrs.OfferEligibility)),
-		escapeMarkdown(string(attrs.Duration)),
-		escapeMarkdown(string(attrs.OfferMode)),
-		attrs.NumberOfPeriods,
-		attrs.TotalNumberOfCodes,
-		attrs.ProductionCodeCount,
-		attrs.SandboxCodeCount,
-		attrs.Active,
-		formatOptionalBool(attrs.AutoRenewEnabled),
-	)
+	h, r := subscriptionOfferCodeRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_accessibility.go
+++ b/internal/asc/output_accessibility.go
@@ -1,16 +1,13 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 type accessibilityDeclarationField struct {
 	Name  string
 	Value string
 }
 
-func printAccessibilityDeclarationsTable(resp *AccessibilityDeclarationsResponse) error {
+func accessibilityDeclarationsRows(resp *AccessibilityDeclarationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Device Family", "State", "Audio Descriptions", "Captions", "Dark Interface", "Differentiate Without Color", "Larger Text", "Reduced Motion", "Sufficient Contrast", "Voice Control", "Voiceover"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -30,51 +27,40 @@ func printAccessibilityDeclarationsTable(resp *AccessibilityDeclarationsResponse
 			formatOptionalBool(attrs.SupportsVoiceover),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAccessibilityDeclarationsTable(resp *AccessibilityDeclarationsResponse) error {
+	h, r := accessibilityDeclarationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAccessibilityDeclarationsMarkdown(resp *AccessibilityDeclarationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Device Family | State | Audio Descriptions | Captions | Dark Interface | Differentiate Without Color | Larger Text | Reduced Motion | Sufficient Contrast | Voice Control | Voiceover |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(fallbackValue(string(attrs.DeviceFamily))),
-			escapeMarkdown(fallbackValue(string(attrs.State))),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsAudioDescriptions)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsCaptions)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsDarkInterface)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsDifferentiateWithoutColorAlone)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsLargerText)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsReducedMotion)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsSufficientContrast)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsVoiceControl)),
-			escapeMarkdown(formatOptionalBool(attrs.SupportsVoiceover)),
-		)
-	}
+	h, r := accessibilityDeclarationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAccessibilityDeclarationTable(resp *AccessibilityDeclarationResponse) error {
+func accessibilityDeclarationRows(resp *AccessibilityDeclarationResponse) ([]string, [][]string) {
 	fields := accessibilityDeclarationFields(resp)
 	headers := []string{"Field", "Value"}
 	rows := make([][]string, 0, len(fields))
 	for _, field := range fields {
 		rows = append(rows, []string{field.Name, field.Value})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAccessibilityDeclarationTable(resp *AccessibilityDeclarationResponse) error {
+	h, r := accessibilityDeclarationRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAccessibilityDeclarationMarkdown(resp *AccessibilityDeclarationResponse) error {
-	fields := accessibilityDeclarationFields(resp)
-	fmt.Fprintln(os.Stdout, "| Field | Value |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, field := range fields {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
-	}
+	h, r := accessibilityDeclarationRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -100,19 +86,20 @@ func accessibilityDeclarationFields(resp *AccessibilityDeclarationResponse) []ac
 	}
 }
 
-func printAccessibilityDeclarationDeleteResultTable(result *AccessibilityDeclarationDeleteResult) error {
+func accessibilityDeclarationDeleteResultRows(result *AccessibilityDeclarationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAccessibilityDeclarationDeleteResultTable(result *AccessibilityDeclarationDeleteResult) error {
+	h, r := accessibilityDeclarationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAccessibilityDeclarationDeleteResultMarkdown(result *AccessibilityDeclarationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := accessibilityDeclarationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_age_rating.go
+++ b/internal/asc/output_age_rating.go
@@ -1,8 +1,6 @@
 package asc
 
 import (
-	"fmt"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -12,24 +10,25 @@ type ageRatingField struct {
 	Value string
 }
 
-func printAgeRatingDeclarationTable(resp *AgeRatingDeclarationResponse) error {
+func ageRatingDeclarationRows(resp *AgeRatingDeclarationResponse) ([]string, [][]string) {
 	fields := ageRatingFields(resp)
 	headers := []string{"Field", "Value"}
 	rows := make([][]string, 0, len(fields))
 	for _, field := range fields {
 		rows = append(rows, []string{field.Name, field.Value})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAgeRatingDeclarationTable(resp *AgeRatingDeclarationResponse) error {
+	h, r := ageRatingDeclarationRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAgeRatingDeclarationMarkdown(resp *AgeRatingDeclarationResponse) error {
-	fields := ageRatingFields(resp)
-	fmt.Fprintln(os.Stdout, "| Field | Value |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, field := range fields {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
-	}
+	h, r := ageRatingDeclarationRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_alternative_distribution.go
+++ b/internal/asc/output_alternative_distribution.go
@@ -2,11 +2,10 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
-func printAlternativeDistributionDomainsTable(resp *AlternativeDistributionDomainsResponse) error {
+func alternativeDistributionDomainsRows(resp *AlternativeDistributionDomainsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Domain", "Reference Name", "Created Date"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -17,25 +16,22 @@ func printAlternativeDistributionDomainsTable(resp *AlternativeDistributionDomai
 			item.Attributes.CreatedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionDomainsTable(resp *AlternativeDistributionDomainsResponse) error {
+	h, r := alternativeDistributionDomainsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionDomainsMarkdown(resp *AlternativeDistributionDomainsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Domain | Reference Name | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Domain),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.CreatedDate),
-		)
-	}
+	h, r := alternativeDistributionDomainsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAlternativeDistributionKeysTable(resp *AlternativeDistributionKeysResponse) error {
+func alternativeDistributionKeysRows(resp *AlternativeDistributionKeysResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Public Key"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -44,23 +40,22 @@ func printAlternativeDistributionKeysTable(resp *AlternativeDistributionKeysResp
 			compactWhitespace(item.Attributes.PublicKey),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionKeysTable(resp *AlternativeDistributionKeysResponse) error {
+	h, r := alternativeDistributionKeysRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionKeysMarkdown(resp *AlternativeDistributionKeysResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Public Key |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.PublicKey),
-		)
-	}
+	h, r := alternativeDistributionKeysRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAlternativeDistributionPackageVersionsTable(resp *AlternativeDistributionPackageVersionsResponse) error {
+func alternativeDistributionPackageVersionsRows(resp *AlternativeDistributionPackageVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State", "File Checksum", "URL", "URL Expiration Date"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -73,27 +68,22 @@ func printAlternativeDistributionPackageVersionsTable(resp *AlternativeDistribut
 			compactWhitespace(item.Attributes.URLExpirationDate),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionPackageVersionsTable(resp *AlternativeDistributionPackageVersionsResponse) error {
+	h, r := alternativeDistributionPackageVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionPackageVersionsMarkdown(resp *AlternativeDistributionPackageVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State | File Checksum | URL | URL Expiration Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(string(item.Attributes.State)),
-			escapeMarkdown(item.Attributes.FileChecksum),
-			escapeMarkdown(item.Attributes.URL),
-			escapeMarkdown(item.Attributes.URLExpirationDate),
-		)
-	}
+	h, r := alternativeDistributionPackageVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAlternativeDistributionPackageVariantsTable(resp *AlternativeDistributionPackageVariantsResponse) error {
+func alternativeDistributionPackageVariantsRows(resp *AlternativeDistributionPackageVariantsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "URL", "URL Expiration Date", "Key Blob", "File Checksum"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -105,26 +95,22 @@ func printAlternativeDistributionPackageVariantsTable(resp *AlternativeDistribut
 			compactWhitespace(item.Attributes.FileChecksum),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionPackageVariantsTable(resp *AlternativeDistributionPackageVariantsResponse) error {
+	h, r := alternativeDistributionPackageVariantsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionPackageVariantsMarkdown(resp *AlternativeDistributionPackageVariantsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | URL | URL Expiration Date | Key Blob | File Checksum |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.URL),
-			escapeMarkdown(item.Attributes.URLExpirationDate),
-			escapeMarkdown(item.Attributes.AlternativeDistributionKeyBlob),
-			escapeMarkdown(item.Attributes.FileChecksum),
-		)
-	}
+	h, r := alternativeDistributionPackageVariantsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAlternativeDistributionPackageDeltasTable(resp *AlternativeDistributionPackageDeltasResponse) error {
+func alternativeDistributionPackageDeltasRows(resp *AlternativeDistributionPackageDeltasResponse) ([]string, [][]string) {
 	headers := []string{"ID", "URL", "URL Expiration Date", "Key Blob", "File Checksum"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -136,42 +122,39 @@ func printAlternativeDistributionPackageDeltasTable(resp *AlternativeDistributio
 			compactWhitespace(item.Attributes.FileChecksum),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionPackageDeltasTable(resp *AlternativeDistributionPackageDeltasResponse) error {
+	h, r := alternativeDistributionPackageDeltasRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionPackageDeltasMarkdown(resp *AlternativeDistributionPackageDeltasResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | URL | URL Expiration Date | Key Blob | File Checksum |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.URL),
-			escapeMarkdown(item.Attributes.URLExpirationDate),
-			escapeMarkdown(item.Attributes.AlternativeDistributionKeyBlob),
-			escapeMarkdown(item.Attributes.FileChecksum),
-		)
-	}
+	h, r := alternativeDistributionPackageDeltasRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAlternativeDistributionPackageTable(resp *AlternativeDistributionPackageResponse) error {
+func alternativeDistributionPackageRows(resp *AlternativeDistributionPackageResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Source File Checksum"}
 	rows := [][]string{{
 		resp.Data.ID,
 		compactWhitespace(formatAlternativeDistributionChecksums(resp.Data.Attributes.SourceFileChecksum)),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionPackageTable(resp *AlternativeDistributionPackageResponse) error {
+	h, r := alternativeDistributionPackageRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionPackageMarkdown(resp *AlternativeDistributionPackageResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Source File Checksum |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(formatAlternativeDistributionChecksums(resp.Data.Attributes.SourceFileChecksum)),
-	)
+	h, r := alternativeDistributionPackageRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -199,17 +182,21 @@ func formatAlternativeDistributionChecksum(label string, checksum *Checksum) str
 	return fmt.Sprintf("%s:%s", label, checksum.Hash)
 }
 
-func printAlternativeDistributionDeleteResultTable(id string, deleted bool) error {
+func alternativeDistributionDeleteResultRows(id string, deleted bool) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{id, fmt.Sprintf("%t", deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAlternativeDistributionDeleteResultTable(id string, deleted bool) error {
+	h, r := alternativeDistributionDeleteResultRows(id, deleted)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAlternativeDistributionDeleteResultMarkdown(id string, deleted bool) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(id), deleted)
+	h, r := alternativeDistributionDeleteResultRows(id, deleted)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_alternative_distribution_test.go
+++ b/internal/asc/output_alternative_distribution_test.go
@@ -49,7 +49,7 @@ func TestPrintMarkdown_AlternativeDistributionDomains(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Domain | Reference Name | Created Date |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Domain") {
 		t.Fatalf("expected domain header, got: %s", output)
 	}
 	if !strings.Contains(output, "domain-1") || !strings.Contains(output, "example.com") || !strings.Contains(output, "Example") {
@@ -97,7 +97,7 @@ func TestPrintMarkdown_AlternativeDistributionKeys(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Public Key |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Public Key") {
 		t.Fatalf("expected key header, got: %s", output)
 	}
 	if !strings.Contains(output, "key-1") || !strings.Contains(output, "KEYDATA") {
@@ -159,7 +159,7 @@ func TestPrintMarkdown_AlternativeDistributionPackage(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Source File Checksum |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Source File Checksum") {
 		t.Fatalf("expected package header, got: %s", output)
 	}
 	if !strings.Contains(output, "package-1") || !strings.Contains(output, "file-hash") || !strings.Contains(output, "composite-hash") {
@@ -213,7 +213,7 @@ func TestPrintMarkdown_AlternativeDistributionPackageVariants(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | URL | URL Expiration Date | Key Blob | File Checksum |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Key Blob") {
 		t.Fatalf("expected variant header, got: %s", output)
 	}
 	if !strings.Contains(output, "variant-1") || !strings.Contains(output, "https://example.com/variant") {
@@ -267,7 +267,7 @@ func TestPrintMarkdown_AlternativeDistributionPackageDeltas(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | URL | URL Expiration Date | Key Blob | File Checksum |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Key Blob") {
 		t.Fatalf("expected delta header, got: %s", output)
 	}
 	if !strings.Contains(output, "delta-1") || !strings.Contains(output, "https://example.com/delta") {

--- a/internal/asc/output_android_ios_mapping.go
+++ b/internal/asc/output_android_ios_mapping.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -12,7 +11,7 @@ type AndroidToIosAppMappingDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printAndroidToIosAppMappingDetailsTable(resp *AndroidToIosAppMappingDetailsResponse) error {
+func androidToIosAppMappingDetailsRows(resp *AndroidToIosAppMappingDetailsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Package Name", "Fingerprints"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -22,37 +21,36 @@ func printAndroidToIosAppMappingDetailsTable(resp *AndroidToIosAppMappingDetails
 			formatAndroidToIosFingerprints(item.Attributes.AppSigningKeyPublicCertificateSha256Fingerprints),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAndroidToIosAppMappingDetailsTable(resp *AndroidToIosAppMappingDetailsResponse) error {
+	h, r := androidToIosAppMappingDetailsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAndroidToIosAppMappingDetailsMarkdown(resp *AndroidToIosAppMappingDetailsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Package Name | Fingerprints |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.PackageName),
-			escapeMarkdown(formatAndroidToIosFingerprints(item.Attributes.AppSigningKeyPublicCertificateSha256Fingerprints)),
-		)
-	}
+	h, r := androidToIosAppMappingDetailsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAndroidToIosAppMappingDeleteResultTable(result *AndroidToIosAppMappingDeleteResult) error {
+func androidToIosAppMappingDeleteResultRows(result *AndroidToIosAppMappingDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAndroidToIosAppMappingDeleteResultTable(result *AndroidToIosAppMappingDeleteResult) error {
+	h, r := androidToIosAppMappingDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAndroidToIosAppMappingDeleteResultMarkdown(result *AndroidToIosAppMappingDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := androidToIosAppMappingDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_app_clips.go
+++ b/internal/asc/output_app_clips.go
@@ -2,55 +2,52 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
-func printAppClipsTable(resp *AppClipsResponse) error {
+func appClipsRows(resp *AppClipsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Bundle ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, item.Attributes.BundleID})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipsTable(resp *AppClipsResponse) error {
+	h, r := appClipsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipsMarkdown(resp *AppClipsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Bundle ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.BundleID),
-		)
-	}
+	h, r := appClipsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipDefaultExperiencesTable(resp *AppClipDefaultExperiencesResponse) error {
+func appClipDefaultExperiencesRows(resp *AppClipDefaultExperiencesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Action"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, string(item.Attributes.Action)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipDefaultExperiencesTable(resp *AppClipDefaultExperiencesResponse) error {
+	h, r := appClipDefaultExperiencesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipDefaultExperiencesMarkdown(resp *AppClipDefaultExperiencesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.Action)),
-		)
-	}
+	h, r := appClipDefaultExperiencesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipDefaultExperienceLocalizationsTable(resp *AppClipDefaultExperienceLocalizationsResponse) error {
+func appClipDefaultExperienceLocalizationsRows(resp *AppClipDefaultExperienceLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Subtitle"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -60,24 +57,22 @@ func printAppClipDefaultExperienceLocalizationsTable(resp *AppClipDefaultExperie
 			compactWhitespace(item.Attributes.Subtitle),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipDefaultExperienceLocalizationsTable(resp *AppClipDefaultExperienceLocalizationsResponse) error {
+	h, r := appClipDefaultExperienceLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipDefaultExperienceLocalizationsMarkdown(resp *AppClipDefaultExperienceLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Subtitle |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Subtitle),
-		)
-	}
+	h, r := appClipDefaultExperienceLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipAdvancedExperiencesTable(resp *AppClipAdvancedExperiencesResponse) error {
+func appClipAdvancedExperiencesRows(resp *AppClipAdvancedExperiencesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Action", "Status", "Business Category", "Default Language", "Powered By", "Link"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -91,28 +86,22 @@ func printAppClipAdvancedExperiencesTable(resp *AppClipAdvancedExperiencesRespon
 			item.Attributes.Link,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipAdvancedExperiencesTable(resp *AppClipAdvancedExperiencesResponse) error {
+	h, r := appClipAdvancedExperiencesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipAdvancedExperiencesMarkdown(resp *AppClipAdvancedExperiencesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Action | Status | Business Category | Default Language | Powered By | Link |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.Action)),
-			escapeMarkdown(item.Attributes.Status),
-			escapeMarkdown(string(item.Attributes.BusinessCategory)),
-			escapeMarkdown(string(item.Attributes.DefaultLanguage)),
-			item.Attributes.IsPoweredBy,
-			escapeMarkdown(item.Attributes.Link),
-		)
-	}
+	h, r := appClipAdvancedExperiencesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaAppClipInvocationLocalizationsTable(resp *BetaAppClipInvocationLocalizationsResponse) error {
+func betaAppClipInvocationLocalizationsRows(resp *BetaAppClipInvocationLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Title"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -122,24 +111,22 @@ func printBetaAppClipInvocationLocalizationsTable(resp *BetaAppClipInvocationLoc
 			compactWhitespace(item.Attributes.Title),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppClipInvocationLocalizationsTable(resp *BetaAppClipInvocationLocalizationsResponse) error {
+	h, r := betaAppClipInvocationLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaAppClipInvocationLocalizationsMarkdown(resp *BetaAppClipInvocationLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Title |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Title),
-		)
-	}
+	h, r := betaAppClipInvocationLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipAdvancedExperienceImageUploadResultTable(result *AppClipAdvancedExperienceImageUploadResult) error {
+func appClipAdvancedExperienceImageUploadResultRows(result *AppClipAdvancedExperienceImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Experience ID", "File Name", "File Size", "State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -149,25 +136,22 @@ func printAppClipAdvancedExperienceImageUploadResultTable(result *AppClipAdvance
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipAdvancedExperienceImageUploadResultTable(result *AppClipAdvancedExperienceImageUploadResult) error {
+	h, r := appClipAdvancedExperienceImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipAdvancedExperienceImageUploadResultMarkdown(result *AppClipAdvancedExperienceImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Experience ID | File Name | File Size | State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.ExperienceID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := appClipAdvancedExperienceImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipAdvancedExperienceImageTable(resp *AppClipAdvancedExperienceImageResponse) error {
+func appClipAdvancedExperienceImageRows(resp *AppClipAdvancedExperienceImageResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "State"}
 	state := ""
 	if resp.Data.Attributes.AssetDeliveryState != nil {
@@ -179,27 +163,22 @@ func printAppClipAdvancedExperienceImageTable(resp *AppClipAdvancedExperienceIma
 		fmt.Sprintf("%d", resp.Data.Attributes.FileSize),
 		state,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipAdvancedExperienceImageTable(resp *AppClipAdvancedExperienceImageResponse) error {
+	h, r := appClipAdvancedExperienceImageRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipAdvancedExperienceImageMarkdown(resp *AppClipAdvancedExperienceImageResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	state := ""
-	if resp.Data.Attributes.AssetDeliveryState != nil {
-		state = resp.Data.Attributes.AssetDeliveryState.State
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.FileName),
-		resp.Data.Attributes.FileSize,
-		escapeMarkdown(state),
-	)
+	h, r := appClipAdvancedExperienceImageRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipHeaderImageUploadResultTable(result *AppClipHeaderImageUploadResult) error {
+func appClipHeaderImageUploadResultRows(result *AppClipHeaderImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Localization ID", "File Name", "File Size", "State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -209,25 +188,22 @@ func printAppClipHeaderImageUploadResultTable(result *AppClipHeaderImageUploadRe
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipHeaderImageUploadResultTable(result *AppClipHeaderImageUploadResult) error {
+	h, r := appClipHeaderImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipHeaderImageUploadResultMarkdown(result *AppClipHeaderImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Localization ID | File Name | File Size | State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.LocalizationID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := appClipHeaderImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipHeaderImageTable(resp *AppClipHeaderImageResponse) error {
+func appClipHeaderImageRows(resp *AppClipHeaderImageResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "State"}
 	state := ""
 	if resp.Data.Attributes.AssetDeliveryState != nil {
@@ -239,160 +215,162 @@ func printAppClipHeaderImageTable(resp *AppClipHeaderImageResponse) error {
 		fmt.Sprintf("%d", resp.Data.Attributes.FileSize),
 		state,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipHeaderImageTable(resp *AppClipHeaderImageResponse) error {
+	h, r := appClipHeaderImageRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipHeaderImageMarkdown(resp *AppClipHeaderImageResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	state := ""
-	if resp.Data.Attributes.AssetDeliveryState != nil {
-		state = resp.Data.Attributes.AssetDeliveryState.State
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.FileName),
-		resp.Data.Attributes.FileSize,
-		escapeMarkdown(state),
-	)
+	h, r := appClipHeaderImageRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipDefaultExperienceDeleteResultTable(result *AppClipDefaultExperienceDeleteResult) error {
+func appClipDefaultExperienceDeleteResultRows(result *AppClipDefaultExperienceDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipDefaultExperienceDeleteResultTable(result *AppClipDefaultExperienceDeleteResult) error {
+	h, r := appClipDefaultExperienceDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipDefaultExperienceDeleteResultMarkdown(result *AppClipDefaultExperienceDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appClipDefaultExperienceDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipDefaultExperienceLocalizationDeleteResultTable(result *AppClipDefaultExperienceLocalizationDeleteResult) error {
+func appClipDefaultExperienceLocalizationDeleteResultRows(result *AppClipDefaultExperienceLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipDefaultExperienceLocalizationDeleteResultTable(result *AppClipDefaultExperienceLocalizationDeleteResult) error {
+	h, r := appClipDefaultExperienceLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipDefaultExperienceLocalizationDeleteResultMarkdown(result *AppClipDefaultExperienceLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appClipDefaultExperienceLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipAdvancedExperienceDeleteResultTable(result *AppClipAdvancedExperienceDeleteResult) error {
+func appClipAdvancedExperienceDeleteResultRows(result *AppClipAdvancedExperienceDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipAdvancedExperienceDeleteResultTable(result *AppClipAdvancedExperienceDeleteResult) error {
+	h, r := appClipAdvancedExperienceDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipAdvancedExperienceDeleteResultMarkdown(result *AppClipAdvancedExperienceDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appClipAdvancedExperienceDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipAdvancedExperienceImageDeleteResultTable(result *AppClipAdvancedExperienceImageDeleteResult) error {
+func appClipAdvancedExperienceImageDeleteResultRows(result *AppClipAdvancedExperienceImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipAdvancedExperienceImageDeleteResultTable(result *AppClipAdvancedExperienceImageDeleteResult) error {
+	h, r := appClipAdvancedExperienceImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipAdvancedExperienceImageDeleteResultMarkdown(result *AppClipAdvancedExperienceImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appClipAdvancedExperienceImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipHeaderImageDeleteResultTable(result *AppClipHeaderImageDeleteResult) error {
+func appClipHeaderImageDeleteResultRows(result *AppClipHeaderImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipHeaderImageDeleteResultTable(result *AppClipHeaderImageDeleteResult) error {
+	h, r := appClipHeaderImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipHeaderImageDeleteResultMarkdown(result *AppClipHeaderImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appClipHeaderImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaAppClipInvocationDeleteResultTable(result *BetaAppClipInvocationDeleteResult) error {
+func betaAppClipInvocationDeleteResultRows(result *BetaAppClipInvocationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppClipInvocationDeleteResultTable(result *BetaAppClipInvocationDeleteResult) error {
+	h, r := betaAppClipInvocationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaAppClipInvocationDeleteResultMarkdown(result *BetaAppClipInvocationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := betaAppClipInvocationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaAppClipInvocationLocalizationDeleteResultTable(result *BetaAppClipInvocationLocalizationDeleteResult) error {
+func betaAppClipInvocationLocalizationDeleteResultRows(result *BetaAppClipInvocationLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppClipInvocationLocalizationDeleteResultTable(result *BetaAppClipInvocationLocalizationDeleteResult) error {
+	h, r := betaAppClipInvocationLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaAppClipInvocationLocalizationDeleteResultMarkdown(result *BetaAppClipInvocationLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := betaAppClipInvocationLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppClipAppStoreReviewDetailTable(resp *AppClipAppStoreReviewDetailResponse) error {
+func appClipAppStoreReviewDetailRows(resp *AppClipAppStoreReviewDetailResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Invocation URLs"}
 	urls := strings.Join(resp.Data.Attributes.InvocationURLs, ", ")
 	rows := [][]string{{resp.Data.ID, compactWhitespace(urls)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppClipAppStoreReviewDetailTable(resp *AppClipAppStoreReviewDetailResponse) error {
+	h, r := appClipAppStoreReviewDetailRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppClipAppStoreReviewDetailMarkdown(resp *AppClipAppStoreReviewDetailResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Invocation URLs |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	urls := strings.Join(resp.Data.Attributes.InvocationURLs, ", ")
-	fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(urls),
-	)
+	h, r := appClipAppStoreReviewDetailRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_app_clips_test.go
+++ b/internal/asc/output_app_clips_test.go
@@ -32,7 +32,7 @@ func TestPrintMarkdown_AppClips(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Bundle ID |") || !strings.Contains(output, "com.example.clip") {
+	if !strings.Contains(output, "Bundle ID") || !strings.Contains(output, "com.example.clip") {
 		t.Fatalf("expected markdown bundle id, got %q", output)
 	}
 }
@@ -56,7 +56,7 @@ func TestPrintMarkdown_AppClips_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Bundle ID |") {
+	if !strings.Contains(output, "Bundle ID") {
 		t.Fatalf("expected markdown header, got %q", output)
 	}
 }
@@ -100,7 +100,7 @@ func TestPrintMarkdown_AppClipDefaultExperienceLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale |") || !strings.Contains(output, "en-US") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "en-US") {
 		t.Fatalf("expected locale in output, got %q", output)
 	}
 }
@@ -112,7 +112,7 @@ func TestPrintMarkdown_AppClipDefaultExperienceLocalizations_Empty(t *testing.T)
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale |") {
+	if !strings.Contains(output, "Locale") {
 		t.Fatalf("expected markdown header, got %q", output)
 	}
 }
@@ -166,7 +166,7 @@ func TestPrintMarkdown_BetaAppClipInvocationLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Title |") || !strings.Contains(output, "Try it") {
+	if !strings.Contains(output, "Title") || !strings.Contains(output, "Try it") {
 		t.Fatalf("expected title in output, got %q", output)
 	}
 }
@@ -178,7 +178,7 @@ func TestPrintMarkdown_BetaAppClipInvocationLocalizations_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Title |") {
+	if !strings.Contains(output, "Title") {
 		t.Fatalf("expected markdown header, got %q", output)
 	}
 }

--- a/internal/asc/output_app_events.go
+++ b/internal/asc/output_app_events.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // AppEventDeleteResult represents CLI output for app event deletions.
 type AppEventDeleteResult struct {
@@ -27,7 +24,7 @@ type AppEventSubmissionResult struct {
 	SubmittedDate *string `json:"submittedDate,omitempty"`
 }
 
-func printAppEventsTable(resp *AppEventsResponse) error {
+func appEventsRows(resp *AppEventsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Type", "State", "Primary Locale", "Priority"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -41,28 +38,22 @@ func printAppEventsTable(resp *AppEventsResponse) error {
 			sanitizeTerminal(attrs.Priority),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventsTable(resp *AppEventsResponse) error {
+	h, r := appEventsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventsMarkdown(resp *AppEventsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Type | State | Primary Locale | Priority |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.ReferenceName),
-			escapeMarkdown(attrs.Badge),
-			escapeMarkdown(attrs.EventState),
-			escapeMarkdown(attrs.PrimaryLocale),
-			escapeMarkdown(attrs.Priority),
-		)
-	}
+	h, r := appEventsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEventLocalizationsTable(resp *AppEventLocalizationsResponse) error {
+func appEventLocalizationsRows(resp *AppEventLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name", "Short Description", "Long Description"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -75,27 +66,22 @@ func printAppEventLocalizationsTable(resp *AppEventLocalizationsResponse) error 
 			compactWhitespace(attrs.LongDescription),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventLocalizationsTable(resp *AppEventLocalizationsResponse) error {
+	h, r := appEventLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventLocalizationsMarkdown(resp *AppEventLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name | Short Description | Long Description |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.Locale),
-			escapeMarkdown(attrs.Name),
-			escapeMarkdown(attrs.ShortDescription),
-			escapeMarkdown(attrs.LongDescription),
-		)
-	}
+	h, r := appEventLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEventScreenshotsTable(resp *AppEventScreenshotsResponse) error {
+func appEventScreenshotsRows(resp *AppEventScreenshotsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Asset Type", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -108,27 +94,22 @@ func printAppEventScreenshotsTable(resp *AppEventScreenshotsResponse) error {
 			sanitizeTerminal(formatAppMediaAssetState(attrs.AssetDeliveryState)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventScreenshotsTable(resp *AppEventScreenshotsResponse) error {
+	h, r := appEventScreenshotsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventScreenshotsMarkdown(resp *AppEventScreenshotsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Asset Type | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.FileName),
-			attrs.FileSize,
-			escapeMarkdown(attrs.AppEventAssetType),
-			escapeMarkdown(formatAppMediaAssetState(attrs.AssetDeliveryState)),
-		)
-	}
+	h, r := appEventScreenshotsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEventVideoClipsTable(resp *AppEventVideoClipsResponse) error {
+func appEventVideoClipsRows(resp *AppEventVideoClipsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Asset Type", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -141,61 +122,58 @@ func printAppEventVideoClipsTable(resp *AppEventVideoClipsResponse) error {
 			sanitizeTerminal(formatAppMediaVideoState(attrs.VideoDeliveryState, attrs.AssetDeliveryState)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventVideoClipsTable(resp *AppEventVideoClipsResponse) error {
+	h, r := appEventVideoClipsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventVideoClipsMarkdown(resp *AppEventVideoClipsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Asset Type | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.FileName),
-			attrs.FileSize,
-			escapeMarkdown(attrs.AppEventAssetType),
-			escapeMarkdown(formatAppMediaVideoState(attrs.VideoDeliveryState, attrs.AssetDeliveryState)),
-		)
-	}
+	h, r := appEventVideoClipsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEventDeleteResultTable(result *AppEventDeleteResult) error {
+func appEventDeleteResultRows(result *AppEventDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventDeleteResultTable(result *AppEventDeleteResult) error {
+	h, r := appEventDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventDeleteResultMarkdown(result *AppEventDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appEventDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEventLocalizationDeleteResultTable(result *AppEventLocalizationDeleteResult) error {
+func appEventLocalizationDeleteResultRows(result *AppEventLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventLocalizationDeleteResultTable(result *AppEventLocalizationDeleteResult) error {
+	h, r := appEventLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventLocalizationDeleteResultMarkdown(result *AppEventLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appEventLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEventSubmissionResultTable(result *AppEventSubmissionResult) error {
+func appEventSubmissionResultRows(result *AppEventSubmissionResult) ([]string, [][]string) {
 	headers := []string{"Submission ID", "Item ID", "Event ID", "App ID", "Platform", "Submitted Date"}
 	submittedDate := ""
 	if result.SubmittedDate != nil {
@@ -209,25 +187,18 @@ func printAppEventSubmissionResultTable(result *AppEventSubmissionResult) error 
 		sanitizeTerminal(result.Platform),
 		sanitizeTerminal(submittedDate),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEventSubmissionResultTable(result *AppEventSubmissionResult) error {
+	h, r := appEventSubmissionResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEventSubmissionResultMarkdown(result *AppEventSubmissionResult) error {
-	fmt.Fprintln(os.Stdout, "| Submission ID | Item ID | Event ID | App ID | Platform | Submitted Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	submittedDate := ""
-	if result.SubmittedDate != nil {
-		submittedDate = *result.SubmittedDate
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(result.SubmissionID),
-		escapeMarkdown(result.ItemID),
-		escapeMarkdown(result.EventID),
-		escapeMarkdown(result.AppID),
-		escapeMarkdown(result.Platform),
-		escapeMarkdown(submittedDate),
-	)
+	h, r := appEventSubmissionResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_app_info.go
+++ b/internal/asc/output_app_info.go
@@ -1,11 +1,8 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
-func printAppInfosTable(resp *AppInfosResponse) error {
+func appInfosRows(resp *AppInfosResponse) ([]string, [][]string) {
 	headers := []string{"ID", "App Store State", "State", "Age Rating", "Kids Age Band"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, info := range resp.Data {
@@ -18,25 +15,18 @@ func printAppInfosTable(resp *AppInfosResponse) error {
 			appInfoAttrString(attrs, "kidsAgeBand"),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppInfosTable(resp *AppInfosResponse) error {
+	h, r := appInfosRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppInfosMarkdown(resp *AppInfosResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | App Store State | State | Age Rating | Kids Age Band |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, info := range resp.Data {
-		attrs := info.Attributes
-		fmt.Fprintf(
-			os.Stdout,
-			"| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(info.ID),
-			escapeMarkdown(appInfoAttrString(attrs, "appStoreState")),
-			escapeMarkdown(appInfoAttrString(attrs, "state")),
-			escapeMarkdown(appInfoAttrString(attrs, "appStoreAgeRating")),
-			escapeMarkdown(appInfoAttrString(attrs, "kidsAgeBand")),
-		)
-	}
+	h, r := appInfosRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_app_info_test.go
+++ b/internal/asc/output_app_info_test.go
@@ -49,7 +49,7 @@ func TestPrintMarkdown_AppInfos(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "info-1") {

--- a/internal/asc/output_app_setup.go
+++ b/internal/asc/output_app_setup.go
@@ -1,10 +1,5 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
 // AppSetupInfoResult represents CLI output for app-setup info updates.
 type AppSetupInfoResult struct {
 	AppID               string                       `json:"appId"`
@@ -12,7 +7,7 @@ type AppSetupInfoResult struct {
 	AppInfoLocalization *AppInfoLocalizationResponse `json:"appInfoLocalization,omitempty"`
 }
 
-func printAppSetupInfoResultTable(result *AppSetupInfoResult) error {
+func appSetupInfoResultRows(result *AppSetupInfoResult) ([]string, [][]string) {
 	headers := []string{"Resource", "ID", "Locale", "Name", "Subtitle", "Bundle ID", "Primary Locale", "Privacy Policy URL"}
 	var rows [][]string
 	if result.App != nil {
@@ -32,34 +27,17 @@ func printAppSetupInfoResultTable(result *AppSetupInfoResult) error {
 			attrs.PrivacyPolicyURL,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppSetupInfoResultTable(result *AppSetupInfoResult) error {
+	h, r := appSetupInfoResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppSetupInfoResultMarkdown(result *AppSetupInfoResult) error {
-	fmt.Fprintln(os.Stdout, "| Resource | ID | Locale | Name | Subtitle | Bundle ID | Primary Locale | Privacy Policy URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	if result.App != nil {
-		attrs := result.App.Data.Attributes
-		fmt.Fprintf(
-			os.Stdout,
-			"| app | %s |  |  |  | %s | %s |  |\n",
-			escapeMarkdown(result.App.Data.ID),
-			escapeMarkdown(attrs.BundleID),
-			escapeMarkdown(attrs.PrimaryLocale),
-		)
-	}
-	if result.AppInfoLocalization != nil {
-		attrs := result.AppInfoLocalization.Data.Attributes
-		fmt.Fprintf(
-			os.Stdout,
-			"| appInfoLocalization | %s | %s | %s | %s |  |  | %s |\n",
-			escapeMarkdown(result.AppInfoLocalization.Data.ID),
-			escapeMarkdown(attrs.Locale),
-			escapeMarkdown(attrs.Name),
-			escapeMarkdown(attrs.Subtitle),
-			escapeMarkdown(attrs.PrivacyPolicyURL),
-		)
-	}
+	h, r := appSetupInfoResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_app_tags.go
+++ b/internal/asc/output_app_tags.go
@@ -1,11 +1,8 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
-func printAppTagsTable(resp *AppTagsResponse) error {
+func appTagsRows(resp *AppTagsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Visible In App Store"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -15,19 +12,17 @@ func printAppTagsTable(resp *AppTagsResponse) error {
 			fmt.Sprintf("%t", item.Attributes.VisibleInAppStore),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppTagsTable(resp *AppTagsResponse) error {
+	h, r := appTagsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppTagsMarkdown(resp *AppTagsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Visible In App Store |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			item.Attributes.VisibleInAppStore,
-		)
-	}
+	h, r := appTagsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_apps.go
+++ b/internal/asc/output_apps.go
@@ -1,11 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
-func printAppsTable(resp *AppsResponse) error {
+func appsRows(resp *AppsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Bundle ID", "SKU"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -16,20 +11,17 @@ func printAppsTable(resp *AppsResponse) error {
 			item.Attributes.SKU,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppsTable(resp *AppsResponse) error {
+	h, r := appsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppsMarkdown(resp *AppsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Bundle ID | SKU |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.BundleID),
-			escapeMarkdown(item.Attributes.SKU),
-		)
-	}
+	h, r := appsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_background_assets.go
+++ b/internal/asc/output_background_assets.go
@@ -2,11 +2,10 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
-func printBackgroundAssetsTable(resp *BackgroundAssetsResponse) error {
+func backgroundAssetsRows(resp *BackgroundAssetsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Asset Pack Identifier", "Archived", "Created Date"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -17,25 +16,22 @@ func printBackgroundAssetsTable(resp *BackgroundAssetsResponse) error {
 			item.Attributes.CreatedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBackgroundAssetsTable(resp *BackgroundAssetsResponse) error {
+	h, r := backgroundAssetsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBackgroundAssetsMarkdown(resp *BackgroundAssetsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Asset Pack Identifier | Archived | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.AssetPackIdentifier),
-			item.Attributes.Archived,
-			escapeMarkdown(item.Attributes.CreatedDate),
-		)
-	}
+	h, r := backgroundAssetsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBackgroundAssetVersionsTable(resp *BackgroundAssetVersionsResponse) error {
+func backgroundAssetVersionsRows(resp *BackgroundAssetVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State", "Platforms", "Created Date"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -47,32 +43,28 @@ func printBackgroundAssetVersionsTable(resp *BackgroundAssetVersionsResponse) er
 			item.Attributes.CreatedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBackgroundAssetVersionsTable(resp *BackgroundAssetVersionsResponse) error {
+	h, r := backgroundAssetVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBackgroundAssetVersionsMarkdown(resp *BackgroundAssetVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State | Platforms | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(item.Attributes.State),
-			escapeMarkdown(formatPlatforms(item.Attributes.Platforms)),
-			escapeMarkdown(item.Attributes.CreatedDate),
-		)
-	}
+	h, r := backgroundAssetVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBackgroundAssetUploadFilesTable(resp *BackgroundAssetUploadFilesResponse) error {
+func backgroundAssetUploadFilesRows(resp *BackgroundAssetUploadFilesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "Asset Type", "File Size", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		state := ""
 		if item.Attributes.AssetDeliveryState != nil && item.Attributes.AssetDeliveryState.State != nil {
-			state = *item.Attributes.AssetDeliveryState.State
+			state = strings.TrimSpace(*item.Attributes.AssetDeliveryState.State)
 		}
 		rows = append(rows, []string{
 			item.ID,
@@ -82,43 +74,36 @@ func printBackgroundAssetUploadFilesTable(resp *BackgroundAssetUploadFilesRespon
 			state,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBackgroundAssetUploadFilesTable(resp *BackgroundAssetUploadFilesResponse) error {
+	h, r := backgroundAssetUploadFilesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBackgroundAssetUploadFilesMarkdown(resp *BackgroundAssetUploadFilesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | Asset Type | File Size | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil && item.Attributes.AssetDeliveryState.State != nil {
-			state = *item.Attributes.AssetDeliveryState.State
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			escapeMarkdown(string(item.Attributes.AssetType)),
-			item.Attributes.FileSize,
-			escapeMarkdown(strings.TrimSpace(state)),
-		)
-	}
+	h, r := backgroundAssetUploadFilesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBackgroundAssetVersionStateTable(id string, state string) error {
+func backgroundAssetVersionStateRows(id string, state string) ([]string, [][]string) {
 	headers := []string{"ID", "State"}
 	rows := [][]string{{id, state}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBackgroundAssetVersionStateTable(id string, state string) error {
+	h, r := backgroundAssetVersionStateRows(id, state)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBackgroundAssetVersionStateMarkdown(id string, state string) error {
-	fmt.Fprintln(os.Stdout, "| ID | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-		escapeMarkdown(id),
-		escapeMarkdown(state),
-	)
+	h, r := backgroundAssetVersionStateRows(id, state)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_beta.go
+++ b/internal/asc/output_beta.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -55,22 +54,6 @@ type BetaFeedbackSubmissionDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printBetaGroupsTable(resp *BetaGroupsResponse) error {
-	headers := []string{"ID", "Name", "Internal", "Public Link Enabled", "Public Link"}
-	rows := make([][]string, 0, len(resp.Data))
-	for _, item := range resp.Data {
-		rows = append(rows, []string{
-			item.ID,
-			compactWhitespace(item.Attributes.Name),
-			fmt.Sprintf("%t", item.Attributes.IsInternalGroup),
-			fmt.Sprintf("%t", item.Attributes.PublicLinkEnabled),
-			item.Attributes.PublicLink,
-		})
-	}
-	RenderTable(headers, rows)
-	return nil
-}
-
 func formatBetaTesterName(attr BetaTesterAttributes) string {
 	first := strings.TrimSpace(attr.FirstName)
 	last := strings.TrimSpace(attr.LastName)
@@ -86,7 +69,34 @@ func formatBetaTesterName(attr BetaTesterAttributes) string {
 	}
 }
 
-func printBetaTestersTable(resp *BetaTestersResponse) error {
+func betaGroupsRows(resp *BetaGroupsResponse) ([]string, [][]string) {
+	headers := []string{"ID", "Name", "Internal", "Public Link Enabled", "Public Link"}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		rows = append(rows, []string{
+			item.ID,
+			compactWhitespace(item.Attributes.Name),
+			fmt.Sprintf("%t", item.Attributes.IsInternalGroup),
+			fmt.Sprintf("%t", item.Attributes.PublicLinkEnabled),
+			item.Attributes.PublicLink,
+		})
+	}
+	return headers, rows
+}
+
+func printBetaGroupsTable(resp *BetaGroupsResponse) error {
+	h, r := betaGroupsRows(resp)
+	RenderTable(h, r)
+	return nil
+}
+
+func printBetaGroupsMarkdown(resp *BetaGroupsResponse) error {
+	h, r := betaGroupsRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func betaTestersRows(resp *BetaTestersResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Email", "Name", "State", "Invite"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -98,7 +108,12 @@ func printBetaTestersTable(resp *BetaTestersResponse) error {
 			string(item.Attributes.InviteType),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaTestersTable(resp *BetaTestersResponse) error {
+	h, r := betaTestersRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
@@ -108,33 +123,9 @@ func printBetaTesterTable(resp *BetaTesterResponse) error {
 	})
 }
 
-func printBetaGroupsMarkdown(resp *BetaGroupsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Internal | Public Link Enabled | Public Link |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %t | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			item.Attributes.IsInternalGroup,
-			item.Attributes.PublicLinkEnabled,
-			escapeMarkdown(item.Attributes.PublicLink),
-		)
-	}
-	return nil
-}
-
 func printBetaTestersMarkdown(resp *BetaTestersResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Email | Name | State | Invite |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Email),
-			escapeMarkdown(formatBetaTesterName(item.Attributes)),
-			escapeMarkdown(string(item.Attributes.State)),
-			escapeMarkdown(string(item.Attributes.InviteType)),
-		)
-	}
+	h, r := betaTestersRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -144,128 +135,128 @@ func printBetaTesterMarkdown(resp *BetaTesterResponse) error {
 	})
 }
 
-func printBetaTesterDeleteResultTable(result *BetaTesterDeleteResult) error {
+func betaTesterDeleteResultRows(result *BetaTesterDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Email", "Deleted"}
 	rows := [][]string{{result.ID, result.Email, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaTesterDeleteResultTable(result *BetaTesterDeleteResult) error {
+	h, r := betaTesterDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaTesterDeleteResultMarkdown(result *BetaTesterDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Email | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.Email),
-		result.Deleted,
-	)
+	h, r := betaTesterDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaTesterGroupsUpdateResultTable(result *BetaTesterGroupsUpdateResult) error {
+func betaTesterGroupsUpdateResultRows(result *BetaTesterGroupsUpdateResult) ([]string, [][]string) {
 	headers := []string{"Tester ID", "Group IDs", "Action"}
 	rows := [][]string{{result.TesterID, strings.Join(result.GroupIDs, ","), result.Action}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaTesterGroupsUpdateResultTable(result *BetaTesterGroupsUpdateResult) error {
+	h, r := betaTesterGroupsUpdateResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaTesterGroupsUpdateResultMarkdown(result *BetaTesterGroupsUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| Tester ID | Group IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.TesterID),
-		escapeMarkdown(strings.Join(result.GroupIDs, ",")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := betaTesterGroupsUpdateResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaTesterAppsUpdateResultTable(result *BetaTesterAppsUpdateResult) error {
+func betaTesterAppsUpdateResultRows(result *BetaTesterAppsUpdateResult) ([]string, [][]string) {
 	headers := []string{"Tester ID", "App IDs", "Action"}
 	rows := [][]string{{result.TesterID, strings.Join(result.AppIDs, ","), result.Action}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaTesterAppsUpdateResultTable(result *BetaTesterAppsUpdateResult) error {
+	h, r := betaTesterAppsUpdateResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaTesterAppsUpdateResultMarkdown(result *BetaTesterAppsUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| Tester ID | App IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.TesterID),
-		escapeMarkdown(strings.Join(result.AppIDs, ",")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := betaTesterAppsUpdateResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaTesterBuildsUpdateResultTable(result *BetaTesterBuildsUpdateResult) error {
+func betaTesterBuildsUpdateResultRows(result *BetaTesterBuildsUpdateResult) ([]string, [][]string) {
 	headers := []string{"Tester ID", "Build IDs", "Action"}
 	rows := [][]string{{result.TesterID, strings.Join(result.BuildIDs, ","), result.Action}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaTesterBuildsUpdateResultTable(result *BetaTesterBuildsUpdateResult) error {
+	h, r := betaTesterBuildsUpdateResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaTesterBuildsUpdateResultMarkdown(result *BetaTesterBuildsUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| Tester ID | Build IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.TesterID),
-		escapeMarkdown(strings.Join(result.BuildIDs, ",")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := betaTesterBuildsUpdateResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppBetaTestersUpdateResultTable(result *AppBetaTestersUpdateResult) error {
+func appBetaTestersUpdateResultRows(result *AppBetaTestersUpdateResult) ([]string, [][]string) {
 	headers := []string{"App ID", "Tester IDs", "Action"}
 	rows := [][]string{{result.AppID, strings.Join(result.TesterIDs, ","), result.Action}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppBetaTestersUpdateResultTable(result *AppBetaTestersUpdateResult) error {
+	h, r := appBetaTestersUpdateResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppBetaTestersUpdateResultMarkdown(result *AppBetaTestersUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| App ID | Tester IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.AppID),
-		escapeMarkdown(strings.Join(result.TesterIDs, ",")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := appBetaTestersUpdateResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaFeedbackSubmissionDeleteResultTable(result *BetaFeedbackSubmissionDeleteResult) error {
+func betaFeedbackSubmissionDeleteResultRows(result *BetaFeedbackSubmissionDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaFeedbackSubmissionDeleteResultTable(result *BetaFeedbackSubmissionDeleteResult) error {
+	h, r := betaFeedbackSubmissionDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaFeedbackSubmissionDeleteResultMarkdown(result *BetaFeedbackSubmissionDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := betaFeedbackSubmissionDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaTesterInvitationResultTable(result *BetaTesterInvitationResult) error {
+func betaTesterInvitationResultRows(result *BetaTesterInvitationResult) ([]string, [][]string) {
 	headers := []string{"Invitation ID", "Tester ID", "App ID", "Email"}
 	rows := [][]string{{result.InvitationID, result.TesterID, result.AppID, result.Email}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaTesterInvitationResultTable(result *BetaTesterInvitationResult) error {
+	h, r := betaTesterInvitationResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaTesterInvitationResultMarkdown(result *BetaTesterInvitationResult) error {
-	fmt.Fprintln(os.Stdout, "| Invitation ID | Tester ID | App ID | Email |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-		escapeMarkdown(result.InvitationID),
-		escapeMarkdown(result.TesterID),
-		escapeMarkdown(result.AppID),
-		escapeMarkdown(result.Email),
-	)
+	h, r := betaTesterInvitationResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_beta_license_agreements.go
+++ b/internal/asc/output_beta_license_agreements.go
@@ -1,10 +1,5 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
 func betaLicenseAgreementAppID(resource BetaLicenseAgreementResource) string {
 	if resource.Relationships == nil || resource.Relationships.App == nil {
 		return ""
@@ -12,7 +7,7 @@ func betaLicenseAgreementAppID(resource BetaLicenseAgreementResource) string {
 	return resource.Relationships.App.Data.ID
 }
 
-func printBetaLicenseAgreementsTable(resp *BetaLicenseAgreementsResponse) error {
+func betaLicenseAgreementsRows(resp *BetaLicenseAgreementsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "App ID", "Agreement Text"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -22,19 +17,17 @@ func printBetaLicenseAgreementsTable(resp *BetaLicenseAgreementsResponse) error 
 			compactWhitespace(item.Attributes.AgreementText),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaLicenseAgreementsTable(resp *BetaLicenseAgreementsResponse) error {
+	h, r := betaLicenseAgreementsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaLicenseAgreementsMarkdown(resp *BetaLicenseAgreementsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | App ID | Agreement Text |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(betaLicenseAgreementAppID(item)),
-			escapeMarkdown(item.Attributes.AgreementText),
-		)
-	}
+	h, r := betaLicenseAgreementsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_build_beta_notifications.go
+++ b/internal/asc/output_build_beta_notifications.go
@@ -1,20 +1,19 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
-func printBuildBetaNotificationTable(resp *BuildBetaNotificationResponse) error {
+func buildBetaNotificationRows(resp *BuildBetaNotificationResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := [][]string{{resp.Data.ID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildBetaNotificationTable(resp *BuildBetaNotificationResponse) error {
+	h, r := buildBetaNotificationRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildBetaNotificationMarkdown(resp *BuildBetaNotificationResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(resp.Data.ID))
+	h, r := buildBetaNotificationRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_builds.go
+++ b/internal/asc/output_builds.go
@@ -80,7 +80,7 @@ func formatEncryptionStatus(usesNonExempt *bool) string {
 	return "exempt"
 }
 
-func printBuildsTable(resp *BuildsResponse) error {
+func buildsRows(resp *BuildsResponse) ([]string, [][]string) {
 	headers := []string{"Version", "Uploaded", "Processing", "Expired", "Encryption"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -92,22 +92,18 @@ func printBuildsTable(resp *BuildsResponse) error {
 			formatEncryptionStatus(item.Attributes.UsesNonExemptEncryption),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildsTable(resp *BuildsResponse) error {
+	h, r := buildsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildsMarkdown(resp *BuildsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Version | Uploaded | Processing | Expired | Encryption |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %t | %s |\n",
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(item.Attributes.UploadedDate),
-			escapeMarkdown(item.Attributes.ProcessingState),
-			item.Attributes.Expired,
-			formatEncryptionStatus(item.Attributes.UsesNonExemptEncryption),
-		)
-	}
+	h, r := buildsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -118,7 +114,7 @@ func buildIconAssetURL(attr BuildIconAttributes) string {
 	return attr.IconAsset.TemplateURL
 }
 
-func printBuildIconsTable(resp *BuildIconsResponse) error {
+func buildIconsRows(resp *BuildIconsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Type", "Masked", "Asset URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -130,22 +126,18 @@ func printBuildIconsTable(resp *BuildIconsResponse) error {
 			sanitizeTerminal(buildIconAssetURL(item.Attributes)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildIconsTable(resp *BuildIconsResponse) error {
+	h, r := buildIconsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildIconsMarkdown(resp *BuildIconsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Type | Masked | Asset URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(string(item.Attributes.IconType)),
-			item.Attributes.Masked,
-			escapeMarkdown(buildIconAssetURL(item.Attributes)),
-		)
-	}
+	h, r := buildIconsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -166,7 +158,7 @@ func buildUploadTimestamp(attr BuildUploadAttributes) string {
 	return ""
 }
 
-func printBuildUploadsTable(resp *BuildUploadsResponse) error {
+func buildUploadsRows(resp *BuildUploadsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "Build", "Platform", "State", "Uploaded"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -179,23 +171,18 @@ func printBuildUploadsTable(resp *BuildUploadsResponse) error {
 			buildUploadTimestamp(item.Attributes),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildUploadsTable(resp *BuildUploadsResponse) error {
+	h, r := buildUploadsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildUploadsMarkdown(resp *BuildUploadsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | Build | Platform | State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.CFBundleShortVersionString),
-			escapeMarkdown(item.Attributes.CFBundleVersion),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(buildUploadState(item.Attributes)),
-			escapeMarkdown(buildUploadTimestamp(item.Attributes)),
-		)
-	}
+	h, r := buildUploadsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -206,7 +193,7 @@ func buildUploadFileState(attr BuildUploadFileAttributes) string {
 	return *attr.AssetDeliveryState.State
 }
 
-func printBuildUploadFilesTable(resp *BuildUploadFilesResponse) error {
+func buildUploadFilesRows(resp *BuildUploadFilesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Asset Type", "State", "Uploaded"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -223,31 +210,22 @@ func printBuildUploadFilesTable(resp *BuildUploadFilesResponse) error {
 			uploaded,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildUploadFilesTable(resp *BuildUploadFilesResponse) error {
+	h, r := buildUploadFilesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildUploadFilesMarkdown(resp *BuildUploadFilesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Asset Type | State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		uploaded := ""
-		if item.Attributes.Uploaded != nil {
-			uploaded = fmt.Sprintf("%t", *item.Attributes.Uploaded)
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			item.Attributes.FileSize,
-			escapeMarkdown(string(item.Attributes.AssetType)),
-			escapeMarkdown(buildUploadFileState(item.Attributes)),
-			escapeMarkdown(uploaded),
-		)
-	}
+	h, r := buildUploadFilesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBuildUploadResultTable(result *BuildUploadResult) error {
+func buildUploadResultRows(result *BuildUploadResult) ([]string, [][]string) {
 	headers := []string{"Upload ID", "File ID", "File Name", "File Size"}
 	values := []string{
 		result.UploadID,
@@ -263,65 +241,48 @@ func printBuildUploadResultTable(result *BuildUploadResult) error {
 		headers = append(headers, "Checksum Verified")
 		values = append(values, fmt.Sprintf("%t", *result.ChecksumVerified))
 	}
-	RenderTable(headers, [][]string{values})
-	if len(result.Operations) == 0 {
-		return nil
-	}
-	fmt.Fprintln(os.Stdout, "\nUpload Operations")
-	opsHeaders := []string{"Method", "URL", "Length", "Offset"}
-	opsRows := make([][]string, 0, len(result.Operations))
-	for _, op := range result.Operations {
-		opsRows = append(opsRows, []string{
+	return headers, [][]string{values}
+}
+
+func buildUploadOperationsRows(operations []UploadOperation) ([]string, [][]string) {
+	headers := []string{"Method", "URL", "Length", "Offset"}
+	rows := make([][]string, 0, len(operations))
+	for _, op := range operations {
+		rows = append(rows, []string{
 			op.Method,
 			op.URL,
 			fmt.Sprintf("%d", op.Length),
 			fmt.Sprintf("%d", op.Offset),
 		})
 	}
-	RenderTable(opsHeaders, opsRows)
+	return headers, rows
+}
+
+func printBuildUploadResultTable(result *BuildUploadResult) error {
+	h, r := buildUploadResultRows(result)
+	RenderTable(h, r)
+	if len(result.Operations) == 0 {
+		return nil
+	}
+	fmt.Fprintln(os.Stdout, "\nUpload Operations")
+	oh, or := buildUploadOperationsRows(result.Operations)
+	RenderTable(oh, or)
 	return nil
 }
 
 func printBuildUploadResultMarkdown(result *BuildUploadResult) error {
-	headers := []string{"Upload ID", "File ID", "File Name", "File Size"}
-	values := []string{
-		escapeMarkdown(result.UploadID),
-		escapeMarkdown(result.FileID),
-		escapeMarkdown(result.FileName),
-		fmt.Sprintf("%d", result.FileSize),
-	}
-	if result.Uploaded != nil {
-		headers = append(headers, "Uploaded")
-		values = append(values, fmt.Sprintf("%t", *result.Uploaded))
-	}
-	if result.ChecksumVerified != nil {
-		headers = append(headers, "Checksum Verified")
-		values = append(values, fmt.Sprintf("%t", *result.ChecksumVerified))
-	}
-	separator := make([]string, len(headers))
-	for i := range separator {
-		separator[i] = "---"
-	}
-	fmt.Fprintf(os.Stdout, "| %s |\n", strings.Join(headers, " | "))
-	fmt.Fprintf(os.Stdout, "| %s |\n", strings.Join(separator, " | "))
-	fmt.Fprintf(os.Stdout, "| %s |\n", strings.Join(values, " | "))
+	h, r := buildUploadResultRows(result)
+	RenderMarkdown(h, r)
 	if len(result.Operations) == 0 {
 		return nil
 	}
-	fmt.Fprintln(os.Stdout, "\n| Method | URL | Length | Offset |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, op := range result.Operations {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %d |\n",
-			escapeMarkdown(op.Method),
-			escapeMarkdown(op.URL),
-			op.Length,
-			op.Offset,
-		)
-	}
+	fmt.Fprintln(os.Stdout, "\nUpload Operations")
+	oh, or := buildUploadOperationsRows(result.Operations)
+	RenderMarkdown(oh, or)
 	return nil
 }
 
-func printBuildExpireAllResultTable(result *BuildExpireAllResult) error {
+func buildExpireAllResultRows(result *BuildExpireAllResult) ([]string, [][]string) {
 	status := "expired"
 	if result.DryRun {
 		status = "would-expire"
@@ -337,100 +298,95 @@ func printBuildExpireAllResultTable(result *BuildExpireAllResult) error {
 			status,
 		})
 	}
-	RenderTable(headers, rows)
-	if len(result.Failures) == 0 {
-		return nil
-	}
-	fmt.Fprintln(os.Stdout, "\nFailures")
-	failHeaders := []string{"ID", "Error"}
-	failRows := make([][]string, 0, len(result.Failures))
-	for _, failure := range result.Failures {
-		failRows = append(failRows, []string{
+	return headers, rows
+}
+
+func buildExpireAllFailureRows(failures []BuildExpireAllFailure) ([]string, [][]string) {
+	headers := []string{"ID", "Error"}
+	rows := make([][]string, 0, len(failures))
+	for _, failure := range failures {
+		rows = append(rows, []string{
 			failure.ID,
 			compactWhitespace(failure.Error),
 		})
 	}
-	RenderTable(failHeaders, failRows)
-	return nil
+	return headers, rows
 }
 
-func printBuildExpireAllResultMarkdown(result *BuildExpireAllResult) error {
-	status := "expired"
-	if result.DryRun {
-		status = "would-expire"
-	}
-	fmt.Fprintln(os.Stdout, "| ID | Version | Uploaded | Age Days | Status |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range result.Builds {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Version),
-			escapeMarkdown(item.UploadedDate),
-			item.AgeDays,
-			status,
-		)
-	}
+func printBuildExpireAllResultTable(result *BuildExpireAllResult) error {
+	h, r := buildExpireAllResultRows(result)
+	RenderTable(h, r)
 	if len(result.Failures) == 0 {
 		return nil
 	}
 	fmt.Fprintln(os.Stdout, "\nFailures")
-	fmt.Fprintln(os.Stdout, "| ID | Error |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, failure := range result.Failures {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(failure.ID),
-			escapeMarkdown(compactWhitespace(failure.Error)),
-		)
-	}
+	fh, fr := buildExpireAllFailureRows(result.Failures)
+	RenderTable(fh, fr)
 	return nil
 }
 
-func printBuildBetaGroupsUpdateTable(result *BuildBetaGroupsUpdateResult) error {
+func printBuildExpireAllResultMarkdown(result *BuildExpireAllResult) error {
+	h, r := buildExpireAllResultRows(result)
+	RenderMarkdown(h, r)
+	if len(result.Failures) == 0 {
+		return nil
+	}
+	fmt.Fprintln(os.Stdout, "\nFailures")
+	fh, fr := buildExpireAllFailureRows(result.Failures)
+	RenderMarkdown(fh, fr)
+	return nil
+}
+
+func buildBetaGroupsUpdateRows(result *BuildBetaGroupsUpdateResult) ([]string, [][]string) {
 	headers := []string{"Build ID", "Group IDs", "Action"}
 	rows := [][]string{{result.BuildID, strings.Join(result.GroupIDs, ", "), result.Action}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildBetaGroupsUpdateTable(result *BuildBetaGroupsUpdateResult) error {
+	h, r := buildBetaGroupsUpdateRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildBetaGroupsUpdateMarkdown(result *BuildBetaGroupsUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| Build ID | Group IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(strings.Join(result.GroupIDs, ", ")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := buildBetaGroupsUpdateRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBuildIndividualTestersUpdateTable(result *BuildIndividualTestersUpdateResult) error {
+func buildIndividualTestersUpdateRows(result *BuildIndividualTestersUpdateResult) ([]string, [][]string) {
 	headers := []string{"Build ID", "Tester IDs", "Action"}
 	rows := [][]string{{result.BuildID, strings.Join(result.TesterIDs, ", "), result.Action}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildIndividualTestersUpdateTable(result *BuildIndividualTestersUpdateResult) error {
+	h, r := buildIndividualTestersUpdateRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildIndividualTestersUpdateMarkdown(result *BuildIndividualTestersUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| Build ID | Tester IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(strings.Join(result.TesterIDs, ", ")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := buildIndividualTestersUpdateRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBuildUploadDeleteResultTable(result *BuildUploadDeleteResult) error {
+func buildUploadDeleteResultRows(result *BuildUploadDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildUploadDeleteResultTable(result *BuildUploadDeleteResult) error {
+	h, r := buildUploadDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBuildUploadDeleteResultMarkdown(result *BuildUploadDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := buildUploadDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_encryption.go
+++ b/internal/asc/output_encryption.go
@@ -1,10 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-	"strings"
-)
+import "strings"
 
 type appEncryptionDeclarationField struct {
 	Name  string
@@ -16,7 +12,7 @@ type appEncryptionDeclarationDocumentField struct {
 	Value string
 }
 
-func printAppEncryptionDeclarationsTable(resp *AppEncryptionDeclarationsResponse) error {
+func appEncryptionDeclarationsRows(resp *AppEncryptionDeclarationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Exempt", "Proprietary Crypto", "Third-Party Crypto", "French Store", "Created", "Code"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -32,47 +28,40 @@ func printAppEncryptionDeclarationsTable(resp *AppEncryptionDeclarationsResponse
 			sanitizeTerminal(fallbackValue(attrs.CodeValue)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEncryptionDeclarationsTable(resp *AppEncryptionDeclarationsResponse) error {
+	h, r := appEncryptionDeclarationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEncryptionDeclarationsMarkdown(resp *AppEncryptionDeclarationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | State | Exempt | Proprietary Crypto | Third-Party Crypto | French Store | Created | Code |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(fallbackValue(string(attrs.AppEncryptionDeclarationState))),
-			escapeMarkdown(formatOptionalBool(attrs.Exempt)),
-			escapeMarkdown(formatOptionalBool(attrs.ContainsProprietaryCryptography)),
-			escapeMarkdown(formatOptionalBool(attrs.ContainsThirdPartyCryptography)),
-			escapeMarkdown(formatOptionalBool(attrs.AvailableOnFrenchStore)),
-			escapeMarkdown(fallbackValue(attrs.CreatedDate)),
-			escapeMarkdown(fallbackValue(attrs.CodeValue)),
-		)
-	}
+	h, r := appEncryptionDeclarationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppEncryptionDeclarationTable(resp *AppEncryptionDeclarationResponse) error {
+func appEncryptionDeclarationRows(resp *AppEncryptionDeclarationResponse) ([]string, [][]string) {
 	fields := appEncryptionDeclarationFields(resp)
 	headers := []string{"Field", "Value"}
 	rows := make([][]string, 0, len(fields))
 	for _, field := range fields {
 		rows = append(rows, []string{field.Name, field.Value})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEncryptionDeclarationTable(resp *AppEncryptionDeclarationResponse) error {
+	h, r := appEncryptionDeclarationRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEncryptionDeclarationMarkdown(resp *AppEncryptionDeclarationResponse) error {
-	fields := appEncryptionDeclarationFields(resp)
-	fmt.Fprintln(os.Stdout, "| Field | Value |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, field := range fields {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
-	}
+	h, r := appEncryptionDeclarationRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -101,24 +90,25 @@ func appEncryptionDeclarationFields(resp *AppEncryptionDeclarationResponse) []ap
 	}
 }
 
-func printAppEncryptionDeclarationDocumentTable(resp *AppEncryptionDeclarationDocumentResponse) error {
+func appEncryptionDeclarationDocumentRows(resp *AppEncryptionDeclarationDocumentResponse) ([]string, [][]string) {
 	fields := appEncryptionDeclarationDocumentFields(resp)
 	headers := []string{"Field", "Value"}
 	rows := make([][]string, 0, len(fields))
 	for _, field := range fields {
 		rows = append(rows, []string{field.Name, field.Value})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEncryptionDeclarationDocumentTable(resp *AppEncryptionDeclarationDocumentResponse) error {
+	h, r := appEncryptionDeclarationDocumentRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEncryptionDeclarationDocumentMarkdown(resp *AppEncryptionDeclarationDocumentResponse) error {
-	fields := appEncryptionDeclarationDocumentFields(resp)
-	fmt.Fprintln(os.Stdout, "| Field | Value |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, field := range fields {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
-	}
+	h, r := appEncryptionDeclarationDocumentRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -139,24 +129,24 @@ func appEncryptionDeclarationDocumentFields(resp *AppEncryptionDeclarationDocume
 	}
 }
 
-func printAppEncryptionDeclarationBuildsUpdateResultTable(result *AppEncryptionDeclarationBuildsUpdateResult) error {
+func appEncryptionDeclarationBuildsUpdateResultRows(result *AppEncryptionDeclarationBuildsUpdateResult) ([]string, [][]string) {
 	headers := []string{"Declaration ID", "Build IDs", "Action"}
 	rows := [][]string{{
 		sanitizeTerminal(result.DeclarationID),
 		sanitizeTerminal(strings.Join(result.BuildIDs, ",")),
 		sanitizeTerminal(result.Action),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppEncryptionDeclarationBuildsUpdateResultTable(result *AppEncryptionDeclarationBuildsUpdateResult) error {
+	h, r := appEncryptionDeclarationBuildsUpdateResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppEncryptionDeclarationBuildsUpdateResultMarkdown(result *AppEncryptionDeclarationBuildsUpdateResult) error {
-	fmt.Fprintln(os.Stdout, "| Declaration ID | Build IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.DeclarationID),
-		escapeMarkdown(strings.Join(result.BuildIDs, ",")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := appEncryptionDeclarationBuildsUpdateResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_feedback.go
+++ b/internal/asc/output_feedback.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -29,7 +28,7 @@ func formatScreenshotURLs(images []FeedbackScreenshotImage) string {
 	return strings.Join(urls, ", ")
 }
 
-func printFeedbackTable(resp *FeedbackResponse) error {
+func feedbackRows(resp *FeedbackResponse) ([]string, [][]string) {
 	hasScreenshots := feedbackHasScreenshots(resp)
 	var headers []string
 	if hasScreenshots {
@@ -54,11 +53,22 @@ func printFeedbackTable(resp *FeedbackResponse) error {
 			compactWhitespace(item.Attributes.Comment),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printFeedbackTable(resp *FeedbackResponse) error {
+	h, r := feedbackRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printCrashesTable(resp *CrashesResponse) error {
+func printFeedbackMarkdown(resp *FeedbackResponse) error {
+	h, r := feedbackRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func crashesRows(resp *CrashesResponse) ([]string, [][]string) {
 	headers := []string{"Created", "Email", "Device", "OS", "Comment"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -70,11 +80,22 @@ func printCrashesTable(resp *CrashesResponse) error {
 			compactWhitespace(item.Attributes.Comment),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCrashesTable(resp *CrashesResponse) error {
+	h, r := crashesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printReviewsTable(resp *ReviewsResponse) error {
+func printCrashesMarkdown(resp *CrashesResponse) error {
+	h, r := crashesRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func reviewsRows(resp *ReviewsResponse) ([]string, [][]string) {
 	headers := []string{"Created", "Rating", "Territory", "Title"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -85,63 +106,17 @@ func printReviewsTable(resp *ReviewsResponse) error {
 			compactWhitespace(item.Attributes.Title),
 		})
 	}
-	RenderTable(headers, rows)
-	return nil
+	return headers, rows
 }
 
-func printFeedbackMarkdown(resp *FeedbackResponse) error {
-	hasScreenshots := feedbackHasScreenshots(resp)
-	if hasScreenshots {
-		fmt.Fprintln(os.Stdout, "| Created | Email | Comment | Screenshots |")
-		fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	} else {
-		fmt.Fprintln(os.Stdout, "| Created | Email | Comment |")
-		fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	}
-	for _, item := range resp.Data {
-		if hasScreenshots {
-			fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-				escapeMarkdown(item.Attributes.CreatedDate),
-				escapeMarkdown(item.Attributes.Email),
-				escapeMarkdown(item.Attributes.Comment),
-				escapeMarkdown(formatScreenshotURLs(item.Attributes.Screenshots)),
-			)
-			continue
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.Attributes.CreatedDate),
-			escapeMarkdown(item.Attributes.Email),
-			escapeMarkdown(item.Attributes.Comment),
-		)
-	}
-	return nil
-}
-
-func printCrashesMarkdown(resp *CrashesResponse) error {
-	fmt.Fprintln(os.Stdout, "| Created | Email | Device | OS | Comment |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.Attributes.CreatedDate),
-			escapeMarkdown(item.Attributes.Email),
-			escapeMarkdown(item.Attributes.DeviceModel),
-			escapeMarkdown(item.Attributes.OSVersion),
-			escapeMarkdown(item.Attributes.Comment),
-		)
-	}
+func printReviewsTable(resp *ReviewsResponse) error {
+	h, r := reviewsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printReviewsMarkdown(resp *ReviewsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Created | Rating | Territory | Title |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s |\n",
-			escapeMarkdown(item.Attributes.CreatedDate),
-			item.Attributes.Rating,
-			escapeMarkdown(item.Attributes.Territory),
-			escapeMarkdown(item.Attributes.Title),
-		)
-	}
+	h, r := reviewsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_game_center.go
+++ b/internal/asc/output_game_center.go
@@ -3,11 +3,10 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 )
 
-func printGameCenterAchievementsTable(resp *GameCenterAchievementsResponse) error {
+func gameCenterAchievementsRows(resp *GameCenterAchievementsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Vendor ID", "Points", "Show Before Earned", "Repeatable", "Archived"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -21,45 +20,40 @@ func printGameCenterAchievementsTable(resp *GameCenterAchievementsResponse) erro
 			fmt.Sprintf("%t", item.Attributes.Archived),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementsTable(resp *GameCenterAchievementsResponse) error {
+	h, r := gameCenterAchievementsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementsMarkdown(resp *GameCenterAchievementsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Vendor ID | Points | Show Before Earned | Repeatable | Archived |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %t | %t | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.VendorIdentifier),
-			item.Attributes.Points,
-			item.Attributes.ShowBeforeEarned,
-			item.Attributes.Repeatable,
-			item.Attributes.Archived,
-		)
-	}
+	h, r := gameCenterAchievementsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementDeleteResultTable(result *GameCenterAchievementDeleteResult) error {
+func gameCenterAchievementDeleteResultRows(result *GameCenterAchievementDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementDeleteResultTable(result *GameCenterAchievementDeleteResult) error {
+	h, r := gameCenterAchievementDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementDeleteResultMarkdown(result *GameCenterAchievementDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterAchievementDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardsTable(resp *GameCenterLeaderboardsResponse) error {
+func gameCenterLeaderboardsRows(resp *GameCenterLeaderboardsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Vendor ID", "Formatter", "Sort", "Submission Type", "Archived"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -73,45 +67,40 @@ func printGameCenterLeaderboardsTable(resp *GameCenterLeaderboardsResponse) erro
 			fmt.Sprintf("%t", item.Attributes.Archived),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardsTable(resp *GameCenterLeaderboardsResponse) error {
+	h, r := gameCenterLeaderboardsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardsMarkdown(resp *GameCenterLeaderboardsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Vendor ID | Formatter | Sort | Submission Type | Archived |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.VendorIdentifier),
-			escapeMarkdown(item.Attributes.DefaultFormatter),
-			escapeMarkdown(item.Attributes.ScoreSortType),
-			escapeMarkdown(item.Attributes.SubmissionType),
-			item.Attributes.Archived,
-		)
-	}
+	h, r := gameCenterLeaderboardsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardDeleteResultTable(result *GameCenterLeaderboardDeleteResult) error {
+func gameCenterLeaderboardDeleteResultRows(result *GameCenterLeaderboardDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardDeleteResultTable(result *GameCenterLeaderboardDeleteResult) error {
+	h, r := gameCenterLeaderboardDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardDeleteResultMarkdown(result *GameCenterLeaderboardDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetsTable(resp *GameCenterLeaderboardSetsResponse) error {
+func gameCenterLeaderboardSetsRows(resp *GameCenterLeaderboardSetsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Vendor ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -121,41 +110,40 @@ func printGameCenterLeaderboardSetsTable(resp *GameCenterLeaderboardSetsResponse
 			item.Attributes.VendorIdentifier,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetsTable(resp *GameCenterLeaderboardSetsResponse) error {
+	h, r := gameCenterLeaderboardSetsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetsMarkdown(resp *GameCenterLeaderboardSetsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Vendor ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.VendorIdentifier),
-		)
-	}
+	h, r := gameCenterLeaderboardSetsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetDeleteResultTable(result *GameCenterLeaderboardSetDeleteResult) error {
+func gameCenterLeaderboardSetDeleteResultRows(result *GameCenterLeaderboardSetDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetDeleteResultTable(result *GameCenterLeaderboardSetDeleteResult) error {
+	h, r := gameCenterLeaderboardSetDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetDeleteResultMarkdown(result *GameCenterLeaderboardSetDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardSetDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardLocalizationsTable(resp *GameCenterLeaderboardLocalizationsResponse) error {
+func gameCenterLeaderboardLocalizationsRows(resp *GameCenterLeaderboardLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name", "Formatter Override", "Formatter Suffix", "Formatter Suffix Singular", "Description"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -169,45 +157,40 @@ func printGameCenterLeaderboardLocalizationsTable(resp *GameCenterLeaderboardLoc
 			formatOptionalString(item.Attributes.Description),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardLocalizationsTable(resp *GameCenterLeaderboardLocalizationsResponse) error {
+	h, r := gameCenterLeaderboardLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardLocalizationsMarkdown(resp *GameCenterLeaderboardLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name | Formatter Override | Formatter Suffix | Formatter Suffix Singular | Description |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(formatOptionalString(item.Attributes.FormatterOverride)),
-			escapeMarkdown(formatOptionalString(item.Attributes.FormatterSuffix)),
-			escapeMarkdown(formatOptionalString(item.Attributes.FormatterSuffixSingular)),
-			escapeMarkdown(formatOptionalString(item.Attributes.Description)),
-		)
-	}
+	h, r := gameCenterLeaderboardLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardLocalizationDeleteResultTable(result *GameCenterLeaderboardLocalizationDeleteResult) error {
+func gameCenterLeaderboardLocalizationDeleteResultRows(result *GameCenterLeaderboardLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardLocalizationDeleteResultTable(result *GameCenterLeaderboardLocalizationDeleteResult) error {
+	h, r := gameCenterLeaderboardLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardLocalizationDeleteResultMarkdown(result *GameCenterLeaderboardLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardReleasesTable(resp *GameCenterLeaderboardReleasesResponse) error {
+func gameCenterLeaderboardReleasesRows(resp *GameCenterLeaderboardReleasesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Live"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -216,40 +199,40 @@ func printGameCenterLeaderboardReleasesTable(resp *GameCenterLeaderboardReleases
 			fmt.Sprintf("%t", item.Attributes.Live),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardReleasesTable(resp *GameCenterLeaderboardReleasesResponse) error {
+	h, r := gameCenterLeaderboardReleasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardReleasesMarkdown(resp *GameCenterLeaderboardReleasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Live |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Live,
-		)
-	}
+	h, r := gameCenterLeaderboardReleasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardReleaseDeleteResultTable(result *GameCenterLeaderboardReleaseDeleteResult) error {
+func gameCenterLeaderboardReleaseDeleteResultRows(result *GameCenterLeaderboardReleaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardReleaseDeleteResultTable(result *GameCenterLeaderboardReleaseDeleteResult) error {
+	h, r := gameCenterLeaderboardReleaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardReleaseDeleteResultMarkdown(result *GameCenterLeaderboardReleaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardReleaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementReleasesTable(resp *GameCenterAchievementReleasesResponse) error {
+func gameCenterAchievementReleasesRows(resp *GameCenterAchievementReleasesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Live"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -258,40 +241,40 @@ func printGameCenterAchievementReleasesTable(resp *GameCenterAchievementReleases
 			fmt.Sprintf("%t", item.Attributes.Live),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementReleasesTable(resp *GameCenterAchievementReleasesResponse) error {
+	h, r := gameCenterAchievementReleasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementReleasesMarkdown(resp *GameCenterAchievementReleasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Live |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Live,
-		)
-	}
+	h, r := gameCenterAchievementReleasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementReleaseDeleteResultTable(result *GameCenterAchievementReleaseDeleteResult) error {
+func gameCenterAchievementReleaseDeleteResultRows(result *GameCenterAchievementReleaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementReleaseDeleteResultTable(result *GameCenterAchievementReleaseDeleteResult) error {
+	h, r := gameCenterAchievementReleaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementReleaseDeleteResultMarkdown(result *GameCenterAchievementReleaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterAchievementReleaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetReleasesTable(resp *GameCenterLeaderboardSetReleasesResponse) error {
+func gameCenterLeaderboardSetReleasesRows(resp *GameCenterLeaderboardSetReleasesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Live"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -300,40 +283,40 @@ func printGameCenterLeaderboardSetReleasesTable(resp *GameCenterLeaderboardSetRe
 			fmt.Sprintf("%t", item.Attributes.Live),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetReleasesTable(resp *GameCenterLeaderboardSetReleasesResponse) error {
+	h, r := gameCenterLeaderboardSetReleasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetReleasesMarkdown(resp *GameCenterLeaderboardSetReleasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Live |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Live,
-		)
-	}
+	h, r := gameCenterLeaderboardSetReleasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetReleaseDeleteResultTable(result *GameCenterLeaderboardSetReleaseDeleteResult) error {
+func gameCenterLeaderboardSetReleaseDeleteResultRows(result *GameCenterLeaderboardSetReleaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetReleaseDeleteResultTable(result *GameCenterLeaderboardSetReleaseDeleteResult) error {
+	h, r := gameCenterLeaderboardSetReleaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetReleaseDeleteResultMarkdown(result *GameCenterLeaderboardSetReleaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardSetReleaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetLocalizationsTable(resp *GameCenterLeaderboardSetLocalizationsResponse) error {
+func gameCenterLeaderboardSetLocalizationsRows(resp *GameCenterLeaderboardSetLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -343,41 +326,40 @@ func printGameCenterLeaderboardSetLocalizationsTable(resp *GameCenterLeaderboard
 			compactWhitespace(item.Attributes.Name),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetLocalizationsTable(resp *GameCenterLeaderboardSetLocalizationsResponse) error {
+	h, r := gameCenterLeaderboardSetLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetLocalizationsMarkdown(resp *GameCenterLeaderboardSetLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-		)
-	}
+	h, r := gameCenterLeaderboardSetLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetLocalizationDeleteResultTable(result *GameCenterLeaderboardSetLocalizationDeleteResult) error {
+func gameCenterLeaderboardSetLocalizationDeleteResultRows(result *GameCenterLeaderboardSetLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetLocalizationDeleteResultTable(result *GameCenterLeaderboardSetLocalizationDeleteResult) error {
+	h, r := gameCenterLeaderboardSetLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetLocalizationDeleteResultMarkdown(result *GameCenterLeaderboardSetLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardSetLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementLocalizationsTable(resp *GameCenterAchievementLocalizationsResponse) error {
+func gameCenterAchievementLocalizationsRows(resp *GameCenterAchievementLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name", "Before Earned Description", "After Earned Description"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -389,43 +371,40 @@ func printGameCenterAchievementLocalizationsTable(resp *GameCenterAchievementLoc
 			compactWhitespace(item.Attributes.AfterEarnedDescription),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementLocalizationsTable(resp *GameCenterAchievementLocalizationsResponse) error {
+	h, r := gameCenterAchievementLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementLocalizationsMarkdown(resp *GameCenterAchievementLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name | Before Earned Description | After Earned Description |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.BeforeEarnedDescription),
-			escapeMarkdown(item.Attributes.AfterEarnedDescription),
-		)
-	}
+	h, r := gameCenterAchievementLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementLocalizationDeleteResultTable(result *GameCenterAchievementLocalizationDeleteResult) error {
+func gameCenterAchievementLocalizationDeleteResultRows(result *GameCenterAchievementLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementLocalizationDeleteResultTable(result *GameCenterAchievementLocalizationDeleteResult) error {
+	h, r := gameCenterAchievementLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementLocalizationDeleteResultMarkdown(result *GameCenterAchievementLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterAchievementLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardImageUploadResultTable(result *GameCenterLeaderboardImageUploadResult) error {
+func gameCenterLeaderboardImageUploadResultRows(result *GameCenterLeaderboardImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Localization ID", "File Name", "File Size", "Delivery State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -435,42 +414,40 @@ func printGameCenterLeaderboardImageUploadResultTable(result *GameCenterLeaderbo
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardImageUploadResultTable(result *GameCenterLeaderboardImageUploadResult) error {
+	h, r := gameCenterLeaderboardImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardImageUploadResultMarkdown(result *GameCenterLeaderboardImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Localization ID | File Name | File Size | Delivery State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.LocalizationID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := gameCenterLeaderboardImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardImageDeleteResultTable(result *GameCenterLeaderboardImageDeleteResult) error {
+func gameCenterLeaderboardImageDeleteResultRows(result *GameCenterLeaderboardImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardImageDeleteResultTable(result *GameCenterLeaderboardImageDeleteResult) error {
+	h, r := gameCenterLeaderboardImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardImageDeleteResultMarkdown(result *GameCenterLeaderboardImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementImageUploadResultTable(result *GameCenterAchievementImageUploadResult) error {
+func gameCenterAchievementImageUploadResultRows(result *GameCenterAchievementImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Localization ID", "File Name", "File Size", "Delivery State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -480,42 +457,40 @@ func printGameCenterAchievementImageUploadResultTable(result *GameCenterAchievem
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementImageUploadResultTable(result *GameCenterAchievementImageUploadResult) error {
+	h, r := gameCenterAchievementImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementImageUploadResultMarkdown(result *GameCenterAchievementImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Localization ID | File Name | File Size | Delivery State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.LocalizationID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := gameCenterAchievementImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementImageDeleteResultTable(result *GameCenterAchievementImageDeleteResult) error {
+func gameCenterAchievementImageDeleteResultRows(result *GameCenterAchievementImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementImageDeleteResultTable(result *GameCenterAchievementImageDeleteResult) error {
+	h, r := gameCenterAchievementImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementImageDeleteResultMarkdown(result *GameCenterAchievementImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterAchievementImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetImageUploadResultTable(result *GameCenterLeaderboardSetImageUploadResult) error {
+func gameCenterLeaderboardSetImageUploadResultRows(result *GameCenterLeaderboardSetImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Localization ID", "File Name", "File Size", "Delivery State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -525,42 +500,40 @@ func printGameCenterLeaderboardSetImageUploadResultTable(result *GameCenterLeade
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetImageUploadResultTable(result *GameCenterLeaderboardSetImageUploadResult) error {
+	h, r := gameCenterLeaderboardSetImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetImageUploadResultMarkdown(result *GameCenterLeaderboardSetImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Localization ID | File Name | File Size | Delivery State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.LocalizationID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := gameCenterLeaderboardSetImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetImageDeleteResultTable(result *GameCenterLeaderboardSetImageDeleteResult) error {
+func gameCenterLeaderboardSetImageDeleteResultRows(result *GameCenterLeaderboardSetImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetImageDeleteResultTable(result *GameCenterLeaderboardSetImageDeleteResult) error {
+	h, r := gameCenterLeaderboardSetImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetImageDeleteResultMarkdown(result *GameCenterLeaderboardSetImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := gameCenterLeaderboardSetImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengesTable(resp *GameCenterChallengesResponse) error {
+func gameCenterChallengesRows(resp *GameCenterChallengesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Vendor ID", "Type", "Repeatable", "Archived"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -573,41 +546,40 @@ func printGameCenterChallengesTable(resp *GameCenterChallengesResponse) error {
 			fmt.Sprintf("%t", item.Attributes.Archived),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengesTable(resp *GameCenterChallengesResponse) error {
+	h, r := gameCenterChallengesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengesMarkdown(resp *GameCenterChallengesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Vendor ID | Type | Repeatable | Archived |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %t | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.VendorIdentifier),
-			escapeMarkdown(item.Attributes.ChallengeType),
-			item.Attributes.Repeatable,
-			item.Attributes.Archived,
-		)
-	}
+	h, r := gameCenterChallengesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeDeleteResultTable(result *GameCenterChallengeDeleteResult) error {
+func gameCenterChallengeDeleteResultRows(result *GameCenterChallengeDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeDeleteResultTable(result *GameCenterChallengeDeleteResult) error {
+	h, r := gameCenterChallengeDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeDeleteResultMarkdown(result *GameCenterChallengeDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterChallengeDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAchievementVersionsTable(resp *GameCenterAchievementVersionsResponse) error {
+func gameCenterAchievementVersionsRows(resp *GameCenterAchievementVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -617,24 +589,22 @@ func printGameCenterAchievementVersionsTable(resp *GameCenterAchievementVersions
 			string(item.Attributes.State),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAchievementVersionsTable(resp *GameCenterAchievementVersionsResponse) error {
+	h, r := gameCenterAchievementVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAchievementVersionsMarkdown(resp *GameCenterAchievementVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Version,
-			escapeMarkdown(string(item.Attributes.State)),
-		)
-	}
+	h, r := gameCenterAchievementVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardVersionsTable(resp *GameCenterLeaderboardVersionsResponse) error {
+func gameCenterLeaderboardVersionsRows(resp *GameCenterLeaderboardVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -644,24 +614,22 @@ func printGameCenterLeaderboardVersionsTable(resp *GameCenterLeaderboardVersions
 			string(item.Attributes.State),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardVersionsTable(resp *GameCenterLeaderboardVersionsResponse) error {
+	h, r := gameCenterLeaderboardVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardVersionsMarkdown(resp *GameCenterLeaderboardVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Version,
-			escapeMarkdown(string(item.Attributes.State)),
-		)
-	}
+	h, r := gameCenterLeaderboardVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardSetVersionsTable(resp *GameCenterLeaderboardSetVersionsResponse) error {
+func gameCenterLeaderboardSetVersionsRows(resp *GameCenterLeaderboardSetVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -671,24 +639,22 @@ func printGameCenterLeaderboardSetVersionsTable(resp *GameCenterLeaderboardSetVe
 			string(item.Attributes.State),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardSetVersionsTable(resp *GameCenterLeaderboardSetVersionsResponse) error {
+	h, r := gameCenterLeaderboardSetVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardSetVersionsMarkdown(resp *GameCenterLeaderboardSetVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Version,
-			escapeMarkdown(string(item.Attributes.State)),
-		)
-	}
+	h, r := gameCenterLeaderboardSetVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeVersionsTable(resp *GameCenterChallengeVersionsResponse) error {
+func gameCenterChallengeVersionsRows(resp *GameCenterChallengeVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -698,24 +664,22 @@ func printGameCenterChallengeVersionsTable(resp *GameCenterChallengeVersionsResp
 			string(item.Attributes.State),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeVersionsTable(resp *GameCenterChallengeVersionsResponse) error {
+	h, r := gameCenterChallengeVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeVersionsMarkdown(resp *GameCenterChallengeVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Version,
-			escapeMarkdown(string(item.Attributes.State)),
-		)
-	}
+	h, r := gameCenterChallengeVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeLocalizationsTable(resp *GameCenterChallengeLocalizationsResponse) error {
+func gameCenterChallengeLocalizationsRows(resp *GameCenterChallengeLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name", "Description"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -726,39 +690,40 @@ func printGameCenterChallengeLocalizationsTable(resp *GameCenterChallengeLocaliz
 			compactWhitespace(item.Attributes.Description),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeLocalizationsTable(resp *GameCenterChallengeLocalizationsResponse) error {
+	h, r := gameCenterChallengeLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeLocalizationsMarkdown(resp *GameCenterChallengeLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name | Description |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Description),
-		)
-	}
+	h, r := gameCenterChallengeLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeLocalizationDeleteResultTable(result *GameCenterChallengeLocalizationDeleteResult) error {
+func gameCenterChallengeLocalizationDeleteResultRows(result *GameCenterChallengeLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeLocalizationDeleteResultTable(result *GameCenterChallengeLocalizationDeleteResult) error {
+	h, r := gameCenterChallengeLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeLocalizationDeleteResultMarkdown(result *GameCenterChallengeLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterChallengeLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeImagesTable(resp *GameCenterChallengeImagesResponse) error {
+func gameCenterChallengeImagesRows(resp *GameCenterChallengeImagesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Delivery State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -773,29 +738,22 @@ func printGameCenterChallengeImagesTable(resp *GameCenterChallengeImagesResponse
 			state,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeImagesTable(resp *GameCenterChallengeImagesResponse) error {
+	h, r := gameCenterChallengeImagesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeImagesMarkdown(resp *GameCenterChallengeImagesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Delivery State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil {
-			state = item.Attributes.AssetDeliveryState.State
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			item.Attributes.FileSize,
-			escapeMarkdown(state),
-		)
-	}
+	h, r := gameCenterChallengeImagesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeImageUploadResultTable(result *GameCenterChallengeImageUploadResult) error {
+func gameCenterChallengeImageUploadResultRows(result *GameCenterChallengeImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Localization ID", "File Name", "File Size", "Delivery State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -805,72 +763,79 @@ func printGameCenterChallengeImageUploadResultTable(result *GameCenterChallengeI
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeImageUploadResultTable(result *GameCenterChallengeImageUploadResult) error {
+	h, r := gameCenterChallengeImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeImageUploadResultMarkdown(result *GameCenterChallengeImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Localization ID | File Name | File Size | Delivery State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.LocalizationID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := gameCenterChallengeImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeImageDeleteResultTable(result *GameCenterChallengeImageDeleteResult) error {
+func gameCenterChallengeImageDeleteResultRows(result *GameCenterChallengeImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeImageDeleteResultTable(result *GameCenterChallengeImageDeleteResult) error {
+	h, r := gameCenterChallengeImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeImageDeleteResultMarkdown(result *GameCenterChallengeImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterChallengeImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeReleasesTable(resp *GameCenterChallengeVersionReleasesResponse) error {
+func gameCenterChallengeReleasesRows(resp *GameCenterChallengeVersionReleasesResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeReleasesTable(resp *GameCenterChallengeVersionReleasesResponse) error {
+	h, r := gameCenterChallengeReleasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeReleasesMarkdown(resp *GameCenterChallengeVersionReleasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(item.ID))
-	}
+	h, r := gameCenterChallengeReleasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterChallengeReleaseDeleteResultTable(result *GameCenterChallengeVersionReleaseDeleteResult) error {
+func gameCenterChallengeReleaseDeleteResultRows(result *GameCenterChallengeVersionReleaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterChallengeReleaseDeleteResultTable(result *GameCenterChallengeVersionReleaseDeleteResult) error {
+	h, r := gameCenterChallengeReleaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterChallengeReleaseDeleteResultMarkdown(result *GameCenterChallengeVersionReleaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterChallengeReleaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivitiesTable(resp *GameCenterActivitiesResponse) error {
+func gameCenterActivitiesRows(resp *GameCenterActivitiesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Vendor ID", "Play Style", "Min Players", "Max Players", "Party Code", "Archived"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -885,43 +850,40 @@ func printGameCenterActivitiesTable(resp *GameCenterActivitiesResponse) error {
 			fmt.Sprintf("%t", item.Attributes.Archived),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivitiesTable(resp *GameCenterActivitiesResponse) error {
+	h, r := gameCenterActivitiesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivitiesMarkdown(resp *GameCenterActivitiesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Vendor ID | Play Style | Min Players | Max Players | Party Code | Archived |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %d | %t | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.VendorIdentifier),
-			escapeMarkdown(item.Attributes.PlayStyle),
-			item.Attributes.MinimumPlayersCount,
-			item.Attributes.MaximumPlayersCount,
-			item.Attributes.SupportsPartyCode,
-			item.Attributes.Archived,
-		)
-	}
+	h, r := gameCenterActivitiesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityDeleteResultTable(result *GameCenterActivityDeleteResult) error {
+func gameCenterActivityDeleteResultRows(result *GameCenterActivityDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityDeleteResultTable(result *GameCenterActivityDeleteResult) error {
+	h, r := gameCenterActivityDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityDeleteResultMarkdown(result *GameCenterActivityDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterActivityDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityVersionsTable(resp *GameCenterActivityVersionsResponse) error {
+func gameCenterActivityVersionsRows(resp *GameCenterActivityVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State", "Fallback URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -932,25 +894,22 @@ func printGameCenterActivityVersionsTable(resp *GameCenterActivityVersionsRespon
 			item.Attributes.FallbackURL,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityVersionsTable(resp *GameCenterActivityVersionsResponse) error {
+	h, r := gameCenterActivityVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityVersionsMarkdown(resp *GameCenterActivityVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State | Fallback URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Version,
-			escapeMarkdown(string(item.Attributes.State)),
-			escapeMarkdown(item.Attributes.FallbackURL),
-		)
-	}
+	h, r := gameCenterActivityVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityLocalizationsTable(resp *GameCenterActivityLocalizationsResponse) error {
+func gameCenterActivityLocalizationsRows(resp *GameCenterActivityLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Name", "Description"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -961,39 +920,40 @@ func printGameCenterActivityLocalizationsTable(resp *GameCenterActivityLocalizat
 			compactWhitespace(item.Attributes.Description),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityLocalizationsTable(resp *GameCenterActivityLocalizationsResponse) error {
+	h, r := gameCenterActivityLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityLocalizationsMarkdown(resp *GameCenterActivityLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Name | Description |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Description),
-		)
-	}
+	h, r := gameCenterActivityLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityLocalizationDeleteResultTable(result *GameCenterActivityLocalizationDeleteResult) error {
+func gameCenterActivityLocalizationDeleteResultRows(result *GameCenterActivityLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityLocalizationDeleteResultTable(result *GameCenterActivityLocalizationDeleteResult) error {
+	h, r := gameCenterActivityLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityLocalizationDeleteResultMarkdown(result *GameCenterActivityLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterActivityLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityImagesTable(resp *GameCenterActivityImagesResponse) error {
+func gameCenterActivityImagesRows(resp *GameCenterActivityImagesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Delivery State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1008,29 +968,22 @@ func printGameCenterActivityImagesTable(resp *GameCenterActivityImagesResponse) 
 			state,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityImagesTable(resp *GameCenterActivityImagesResponse) error {
+	h, r := gameCenterActivityImagesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityImagesMarkdown(resp *GameCenterActivityImagesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Delivery State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil {
-			state = item.Attributes.AssetDeliveryState.State
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			item.Attributes.FileSize,
-			escapeMarkdown(state),
-		)
-	}
+	h, r := gameCenterActivityImagesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityImageUploadResultTable(result *GameCenterActivityImageUploadResult) error {
+func gameCenterActivityImageUploadResultRows(result *GameCenterActivityImageUploadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Localization ID", "File Name", "File Size", "Delivery State", "Uploaded"}
 	rows := [][]string{{
 		result.ID,
@@ -1040,72 +993,79 @@ func printGameCenterActivityImageUploadResultTable(result *GameCenterActivityIma
 		result.AssetDeliveryState,
 		fmt.Sprintf("%t", result.Uploaded),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityImageUploadResultTable(result *GameCenterActivityImageUploadResult) error {
+	h, r := gameCenterActivityImageUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityImageUploadResultMarkdown(result *GameCenterActivityImageUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Localization ID | File Name | File Size | Delivery State | Uploaded |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s | %t |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.LocalizationID),
-		escapeMarkdown(result.FileName),
-		result.FileSize,
-		escapeMarkdown(result.AssetDeliveryState),
-		result.Uploaded,
-	)
+	h, r := gameCenterActivityImageUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityImageDeleteResultTable(result *GameCenterActivityImageDeleteResult) error {
+func gameCenterActivityImageDeleteResultRows(result *GameCenterActivityImageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityImageDeleteResultTable(result *GameCenterActivityImageDeleteResult) error {
+	h, r := gameCenterActivityImageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityImageDeleteResultMarkdown(result *GameCenterActivityImageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterActivityImageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityReleasesTable(resp *GameCenterActivityVersionReleasesResponse) error {
+func gameCenterActivityReleasesRows(resp *GameCenterActivityVersionReleasesResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityReleasesTable(resp *GameCenterActivityVersionReleasesResponse) error {
+	h, r := gameCenterActivityReleasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityReleasesMarkdown(resp *GameCenterActivityVersionReleasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(item.ID))
-	}
+	h, r := gameCenterActivityReleasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterActivityReleaseDeleteResultTable(result *GameCenterActivityVersionReleaseDeleteResult) error {
+func gameCenterActivityReleaseDeleteResultRows(result *GameCenterActivityVersionReleaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterActivityReleaseDeleteResultTable(result *GameCenterActivityVersionReleaseDeleteResult) error {
+	h, r := gameCenterActivityReleaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterActivityReleaseDeleteResultMarkdown(result *GameCenterActivityVersionReleaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterActivityReleaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterGroupsTable(resp *GameCenterGroupsResponse) error {
+func gameCenterGroupsRows(resp *GameCenterGroupsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1114,56 +1074,61 @@ func printGameCenterGroupsTable(resp *GameCenterGroupsResponse) error {
 			compactWhitespace(item.Attributes.ReferenceName),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterGroupsTable(resp *GameCenterGroupsResponse) error {
+	h, r := gameCenterGroupsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterGroupsMarkdown(resp *GameCenterGroupsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-		)
-	}
+	h, r := gameCenterGroupsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterGroupDeleteResultTable(result *GameCenterGroupDeleteResult) error {
+func gameCenterGroupDeleteResultRows(result *GameCenterGroupDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterGroupDeleteResultTable(result *GameCenterGroupDeleteResult) error {
+	h, r := gameCenterGroupDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterGroupDeleteResultMarkdown(result *GameCenterGroupDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterGroupDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterAppVersionsTable(resp *GameCenterAppVersionsResponse) error {
+func gameCenterAppVersionsRows(resp *GameCenterAppVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Enabled"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, fmt.Sprintf("%t", item.Attributes.Enabled)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterAppVersionsTable(resp *GameCenterAppVersionsResponse) error {
+	h, r := gameCenterAppVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterAppVersionsMarkdown(resp *GameCenterAppVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Enabled |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(item.ID), item.Attributes.Enabled)
-	}
+	h, r := gameCenterAppVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterEnabledVersionsTable(resp *GameCenterEnabledVersionsResponse) error {
+func gameCenterEnabledVersionsRows(resp *GameCenterEnabledVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Platform", "Version", "Icon Template URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1178,29 +1143,22 @@ func printGameCenterEnabledVersionsTable(resp *GameCenterEnabledVersionsResponse
 			iconURL,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterEnabledVersionsTable(resp *GameCenterEnabledVersionsResponse) error {
+	h, r := gameCenterEnabledVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterEnabledVersionsMarkdown(resp *GameCenterEnabledVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Platform | Version | Icon Template URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		iconURL := ""
-		if item.Attributes.IconAsset != nil {
-			iconURL = item.Attributes.IconAsset.TemplateURL
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(item.Attributes.VersionString),
-			escapeMarkdown(iconURL),
-		)
-	}
+	h, r := gameCenterEnabledVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterDetailsTable(resp *GameCenterDetailsResponse) error {
+func gameCenterDetailsRows(resp *GameCenterDetailsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Arcade Enabled", "Challenge Enabled", "Leaderboard Enabled", "Leaderboard Set Enabled", "Achievement Enabled", "Multiplayer Session", "Turn-Based Session"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1215,29 +1173,22 @@ func printGameCenterDetailsTable(resp *GameCenterDetailsResponse) error {
 			fmt.Sprintf("%t", item.Attributes.MultiplayerTurnBasedSessionEnabled),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterDetailsTable(resp *GameCenterDetailsResponse) error {
+	h, r := gameCenterDetailsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterDetailsMarkdown(resp *GameCenterDetailsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Arcade Enabled | Challenge Enabled | Leaderboard Enabled | Leaderboard Set Enabled | Achievement Enabled | Multiplayer Session | Turn-Based Session |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t | %t | %t | %t | %t | %t | %t |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.ArcadeEnabled,
-			item.Attributes.ChallengeEnabled,
-			item.Attributes.LeaderboardEnabled,
-			item.Attributes.LeaderboardSetEnabled,
-			item.Attributes.AchievementEnabled,
-			item.Attributes.MultiplayerSessionEnabled,
-			item.Attributes.MultiplayerTurnBasedSessionEnabled,
-		)
-	}
+	h, r := gameCenterDetailsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingQueuesTable(resp *GameCenterMatchmakingQueuesResponse) error {
+func gameCenterMatchmakingQueuesRows(resp *GameCenterMatchmakingQueuesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Classic Bundle IDs"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1247,38 +1198,40 @@ func printGameCenterMatchmakingQueuesTable(resp *GameCenterMatchmakingQueuesResp
 			formatStringList(item.Attributes.ClassicMatchmakingBundleIDs),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingQueuesTable(resp *GameCenterMatchmakingQueuesResponse) error {
+	h, r := gameCenterMatchmakingQueuesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingQueuesMarkdown(resp *GameCenterMatchmakingQueuesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Classic Bundle IDs |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(formatStringList(item.Attributes.ClassicMatchmakingBundleIDs)),
-		)
-	}
+	h, r := gameCenterMatchmakingQueuesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingQueueDeleteResultTable(result *GameCenterMatchmakingQueueDeleteResult) error {
+func gameCenterMatchmakingQueueDeleteResultRows(result *GameCenterMatchmakingQueueDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingQueueDeleteResultTable(result *GameCenterMatchmakingQueueDeleteResult) error {
+	h, r := gameCenterMatchmakingQueueDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingQueueDeleteResultMarkdown(result *GameCenterMatchmakingQueueDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterMatchmakingQueueDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingRuleSetsTable(resp *GameCenterMatchmakingRuleSetsResponse) error {
+func gameCenterMatchmakingRuleSetsRows(resp *GameCenterMatchmakingRuleSetsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Language", "Min Players", "Max Players"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1290,40 +1243,40 @@ func printGameCenterMatchmakingRuleSetsTable(resp *GameCenterMatchmakingRuleSets
 			fmt.Sprintf("%d", item.Attributes.MaxPlayers),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingRuleSetsTable(resp *GameCenterMatchmakingRuleSetsResponse) error {
+	h, r := gameCenterMatchmakingRuleSetsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingRuleSetsMarkdown(resp *GameCenterMatchmakingRuleSetsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Language | Min Players | Max Players |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %d | %d |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			item.Attributes.RuleLanguageVersion,
-			item.Attributes.MinPlayers,
-			item.Attributes.MaxPlayers,
-		)
-	}
+	h, r := gameCenterMatchmakingRuleSetsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingRuleSetDeleteResultTable(result *GameCenterMatchmakingRuleSetDeleteResult) error {
+func gameCenterMatchmakingRuleSetDeleteResultRows(result *GameCenterMatchmakingRuleSetDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingRuleSetDeleteResultTable(result *GameCenterMatchmakingRuleSetDeleteResult) error {
+	h, r := gameCenterMatchmakingRuleSetDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingRuleSetDeleteResultMarkdown(result *GameCenterMatchmakingRuleSetDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterMatchmakingRuleSetDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingRulesTable(resp *GameCenterMatchmakingRulesResponse) error {
+func gameCenterMatchmakingRulesRows(resp *GameCenterMatchmakingRulesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Type", "Weight"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1334,39 +1287,40 @@ func printGameCenterMatchmakingRulesTable(resp *GameCenterMatchmakingRulesRespon
 			fmt.Sprintf("%g", item.Attributes.Weight),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingRulesTable(resp *GameCenterMatchmakingRulesResponse) error {
+	h, r := gameCenterMatchmakingRulesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingRulesMarkdown(resp *GameCenterMatchmakingRulesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Type | Weight |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %g |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			escapeMarkdown(item.Attributes.Type),
-			item.Attributes.Weight,
-		)
-	}
+	h, r := gameCenterMatchmakingRulesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingRuleDeleteResultTable(result *GameCenterMatchmakingRuleDeleteResult) error {
+func gameCenterMatchmakingRuleDeleteResultRows(result *GameCenterMatchmakingRuleDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingRuleDeleteResultTable(result *GameCenterMatchmakingRuleDeleteResult) error {
+	h, r := gameCenterMatchmakingRuleDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingRuleDeleteResultMarkdown(result *GameCenterMatchmakingRuleDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterMatchmakingRuleDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingTeamsTable(resp *GameCenterMatchmakingTeamsResponse) error {
+func gameCenterMatchmakingTeamsRows(resp *GameCenterMatchmakingTeamsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Min Players", "Max Players"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -1377,39 +1331,40 @@ func printGameCenterMatchmakingTeamsTable(resp *GameCenterMatchmakingTeamsRespon
 			fmt.Sprintf("%d", item.Attributes.MaxPlayers),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingTeamsTable(resp *GameCenterMatchmakingTeamsResponse) error {
+	h, r := gameCenterMatchmakingTeamsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingTeamsMarkdown(resp *GameCenterMatchmakingTeamsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Min Players | Max Players |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %d | %d |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ReferenceName),
-			item.Attributes.MinPlayers,
-			item.Attributes.MaxPlayers,
-		)
-	}
+	h, r := gameCenterMatchmakingTeamsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingTeamDeleteResultTable(result *GameCenterMatchmakingTeamDeleteResult) error {
+func gameCenterMatchmakingTeamDeleteResultRows(result *GameCenterMatchmakingTeamDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingTeamDeleteResultTable(result *GameCenterMatchmakingTeamDeleteResult) error {
+	h, r := gameCenterMatchmakingTeamDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingTeamDeleteResultMarkdown(result *GameCenterMatchmakingTeamDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := gameCenterMatchmakingTeamDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMetricsTable(resp *GameCenterMetricsResponse) error {
+func gameCenterMetricsRows(resp *GameCenterMetricsResponse) ([]string, [][]string) {
 	headers := []string{"Start", "End", "Granularity", "Values", "Dimensions"}
 	var rows [][]string
 	for _, item := range resp.Data {
@@ -1423,42 +1378,40 @@ func printGameCenterMetricsTable(resp *GameCenterMetricsResponse) error {
 			})
 		}
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMetricsTable(resp *GameCenterMetricsResponse) error {
+	h, r := gameCenterMetricsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMetricsMarkdown(resp *GameCenterMetricsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Start | End | Granularity | Values | Dimensions |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		for _, point := range item.DataPoints {
-			fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-				escapeMarkdown(point.Start),
-				escapeMarkdown(point.End),
-				escapeMarkdown(formatMetricGranularity(item.Granularity)),
-				escapeMarkdown(formatMetricJSON(point.Values)),
-				escapeMarkdown(formatMetricJSON(item.Dimensions)),
-			)
-		}
-	}
+	h, r := gameCenterMetricsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterMatchmakingRuleSetTestTable(resp *GameCenterMatchmakingRuleSetTestResponse) error {
+func gameCenterMatchmakingRuleSetTestRows(resp *GameCenterMatchmakingRuleSetTestResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := [][]string{{resp.Data.ID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterMatchmakingRuleSetTestTable(resp *GameCenterMatchmakingRuleSetTestResponse) error {
+	h, r := gameCenterMatchmakingRuleSetTestRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterMatchmakingRuleSetTestMarkdown(resp *GameCenterMatchmakingRuleSetTestResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(resp.Data.ID))
+	h, r := gameCenterMatchmakingRuleSetTestRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterLeaderboardEntrySubmissionTable(resp *GameCenterLeaderboardEntrySubmissionResponse) error {
+func gameCenterLeaderboardEntrySubmissionRows(resp *GameCenterLeaderboardEntrySubmissionResponse) ([]string, [][]string) {
 	attrs := resp.Data.Attributes
 	submittedDate := ""
 	if attrs.SubmittedDate != nil {
@@ -1473,30 +1426,22 @@ func printGameCenterLeaderboardEntrySubmissionTable(resp *GameCenterLeaderboardE
 		compactWhitespace(attrs.ScopedPlayerID),
 		compactWhitespace(submittedDate),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterLeaderboardEntrySubmissionTable(resp *GameCenterLeaderboardEntrySubmissionResponse) error {
+	h, r := gameCenterLeaderboardEntrySubmissionRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterLeaderboardEntrySubmissionMarkdown(resp *GameCenterLeaderboardEntrySubmissionResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Vendor ID | Score | Bundle ID | Scoped Player ID | Submitted Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	attrs := resp.Data.Attributes
-	submittedDate := ""
-	if attrs.SubmittedDate != nil {
-		submittedDate = *attrs.SubmittedDate
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(attrs.VendorIdentifier),
-		escapeMarkdown(attrs.Score),
-		escapeMarkdown(attrs.BundleID),
-		escapeMarkdown(attrs.ScopedPlayerID),
-		escapeMarkdown(submittedDate),
-	)
+	h, r := gameCenterLeaderboardEntrySubmissionRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printGameCenterPlayerAchievementSubmissionTable(resp *GameCenterPlayerAchievementSubmissionResponse) error {
+func gameCenterPlayerAchievementSubmissionRows(resp *GameCenterPlayerAchievementSubmissionResponse) ([]string, [][]string) {
 	attrs := resp.Data.Attributes
 	submittedDate := ""
 	if attrs.SubmittedDate != nil {
@@ -1511,26 +1456,18 @@ func printGameCenterPlayerAchievementSubmissionTable(resp *GameCenterPlayerAchie
 		compactWhitespace(attrs.ScopedPlayerID),
 		compactWhitespace(submittedDate),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printGameCenterPlayerAchievementSubmissionTable(resp *GameCenterPlayerAchievementSubmissionResponse) error {
+	h, r := gameCenterPlayerAchievementSubmissionRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printGameCenterPlayerAchievementSubmissionMarkdown(resp *GameCenterPlayerAchievementSubmissionResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Vendor ID | Percent | Bundle ID | Scoped Player ID | Submitted Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	attrs := resp.Data.Attributes
-	submittedDate := ""
-	if attrs.SubmittedDate != nil {
-		submittedDate = *attrs.SubmittedDate
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %d | %s | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(attrs.VendorIdentifier),
-		attrs.PercentageAchieved,
-		escapeMarkdown(attrs.BundleID),
-		escapeMarkdown(attrs.ScopedPlayerID),
-		escapeMarkdown(submittedDate),
-	)
+	h, r := gameCenterPlayerAchievementSubmissionRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_game_center_v2_test.go
+++ b/internal/asc/output_game_center_v2_test.go
@@ -47,7 +47,7 @@ func TestPrintMarkdown_GameCenterLeaderboardVersions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Version | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Version") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "IN_REVIEW") {

--- a/internal/asc/output_game_center_versions_test.go
+++ b/internal/asc/output_game_center_versions_test.go
@@ -45,7 +45,7 @@ func TestPrintMarkdown_GameCenterAppVersions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Enabled |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Enabled") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "gcav-1") {

--- a/internal/asc/output_helpers.go
+++ b/internal/asc/output_helpers.go
@@ -6,8 +6,3 @@ func compactWhitespace(input string) string {
 	clean := sanitizeTerminal(input)
 	return strings.Join(strings.Fields(clean), " ")
 }
-
-func escapeMarkdown(input string) string {
-	clean := compactWhitespace(input)
-	return strings.ReplaceAll(clean, "|", "\\|")
-}

--- a/internal/asc/output_linkages.go
+++ b/internal/asc/output_linkages.go
@@ -1,28 +1,22 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
-func printLinkagesTable(resp *LinkagesResponse) error {
+func linkagesRows(resp *LinkagesResponse) ([]string, [][]string) {
 	headers := []string{"Type", "ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{string(item.Type), item.ID})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printLinkagesTable(resp *LinkagesResponse) error {
+	h, r := linkagesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printLinkagesMarkdown(resp *LinkagesResponse) error {
-	fmt.Fprintln(os.Stdout, "| Type | ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(string(item.Type)),
-			escapeMarkdown(item.ID),
-		)
-	}
+	h, r := linkagesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_localizations.go
+++ b/internal/asc/output_localizations.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // AppStoreVersionLocalizationDeleteResult represents CLI output for localization deletions.
 type AppStoreVersionLocalizationDeleteResult struct {
@@ -56,7 +53,7 @@ type LocalizationUploadResult struct {
 	Results   []LocalizationUploadLocaleResult `json:"results"`
 }
 
-func printAppStoreVersionLocalizationsTable(resp *AppStoreVersionLocalizationsResponse) error {
+func appStoreVersionLocalizationsRows(resp *AppStoreVersionLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"Locale", "Whats New", "Keywords"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -66,11 +63,22 @@ func printAppStoreVersionLocalizationsTable(resp *AppStoreVersionLocalizationsRe
 			compactWhitespace(item.Attributes.Keywords),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionLocalizationsTable(resp *AppStoreVersionLocalizationsResponse) error {
+	h, r := appStoreVersionLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printBetaAppLocalizationsTable(resp *BetaAppLocalizationsResponse) error {
+func printAppStoreVersionLocalizationsMarkdown(resp *AppStoreVersionLocalizationsResponse) error {
+	h, r := appStoreVersionLocalizationsRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func betaAppLocalizationsRows(resp *BetaAppLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"Locale", "Description", "Feedback Email", "Marketing URL", "Privacy Policy URL", "TVOS Privacy Policy"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -83,11 +91,22 @@ func printBetaAppLocalizationsTable(resp *BetaAppLocalizationsResponse) error {
 			item.Attributes.TvOsPrivacyPolicy,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppLocalizationsTable(resp *BetaAppLocalizationsResponse) error {
+	h, r := betaAppLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printBetaBuildLocalizationsTable(resp *BetaBuildLocalizationsResponse) error {
+func printBetaAppLocalizationsMarkdown(resp *BetaAppLocalizationsResponse) error {
+	h, r := betaAppLocalizationsRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func betaBuildLocalizationsRows(resp *BetaBuildLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"Locale", "What to Test"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -96,11 +115,22 @@ func printBetaBuildLocalizationsTable(resp *BetaBuildLocalizationsResponse) erro
 			compactWhitespace(item.Attributes.WhatsNew),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaBuildLocalizationsTable(resp *BetaBuildLocalizationsResponse) error {
+	h, r := betaBuildLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printAppInfoLocalizationsTable(resp *AppInfoLocalizationsResponse) error {
+func printBetaBuildLocalizationsMarkdown(resp *BetaBuildLocalizationsResponse) error {
+	h, r := betaBuildLocalizationsRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appInfoLocalizationsRows(resp *AppInfoLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"Locale", "Name", "Subtitle", "Privacy Policy URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -111,88 +141,43 @@ func printAppInfoLocalizationsTable(resp *AppInfoLocalizationsResponse) error {
 			item.Attributes.PrivacyPolicyURL,
 		})
 	}
-	RenderTable(headers, rows)
-	return nil
+	return headers, rows
 }
 
-func printAppStoreVersionLocalizationsMarkdown(resp *AppStoreVersionLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Locale | Whats New | Keywords |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.WhatsNew),
-			escapeMarkdown(item.Attributes.Keywords),
-		)
-	}
-	return nil
-}
-
-func printBetaAppLocalizationsMarkdown(resp *BetaAppLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Locale | Description | Feedback Email | Marketing URL | Privacy Policy URL | TVOS Privacy Policy |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Description),
-			escapeMarkdown(item.Attributes.FeedbackEmail),
-			escapeMarkdown(item.Attributes.MarketingURL),
-			escapeMarkdown(item.Attributes.PrivacyPolicyURL),
-			escapeMarkdown(item.Attributes.TvOsPrivacyPolicy),
-		)
-	}
-	return nil
-}
-
-func printBetaBuildLocalizationsMarkdown(resp *BetaBuildLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Locale | What to Test |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.WhatsNew),
-		)
-	}
+func printAppInfoLocalizationsTable(resp *AppInfoLocalizationsResponse) error {
+	h, r := appInfoLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppInfoLocalizationsMarkdown(resp *AppInfoLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Locale | Name | Subtitle | Privacy Policy URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Subtitle),
-			escapeMarkdown(item.Attributes.PrivacyPolicyURL),
-		)
-	}
+	h, r := appInfoLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printLocalizationDownloadResultTable(result *LocalizationDownloadResult) error {
+func localizationDownloadResultRows(result *LocalizationDownloadResult) ([]string, [][]string) {
 	headers := []string{"Locale", "Path"}
 	rows := make([][]string, 0, len(result.Files))
 	for _, file := range result.Files {
 		rows = append(rows, []string{file.Locale, file.Path})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printLocalizationDownloadResultTable(result *LocalizationDownloadResult) error {
+	h, r := localizationDownloadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printLocalizationDownloadResultMarkdown(result *LocalizationDownloadResult) error {
-	fmt.Fprintln(os.Stdout, "| Locale | Path |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, file := range result.Files {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(file.Locale),
-			escapeMarkdown(file.Path),
-		)
-	}
+	h, r := localizationDownloadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printLocalizationUploadResultTable(result *LocalizationUploadResult) error {
+func localizationUploadResultRows(result *LocalizationUploadResult) ([]string, [][]string) {
 	headers := []string{"Locale", "Action", "Localization ID"}
 	rows := make([][]string, 0, len(result.Results))
 	for _, item := range result.Results {
@@ -202,70 +187,71 @@ func printLocalizationUploadResultTable(result *LocalizationUploadResult) error 
 			item.LocalizationID,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printLocalizationUploadResultTable(result *LocalizationUploadResult) error {
+	h, r := localizationUploadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printLocalizationUploadResultMarkdown(result *LocalizationUploadResult) error {
-	fmt.Fprintln(os.Stdout, "| Locale | Action | Localization ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range result.Results {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.Locale),
-			escapeMarkdown(item.Action),
-			escapeMarkdown(item.LocalizationID),
-		)
-	}
+	h, r := localizationUploadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionLocalizationDeleteResultTable(result *AppStoreVersionLocalizationDeleteResult) error {
+func appStoreVersionLocalizationDeleteResultRows(result *AppStoreVersionLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionLocalizationDeleteResultTable(result *AppStoreVersionLocalizationDeleteResult) error {
+	h, r := appStoreVersionLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionLocalizationDeleteResultMarkdown(result *AppStoreVersionLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appStoreVersionLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaAppLocalizationDeleteResultTable(result *BetaAppLocalizationDeleteResult) error {
+func betaAppLocalizationDeleteResultRows(result *BetaAppLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppLocalizationDeleteResultTable(result *BetaAppLocalizationDeleteResult) error {
+	h, r := betaAppLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaAppLocalizationDeleteResultMarkdown(result *BetaAppLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := betaAppLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaBuildLocalizationDeleteResultTable(result *BetaBuildLocalizationDeleteResult) error {
+func betaBuildLocalizationDeleteResultRows(result *BetaBuildLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaBuildLocalizationDeleteResultTable(result *BetaBuildLocalizationDeleteResult) error {
+	h, r := betaBuildLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaBuildLocalizationDeleteResultMarkdown(result *BetaBuildLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := betaBuildLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_marketplace.go
+++ b/internal/asc/output_marketplace.go
@@ -2,10 +2,9 @@ package asc
 
 import (
 	"fmt"
-	"os"
 )
 
-func printMarketplaceSearchDetailsTable(resp *MarketplaceSearchDetailsResponse) error {
+func marketplaceSearchDetailsRows(resp *MarketplaceSearchDetailsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Catalog URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -14,19 +13,18 @@ func printMarketplaceSearchDetailsTable(resp *MarketplaceSearchDetailsResponse) 
 			compactWhitespace(item.Attributes.CatalogURL),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printMarketplaceSearchDetailsTable(resp *MarketplaceSearchDetailsResponse) error {
+	h, r := marketplaceSearchDetailsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printMarketplaceSearchDetailsMarkdown(resp *MarketplaceSearchDetailsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Catalog URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.CatalogURL),
-		)
-	}
+	h, r := marketplaceSearchDetailsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -42,7 +40,7 @@ func printMarketplaceSearchDetailMarkdown(resp *MarketplaceSearchDetailResponse)
 	})
 }
 
-func printMarketplaceWebhooksTable(resp *MarketplaceWebhooksResponse) error {
+func marketplaceWebhooksRows(resp *MarketplaceWebhooksResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Endpoint URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -51,19 +49,18 @@ func printMarketplaceWebhooksTable(resp *MarketplaceWebhooksResponse) error {
 			compactWhitespace(item.Attributes.EndpointURL),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printMarketplaceWebhooksTable(resp *MarketplaceWebhooksResponse) error {
+	h, r := marketplaceWebhooksRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printMarketplaceWebhooksMarkdown(resp *MarketplaceWebhooksResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Endpoint URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.EndpointURL),
-		)
-	}
+	h, r := marketplaceWebhooksRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -79,36 +76,38 @@ func printMarketplaceWebhookMarkdown(resp *MarketplaceWebhookResponse) error {
 	})
 }
 
-func printMarketplaceSearchDetailDeleteResultTable(result *MarketplaceSearchDetailDeleteResult) error {
+func marketplaceSearchDetailDeleteResultRows(result *MarketplaceSearchDetailDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printMarketplaceSearchDetailDeleteResultTable(result *MarketplaceSearchDetailDeleteResult) error {
+	h, r := marketplaceSearchDetailDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printMarketplaceSearchDetailDeleteResultMarkdown(result *MarketplaceSearchDetailDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := marketplaceSearchDetailDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printMarketplaceWebhookDeleteResultTable(result *MarketplaceWebhookDeleteResult) error {
+func marketplaceWebhookDeleteResultRows(result *MarketplaceWebhookDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printMarketplaceWebhookDeleteResultTable(result *MarketplaceWebhookDeleteResult) error {
+	h, r := marketplaceWebhookDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printMarketplaceWebhookDeleteResultMarkdown(result *MarketplaceWebhookDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := marketplaceWebhookDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_merchant_ids.go
+++ b/internal/asc/output_merchant_ids.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // MerchantIDDeleteResult represents CLI output for merchant ID deletions.
 type MerchantIDDeleteResult struct {
@@ -11,7 +8,7 @@ type MerchantIDDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printMerchantIDsTable(resp *MerchantIDsResponse) error {
+func merchantIDsRows(resp *MerchantIDsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Identifier"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -21,36 +18,35 @@ func printMerchantIDsTable(resp *MerchantIDsResponse) error {
 			item.Attributes.Identifier,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printMerchantIDsTable(resp *MerchantIDsResponse) error {
+	h, r := merchantIDsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printMerchantIDsMarkdown(resp *MerchantIDsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Identifier |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Identifier),
-		)
-	}
+	h, r := merchantIDsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printMerchantIDDeleteResultTable(result *MerchantIDDeleteResult) error {
+func merchantIDDeleteResultRows(result *MerchantIDDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printMerchantIDDeleteResultTable(result *MerchantIDDeleteResult) error {
+	h, r := merchantIDDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printMerchantIDDeleteResultMarkdown(result *MerchantIDDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := merchantIDDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_merchant_ids_test.go
+++ b/internal/asc/output_merchant_ids_test.go
@@ -47,7 +47,7 @@ func TestPrintMarkdown_MerchantIDs(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Identifier |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Identifier") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "merchant.com.example") {
@@ -77,7 +77,7 @@ func TestPrintMarkdown_MerchantIDDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "m1") {

--- a/internal/asc/output_notary.go
+++ b/internal/asc/output_notary.go
@@ -1,23 +1,30 @@
 package asc
 
-import (
-	"fmt"
-)
-
-func printNotarySubmissionStatusTable(resp *NotarySubmissionStatusResponse) error {
-	headers := []string{"ID", "STATUS", "NAME", "CREATED"}
+func notarySubmissionStatusRows(resp *NotarySubmissionStatusResponse) ([]string, [][]string) {
+	headers := []string{"ID", "Status", "Name", "Created"}
 	rows := [][]string{{
 		resp.Data.ID,
 		string(resp.Data.Attributes.Status),
 		compactWhitespace(resp.Data.Attributes.Name),
 		resp.Data.Attributes.CreatedDate,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printNotarySubmissionStatusTable(resp *NotarySubmissionStatusResponse) error {
+	h, r := notarySubmissionStatusRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printNotarySubmissionsListTable(resp *NotarySubmissionsListResponse) error {
-	headers := []string{"ID", "STATUS", "NAME", "CREATED"}
+func printNotarySubmissionStatusMarkdown(resp *NotarySubmissionStatusResponse) error {
+	h, r := notarySubmissionStatusRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func notarySubmissionsListRows(resp *NotarySubmissionsListResponse) ([]string, [][]string) {
+	headers := []string{"ID", "Status", "Name", "Created"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{
@@ -27,49 +34,35 @@ func printNotarySubmissionsListTable(resp *NotarySubmissionsListResponse) error 
 			item.Attributes.CreatedDate,
 		})
 	}
-	RenderTable(headers, rows)
-	return nil
+	return headers, rows
 }
 
-func printNotarySubmissionLogsTable(resp *NotarySubmissionLogsResponse) error {
-	headers := []string{"ID", "DEVELOPER LOG URL"}
-	rows := [][]string{{resp.Data.ID, resp.Data.Attributes.DeveloperLogURL}}
-	RenderTable(headers, rows)
-	return nil
-}
-
-func printNotarySubmissionStatusMarkdown(resp *NotarySubmissionStatusResponse) error {
-	fmt.Println("| ID | Status | Name | Created |")
-	fmt.Println("|----|--------|------|---------|")
-	fmt.Printf("| %s | %s | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(string(resp.Data.Attributes.Status)),
-		escapeMarkdown(resp.Data.Attributes.Name),
-		escapeMarkdown(resp.Data.Attributes.CreatedDate),
-	)
+func printNotarySubmissionsListTable(resp *NotarySubmissionsListResponse) error {
+	h, r := notarySubmissionsListRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printNotarySubmissionsListMarkdown(resp *NotarySubmissionsListResponse) error {
-	fmt.Println("| ID | Status | Name | Created |")
-	fmt.Println("|----|--------|------|---------|")
-	for _, item := range resp.Data {
-		fmt.Printf("| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.Status)),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.CreatedDate),
-		)
-	}
+	h, r := notarySubmissionsListRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func notarySubmissionLogsRows(resp *NotarySubmissionLogsResponse) ([]string, [][]string) {
+	headers := []string{"ID", "Developer Log URL"}
+	rows := [][]string{{resp.Data.ID, resp.Data.Attributes.DeveloperLogURL}}
+	return headers, rows
+}
+
+func printNotarySubmissionLogsTable(resp *NotarySubmissionLogsResponse) error {
+	h, r := notarySubmissionLogsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printNotarySubmissionLogsMarkdown(resp *NotarySubmissionLogsResponse) error {
-	fmt.Println("| ID | Developer Log URL |")
-	fmt.Println("|----|-------------------|")
-	fmt.Printf("| %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.DeveloperLogURL),
-	)
+	h, r := notarySubmissionLogsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_notary_test.go
+++ b/internal/asc/output_notary_test.go
@@ -53,7 +53,7 @@ func TestPrintMarkdown_NotarySubmissionStatus(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Status | Name | Created |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Status") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "sub-456") {
@@ -122,7 +122,7 @@ func TestPrintMarkdown_NotarySubmissionsList(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Status | Name | Created |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Status") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "sub-a") {
@@ -185,7 +185,7 @@ func TestPrintMarkdown_NotarySubmissionLogs(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Developer Log URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Developer Log URL") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "sub-log-2") {

--- a/internal/asc/output_pass_type_ids.go
+++ b/internal/asc/output_pass_type_ids.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // PassTypeIDDeleteResult represents CLI output for pass type ID deletions.
 type PassTypeIDDeleteResult struct {
@@ -11,7 +8,7 @@ type PassTypeIDDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printPassTypeIDsTable(resp *PassTypeIDsResponse) error {
+func passTypeIDsRows(resp *PassTypeIDsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Identifier"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -21,36 +18,35 @@ func printPassTypeIDsTable(resp *PassTypeIDsResponse) error {
 			item.Attributes.Identifier,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printPassTypeIDsTable(resp *PassTypeIDsResponse) error {
+	h, r := passTypeIDsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printPassTypeIDsMarkdown(resp *PassTypeIDsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Identifier |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Identifier),
-		)
-	}
+	h, r := passTypeIDsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printPassTypeIDDeleteResultTable(result *PassTypeIDDeleteResult) error {
+func passTypeIDDeleteResultRows(result *PassTypeIDDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printPassTypeIDDeleteResultTable(result *PassTypeIDDeleteResult) error {
+	h, r := passTypeIDDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printPassTypeIDDeleteResultMarkdown(result *PassTypeIDDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := passTypeIDDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_pass_type_ids_test.go
+++ b/internal/asc/output_pass_type_ids_test.go
@@ -47,7 +47,7 @@ func TestPrintMarkdown_PassTypeIDs(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Identifier |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Identifier") {
 		t.Fatalf("expected pass type IDs header, got: %s", output)
 	}
 	if !strings.Contains(output, "pass-1") || !strings.Contains(output, "Wallet") || !strings.Contains(output, "pass.com.example") {
@@ -77,7 +77,7 @@ func TestPrintMarkdown_PassTypeIDDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected delete header, got: %s", output)
 	}
 	if !strings.Contains(output, "pass-1") || !strings.Contains(output, "true") {

--- a/internal/asc/output_performance.go
+++ b/internal/asc/output_performance.go
@@ -3,7 +3,6 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
 // PerformanceDownloadResult represents CLI output for performance downloads.
@@ -95,12 +94,11 @@ func summarizeDiagnosticLogs(resp *DiagnosticLogsResponse) (diagnosticLogsSummar
 	}, nil
 }
 
-func printPerfPowerMetricsTable(resp *PerfPowerMetricsResponse) error {
+func perfPowerMetricsRows(resp *PerfPowerMetricsResponse) ([]string, [][]string, error) {
 	summary, err := summarizePerfPowerMetrics(resp)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-
 	headers := []string{"Version", "Products", "Trending Up", "Regressions"}
 	rows := [][]string{{
 		summary.Version,
@@ -108,28 +106,28 @@ func printPerfPowerMetricsTable(resp *PerfPowerMetricsResponse) error {
 		fmt.Sprintf("%d", summary.TrendingUpCount),
 		fmt.Sprintf("%d", summary.RegressionCount),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printPerfPowerMetricsTable(resp *PerfPowerMetricsResponse) error {
+	h, r, err := perfPowerMetricsRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printPerfPowerMetricsMarkdown(resp *PerfPowerMetricsResponse) error {
-	summary, err := summarizePerfPowerMetrics(resp)
+	h, r, err := perfPowerMetricsRows(resp)
 	if err != nil {
 		return err
 	}
-
-	fmt.Fprintln(os.Stdout, "| Version | Products | Trending Up | Regressions |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %d | %d | %d |\n",
-		escapeMarkdown(summary.Version),
-		summary.ProductCount,
-		summary.TrendingUpCount,
-		summary.RegressionCount,
-	)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printDiagnosticSignaturesTable(resp *DiagnosticSignaturesResponse) error {
+func diagnosticSignaturesRows(resp *DiagnosticSignaturesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Type", "Weight", "Insight", "Signature"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -145,35 +143,26 @@ func printDiagnosticSignaturesTable(resp *DiagnosticSignaturesResponse) error {
 			item.Attributes.Signature,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printDiagnosticSignaturesTable(resp *DiagnosticSignaturesResponse) error {
+	h, r := diagnosticSignaturesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printDiagnosticSignaturesMarkdown(resp *DiagnosticSignaturesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Type | Weight | Insight | Signature |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		insight := ""
-		if item.Attributes.Insight != nil {
-			insight = string(item.Attributes.Insight.Direction)
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %.2f | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.DiagnosticType)),
-			item.Attributes.Weight,
-			escapeMarkdown(insight),
-			escapeMarkdown(item.Attributes.Signature),
-		)
-	}
+	h, r := diagnosticSignaturesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printDiagnosticLogsTable(resp *DiagnosticLogsResponse) error {
+func diagnosticLogsRows(resp *DiagnosticLogsResponse) ([]string, [][]string, error) {
 	summary, err := summarizeDiagnosticLogs(resp)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-
 	headers := []string{"Version", "Products", "Logs", "Insights"}
 	rows := [][]string{{
 		summary.Version,
@@ -181,28 +170,28 @@ func printDiagnosticLogsTable(resp *DiagnosticLogsResponse) error {
 		fmt.Sprintf("%d", summary.LogCount),
 		fmt.Sprintf("%d", summary.InsightCount),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printDiagnosticLogsTable(resp *DiagnosticLogsResponse) error {
+	h, r, err := diagnosticLogsRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printDiagnosticLogsMarkdown(resp *DiagnosticLogsResponse) error {
-	summary, err := summarizeDiagnosticLogs(resp)
+	h, r, err := diagnosticLogsRows(resp)
 	if err != nil {
 		return err
 	}
-
-	fmt.Fprintln(os.Stdout, "| Version | Products | Logs | Insights |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %d | %d | %d |\n",
-		escapeMarkdown(summary.Version),
-		summary.ProductCount,
-		summary.LogCount,
-		summary.InsightCount,
-	)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printPerformanceDownloadResultTable(result *PerformanceDownloadResult) error {
+func performanceDownloadResultRows(result *PerformanceDownloadResult) ([]string, [][]string) {
 	headers := []string{"Type", "App ID", "Build ID", "Diagnostic ID", "Compressed File", "Compressed Size", "Decompressed File", "Decompressed Size"}
 	rows := [][]string{{
 		result.DownloadType,
@@ -214,22 +203,17 @@ func printPerformanceDownloadResultTable(result *PerformanceDownloadResult) erro
 		result.DecompressedPath,
 		fmt.Sprintf("%d", result.DecompressedSize),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printPerformanceDownloadResultTable(result *PerformanceDownloadResult) error {
+	h, r := performanceDownloadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printPerformanceDownloadResultMarkdown(result *PerformanceDownloadResult) error {
-	fmt.Fprintln(os.Stdout, "| Type | App ID | Build ID | Diagnostic ID | Compressed File | Compressed Size | Decompressed File | Decompressed Size |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %d | %s | %d |\n",
-		escapeMarkdown(result.DownloadType),
-		escapeMarkdown(result.AppID),
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(result.DiagnosticSignatureID),
-		escapeMarkdown(result.FilePath),
-		result.FileSize,
-		escapeMarkdown(result.DecompressedPath),
-		result.DecompressedSize,
-	)
+	h, r := performanceDownloadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_product_pages.go
+++ b/internal/asc/output_product_pages.go
@@ -2,10 +2,9 @@ package asc
 
 import (
 	"fmt"
-	"os"
 )
 
-func printAppCustomProductPagesTable(resp *AppCustomProductPagesResponse) error {
+func appCustomProductPagesRows(resp *AppCustomProductPagesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Visible", "URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -16,25 +15,22 @@ func printAppCustomProductPagesTable(resp *AppCustomProductPagesResponse) error 
 			compactWhitespace(item.Attributes.URL),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppCustomProductPagesTable(resp *AppCustomProductPagesResponse) error {
+	h, r := appCustomProductPagesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppCustomProductPagesMarkdown(resp *AppCustomProductPagesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Visible | URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(boolValue(item.Attributes.Visible)),
-			escapeMarkdown(item.Attributes.URL),
-		)
-	}
+	h, r := appCustomProductPagesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppCustomProductPageVersionsTable(resp *AppCustomProductPageVersionsResponse) error {
+func appCustomProductPageVersionsRows(resp *AppCustomProductPageVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "State", "Deep Link"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -45,25 +41,22 @@ func printAppCustomProductPageVersionsTable(resp *AppCustomProductPageVersionsRe
 			compactWhitespace(item.Attributes.DeepLink),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppCustomProductPageVersionsTable(resp *AppCustomProductPageVersionsResponse) error {
+	h, r := appCustomProductPageVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppCustomProductPageVersionsMarkdown(resp *AppCustomProductPageVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | State | Deep Link |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(item.Attributes.State),
-			escapeMarkdown(item.Attributes.DeepLink),
-		)
-	}
+	h, r := appCustomProductPageVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppCustomProductPageLocalizationsTable(resp *AppCustomProductPageLocalizationsResponse) error {
+func appCustomProductPageLocalizationsRows(resp *AppCustomProductPageLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Promotional Text"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -73,43 +66,43 @@ func printAppCustomProductPageLocalizationsTable(resp *AppCustomProductPageLocal
 			compactWhitespace(item.Attributes.PromotionalText),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppCustomProductPageLocalizationsTable(resp *AppCustomProductPageLocalizationsResponse) error {
+	h, r := appCustomProductPageLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppCustomProductPageLocalizationsMarkdown(resp *AppCustomProductPageLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Promotional Text |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(item.Attributes.PromotionalText),
-		)
-	}
+	h, r := appCustomProductPageLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppKeywordsTable(resp *AppKeywordsResponse) error {
+func appKeywordsRows(resp *AppKeywordsResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppKeywordsTable(resp *AppKeywordsResponse) error {
+	h, r := appKeywordsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppKeywordsMarkdown(resp *AppKeywordsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(item.ID))
-	}
+	h, r := appKeywordsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentsTable(resp *AppStoreVersionExperimentsResponse) error {
+func appStoreVersionExperimentsRows(resp *AppStoreVersionExperimentsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Traffic Proportion", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -120,25 +113,22 @@ func printAppStoreVersionExperimentsTable(resp *AppStoreVersionExperimentsRespon
 			compactWhitespace(item.Attributes.State),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentsTable(resp *AppStoreVersionExperimentsResponse) error {
+	h, r := appStoreVersionExperimentsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentsMarkdown(resp *AppStoreVersionExperimentsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Traffic Proportion | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(formatOptionalInt(item.Attributes.TrafficProportion)),
-			escapeMarkdown(item.Attributes.State),
-		)
-	}
+	h, r := appStoreVersionExperimentsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentsV2Table(resp *AppStoreVersionExperimentsV2Response) error {
+func appStoreVersionExperimentsV2Rows(resp *AppStoreVersionExperimentsV2Response) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Platform", "Traffic Proportion", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -150,26 +140,22 @@ func printAppStoreVersionExperimentsV2Table(resp *AppStoreVersionExperimentsV2Re
 			compactWhitespace(item.Attributes.State),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentsV2Table(resp *AppStoreVersionExperimentsV2Response) error {
+	h, r := appStoreVersionExperimentsV2Rows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentsV2Markdown(resp *AppStoreVersionExperimentsV2Response) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Platform | Traffic Proportion | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(formatOptionalInt(item.Attributes.TrafficProportion)),
-			escapeMarkdown(item.Attributes.State),
-		)
-	}
+	h, r := appStoreVersionExperimentsV2Rows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentTreatmentsTable(resp *AppStoreVersionExperimentTreatmentsResponse) error {
+func appStoreVersionExperimentTreatmentsRows(resp *AppStoreVersionExperimentTreatmentsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "App Icon Name", "Promoted Date"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -180,25 +166,22 @@ func printAppStoreVersionExperimentTreatmentsTable(resp *AppStoreVersionExperime
 			compactWhitespace(item.Attributes.PromotedDate),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentTreatmentsTable(resp *AppStoreVersionExperimentTreatmentsResponse) error {
+	h, r := appStoreVersionExperimentTreatmentsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentTreatmentsMarkdown(resp *AppStoreVersionExperimentTreatmentsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | App Icon Name | Promoted Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.AppIconName),
-			escapeMarkdown(item.Attributes.PromotedDate),
-		)
-	}
+	h, r := appStoreVersionExperimentTreatmentsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentTreatmentLocalizationsTable(resp *AppStoreVersionExperimentTreatmentLocalizationsResponse) error {
+func appStoreVersionExperimentTreatmentLocalizationsRows(resp *AppStoreVersionExperimentTreatmentLocalizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -207,88 +190,107 @@ func printAppStoreVersionExperimentTreatmentLocalizationsTable(resp *AppStoreVer
 			compactWhitespace(item.Attributes.Locale),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentTreatmentLocalizationsTable(resp *AppStoreVersionExperimentTreatmentLocalizationsResponse) error {
+	h, r := appStoreVersionExperimentTreatmentLocalizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentTreatmentLocalizationsMarkdown(resp *AppStoreVersionExperimentTreatmentLocalizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-		)
-	}
+	h, r := appStoreVersionExperimentTreatmentLocalizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppCustomProductPageDeleteResultTable(result *AppCustomProductPageDeleteResult) error {
+func appCustomProductPageDeleteResultRows(result *AppCustomProductPageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppCustomProductPageDeleteResultTable(result *AppCustomProductPageDeleteResult) error {
+	h, r := appCustomProductPageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppCustomProductPageDeleteResultMarkdown(result *AppCustomProductPageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := appCustomProductPageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppCustomProductPageLocalizationDeleteResultTable(result *AppCustomProductPageLocalizationDeleteResult) error {
+func appCustomProductPageLocalizationDeleteResultRows(result *AppCustomProductPageLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppCustomProductPageLocalizationDeleteResultTable(result *AppCustomProductPageLocalizationDeleteResult) error {
+	h, r := appCustomProductPageLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppCustomProductPageLocalizationDeleteResultMarkdown(result *AppCustomProductPageLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := appCustomProductPageLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentDeleteResultTable(result *AppStoreVersionExperimentDeleteResult) error {
+func appStoreVersionExperimentDeleteResultRows(result *AppStoreVersionExperimentDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentDeleteResultTable(result *AppStoreVersionExperimentDeleteResult) error {
+	h, r := appStoreVersionExperimentDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentDeleteResultMarkdown(result *AppStoreVersionExperimentDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := appStoreVersionExperimentDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentTreatmentDeleteResultTable(result *AppStoreVersionExperimentTreatmentDeleteResult) error {
+func appStoreVersionExperimentTreatmentDeleteResultRows(result *AppStoreVersionExperimentTreatmentDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentTreatmentDeleteResultTable(result *AppStoreVersionExperimentTreatmentDeleteResult) error {
+	h, r := appStoreVersionExperimentTreatmentDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentTreatmentDeleteResultMarkdown(result *AppStoreVersionExperimentTreatmentDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := appStoreVersionExperimentTreatmentDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionExperimentTreatmentLocalizationDeleteResultTable(result *AppStoreVersionExperimentTreatmentLocalizationDeleteResult) error {
+func appStoreVersionExperimentTreatmentLocalizationDeleteResultRows(result *AppStoreVersionExperimentTreatmentLocalizationDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionExperimentTreatmentLocalizationDeleteResultTable(result *AppStoreVersionExperimentTreatmentLocalizationDeleteResult) error {
+	h, r := appStoreVersionExperimentTreatmentLocalizationDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionExperimentTreatmentLocalizationDeleteResultMarkdown(result *AppStoreVersionExperimentTreatmentLocalizationDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := appStoreVersionExperimentTreatmentLocalizationDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_product_pages_test.go
+++ b/internal/asc/output_product_pages_test.go
@@ -49,7 +49,7 @@ func TestPrintMarkdown_AppCustomProductPages(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Visible | URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Visible") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Summer Campaign") {
@@ -76,7 +76,7 @@ func TestPrintMarkdown_AppCustomProductPages_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Visible | URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Visible") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -125,7 +125,7 @@ func TestPrintMarkdown_AppCustomProductPageVersions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Version | State | Deep Link |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deep Link") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "READY_FOR_REVIEW") {
@@ -152,7 +152,7 @@ func TestPrintMarkdown_AppCustomProductPageVersions_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Version | State | Deep Link |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deep Link") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -199,7 +199,7 @@ func TestPrintMarkdown_AppCustomProductPageLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale | Promotional Text |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Promotional Text") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "en-US") {
@@ -226,7 +226,7 @@ func TestPrintMarkdown_AppCustomProductPageLocalizations_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale | Promotional Text |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Promotional Text") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -265,7 +265,7 @@ func TestPrintMarkdown_AppKeywords(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "keyword-1") {
@@ -292,7 +292,7 @@ func TestPrintMarkdown_AppKeywords_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -337,7 +337,7 @@ func TestPrintMarkdown_AppPreviewSets(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Preview Type |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Preview Type") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "IPHONE_65") {
@@ -364,7 +364,7 @@ func TestPrintMarkdown_AppPreviewSets_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Preview Type |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Preview Type") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -409,7 +409,7 @@ func TestPrintMarkdown_AppScreenshotSets(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Display Type |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Display Type") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "APP_IPHONE_65") {
@@ -436,7 +436,7 @@ func TestPrintMarkdown_AppScreenshotSets_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Display Type |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Display Type") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -485,7 +485,7 @@ func TestPrintMarkdown_AppStoreVersionExperiments(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Traffic Proportion | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Traffic Proportion") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "IN_REVIEW") {
@@ -512,7 +512,7 @@ func TestPrintMarkdown_AppStoreVersionExperiments_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Traffic Proportion | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Traffic Proportion") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -563,7 +563,7 @@ func TestPrintMarkdown_AppStoreVersionExperimentsV2(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Platform | Traffic Proportion | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Platform") || !strings.Contains(output, "Traffic Proportion") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Icon Test V2") {
@@ -590,7 +590,7 @@ func TestPrintMarkdown_AppStoreVersionExperimentsV2_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Platform | Traffic Proportion | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Platform") || !strings.Contains(output, "Traffic Proportion") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -639,7 +639,7 @@ func TestPrintMarkdown_AppStoreVersionExperimentTreatments(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | App Icon Name | Promoted Date |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "App Icon Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Variant A") {
@@ -666,7 +666,7 @@ func TestPrintMarkdown_AppStoreVersionExperimentTreatments_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | App Icon Name | Promoted Date |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "App Icon Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -711,7 +711,7 @@ func TestPrintMarkdown_AppStoreVersionExperimentTreatmentLocalizations(t *testin
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Locale") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "fr-FR") {
@@ -738,7 +738,7 @@ func TestPrintMarkdown_AppStoreVersionExperimentTreatmentLocalizations_Empty(t *
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Locale") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -765,7 +765,7 @@ func TestPrintMarkdown_AppCustomProductPageDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "page-1") {

--- a/internal/asc/output_promoted_purchases.go
+++ b/internal/asc/output_promoted_purchases.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -27,7 +26,7 @@ func promotedPurchaseBool(value *bool) string {
 	return strconv.FormatBool(*value)
 }
 
-func printPromotedPurchasesTable(resp *PromotedPurchasesResponse) error {
+func promotedPurchasesRows(resp *PromotedPurchasesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Visible For All Users", "Enabled", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -38,56 +37,57 @@ func printPromotedPurchasesTable(resp *PromotedPurchasesResponse) error {
 			item.Attributes.State,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printPromotedPurchasesTable(resp *PromotedPurchasesResponse) error {
+	h, r := promotedPurchasesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printPromotedPurchasesMarkdown(resp *PromotedPurchasesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Visible For All Users | Enabled | State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(promotedPurchaseBool(item.Attributes.VisibleForAllUsers)),
-			escapeMarkdown(promotedPurchaseBool(item.Attributes.Enabled)),
-			escapeMarkdown(item.Attributes.State),
-		)
-	}
+	h, r := promotedPurchasesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printPromotedPurchaseDeleteResultTable(result *PromotedPurchaseDeleteResult) error {
+func promotedPurchaseDeleteResultRows(result *PromotedPurchaseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printPromotedPurchaseDeleteResultTable(result *PromotedPurchaseDeleteResult) error {
+	h, r := promotedPurchaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printPromotedPurchaseDeleteResultMarkdown(result *PromotedPurchaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := promotedPurchaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPromotedPurchasesLinkResultTable(result *AppPromotedPurchasesLinkResult) error {
+func appPromotedPurchasesLinkResultRows(result *AppPromotedPurchasesLinkResult) ([]string, [][]string) {
 	headers := []string{"App ID", "Promoted Purchase IDs", "Action"}
 	rows := [][]string{{
 		result.AppID,
 		strings.Join(result.PromotedPurchaseIDs, ", "),
 		result.Action,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPromotedPurchasesLinkResultTable(result *AppPromotedPurchasesLinkResult) error {
+	h, r := appPromotedPurchasesLinkResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPromotedPurchasesLinkResultMarkdown(result *AppPromotedPurchasesLinkResult) error {
-	fmt.Fprintln(os.Stdout, "| App ID | Promoted Purchase IDs | Action |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.AppID),
-		escapeMarkdown(strings.Join(result.PromotedPurchaseIDs, ", ")),
-		escapeMarkdown(result.Action),
-	)
+	h, r := appPromotedPurchasesLinkResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_promotions.go
+++ b/internal/asc/output_promotions.go
@@ -1,10 +1,5 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
 // AppStoreVersionPromotionCreateResult represents CLI output for promotion creation.
 type AppStoreVersionPromotionCreateResult struct {
 	PromotionID string `json:"promotionId"`
@@ -12,20 +7,20 @@ type AppStoreVersionPromotionCreateResult struct {
 	TreatmentID string `json:"treatmentId,omitempty"`
 }
 
-func printAppStoreVersionPromotionCreateTable(result *AppStoreVersionPromotionCreateResult) error {
+func appStoreVersionPromotionCreateRows(result *AppStoreVersionPromotionCreateResult) ([]string, [][]string) {
 	headers := []string{"Promotion ID", "Version ID", "Treatment ID"}
 	rows := [][]string{{result.PromotionID, result.VersionID, result.TreatmentID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionPromotionCreateTable(result *AppStoreVersionPromotionCreateResult) error {
+	h, r := appStoreVersionPromotionCreateRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionPromotionCreateMarkdown(result *AppStoreVersionPromotionCreateResult) error {
-	fmt.Fprintln(os.Stdout, "| Promotion ID | Version ID | Treatment ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.PromotionID),
-		escapeMarkdown(result.VersionID),
-		escapeMarkdown(result.TreatmentID),
-	)
+	h, r := appStoreVersionPromotionCreateRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_publish.go
+++ b/internal/asc/output_publish.go
@@ -2,11 +2,10 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
-func printTestFlightPublishResultTable(result *TestFlightPublishResult) error {
+func testFlightPublishResultRows(result *TestFlightPublishResult) ([]string, [][]string) {
 	headers := []string{"Build ID", "Version", "Build Number", "Processing", "Groups", "Uploaded", "Notified"}
 	rows := [][]string{{
 		result.BuildID,
@@ -17,26 +16,22 @@ func printTestFlightPublishResultTable(result *TestFlightPublishResult) error {
 		fmt.Sprintf("%t", result.Uploaded),
 		fmt.Sprintf("%t", result.Notified),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printTestFlightPublishResultTable(result *TestFlightPublishResult) error {
+	h, r := testFlightPublishResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printTestFlightPublishResultMarkdown(result *TestFlightPublishResult) error {
-	fmt.Fprintln(os.Stdout, "| Build ID | Version | Build Number | Processing | Groups | Uploaded | Notified |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %t | %t |\n",
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(result.BuildVersion),
-		escapeMarkdown(result.BuildNumber),
-		escapeMarkdown(result.ProcessingState),
-		escapeMarkdown(strings.Join(result.GroupIDs, ", ")),
-		result.Uploaded,
-		result.Notified,
-	)
+	h, r := testFlightPublishResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStorePublishResultTable(result *AppStorePublishResult) error {
+func appStorePublishResultRows(result *AppStorePublishResult) ([]string, [][]string) {
 	headers := []string{"Build ID", "Version ID", "Submission ID", "Uploaded", "Attached", "Submitted"}
 	rows := [][]string{{
 		result.BuildID,
@@ -46,20 +41,17 @@ func printAppStorePublishResultTable(result *AppStorePublishResult) error {
 		fmt.Sprintf("%t", result.Attached),
 		fmt.Sprintf("%t", result.Submitted),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStorePublishResultTable(result *AppStorePublishResult) error {
+	h, r := appStorePublishResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStorePublishResultMarkdown(result *AppStorePublishResult) error {
-	fmt.Fprintln(os.Stdout, "| Build ID | Version ID | Submission ID | Uploaded | Attached | Submitted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %t | %t | %t |\n",
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(result.VersionID),
-		escapeMarkdown(result.SubmissionID),
-		result.Uploaded,
-		result.Attached,
-		result.Submitted,
-	)
+	h, r := appStorePublishResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_review_attachments.go
+++ b/internal/asc/output_review_attachments.go
@@ -1,16 +1,13 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 type appStoreReviewAttachmentField struct {
 	Name  string
 	Value string
 }
 
-func printAppStoreReviewAttachmentsTable(resp *AppStoreReviewAttachmentsResponse) error {
+func appStoreReviewAttachmentsRows(resp *AppStoreReviewAttachmentsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Checksum", "Delivery State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -23,44 +20,40 @@ func printAppStoreReviewAttachmentsTable(resp *AppStoreReviewAttachmentsResponse
 			sanitizeTerminal(formatAssetDeliveryState(attrs.AssetDeliveryState)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreReviewAttachmentsTable(resp *AppStoreReviewAttachmentsResponse) error {
+	h, r := appStoreReviewAttachmentsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreReviewAttachmentsMarkdown(resp *AppStoreReviewAttachmentsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | File Name | File Size | Checksum | Delivery State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(fallbackValue(attrs.FileName)),
-			escapeMarkdown(formatAttachmentFileSize(attrs.FileSize)),
-			escapeMarkdown(fallbackValue(attrs.SourceFileChecksum)),
-			escapeMarkdown(formatAssetDeliveryState(attrs.AssetDeliveryState)),
-		)
-	}
+	h, r := appStoreReviewAttachmentsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreReviewAttachmentTable(resp *AppStoreReviewAttachmentResponse) error {
+func appStoreReviewAttachmentRows(resp *AppStoreReviewAttachmentResponse) ([]string, [][]string) {
 	fields := appStoreReviewAttachmentFields(resp)
 	headers := []string{"Field", "Value"}
 	rows := make([][]string, 0, len(fields))
 	for _, field := range fields {
 		rows = append(rows, []string{field.Name, field.Value})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreReviewAttachmentTable(resp *AppStoreReviewAttachmentResponse) error {
+	h, r := appStoreReviewAttachmentRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreReviewAttachmentMarkdown(resp *AppStoreReviewAttachmentResponse) error {
-	fields := appStoreReviewAttachmentFields(resp)
-	fmt.Fprintln(os.Stdout, "| Field | Value |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, field := range fields {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
-	}
+	h, r := appStoreReviewAttachmentRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -79,17 +72,21 @@ func appStoreReviewAttachmentFields(resp *AppStoreReviewAttachmentResponse) []ap
 	}
 }
 
-func printAppStoreReviewAttachmentDeleteResultTable(result *AppStoreReviewAttachmentDeleteResult) error {
+func appStoreReviewAttachmentDeleteResultRows(result *AppStoreReviewAttachmentDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreReviewAttachmentDeleteResultTable(result *AppStoreReviewAttachmentDeleteResult) error {
+	h, r := appStoreReviewAttachmentDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreReviewAttachmentDeleteResultMarkdown(result *AppStoreReviewAttachmentDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := appStoreReviewAttachmentDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_review_details.go
+++ b/internal/asc/output_review_details.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -21,7 +20,7 @@ func formatReviewDetailContactName(attr AppStoreReviewDetailAttributes) string {
 	}
 }
 
-func printAppStoreReviewDetailTable(resp *AppStoreReviewDetailResponse) error {
+func appStoreReviewDetailRows(resp *AppStoreReviewDetailResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Contact", "Email", "Phone", "Demo Required", "Demo Account", "Notes"}
 	attr := resp.Data.Attributes
 	rows := [][]string{{
@@ -33,22 +32,17 @@ func printAppStoreReviewDetailTable(resp *AppStoreReviewDetailResponse) error {
 		compactWhitespace(attr.DemoAccountName),
 		compactWhitespace(attr.Notes),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreReviewDetailTable(resp *AppStoreReviewDetailResponse) error {
+	h, r := appStoreReviewDetailRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreReviewDetailMarkdown(resp *AppStoreReviewDetailResponse) error {
-	attr := resp.Data.Attributes
-	fmt.Fprintln(os.Stdout, "| ID | Contact | Email | Phone | Demo Required | Demo Account | Notes |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %t | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(formatReviewDetailContactName(attr)),
-		escapeMarkdown(attr.ContactEmail),
-		escapeMarkdown(attr.ContactPhone),
-		attr.DemoAccountRequired,
-		escapeMarkdown(attr.DemoAccountName),
-		escapeMarkdown(attr.Notes),
-	)
+	h, r := appStoreReviewDetailRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_review_summarizations.go
+++ b/internal/asc/output_review_summarizations.go
@@ -1,10 +1,5 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
 func customerReviewSummarizationTerritoryID(resource CustomerReviewSummarizationResource) string {
 	if resource.Relationships == nil || resource.Relationships.Territory == nil {
 		return ""
@@ -12,7 +7,7 @@ func customerReviewSummarizationTerritoryID(resource CustomerReviewSummarization
 	return resource.Relationships.Territory.Data.ID
 }
 
-func printCustomerReviewSummarizationsTable(resp *CustomerReviewSummarizationsResponse) error {
+func customerReviewSummarizationsRows(resp *CustomerReviewSummarizationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Locale", "Platform", "Territory", "Created", "Text"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -25,22 +20,17 @@ func printCustomerReviewSummarizationsTable(resp *CustomerReviewSummarizationsRe
 			compactWhitespace(item.Attributes.Text),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCustomerReviewSummarizationsTable(resp *CustomerReviewSummarizationsResponse) error {
+	h, r := customerReviewSummarizationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCustomerReviewSummarizationsMarkdown(resp *CustomerReviewSummarizationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Locale | Platform | Territory | Created | Text |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Locale),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(customerReviewSummarizationTerritoryID(item)),
-			escapeMarkdown(item.Attributes.CreatedDate),
-			escapeMarkdown(item.Attributes.Text),
-		)
-	}
+	h, r := customerReviewSummarizationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_routing_coverage.go
+++ b/internal/asc/output_routing_coverage.go
@@ -1,33 +1,31 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 type routingAppCoverageField struct {
 	Name  string
 	Value string
 }
 
-func printRoutingAppCoverageTable(resp *RoutingAppCoverageResponse) error {
+func routingAppCoverageRows(resp *RoutingAppCoverageResponse) ([]string, [][]string) {
 	fields := routingAppCoverageFields(resp)
 	headers := []string{"Field", "Value"}
 	rows := make([][]string, 0, len(fields))
 	for _, field := range fields {
 		rows = append(rows, []string{field.Name, field.Value})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printRoutingAppCoverageTable(resp *RoutingAppCoverageResponse) error {
+	h, r := routingAppCoverageRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printRoutingAppCoverageMarkdown(resp *RoutingAppCoverageResponse) error {
-	fields := routingAppCoverageFields(resp)
-	fmt.Fprintln(os.Stdout, "| Field | Value |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, field := range fields {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n", escapeMarkdown(field.Name), escapeMarkdown(field.Value))
-	}
+	h, r := routingAppCoverageRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -46,16 +44,20 @@ func routingAppCoverageFields(resp *RoutingAppCoverageResponse) []routingAppCove
 	}
 }
 
-func printRoutingAppCoverageDeleteResultTable(result *RoutingAppCoverageDeleteResult) error {
+func routingAppCoverageDeleteResultRows(result *RoutingAppCoverageDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printRoutingAppCoverageDeleteResultTable(result *RoutingAppCoverageDeleteResult) error {
+	h, r := routingAppCoverageDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printRoutingAppCoverageDeleteResultMarkdown(result *RoutingAppCoverageDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := routingAppCoverageDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_territory_age_ratings.go
+++ b/internal/asc/output_territory_age_ratings.go
@@ -3,37 +3,36 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
-func printTerritoryAgeRatingsTable(resp *TerritoryAgeRatingsResponse) error {
+func territoryAgeRatingsRows(resp *TerritoryAgeRatingsResponse) ([]string, [][]string, error) {
 	headers := []string{"ID", "Territory", "App Store Age Rating"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		territoryID, err := territoryAgeRatingTerritoryID(item.Relationships)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		rows = append(rows, []string{item.ID, territoryID, string(item.Attributes.AppStoreAgeRating)})
 	}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printTerritoryAgeRatingsTable(resp *TerritoryAgeRatingsResponse) error {
+	h, r, err := territoryAgeRatingsRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printTerritoryAgeRatingsMarkdown(resp *TerritoryAgeRatingsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Territory | App Store Age Rating |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		territoryID, err := territoryAgeRatingTerritoryID(item.Relationships)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(territoryID),
-			escapeMarkdown(string(item.Attributes.AppStoreAgeRating)),
-		)
+	h, r, err := territoryAgeRatingsRows(resp)
+	if err != nil {
+		return err
 	}
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -136,7 +136,7 @@ func TestPrintMarkdown_FeedbackWithScreenshots(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Screenshots |") {
+	if !strings.Contains(output, "Screenshots") {
 		t.Fatalf("expected screenshots column, got: %s", output)
 	}
 	if !strings.Contains(output, "https://example.com/shot.png") {
@@ -163,7 +163,7 @@ func TestPrintMarkdown_Reviews(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Created | Rating |") {
+	if !strings.Contains(output, "Created") || !strings.Contains(output, "Rating") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Great app") {
@@ -241,7 +241,7 @@ func TestPrintMarkdown_OfferCodes(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "code-1") {
@@ -305,7 +305,7 @@ func TestPrintMarkdown_SubscriptionOfferCode(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Customer Eligibilities |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Customer Eligibilities") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Launch Offer") || !strings.Contains(output, "NEW, EXISTING") {
@@ -361,7 +361,7 @@ func TestPrintMarkdown_OfferCodeCustomCodes(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Custom Code |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Custom Code") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "SPRING2026") {
@@ -417,7 +417,7 @@ func TestPrintMarkdown_IAPOfferCodeCustomCodes(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Custom Code |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Custom Code") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "IAP2026") {
@@ -473,7 +473,7 @@ func TestPrintMarkdown_IAPOfferCodeOneTimeUseCodes(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Codes |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Codes") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "SANDBOX") {
@@ -500,7 +500,7 @@ func TestPrintMarkdown_OfferCodeValuesResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Code |") || !strings.Contains(output, "CODE2") {
+	if !strings.Contains(output, "Code") || !strings.Contains(output, "CODE2") {
 		t.Fatalf("expected codes in output, got: %s", output)
 	}
 }
@@ -548,7 +548,7 @@ func TestPrintMarkdown_InAppPurchases(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Reference Name |") || !strings.Contains(output, "Legacy Pro") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Reference Name") || !strings.Contains(output, "Legacy Pro") {
 		t.Fatalf("expected reference name in output, got: %s", output)
 	}
 }
@@ -625,7 +625,7 @@ func TestPrintMarkdown_OfferCodePrices(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Territory") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "PRICE-1") {
@@ -705,7 +705,7 @@ func TestPrintMarkdown_IAPOfferCodePrices(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Territory") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "PRICE-1") {
@@ -749,7 +749,7 @@ func TestPrintMarkdown_TerritoryResponse(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Currency |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Currency") {
 		t.Fatalf("expected currency header, got: %s", output)
 	}
 	if !strings.Contains(output, "USD") {
@@ -823,7 +823,7 @@ func TestPrintMarkdown_WinBackOffers(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "offer-2") {
@@ -891,7 +891,7 @@ func TestPrintMarkdown_WinBackOfferPrices(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "GBR") || !strings.Contains(output, "PRICE_POINT_2") {
@@ -972,7 +972,7 @@ func TestPrintMarkdown_Apps(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Bundle ID | SKU |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Bundle ID") || !strings.Contains(output, "SKU") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Demo App") {
@@ -1001,7 +1001,7 @@ func TestPrintMarkdown_TerritoryAgeRatings(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Territory | App Store Age Rating |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "App Store Age Rating") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "CA") {
@@ -1058,7 +1058,7 @@ func TestPrintMarkdown_Actors(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Type | Name | Email | API Key ID |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "API Key ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "APIKEY123") {
@@ -1129,7 +1129,7 @@ func TestPrintMarkdown_AppStoreVersionLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale | Whats New |") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "Whats New") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "en-US") {
@@ -1152,7 +1152,7 @@ func TestPrintMarkdown_AppStoreVersionLocalization(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale | Whats New |") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "Whats New") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "en-US") {
@@ -1188,7 +1188,7 @@ func TestPrintMarkdown_AppStoreVersionLocalizationDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "loc-1") {
@@ -1258,7 +1258,7 @@ func TestPrintMarkdown_BetaBuildLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale | What to Test |") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "What to Test") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "en-US") {
@@ -1281,7 +1281,7 @@ func TestPrintMarkdown_BetaBuildLocalization(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale | What to Test |") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "What to Test") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "en-US") {
@@ -1317,7 +1317,7 @@ func TestPrintMarkdown_BetaBuildLocalizationDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "loc-1") {
@@ -1375,7 +1375,7 @@ func TestPrintMarkdown_AgeRatingDeclaration(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Field | Value |") {
+	if !strings.Contains(output, "Field") || !strings.Contains(output, "Value") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "true") {
@@ -1429,7 +1429,7 @@ func TestPrintMarkdown_AppInfoLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Locale | Name | Subtitle |") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "Subtitle") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Demo App") {
@@ -1467,7 +1467,7 @@ func TestPrintMarkdown_LocalizationUploadResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Locale | Action |") {
+	if !strings.Contains(output, "Locale") || !strings.Contains(output, "Action") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "loc-1") {
@@ -1517,7 +1517,7 @@ func TestPrintMarkdown_AppTags(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Visible In App Store |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Visible In App Store") {
 		t.Fatalf("expected app tags header, got: %s", output)
 	}
 	if !strings.Contains(output, "Strategy") {
@@ -1573,7 +1573,7 @@ func TestPrintMarkdown_PromotedPurchases(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Visible For All Users | Enabled | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Visible For All Users") {
 		t.Fatalf("expected promoted purchases header, got: %s", output)
 	}
 	if !strings.Contains(output, "promo-2") {
@@ -1627,7 +1627,7 @@ func TestPrintMarkdown_Nominations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Type | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Name") || !strings.Contains(output, "Type") {
 		t.Fatalf("expected nominations header, got: %s", output)
 	}
 	if !strings.Contains(output, "Spring Launch") {
@@ -1663,7 +1663,7 @@ func TestPrintMarkdown_NominationDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected delete markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "nom-1") {
@@ -1701,7 +1701,7 @@ func TestPrintMarkdown_Linkages(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Type | ID |") {
+	if !strings.Contains(output, "Type") || !strings.Contains(output, "ID") {
 		t.Fatalf("expected linkages header, got: %s", output)
 	}
 	if !strings.Contains(output, "territories") || !strings.Contains(output, "USA") {
@@ -1765,7 +1765,7 @@ func TestPrintMarkdown_ReviewSubmissions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "State") {
 		t.Fatalf("expected review submission markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "submission-1") || !strings.Contains(output, "READY_FOR_REVIEW") {
@@ -1821,7 +1821,7 @@ func TestPrintMarkdown_ReviewSubmissionItems(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | State |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "State") {
 		t.Fatalf("expected review item markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "item-1") || !strings.Contains(output, "appStoreVersions") {
@@ -1872,7 +1872,7 @@ func TestPrintMarkdown_BetaGroups(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Internal |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Internal") {
 		t.Fatalf("expected beta groups header, got: %s", output)
 	}
 	if !strings.Contains(output, "Beta") {
@@ -1926,7 +1926,7 @@ func TestPrintMarkdown_BetaTesters(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Email | Name | State | Invite |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Email") || !strings.Contains(output, "Invite") {
 		t.Fatalf("expected beta testers header, got: %s", output)
 	}
 	if !strings.Contains(output, "tester@example.com") {
@@ -1980,7 +1980,7 @@ func TestPrintMarkdown_Builds(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version | Uploaded | Processing | Expired |") {
+	if !strings.Contains(output, "Version") || !strings.Contains(output, "Uploaded") || !strings.Contains(output, "Processing") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "1.2.3") {
@@ -2038,7 +2038,7 @@ func TestPrintMarkdown_BuildIcons(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Type | Masked | Asset URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Masked") || !strings.Contains(output, "Asset URL") {
 		t.Fatalf("expected build icons markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "AppIcon") {
@@ -2106,7 +2106,7 @@ func TestPrintMarkdown_BuildBundles(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Bundle ID | Type |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Bundle ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "APP_CLIP") {
@@ -2170,7 +2170,7 @@ func TestPrintMarkdown_BuildBundleFileSizes(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Device Model | OS Version |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Device Model") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "4096") {
@@ -2222,7 +2222,7 @@ func TestPrintMarkdown_BetaAppClipInvocations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "URL") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "inv-1") {
@@ -2286,7 +2286,7 @@ func TestPrintMarkdown_AppClipDomainStatusResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Build Bundle ID | Available | Status ID |") {
+	if !strings.Contains(output, "Build Bundle ID") || !strings.Contains(output, "Status ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "example.com") {
@@ -2339,7 +2339,7 @@ func TestPrintMarkdown_BuildExpireAllResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Version | Uploaded | Age Days | Status |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Age Days") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "would-expire") {
@@ -2396,7 +2396,7 @@ func TestPrintMarkdown_AppStoreVersions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version | Platform |") {
+	if !strings.Contains(output, "Version") || !strings.Contains(output, "Platform") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "READY_FOR_REVIEW") {
@@ -2446,7 +2446,7 @@ func TestPrintMarkdown_BuildInfo(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version | Uploaded | Processing | Expired |") {
+	if !strings.Contains(output, "Version") || !strings.Contains(output, "Uploaded") || !strings.Contains(output, "Processing") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "2.0.0") {
@@ -2530,7 +2530,7 @@ func TestPrintMarkdown_BuildUploadResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Upload ID | File ID |") {
+	if !strings.Contains(output, "Upload ID") || !strings.Contains(output, "File ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "UPLOAD_123") {
@@ -2597,7 +2597,7 @@ func TestPrintMarkdown_AppPreviewUploadResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Localization ID | Set ID | Preview Type |") {
+	if !strings.Contains(output, "Localization ID") || !strings.Contains(output, "Preview Type") {
 		t.Fatalf("expected preview header, got: %s", output)
 	}
 	if !strings.Contains(output, "PREVIEW_123") {
@@ -2677,7 +2677,7 @@ func TestPrintMarkdown_SubmissionResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Submission ID | Created Date |") {
+	if !strings.Contains(output, "Submission ID") || !strings.Contains(output, "Created Date") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "SUBMIT_123") {
@@ -2719,7 +2719,7 @@ func TestPrintMarkdown_SubmissionCreateResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Submission ID | Version ID | Build ID | Created Date |") {
+	if !strings.Contains(output, "Submission ID") || !strings.Contains(output, "Build ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "VERSION_123") {
@@ -2765,7 +2765,7 @@ func TestPrintMarkdown_SubmissionStatusResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Submission ID | Version ID | Version | Platform | State | Created Date |") {
+	if !strings.Contains(output, "Submission ID") || !strings.Contains(output, "Version ID") || !strings.Contains(output, "Platform") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "WAITING_FOR_REVIEW") {
@@ -2801,7 +2801,7 @@ func TestPrintMarkdown_SubmissionCancelResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Submission ID | Cancelled |") {
+	if !strings.Contains(output, "Submission ID") || !strings.Contains(output, "Cancelled") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "SUBMIT_123") {
@@ -2847,7 +2847,7 @@ func TestPrintMarkdown_AppStoreVersionDetailResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version ID | Version | Platform | State | Build ID |") {
+	if !strings.Contains(output, "Version ID") || !strings.Contains(output, "Build ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "SUBMIT_123") {
@@ -2899,7 +2899,7 @@ func TestPrintMarkdown_AppStoreVersionPhasedReleaseResponse(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Phased Release ID | State | Start Date | Current Day | Total Pause Duration |") {
+	if !strings.Contains(output, "Phased Release ID") || !strings.Contains(output, "Current Day") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "PHASED_123") {
@@ -2935,7 +2935,7 @@ func TestPrintMarkdown_AppStoreVersionPhasedReleaseDeleteResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Phased Release ID | Deleted |") {
+	if !strings.Contains(output, "Phased Release ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "PHASED_123") {
@@ -2973,7 +2973,7 @@ func TestPrintMarkdown_AppStoreVersionAttachBuildResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version ID | Build ID | Attached |") {
+	if !strings.Contains(output, "Version ID") || !strings.Contains(output, "Attached") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "VERSION_123") {
@@ -3009,7 +3009,7 @@ func TestPrintMarkdown_AppStoreVersionReleaseRequestResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Release Request ID | Version ID |") {
+	if !strings.Contains(output, "Release Request ID") || !strings.Contains(output, "Version ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "VERSION_123") {
@@ -3047,7 +3047,7 @@ func TestPrintMarkdown_BuildBetaGroupsUpdateResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Build ID | Group IDs | Action |") {
+	if !strings.Contains(output, "Build ID") || !strings.Contains(output, "Group IDs") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "GROUP_1, GROUP_2") {
@@ -3085,7 +3085,7 @@ func TestPrintMarkdown_BuildIndividualTestersUpdateResult(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Build ID | Tester IDs | Action |") {
+	if !strings.Contains(output, "Build ID") || !strings.Contains(output, "Tester IDs") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "TESTER_1, TESTER_2") {
@@ -3121,7 +3121,7 @@ func TestPrintMarkdown_BuildUploadDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "upload-2") {
@@ -3157,7 +3157,7 @@ func TestPrintMarkdown_PromotedPurchaseDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "promo-2") {
@@ -3195,7 +3195,7 @@ func TestPrintMarkdown_AppPromotedPurchasesLinkResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| App ID | Promoted Purchase IDs | Action |") {
+	if !strings.Contains(output, "App ID") || !strings.Contains(output, "Promoted Purchase IDs") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "promo-1, promo-2") {
@@ -3264,7 +3264,7 @@ func TestPrintMarkdown_FinanceReportResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Vendor | Type | Region |") {
+	if !strings.Contains(output, "Vendor") || !strings.Contains(output, "Region") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "finance_report_2025-12_FINANCE_DETAIL_Z1.tsv.gz") {
@@ -3312,10 +3312,10 @@ func TestPrintMarkdown_FinanceRegionsResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Region | Currency | Code | Countries or Regions |") {
+	if !strings.Contains(output, "Region") || !strings.Contains(output, "Countries or Regions") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
-	if !strings.Contains(output, "| Americas | USD | US | United States |") {
+	if !strings.Contains(output, "Americas") || !strings.Contains(output, "United States") {
 		t.Fatalf("expected region row, got: %s", output)
 	}
 }
@@ -3333,7 +3333,7 @@ func TestPrintMarkdown_AnalyticsReportRequestResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Request ID |") {
+	if !strings.Contains(output, "Request ID") {
 		t.Fatalf("expected request header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "req-1") {
@@ -3427,7 +3427,7 @@ func TestPrintMarkdown_BetaTesterGroupsUpdateResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Tester ID | Group IDs | Action |") {
+	if !strings.Contains(output, "Tester ID") || !strings.Contains(output, "Group IDs") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "group-1,group-2") {
@@ -3465,7 +3465,7 @@ func TestPrintMarkdown_SandboxTesterClearHistoryResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Request ID | Tester ID | Cleared |") {
+	if !strings.Contains(output, "Request ID") || !strings.Contains(output, "Cleared") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "request-1") {
@@ -3520,7 +3520,7 @@ func TestPrintMarkdown_Devices(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | UDID | Platform | Status |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "UDID") || !strings.Contains(output, "Platform") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "UDID-1") {
@@ -3570,7 +3570,7 @@ func TestPrintMarkdown_AccessibilityDeclaration(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Field | Value |") {
+	if !strings.Contains(output, "Field") || !strings.Contains(output, "Value") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Supports Voiceover") {
@@ -3626,7 +3626,7 @@ func TestPrintMarkdown_AppStoreReviewDetail(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Contact | Email |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Contact") || !strings.Contains(output, "Email") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Dev Example") {
@@ -3681,7 +3681,7 @@ func TestPrintMarkdown_AppStoreReviewAttachment(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Field | Value |") {
+	if !strings.Contains(output, "Field") || !strings.Contains(output, "Value") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "File Name") {
@@ -3739,7 +3739,7 @@ func TestPrintMarkdown_EndAppAvailabilityPreOrder(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID |") {
+	if !strings.Contains(output, "ID") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "end-1") {
@@ -3793,7 +3793,7 @@ func TestPrintMarkdown_RoutingAppCoverage(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Field | Value |") {
+	if !strings.Contains(output, "Field") || !strings.Contains(output, "Value") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "File Name") {
@@ -3873,7 +3873,7 @@ func TestPrintMarkdown_AppEncryptionDeclaration(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Field | Value |") {
+	if !strings.Contains(output, "Field") || !strings.Contains(output, "Value") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "App Description") {
@@ -3953,10 +3953,10 @@ func TestPrintMarkdown_PerfPowerMetrics(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version | Products |") {
+	if !strings.Contains(output, "Version") || !strings.Contains(output, "Products") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
-	if !strings.Contains(output, "| 1 | 1 |") {
+	if !strings.Contains(output, "1") {
 		t.Fatalf("expected summary values in output, got: %s", output)
 	}
 }
@@ -4000,10 +4000,10 @@ func TestPrintMarkdown_DiagnosticLogs(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Version | Products | Logs | Insights |") {
+	if !strings.Contains(output, "Version") || !strings.Contains(output, "Products") || !strings.Contains(output, "Insights") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
-	if !strings.Contains(output, "| 1 | 2 | 3 | 1 |") {
+	if !strings.Contains(output, "2") || !strings.Contains(output, "3") {
 		t.Fatalf("expected summary values in output, got: %s", output)
 	}
 }
@@ -4065,7 +4065,7 @@ func TestPrintMarkdown_MarketplaceSearchDetail(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Catalog URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Catalog URL") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "detail-1") {
@@ -4113,7 +4113,7 @@ func TestPrintMarkdown_MarketplaceWebhooks(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Endpoint URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Endpoint URL") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "webhook-1") {
@@ -4162,7 +4162,7 @@ func TestPrintMarkdown_AndroidToIosAppMappingDetail(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| Package Name |") {
+	if !strings.Contains(output, "Package Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "com.example.android") {
@@ -4216,7 +4216,7 @@ func TestPrintMarkdown_MarketplaceWebhookDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "webhook-1") {
@@ -4269,7 +4269,7 @@ func TestPrintMarkdown_AppEvents(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Reference Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Reference Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Launch Party") {
@@ -4296,7 +4296,7 @@ func TestPrintMarkdown_AppEvents_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Reference Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Reference Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -4345,7 +4345,7 @@ func TestPrintMarkdown_AppEventLocalizations(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Locale") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "fr-FR") {
@@ -4372,7 +4372,7 @@ func TestPrintMarkdown_AppEventLocalizations_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Locale |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Locale") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -4397,7 +4397,7 @@ func TestPrintMarkdown_AppEventScreenshots(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | File Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "File Name") {
 		t.Fatalf("expected screenshots markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "event.png") {
@@ -4440,7 +4440,7 @@ func TestPrintMarkdown_AppEventScreenshots_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | File Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "File Name") {
 		t.Fatalf("expected screenshots markdown header, got: %s", output)
 	}
 }
@@ -4521,7 +4521,7 @@ func TestPrintMarkdown_AppEventVideoClips(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | File Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "File Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "clip2.mov") {
@@ -4536,7 +4536,7 @@ func TestPrintMarkdown_AppEventVideoClips_Empty(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | File Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "File Name") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -4579,7 +4579,7 @@ func TestPrintMarkdown_AppEventSubmissionResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Submission ID |") {
+	if !strings.Contains(output, "Submission ID") {
 		t.Fatalf("expected submission markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "event-2") {
@@ -4609,7 +4609,7 @@ func TestPrintMarkdown_AppEventDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "event-3") {
@@ -4639,7 +4639,7 @@ func TestPrintMarkdown_AppEventLocalizationDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "loc-3") {

--- a/internal/asc/output_testflight.go
+++ b/internal/asc/output_testflight.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 )
@@ -22,7 +21,7 @@ func formatBetaReviewContactName(attr BetaAppReviewDetailAttributes) string {
 	}
 }
 
-func printBetaAppReviewDetailsTable(resp *BetaAppReviewDetailsResponse) error {
+func betaAppReviewDetailsRows(resp *BetaAppReviewDetailsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Contact", "Email", "Phone", "Demo Required", "Demo Account", "Notes"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -36,7 +35,12 @@ func printBetaAppReviewDetailsTable(resp *BetaAppReviewDetailsResponse) error {
 			compactWhitespace(item.Attributes.Notes),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppReviewDetailsTable(resp *BetaAppReviewDetailsResponse) error {
+	h, r := betaAppReviewDetailsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
@@ -47,19 +51,8 @@ func printBetaAppReviewDetailTable(resp *BetaAppReviewDetailResponse) error {
 }
 
 func printBetaAppReviewDetailsMarkdown(resp *BetaAppReviewDetailsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Contact | Email | Phone | Demo Required | Demo Account | Notes |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %t | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(formatBetaReviewContactName(item.Attributes)),
-			escapeMarkdown(item.Attributes.ContactEmail),
-			escapeMarkdown(item.Attributes.ContactPhone),
-			item.Attributes.DemoAccountRequired,
-			escapeMarkdown(item.Attributes.DemoAccountName),
-			escapeMarkdown(item.Attributes.Notes),
-		)
-	}
+	h, r := betaAppReviewDetailsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -69,7 +62,7 @@ func printBetaAppReviewDetailMarkdown(resp *BetaAppReviewDetailResponse) error {
 	})
 }
 
-func printBetaAppReviewSubmissionsTable(resp *BetaAppReviewSubmissionsResponse) error {
+func betaAppReviewSubmissionsRows(resp *BetaAppReviewSubmissionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Submitted Date"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -79,7 +72,12 @@ func printBetaAppReviewSubmissionsTable(resp *BetaAppReviewSubmissionsResponse) 
 			compactWhitespace(item.Attributes.SubmittedDate),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaAppReviewSubmissionsTable(resp *BetaAppReviewSubmissionsResponse) error {
+	h, r := betaAppReviewSubmissionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
@@ -90,15 +88,8 @@ func printBetaAppReviewSubmissionTable(resp *BetaAppReviewSubmissionResponse) er
 }
 
 func printBetaAppReviewSubmissionsMarkdown(resp *BetaAppReviewSubmissionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | State | Submitted Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.BetaReviewState),
-			escapeMarkdown(item.Attributes.SubmittedDate),
-		)
-	}
+	h, r := betaAppReviewSubmissionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -108,7 +99,7 @@ func printBetaAppReviewSubmissionMarkdown(resp *BetaAppReviewSubmissionResponse)
 	})
 }
 
-func printBuildBetaDetailsTable(resp *BuildBetaDetailsResponse) error {
+func buildBetaDetailsRows(resp *BuildBetaDetailsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Auto Notify", "Internal State", "External State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -119,7 +110,12 @@ func printBuildBetaDetailsTable(resp *BuildBetaDetailsResponse) error {
 			compactWhitespace(item.Attributes.ExternalBuildState),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBuildBetaDetailsTable(resp *BuildBetaDetailsResponse) error {
+	h, r := buildBetaDetailsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
@@ -130,16 +126,8 @@ func printBuildBetaDetailTable(resp *BuildBetaDetailResponse) error {
 }
 
 func printBuildBetaDetailsMarkdown(resp *BuildBetaDetailsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Auto Notify | Internal State | External State |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.AutoNotifyEnabled,
-			escapeMarkdown(item.Attributes.InternalBuildState),
-			escapeMarkdown(item.Attributes.ExternalBuildState),
-		)
-	}
+	h, r := buildBetaDetailsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -149,7 +137,7 @@ func printBuildBetaDetailMarkdown(resp *BuildBetaDetailResponse) error {
 	})
 }
 
-func printBetaRecruitmentCriterionOptionsTable(resp *BetaRecruitmentCriterionOptionsResponse) error {
+func betaRecruitmentCriterionOptionsRows(resp *BetaRecruitmentCriterionOptionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Device Family OS Versions"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -158,58 +146,58 @@ func printBetaRecruitmentCriterionOptionsTable(resp *BetaRecruitmentCriterionOpt
 			compactWhitespace(formatDeviceFamilyOsVersions(item.Attributes.DeviceFamilyOsVersions)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaRecruitmentCriterionOptionsTable(resp *BetaRecruitmentCriterionOptionsResponse) error {
+	h, r := betaRecruitmentCriterionOptionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaRecruitmentCriterionOptionsMarkdown(resp *BetaRecruitmentCriterionOptionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Device Family OS Versions |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(formatDeviceFamilyOsVersions(item.Attributes.DeviceFamilyOsVersions)),
-		)
-	}
+	h, r := betaRecruitmentCriterionOptionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaRecruitmentCriteriaTable(resp *BetaRecruitmentCriteriaResponse) error {
+func betaRecruitmentCriteriaRows(resp *BetaRecruitmentCriteriaResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Last Modified", "Filters"}
 	rows := [][]string{{
 		resp.Data.ID,
 		compactWhitespace(resp.Data.Attributes.LastModifiedDate),
 		compactWhitespace(formatDeviceFamilyOsVersionFilters(resp.Data.Attributes.DeviceFamilyOsVersionFilters)),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaRecruitmentCriteriaTable(resp *BetaRecruitmentCriteriaResponse) error {
+	h, r := betaRecruitmentCriteriaRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaRecruitmentCriteriaMarkdown(resp *BetaRecruitmentCriteriaResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Last Modified | Filters |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.LastModifiedDate),
-		escapeMarkdown(formatDeviceFamilyOsVersionFilters(resp.Data.Attributes.DeviceFamilyOsVersionFilters)),
-	)
+	h, r := betaRecruitmentCriteriaRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBetaRecruitmentCriteriaDeleteResultTable(result *BetaRecruitmentCriteriaDeleteResult) error {
+func betaRecruitmentCriteriaDeleteResultRows(result *BetaRecruitmentCriteriaDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaRecruitmentCriteriaDeleteResultTable(result *BetaRecruitmentCriteriaDeleteResult) error {
+	h, r := betaRecruitmentCriteriaDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaRecruitmentCriteriaDeleteResultMarkdown(result *BetaRecruitmentCriteriaDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := betaRecruitmentCriteriaDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -271,7 +259,7 @@ func formatMetricAttributes(attrs BetaGroupMetricAttributes) string {
 	return strings.Join(parts, ", ")
 }
 
-func printBetaGroupMetricsTable(items []Resource[BetaGroupMetricAttributes]) error {
+func betaGroupMetricsRows(items []Resource[BetaGroupMetricAttributes]) ([]string, [][]string) {
 	headers := []string{"ID", "Attributes"}
 	rows := make([][]string, 0, len(items))
 	for _, item := range items {
@@ -280,18 +268,17 @@ func printBetaGroupMetricsTable(items []Resource[BetaGroupMetricAttributes]) err
 			compactWhitespace(formatMetricAttributes(item.Attributes)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBetaGroupMetricsTable(items []Resource[BetaGroupMetricAttributes]) error {
+	h, r := betaGroupMetricsRows(items)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBetaGroupMetricsMarkdown(items []Resource[BetaGroupMetricAttributes]) error {
-	fmt.Fprintln(os.Stdout, "| ID | Attributes |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range items {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(formatMetricAttributes(item.Attributes)),
-		)
-	}
+	h, r := betaGroupMetricsRows(items)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_versions.go
+++ b/internal/asc/output_versions.go
@@ -1,9 +1,6 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // AppStoreVersionSubmissionResult represents CLI output for submissions.
 type AppStoreVersionSubmissionResult struct {
@@ -59,7 +56,7 @@ type AppStoreVersionReleaseRequestResult struct {
 	VersionID        string `json:"versionId"`
 }
 
-func printAppStoreVersionsTable(resp *AppStoreVersionsResponse) error {
+func appStoreVersionsRows(resp *AppStoreVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "Platform", "State", "Created"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -75,11 +72,22 @@ func printAppStoreVersionsTable(resp *AppStoreVersionsResponse) error {
 			item.Attributes.CreatedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionsTable(resp *AppStoreVersionsResponse) error {
+	h, r := appStoreVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
-func printPreReleaseVersionsTable(resp *PreReleaseVersionsResponse) error {
+func printAppStoreVersionsMarkdown(resp *AppStoreVersionsResponse) error {
+	h, r := appStoreVersionsRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func preReleaseVersionsRows(resp *PreReleaseVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "Platform"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -89,90 +97,124 @@ func printPreReleaseVersionsTable(resp *PreReleaseVersionsResponse) error {
 			string(item.Attributes.Platform),
 		})
 	}
-	RenderTable(headers, rows)
-	return nil
+	return headers, rows
 }
 
-func printAppStoreVersionsMarkdown(resp *AppStoreVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | Platform | State | Created |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		state := item.Attributes.AppVersionState
-		if state == "" {
-			state = item.Attributes.AppStoreState
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.VersionString),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(state),
-			escapeMarkdown(item.Attributes.CreatedDate),
-		)
-	}
+func printPreReleaseVersionsTable(resp *PreReleaseVersionsResponse) error {
+	h, r := preReleaseVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printPreReleaseVersionsMarkdown(resp *PreReleaseVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | Platform |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(string(item.Attributes.Platform)),
-		)
-	}
+	h, r := preReleaseVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppStoreVersionSubmissionTable(result *AppStoreVersionSubmissionResult) error {
+func appStoreVersionSubmissionRows(result *AppStoreVersionSubmissionResult) ([]string, [][]string) {
 	headers := []string{"Submission ID", "Created Date"}
 	createdDate := ""
 	if result.CreatedDate != nil {
 		createdDate = *result.CreatedDate
 	}
 	rows := [][]string{{result.SubmissionID, createdDate}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionSubmissionTable(result *AppStoreVersionSubmissionResult) error {
+	h, r := appStoreVersionSubmissionRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
-func printAppStoreVersionSubmissionCreateTable(result *AppStoreVersionSubmissionCreateResult) error {
+func printAppStoreVersionSubmissionMarkdown(result *AppStoreVersionSubmissionResult) error {
+	h, r := appStoreVersionSubmissionRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionSubmissionCreateRows(result *AppStoreVersionSubmissionCreateResult) ([]string, [][]string) {
 	headers := []string{"Submission ID", "Version ID", "Build ID", "Created Date"}
 	createdDate := ""
 	if result.CreatedDate != nil {
 		createdDate = *result.CreatedDate
 	}
 	rows := [][]string{{result.SubmissionID, result.VersionID, result.BuildID, createdDate}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionSubmissionCreateTable(result *AppStoreVersionSubmissionCreateResult) error {
+	h, r := appStoreVersionSubmissionCreateRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
-func printAppStoreVersionSubmissionStatusTable(result *AppStoreVersionSubmissionStatusResult) error {
+func printAppStoreVersionSubmissionCreateMarkdown(result *AppStoreVersionSubmissionCreateResult) error {
+	h, r := appStoreVersionSubmissionCreateRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionSubmissionStatusRows(result *AppStoreVersionSubmissionStatusResult) ([]string, [][]string) {
 	headers := []string{"Submission ID", "Version ID", "Version", "Platform", "State", "Created Date"}
 	createdDate := ""
 	if result.CreatedDate != nil {
 		createdDate = *result.CreatedDate
 	}
 	rows := [][]string{{result.ID, result.VersionID, result.VersionString, result.Platform, result.State, createdDate}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppStoreVersionSubmissionStatusTable(result *AppStoreVersionSubmissionStatusResult) error {
+	h, r := appStoreVersionSubmissionStatusRows(result)
+	RenderTable(h, r)
 	return nil
+}
+
+func printAppStoreVersionSubmissionStatusMarkdown(result *AppStoreVersionSubmissionStatusResult) error {
+	h, r := appStoreVersionSubmissionStatusRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionSubmissionCancelRows(result *AppStoreVersionSubmissionCancelResult) ([]string, [][]string) {
+	headers := []string{"Submission ID", "Cancelled"}
+	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Cancelled)}}
+	return headers, rows
 }
 
 func printAppStoreVersionSubmissionCancelTable(result *AppStoreVersionSubmissionCancelResult) error {
-	headers := []string{"Submission ID", "Cancelled"}
-	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Cancelled)}}
-	RenderTable(headers, rows)
+	h, r := appStoreVersionSubmissionCancelRows(result)
+	RenderTable(h, r)
 	return nil
+}
+
+func printAppStoreVersionSubmissionCancelMarkdown(result *AppStoreVersionSubmissionCancelResult) error {
+	h, r := appStoreVersionSubmissionCancelRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionDetailRows(result *AppStoreVersionDetailResult) ([]string, [][]string) {
+	headers := []string{"Version ID", "Version", "Platform", "State", "Build ID", "Build Version", "Submission ID"}
+	rows := [][]string{{result.ID, result.VersionString, result.Platform, result.State, result.BuildID, result.BuildVersion, result.SubmissionID}}
+	return headers, rows
 }
 
 func printAppStoreVersionDetailTable(result *AppStoreVersionDetailResult) error {
-	headers := []string{"Version ID", "Version", "Platform", "State", "Build ID", "Build Version", "Submission ID"}
-	rows := [][]string{{result.ID, result.VersionString, result.Platform, result.State, result.BuildID, result.BuildVersion, result.SubmissionID}}
-	RenderTable(headers, rows)
+	h, r := appStoreVersionDetailRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
-func printAppStoreVersionPhasedReleaseTable(resp *AppStoreVersionPhasedReleaseResponse) error {
+func printAppStoreVersionDetailMarkdown(result *AppStoreVersionDetailResult) error {
+	h, r := appStoreVersionDetailRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionPhasedReleaseRows(resp *AppStoreVersionPhasedReleaseResponse) ([]string, [][]string) {
 	headers := []string{"Phased Release ID", "State", "Start Date", "Current Day", "Total Pause Duration"}
 	attrs := resp.Data.Attributes
 	rows := [][]string{{
@@ -182,145 +224,71 @@ func printAppStoreVersionPhasedReleaseTable(resp *AppStoreVersionPhasedReleaseRe
 		fmt.Sprintf("%d", attrs.CurrentDayNumber),
 		fmt.Sprintf("%d", attrs.TotalPauseDuration),
 	}}
-	RenderTable(headers, rows)
-	return nil
+	return headers, rows
 }
 
-func printAppStoreVersionPhasedReleaseDeleteResultTable(result *AppStoreVersionPhasedReleaseDeleteResult) error {
-	headers := []string{"Phased Release ID", "Deleted"}
-	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
-	return nil
-}
-
-func printAppStoreVersionAttachBuildTable(result *AppStoreVersionAttachBuildResult) error {
-	headers := []string{"Version ID", "Build ID", "Attached"}
-	rows := [][]string{{result.VersionID, result.BuildID, fmt.Sprintf("%t", result.Attached)}}
-	RenderTable(headers, rows)
-	return nil
-}
-
-func printAppStoreVersionReleaseRequestTable(result *AppStoreVersionReleaseRequestResult) error {
-	headers := []string{"Release Request ID", "Version ID"}
-	rows := [][]string{{result.ReleaseRequestID, result.VersionID}}
-	RenderTable(headers, rows)
-	return nil
-}
-
-func printAppStoreVersionSubmissionMarkdown(result *AppStoreVersionSubmissionResult) error {
-	fmt.Fprintln(os.Stdout, "| Submission ID | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	createdDate := ""
-	if result.CreatedDate != nil {
-		createdDate = *result.CreatedDate
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-		escapeMarkdown(result.SubmissionID),
-		escapeMarkdown(createdDate),
-	)
-	return nil
-}
-
-func printAppStoreVersionSubmissionCreateMarkdown(result *AppStoreVersionSubmissionCreateResult) error {
-	fmt.Fprintln(os.Stdout, "| Submission ID | Version ID | Build ID | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	createdDate := ""
-	if result.CreatedDate != nil {
-		createdDate = *result.CreatedDate
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-		escapeMarkdown(result.SubmissionID),
-		escapeMarkdown(result.VersionID),
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(createdDate),
-	)
-	return nil
-}
-
-func printAppStoreVersionSubmissionStatusMarkdown(result *AppStoreVersionSubmissionStatusResult) error {
-	fmt.Fprintln(os.Stdout, "| Submission ID | Version ID | Version | Platform | State | Created Date |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	createdDate := ""
-	if result.CreatedDate != nil {
-		createdDate = *result.CreatedDate
-	}
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.VersionID),
-		escapeMarkdown(result.VersionString),
-		escapeMarkdown(result.Platform),
-		escapeMarkdown(result.State),
-		escapeMarkdown(createdDate),
-	)
-	return nil
-}
-
-func printAppStoreVersionSubmissionCancelMarkdown(result *AppStoreVersionSubmissionCancelResult) error {
-	fmt.Fprintln(os.Stdout, "| Submission ID | Cancelled |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Cancelled,
-	)
-	return nil
-}
-
-func printAppStoreVersionDetailMarkdown(result *AppStoreVersionDetailResult) error {
-	fmt.Fprintln(os.Stdout, "| Version ID | Version | Platform | State | Build ID | Build Version | Submission ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.VersionString),
-		escapeMarkdown(result.Platform),
-		escapeMarkdown(result.State),
-		escapeMarkdown(result.BuildID),
-		escapeMarkdown(result.BuildVersion),
-		escapeMarkdown(result.SubmissionID),
-	)
+func printAppStoreVersionPhasedReleaseTable(resp *AppStoreVersionPhasedReleaseResponse) error {
+	h, r := appStoreVersionPhasedReleaseRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionPhasedReleaseMarkdown(resp *AppStoreVersionPhasedReleaseResponse) error {
-	fmt.Fprintln(os.Stdout, "| Phased Release ID | State | Start Date | Current Day | Total Pause Duration |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	attrs := resp.Data.Attributes
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %d |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(string(attrs.PhasedReleaseState)),
-		escapeMarkdown(attrs.StartDate),
-		attrs.CurrentDayNumber,
-		attrs.TotalPauseDuration,
-	)
+	h, r := appStoreVersionPhasedReleaseRows(resp)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionPhasedReleaseDeleteResultRows(result *AppStoreVersionPhasedReleaseDeleteResult) ([]string, [][]string) {
+	headers := []string{"Phased Release ID", "Deleted"}
+	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
+	return headers, rows
+}
+
+func printAppStoreVersionPhasedReleaseDeleteResultTable(result *AppStoreVersionPhasedReleaseDeleteResult) error {
+	h, r := appStoreVersionPhasedReleaseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionPhasedReleaseDeleteResultMarkdown(result *AppStoreVersionPhasedReleaseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| Phased Release ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := appStoreVersionPhasedReleaseDeleteResultRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionAttachBuildRows(result *AppStoreVersionAttachBuildResult) ([]string, [][]string) {
+	headers := []string{"Version ID", "Build ID", "Attached"}
+	rows := [][]string{{result.VersionID, result.BuildID, fmt.Sprintf("%t", result.Attached)}}
+	return headers, rows
+}
+
+func printAppStoreVersionAttachBuildTable(result *AppStoreVersionAttachBuildResult) error {
+	h, r := appStoreVersionAttachBuildRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionAttachBuildMarkdown(result *AppStoreVersionAttachBuildResult) error {
-	fmt.Fprintln(os.Stdout, "| Version ID | Build ID | Attached |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %t |\n",
-		escapeMarkdown(result.VersionID),
-		escapeMarkdown(result.BuildID),
-		result.Attached,
-	)
+	h, r := appStoreVersionAttachBuildRows(result)
+	RenderMarkdown(h, r)
+	return nil
+}
+
+func appStoreVersionReleaseRequestRows(result *AppStoreVersionReleaseRequestResult) ([]string, [][]string) {
+	headers := []string{"Release Request ID", "Version ID"}
+	rows := [][]string{{result.ReleaseRequestID, result.VersionID}}
+	return headers, rows
+}
+
+func printAppStoreVersionReleaseRequestTable(result *AppStoreVersionReleaseRequestResult) error {
+	h, r := appStoreVersionReleaseRequestRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppStoreVersionReleaseRequestMarkdown(result *AppStoreVersionReleaseRequestResult) error {
-	fmt.Fprintln(os.Stdout, "| Release Request ID | Version ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-		escapeMarkdown(result.ReleaseRequestID),
-		escapeMarkdown(result.VersionID),
-	)
+	h, r := appStoreVersionReleaseRequestRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_webhooks.go
+++ b/internal/asc/output_webhooks.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -24,7 +23,7 @@ func webhookEventTypes(values []WebhookEventType) string {
 	return strings.Join(items, ", ")
 }
 
-func printWebhooksTable(resp *WebhooksResponse) error {
+func webhooksRows(resp *WebhooksResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Enabled", "URL", "Events"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -36,26 +35,22 @@ func printWebhooksTable(resp *WebhooksResponse) error {
 			compactWhitespace(webhookEventTypes(item.Attributes.EventTypes)),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printWebhooksTable(resp *WebhooksResponse) error {
+	h, r := webhooksRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printWebhooksMarkdown(resp *WebhooksResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Enabled | URL | Events |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(strconv.FormatBool(item.Attributes.Enabled)),
-			escapeMarkdown(item.Attributes.URL),
-			escapeMarkdown(webhookEventTypes(item.Attributes.EventTypes)),
-		)
-	}
+	h, r := webhooksRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printWebhookDeliveriesTable(resp *WebhookDeliveriesResponse) error {
+func webhookDeliveriesRows(resp *WebhookDeliveriesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Created", "Sent", "Error"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -67,49 +62,53 @@ func printWebhookDeliveriesTable(resp *WebhookDeliveriesResponse) error {
 			compactWhitespace(item.Attributes.ErrorMessage),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printWebhookDeliveriesTable(resp *WebhookDeliveriesResponse) error {
+	h, r := webhookDeliveriesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printWebhookDeliveriesMarkdown(resp *WebhookDeliveriesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | State | Created | Sent | Error |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.DeliveryState),
-			escapeMarkdown(item.Attributes.CreatedDate),
-			escapeMarkdown(item.Attributes.SentDate),
-			escapeMarkdown(item.Attributes.ErrorMessage),
-		)
-	}
+	h, r := webhookDeliveriesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printWebhookDeleteResultTable(result *WebhookDeleteResult) error {
+func webhookDeleteResultRows(result *WebhookDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printWebhookDeleteResultTable(result *WebhookDeleteResult) error {
+	h, r := webhookDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printWebhookDeleteResultMarkdown(result *WebhookDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := webhookDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printWebhookPingTable(resp *WebhookPingResponse) error {
+func webhookPingRows(resp *WebhookPingResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := [][]string{{resp.Data.ID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printWebhookPingTable(resp *WebhookPingResponse) error {
+	h, r := webhookPingRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printWebhookPingMarkdown(resp *WebhookPingResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(resp.Data.ID))
+	h, r := webhookPingRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/output_webhooks_test.go
+++ b/internal/asc/output_webhooks_test.go
@@ -51,7 +51,7 @@ func TestPrintMarkdown_Webhooks(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Enabled | URL | Events |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Events") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "Build Updates") {
@@ -101,7 +101,7 @@ func TestPrintMarkdown_WebhookDeliveries(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | State | Created | Sent | Error |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "State") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "deliv-1") {
@@ -131,7 +131,7 @@ func TestPrintMarkdown_WebhookDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "wh-1") {

--- a/internal/asc/output_win_back_offers.go
+++ b/internal/asc/output_win_back_offers.go
@@ -3,7 +3,6 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 )
 
@@ -13,7 +12,7 @@ type WinBackOfferDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printWinBackOffersTable(resp *WinBackOffersResponse) error {
+func winBackOffersRows(resp *WinBackOffersResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name", "Offer ID", "Duration", "Mode", "Periods", "Paid Months", "Last Subscribed", "Wait Months", "Start Date", "End Date", "Priority", "Promotion Intent"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -34,79 +33,67 @@ func printWinBackOffersTable(resp *WinBackOffersResponse) error {
 			formatPromotionIntent(attrs.PromotionIntent),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printWinBackOffersTable(resp *WinBackOffersResponse) error {
+	h, r := winBackOffersRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printWinBackOffersMarkdown(resp *WinBackOffersResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Reference Name | Offer ID | Duration | Mode | Periods | Paid Months | Last Subscribed | Wait Months | Start Date | End Date | Priority | Promotion Intent |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		attrs := item.Attributes
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(attrs.ReferenceName),
-			escapeMarkdown(attrs.OfferID),
-			escapeMarkdown(string(attrs.Duration)),
-			escapeMarkdown(string(attrs.OfferMode)),
-			escapeMarkdown(formatInt(attrs.PeriodCount)),
-			escapeMarkdown(formatInt(attrs.CustomerEligibilityPaidSubscriptionDurationInMonths)),
-			escapeMarkdown(formatIntegerRange(attrs.CustomerEligibilityTimeSinceLastSubscribedInMonths)),
-			escapeMarkdown(formatOptionalInt(attrs.CustomerEligibilityWaitBetweenOffersInMonths)),
-			escapeMarkdown(attrs.StartDate),
-			escapeMarkdown(formatOptionalString(attrs.EndDate)),
-			escapeMarkdown(string(attrs.Priority)),
-			escapeMarkdown(formatPromotionIntent(attrs.PromotionIntent)),
-		)
-	}
+	h, r := winBackOffersRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printWinBackOfferPricesTable(resp *WinBackOfferPricesResponse) error {
+func winBackOfferPricesRows(resp *WinBackOfferPricesResponse) ([]string, [][]string, error) {
 	headers := []string{"ID", "Territory", "Price Point"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		territoryID, pricePointID, err := winBackOfferPriceRelationshipIDs(item.Relationships)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		rows = append(rows, []string{item.ID, territoryID, pricePointID})
 	}
-	RenderTable(headers, rows)
+	return headers, rows, nil
+}
+
+func printWinBackOfferPricesTable(resp *WinBackOfferPricesResponse) error {
+	h, r, err := winBackOfferPricesRows(resp)
+	if err != nil {
+		return err
+	}
+	RenderTable(h, r)
 	return nil
 }
 
 func printWinBackOfferPricesMarkdown(resp *WinBackOfferPricesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Territory | Price Point |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		territoryID, pricePointID, err := winBackOfferPriceRelationshipIDs(item.Relationships)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(territoryID),
-			escapeMarkdown(pricePointID),
-		)
+	h, r, err := winBackOfferPricesRows(resp)
+	if err != nil {
+		return err
 	}
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printWinBackOfferDeleteResultTable(result *WinBackOfferDeleteResult) error {
+func winBackOfferDeleteResultRows(result *WinBackOfferDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printWinBackOfferDeleteResultTable(result *WinBackOfferDeleteResult) error {
+	h, r := winBackOfferDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printWinBackOfferDeleteResultMarkdown(result *WinBackOfferDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := winBackOfferDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/pre_orders_output.go
+++ b/internal/asc/pre_orders_output.go
@@ -1,20 +1,19 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
-
-func printEndAppAvailabilityPreOrderTable(resp *EndAppAvailabilityPreOrderResponse) error {
+func endAppAvailabilityPreOrderRows(resp *EndAppAvailabilityPreOrderResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := [][]string{{resp.Data.ID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printEndAppAvailabilityPreOrderTable(resp *EndAppAvailabilityPreOrderResponse) error {
+	h, r := endAppAvailabilityPreOrderRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printEndAppAvailabilityPreOrderMarkdown(resp *EndAppAvailabilityPreOrderResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(resp.Data.ID))
+	h, r := endAppAvailabilityPreOrderRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/pricing_output.go
+++ b/internal/asc/pricing_output.go
@@ -1,33 +1,29 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
-func printTerritoriesTable(resp *TerritoriesResponse) error {
+func territoriesRows(resp *TerritoriesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Currency"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{item.ID, item.Attributes.Currency})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printTerritoriesTable(resp *TerritoriesResponse) error {
+	h, r := territoriesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printTerritoriesMarkdown(resp *TerritoriesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Currency |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Currency),
-		)
-	}
+	h, r := territoriesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPricePointsTable(resp *AppPricePointsV3Response) error {
+func appPricePointsRows(resp *AppPricePointsV3Response) ([]string, [][]string) {
 	headers := []string{"ID", "Customer Price", "Proceeds"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -37,24 +33,22 @@ func printAppPricePointsTable(resp *AppPricePointsV3Response) error {
 			item.Attributes.Proceeds,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPricePointsTable(resp *AppPricePointsV3Response) error {
+	h, r := appPricePointsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPricePointsMarkdown(resp *AppPricePointsV3Response) error {
-	fmt.Fprintln(os.Stdout, "| ID | Customer Price | Proceeds |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.CustomerPrice),
-			escapeMarkdown(item.Attributes.Proceeds),
-		)
-	}
+	h, r := appPricePointsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPricesTable(resp *AppPricesResponse) error {
+func appPricesRows(resp *AppPricesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Start Date", "End Date", "Manual"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -65,56 +59,58 @@ func printAppPricesTable(resp *AppPricesResponse) error {
 			fmt.Sprintf("%t", item.Attributes.Manual),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPricesTable(resp *AppPricesResponse) error {
+	h, r := appPricesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPricesMarkdown(resp *AppPricesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Start Date | End Date | Manual |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.StartDate),
-			escapeMarkdown(item.Attributes.EndDate),
-			item.Attributes.Manual,
-		)
-	}
+	h, r := appPricesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppPriceScheduleTable(resp *AppPriceScheduleResponse) error {
+func appPriceScheduleRows(resp *AppPriceScheduleResponse) ([]string, [][]string) {
 	headers := []string{"ID"}
 	rows := [][]string{{resp.Data.ID}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppPriceScheduleTable(resp *AppPriceScheduleResponse) error {
+	h, r := appPriceScheduleRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppPriceScheduleMarkdown(resp *AppPriceScheduleResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID |")
-	fmt.Fprintln(os.Stdout, "| --- |")
-	fmt.Fprintf(os.Stdout, "| %s |\n", escapeMarkdown(resp.Data.ID))
+	h, r := appPriceScheduleRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printAppAvailabilityTable(resp *AppAvailabilityV2Response) error {
+func appAvailabilityRows(resp *AppAvailabilityV2Response) ([]string, [][]string) {
 	headers := []string{"ID", "Available In New Territories"}
 	rows := [][]string{{resp.Data.ID, fmt.Sprintf("%t", resp.Data.Attributes.AvailableInNewTerritories)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printAppAvailabilityTable(resp *AppAvailabilityV2Response) error {
+	h, r := appAvailabilityRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printAppAvailabilityMarkdown(resp *AppAvailabilityV2Response) error {
-	fmt.Fprintln(os.Stdout, "| ID | Available In New Territories |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(resp.Data.ID),
-		resp.Data.Attributes.AvailableInNewTerritories,
-	)
+	h, r := appAvailabilityRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printTerritoryAvailabilitiesTable(resp *TerritoryAvailabilitiesResponse) error {
+func territoryAvailabilitiesRows(resp *TerritoryAvailabilitiesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Available", "Release Date", "Preorder Enabled"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -125,20 +121,17 @@ func printTerritoryAvailabilitiesTable(resp *TerritoryAvailabilitiesResponse) er
 			fmt.Sprintf("%t", item.Attributes.PreOrderEnabled),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printTerritoryAvailabilitiesTable(resp *TerritoryAvailabilitiesResponse) error {
+	h, r := territoryAvailabilitiesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printTerritoryAvailabilitiesMarkdown(resp *TerritoryAvailabilitiesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Available | Release Date | Preorder Enabled |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %t | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Available,
-			escapeMarkdown(item.Attributes.ReleaseDate),
-			item.Attributes.PreOrderEnabled,
-		)
-	}
+	h, r := territoryAvailabilitiesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/review_responses_output.go
+++ b/internal/asc/review_responses_output.go
@@ -1,11 +1,8 @@
 package asc
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
-func printCustomerReviewResponseTable(resp *CustomerReviewResponseResponse) error {
+func customerReviewResponseRows(resp *CustomerReviewResponseResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Last Modified", "Response Body"}
 	rows := [][]string{{
 		resp.Data.ID,
@@ -13,35 +10,35 @@ func printCustomerReviewResponseTable(resp *CustomerReviewResponseResponse) erro
 		sanitizeTerminal(resp.Data.Attributes.LastModified),
 		compactWhitespace(resp.Data.Attributes.ResponseBody),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCustomerReviewResponseTable(resp *CustomerReviewResponseResponse) error {
+	h, r := customerReviewResponseRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCustomerReviewResponseMarkdown(resp *CustomerReviewResponseResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | State | Last Modified | Response Body |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-		escapeMarkdown(resp.Data.ID),
-		escapeMarkdown(resp.Data.Attributes.State),
-		escapeMarkdown(resp.Data.Attributes.LastModified),
-		escapeMarkdown(resp.Data.Attributes.ResponseBody),
-	)
+	h, r := customerReviewResponseRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCustomerReviewResponseDeleteResultTable(result *CustomerReviewResponseDeleteResult) error {
+func customerReviewResponseDeleteResultRows(result *CustomerReviewResponseDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCustomerReviewResponseDeleteResultTable(result *CustomerReviewResponseDeleteResult) error {
+	h, r := customerReviewResponseDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCustomerReviewResponseDeleteResultMarkdown(result *CustomerReviewResponseDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := customerReviewResponseDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/review_submissions_output.go
+++ b/internal/asc/review_submissions_output.go
@@ -2,11 +2,10 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 )
 
-func printReviewSubmissionsTable(resp *ReviewSubmissionsResponse) error {
+func reviewSubmissionsRows(resp *ReviewSubmissionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Platform", "Submitted Date", "App ID", "Items"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -21,29 +20,22 @@ func printReviewSubmissionsTable(resp *ReviewSubmissionsResponse) error {
 			itemCount,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printReviewSubmissionsTable(resp *ReviewSubmissionsResponse) error {
+	h, r := reviewSubmissionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printReviewSubmissionsMarkdown(resp *ReviewSubmissionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | State | Platform | Submitted Date | App ID | Items |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		appID := reviewSubmissionAppID(item.Relationships)
-		itemCount := reviewSubmissionItemCount(item.Relationships)
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(string(item.Attributes.SubmissionState)),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(item.Attributes.SubmittedDate),
-			escapeMarkdown(appID),
-			escapeMarkdown(itemCount),
-		)
-	}
+	h, r := reviewSubmissionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printReviewSubmissionItemsTable(resp *ReviewSubmissionItemsResponse) error {
+func reviewSubmissionItemsRows(resp *ReviewSubmissionItemsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Item Type", "Item ID", "Submission ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -57,41 +49,36 @@ func printReviewSubmissionItemsTable(resp *ReviewSubmissionItemsResponse) error 
 			sanitizeTerminal(submissionID),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printReviewSubmissionItemsTable(resp *ReviewSubmissionItemsResponse) error {
+	h, r := reviewSubmissionItemsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printReviewSubmissionItemsMarkdown(resp *ReviewSubmissionItemsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | State | Item Type | Item ID | Submission ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		itemType, itemID := reviewSubmissionItemTarget(item.Relationships)
-		submissionID := reviewSubmissionItemSubmissionID(item.Relationships)
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.State),
-			escapeMarkdown(itemType),
-			escapeMarkdown(itemID),
-			escapeMarkdown(submissionID),
-		)
-	}
+	h, r := reviewSubmissionItemsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printReviewSubmissionItemDeleteResultTable(result *ReviewSubmissionItemDeleteResult) error {
+func reviewSubmissionItemDeleteResultRows(result *ReviewSubmissionItemDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printReviewSubmissionItemDeleteResultTable(result *ReviewSubmissionItemDeleteResult) error {
+	h, r := reviewSubmissionItemDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printReviewSubmissionItemDeleteResultMarkdown(result *ReviewSubmissionItemDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := reviewSubmissionItemDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/sandbox_output.go
+++ b/internal/asc/sandbox_output.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -17,7 +16,7 @@ func formatSandboxTesterName(attr SandboxTesterAttributes) string {
 	return compactWhitespace(strings.TrimSpace(attr.FirstName + " " + attr.LastName))
 }
 
-func printSandboxTestersTable(resp *SandboxTestersResponse) error {
+func sandboxTestersRows(resp *SandboxTestersResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Email", "Name", "Territory"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -28,42 +27,39 @@ func printSandboxTestersTable(resp *SandboxTestersResponse) error {
 			sandboxTesterTerritory(item.Attributes),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printSandboxTestersTable(resp *SandboxTestersResponse) error {
+	h, r := sandboxTestersRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printSandboxTestersMarkdown(resp *SandboxTestersResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Email | Name | Territory |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(sandboxTesterEmail(item.Attributes)),
-			escapeMarkdown(formatSandboxTesterName(item.Attributes)),
-			escapeMarkdown(sandboxTesterTerritory(item.Attributes)),
-		)
-	}
+	h, r := sandboxTestersRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printSandboxTesterClearHistoryResultTable(result *SandboxTesterClearHistoryResult) error {
+func sandboxTesterClearHistoryResultRows(result *SandboxTesterClearHistoryResult) ([]string, [][]string) {
 	headers := []string{"Request ID", "Tester ID", "Cleared"}
 	rows := [][]string{{
 		result.RequestID,
 		result.TesterID,
 		fmt.Sprintf("%t", result.Cleared),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printSandboxTesterClearHistoryResultTable(result *SandboxTesterClearHistoryResult) error {
+	h, r := sandboxTesterClearHistoryResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printSandboxTesterClearHistoryResultMarkdown(result *SandboxTesterClearHistoryResult) error {
-	fmt.Fprintln(os.Stdout, "| Request ID | Tester ID | Cleared |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %t |\n",
-		escapeMarkdown(result.RequestID),
-		escapeMarkdown(result.TesterID),
-		result.Cleared,
-	)
+	h, r := sandboxTesterClearHistoryResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/signing_output.go
+++ b/internal/asc/signing_output.go
@@ -3,7 +3,6 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -38,7 +37,7 @@ type ProfileDownloadResult struct {
 	OutputPath string `json:"outputPath"`
 }
 
-func printBundleIDsTable(resp *BundleIDsResponse) error {
+func bundleIDsRows(resp *BundleIDsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Identifier", "Platform", "Seed ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -50,26 +49,22 @@ func printBundleIDsTable(resp *BundleIDsResponse) error {
 			item.Attributes.SeedID,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBundleIDsTable(resp *BundleIDsResponse) error {
+	h, r := bundleIDsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBundleIDsMarkdown(resp *BundleIDsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Identifier | Platform | Seed ID |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.Identifier),
-			escapeMarkdown(string(item.Attributes.Platform)),
-			escapeMarkdown(item.Attributes.SeedID),
-		)
-	}
+	h, r := bundleIDsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBundleIDCapabilitiesTable(resp *BundleIDCapabilitiesResponse) error {
+func bundleIDCapabilitiesRows(resp *BundleIDCapabilitiesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Capability", "Settings"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -79,58 +74,58 @@ func printBundleIDCapabilitiesTable(resp *BundleIDCapabilitiesResponse) error {
 			formatCapabilitySettings(item.Attributes.Settings),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBundleIDCapabilitiesTable(resp *BundleIDCapabilitiesResponse) error {
+	h, r := bundleIDCapabilitiesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBundleIDCapabilitiesMarkdown(resp *BundleIDCapabilitiesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Capability | Settings |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(item.Attributes.CapabilityType),
-			escapeMarkdown(formatCapabilitySettings(item.Attributes.Settings)),
-		)
-	}
+	h, r := bundleIDCapabilitiesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBundleIDDeleteResultTable(result *BundleIDDeleteResult) error {
+func bundleIDDeleteResultRows(result *BundleIDDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBundleIDDeleteResultTable(result *BundleIDDeleteResult) error {
+	h, r := bundleIDDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBundleIDDeleteResultMarkdown(result *BundleIDDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := bundleIDDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printBundleIDCapabilityDeleteResultTable(result *BundleIDCapabilityDeleteResult) error {
+func bundleIDCapabilityDeleteResultRows(result *BundleIDCapabilityDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printBundleIDCapabilityDeleteResultTable(result *BundleIDCapabilityDeleteResult) error {
+	h, r := bundleIDCapabilityDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printBundleIDCapabilityDeleteResultMarkdown(result *BundleIDCapabilityDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := bundleIDCapabilityDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCertificatesTable(resp *CertificatesResponse) error {
+func certificatesRows(resp *CertificatesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Type", "Expiration", "Serial"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -142,43 +137,40 @@ func printCertificatesTable(resp *CertificatesResponse) error {
 			item.Attributes.SerialNumber,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCertificatesTable(resp *CertificatesResponse) error {
+	h, r := certificatesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCertificatesMarkdown(resp *CertificatesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Type | Expiration | Serial |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(certificateDisplayName(item.Attributes)),
-			escapeMarkdown(item.Attributes.CertificateType),
-			escapeMarkdown(item.Attributes.ExpirationDate),
-			escapeMarkdown(item.Attributes.SerialNumber),
-		)
-	}
+	h, r := certificatesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCertificateRevokeResultTable(result *CertificateRevokeResult) error {
+func certificateRevokeResultRows(result *CertificateRevokeResult) ([]string, [][]string) {
 	headers := []string{"ID", "Revoked"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Revoked)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCertificateRevokeResultTable(result *CertificateRevokeResult) error {
+	h, r := certificateRevokeResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCertificateRevokeResultMarkdown(result *CertificateRevokeResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Revoked |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Revoked,
-	)
+	h, r := certificateRevokeResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printProfilesTable(resp *ProfilesResponse) error {
+func profilesRows(resp *ProfilesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Type", "State", "Expiration"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -190,61 +182,58 @@ func printProfilesTable(resp *ProfilesResponse) error {
 			item.Attributes.ExpirationDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printProfilesTable(resp *ProfilesResponse) error {
+	h, r := profilesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printProfilesMarkdown(resp *ProfilesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Type | State | Expiration |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			item.ID,
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.ProfileType),
-			escapeMarkdown(string(item.Attributes.ProfileState)),
-			escapeMarkdown(item.Attributes.ExpirationDate),
-		)
-	}
+	h, r := profilesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printProfileDeleteResultTable(result *ProfileDeleteResult) error {
+func profileDeleteResultRows(result *ProfileDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printProfileDeleteResultTable(result *ProfileDeleteResult) error {
+	h, r := profileDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printProfileDeleteResultMarkdown(result *ProfileDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n",
-		escapeMarkdown(result.ID),
-		result.Deleted,
-	)
+	h, r := profileDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printProfileDownloadResultTable(result *ProfileDownloadResult) error {
+func profileDownloadResultRows(result *ProfileDownloadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Output Path"}
 	rows := [][]string{{
 		result.ID,
 		compactWhitespace(result.Name),
 		result.OutputPath,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printProfileDownloadResultTable(result *ProfileDownloadResult) error {
+	h, r := profileDownloadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printProfileDownloadResultMarkdown(result *ProfileDownloadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Output Path |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.Name),
-		escapeMarkdown(result.OutputPath),
-	)
+	h, r := profileDownloadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -255,7 +244,7 @@ func joinSigningList(values []string) string {
 	return strings.Join(values, ", ")
 }
 
-func printSigningFetchResultTable(result *SigningFetchResult) error {
+func signingFetchResultRows(result *SigningFetchResult) ([]string, [][]string) {
 	headers := []string{"Bundle ID", "Bundle ID Resource", "Profile Type", "Profile ID", "Profile File", "Certificate IDs", "Certificate Files", "Created"}
 	rows := [][]string{{
 		result.BundleID,
@@ -267,23 +256,18 @@ func printSigningFetchResultTable(result *SigningFetchResult) error {
 		joinSigningList(result.CertificateFiles),
 		fmt.Sprintf("%t", result.Created),
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printSigningFetchResultTable(result *SigningFetchResult) error {
+	h, r := signingFetchResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printSigningFetchResultMarkdown(result *SigningFetchResult) error {
-	fmt.Fprintln(os.Stdout, "| Bundle ID | Bundle ID Resource | Profile Type | Profile ID | Profile File | Certificate IDs | Certificate Files | Created |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s | %s | %t |\n",
-		escapeMarkdown(result.BundleID),
-		escapeMarkdown(result.BundleIDResource),
-		escapeMarkdown(result.ProfileType),
-		escapeMarkdown(result.ProfileID),
-		escapeMarkdown(result.ProfileFile),
-		escapeMarkdown(joinSigningList(result.CertificateIDs)),
-		escapeMarkdown(joinSigningList(result.CertificateFiles)),
-		result.Created,
-	)
+	h, r := signingFetchResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/subscriptions_output_test.go
+++ b/internal/asc/subscriptions_output_test.go
@@ -52,7 +52,7 @@ func TestPrintMarkdown_SubscriptionPrices(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Territory | Price Point |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Territory") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 	if !strings.Contains(output, "PRICE_POINT_1") {
@@ -79,7 +79,7 @@ func TestPrintMarkdown_SubscriptionPriceDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header, got: %s", output)
 	}
 }
@@ -123,7 +123,7 @@ func TestPrintMarkdown_SubscriptionGracePeriod(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Opt In |") || !strings.Contains(output, "DAY_28") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Opt In") || !strings.Contains(output, "DAY_28") {
 		t.Fatalf("expected grace period fields in output, got: %s", output)
 	}
 }

--- a/internal/asc/table_render.go
+++ b/internal/asc/table_render.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 )
 
@@ -18,6 +19,29 @@ func RenderTable(headers []string, rows [][]string) {
 					AutoFormat: tw.Off,
 				},
 				Alignment: tw.CellAlignment{Global: tw.AlignCenter},
+			},
+			Row: tw.CellConfig{
+				Alignment: tw.CellAlignment{Global: tw.AlignLeft},
+			},
+		}),
+	)
+	table.Header(headers)
+	_ = table.Bulk(rows)
+	_ = table.Render()
+}
+
+// RenderMarkdown writes a Markdown-formatted table to stdout.
+// Headers preserve their original casing. Data rows are left-aligned.
+// Pipe characters in cell values are escaped automatically by the renderer.
+func RenderMarkdown(headers []string, rows [][]string) {
+	table := tablewriter.NewTable(os.Stdout,
+		tablewriter.WithRenderer(renderer.NewMarkdown()),
+		tablewriter.WithConfig(tablewriter.Config{
+			Header: tw.CellConfig{
+				Formatting: tw.CellFormatting{
+					AutoFormat: tw.Off,
+				},
+				Alignment: tw.CellAlignment{Global: tw.AlignLeft},
 			},
 			Row: tw.CellConfig{
 				Alignment: tw.CellAlignment{Global: tw.AlignLeft},

--- a/internal/asc/users_output.go
+++ b/internal/asc/users_output.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -29,7 +28,7 @@ func formatUserUsername(attr UserAttributes) string {
 	return strings.TrimSpace(attr.Email)
 }
 
-func printUsersTable(resp *UsersResponse) error {
+func usersRows(resp *UsersResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Username", "Name", "Roles", "All Apps", "Provisioning"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -42,27 +41,22 @@ func printUsersTable(resp *UsersResponse) error {
 			fmt.Sprintf("%t", item.Attributes.ProvisioningAllowed),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printUsersTable(resp *UsersResponse) error {
+	h, r := usersRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printUsersMarkdown(resp *UsersResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Username | Name | Roles | All Apps | Provisioning |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %t | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(formatUserUsername(item.Attributes)),
-			escapeMarkdown(formatPersonName(item.Attributes.FirstName, item.Attributes.LastName)),
-			escapeMarkdown(strings.Join(item.Attributes.Roles, ",")),
-			item.Attributes.AllAppsVisible,
-			item.Attributes.ProvisioningAllowed,
-		)
-	}
+	h, r := usersRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printUserInvitationsTable(resp *UserInvitationsResponse) error {
+func userInvitationsRows(resp *UserInvitationsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Email", "Name", "Roles", "All Apps", "Provisioning", "Expires"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -76,51 +70,53 @@ func printUserInvitationsTable(resp *UserInvitationsResponse) error {
 			compactWhitespace(item.Attributes.ExpirationDate),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printUserInvitationsTable(resp *UserInvitationsResponse) error {
+	h, r := userInvitationsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printUserInvitationsMarkdown(resp *UserInvitationsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Email | Name | Roles | All Apps | Provisioning | Expires |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %t | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Email),
-			escapeMarkdown(formatPersonName(item.Attributes.FirstName, item.Attributes.LastName)),
-			escapeMarkdown(strings.Join(item.Attributes.Roles, ",")),
-			item.Attributes.AllAppsVisible,
-			item.Attributes.ProvisioningAllowed,
-			escapeMarkdown(item.Attributes.ExpirationDate),
-		)
-	}
+	h, r := userInvitationsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printUserDeleteResultTable(result *UserDeleteResult) error {
+func userDeleteResultRows(result *UserDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printUserDeleteResultTable(result *UserDeleteResult) error {
+	h, r := userDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printUserDeleteResultMarkdown(result *UserDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := userDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printUserInvitationRevokeResultTable(result *UserInvitationRevokeResult) error {
+func userInvitationRevokeResultRows(result *UserInvitationRevokeResult) ([]string, [][]string) {
 	headers := []string{"ID", "Revoked"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Revoked)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printUserInvitationRevokeResultTable(result *UserInvitationRevokeResult) error {
+	h, r := userInvitationRevokeResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printUserInvitationRevokeResultMarkdown(result *UserInvitationRevokeResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Revoked |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Revoked)
+	h, r := userInvitationRevokeResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }

--- a/internal/asc/xcode_cloud_output.go
+++ b/internal/asc/xcode_cloud_output.go
@@ -2,7 +2,6 @@ package asc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -28,7 +27,7 @@ type CiProductDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func printXcodeCloudRunResultTable(result *XcodeCloudRunResult) error {
+func xcodeCloudRunResultRows(result *XcodeCloudRunResult) ([]string, [][]string) {
 	headers := []string{"Build Run ID", "Build #", "Workflow ID", "Workflow Name", "Git Ref ID", "Git Ref Name", "Progress", "Status", "Start Reason", "Created"}
 	rows := [][]string{{
 		result.BuildRunID,
@@ -42,29 +41,22 @@ func printXcodeCloudRunResultTable(result *XcodeCloudRunResult) error {
 		result.StartReason,
 		result.CreatedDate,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printXcodeCloudRunResultTable(result *XcodeCloudRunResult) error {
+	h, r := xcodeCloudRunResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printXcodeCloudRunResultMarkdown(result *XcodeCloudRunResult) error {
-	fmt.Fprintln(os.Stdout, "| Build Run ID | Build # | Workflow ID | Workflow Name | Git Ref ID | Git Ref Name | Progress | Status | Start Reason | Created |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(result.BuildRunID),
-		result.BuildNumber,
-		escapeMarkdown(result.WorkflowID),
-		escapeMarkdown(result.WorkflowName),
-		escapeMarkdown(result.GitReferenceID),
-		escapeMarkdown(result.GitReferenceName),
-		escapeMarkdown(result.ExecutionProgress),
-		escapeMarkdown(result.CompletionStatus),
-		escapeMarkdown(result.StartReason),
-		escapeMarkdown(result.CreatedDate),
-	)
+	h, r := xcodeCloudRunResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printXcodeCloudStatusResultTable(result *XcodeCloudStatusResult) error {
+func xcodeCloudStatusResultRows(result *XcodeCloudStatusResult) ([]string, [][]string) {
 	headers := []string{"Build Run ID", "Build #", "Workflow ID", "Progress", "Status", "Start Reason", "Cancel Reason", "Created", "Started", "Finished"}
 	rows := [][]string{{
 		result.BuildRunID,
@@ -78,29 +70,22 @@ func printXcodeCloudStatusResultTable(result *XcodeCloudStatusResult) error {
 		result.StartedDate,
 		result.FinishedDate,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printXcodeCloudStatusResultTable(result *XcodeCloudStatusResult) error {
+	h, r := xcodeCloudStatusResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printXcodeCloudStatusResultMarkdown(result *XcodeCloudStatusResult) error {
-	fmt.Fprintln(os.Stdout, "| Build Run ID | Build # | Workflow ID | Progress | Status | Start Reason | Cancel Reason | Created | Started | Finished |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s |\n",
-		escapeMarkdown(result.BuildRunID),
-		result.BuildNumber,
-		escapeMarkdown(result.WorkflowID),
-		escapeMarkdown(result.ExecutionProgress),
-		escapeMarkdown(result.CompletionStatus),
-		escapeMarkdown(result.StartReason),
-		escapeMarkdown(result.CancelReason),
-		escapeMarkdown(result.CreatedDate),
-		escapeMarkdown(result.StartedDate),
-		escapeMarkdown(result.FinishedDate),
-	)
+	h, r := xcodeCloudStatusResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiProductsTable(resp *CiProductsResponse) error {
+func ciProductsRows(resp *CiProductsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Bundle ID", "Type", "Created"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -112,26 +97,22 @@ func printCiProductsTable(resp *CiProductsResponse) error {
 			item.Attributes.CreatedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiProductsTable(resp *CiProductsResponse) error {
+	h, r := ciProductsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiProductsMarkdown(resp *CiProductsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Bundle ID | Type | Created |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.BundleID),
-			escapeMarkdown(item.Attributes.ProductType),
-			escapeMarkdown(item.Attributes.CreatedDate),
-		)
-	}
+	h, r := ciProductsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiWorkflowsTable(resp *CiWorkflowsResponse) error {
+func ciWorkflowsRows(resp *CiWorkflowsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Enabled", "Last Modified"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -142,25 +123,22 @@ func printCiWorkflowsTable(resp *CiWorkflowsResponse) error {
 			item.Attributes.LastModifiedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiWorkflowsTable(resp *CiWorkflowsResponse) error {
+	h, r := ciWorkflowsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiWorkflowsMarkdown(resp *CiWorkflowsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Enabled | Last Modified |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			item.Attributes.IsEnabled,
-			escapeMarkdown(item.Attributes.LastModifiedDate),
-		)
-	}
+	h, r := ciWorkflowsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printScmRepositoriesTable(resp *ScmRepositoriesResponse) error {
+func scmRepositoriesRows(resp *ScmRepositoriesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Owner", "Repository", "HTTP URL", "SSH URL", "Last Accessed"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -173,27 +151,22 @@ func printScmRepositoriesTable(resp *ScmRepositoriesResponse) error {
 			item.Attributes.LastAccessedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printScmRepositoriesTable(resp *ScmRepositoriesResponse) error {
+	h, r := scmRepositoriesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printScmRepositoriesMarkdown(resp *ScmRepositoriesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Owner | Repository | HTTP URL | SSH URL | Last Accessed |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.OwnerName),
-			escapeMarkdown(item.Attributes.RepositoryName),
-			escapeMarkdown(item.Attributes.HTTPCloneURL),
-			escapeMarkdown(item.Attributes.SSHCloneURL),
-			escapeMarkdown(item.Attributes.LastAccessedDate),
-		)
-	}
+	h, r := scmRepositoriesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printScmProvidersTable(resp *ScmProvidersResponse) error {
+func scmProvidersRows(resp *ScmProvidersResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Provider Type", "URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -203,20 +176,18 @@ func printScmProvidersTable(resp *ScmProvidersResponse) error {
 			item.Attributes.URL,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printScmProvidersTable(resp *ScmProvidersResponse) error {
+	h, r := scmProvidersRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printScmProvidersMarkdown(resp *ScmProvidersResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Provider Type | URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(formatScmProviderType(item.Attributes.ScmProviderType)),
-			escapeMarkdown(item.Attributes.URL),
-		)
-	}
+	h, r := scmProvidersRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -230,7 +201,7 @@ func formatScmProviderType(providerType *ScmProviderType) string {
 	return strings.TrimSpace(providerType.Kind)
 }
 
-func printScmGitReferencesTable(resp *ScmGitReferencesResponse) error {
+func scmGitReferencesRows(resp *ScmGitReferencesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Canonical Name", "Kind", "Deleted"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -242,26 +213,22 @@ func printScmGitReferencesTable(resp *ScmGitReferencesResponse) error {
 			fmt.Sprintf("%t", item.Attributes.IsDeleted),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printScmGitReferencesTable(resp *ScmGitReferencesResponse) error {
+	h, r := scmGitReferencesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printScmGitReferencesMarkdown(resp *ScmGitReferencesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Canonical Name | Kind | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %t |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.CanonicalName),
-			escapeMarkdown(item.Attributes.Kind),
-			item.Attributes.IsDeleted,
-		)
-	}
+	h, r := scmGitReferencesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printScmPullRequestsTable(resp *ScmPullRequestsResponse) error {
+func scmPullRequestsRows(resp *ScmPullRequestsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Number", "Title", "Source", "Destination", "Closed", "Cross Repo", "Web URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -276,29 +243,22 @@ func printScmPullRequestsTable(resp *ScmPullRequestsResponse) error {
 			item.Attributes.WebURL,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printScmPullRequestsTable(resp *ScmPullRequestsResponse) error {
+	h, r := scmPullRequestsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printScmPullRequestsMarkdown(resp *ScmPullRequestsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Number | Title | Source | Destination | Closed | Cross Repo | Web URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s | %s | %t | %t | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Number,
-			escapeMarkdown(item.Attributes.Title),
-			escapeMarkdown(formatScmRef(item.Attributes.SourceRepositoryOwner, item.Attributes.SourceRepositoryName, item.Attributes.SourceBranchName)),
-			escapeMarkdown(formatScmRef(item.Attributes.DestinationRepositoryOwner, item.Attributes.DestinationRepositoryName, item.Attributes.DestinationBranchName)),
-			item.Attributes.IsClosed,
-			item.Attributes.IsCrossRepository,
-			escapeMarkdown(item.Attributes.WebURL),
-		)
-	}
+	h, r := scmPullRequestsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiMacOsVersionsTable(resp *CiMacOsVersionsResponse) error {
+func ciMacOsVersionsRows(resp *CiMacOsVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "Name"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -308,24 +268,22 @@ func printCiMacOsVersionsTable(resp *CiMacOsVersionsResponse) error {
 			item.Attributes.Name,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiMacOsVersionsTable(resp *CiMacOsVersionsResponse) error {
+	h, r := ciMacOsVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiMacOsVersionsMarkdown(resp *CiMacOsVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | Name |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(item.Attributes.Name),
-		)
-	}
+	h, r := ciMacOsVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiXcodeVersionsTable(resp *CiXcodeVersionsResponse) error {
+func ciXcodeVersionsRows(resp *CiXcodeVersionsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Version", "Name"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -335,20 +293,18 @@ func printCiXcodeVersionsTable(resp *CiXcodeVersionsResponse) error {
 			item.Attributes.Name,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiXcodeVersionsTable(resp *CiXcodeVersionsResponse) error {
+	h, r := ciXcodeVersionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiXcodeVersionsMarkdown(resp *CiXcodeVersionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Version | Name |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.Version),
-			escapeMarkdown(item.Attributes.Name),
-		)
-	}
+	h, r := ciXcodeVersionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -373,7 +329,7 @@ func formatScmRepo(owner, repo string) string {
 	return fmt.Sprintf("%s/%s", owner, repo)
 }
 
-func printCiBuildRunsTable(resp *CiBuildRunsResponse) error {
+func ciBuildRunsRows(resp *CiBuildRunsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Build #", "Progress", "Status", "Start Reason", "Created", "Started", "Finished"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -388,29 +344,22 @@ func printCiBuildRunsTable(resp *CiBuildRunsResponse) error {
 			item.Attributes.FinishedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiBuildRunsTable(resp *CiBuildRunsResponse) error {
+	h, r := ciBuildRunsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiBuildRunsMarkdown(resp *CiBuildRunsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Build # | Progress | Status | Start Reason | Created | Started | Finished |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %d | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			item.Attributes.Number,
-			escapeMarkdown(string(item.Attributes.ExecutionProgress)),
-			escapeMarkdown(string(item.Attributes.CompletionStatus)),
-			escapeMarkdown(item.Attributes.StartReason),
-			escapeMarkdown(item.Attributes.CreatedDate),
-			escapeMarkdown(item.Attributes.StartedDate),
-			escapeMarkdown(item.Attributes.FinishedDate),
-		)
-	}
+	h, r := ciBuildRunsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiBuildActionsTable(resp *CiBuildActionsResponse) error {
+func ciBuildActionsRows(resp *CiBuildActionsResponse) ([]string, [][]string) {
 	headers := []string{"Name", "Type", "Progress", "Status", "Errors", "Warnings", "Started", "Finished"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -431,35 +380,22 @@ func printCiBuildActionsTable(resp *CiBuildActionsResponse) error {
 			item.Attributes.FinishedDate,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiBuildActionsTable(resp *CiBuildActionsResponse) error {
+	h, r := ciBuildActionsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiBuildActionsMarkdown(resp *CiBuildActionsResponse) error {
-	fmt.Fprintln(os.Stdout, "| Name | Type | Progress | Status | Errors | Warnings | Started | Finished |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		errors := 0
-		warnings := 0
-		if item.Attributes.IssueCounts != nil {
-			errors = item.Attributes.IssueCounts.Errors
-			warnings = item.Attributes.IssueCounts.Warnings
-		}
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %d | %d | %s | %s |\n",
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(item.Attributes.ActionType),
-			escapeMarkdown(string(item.Attributes.ExecutionProgress)),
-			escapeMarkdown(string(item.Attributes.CompletionStatus)),
-			errors,
-			warnings,
-			escapeMarkdown(item.Attributes.StartedDate),
-			escapeMarkdown(item.Attributes.FinishedDate),
-		)
-	}
+	h, r := ciBuildActionsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiArtifactsTable(resp *CiArtifactsResponse) error {
+func ciArtifactsRows(resp *CiArtifactsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Type", "Size", "Download URL"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -471,22 +407,18 @@ func printCiArtifactsTable(resp *CiArtifactsResponse) error {
 			item.Attributes.DownloadURL,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiArtifactsTable(resp *CiArtifactsResponse) error {
+	h, r := ciArtifactsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiArtifactsMarkdown(resp *CiArtifactsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Type | Size | Download URL |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.FileName),
-			escapeMarkdown(item.Attributes.FileType),
-			item.Attributes.FileSize,
-			escapeMarkdown(item.Attributes.DownloadURL),
-		)
-	}
+	h, r := ciArtifactsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -498,7 +430,7 @@ func printCiArtifactMarkdown(resp *CiArtifactResponse) error {
 	return printCiArtifactsMarkdown(&CiArtifactsResponse{Data: []CiArtifactResource{resp.Data}})
 }
 
-func printCiTestResultsTable(resp *CiTestResultsResponse) error {
+func ciTestResultsRows(resp *CiTestResultsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Class", "Name", "Status", "Duration"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -510,22 +442,18 @@ func printCiTestResultsTable(resp *CiTestResultsResponse) error {
 			formatTestDuration(item),
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiTestResultsTable(resp *CiTestResultsResponse) error {
+	h, r := ciTestResultsRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiTestResultsMarkdown(resp *CiTestResultsResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Class | Name | Status | Duration |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.ClassName),
-			escapeMarkdown(item.Attributes.Name),
-			escapeMarkdown(string(item.Attributes.Status)),
-			escapeMarkdown(formatTestDuration(item)),
-		)
-	}
+	h, r := ciTestResultsRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -537,7 +465,7 @@ func printCiTestResultMarkdown(resp *CiTestResultResponse) error {
 	return printCiTestResultsMarkdown(&CiTestResultsResponse{Data: []CiTestResultResource{resp.Data}})
 }
 
-func printCiIssuesTable(resp *CiIssuesResponse) error {
+func ciIssuesRows(resp *CiIssuesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Type", "File", "Line", "Message"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
@@ -550,23 +478,18 @@ func printCiIssuesTable(resp *CiIssuesResponse) error {
 			item.Attributes.Message,
 		})
 	}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiIssuesTable(resp *CiIssuesResponse) error {
+	h, r := ciIssuesRows(resp)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiIssuesMarkdown(resp *CiIssuesResponse) error {
-	fmt.Fprintln(os.Stdout, "| ID | Type | File | Line | Message |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- |")
-	for _, item := range resp.Data {
-		filePath, lineNumber := formatFileLocation(item.Attributes.FileSource)
-		fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s | %s |\n",
-			escapeMarkdown(item.ID),
-			escapeMarkdown(item.Attributes.IssueType),
-			escapeMarkdown(filePath),
-			escapeMarkdown(lineNumber),
-			escapeMarkdown(item.Attributes.Message),
-		)
-	}
+	h, r := ciIssuesRows(resp)
+	RenderMarkdown(h, r)
 	return nil
 }
 
@@ -578,7 +501,7 @@ func printCiIssueMarkdown(resp *CiIssueResponse) error {
 	return printCiIssuesMarkdown(&CiIssuesResponse{Data: []CiIssueResource{resp.Data}})
 }
 
-func printCiArtifactDownloadResultTable(result *CiArtifactDownloadResult) error {
+func ciArtifactDownloadResultRows(result *CiArtifactDownloadResult) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Type", "Size", "Bytes Written", "Output Path"}
 	rows := [][]string{{
 		result.ID,
@@ -588,49 +511,54 @@ func printCiArtifactDownloadResultTable(result *CiArtifactDownloadResult) error 
 		fmt.Sprintf("%d", result.BytesWritten),
 		result.OutputPath,
 	}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiArtifactDownloadResultTable(result *CiArtifactDownloadResult) error {
+	h, r := ciArtifactDownloadResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiArtifactDownloadResultMarkdown(result *CiArtifactDownloadResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Type | Size | Bytes Written | Output Path |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %s | %s | %d | %d | %s |\n",
-		escapeMarkdown(result.ID),
-		escapeMarkdown(result.FileName),
-		escapeMarkdown(result.FileType),
-		result.FileSize,
-		result.BytesWritten,
-		escapeMarkdown(result.OutputPath),
-	)
+	h, r := ciArtifactDownloadResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiWorkflowDeleteResultTable(result *CiWorkflowDeleteResult) error {
+func ciWorkflowDeleteResultRows(result *CiWorkflowDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiWorkflowDeleteResultTable(result *CiWorkflowDeleteResult) error {
+	h, r := ciWorkflowDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiWorkflowDeleteResultMarkdown(result *CiWorkflowDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := ciWorkflowDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 
-func printCiProductDeleteResultTable(result *CiProductDeleteResult) error {
+func ciProductDeleteResultRows(result *CiProductDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
-	RenderTable(headers, rows)
+	return headers, rows
+}
+
+func printCiProductDeleteResultTable(result *CiProductDeleteResult) error {
+	h, r := ciProductDeleteResultRows(result)
+	RenderTable(h, r)
 	return nil
 }
 
 func printCiProductDeleteResultMarkdown(result *CiProductDeleteResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Deleted |")
-	fmt.Fprintln(os.Stdout, "| --- | --- |")
-	fmt.Fprintf(os.Stdout, "| %s | %t |\n", escapeMarkdown(result.ID), result.Deleted)
+	h, r := ciProductDeleteResultRows(result)
+	RenderMarkdown(h, r)
 	return nil
 }
 

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -87,7 +87,7 @@ func TestPrintMarkdown_XcodeCloudRunResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Build Run ID |") {
+	if !strings.Contains(output, "Build Run ID") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "run-123") {
@@ -145,7 +145,7 @@ func TestPrintMarkdown_XcodeCloudStatusResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| Build Run ID |") {
+	if !strings.Contains(output, "Build Run ID") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "FAILED") {
@@ -199,7 +199,7 @@ func TestPrintMarkdown_CiProducts(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Bundle ID |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Bundle ID") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "MyApp") {
@@ -251,7 +251,7 @@ func TestPrintMarkdown_CiWorkflows(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Enabled |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Enabled") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "Deploy") {
@@ -310,7 +310,7 @@ func TestPrintMarkdown_CiBuildRuns(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Build # |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Build #") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "RUNNING") {
@@ -363,7 +363,7 @@ func TestPrintMarkdown_CiArtifacts(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Type |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Name") || !strings.Contains(output, "Type") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "Logs.zip") {
@@ -418,7 +418,7 @@ func TestPrintMarkdown_CiTestResults(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Class | Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Class") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "FAILURE") {
@@ -472,7 +472,7 @@ func TestPrintMarkdown_CiIssues(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Type | File |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Type") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "WARNING") {
@@ -586,7 +586,7 @@ func TestPrintMarkdown_ScmRepositories(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Owner | Repository |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Repository") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "example") {
@@ -642,7 +642,7 @@ func TestPrintMarkdown_ScmProviders(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Provider Type | URL |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Provider Type") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "gitlab.com") {
@@ -695,7 +695,7 @@ func TestPrintMarkdown_ScmGitReferences(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Name | Canonical Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Canonical Name") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "refs/tags/release") {
@@ -759,7 +759,7 @@ func TestPrintMarkdown_ScmPullRequests(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Number | Title |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Title") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "Fix bug") {
@@ -809,7 +809,7 @@ func TestPrintMarkdown_CiMacOsVersions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Version | Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Version") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "Ventura") {
@@ -859,7 +859,7 @@ func TestPrintMarkdown_CiXcodeVersions(t *testing.T) {
 		return PrintMarkdown(resp)
 	})
 
-	if !strings.Contains(output, "| ID | Version | Name |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Version") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "Xcode 14.3") {
@@ -889,7 +889,7 @@ func TestPrintMarkdown_CiWorkflowDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "wf-2") {
@@ -919,7 +919,7 @@ func TestPrintMarkdown_CiProductDeleteResult(t *testing.T) {
 		return PrintMarkdown(result)
 	})
 
-	if !strings.Contains(output, "| ID | Deleted |") {
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "Deleted") {
 		t.Fatalf("expected markdown header in output, got: %s", output)
 	}
 	if !strings.Contains(output, "prod-2") {

--- a/internal/cli/iap/prices.go
+++ b/internal/cli/iap/prices.go
@@ -1005,22 +1005,21 @@ func printIAPPricesTable(result *iapPricesResult) error {
 }
 
 func printIAPPricesMarkdown(result *iapPricesResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Product ID | Type | Base Territory | Current Price | Estimated Proceeds | Scheduled Changes |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- |")
+	headers := []string{"ID", "Name", "Product ID", "Type", "Base Territory", "Current Price", "Estimated Proceeds", "Scheduled Changes"}
+	rows := make([][]string, 0, len(result.IAPs))
 	for _, item := range result.IAPs {
-		fmt.Fprintf(
-			os.Stdout,
-			"| %s | %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeMarkdownCell(item.ID),
-			escapeMarkdownCell(item.Name),
-			escapeMarkdownCell(item.ProductID),
-			escapeMarkdownCell(item.Type),
-			escapeMarkdownCell(item.BaseTerritory),
-			escapeMarkdownCell(formatIAPMoney(item.CurrentPrice)),
-			escapeMarkdownCell(formatIAPMoney(item.EstimatedProceeds)),
-			escapeMarkdownCell(formatScheduledChanges(item.ScheduledChanges)),
-		)
+		rows = append(rows, []string{
+			item.ID,
+			compactIAPText(item.Name),
+			item.ProductID,
+			item.Type,
+			item.BaseTerritory,
+			formatIAPMoney(item.CurrentPrice),
+			formatIAPMoney(item.EstimatedProceeds),
+			formatScheduledChanges(item.ScheduledChanges),
+		})
 	}
+	asc.RenderMarkdown(headers, rows)
 	return nil
 }
 
@@ -1049,12 +1048,6 @@ func formatScheduledChanges(changes []iapScheduledChange) string {
 		)
 	}
 	return strings.Join(formatted, "; ")
-}
-
-func escapeMarkdownCell(value string) string {
-	value = strings.ReplaceAll(value, "|", "\\|")
-	value = strings.ReplaceAll(value, "\n", " ")
-	return strings.TrimSpace(value)
 }
 
 func compactIAPText(value string) string {

--- a/internal/cli/migrate/migrate_output.go
+++ b/internal/cli/migrate/migrate_output.go
@@ -16,10 +16,13 @@ func printMigrateImportResultMarkdown(result *MigrateImportResult) error {
 	// Version localizations
 	fmt.Println("### Version Localizations Found")
 	fmt.Println()
-	fmt.Println("| Locale | Fields |")
-	fmt.Println("|--------|--------|")
-	for _, loc := range result.Localizations {
-		fmt.Printf("| %s | %d |\n", loc.Locale, countNonEmptyFields(loc))
+	{
+		headers := []string{"Locale", "Fields"}
+		rows := make([][]string, 0, len(result.Localizations))
+		for _, loc := range result.Localizations {
+			rows = append(rows, []string{loc.Locale, fmt.Sprintf("%d", countNonEmptyFields(loc))})
+		}
+		asc.RenderMarkdown(headers, rows)
 	}
 
 	// App Info localizations
@@ -27,8 +30,8 @@ func printMigrateImportResultMarkdown(result *MigrateImportResult) error {
 		fmt.Println()
 		fmt.Println("### App Info Localizations Found")
 		fmt.Println()
-		fmt.Println("| Locale | Name | Subtitle |")
-		fmt.Println("|--------|------|----------|")
+		headers := []string{"Locale", "Name", "Subtitle"}
+		rows := make([][]string, 0, len(result.AppInfoLocalizations))
 		for _, loc := range result.AppInfoLocalizations {
 			name := "-"
 			if loc.Name != "" {
@@ -38,8 +41,9 @@ func printMigrateImportResultMarkdown(result *MigrateImportResult) error {
 			if loc.Subtitle != "" {
 				subtitle = "✓"
 			}
-			fmt.Printf("| %s | %s | %s |\n", loc.Locale, name, subtitle)
+			rows = append(rows, []string{loc.Locale, name, subtitle})
 		}
+		asc.RenderMarkdown(headers, rows)
 	}
 
 	if len(result.Uploaded) > 0 {
@@ -161,8 +165,8 @@ func printMigrateValidateResultMarkdown(result *MigrateValidateResult) error {
 		fmt.Println()
 		fmt.Println("### Issues")
 		fmt.Println()
-		fmt.Println("| Locale | Field | Severity | Message | Length | Limit |")
-		fmt.Println("|--------|-------|----------|---------|--------|-------|")
+		headers := []string{"Locale", "Field", "Severity", "Message", "Length", "Limit"}
+		rows := make([][]string, 0, len(result.Issues))
 		for _, issue := range result.Issues {
 			length := "-"
 			limit := "-"
@@ -172,9 +176,9 @@ func printMigrateValidateResultMarkdown(result *MigrateValidateResult) error {
 			if issue.Limit > 0 {
 				limit = fmt.Sprintf("%d", issue.Limit)
 			}
-			fmt.Printf("| %s | %s | %s | %s | %s | %s |\n",
-				issue.Locale, issue.Field, issue.Severity, issue.Message, length, limit)
+			rows = append(rows, []string{issue.Locale, issue.Field, issue.Severity, issue.Message, length, limit})
 		}
+		asc.RenderMarkdown(headers, rows)
 	}
 
 	return nil

--- a/internal/cli/reviews/reviews_ratings.go
+++ b/internal/cli/reviews/reviews_ratings.go
@@ -207,14 +207,17 @@ func printGlobalRatingsMarkdown(g *itunes.GlobalRatings) error {
 	}
 
 	fmt.Print("\n### By Country\n\n")
-	fmt.Println("| Country | Rating | Count |")
-	fmt.Println("|---------|--------|-------|")
-	for _, r := range g.ByCountry {
-		name := r.CountryName
-		if name == "" {
-			name = r.Country
+	{
+		headers := []string{"Country", "Rating", "Count"}
+		rows := make([][]string, 0, len(g.ByCountry))
+		for _, r := range g.ByCountry {
+			name := r.CountryName
+			if name == "" {
+				name = r.Country
+			}
+			rows = append(rows, []string{name, fmt.Sprintf("%.2f", r.AverageRating), formatNumber(r.RatingCount)})
 		}
-		fmt.Printf("| %s | %.2f | %s |\n", name, r.AverageRating, formatNumber(r.RatingCount))
+		asc.RenderMarkdown(headers, rows)
 	}
 	fmt.Println()
 	return nil
@@ -251,20 +254,25 @@ func printHistogramRows(histogram map[int]int64) {
 }
 
 func printHistogramMarkdown(histogram map[int]int64) {
-	fmt.Println("| Stars | Count | Percentage |")
-	fmt.Println("|-------|-------|------------|")
 	var total int64
 	for _, count := range histogram {
 		total += count
 	}
+	headers := []string{"Stars", "Count", "Percentage"}
+	rows := make([][]string, 0, 5)
 	for star := 5; star >= 1; star-- {
 		count := histogram[star]
 		pct := float64(0)
 		if total > 0 {
 			pct = float64(count) / float64(total) * 100
 		}
-		fmt.Printf("| %d★ | %s | %.1f%% |\n", star, formatNumber(count), pct)
+		rows = append(rows, []string{
+			fmt.Sprintf("%d★", star),
+			formatNumber(count),
+			fmt.Sprintf("%.1f%%", pct),
+		})
 	}
+	asc.RenderMarkdown(headers, rows)
 }
 
 func formatNumber(n int64) string {

--- a/internal/cli/subscriptions/pricing.go
+++ b/internal/cli/subscriptions/pricing.go
@@ -520,23 +520,22 @@ func printSubscriptionPricingTable(result *subscriptionPricingResult) error {
 }
 
 func printSubscriptionPricingMarkdown(result *subscriptionPricingResult) error {
-	fmt.Fprintln(os.Stdout, "| ID | Name | Product ID | Period | State | Group | Current Price | Proceeds | Proceeds Y2 |")
-	fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+	headers := []string{"ID", "Name", "Product ID", "Period", "State", "Group", "Current Price", "Proceeds", "Proceeds Y2"}
+	rows := make([][]string, 0, len(result.Subscriptions))
 	for _, item := range result.Subscriptions {
-		fmt.Fprintf(
-			os.Stdout,
-			"| %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
-			escapeSubCell(item.ID),
-			escapeSubCell(item.Name),
-			escapeSubCell(item.ProductID),
-			escapeSubCell(item.SubscriptionPeriod),
-			escapeSubCell(item.State),
-			escapeSubCell(item.GroupName),
-			escapeSubCell(formatSubMoney(item.CurrentPrice)),
-			escapeSubCell(formatSubMoney(item.Proceeds)),
-			escapeSubCell(formatSubMoney(item.ProceedsYear2)),
-		)
+		rows = append(rows, []string{
+			item.ID,
+			compactSubText(item.Name),
+			item.ProductID,
+			item.SubscriptionPeriod,
+			item.State,
+			compactSubText(item.GroupName),
+			formatSubMoney(item.CurrentPrice),
+			formatSubMoney(item.Proceeds),
+			formatSubMoney(item.ProceedsYear2),
+		})
 	}
+	asc.RenderMarkdown(headers, rows)
 	return nil
 }
 
@@ -545,12 +544,6 @@ func formatSubMoney(value *subMoney) string {
 		return ""
 	}
 	return strings.TrimSpace(strings.TrimSpace(value.Amount) + " " + strings.TrimSpace(value.Currency))
-}
-
-func escapeSubCell(value string) string {
-	value = strings.ReplaceAll(value, "|", "\\|")
-	value = strings.ReplaceAll(value, "\n", " ")
-	return strings.TrimSpace(value)
 }
 
 func compactSubText(value string) string {


### PR DESCRIPTION
## Summary
- Replace all 60+ hand-written `printXxxMarkdown` functions with `tablewriter`'s built-in Markdown renderer
- Each table/markdown pair now shares a `xxxRows()` function that builds headers + rows once
- `printXxxTable` calls `RenderTable(h, r)`, `printXxxMarkdown` calls `RenderMarkdown(h, r)`
- Pipe escaping is handled automatically by the renderer — `escapeMarkdown` helper removed
- **Net -763 lines** across 80 files

## Before (hand-written per type)
```go
func printAppsMarkdown(resp *AppsResponse) error {
    fmt.Fprintln(os.Stdout, "| ID | Name | Bundle ID | SKU |")
    fmt.Fprintln(os.Stdout, "| --- | --- | --- | --- |")
    for _, item := range resp.Data {
        fmt.Fprintf(os.Stdout, "| %s | %s | %s | %s |\n",
            item.ID, escapeMarkdown(item.Attributes.Name), ...)
    }
    return nil
}
```

## After (shared rows, renderer handles formatting)
```go
func appsRows(resp *AppsResponse) ([]string, [][]string) {
    headers := []string{"ID", "Name", "Bundle ID", "SKU"}
    rows := make([][]string, 0, len(resp.Data))
    for _, item := range resp.Data {
        rows = append(rows, []string{item.ID, compactWhitespace(item.Attributes.Name), ...})
    }
    return headers, rows
}

func printAppsTable(resp *AppsResponse) error {
    h, r := appsRows(resp)
    RenderTable(h, r)
    return nil
}

func printAppsMarkdown(resp *AppsResponse) error {
    h, r := appsRows(resp)
    RenderMarkdown(h, r)
    return nil
}
```

## Test plan
- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes (all 7600+ tests)
- [x] Manual: `asc apps list --output markdown` renders proper markdown
- [x] Manual: `asc apps list --output table` still renders bordered tables

Partially addresses #444