### PR TITLE
Add arunavo4 apps to wall of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | DoubleMemory | [Open](https://doublememory.com) | Shaomeng Zhang | iOS |
 | Fisherman SMS Filtering | [Open](https://apps.apple.com/app/id6449192504) | MGidnian | iOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |
+| Lumical: Scan to Calendar | [Open](https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309) | arunavo4 | iOS |
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
 | Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |
 | TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
 | Unlimited Clipboard History | [Open](https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056) | yspreen | macOS |
+| XO: Have I Ever | [Open](https://apps.apple.com/us/app/xo-have-i-ever/id6757594745) | arunavo4 | iOS |
 <!-- WALL-OF-APPS:END -->
 
 ### Add Your App to the Wall

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -52,5 +52,17 @@
     "link": "https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901",
     "creator": "joeycast",
     "platform": ["iOS", "macOS"]
+  },
+  {
+    "app": "Lumical: Scan to Calendar",
+    "link": "https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309",
+    "creator": "arunavo4",
+    "platform": ["iOS"]
+  },
+  {
+    "app": "XO: Have I Ever",
+    "link": "https://apps.apple.com/us/app/xo-have-i-ever/id6757594745",
+    "creator": "arunavo4",
+    "platform": ["iOS"]
   }
 ]


### PR DESCRIPTION
## Summary

- Added two iOS apps by `arunavo4` to the Wall of Apps:
  - `Lumical: Scan to Calendar` ([App Store](https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309))
  - `XO: Have I Ever` ([App Store](https://apps.apple.com/us/app/xo-have-i-ever/id6757594745))
- Updated `docs/wall-of-apps.json` with both entries.
- Regenerated the Wall snippet in `README.md` so documentation stays in sync.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
