### PR TITLE
Missing OpenAPI endpoints

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1503,6 +1503,39 @@ func (c *Client) UpdateAppInfoLocalization(ctx context.Context, localizationID s
 	return &response, nil
 }
 
+// GetAppInfoLocalization retrieves an app info localization by ID.
+func (c *Client) GetAppInfoLocalization(ctx context.Context, localizationID string) (*AppInfoLocalizationResponse, error) {
+	localizationID = strings.TrimSpace(localizationID)
+	if localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfoLocalizations/%s", localizationID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppInfoLocalizationResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// DeleteAppInfoLocalization deletes an app info localization by ID.
+func (c *Client) DeleteAppInfoLocalization(ctx context.Context, localizationID string) error {
+	localizationID = strings.TrimSpace(localizationID)
+	if localizationID == "" {
+		return fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appInfoLocalizations/%s", localizationID)
+	_, err := c.do(ctx, "DELETE", path, nil)
+	return err
+}
+
 // GetAppInfos retrieves app info records for an app.
 func (c *Client) GetAppInfos(ctx context.Context, appID string) (*AppInfosResponse, error) {
 	path := fmt.Sprintf("/v1/apps/%s/appInfos", appID)

--- a/internal/asc/client_app_info_localizations_detail_test.go
+++ b/internal/asc/client_app_info_localizations_detail_test.go
@@ -1,0 +1,45 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetAppInfoLocalization_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appInfoLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/appInfoLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetAppInfoLocalization(context.Background(), "loc-1")
+	if err != nil {
+		t.Fatalf("GetAppInfoLocalization() error: %v", err)
+	}
+	if resp.Data.ID != "loc-1" {
+		t.Fatalf("expected id loc-1, got %q", resp.Data.ID)
+	}
+}
+
+func TestDeleteAppInfoLocalization_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, "")
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appInfoLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/appInfoLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteAppInfoLocalization(context.Background(), "loc-1"); err != nil {
+		t.Fatalf("DeleteAppInfoLocalization() error: %v", err)
+	}
+}

--- a/internal/asc/client_game_center.go
+++ b/internal/asc/client_game_center.go
@@ -612,6 +612,22 @@ func (c *Client) GetGameCenterLeaderboardReleases(ctx context.Context, leaderboa
 	return &response, nil
 }
 
