### PR TITLE
Add Parsely to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1728,6 +1728,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
 | Mixtape | [Open](https://apps.apple.com/us/app/mixtape-personal-music-gift/id6756442910) | jimripple | iOS |
 | Morning Pages | [Open](https://apps.apple.com/us/app/morning-pages/id6738604034) | zchwyng | iOS, macOS |
+| Parsely | [Open](https://testflight.apple.com/join/HjUZtzVm) | sambitcreate | iOS |
 | Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |
 | TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
 | Unlimited Clipboard History | [Open](https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056) | yspreen | macOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -88,5 +88,11 @@
     "link": "https://apps.apple.com/us/app/mixtape-personal-music-gift/id6756442910",
     "creator": "jimripple",
     "platform": ["iOS"]
+  },
+  {
+    "app": "Parsely",
+    "link": "https://testflight.apple.com/join/HjUZtzVm",
+    "creator": "sambitcreate",
+    "platform": ["iOS"]
   }
 ]


### PR DESCRIPTION
## Summary

- Added Parsely (TestFlight) to Wall of Apps in docs/wall-of-apps.json and README.md

## Wall of Apps (only if this PR adds/updates a Wall app)

- App: Parsely
- Link: https://testflight.apple.com/join/HjUZtzVm
- Creator: sambitcreate
- Platform: iOS