### PR TITLE
ci(lint): enable errorlint linter (phase 3)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - unused
     - misspell
     - unparam
+    - errorlint
 
 linters-settings:
   misspell:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,7 +35,7 @@ func Run(args []string, versionInfo string) int {
 	defer shared.CleanupTempPrivateKeys()
 
 	if err := root.Parse(args); err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			return ExitSuccess
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -2580,7 +2580,7 @@ func TestWithRetry_ZeroRetries(t *testing.T) {
 	if callCount != 1 {
 		t.Fatalf("expected 1 call (no retries), got %d", callCount)
 	}
-	if err != wantErr {
+	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected error %v, got %v", wantErr, err)
 	}
 }
@@ -2644,7 +2644,7 @@ func TestWithRetry_NonRetryableErrorFailsFast(t *testing.T) {
 	if callCount != 1 {
 		t.Fatalf("expected 1 call (no retries for non-retryable error), got %d", callCount)
 	}
-	if err != wantErr {
+	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected error %v, got %v", wantErr, err)
 	}
 }

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -396,14 +396,14 @@ func uploadMultipartToS3(ctx context.Context, creds S3Credentials, data io.Reade
 	parts, err := uploadMultipartParts(ctx, host, encodedPath, creds, uploadID, data, contentLength)
 	if err != nil {
 		if abortErr := abortMultipartUpload(ctx, host, encodedPath, creds, uploadID); abortErr != nil {
-			return fmt.Errorf("%w (abort failed: %v)", err, abortErr)
+			return fmt.Errorf("%w (abort failed: %w)", err, abortErr)
 		}
 		return err
 	}
 
 	if err := completeMultipartUpload(ctx, host, encodedPath, creds, uploadID, parts); err != nil {
 		if abortErr := abortMultipartUpload(ctx, host, encodedPath, creds, uploadID); abortErr != nil {
-			return fmt.Errorf("%w (abort failed: %v)", err, abortErr)
+			return fmt.Errorf("%w (abort failed: %w)", err, abortErr)
 		}
 		return err
 	}

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -493,7 +493,7 @@ func GetCredentialsWithSource(profile string) (*config.Config, string, error) {
 	}
 	if !isKeyringUnavailable(err) {
 		if isKeychainAccessDeniedError(err) {
-			return nil, "", fmt.Errorf("%w: %v", ErrKeychainAccessDenied, err)
+			return nil, "", fmt.Errorf("%w: %w", ErrKeychainAccessDenied, err)
 		}
 		return nil, "", err
 	}
@@ -584,7 +584,7 @@ func selectCredential(profile string, credentials []Credential) (*config.Config,
 
 func getCredentialsFromConfig(profile string) (*config.Config, error) {
 	cfg, err := config.Load()
-	if err != nil && err != config.ErrNotFound {
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
 		return nil, err
 	}
 	if cfg != nil {
@@ -599,8 +599,8 @@ func getCredentialsFromConfig(profile string) (*config.Config, error) {
 
 	globalCfg, _, globalErr := loadGlobalConfigForCredentials()
 	if globalErr != nil {
-		if globalErr == config.ErrNotFound {
-			if err == config.ErrNotFound {
+		if errors.Is(globalErr, config.ErrNotFound) {
+			if errors.Is(err, config.ErrNotFound) {
 				return nil, err
 			}
 			return nil, fmt.Errorf("default credentials not found")
@@ -830,7 +830,7 @@ func storeInConfig(name string, payload credentialPayload) error {
 
 func storeInConfigAt(name string, payload credentialPayload, configPath string) error {
 	cfg, err := config.LoadAt(configPath)
-	if err != nil && err != config.ErrNotFound {
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
 		return err
 	}
 	if cfg == nil {
@@ -1052,7 +1052,7 @@ func listFromConfig() ([]Credential, error) {
 	}
 	cfg, err := config.LoadAt(path)
 	if err != nil {
-		if err == config.ErrNotFound {
+		if errors.Is(err, config.ErrNotFound) {
 			return []Credential{}, nil
 		}
 		return nil, err
@@ -1063,7 +1063,7 @@ func listFromConfig() ([]Credential, error) {
 		}
 		globalCfg, globalPath, err := loadGlobalConfigForCredentials()
 		if err != nil {
-			if err == config.ErrNotFound {
+			if errors.Is(err, config.ErrNotFound) {
 				return []Credential{}, nil
 			}
 			return nil, err
@@ -1107,7 +1107,7 @@ func SetDefaultCredentials(name string) error {
 
 func saveDefaultName(name string) error {
 	cfg, err := config.Load()
-	if err != nil && err != config.ErrNotFound {
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
 		return err
 	}
 	if cfg == nil {
@@ -1140,7 +1140,7 @@ func saveDefaultName(name string) error {
 func defaultName() (string, error) {
 	cfg, err := config.Load()
 	if err != nil {
-		if err == config.ErrNotFound {
+		if errors.Is(err, config.ErrNotFound) {
 			return "", nil
 		}
 		return "", err
@@ -1151,7 +1151,7 @@ func defaultName() (string, error) {
 func clearDefaultNameIf(name string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		if err == config.ErrNotFound {
+		if errors.Is(err, config.ErrNotFound) {
 			return nil
 		}
 		return err

--- a/internal/cli/alternativedistribution/alternative_distribution_test.go
+++ b/internal/cli/alternativedistribution/alternative_distribution_test.go
@@ -2,6 +2,7 @@ package alternativedistribution
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -12,7 +13,7 @@ func TestAlternativeDistributionDomainsGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --domain-id is missing, got %v", err)
 	}
 }
@@ -23,7 +24,7 @@ func TestAlternativeDistributionDomainsCreateCommand_MissingDomain(t *testing.T)
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --domain is missing, got %v", err)
 	}
 }
@@ -34,7 +35,7 @@ func TestAlternativeDistributionDomainsCreateCommand_MissingReferenceName(t *tes
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --reference-name is missing, got %v", err)
 	}
 }
@@ -45,7 +46,7 @@ func TestAlternativeDistributionDomainsDeleteCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --domain-id is missing, got %v", err)
 	}
 }
@@ -56,7 +57,7 @@ func TestAlternativeDistributionDomainsDeleteCommand_MissingConfirm(t *testing.T
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -67,7 +68,7 @@ func TestAlternativeDistributionDomainsListCommand_InvalidLimit(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --limit, got %v", err)
 	}
 }
@@ -78,7 +79,7 @@ func TestAlternativeDistributionKeysGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --key-id is missing, got %v", err)
 	}
 }
@@ -91,7 +92,7 @@ func TestAlternativeDistributionKeysCreateCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -102,7 +103,7 @@ func TestAlternativeDistributionKeysCreateCommand_MissingKey(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when key input is missing, got %v", err)
 	}
 }
@@ -113,7 +114,7 @@ func TestAlternativeDistributionKeysCreateCommand_ConflictingKeyInputs(t *testin
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for conflicting key inputs, got %v", err)
 	}
 }
@@ -124,7 +125,7 @@ func TestAlternativeDistributionKeysDeleteCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --key-id is missing, got %v", err)
 	}
 }
@@ -135,7 +136,7 @@ func TestAlternativeDistributionKeysDeleteCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -148,7 +149,7 @@ func TestAlternativeDistributionKeysAppCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -159,7 +160,7 @@ func TestAlternativeDistributionPackagesGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --package-id is missing, got %v", err)
 	}
 }
@@ -170,7 +171,7 @@ func TestAlternativeDistributionPackagesCreateCommand_MissingAppStoreVersionID(t
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app-store-version-id is missing, got %v", err)
 	}
 }
@@ -181,7 +182,7 @@ func TestAlternativeDistributionPackagesAppStoreVersionCommand_MissingID(t *test
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app-store-version-id is missing, got %v", err)
 	}
 }
@@ -192,7 +193,7 @@ func TestAlternativeDistributionPackageVariantsCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --variant-id is missing, got %v", err)
 	}
 }
@@ -203,7 +204,7 @@ func TestAlternativeDistributionPackageDeltasCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --delta-id is missing, got %v", err)
 	}
 }
@@ -214,7 +215,7 @@ func TestAlternativeDistributionPackageVersionsGetCommand_MissingID(t *testing.T
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -225,7 +226,7 @@ func TestAlternativeDistributionPackageVersionsListCommand_MissingID(t *testing.
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --package-id is missing, got %v", err)
 	}
 }
@@ -236,7 +237,7 @@ func TestAlternativeDistributionPackageVersionsDeltasCommand_MissingID(t *testin
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -247,7 +248,7 @@ func TestAlternativeDistributionPackageVersionsVariantsCommand_MissingID(t *test
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -258,7 +259,7 @@ func TestAlternativeDistributionPackageVersionsDeltasCommand_InvalidLimit(t *tes
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --limit, got %v", err)
 	}
 }
@@ -269,7 +270,7 @@ func TestAlternativeDistributionPackageVersionsListCommand_InvalidLimit(t *testi
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --limit, got %v", err)
 	}
 }

--- a/internal/cli/apps/app_setup_test.go
+++ b/internal/cli/apps/app_setup_test.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestAppSetupInfoSetCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -30,7 +31,7 @@ func TestAppSetupInfoSetCommand_MissingUpdates(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when no update flags provided, got %v", err)
 	}
 }
@@ -42,7 +43,7 @@ func TestAppSetupInfoSetCommand_MissingLocale(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when locale is missing, got %v", err)
 	}
 }
@@ -94,7 +95,7 @@ func TestAppSetupAvailabilitySetCommand_MissingFlags(t *testing.T) {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
-			if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("expected flag.ErrHelp, got %v", err)
 			}
 		})
@@ -120,7 +121,7 @@ func TestAppSetupPricingSetCommand_MissingFlags(t *testing.T) {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
-			if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("expected flag.ErrHelp, got %v", err)
 			}
 		})