+// GetGameCenterLeaderboardRelease retrieves a leaderboard release by ID.
+func (c *Client) GetGameCenterLeaderboardRelease(ctx context.Context, releaseID string) (*GameCenterLeaderboardReleaseResponse, error) {
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardReleases/%s", strings.TrimSpace(releaseID))
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GameCenterLeaderboardReleaseResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // CreateGameCenterLeaderboardRelease creates a new Game Center leaderboard release.
 func (c *Client) CreateGameCenterLeaderboardRelease(ctx context.Context, gcDetailID, leaderboardID string) (*GameCenterLeaderboardReleaseResponse, error) {
 	payload := GameCenterLeaderboardReleaseCreateRequest{
@@ -682,6 +698,22 @@ func (c *Client) GetGameCenterAchievementReleases(ctx context.Context, achieveme
 	}
 
 	var response GameCenterAchievementReleasesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetGameCenterAchievementRelease retrieves an achievement release by ID.
+func (c *Client) GetGameCenterAchievementRelease(ctx context.Context, releaseID string) (*GameCenterAchievementReleaseResponse, error) {
+	path := fmt.Sprintf("/v1/gameCenterAchievementReleases/%s", strings.TrimSpace(releaseID))
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GameCenterAchievementReleaseResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
@@ -813,6 +845,22 @@ func (c *Client) GetGameCenterLeaderboardSetReleases(ctx context.Context, setID 
 	}
 
 	var response GameCenterLeaderboardSetReleasesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetGameCenterLeaderboardSetRelease retrieves a leaderboard set release by ID.
+func (c *Client) GetGameCenterLeaderboardSetRelease(ctx context.Context, releaseID string) (*GameCenterLeaderboardSetReleaseResponse, error) {
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardSetReleases/%s", strings.TrimSpace(releaseID))
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GameCenterLeaderboardSetReleaseResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}

--- a/internal/asc/client_game_center_releases_detail_test.go
+++ b/internal/asc/client_game_center_releases_detail_test.go
@@ -1,0 +1,76 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetGameCenterAchievementRelease_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"gameCenterAchievementReleases","id":"rel-1","attributes":{"live":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/gameCenterAchievementReleases/rel-1" {
+			t.Fatalf("expected path /v1/gameCenterAchievementReleases/rel-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetGameCenterAchievementRelease(context.Background(), "rel-1")
+	if err != nil {
+		t.Fatalf("GetGameCenterAchievementRelease() error: %v", err)
+	}
+	if resp.Data.ID != "rel-1" {
+		t.Fatalf("expected id rel-1, got %q", resp.Data.ID)
+	}
+	if !resp.Data.Attributes.Live {
+		t.Fatalf("expected live to be true")
+	}
+}
+
+func TestGetGameCenterLeaderboardRelease_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"gameCenterLeaderboardReleases","id":"rel-2","attributes":{"live":false}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/gameCenterLeaderboardReleases/rel-2" {
+			t.Fatalf("expected path /v1/gameCenterLeaderboardReleases/rel-2, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetGameCenterLeaderboardRelease(context.Background(), "rel-2")
+	if err != nil {
+		t.Fatalf("GetGameCenterLeaderboardRelease() error: %v", err)
+	}
+	if resp.Data.ID != "rel-2" {
+		t.Fatalf("expected id rel-2, got %q", resp.Data.ID)
+	}
+	if resp.Data.Attributes.Live {
+		t.Fatalf("expected live to be false")
+	}
+}
+
+func TestGetGameCenterLeaderboardSetRelease_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"gameCenterLeaderboardSetReleases","id":"rel-3","attributes":{"live":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/gameCenterLeaderboardSetReleases/rel-3" {
+			t.Fatalf("expected path /v1/gameCenterLeaderboardSetReleases/rel-3, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetGameCenterLeaderboardSetRelease(context.Background(), "rel-3")
+	if err != nil {
+		t.Fatalf("GetGameCenterLeaderboardSetRelease() error: %v", err)
+	}
+	if resp.Data.ID != "rel-3" {
+		t.Fatalf("expected id rel-3, got %q", resp.Data.ID)
+	}
+}

--- a/internal/asc/client_iap_missing_endpoints_test.go
+++ b/internal/asc/client_iap_missing_endpoints_test.go
@@ -1,0 +1,99 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGetInAppPurchaseLocalization_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"inAppPurchaseLocalizations","id":"loc-1","attributes":{"name":"Name","locale":"en-US"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchaseLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/inAppPurchaseLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetInAppPurchaseLocalization(context.Background(), "loc-1")
+	if err != nil {
+		t.Fatalf("GetInAppPurchaseLocalization() error: %v", err)
+	}
+	if resp.Data.ID != "loc-1" {
+		t.Fatalf("expected id loc-1, got %q", resp.Data.ID)
+	}
+}
+
+func TestUpdateInAppPurchaseOfferCodeCustomCode_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"inAppPurchaseOfferCodeCustomCodes","id":"cc-1","attributes":{"active":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchaseOfferCodeCustomCodes/cc-1" {
+			t.Fatalf("expected path /v1/inAppPurchaseOfferCodeCustomCodes/cc-1, got %s", req.URL.Path)
+		}
+
+		var payload InAppPurchaseOfferCodeCustomCodeUpdateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload error: %v", err)
+		}
+		if payload.Data.Type != ResourceTypeInAppPurchaseOfferCodeCustomCodes {
+			t.Fatalf("expected type %s, got %q", ResourceTypeInAppPurchaseOfferCodeCustomCodes, payload.Data.Type)
+		}
+		if payload.Data.ID != "cc-1" {
+			t.Fatalf("expected id cc-1, got %q", payload.Data.ID)
+		}
+		if payload.Data.Attributes == nil || payload.Data.Attributes.Active == nil || !*payload.Data.Attributes.Active {
+			t.Fatalf("expected active=true in request payload")
+		}
+
+		assertAuthorized(t, req)
+	}, response)
+
+	active := true
+	if _, err := client.UpdateInAppPurchaseOfferCodeCustomCode(context.Background(), "cc-1", InAppPurchaseOfferCodeCustomCodeUpdateAttributes{
+		Active: &active,
+	}); err != nil {
+		t.Fatalf("UpdateInAppPurchaseOfferCodeCustomCode() error: %v", err)
+	}
+}
+
+func TestUpdateInAppPurchaseOfferCodeOneTimeUseCode_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"inAppPurchaseOfferCodeOneTimeUseCodes","id":"otuc-1","attributes":{"active":false}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchaseOfferCodeOneTimeUseCodes/otuc-1" {
+			t.Fatalf("expected path /v1/inAppPurchaseOfferCodeOneTimeUseCodes/otuc-1, got %s", req.URL.Path)
+		}
+
+		var payload InAppPurchaseOfferCodeOneTimeUseCodeUpdateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload error: %v", err)
+		}
+		if payload.Data.Type != ResourceTypeInAppPurchaseOfferCodeOneTimeUseCodes {
+			t.Fatalf("expected type %s, got %q", ResourceTypeInAppPurchaseOfferCodeOneTimeUseCodes, payload.Data.Type)
+		}
+		if payload.Data.ID != "otuc-1" {
+			t.Fatalf("expected id otuc-1, got %q", payload.Data.ID)
+		}
+		if payload.Data.Attributes == nil || payload.Data.Attributes.Active == nil || *payload.Data.Attributes.Active {
+			t.Fatalf("expected active=false in request payload")
+		}
+
+		assertAuthorized(t, req)
+	}, response)
+
+	active := false
+	if _, err := client.UpdateInAppPurchaseOfferCodeOneTimeUseCode(context.Background(), "otuc-1", InAppPurchaseOfferCodeOneTimeUseCodeUpdateAttributes{
+		Active: &active,
+	}); err != nil {
+		t.Fatalf("UpdateInAppPurchaseOfferCodeOneTimeUseCode() error: %v", err)
+	}
+}

