### PR TITLE
docs: add Hall of Fame section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,12 @@ Do not commit secrets.
 If you find a security issue, please report it responsibly by opening a private issue
 or contacting the maintainer directly.
 
-## Hall of Fame
+## Wall of Apps
 
 Apps shipping with asc-cli. To add your app:
 
 1. Fork the repo
-2. Add your app to the Hall of Fame section in `README.md`
+2. Add your app to the Wall of Apps section in `README.md`
 3. Open a PR with the format: `[App Name](App Store URL)`
 
 Format:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A **fast**, **lightweight**, and **scriptable** CLI for App Store Connect. Autom
 | Slow, heavy tooling | Single Go binary, instant startup |
 | Poor scripting support | JSON output, explicit flags, clean exit codes |
 
-## Hall of Fame
+## Wall of Apps
 
 Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls)!
 


### PR DESCRIPTION
## Summary
- Add Hall of Fame section to README listing apps shipping with asc-cli
- Add submission instructions to CONTRIBUTING.md
- Add CodexMonitor as the first entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)