@@ -134,7 +135,7 @@ func TestAppSetupLocalizationsUploadCommand_MissingPath(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --path is missing, got %v", err)
 	}
 }

--- a/internal/cli/backgroundassets/background_assets_test.go
+++ b/internal/cli/backgroundassets/background_assets_test.go
@@ -2,6 +2,7 @@ package backgroundassets
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -14,7 +15,7 @@ func TestBackgroundAssetsListCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestBackgroundAssetsListCommand_InvalidLimit(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --limit, got %v", err)
 	}
 }
@@ -36,7 +37,7 @@ func TestBackgroundAssetsGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -49,7 +50,7 @@ func TestBackgroundAssetsCreateCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -60,7 +61,7 @@ func TestBackgroundAssetsCreateCommand_MissingAssetPackIdentifier(t *testing.T) 
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --asset-pack-identifier is missing, got %v", err)
 	}
 }
@@ -71,7 +72,7 @@ func TestBackgroundAssetsUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -82,7 +83,7 @@ func TestBackgroundAssetsUpdateCommand_MissingArchived(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --archived is missing, got %v", err)
 	}
 }
@@ -93,7 +94,7 @@ func TestBackgroundAssetsVersionsListCommand_MissingAssetID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --background-asset-id is missing, got %v", err)
 	}
 }
