### PR TITLE
Add Dandelion to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | Fisherman SMS Filtering | [Open](https://apps.apple.com/app/id6449192504) | MGidnian | iOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
-| Dandelion | [Open](https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901) | joeycast | iOS |
+| Dandelion | [Open](https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901) | joeycast | iOS, macOS |
 | Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |
 | TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
 | Unlimited Clipboard History | [Open](https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056) | yspreen | macOS |


### PR DESCRIPTION
## Summary
Adds Dandelion to the README "Wall of Apps" section as an app that uses this project.

## Changes
- Added one row in the Wall of Apps table in `/README.md`:
  - App: `Dandelion`
  - Link: `https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901`
  - Creator: `joeycast`
  - Platform: `iOS, macOS`

## Notes
This is a documentation-only change.
