### PR TITLE
Upload timeout resolution

### DIFF
--- a/internal/asc/assets_upload.go
+++ b/internal/asc/assets_upload.go
@@ -41,7 +41,7 @@ func UploadAssetFromFile(ctx context.Context, file *os.File, fileSize int64, ope
 		return fmt.Errorf("no upload operations provided")
 	}
 
-	client := &http.Client{Timeout: ResolveTimeout()}
+	client := &http.Client{Timeout: ResolveUploadTimeout()}
 
 	for i, op := range operations {
 		method := strings.ToUpper(strings.TrimSpace(op.Method))

--- a/internal/asc/assets_upload_test.go
+++ b/internal/asc/assets_upload_test.go
@@ -2,13 +2,16 @@ package asc
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestValidateImageFileRejectsSymlink(t *testing.T) {
@@ -126,4 +129,80 @@ func TestUploadAssetFromFileUploadsChunks(t *testing.T) {
 	if atomic.LoadInt32(&call) != 2 {
 		t.Fatalf("expected 2 upload calls, got %d", call)
 	}
+}
+
+func TestUploadAssetFromFileUsesUploadTimeoutEnv(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "10ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "250ms")
+	t.Setenv("ASC_UPLOAD_TIMEOUT_SECONDS", "")
+
+	file := createTempAssetFile(t, []byte("abc"))
+	defer file.Close()
+
+	var callCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		time.Sleep(60 * time.Millisecond)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ops := []UploadOperation{
+		{Method: http.MethodPut, URL: server.URL + "/part1", Length: 3, Offset: 0},
+	}
+
+	if err := UploadAssetFromFile(context.Background(), file, 3, ops); err != nil {
+		t.Fatalf("UploadAssetFromFile() error: %v", err)
+	}
+	if atomic.LoadInt32(&callCount) != 1 {
+		t.Fatalf("expected 1 upload call, got %d", callCount)
+	}
+}
+
+func TestUploadAssetFromFileUsesUploadTimeoutWhenShorter(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "250ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "10ms")
+	t.Setenv("ASC_UPLOAD_TIMEOUT_SECONDS", "")
+
+	file := createTempAssetFile(t, []byte("abc"))
+	defer file.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(60 * time.Millisecond)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ops := []UploadOperation{
+		{Method: http.MethodPut, URL: server.URL + "/part1", Length: 3, Offset: 0},
+	}
+
+	err := UploadAssetFromFile(context.Background(), file, 3, ops)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "Client.Timeout exceeded") {
+		t.Fatalf("expected client timeout error, got %v", err)
+	}
+}
+
+func createTempAssetFile(t *testing.T, content []byte) *os.File {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "asset.bin")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+
+	return file
 }


### PR DESCRIPTION
## Summary

- Fixes `UploadAssetFromFile` to correctly use `ASC_UPLOAD_TIMEOUT` for HTTP client timeouts, rather than `ASC_TIMEOUT`.
- Adds new behavioral tests to explicitly verify that `ASC_UPLOAD_TIMEOUT` is honored, covering both success (longer upload timeout) and failure (shorter upload timeout) scenarios.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I edited `docs/wall-of-apps.json` (not the generated Wall block in `README.md` directly)
- [ ] I ran `make update-wall-of-apps`
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

---
<p><a href="https://cursor.com/background-agent?bcId=bc-689502de-e55f-4c3a-8675-17dfd8162779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-689502de-e55f-4c3a-8675-17dfd8162779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