--- a/internal/asc/client_iap_subresources.go
+++ b/internal/asc/client_iap_subresources.go
@@ -107,6 +107,27 @@ func (c *Client) DeleteInAppPurchaseLocalization(ctx context.Context, localizati
 	return err
 }
 
+// GetInAppPurchaseLocalization retrieves an IAP localization by ID.
+func (c *Client) GetInAppPurchaseLocalization(ctx context.Context, localizationID string) (*InAppPurchaseLocalizationResponse, error) {
+	localizationID = strings.TrimSpace(localizationID)
+	if localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseLocalizations/%s", localizationID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseLocalizationResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetInAppPurchaseImages retrieves images for an in-app purchase.
 func (c *Client) GetInAppPurchaseImages(ctx context.Context, iapID string, opts ...IAPImagesOption) (*InAppPurchaseImagesResponse, error) {
 	query := &iapImagesQuery{}
@@ -1011,6 +1032,42 @@ func (c *Client) CreateInAppPurchaseOfferCodeCustomCode(ctx context.Context, req
 	return &response, nil
 }
 
+// UpdateInAppPurchaseOfferCodeCustomCode updates a custom code by ID.
+func (c *Client) UpdateInAppPurchaseOfferCodeCustomCode(ctx context.Context, customCodeID string, attrs InAppPurchaseOfferCodeCustomCodeUpdateAttributes) (*InAppPurchaseOfferCodeCustomCodeResponse, error) {
+	customCodeID = strings.TrimSpace(customCodeID)
+	if customCodeID == "" {
+		return nil, fmt.Errorf("customCodeID is required")
+	}
+
+	payload := InAppPurchaseOfferCodeCustomCodeUpdateRequest{
+		Data: InAppPurchaseOfferCodeCustomCodeUpdateData{
+			Type: ResourceTypeInAppPurchaseOfferCodeCustomCodes,
+			ID:   customCodeID,
+		},
+	}
+	if attrs.Active != nil {
+		payload.Data.Attributes = &attrs
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseOfferCodeCustomCodes/%s", customCodeID)
+	data, err := c.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseOfferCodeCustomCodeResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetInAppPurchaseOfferCodeOneTimeUseCodes retrieves one-time use codes for an offer code.
 func (c *Client) GetInAppPurchaseOfferCodeOneTimeUseCodes(ctx context.Context, offerCodeID string, opts ...IAPOfferCodeOneTimeUseCodesOption) (*InAppPurchaseOfferCodeOneTimeUseCodesResponse, error) {
 	query := &iapOfferCodeOneTimeUseCodesQuery{}
@@ -1089,6 +1146,42 @@ func (c *Client) CreateInAppPurchaseOfferCodeOneTimeUseCode(ctx context.Context,
 	}
 
 	data, err := c.do(ctx, http.MethodPost, "/v1/inAppPurchaseOfferCodeOneTimeUseCodes", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseOfferCodeOneTimeUseCodeResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// UpdateInAppPurchaseOfferCodeOneTimeUseCode updates a one-time use code batch by ID.
+func (c *Client) UpdateInAppPurchaseOfferCodeOneTimeUseCode(ctx context.Context, oneTimeUseCodeID string, attrs InAppPurchaseOfferCodeOneTimeUseCodeUpdateAttributes) (*InAppPurchaseOfferCodeOneTimeUseCodeResponse, error) {
+	oneTimeUseCodeID = strings.TrimSpace(oneTimeUseCodeID)
+	if oneTimeUseCodeID == "" {
+		return nil, fmt.Errorf("oneTimeUseCodeID is required")
+	}
+
+	payload := InAppPurchaseOfferCodeOneTimeUseCodeUpdateRequest{
+		Data: InAppPurchaseOfferCodeOneTimeUseCodeUpdateData{
+			Type: ResourceTypeInAppPurchaseOfferCodeOneTimeUseCodes,
+			ID:   oneTimeUseCodeID,
+		},
+	}
+	if attrs.Active != nil {
+		payload.Data.Attributes = &attrs
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseOfferCodeOneTimeUseCodes/%s", oneTimeUseCodeID)
+	data, err := c.do(ctx, http.MethodPatch, path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asc/iap_resources.go
+++ b/internal/asc/iap_resources.go
@@ -349,6 +349,23 @@ type InAppPurchaseOfferCodeCustomCodeCreateRequest struct {
 	Data InAppPurchaseOfferCodeCustomCodeCreateData `json:"data"`
 }
 
+// InAppPurchaseOfferCodeCustomCodeUpdateAttributes describes attributes for updating custom codes.
+type InAppPurchaseOfferCodeCustomCodeUpdateAttributes struct {
+	Active *bool `json:"active,omitempty"`
+}
+
+// InAppPurchaseOfferCodeCustomCodeUpdateData is the data portion of an update request.
+type InAppPurchaseOfferCodeCustomCodeUpdateData struct {
+	Type       ResourceType                                      `json:"type"`
+	ID         string                                            `json:"id"`
+	Attributes *InAppPurchaseOfferCodeCustomCodeUpdateAttributes `json:"attributes,omitempty"`
+}
+
+// InAppPurchaseOfferCodeCustomCodeUpdateRequest is a request to update custom codes.
+type InAppPurchaseOfferCodeCustomCodeUpdateRequest struct {
+	Data InAppPurchaseOfferCodeCustomCodeUpdateData `json:"data"`
+}
+
 type InAppPurchaseOfferCodeOneTimeUseCodeAttributes struct {
 	NumberOfCodes  int    `json:"numberOfCodes,omitempty"`
 	CreatedDate    string `json:"createdDate,omitempty"`
@@ -383,6 +400,23 @@ type InAppPurchaseOfferCodeOneTimeUseCodeCreateData struct {
 // InAppPurchaseOfferCodeOneTimeUseCodeCreateRequest is a request to generate one-time use codes.
 type InAppPurchaseOfferCodeOneTimeUseCodeCreateRequest struct {
 	Data InAppPurchaseOfferCodeOneTimeUseCodeCreateData `json:"data"`
+}
+
+// InAppPurchaseOfferCodeOneTimeUseCodeUpdateAttributes describes attributes for updating one-time use codes.
+type InAppPurchaseOfferCodeOneTimeUseCodeUpdateAttributes struct {
+	Active *bool `json:"active,omitempty"`
+}
+
+// InAppPurchaseOfferCodeOneTimeUseCodeUpdateData is the data portion of an update request.
+type InAppPurchaseOfferCodeOneTimeUseCodeUpdateData struct {
+	Type       ResourceType                                          `json:"type"`
+	ID         string                                                `json:"id"`
+	Attributes *InAppPurchaseOfferCodeOneTimeUseCodeUpdateAttributes `json:"attributes,omitempty"`
+}
+
+// InAppPurchaseOfferCodeOneTimeUseCodeUpdateRequest is a request to update one-time use codes.
+type InAppPurchaseOfferCodeOneTimeUseCodeUpdateRequest struct {
+	Data InAppPurchaseOfferCodeOneTimeUseCodeUpdateData `json:"data"`
 }
 
 // In-app purchase submissions.


### PR DESCRIPTION
## Summary

- Implemented 8 missing non-relationship endpoints from the App Store Connect API OpenAPI snapshot.
- Added client methods for:
  - `GET /v1/appInfoLocalizations/{id}`
  - `DELETE /v1/appInfoLocalizations/{id}`
  - `GET /v1/gameCenterAchievementReleases/{id}`
  - `GET /v1/gameCenterLeaderboardReleases/{id}`
  - `GET /v1/gameCenterLeaderboardSetReleases/{id}`
  - `GET /v1/inAppPurchaseLocalizations/{id}`
  - `PATCH /v1/inAppPurchaseOfferCodeCustomCodes/{id}`
  - `PATCH /v1/inAppPurchaseOfferCodeOneTimeUseCodes/{id}`
- Included new request-shaping tests for all added endpoints.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f5e0f383-4b93-4ea6-8120-1afde7401653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5e0f383-4b93-4ea6-8120-1afde7401653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