@@ -104,7 +105,7 @@ func TestBackgroundAssetsVersionsGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -115,7 +116,7 @@ func TestBackgroundAssetsVersionsCreateCommand_MissingAssetID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --background-asset-id is missing, got %v", err)
 	}
 }
@@ -126,7 +127,7 @@ func TestBackgroundAssetsUploadFilesListCommand_MissingVersionID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -137,7 +138,7 @@ func TestBackgroundAssetsUploadFilesGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --upload-file-id is missing, got %v", err)
 	}
 }
@@ -148,7 +149,7 @@ func TestBackgroundAssetsUploadFilesCreateCommand_MissingVersionID(t *testing.T)
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -159,7 +160,7 @@ func TestBackgroundAssetsUploadFilesCreateCommand_MissingFile(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --file is missing, got %v", err)
 	}
 }
@@ -170,7 +171,7 @@ func TestBackgroundAssetsUploadFilesCreateCommand_MissingAssetType(t *testing.T)
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --asset-type is missing, got %v", err)
 	}
 }
@@ -181,7 +182,7 @@ func TestBackgroundAssetsUploadFilesUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --upload-file-id is missing, got %v", err)
 	}
 }
@@ -192,7 +193,7 @@ func TestBackgroundAssetsUploadFilesUpdateCommand_MissingUploaded(t *testing.T) 
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --uploaded is missing, got %v", err)
 	}
 }

