### PR TITLE
ci(lint): enable misspell linter (phase 1)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,16 @@ linters:
     - errcheck
     - ineffassign
     - unused
-    # (intentionally NOT enabling `misspell` or `unparam` yet; both create large
-    # cleanup churn with current codebase conventions)
+    - misspell
+    # (intentionally NOT enabling `unparam` yet; creates large cleanup churn
+    # with current codebase conventions)
+
+linters-settings:
+  misspell:
+    # Words used intentionally in Apple/ASC API context.
+    ignore-words:
+      - cancelled
+      - cancelling
 
 issues:
   # Keep defaults, but avoid noisy duplicates.


### PR DESCRIPTION
## Summary

- Enables the `misspell` golangci-lint linter as phase 1 of #602.
- Adds `ignore-words` for Apple/ASC domain terms (`cancelled`, `cancelling`) to avoid false positives.
- Config-only change — the codebase already has zero misspellings, so no code fixes needed.

## Checks run

- `make lint` — passes
- `ASC_BYPASS_KEYCHAIN=1 make test` — passes

Closes phase 1 of #602.