### PR TITLE
Add Unlimited Clipboard History app to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
 | Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |
 | TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
+| Unlimited Clipboard History | [Open](https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056?mt=12) | yspreen | macOS |
 <!-- WALL-OF-APPS:END -->
 
 ### Add Your App to the Wall


### PR DESCRIPTION
## Summary

- 

## Validation

- [ ] `make format`
- [ ] `make lint`
- [ ] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I edited `docs/wall-of-apps.json` (not the generated Wall block in `README.md` directly)
- [ ] I ran `make update-wall-of-apps`
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
