### PR TITLE
Fix: skip non-locale directories in fastlane metadata import

### DIFF
--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -466,7 +466,7 @@ func readFastlaneMetadata(metadataDir string) ([]FastlaneLocalization, error) {
 
 		normalized, err := normalizeLocale(locale)
 		if err != nil {
-			return nil, fmt.Errorf("invalid locale %q in metadata: %w", locale, err)
+			continue // Skip non-locale directories (e.g. trade_representative_contact_information)
 		}
 		if seen[normalized] {
 			return nil, fmt.Errorf("duplicate locale %q in metadata", normalized)
@@ -511,7 +511,7 @@ func readFastlaneAppInfoMetadata(metadataDir string) ([]AppInfoFastlaneLocalizat
 
 		normalized, err := normalizeLocale(locale)
 		if err != nil {
-			return nil, fmt.Errorf("invalid locale %q in metadata: %w", locale, err)
+			continue // Skip non-locale directories (e.g. trade_representative_contact_information)
 		}
 		if seen[normalized] {
 			return nil, fmt.Errorf("duplicate locale %q in metadata", normalized)

--- a/internal/cli/migrate/migrate_test.go
+++ b/internal/cli/migrate/migrate_test.go
@@ -615,3 +615,67 @@ func TestValidateAppInfoLocalization_UsesRuneCount(t *testing.T) {
 		}
 	}
 }
+
+func TestReadFastlaneMetadata_SkipsNonLocaleDirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create non-locale directories that should be skipped
+	for _, name := range []string{"trade_representative_contact_information", "apple_tv_privacy_policy"} {
+		if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+			t.Fatalf("failed to create dir %s: %v", name, err)
+		}
+	}
+
+	// Create a valid locale directory
+	enDir := filepath.Join(dir, "en-US")
+	if err := os.MkdirAll(enDir, 0o755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(enDir, "description.txt"), []byte("English description"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	locs, err := readFastlaneMetadata(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(locs) != 1 {
+		t.Errorf("expected 1 localization (non-locale dirs skipped), got %d", len(locs))
+	}
+	if locs[0].Locale != "en-US" {
+		t.Errorf("expected locale 'en-US', got %q", locs[0].Locale)
+	}
+}
+
+func TestReadFastlaneAppInfoMetadata_SkipsNonLocaleDirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create non-locale directories that should be skipped
+	for _, name := range []string{"trade_representative_contact_information", "review_information"} {
+		if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+			t.Fatalf("failed to create dir %s: %v", name, err)
+		}
+	}
+
+	// Create a valid locale directory with content
+	enDir := filepath.Join(dir, "en-US")
+	if err := os.MkdirAll(enDir, 0o755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(enDir, "name.txt"), []byte("My App"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	locs, err := readFastlaneAppInfoMetadata(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(locs) != 1 {
+		t.Errorf("expected 1 localization (non-locale dirs skipped), got %d", len(locs))
+	}
+	if locs[0].Locale != "en-US" {
+		t.Errorf("expected locale 'en-US', got %q", locs[0].Locale)
+	}
+}


### PR DESCRIPTION
## Summary
- `asc migrate import` fails when `fastlane/metadata/` contains non-locale subdirectories like `trade_representative_contact_information`
- Instead of returning an error when `normalizeLocale()` rejects a directory name, both `readFastlaneMetadata()` and `readFastlaneAppInfoMetadata()` now skip it with `continue`
- This handles any non-locale directory generically, not just the ones currently known

## Changes
- `internal/cli/migrate/migrate.go`: Changed error return to `continue` in both metadata reader functions
- `internal/cli/migrate/migrate_test.go`: Added tests for both functions to verify non-locale directories are skipped

## Test plan
- [x] New tests pass: `TestReadFastlaneMetadata_SkipsNonLocaleDirectories` and `TestReadFastlaneAppInfoMetadata_SkipsNonLocaleDirectories`
- [x] Existing tests unchanged and passing (including `TestReadFastlaneMetadata_SkipsSpecialDirectories`)
- [x] Full test suite passes (`go test ./...` — all 83 packages)

Fixes #611

🤖 Generated with [Claude Code](https://claude.ai/claude-code)