--- a/internal/cli/builds/builds_latest_test.go
+++ b/internal/cli/builds/builds_latest_test.go
@@ -2,6 +2,7 @@ package builds
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ func TestBuildsLatestCommand_MissingApp(t *testing.T) {
 	cmd := BuildsLatestCommand()
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -50,7 +51,7 @@ func TestBuildsLatestCommand_InvalidPlatform(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp for invalid platform, got %v", err)
 	}
 }
@@ -75,7 +76,7 @@ func TestBuildsLatestCommand_ValidPlatforms(t *testing.T) {
 			err := cmd.Exec(context.Background(), []string{})
 
 			// Should not be flag.ErrHelp for valid platforms (will fail later due to no auth)
-			if err == flag.ErrHelp {
+			if errors.Is(err, flag.ErrHelp) {
 				t.Errorf("platform %s should be valid but got flag.ErrHelp", platform)
 			}
 		})
@@ -92,7 +93,7 @@ func TestBuildsLatestCommand_InvalidInitialBuildNumber(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp for invalid initial build number, got %v", err)
 	}
 }
@@ -142,7 +143,7 @@ func TestBuildsLatestCommand_UsesAppIDEnv(t *testing.T) {
 	err := cmd.Exec(context.Background(), []string{})
 
 	// Should not be flag.ErrHelp since env var provides the app ID
-	if err == flag.ErrHelp {
+	if errors.Is(err, flag.ErrHelp) {
 		t.Errorf("should use ASC_APP_ID env var but got flag.ErrHelp")
 	}
 }

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -2,6 +2,7 @@ package bundleids
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -13,7 +14,7 @@ func TestBundleIDsGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestBundleIDsCreateCommand_MissingIdentifier(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --identifier is missing, got %v", err)
 	}
 }
@@ -37,7 +38,7 @@ func TestBundleIDsCreateCommand_MissingName(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --name is missing, got %v", err)
 	}
 }
@@ -49,7 +50,7 @@ func TestBundleIDsUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -61,7 +62,7 @@ func TestBundleIDsUpdateCommand_MissingName(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --name is missing, got %v", err)
 	}
 }
@@ -73,7 +74,7 @@ func TestBundleIDsDeleteCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -85,7 +86,7 @@ func TestBundleIDsCapabilitiesListCommand_MissingBundle(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --bundle is missing, got %v", err)
 	}
 }
@@ -97,7 +98,7 @@ func TestBundleIDsCapabilitiesAddCommand_MissingBundle(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --bundle is missing, got %v", err)
 	}
 }
@@ -109,7 +110,7 @@ func TestBundleIDsCapabilitiesAddCommand_MissingCapability(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --capability is missing, got %v", err)
 	}
 }
@@ -121,7 +122,7 @@ func TestBundleIDsCapabilitiesRemoveCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -133,7 +134,7 @@ func TestBundleIDsCapabilitiesRemoveCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -2,6 +2,7 @@ package certificates
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -13,7 +14,7 @@ func TestCertificatesCreateCommand_MissingType(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --certificate-type is missing, got %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestCertificatesCreateCommand_MissingCSR(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --csr is missing, got %v", err)
 	}
 }
@@ -37,7 +38,7 @@ func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -49,7 +50,7 @@ func TestCertificatesRevokeCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -61,7 +62,7 @@ func TestCertificatesUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -73,7 +74,7 @@ func TestCertificatesUpdateCommand_MissingActivated(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --activated is missing, got %v", err)
 	}
 }
@@ -85,7 +86,7 @@ func TestCertificatesGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -97,7 +98,7 @@ func TestCertificatesRelationshipsPassTypeIDCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }

--- a/internal/cli/completion/completion_test.go
+++ b/internal/cli/completion/completion_test.go
@@ -3,6 +3,7 @@ package completion
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"io"
 	"os"
@@ -42,7 +43,7 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	if err := cmd.FlagSet.Parse([]string{}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
-	if err := cmd.Exec(context.Background(), nil); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp for missing shell, got %v", err)
 	}
 
