### PR TITLE
asc: add missing relationship endpoints (issue #619)

### DIFF
--- a/internal/asc/client_iap_subresources.go
+++ b/internal/asc/client_iap_subresources.go
@@ -1323,3 +1323,550 @@ func (c *Client) CreateInAppPurchaseSubmission(ctx context.Context, iapID string
 
 	return &response, nil
 }
+
+// InAppPurchasePriceScheduleBaseTerritoryLinkageResponse is the response for base territory relationship endpoints.
+type InAppPurchasePriceScheduleBaseTerritoryLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// InAppPurchaseAppStoreReviewScreenshotLinkageResponse is the response for app store review screenshot relationship endpoints.
+type InAppPurchaseAppStoreReviewScreenshotLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// InAppPurchaseContentLinkageResponse is the response for content relationship endpoints.
+type InAppPurchaseContentLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// InAppPurchaseIapPriceScheduleLinkageResponse is the response for IAP price schedule relationship endpoints.
+type InAppPurchaseIapPriceScheduleLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// InAppPurchaseInAppPurchaseAvailabilityLinkageResponse is the response for availability relationship endpoints.
+type InAppPurchaseInAppPurchaseAvailabilityLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// InAppPurchasePromotedPurchaseLinkageResponse is the response for promoted purchase relationship endpoints.
+type InAppPurchasePromotedPurchaseLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetInAppPurchaseAvailabilityAvailableTerritoriesRelationships retrieves available territory linkages for an IAP availability.
+func (c *Client) GetInAppPurchaseAvailabilityAvailableTerritoriesRelationships(ctx context.Context, availabilityID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	availabilityID = strings.TrimSpace(availabilityID)
+	if query.nextURL == "" && availabilityID == "" {
+		return nil, fmt.Errorf("availabilityID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseAvailabilities/%s/relationships/availableTerritories", availabilityID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseAvailabilityAvailableTerritoriesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseOfferCodeCustomCodesRelationships retrieves custom code linkages for an IAP offer code.
+func (c *Client) GetInAppPurchaseOfferCodeCustomCodesRelationships(ctx context.Context, offerCodeID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	offerCodeID = strings.TrimSpace(offerCodeID)
+	if query.nextURL == "" && offerCodeID == "" {
+		return nil, fmt.Errorf("offerCodeID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseOfferCodes/%s/relationships/customCodes", offerCodeID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseOfferCodeCustomCodesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseOfferCodeOneTimeUseCodesRelationships retrieves one-time use code linkages for an IAP offer code.
+func (c *Client) GetInAppPurchaseOfferCodeOneTimeUseCodesRelationships(ctx context.Context, offerCodeID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	offerCodeID = strings.TrimSpace(offerCodeID)
+	if query.nextURL == "" && offerCodeID == "" {
+		return nil, fmt.Errorf("offerCodeID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseOfferCodes/%s/relationships/oneTimeUseCodes", offerCodeID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseOfferCodeOneTimeUseCodesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseOfferCodePricesRelationships retrieves price linkages for an IAP offer code.
+func (c *Client) GetInAppPurchaseOfferCodePricesRelationships(ctx context.Context, offerCodeID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	offerCodeID = strings.TrimSpace(offerCodeID)
+	if query.nextURL == "" && offerCodeID == "" {
+		return nil, fmt.Errorf("offerCodeID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchaseOfferCodes/%s/relationships/prices", offerCodeID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseOfferCodePricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchasePricePointEqualizationsRelationships retrieves equalization linkages for an IAP price point.
+func (c *Client) GetInAppPurchasePricePointEqualizationsRelationships(ctx context.Context, pricePointID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	pricePointID = strings.TrimSpace(pricePointID)
+	if query.nextURL == "" && pricePointID == "" {
+		return nil, fmt.Errorf("pricePointID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchasePricePoints/%s/relationships/equalizations", pricePointID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchasePricePointEqualizationsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchasePriceScheduleAutomaticPricesRelationships retrieves automatic price linkages for an IAP price schedule.
+func (c *Client) GetInAppPurchasePriceScheduleAutomaticPricesRelationships(ctx context.Context, scheduleID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	scheduleID = strings.TrimSpace(scheduleID)
+	if query.nextURL == "" && scheduleID == "" {
+		return nil, fmt.Errorf("scheduleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchasePriceSchedules/%s/relationships/automaticPrices", scheduleID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchasePriceScheduleAutomaticPricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchasePriceScheduleBaseTerritoryRelationship retrieves the base territory linkage for an IAP price schedule.
+func (c *Client) GetInAppPurchasePriceScheduleBaseTerritoryRelationship(ctx context.Context, scheduleID string) (*InAppPurchasePriceScheduleBaseTerritoryLinkageResponse, error) {
+	scheduleID = strings.TrimSpace(scheduleID)
+	if scheduleID == "" {
+		return nil, fmt.Errorf("scheduleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchasePriceSchedules/%s/relationships/baseTerritory", scheduleID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchasePriceScheduleBaseTerritoryLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchasePriceScheduleManualPricesRelationships retrieves manual price linkages for an IAP price schedule.
+func (c *Client) GetInAppPurchasePriceScheduleManualPricesRelationships(ctx context.Context, scheduleID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	scheduleID = strings.TrimSpace(scheduleID)
+	if query.nextURL == "" && scheduleID == "" {
+		return nil, fmt.Errorf("scheduleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/inAppPurchasePriceSchedules/%s/relationships/manualPrices", scheduleID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchasePriceScheduleManualPricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseAppStoreReviewScreenshotRelationship retrieves the app store review screenshot linkage for an IAP.
+func (c *Client) GetInAppPurchaseAppStoreReviewScreenshotRelationship(ctx context.Context, iapID string) (*InAppPurchaseAppStoreReviewScreenshotLinkageResponse, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/appStoreReviewScreenshot", iapID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseAppStoreReviewScreenshotLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseContentRelationship retrieves the content linkage for an IAP.
+func (c *Client) GetInAppPurchaseContentRelationship(ctx context.Context, iapID string) (*InAppPurchaseContentLinkageResponse, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/content", iapID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseContentLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseIapPriceScheduleRelationship retrieves the IAP price schedule linkage for an IAP.
+func (c *Client) GetInAppPurchaseIapPriceScheduleRelationship(ctx context.Context, iapID string) (*InAppPurchaseIapPriceScheduleLinkageResponse, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/iapPriceSchedule", iapID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseIapPriceScheduleLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseImagesRelationships retrieves image linkages for an IAP.
+func (c *Client) GetInAppPurchaseImagesRelationships(ctx context.Context, iapID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	iapID = strings.TrimSpace(iapID)
+	if query.nextURL == "" && iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/images", iapID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseImagesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseInAppPurchaseAvailabilityRelationship retrieves the availability linkage for an IAP.
+func (c *Client) GetInAppPurchaseInAppPurchaseAvailabilityRelationship(ctx context.Context, iapID string) (*InAppPurchaseInAppPurchaseAvailabilityLinkageResponse, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/inAppPurchaseAvailability", iapID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchaseInAppPurchaseAvailabilityLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseInAppPurchaseLocalizationsRelationships retrieves localization linkages for an IAP.
+func (c *Client) GetInAppPurchaseInAppPurchaseLocalizationsRelationships(ctx context.Context, iapID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	iapID = strings.TrimSpace(iapID)
+	if query.nextURL == "" && iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/inAppPurchaseLocalizations", iapID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseLocalizationsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchaseOfferCodesRelationships retrieves offer code linkages for an IAP.
+func (c *Client) GetInAppPurchaseOfferCodesRelationships(ctx context.Context, iapID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	iapID = strings.TrimSpace(iapID)
+	if query.nextURL == "" && iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/offerCodes", iapID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchaseOfferCodesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchasePricePointsRelationships retrieves price point linkages for an IAP.
+func (c *Client) GetInAppPurchasePricePointsRelationships(ctx context.Context, iapID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	iapID = strings.TrimSpace(iapID)
+	if query.nextURL == "" && iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/pricePoints", iapID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("inAppPurchasePricePointsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetInAppPurchasePromotedPurchaseRelationship retrieves the promoted purchase linkage for an IAP.
+func (c *Client) GetInAppPurchasePromotedPurchaseRelationship(ctx context.Context, iapID string) (*InAppPurchasePromotedPurchaseLinkageResponse, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return nil, fmt.Errorf("iapID is required")
+	}
+
+	path := fmt.Sprintf("/v2/inAppPurchases/%s/relationships/promotedPurchase", iapID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InAppPurchasePromotedPurchaseLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/client_pricing.go
+++ b/internal/asc/client_pricing.go
@@ -114,6 +114,41 @@ func (c *Client) GetAppPricePointEqualizations(ctx context.Context, pricePointID
 	return &response, nil
 }
 
+// GetAppPricePointEqualizationsRelationships retrieves equalization linkages for an app price point.
+func (c *Client) GetAppPricePointEqualizationsRelationships(ctx context.Context, pricePointID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	pricePointID = strings.TrimSpace(pricePointID)
+	if query.nextURL == "" && pricePointID == "" {
+		return nil, fmt.Errorf("pricePointID is required")
+	}
+
+	path := fmt.Sprintf("/v3/appPricePoints/%s/relationships/equalizations", pricePointID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appPricePointEqualizationsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetAppPriceSchedule retrieves the app price schedule for an app.
 func (c *Client) GetAppPriceSchedule(ctx context.Context, appID string) (*AppPriceScheduleResponse, error) {
 	appID = strings.TrimSpace(appID)
@@ -251,6 +286,33 @@ func (c *Client) GetAppPriceScheduleBaseTerritory(ctx context.Context, scheduleI
 	return &response, nil
 }
 
+// AppPriceScheduleBaseTerritoryLinkageResponse is the response for base territory relationship endpoints.
+type AppPriceScheduleBaseTerritoryLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetAppPriceScheduleBaseTerritoryRelationship retrieves the base territory linkage for a schedule.
+func (c *Client) GetAppPriceScheduleBaseTerritoryRelationship(ctx context.Context, scheduleID string) (*AppPriceScheduleBaseTerritoryLinkageResponse, error) {
+	scheduleID = strings.TrimSpace(scheduleID)
+	if scheduleID == "" {
+		return nil, fmt.Errorf("scheduleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appPriceSchedules/%s/relationships/baseTerritory", scheduleID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AppPriceScheduleBaseTerritoryLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetAppPriceScheduleManualPrices retrieves manual prices for a schedule.
 func (c *Client) GetAppPriceScheduleManualPrices(ctx context.Context, scheduleID string) (*AppPricesResponse, error) {
 	scheduleID = strings.TrimSpace(scheduleID)
@@ -269,6 +331,41 @@ func (c *Client) GetAppPriceScheduleManualPrices(ctx context.Context, scheduleID
 	return &response, nil
 }
 
+// GetAppPriceScheduleManualPricesRelationships retrieves manual price linkages for a schedule.
+func (c *Client) GetAppPriceScheduleManualPricesRelationships(ctx context.Context, scheduleID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	scheduleID = strings.TrimSpace(scheduleID)
+	if query.nextURL == "" && scheduleID == "" {
+		return nil, fmt.Errorf("scheduleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appPriceSchedules/%s/relationships/manualPrices", scheduleID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appPriceScheduleManualPricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetAppPriceScheduleAutomaticPrices retrieves automatic prices for a schedule.
 func (c *Client) GetAppPriceScheduleAutomaticPrices(ctx context.Context, scheduleID string) (*AppPricesResponse, error) {
 	scheduleID = strings.TrimSpace(scheduleID)
@@ -282,6 +379,41 @@ func (c *Client) GetAppPriceScheduleAutomaticPrices(ctx context.Context, schedul
 	var response AppPricesResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse automatic prices response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetAppPriceScheduleAutomaticPricesRelationships retrieves automatic price linkages for a schedule.
+func (c *Client) GetAppPriceScheduleAutomaticPricesRelationships(ctx context.Context, scheduleID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	scheduleID = strings.TrimSpace(scheduleID)
+	if query.nextURL == "" && scheduleID == "" {
+		return nil, fmt.Errorf("scheduleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/appPriceSchedules/%s/relationships/automaticPrices", scheduleID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appPriceScheduleAutomaticPricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	return &response, nil

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -563,6 +563,41 @@ func (c *Client) GetSubscriptionPromotionalOfferPrices(ctx context.Context, offe
 	return &response, nil
 }
 
+// GetSubscriptionPromotionalOfferPricesRelationships retrieves price linkages for a promotional offer.
+func (c *Client) GetSubscriptionPromotionalOfferPricesRelationships(ctx context.Context, offerID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	offerID = strings.TrimSpace(offerID)
+	if query.nextURL == "" && offerID == "" {
+		return nil, fmt.Errorf("offerID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionPromotionalOffers/%s/relationships/prices", offerID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPromotionalOfferPricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetSubscriptionOfferCodes retrieves offer codes for a subscription.
 func (c *Client) GetSubscriptionOfferCodes(ctx context.Context, subscriptionID string, opts ...SubscriptionOfferCodesOption) (*SubscriptionOfferCodesResponse, error) {
 	query := &subscriptionOfferCodesQuery{}
@@ -744,6 +779,41 @@ func (c *Client) GetSubscriptionOfferCodeCustomCodes(ctx context.Context, offerC
 	return &response, nil
 }
 
+// GetSubscriptionOfferCodeCustomCodesRelationships retrieves custom code linkages for a subscription offer code.
+func (c *Client) GetSubscriptionOfferCodeCustomCodesRelationships(ctx context.Context, offerCodeID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	offerCodeID = strings.TrimSpace(offerCodeID)
+	if query.nextURL == "" && offerCodeID == "" {
+		return nil, fmt.Errorf("offerCodeID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionOfferCodes/%s/relationships/customCodes", offerCodeID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionOfferCodeCustomCodesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetSubscriptionOfferCodePrices retrieves prices for an offer code.
 func (c *Client) GetSubscriptionOfferCodePrices(ctx context.Context, offerCodeID string, opts ...SubscriptionOfferCodePricesOption) (*SubscriptionOfferCodePricesResponse, error) {
 	query := &subscriptionOfferCodePricesQuery{}
@@ -770,6 +840,41 @@ func (c *Client) GetSubscriptionOfferCodePrices(ctx context.Context, offerCodeID
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
+	return &response, nil
+}
+
+// GetSubscriptionOfferCodePricesRelationships retrieves price linkages for a subscription offer code.
+func (c *Client) GetSubscriptionOfferCodePricesRelationships(ctx context.Context, offerCodeID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	offerCodeID = strings.TrimSpace(offerCodeID)
+	if query.nextURL == "" && offerCodeID == "" {
+		return nil, fmt.Errorf("offerCodeID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionOfferCodes/%s/relationships/prices", offerCodeID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionOfferCodePricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
 	return &response, nil
 }
 
@@ -872,6 +977,41 @@ func (c *Client) GetSubscriptionPricePointEqualizations(ctx context.Context, pri
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
+	return &response, nil
+}
+
+// GetSubscriptionPricePointEqualizationsRelationships retrieves equalization linkages for a subscription price point.
+func (c *Client) GetSubscriptionPricePointEqualizationsRelationships(ctx context.Context, pricePointID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	pricePointID = strings.TrimSpace(pricePointID)
+	if query.nextURL == "" && pricePointID == "" {
+		return nil, fmt.Errorf("pricePointID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionPricePoints/%s/relationships/equalizations", pricePointID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPricePointEqualizationsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
 	return &response, nil
 }
 

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -483,3 +483,496 @@ func (c *Client) GetSubscriptionPromotedPurchase(ctx context.Context, subID stri
 
 	return &response, nil
 }
+
+// SubscriptionAppStoreReviewScreenshotLinkageResponse is the response for app store review screenshot relationship endpoints.
+type SubscriptionAppStoreReviewScreenshotLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// SubscriptionPromotedPurchaseLinkageResponse is the response for promoted purchase relationship endpoints.
+type SubscriptionPromotedPurchaseLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// SubscriptionSubscriptionAvailabilityLinkageResponse is the response for subscription availability relationship endpoints.
+type SubscriptionSubscriptionAvailabilityLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetSubscriptionAvailabilityAvailableTerritoriesRelationships retrieves available territory linkages for an availability.
+func (c *Client) GetSubscriptionAvailabilityAvailableTerritoriesRelationships(ctx context.Context, availabilityID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	availabilityID = strings.TrimSpace(availabilityID)
+	if query.nextURL == "" && availabilityID == "" {
+		return nil, fmt.Errorf("availabilityID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionAvailabilities/%s/relationships/availableTerritories", availabilityID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionAvailabilityAvailableTerritoriesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionGroupSubscriptionGroupLocalizationsRelationships retrieves localization linkages for a subscription group.
+func (c *Client) GetSubscriptionGroupSubscriptionGroupLocalizationsRelationships(ctx context.Context, groupID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	groupID = strings.TrimSpace(groupID)
+	if query.nextURL == "" && groupID == "" {
+		return nil, fmt.Errorf("groupID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionGroups/%s/relationships/subscriptionGroupLocalizations", groupID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionGroupLocalizationsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionGroupSubscriptionsRelationships retrieves subscription linkages for a subscription group.
+func (c *Client) GetSubscriptionGroupSubscriptionsRelationships(ctx context.Context, groupID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	groupID = strings.TrimSpace(groupID)
+	if query.nextURL == "" && groupID == "" {
+		return nil, fmt.Errorf("groupID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptionGroups/%s/relationships/subscriptions", groupID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionGroupSubscriptionsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionAppStoreReviewScreenshotRelationship retrieves the review screenshot linkage for a subscription.
+func (c *Client) GetSubscriptionAppStoreReviewScreenshotRelationship(ctx context.Context, subID string) (*SubscriptionAppStoreReviewScreenshotLinkageResponse, error) {
+	subID = strings.TrimSpace(subID)
+	if subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/appStoreReviewScreenshot", subID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionAppStoreReviewScreenshotLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionImagesRelationships retrieves image linkages for a subscription.
+func (c *Client) GetSubscriptionImagesRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/images", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionImagesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionIntroductoryOffersRelationships retrieves introductory offer linkages for a subscription.
+func (c *Client) GetSubscriptionIntroductoryOffersRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/introductoryOffers", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionIntroductoryOffersRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// RemoveSubscriptionIntroductoryOffers removes introductory offer relationships from a subscription.
+func (c *Client) RemoveSubscriptionIntroductoryOffers(ctx context.Context, subID string, offerIDs []string) error {
+	subID = strings.TrimSpace(subID)
+	offerIDs = normalizeList(offerIDs)
+	if subID == "" {
+		return fmt.Errorf("subscription ID is required")
+	}
+	if len(offerIDs) == 0 {
+		return fmt.Errorf("offerIDs are required")
+	}
+
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, len(offerIDs)),
+	}
+	for i, id := range offerIDs {
+		payload.Data[i] = RelationshipData{
+			Type: ResourceTypeSubscriptionIntroductoryOffers,
+			ID:   id,
+		}
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/introductoryOffers", subID)
+	_, err = c.do(ctx, http.MethodDelete, path, body)
+	return err
+}
+
+// GetSubscriptionOfferCodesRelationships retrieves offer code linkages for a subscription.
+func (c *Client) GetSubscriptionOfferCodesRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/offerCodes", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionOfferCodesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionPricePointsRelationships retrieves price point linkages for a subscription.
+func (c *Client) GetSubscriptionPricePointsRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/pricePoints", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPricePointsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionPricesRelationships retrieves price linkages for a subscription.
+func (c *Client) GetSubscriptionPricesRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/prices", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPricesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// RemoveSubscriptionPrices removes price relationships from a subscription.
+func (c *Client) RemoveSubscriptionPrices(ctx context.Context, subID string, priceIDs []string) error {
+	subID = strings.TrimSpace(subID)
+	priceIDs = normalizeList(priceIDs)
+	if subID == "" {
+		return fmt.Errorf("subscription ID is required")
+	}
+	if len(priceIDs) == 0 {
+		return fmt.Errorf("priceIDs are required")
+	}
+
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, len(priceIDs)),
+	}
+	for i, id := range priceIDs {
+		payload.Data[i] = RelationshipData{
+			Type: ResourceTypeSubscriptionPrices,
+			ID:   id,
+		}
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/prices", subID)
+	_, err = c.do(ctx, http.MethodDelete, path, body)
+	return err
+}
+
+// GetSubscriptionPromotedPurchaseRelationship retrieves the promoted purchase linkage for a subscription.
+func (c *Client) GetSubscriptionPromotedPurchaseRelationship(ctx context.Context, subID string) (*SubscriptionPromotedPurchaseLinkageResponse, error) {
+	subID = strings.TrimSpace(subID)
+	if subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/promotedPurchase", subID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionPromotedPurchaseLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionPromotionalOffersRelationships retrieves promotional offer linkages for a subscription.
+func (c *Client) GetSubscriptionPromotionalOffersRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/promotionalOffers", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPromotionalOffersRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionSubscriptionAvailabilityRelationship retrieves the subscription availability linkage for a subscription.
+func (c *Client) GetSubscriptionSubscriptionAvailabilityRelationship(ctx context.Context, subID string) (*SubscriptionSubscriptionAvailabilityLinkageResponse, error) {
+	subID = strings.TrimSpace(subID)
+	if subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/subscriptionAvailability", subID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionSubscriptionAvailabilityLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionSubscriptionLocalizationsRelationships retrieves subscription localization linkages for a subscription.
+func (c *Client) GetSubscriptionSubscriptionLocalizationsRelationships(ctx context.Context, subID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	subID = strings.TrimSpace(subID)
+	if query.nextURL == "" && subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/relationships/subscriptionLocalizations", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionSubscriptionLocalizationsRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/iap_relationships_http_test.go
+++ b/internal/asc/iap_relationships_http_test.go
@@ -1,0 +1,211 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestIAPRelationshipEndpoints(t *testing.T) {
+	t.Run("to-many relationships use LinkagesResponse", func(t *testing.T) {
+		linkagesBody := `{"data":[],"links":{}}`
+
+		cases := []struct {
+			name     string
+			call     func(*Client) error
+			wantPath string
+		}{
+			{
+				name: "iap availability available territories",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseAvailabilityAvailableTerritoriesRelationships(context.Background(), "avail-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchaseAvailabilities/avail-1/relationships/availableTerritories",
+			},
+			{
+				name: "iap offer code custom codes",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseOfferCodeCustomCodesRelationships(context.Background(), "oc-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchaseOfferCodes/oc-1/relationships/customCodes",
+			},
+			{
+				name: "iap offer code one-time use codes",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseOfferCodeOneTimeUseCodesRelationships(context.Background(), "oc-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchaseOfferCodes/oc-1/relationships/oneTimeUseCodes",
+			},
+			{
+				name: "iap offer code prices",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseOfferCodePricesRelationships(context.Background(), "oc-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchaseOfferCodes/oc-1/relationships/prices",
+			},
+			{
+				name: "iap price point equalizations",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchasePricePointEqualizationsRelationships(context.Background(), "pp-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchasePricePoints/pp-1/relationships/equalizations",
+			},
+			{
+				name: "iap price schedule automatic prices",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchasePriceScheduleAutomaticPricesRelationships(context.Background(), "sch-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchasePriceSchedules/sch-1/relationships/automaticPrices",
+			},
+			{
+				name: "iap price schedule manual prices",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchasePriceScheduleManualPricesRelationships(context.Background(), "sch-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v1/inAppPurchasePriceSchedules/sch-1/relationships/manualPrices",
+			},
+			{
+				name: "in-app purchase images",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseImagesRelationships(context.Background(), "iap-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/images",
+			},
+			{
+				name: "in-app purchase localizations",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseInAppPurchaseLocalizationsRelationships(context.Background(), "iap-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/inAppPurchaseLocalizations",
+			},
+			{
+				name: "in-app purchase offer codes",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseOfferCodesRelationships(context.Background(), "iap-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/offerCodes",
+			},
+			{
+				name: "in-app purchase price points",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchasePricePointsRelationships(context.Background(), "iap-1", WithLinkagesLimit(4))
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/pricePoints",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				response := jsonResponse(http.StatusOK, linkagesBody)
+				client := newTestClient(t, func(req *http.Request) {
+					if req.Method != http.MethodGet {
+						t.Fatalf("expected GET, got %s", req.Method)
+					}
+					if req.URL.Path != tc.wantPath {
+						t.Fatalf("expected path %s, got %s", tc.wantPath, req.URL.Path)
+					}
+					if req.URL.Query().Get("limit") != "4" {
+						t.Fatalf("expected limit=4, got %q", req.URL.Query().Get("limit"))
+					}
+					assertAuthorized(t, req)
+				}, response)
+
+				if err := tc.call(client); err != nil {
+					t.Fatalf("request error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("to-one relationships use ResourceData linkage", func(t *testing.T) {
+		toOneBody := `{"data":{"type":"apps","id":"a1"},"links":{}}`
+
+		cases := []struct {
+			name     string
+			call     func(*Client) error
+			wantPath string
+		}{
+			{
+				name: "iap price schedule base territory",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchasePriceScheduleBaseTerritoryRelationship(context.Background(), "sch-1")
+					return err
+				},
+				wantPath: "/v1/inAppPurchasePriceSchedules/sch-1/relationships/baseTerritory",
+			},
+			{
+				name: "in-app purchase review screenshot",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseAppStoreReviewScreenshotRelationship(context.Background(), "iap-1")
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/appStoreReviewScreenshot",
+			},
+			{
+				name: "in-app purchase content",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseContentRelationship(context.Background(), "iap-1")
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/content",
+			},
+			{
+				name: "in-app purchase price schedule",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseIapPriceScheduleRelationship(context.Background(), "iap-1")
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/iapPriceSchedule",
+			},
+			{
+				name: "in-app purchase availability",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchaseInAppPurchaseAvailabilityRelationship(context.Background(), "iap-1")
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/inAppPurchaseAvailability",
+			},
+			{
+				name: "in-app purchase promoted purchase",
+				call: func(c *Client) error {
+					_, err := c.GetInAppPurchasePromotedPurchaseRelationship(context.Background(), "iap-1")
+					return err
+				},
+				wantPath: "/v2/inAppPurchases/iap-1/relationships/promotedPurchase",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				response := jsonResponse(http.StatusOK, toOneBody)
+				client := newTestClient(t, func(req *http.Request) {
+					if req.Method != http.MethodGet {
+						t.Fatalf("expected GET, got %s", req.Method)
+					}
+					if req.URL.Path != tc.wantPath {
+						t.Fatalf("expected path %s, got %s", tc.wantPath, req.URL.Path)
+					}
+					if len(req.URL.Query()) != 0 {
+						t.Fatalf("expected no query params, got %q", req.URL.RawQuery)
+					}
+					assertAuthorized(t, req)
+				}, response)
+
+				if err := tc.call(client); err != nil {
+					t.Fatalf("request error: %v", err)
+				}
+			})
+		}
+	})
+}

--- a/internal/asc/pricing_relationships_http_test.go
+++ b/internal/asc/pricing_relationships_http_test.go
@@ -1,0 +1,88 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestPricingRelationshipEndpoints(t *testing.T) {
+	t.Run("to-many relationships use LinkagesResponse", func(t *testing.T) {
+		linkagesBody := `{"data":[],"links":{}}`
+
+		cases := []struct {
+			name     string
+			call     func(*Client) error
+			wantPath string
+		}{
+			{
+				name: "app price schedule automatic prices",
+				call: func(c *Client) error {
+					_, err := c.GetAppPriceScheduleAutomaticPricesRelationships(context.Background(), "sch-1", WithLinkagesLimit(3))
+					return err
+				},
+				wantPath: "/v1/appPriceSchedules/sch-1/relationships/automaticPrices",
+			},
+			{
+				name: "app price schedule manual prices",
+				call: func(c *Client) error {
+					_, err := c.GetAppPriceScheduleManualPricesRelationships(context.Background(), "sch-1", WithLinkagesLimit(3))
+					return err
+				},
+				wantPath: "/v1/appPriceSchedules/sch-1/relationships/manualPrices",
+			},
+			{
+				name: "app price point equalizations",
+				call: func(c *Client) error {
+					_, err := c.GetAppPricePointEqualizationsRelationships(context.Background(), "pp-1", WithLinkagesLimit(3))
+					return err
+				},
+				wantPath: "/v3/appPricePoints/pp-1/relationships/equalizations",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				response := jsonResponse(http.StatusOK, linkagesBody)
+				client := newTestClient(t, func(req *http.Request) {
+					if req.Method != http.MethodGet {
+						t.Fatalf("expected GET, got %s", req.Method)
+					}
+					if req.URL.Path != tc.wantPath {
+						t.Fatalf("expected path %s, got %s", tc.wantPath, req.URL.Path)
+					}
+					if req.URL.Query().Get("limit") != "3" {
+						t.Fatalf("expected limit=3, got %q", req.URL.Query().Get("limit"))
+					}
+					assertAuthorized(t, req)
+				}, response)
+
+				if err := tc.call(client); err != nil {
+					t.Fatalf("request error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("to-one relationships use ResourceData linkage", func(t *testing.T) {
+		toOneBody := `{"data":{"type":"territories","id":"USA"},"links":{}}`
+
+		response := jsonResponse(http.StatusOK, toOneBody)
+		client := newTestClient(t, func(req *http.Request) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/appPriceSchedules/sch-1/relationships/baseTerritory" {
+				t.Fatalf("expected path /v1/appPriceSchedules/sch-1/relationships/baseTerritory, got %s", req.URL.Path)
+			}
+			if len(req.URL.Query()) != 0 {
+				t.Fatalf("expected no query params, got %q", req.URL.RawQuery)
+			}
+			assertAuthorized(t, req)
+		}, response)
+
+		if _, err := client.GetAppPriceScheduleBaseTerritoryRelationship(context.Background(), "sch-1"); err != nil {
+			t.Fatalf("GetAppPriceScheduleBaseTerritoryRelationship() error: %v", err)
+		}
+	})
+}

--- a/internal/asc/subscriptions_relationships_http_test.go
+++ b/internal/asc/subscriptions_relationships_http_test.go
@@ -1,0 +1,282 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestSubscriptionRelationshipEndpoints(t *testing.T) {
+	t.Run("to-many relationships use LinkagesResponse", func(t *testing.T) {
+		linkagesBody := `{"data":[],"links":{}}`
+
+		cases := []struct {
+			name     string
+			call     func(*Client) error
+			wantPath string
+		}{
+			{
+				name: "subscription availability available territories",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionAvailabilityAvailableTerritoriesRelationships(context.Background(), "avail-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionAvailabilities/avail-1/relationships/availableTerritories",
+			},
+			{
+				name: "subscription group localizations",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionGroupSubscriptionGroupLocalizationsRelationships(context.Background(), "group-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionGroups/group-1/relationships/subscriptionGroupLocalizations",
+			},
+			{
+				name: "subscription group subscriptions",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionGroupSubscriptionsRelationships(context.Background(), "group-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionGroups/group-1/relationships/subscriptions",
+			},
+			{
+				name: "subscription offer code custom codes",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionOfferCodeCustomCodesRelationships(context.Background(), "oc-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionOfferCodes/oc-1/relationships/customCodes",
+			},
+			{
+				name: "subscription offer code one-time use codes",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionOfferCodeOneTimeUseCodesRelationships(context.Background(), "oc-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionOfferCodes/oc-1/relationships/oneTimeUseCodes",
+			},
+			{
+				name: "subscription offer code prices",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionOfferCodePricesRelationships(context.Background(), "oc-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionOfferCodes/oc-1/relationships/prices",
+			},
+			{
+				name: "subscription price point equalizations",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionPricePointEqualizationsRelationships(context.Background(), "pp-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionPricePoints/pp-1/relationships/equalizations",
+			},
+			{
+				name: "subscription promotional offer prices",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionPromotionalOfferPricesRelationships(context.Background(), "promo-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptionPromotionalOffers/promo-1/relationships/prices",
+			},
+			{
+				name: "subscription images",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionImagesRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/images",
+			},
+			{
+				name: "subscription introductory offers",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionIntroductoryOffersRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/introductoryOffers",
+			},
+			{
+				name: "subscription offer codes",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionOfferCodesRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/offerCodes",
+			},
+			{
+				name: "subscription price points",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionPricePointsRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/pricePoints",
+			},
+			{
+				name: "subscription prices",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionPricesRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/prices",
+			},
+			{
+				name: "subscription promotional offers",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionPromotionalOffersRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/promotionalOffers",
+			},
+			{
+				name: "subscription localizations",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionSubscriptionLocalizationsRelationships(context.Background(), "sub-1", WithLinkagesLimit(5))
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/subscriptionLocalizations",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				response := jsonResponse(http.StatusOK, linkagesBody)
+				client := newTestClient(t, func(req *http.Request) {
+					if req.Method != http.MethodGet {
+						t.Fatalf("expected GET, got %s", req.Method)
+					}
+					if req.URL.Path != tc.wantPath {
+						t.Fatalf("expected path %s, got %s", tc.wantPath, req.URL.Path)
+					}
+					if req.URL.Query().Get("limit") != "5" {
+						t.Fatalf("expected limit=5, got %q", req.URL.Query().Get("limit"))
+					}
+					assertAuthorized(t, req)
+				}, response)
+
+				if err := tc.call(client); err != nil {
+					t.Fatalf("request error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("to-one relationships use ResourceData linkage", func(t *testing.T) {
+		toOneBody := `{"data":{"type":"apps","id":"a1"},"links":{}}`
+
+		cases := []struct {
+			name     string
+			call     func(*Client) error
+			wantPath string
+		}{
+			{
+				name: "subscription review screenshot",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionAppStoreReviewScreenshotRelationship(context.Background(), "sub-1")
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/appStoreReviewScreenshot",
+			},
+			{
+				name: "subscription promoted purchase",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionPromotedPurchaseRelationship(context.Background(), "sub-1")
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/promotedPurchase",
+			},
+			{
+				name: "subscription availability",
+				call: func(c *Client) error {
+					_, err := c.GetSubscriptionSubscriptionAvailabilityRelationship(context.Background(), "sub-1")
+					return err
+				},
+				wantPath: "/v1/subscriptions/sub-1/relationships/subscriptionAvailability",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				response := jsonResponse(http.StatusOK, toOneBody)
+				client := newTestClient(t, func(req *http.Request) {
+					if req.Method != http.MethodGet {
+						t.Fatalf("expected GET, got %s", req.Method)
+					}
+					if req.URL.Path != tc.wantPath {
+						t.Fatalf("expected path %s, got %s", tc.wantPath, req.URL.Path)
+					}
+					if len(req.URL.Query()) != 0 {
+						t.Fatalf("expected no query params, got %q", req.URL.RawQuery)
+					}
+					assertAuthorized(t, req)
+				}, response)
+
+				if err := tc.call(client); err != nil {
+					t.Fatalf("request error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("delete relationships send RelationshipRequest payloads", func(t *testing.T) {
+		response := jsonResponse(http.StatusNoContent, `{}`)
+
+		t.Run("introductory offers", func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodDelete {
+					t.Fatalf("expected DELETE, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/subscriptions/sub-1/relationships/introductoryOffers" {
+					t.Fatalf("expected path /v1/subscriptions/sub-1/relationships/introductoryOffers, got %s", req.URL.Path)
+				}
+				var payload RelationshipRequest
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("failed to decode request: %v", err)
+				}
+				if len(payload.Data) != 2 {
+					t.Fatalf("expected 2 relationship items, got %d", len(payload.Data))
+				}
+				if payload.Data[0].Type != ResourceTypeSubscriptionIntroductoryOffers || payload.Data[0].ID != "offer-1" {
+					t.Fatalf("unexpected first relationship: %+v", payload.Data[0])
+				}
+				if payload.Data[1].Type != ResourceTypeSubscriptionIntroductoryOffers || payload.Data[1].ID != "offer-2" {
+					t.Fatalf("unexpected second relationship: %+v", payload.Data[1])
+				}
+				assertAuthorized(t, req)
+			}, response)
+
+			if err := client.RemoveSubscriptionIntroductoryOffers(context.Background(), "sub-1", []string{"offer-1", "offer-2"}); err != nil {
+				t.Fatalf("RemoveSubscriptionIntroductoryOffers() error: %v", err)
+			}
+		})
+
+		t.Run("prices", func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodDelete {
+					t.Fatalf("expected DELETE, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/subscriptions/sub-1/relationships/prices" {
+					t.Fatalf("expected path /v1/subscriptions/sub-1/relationships/prices, got %s", req.URL.Path)
+				}
+				var payload RelationshipRequest
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("failed to decode request: %v", err)
+				}
+				if len(payload.Data) != 2 {
+					t.Fatalf("expected 2 relationship items, got %d", len(payload.Data))
+				}
+				if payload.Data[0].Type != ResourceTypeSubscriptionPrices || payload.Data[0].ID != "price-1" {
+					t.Fatalf("unexpected first relationship: %+v", payload.Data[0])
+				}
+				if payload.Data[1].Type != ResourceTypeSubscriptionPrices || payload.Data[1].ID != "price-2" {
+					t.Fatalf("unexpected second relationship: %+v", payload.Data[1])
+				}
+				assertAuthorized(t, req)
+			}, response)
+
+			if err := client.RemoveSubscriptionPrices(context.Background(), "sub-1", []string{"price-1", "price-2"}); err != nil {
+				t.Fatalf("RemoveSubscriptionPrices() error: %v", err)
+			}
+		})
+	})
+}

--- a/internal/cli/cmdtest/release_notes_generate_test.go
+++ b/internal/cli/cmdtest/release_notes_generate_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestReleaseNotesGenerate_JSON(t *testing.T) {
+	unsetGitHookEnv(t)
+
 	resetDefaultOutput(t)
 	t.Setenv("ASC_DEFAULT_OUTPUT", "json")
 
@@ -92,6 +94,8 @@ func TestReleaseNotesGenerate_MissingSinceIsUsage(t *testing.T) {
 }
 
 func TestReleaseNotesGenerate_NotGitRepoReturnsError(t *testing.T) {
+	unsetGitHookEnv(t)
+
 	resetDefaultOutput(t)
 	t.Setenv("ASC_DEFAULT_OUTPUT", "json")
 
@@ -118,6 +122,8 @@ func TestReleaseNotesGenerate_NotGitRepoReturnsError(t *testing.T) {
 }
 
 func TestReleaseNotesGenerate_TruncatesToMaxChars(t *testing.T) {
+	unsetGitHookEnv(t)
+
 	resetDefaultOutput(t)
 	t.Setenv("ASC_DEFAULT_OUTPUT", "json")
 
@@ -188,11 +194,56 @@ func initTempGitRepo(t *testing.T) string {
 	return dir
 }
 
+func unsetGitHookEnv(t *testing.T) {
+	t.Helper()
+
+	// When `go test` runs under a git hook, git exports repository-scoped env vars.
+	// Clear them so any git invocation in the tests/CLI uses the temp repo.
+	keys := []string{
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_INDEX_FILE",
+		"GIT_COMMON_DIR",
+	}
+
+	original := map[string]string{}
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			original[k] = v
+			_ = os.Unsetenv(k)
+		}
+	}
+	t.Cleanup(func() {
+		for _, k := range keys {
+			if v, ok := original[k]; ok {
+				_ = os.Setenv(k, v)
+			} else {
+				_ = os.Unsetenv(k)
+			}
+		}
+	})
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
 	c := exec.Command("git", args...)
 	c.Dir = dir
+	// Git sets GIT_DIR/GIT_WORK_TREE for hook processes. If `go test` runs under a
+	// hook, these env vars can leak into this helper and cause our git commands
+	// to operate on the outer repo instead of the temp repo.
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GIT_DIR=") ||
+			strings.HasPrefix(kv, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(kv, "GIT_INDEX_FILE=") ||
+			strings.HasPrefix(kv, "GIT_COMMON_DIR=") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	c.Env = filtered
 	out, err := c.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(out))


### PR DESCRIPTION
## Summary
- Add missing relationship GET endpoints for subscriptions, IAP, and pricing (linkages + to-one linkage responses) per OpenAPI.
- Add missing subscription relationship DELETE endpoints (introductory offers + prices) using existing relationship payload helpers.
- Add request-shaping HTTP tests for the new relationship endpoints.
- Harden release-notes cmdtests against git hook env var leakage (GIT_DIR/GIT_WORK_TREE/etc).

Closes #619.

## Test plan
- make format
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test