### PR TITLE
Add Fisherman SMS Filtering to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 |:----|:-----|:--------|:---------|
 | CodexMonitor | [Open](https://github.com/Dimillian/CodexMonitor) | Dimillian | macOS, iOS |
 | DoubleMemory | [Open](https://doublememory.com) | Shaomeng Zhang | iOS |
+| Fisherman SMS Filtering | [Open](https://apps.apple.com/app/id6449192504) | MGidnian | iOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
 | Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -40,5 +40,11 @@
     "link": "https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056",
     "creator": "yspreen",
     "platform": ["macOS"]
+  },
+  {
+    "app": "Fisherman SMS Filtering",
+    "link": "https://apps.apple.com/app/id6449192504",
+    "creator": "MGidnian",
+    "platform": ["iOS"]
   }
 ]


### PR DESCRIPTION
## Summary\n- add Fisherman SMS Filtering to docs/wall-of-apps.json\n- regenerate README.md wall snippet via make update-wall-of-apps\n\n## Verification\n- ran: make update-wall-of-apps\n- confirmed README includes the new Fisherman row\n