@@ -51,7 +52,7 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	if err := cmd.FlagSet.Parse([]string{"--shell", "tcsh"}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
-	if err := cmd.Exec(context.Background(), nil); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp for unsupported shell, got %v", err)
 	}
 

--- a/internal/cli/devices/devices_test.go
+++ b/internal/cli/devices/devices_test.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"strings"
 	"testing"
@@ -15,7 +16,7 @@ func TestDevicesRegisterCommand_MissingName(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --name is missing, got %v", err)
 	}
 }
@@ -27,7 +28,7 @@ func TestDevicesRegisterCommand_MissingUDID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --udid is missing, got %v", err)
 	}
 }
@@ -39,7 +40,7 @@ func TestDevicesRegisterCommand_MissingPlatform(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --platform is missing, got %v", err)
 	}
 }
@@ -51,7 +52,7 @@ func TestDevicesRegisterCommand_UDIDConflict(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when udid flags conflict, got %v", err)
 	}
 }
@@ -63,7 +64,7 @@ func TestDevicesUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -75,7 +76,7 @@ func TestDevicesUpdateCommand_MissingStatus(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --status is missing, got %v", err)
 	}
 }

--- a/internal/cli/marketplace/marketplace_test.go
+++ b/internal/cli/marketplace/marketplace_test.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -14,7 +15,7 @@ func TestMarketplaceSearchDetailsGetCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestMarketplaceSearchDetailsGetCommand_InvalidFields(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --fields, got %v", err)
 	}
 }
@@ -38,7 +39,7 @@ func TestMarketplaceSearchDetailsCreateCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -49,7 +50,7 @@ func TestMarketplaceSearchDetailsCreateCommand_MissingCatalogURL(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --catalog-url is missing, got %v", err)
 	}
 }
@@ -60,7 +61,7 @@ func TestMarketplaceSearchDetailsUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --search-detail-id is missing, got %v", err)
 	}
 }
@@ -71,7 +72,7 @@ func TestMarketplaceSearchDetailsUpdateCommand_MissingUpdates(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when update flags are missing, got %v", err)
 	}
 }
@@ -82,7 +83,7 @@ func TestMarketplaceSearchDetailsDeleteCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --search-detail-id is missing, got %v", err)
 	}
 }
@@ -93,7 +94,7 @@ func TestMarketplaceSearchDetailsDeleteCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -104,7 +105,7 @@ func TestMarketplaceWebhooksGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --webhook-id is missing, got %v", err)
 	}
 }
@@ -115,7 +116,7 @@ func TestMarketplaceWebhooksCreateCommand_MissingURL(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --url is missing, got %v", err)
 	}
 }
@@ -126,7 +127,7 @@ func TestMarketplaceWebhooksCreateCommand_MissingSecret(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --secret is missing, got %v", err)
 	}
 }
@@ -137,7 +138,7 @@ func TestMarketplaceWebhooksUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --webhook-id is missing, got %v", err)
 	}
 }
@@ -148,7 +149,7 @@ func TestMarketplaceWebhooksUpdateCommand_MissingUpdates(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when update flags are missing, got %v", err)
 	}
 }
@@ -159,7 +160,7 @@ func TestMarketplaceWebhooksDeleteCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --webhook-id is missing, got %v", err)
 	}
 }
@@ -170,7 +171,7 @@ func TestMarketplaceWebhooksDeleteCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -181,7 +182,7 @@ func TestMarketplaceWebhooksListCommand_InvalidLimit(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --limit, got %v", err)
 	}
 }
@@ -192,7 +193,7 @@ func TestMarketplaceWebhooksListCommand_InvalidFields(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err == nil || err == flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); err == nil || errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected validation error for invalid --fields, got %v", err)
 	}
 }

--- a/internal/cli/preorders/pre_orders_test.go
+++ b/internal/cli/preorders/pre_orders_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"path/filepath"
 	"testing"
@@ -22,7 +23,7 @@ func TestPreOrdersGetCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -34,7 +35,7 @@ func TestPreOrdersListCommand_MissingAvailability(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --availability is missing, got %v", err)
 	}
 }
