### PR TITLE
Add Repetti and TV Show Tracker to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | DoubleMemory | [Open](https://doublememory.com) | Shaomeng Zhang | iOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
+| Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |
+| TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
 <!-- WALL-OF-APPS:END -->
 
 ### Add Your App to the Wall


### PR DESCRIPTION
Thanks to this amazing CLI tool, appstore submissions are now a blast! keep up the good work! i submited just two of the apps i've used asc with but only to not spam this repo... i'm using asc on a daily basis and on over 10 apps!