### PR TITLE
Updated DoubleMemory on Wall of Apps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,7 +1720,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | bijou.fm | [Open](https://apps.apple.com/us/app/bijou-fm-for-last-fm/id6450460066) | zchwyng | iOS, macOS, tvOS, visionOS |
 | CodexMonitor | [Open](https://github.com/Dimillian/CodexMonitor) | Dimillian | macOS, iOS |
 | Dandelion | [Open](https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901) | joeycast | iOS, macOS |
-| DoubleMemory | [Open](https://doublememory.com) | Shaomeng Zhang | iOS |
+| DoubleMemory | [Open](https://apps.apple.com/app/id6737529034) | randomor | iOS, macOS |
 | Dripped | [Open](https://apps.apple.com/app/id6749790183) | mithileshchellapan | iOS |
 | Fisherman SMS Filtering | [Open](https://apps.apple.com/app/id6449192504) | MGidnian | iOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -13,9 +13,9 @@
   },
   {
     "app": "DoubleMemory",
-    "link": "https://doublememory.com",
-    "creator": "Shaomeng Zhang",
-    "platform": ["iOS"]
+    "link": "https://apps.apple.com/app/id6737529034",
+    "creator": "randomor",
+    "platform": ["iOS", "macOS"]
   },
   {
     "app": "kora: Music Reviews & Ratings",
@@ -94,8 +94,7 @@
     "link": "https://testflight.apple.com/join/HjUZtzVm",
     "creator": "sambitcreate",
     "platform": ["iOS"]
-  }
-  ,
+  },
   {
     "app": "Steps: Workout & Pedometer",
     "link": "https://apps.apple.com/us/app/steps-workout-pedometer/id6746096378",


### PR DESCRIPTION


## Summary

- Updated doublememory with proper platform and app store link

## Validation

- [ ] `make format`
- [ ] `make lint`
- [ ] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