@@ -60,7 +61,7 @@ func TestPreOrdersEnableCommand_MissingFlags(t *testing.T) {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
-			if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("expected flag.ErrHelp, got %v", err)
 			}
 		})
@@ -78,7 +79,7 @@ func TestPreOrdersEnableCommand_InvalidDate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid release date")
 	}
-	if err == flag.ErrHelp {
+	if errors.Is(err, flag.ErrHelp) {
 		t.Fatal("expected non-ErrHelp error for invalid release date")
 	}
 }
@@ -90,7 +91,7 @@ func TestPreOrdersUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --territory-availability is missing, got %v", err)
 	}
 }
@@ -102,7 +103,7 @@ func TestPreOrdersUpdateCommand_MissingReleaseDate(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --release-date is missing, got %v", err)
 	}
 }
@@ -118,7 +119,7 @@ func TestPreOrdersUpdateCommand_InvalidDate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid release date")
 	}
-	if err == flag.ErrHelp {
+	if errors.Is(err, flag.ErrHelp) {
 		t.Fatal("expected non-ErrHelp error for invalid release date")
 	}
 }
@@ -130,7 +131,7 @@ func TestPreOrdersDisableCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --territory-availability is missing, got %v", err)
 	}
 }
@@ -142,7 +143,7 @@ func TestPreOrdersEndCommand_MissingIDs(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --territory-availability is missing, got %v", err)
 	}
 }

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -2,6 +2,7 @@ package pricing
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestPricingPricePointsCommand_MissingApp(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -28,7 +29,7 @@ func TestPricingPricePointsGetCommand_MissingPricePoint(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --price-point is missing, got %v", err)
 	}
 }
@@ -40,7 +41,7 @@ func TestPricingPricePointsEqualizationsCommand_MissingPricePoint(t *testing.T) 
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --price-point is missing, got %v", err)
 	}
 }
@@ -53,7 +54,7 @@ func TestPricingScheduleGetCommand_MissingAppAndID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -65,7 +66,7 @@ func TestPricingScheduleGetCommand_MutuallyExclusive(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app and --id are both set, got %v", err)
 	}
 }
@@ -77,7 +78,7 @@ func TestPricingScheduleManualPricesCommand_MissingSchedule(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --schedule is missing, got %v", err)
 	}
 }
@@ -89,7 +90,7 @@ func TestPricingScheduleAutomaticPricesCommand_MissingSchedule(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --schedule is missing, got %v", err)
 	}
 }
@@ -114,7 +115,7 @@ func TestPricingScheduleCreateCommand_MissingFlags(t *testing.T) {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
-			if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("expected flag.ErrHelp, got %v", err)
 			}
 		})
@@ -132,7 +133,7 @@ func TestPricingScheduleCreateCommand_InvalidDate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid start date")
 	}
-	if err == flag.ErrHelp {
+	if errors.Is(err, flag.ErrHelp) {
 		t.Fatal("expected non-ErrHelp error for invalid start date")
 	}
 }
@@ -145,7 +146,7 @@ func TestPricingAvailabilityGetCommand_MissingAppAndID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
 	}
 }
@@ -157,7 +158,7 @@ func TestPricingAvailabilityGetCommand_MutuallyExclusive(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --app and --id are both set, got %v", err)
 	}
 }
@@ -169,7 +170,7 @@ func TestPricingAvailabilityTerritoryAvailabilitiesCommand_MissingAvailability(t
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --availability is missing, got %v", err)
 	}
 }
@@ -193,7 +194,7 @@ func TestPricingAvailabilitySetCommand_MissingFlags(t *testing.T) {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
-			if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("expected flag.ErrHelp, got %v", err)
 			}
 		})

--- a/internal/cli/profiles/profiles_test.go
+++ b/internal/cli/profiles/profiles_test.go
@@ -2,6 +2,7 @@ package profiles
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -13,7 +14,7 @@ func TestProfilesGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestProfilesCreateCommand_MissingName(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --name is missing, got %v", err)
 	}
 }
@@ -37,7 +38,7 @@ func TestProfilesCreateCommand_MissingProfileType(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --profile-type is missing, got %v", err)
 	}
 }
