### PR TITLE
V1.0 whatsNew validation

### DIFF
--- a/internal/validation/report.go
+++ b/internal/validation/report.go
@@ -4,7 +4,7 @@ package validation
 func Validate(input Input, strict bool) Report {
 	checks := make([]CheckResult, 0)
 	checks = append(checks, metadataLengthChecks(input.VersionLocalizations, input.AppInfoLocalizations)...)
-	checks = append(checks, requiredFieldChecks(input.PrimaryLocale, input.VersionLocalizations, input.AppInfoLocalizations)...)
+	checks = append(checks, requiredFieldChecks(input.PrimaryLocale, input.VersionString, input.VersionLocalizations, input.AppInfoLocalizations)...)
 	checks = append(checks, screenshotChecks(input.Platform, input.ScreenshotSets)...)
 	checks = append(checks, ageRatingChecks(input.AgeRatingDeclaration)...)
 

--- a/internal/validation/required_fields_test.go
+++ b/internal/validation/required_fields_test.go
@@ -3,7 +3,7 @@ package validation
 import "testing"
 
 func TestRequiredFieldChecks_MissingPrimaryLocale(t *testing.T) {
-	checks := requiredFieldChecks("en-US", []VersionLocalization{
+	checks := requiredFieldChecks("en-US", "1.2.3", []VersionLocalization{
 		{Locale: "fr-FR", Description: "desc", Keywords: "kw", SupportURL: "https://example.com"},
 	}, []AppInfoLocalization{
 		{Locale: "fr-FR", Name: "Name"},
@@ -15,7 +15,7 @@ func TestRequiredFieldChecks_MissingPrimaryLocale(t *testing.T) {
 }
 
 func TestRequiredFieldChecks_MissingFields(t *testing.T) {
-	checks := requiredFieldChecks("", []VersionLocalization{
+	checks := requiredFieldChecks("", "1.2.3", []VersionLocalization{
 		{Locale: "en-US"},
 	}, []AppInfoLocalization{
 		{Locale: "en-US"},
@@ -32,5 +32,29 @@ func TestRequiredFieldChecks_MissingFields(t *testing.T) {
 	}
 	if !hasCheckID(checks, "metadata.required.name") {
 		t.Fatalf("expected name required check")
+	}
+}
+
+func TestRequiredFieldChecks_SkipsWhatsNewOnInitialRelease(t *testing.T) {
+	checks := requiredFieldChecks("", "1.0", []VersionLocalization{
+		{Locale: "en-US", Description: "desc", Keywords: "kw", SupportURL: "https://example.com"},
+	}, []AppInfoLocalization{
+		{Locale: "en-US", Name: "Name"},
+	})
+
+	if hasCheckID(checks, "metadata.required.whats_new") {
+		t.Fatalf("did not expect whatsNew warning for initial release")
+	}
+}
+
+func TestRequiredFieldChecks_WarnsWhatsNewOnUpdateRelease(t *testing.T) {
+	checks := requiredFieldChecks("", "1.0.1", []VersionLocalization{
+		{Locale: "en-US", Description: "desc", Keywords: "kw", SupportURL: "https://example.com"},
+	}, []AppInfoLocalization{
+		{Locale: "en-US", Name: "Name"},
+	})
+
+	if !hasCheckID(checks, "metadata.required.whats_new") {
+		t.Fatalf("expected whatsNew warning for update release")
 	}
 }


### PR DESCRIPTION
## Summary

- `asc validate` no longer warns about an empty `whatsNew` field for initial `1.0` releases (e.g., `1.0`, `1.0.0`).
- This prevents `--strict` validation from failing solely due to the "What's New is empty" warning on first submissions.
- Added unit and CLI regression tests to confirm the new behavior.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6c563ad8-8f4b-4f1f-9f1b-954c2742ecd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c563ad8-8f4b-4f1f-9f1b-954c2742ecd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