@@ -49,7 +50,7 @@ func TestProfilesCreateCommand_MissingBundle(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --bundle is missing, got %v", err)
 	}
 }
@@ -61,7 +62,7 @@ func TestProfilesCreateCommand_MissingCertificate(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --certificate is missing, got %v", err)
 	}
 }
@@ -73,7 +74,7 @@ func TestProfilesDeleteCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -85,7 +86,7 @@ func TestProfilesDeleteCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -97,7 +98,7 @@ func TestProfilesDownloadCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -109,7 +110,7 @@ func TestProfilesDownloadCommand_MissingOutput(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --output is missing, got %v", err)
 	}
 }
@@ -121,7 +122,7 @@ func TestProfilesRelationshipsBundleIDCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -133,7 +134,7 @@ func TestProfilesRelationshipsCertificatesCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -145,7 +146,7 @@ func TestProfilesRelationshipsDevicesCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }

--- a/internal/cli/users/users_test.go
+++ b/internal/cli/users/users_test.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 
@@ -15,7 +16,7 @@ func TestUsersGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -27,7 +28,7 @@ func TestUsersUpdateCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -39,7 +40,7 @@ func TestUsersUpdateCommand_MissingRoles(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --roles is missing, got %v", err)
 	}
 }
@@ -51,7 +52,7 @@ func TestUsersDeleteCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -63,7 +64,7 @@ func TestUsersDeleteCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -75,7 +76,7 @@ func TestUsersInviteCommand_MissingEmail(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --email is missing, got %v", err)
 	}
 }
@@ -87,7 +88,7 @@ func TestUsersInviteCommand_MissingFirstName(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --first-name is missing, got %v", err)
 	}
 }
@@ -99,7 +100,7 @@ func TestUsersInviteCommand_MissingLastName(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --last-name is missing, got %v", err)
 	}
 }
@@ -111,7 +112,7 @@ func TestUsersInviteCommand_MissingRoles(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --roles is missing, got %v", err)
 	}
 }
@@ -123,7 +124,7 @@ func TestUsersInviteCommand_MissingAccess(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --all-apps or --visible-app is missing, got %v", err)
 	}
 }
@@ -139,7 +140,7 @@ func TestUsersInviteCommand_ConflictingAccess(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for conflicting access flags")
 	}
-	if err == flag.ErrHelp {
+	if errors.Is(err, flag.ErrHelp) {
 		// This is acceptable - the command shows help when there's a conflict
 		return
 	}
@@ -152,7 +153,7 @@ func TestUsersInvitesGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -164,7 +165,7 @@ func TestUsersInvitesRevokeCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }
@@ -176,7 +177,7 @@ func TestUsersInvitesRevokeCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -188,7 +189,7 @@ func TestUsersVisibleAppsListCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -200,7 +201,7 @@ func TestUsersVisibleAppsGetCommand_MissingID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }

--- a/internal/cli/versions/phased_release_test.go
+++ b/internal/cli/versions/phased_release_test.go
@@ -2,6 +2,7 @@ package versions
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestPhasedReleaseGetCommand_MissingVersion(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --version is missing, got %v", err)
 	}
 }
@@ -29,7 +30,7 @@ func TestPhasedReleaseCreateCommand_MissingVersion(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --version is missing, got %v", err)
 	}
 }
@@ -42,7 +43,7 @@ func TestPhasedReleaseCreateCommand_InvalidState(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp for invalid state, got %v", err)
 	}
 }
@@ -62,7 +63,7 @@ func TestPhasedReleaseCreateCommand_ValidStates(t *testing.T) {
 
 			err := cmd.Exec(context.Background(), []string{})
 			// Should not be flag.ErrHelp for valid states (will fail later due to no auth)
-			if err == flag.ErrHelp {
+			if errors.Is(err, flag.ErrHelp) {
 				t.Errorf("state %s should be valid but got flag.ErrHelp", state)
 			}
 		})
@@ -77,7 +78,7 @@ func TestPhasedReleaseUpdateCommand_MissingID(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -90,7 +91,7 @@ func TestPhasedReleaseUpdateCommand_MissingState(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --state is missing, got %v", err)
 	}
 }
@@ -103,7 +104,7 @@ func TestPhasedReleaseUpdateCommand_InvalidState(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp for invalid state, got %v", err)
 	}
 }
@@ -123,7 +124,7 @@ func TestPhasedReleaseUpdateCommand_ValidStates(t *testing.T) {
 
 			err := cmd.Exec(context.Background(), []string{})
 			// Should not be flag.ErrHelp for valid states (will fail later due to no auth)
-			if err == flag.ErrHelp {
+			if errors.Is(err, flag.ErrHelp) {
 				t.Errorf("state %s should be valid but got flag.ErrHelp", state)
 			}
 		})
@@ -138,7 +139,7 @@ func TestPhasedReleaseDeleteCommand_MissingID(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --id is missing, got %v", err)
 	}
 }
@@ -151,7 +152,7 @@ func TestPhasedReleaseDeleteCommand_MissingConfirm(t *testing.T) {
 	}
 
 	err := cmd.Exec(context.Background(), []string{})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }

--- a/internal/cli/versions/versions_release_test.go
+++ b/internal/cli/versions/versions_release_test.go
@@ -2,6 +2,7 @@ package versions
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"testing"
 )
@@ -13,7 +14,7 @@ func TestVersionsReleaseCommand_MissingVersionID(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --version-id is missing, got %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestVersionsReleaseCommand_MissingConfirm(t *testing.T) {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	if err := cmd.Exec(context.Background(), []string{}); err != flag.ErrHelp {
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("expected flag.ErrHelp when --confirm is missing, got %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -350,7 +350,7 @@ func (c *Config) Validate() error {
 }
 
 func wrapInvalidConfig(err error) error {
-	return fmt.Errorf("%w: %s", ErrInvalidConfig, err)
+	return fmt.Errorf("%w: %w", ErrInvalidConfig, err)
 }
 
 func validateDurationValue(field string, value DurationValue) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,7 +98,7 @@ func TestConfigSaveLoadRemove(t *testing.T) {
 		t.Fatalf("Remove() error: %v", err)
 	}
 
-	if _, err := Load(); err != ErrNotFound {
+	if _, err := Load(); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound after Remove(), got %v", err)
 	}
 }
@@ -107,7 +107,7 @@ func TestLoadMissingConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(tempDir, "missing.json"))
 
-	if _, err := Load(); err != ErrNotFound {
+	if _, err := Load(); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for missing config, got %v", err)
 	}
 }

--- a/tools/generate-app/main.go
+++ b/tools/generate-app/main.go
@@ -69,7 +69,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) error {
 	if err != nil {
 		restoreErr := os.WriteFile(jsonPath, originalJSON, 0o644)
 		if restoreErr != nil {
-			return fmt.Errorf("%w (also failed to restore source JSON: %v)", err, restoreErr)
+			return fmt.Errorf("%w (also failed to restore source JSON: %w)", err, restoreErr)
 		}
 		return err
 	}


### PR DESCRIPTION
## Summary

Enables the `errorlint` golangci-lint linter as phase 3 of #602, completing all three phases.

All fixes are mechanical with no behavioral changes:

- **`errors.Is()` instead of `==`/`!=`** for sentinel error comparisons (`flag.ErrHelp`, `config.ErrNotFound`, `wantErr` in tests)
- **`%w` instead of `%v`** when wrapping errors with `fmt.Errorf` (notary abort errors, keychain access denied, config validation, generate-app restore)

### Files changed (23 total)

| Category | Files | Fix |
|----------|-------|-----|
| Production code | `cmd/run.go`, `internal/asc/notary.go`, `internal/auth/keychain.go`, `internal/config/config.go`, `tools/generate-app/main.go` | `errors.Is()` + `%w` wrapping |
| Test files | `internal/asc/client_test.go`, `internal/config/config_test.go`, + 11 CLI test files | `errors.Is()` for `flag.ErrHelp` and sentinel errors |

## Checks run

- `make format` — clean
- `make lint` — passes with `errorlint` enabled
- `ASC_BYPASS_KEYCHAIN=1 make test` — all tests pass

Completes #602 (all three phases: misspell, unparam, errorlint).