### PR TITLE
coverage: add missing builds/TestFlight relationship endpoints

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1333,6 +1333,33 @@ func (c *Client) GetBetaBuildLocalizationBuild(ctx context.Context, localization
 	return &response, nil
 }
 
+// BetaBuildLocalizationBuildLinkageResponse is the response for beta build localization build relationships.
+type BetaBuildLocalizationBuildLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBetaBuildLocalizationBuildRelationship retrieves the build linkage for a beta build localization.
+func (c *Client) GetBetaBuildLocalizationBuildRelationship(ctx context.Context, localizationID string) (*BetaBuildLocalizationBuildLinkageResponse, error) {
+	localizationID = strings.TrimSpace(localizationID)
+	if localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaBuildLocalizations/%s/relationships/build", localizationID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaBuildLocalizationBuildLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // CreateBetaBuildLocalization creates a beta build localization for a build.
 func (c *Client) CreateBetaBuildLocalization(ctx context.Context, buildID string, attributes BetaBuildLocalizationAttributes) (*BetaBuildLocalizationResponse, error) {
 	payload := BetaBuildLocalizationCreateRequest{

--- a/internal/asc/client_beta_app_localizations.go
+++ b/internal/asc/client_beta_app_localizations.go
@@ -79,6 +79,33 @@ func (c *Client) GetBetaAppLocalizationApp(ctx context.Context, localizationID s
 	return &response, nil
 }
 
+// BetaAppLocalizationAppLinkageResponse is the response for beta app localization app relationships.
+type BetaAppLocalizationAppLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBetaAppLocalizationAppRelationship retrieves the app linkage for a beta app localization.
+func (c *Client) GetBetaAppLocalizationAppRelationship(ctx context.Context, localizationID string) (*BetaAppLocalizationAppLinkageResponse, error) {
+	localizationID = strings.TrimSpace(localizationID)
+	if localizationID == "" {
+		return nil, fmt.Errorf("localizationID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaAppLocalizations/%s/relationships/app", localizationID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaAppLocalizationAppLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // CreateBetaAppLocalization creates a beta app localization for an app.
 func (c *Client) CreateBetaAppLocalization(ctx context.Context, appID string, attrs BetaAppLocalizationAttributes) (*BetaAppLocalizationResponse, error) {
 	appID = strings.TrimSpace(appID)

--- a/internal/asc/client_beta_feedback.go
+++ b/internal/asc/client_beta_feedback.go
@@ -82,6 +82,33 @@ func (c *Client) GetBetaFeedbackCrashSubmissionCrashLog(ctx context.Context, sub
 	return &response, nil
 }
 
+// BetaFeedbackCrashSubmissionCrashLogLinkageResponse is the response for crash log relationships.
+type BetaFeedbackCrashSubmissionCrashLogLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBetaFeedbackCrashSubmissionCrashLogRelationship retrieves the crash log linkage for a crash submission.
+func (c *Client) GetBetaFeedbackCrashSubmissionCrashLogRelationship(ctx context.Context, submissionID string) (*BetaFeedbackCrashSubmissionCrashLogLinkageResponse, error) {
+	submissionID = strings.TrimSpace(submissionID)
+	if submissionID == "" {
+		return nil, fmt.Errorf("submissionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaFeedbackCrashSubmissions/%s/relationships/crashLog", submissionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaFeedbackCrashSubmissionCrashLogLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetBetaFeedbackScreenshotSubmission retrieves a beta feedback screenshot submission by ID.
 func (c *Client) GetBetaFeedbackScreenshotSubmission(ctx context.Context, submissionID string) (*BetaFeedbackScreenshotSubmissionResponse, error) {
 	submissionID = strings.TrimSpace(submissionID)

--- a/internal/asc/client_build_bundles.go
+++ b/internal/asc/client_build_bundles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // BuildBundleType represents the type of build bundle.
@@ -217,6 +218,104 @@ func (c *Client) GetBuildBundleBetaAppClipInvocations(ctx context.Context, build
 	}
 
 	var response BetaAppClipInvocationsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// BuildBundleAppClipDomainCacheStatusLinkageResponse is the response for App Clip domain cache status relationships.
+type BuildBundleAppClipDomainCacheStatusLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// BuildBundleAppClipDomainDebugStatusLinkageResponse is the response for App Clip domain debug status relationships.
+type BuildBundleAppClipDomainDebugStatusLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBuildBundleAppClipDomainCacheStatusRelationship retrieves the app clip domain cache status linkage for a build bundle.
+func (c *Client) GetBuildBundleAppClipDomainCacheStatusRelationship(ctx context.Context, buildBundleID string) (*BuildBundleAppClipDomainCacheStatusLinkageResponse, error) {
+	buildBundleID = strings.TrimSpace(buildBundleID)
+	if buildBundleID == "" {
+		return nil, fmt.Errorf("buildBundleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/buildBundles/%s/relationships/appClipDomainCacheStatus", buildBundleID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildBundleAppClipDomainCacheStatusLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetBuildBundleAppClipDomainDebugStatusRelationship retrieves the app clip domain debug status linkage for a build bundle.
+func (c *Client) GetBuildBundleAppClipDomainDebugStatusRelationship(ctx context.Context, buildBundleID string) (*BuildBundleAppClipDomainDebugStatusLinkageResponse, error) {
+	buildBundleID = strings.TrimSpace(buildBundleID)
+	if buildBundleID == "" {
+		return nil, fmt.Errorf("buildBundleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/buildBundles/%s/relationships/appClipDomainDebugStatus", buildBundleID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildBundleAppClipDomainDebugStatusLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetBuildBundleBetaAppClipInvocationsRelationships retrieves beta app clip invocation linkages for a build bundle.
+func (c *Client) GetBuildBundleBetaAppClipInvocationsRelationships(ctx context.Context, buildBundleID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getBuildBundleLinkages(ctx, buildBundleID, "betaAppClipInvocations", opts...)
+}
+
+// GetBuildBundleBuildBundleFileSizesRelationships retrieves build bundle file size linkages for a build bundle.
+func (c *Client) GetBuildBundleBuildBundleFileSizesRelationships(ctx context.Context, buildBundleID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getBuildBundleLinkages(ctx, buildBundleID, "buildBundleFileSizes", opts...)
+}
+
+func (c *Client) getBuildBundleLinkages(ctx context.Context, buildBundleID, relationship string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	buildBundleID = strings.TrimSpace(buildBundleID)
+	if query.nextURL == "" && buildBundleID == "" {
+		return nil, fmt.Errorf("buildBundleID is required")
+	}
+
+	path := fmt.Sprintf("/v1/buildBundles/%s/relationships/%s", buildBundleID, relationship)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("buildBundleRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}

--- a/internal/asc/client_build_relationships.go
+++ b/internal/asc/client_build_relationships.go
@@ -31,6 +31,23 @@ type BuildPreReleaseVersionLinkageResponse struct {
 	Links Links        `json:"links"`
 }
 
+// BuildAppEncryptionDeclarationLinkageResponse is the response for build app encryption declaration relationships.
+type BuildAppEncryptionDeclarationLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// BuildBetaAppReviewSubmissionLinkageResponse is the response for build beta app review submission relationships.
+type BuildBetaAppReviewSubmissionLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// BuildAppEncryptionDeclarationRelationshipUpdateRequest is a request to update the appEncryptionDeclaration relationship on a build.
+type BuildAppEncryptionDeclarationRelationshipUpdateRequest struct {
+	Data ResourceData `json:"data"`
+}
+
 // GetBuildAppRelationship retrieves the app linkage for a build.
 func (c *Client) GetBuildAppRelationship(ctx context.Context, buildID string) (*BuildAppLinkageResponse, error) {
 	buildID = strings.TrimSpace(buildID)
@@ -50,6 +67,75 @@ func (c *Client) GetBuildAppRelationship(ctx context.Context, buildID string) (*
 	}
 
 	return &response, nil
+}
+
+// GetBuildAppEncryptionDeclarationRelationship retrieves the app encryption declaration linkage for a build.
+func (c *Client) GetBuildAppEncryptionDeclarationRelationship(ctx context.Context, buildID string) (*BuildAppEncryptionDeclarationLinkageResponse, error) {
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("buildID is required")
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s/relationships/appEncryptionDeclaration", buildID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildAppEncryptionDeclarationLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetBuildBetaAppReviewSubmissionRelationship retrieves the beta app review submission linkage for a build.
+func (c *Client) GetBuildBetaAppReviewSubmissionRelationship(ctx context.Context, buildID string) (*BuildBetaAppReviewSubmissionLinkageResponse, error) {
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("buildID is required")
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s/relationships/betaAppReviewSubmission", buildID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildBetaAppReviewSubmissionLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// UpdateBuildAppEncryptionDeclarationRelationship updates the app encryption declaration relationship on a build.
+func (c *Client) UpdateBuildAppEncryptionDeclarationRelationship(ctx context.Context, buildID, declarationID string) error {
+	buildID = strings.TrimSpace(buildID)
+	declarationID = strings.TrimSpace(declarationID)
+	if buildID == "" {
+		return fmt.Errorf("buildID is required")
+	}
+	if declarationID == "" {
+		return fmt.Errorf("declarationID is required")
+	}
+
+	request := BuildAppEncryptionDeclarationRelationshipUpdateRequest{
+		Data: ResourceData{
+			Type: ResourceTypeAppEncryptionDeclarations,
+			ID:   declarationID,
+		},
+	}
+	body, err := BuildRequestBody(request)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s/relationships/appEncryptionDeclaration", buildID)
+	_, err = c.do(ctx, "PATCH", path, body)
+	return err
 }
 
 // GetBuildAppStoreVersionRelationship retrieves the app store version linkage for a build.

--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -592,6 +592,41 @@ func (c *Client) GetBuildUploadFiles(ctx context.Context, uploadID string, opts 
 	return &response, nil
 }
 
+// GetBuildUploadBuildUploadFilesRelationships retrieves build upload file linkages for a build upload.
+func (c *Client) GetBuildUploadBuildUploadFilesRelationships(ctx context.Context, uploadID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	uploadID = strings.TrimSpace(uploadID)
+	if query.nextURL == "" && uploadID == "" {
+		return nil, fmt.Errorf("uploadID is required")
+	}
+
+	path := fmt.Sprintf("/v1/buildUploads/%s/relationships/buildUploadFiles", uploadID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("buildUploadFilesRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetBuildUploadFile retrieves a build upload file by ID.
 func (c *Client) GetBuildUploadFile(ctx context.Context, id string) (*BuildUploadFileResponse, error) {
 	id = strings.TrimSpace(id)

--- a/internal/asc/client_http_issue_621_builds_testflight_relationships_test.go
+++ b/internal/asc/client_http_issue_621_builds_testflight_relationships_test.go
@@ -1,0 +1,292 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestIssue621_BuildsTestFlightRelationshipEndpoints_GET(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		linkagesOK = `{"data":[{"type":"apps","id":"1"}],"links":{}}`
+		toOneOK    = `{"data":{"type":"apps","id":"1"},"links":{}}`
+	)
+
+	tests := []struct {
+		name     string
+		wantPath string
+		body     string
+		call     func(*Client) error
+	}{
+		{
+			name:     "GetBetaAppLocalizationAppRelationship",
+			wantPath: "/v1/betaAppLocalizations/loc-1/relationships/app",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaAppLocalizationAppRelationship(ctx, "loc-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaAppReviewDetailAppRelationship",
+			wantPath: "/v1/betaAppReviewDetails/detail-1/relationships/app",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaAppReviewDetailAppRelationship(ctx, "detail-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaAppReviewSubmissionBuildRelationship",
+			wantPath: "/v1/betaAppReviewSubmissions/sub-1/relationships/build",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaAppReviewSubmissionBuildRelationship(ctx, "sub-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaBuildLocalizationBuildRelationship",
+			wantPath: "/v1/betaBuildLocalizations/bbl-1/relationships/build",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaBuildLocalizationBuildRelationship(ctx, "bbl-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaFeedbackCrashSubmissionCrashLogRelationship",
+			wantPath: "/v1/betaFeedbackCrashSubmissions/crash-1/relationships/crashLog",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaFeedbackCrashSubmissionCrashLogRelationship(ctx, "crash-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaGroupAppRelationship",
+			wantPath: "/v1/betaGroups/group-1/relationships/app",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaGroupAppRelationship(ctx, "group-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaGroupBetaRecruitmentCriteriaRelationship",
+			wantPath: "/v1/betaGroups/group-1/relationships/betaRecruitmentCriteria",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaGroupBetaRecruitmentCriteriaRelationship(ctx, "group-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBetaGroupBetaRecruitmentCriterionCompatibleBuildCheckRelationship",
+			wantPath: "/v1/betaGroups/group-1/relationships/betaRecruitmentCriterionCompatibleBuildCheck",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBetaGroupBetaRecruitmentCriterionCompatibleBuildCheckRelationship(ctx, "group-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildBetaDetailBuildRelationship",
+			wantPath: "/v1/buildBetaDetails/detail-1/relationships/build",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildBetaDetailBuildRelationship(ctx, "detail-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildBundleAppClipDomainCacheStatusRelationship",
+			wantPath: "/v1/buildBundles/bb-1/relationships/appClipDomainCacheStatus",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildBundleAppClipDomainCacheStatusRelationship(ctx, "bb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildBundleAppClipDomainDebugStatusRelationship",
+			wantPath: "/v1/buildBundles/bb-1/relationships/appClipDomainDebugStatus",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildBundleAppClipDomainDebugStatusRelationship(ctx, "bb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildBundleBetaAppClipInvocationsRelationships",
+			wantPath: "/v1/buildBundles/bb-1/relationships/betaAppClipInvocations",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildBundleBetaAppClipInvocationsRelationships(ctx, "bb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildBundleBuildBundleFileSizesRelationships",
+			wantPath: "/v1/buildBundles/bb-1/relationships/buildBundleFileSizes",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildBundleBuildBundleFileSizesRelationships(ctx, "bb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildUploadBuildUploadFilesRelationships",
+			wantPath: "/v1/buildUploads/upl-1/relationships/buildUploadFiles",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildUploadBuildUploadFilesRelationships(ctx, "upl-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildAppEncryptionDeclarationRelationship",
+			wantPath: "/v1/builds/build-1/relationships/appEncryptionDeclaration",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildAppEncryptionDeclarationRelationship(ctx, "build-1")
+				return err
+			},
+		},
+		{
+			name:     "GetBuildBetaAppReviewSubmissionRelationship",
+			wantPath: "/v1/builds/build-1/relationships/betaAppReviewSubmission",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetBuildBetaAppReviewSubmissionRelationship(ctx, "build-1")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != tt.wantPath {
+					t.Fatalf("expected path %s, got %s", tt.wantPath, req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			}, jsonResponse(http.StatusOK, tt.body))
+
+			if err := tt.call(client); err != nil {
+				t.Fatalf("request error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIssue621_BuildsTestFlightRelationshipEndpoints_Mutations(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		wantMethod string
+		wantPath   string
+		wantBodyFn func(*testing.T, []byte)
+		call       func(*Client) error
+	}{
+		{
+			name:       "AddBuildsToBetaGroup (POST /v1/betaGroups/{id}/relationships/builds)",
+			wantMethod: http.MethodPost,
+			wantPath:   "/v1/betaGroups/group-1/relationships/builds",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got RelationshipRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if len(got.Data) != 2 {
+					t.Fatalf("expected 2 relationship items, got %d", len(got.Data))
+				}
+				if got.Data[0].Type != ResourceTypeBuilds || got.Data[0].ID != "build-1" {
+					t.Fatalf("unexpected first item: %#v", got.Data[0])
+				}
+				if got.Data[1].Type != ResourceTypeBuilds || got.Data[1].ID != "build-2" {
+					t.Fatalf("unexpected second item: %#v", got.Data[1])
+				}
+			},
+			call: func(client *Client) error {
+				return client.AddBuildsToBetaGroup(ctx, "group-1", []string{"build-1", "build-2"})
+			},
+		},
+		{
+			name:       "RemoveBuildsFromBetaGroup (DELETE /v1/betaGroups/{id}/relationships/builds)",
+			wantMethod: http.MethodDelete,
+			wantPath:   "/v1/betaGroups/group-1/relationships/builds",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got RelationshipRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if len(got.Data) != 1 {
+					t.Fatalf("expected 1 relationship item, got %d", len(got.Data))
+				}
+				if got.Data[0].Type != ResourceTypeBuilds || got.Data[0].ID != "build-1" {
+					t.Fatalf("unexpected item: %#v", got.Data[0])
+				}
+			},
+			call: func(client *Client) error {
+				return client.RemoveBuildsFromBetaGroup(ctx, "group-1", []string{"build-1"})
+			},
+		},
+		{
+			name:       "UpdateBuildAppEncryptionDeclarationRelationship (PATCH /v1/builds/{id}/relationships/appEncryptionDeclaration)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v1/builds/build-1/relationships/appEncryptionDeclaration",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got BuildAppEncryptionDeclarationRelationshipUpdateRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeAppEncryptionDeclarations {
+					t.Fatalf("expected type %q, got %q", ResourceTypeAppEncryptionDeclarations, got.Data.Type)
+				}
+				if got.Data.ID != "decl-1" {
+					t.Fatalf("expected id %q, got %q", "decl-1", got.Data.ID)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateBuildAppEncryptionDeclarationRelationship(ctx, "build-1", "decl-1")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != tt.wantMethod {
+					t.Fatalf("expected %s, got %s", tt.wantMethod, req.Method)
+				}
+				if req.URL.Path != tt.wantPath {
+					t.Fatalf("expected path %s, got %s", tt.wantPath, req.URL.Path)
+				}
+
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				tt.wantBodyFn(t, body)
+
+				assertAuthorized(t, req)
+			}, jsonResponse(http.StatusNoContent, ""))
+
+			if err := tt.call(client); err != nil {
+				t.Fatalf("request error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/asc/client_testflight_relationships.go
+++ b/internal/asc/client_testflight_relationships.go
@@ -17,6 +17,146 @@ func (c *Client) GetBetaGroupBuildsRelationships(ctx context.Context, groupID st
 	return c.getBetaGroupLinkages(ctx, groupID, "builds", opts...)
 }
 
+// BetaGroupAppLinkageResponse is the response for beta group app relationships.
+type BetaGroupAppLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// BetaGroupBetaRecruitmentCriteriaLinkageResponse is the response for recruitment criteria relationships.
+type BetaGroupBetaRecruitmentCriteriaLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse is the response for compatible build check relationships.
+type BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBetaGroupAppRelationship retrieves the app linkage for a beta group.
+func (c *Client) GetBetaGroupAppRelationship(ctx context.Context, groupID string) (*BetaGroupAppLinkageResponse, error) {
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		return nil, fmt.Errorf("groupID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/app", groupID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaGroupAppLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
+// GetBetaGroupBetaRecruitmentCriteriaRelationship retrieves the recruitment criteria linkage for a beta group.
+func (c *Client) GetBetaGroupBetaRecruitmentCriteriaRelationship(ctx context.Context, groupID string) (*BetaGroupBetaRecruitmentCriteriaLinkageResponse, error) {
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		return nil, fmt.Errorf("groupID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/betaRecruitmentCriteria", groupID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaGroupBetaRecruitmentCriteriaLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
+// GetBetaGroupBetaRecruitmentCriterionCompatibleBuildCheckRelationship retrieves compatible build check linkage for a beta group.
+func (c *Client) GetBetaGroupBetaRecruitmentCriterionCompatibleBuildCheckRelationship(ctx context.Context, groupID string) (*BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse, error) {
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		return nil, fmt.Errorf("groupID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/betaRecruitmentCriterionCompatibleBuildCheck", groupID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
+// AddBuildsToBetaGroup adds builds to a beta group.
+func (c *Client) AddBuildsToBetaGroup(ctx context.Context, groupID string, buildIDs []string) error {
+	groupID = strings.TrimSpace(groupID)
+	buildIDs = normalizeList(buildIDs)
+	if groupID == "" {
+		return fmt.Errorf("groupID is required")
+	}
+	if len(buildIDs) == 0 {
+		return fmt.Errorf("buildIDs are required")
+	}
+
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, len(buildIDs)),
+	}
+	for i, id := range buildIDs {
+		payload.Data[i] = RelationshipData{
+			Type: ResourceTypeBuilds,
+			ID:   id,
+		}
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/builds", groupID)
+	_, err = c.do(ctx, "POST", path, body)
+	return err
+}
+
+// RemoveBuildsFromBetaGroup removes builds from a beta group.
+func (c *Client) RemoveBuildsFromBetaGroup(ctx context.Context, groupID string, buildIDs []string) error {
+	groupID = strings.TrimSpace(groupID)
+	buildIDs = normalizeList(buildIDs)
+	if groupID == "" {
+		return fmt.Errorf("groupID is required")
+	}
+	if len(buildIDs) == 0 {
+		return fmt.Errorf("buildIDs are required")
+	}
+
+	payload := RelationshipRequest{
+		Data: make([]RelationshipData, len(buildIDs)),
+	}
+	for i, id := range buildIDs {
+		payload.Data[i] = RelationshipData{
+			Type: ResourceTypeBuilds,
+			ID:   id,
+		}
+	}
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/betaGroups/%s/relationships/builds", groupID)
+	_, err = c.do(ctx, "DELETE", path, body)
+	return err
+}
+
 // GetBetaTesterAppsRelationships retrieves app linkages for a beta tester.
 func (c *Client) GetBetaTesterAppsRelationships(ctx context.Context, testerID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
 	return c.getBetaTesterLinkages(ctx, testerID, "apps", opts...)

--- a/internal/asc/client_testflight_review.go
+++ b/internal/asc/client_testflight_review.go
@@ -79,6 +79,33 @@ func (c *Client) GetBetaAppReviewDetailApp(ctx context.Context, detailID string)
 	return &response, nil
 }
 
+// BetaAppReviewDetailAppLinkageResponse is the response for beta app review detail app relationships.
+type BetaAppReviewDetailAppLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBetaAppReviewDetailAppRelationship retrieves the app linkage for a beta app review detail.
+func (c *Client) GetBetaAppReviewDetailAppRelationship(ctx context.Context, detailID string) (*BetaAppReviewDetailAppLinkageResponse, error) {
+	detailID = strings.TrimSpace(detailID)
+	if detailID == "" {
+		return nil, fmt.Errorf("detailID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaAppReviewDetails/%s/relationships/app", detailID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaAppReviewDetailAppLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // UpdateBetaAppReviewDetail updates beta app review details by ID.
 func (c *Client) UpdateBetaAppReviewDetail(ctx context.Context, detailID string, attrs BetaAppReviewDetailUpdateAttributes) (*BetaAppReviewDetailResponse, error) {
 	detailID = strings.TrimSpace(detailID)
@@ -223,6 +250,33 @@ func (c *Client) GetBetaAppReviewSubmissionBuild(ctx context.Context, submission
 	return &response, nil
 }
 
+// BetaAppReviewSubmissionBuildLinkageResponse is the response for beta app review submission build relationships.
+type BetaAppReviewSubmissionBuildLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBetaAppReviewSubmissionBuildRelationship retrieves the build linkage for a beta app review submission.
+func (c *Client) GetBetaAppReviewSubmissionBuildRelationship(ctx context.Context, submissionID string) (*BetaAppReviewSubmissionBuildLinkageResponse, error) {
+	submissionID = strings.TrimSpace(submissionID)
+	if submissionID == "" {
+		return nil, fmt.Errorf("submissionID is required")
+	}
+
+	path := fmt.Sprintf("/v1/betaAppReviewSubmissions/%s/relationships/build", submissionID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BetaAppReviewSubmissionBuildLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetBuildBetaDetails retrieves build beta details.
 func (c *Client) GetBuildBetaDetails(ctx context.Context, opts ...BuildBetaDetailsOption) (*BuildBetaDetailsResponse, error) {
 	query := &buildBetaDetailsQuery{}
@@ -288,6 +342,33 @@ func (c *Client) GetBuildBetaDetailBuild(ctx context.Context, detailID string) (
 	}
 
 	var response BuildResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// BuildBetaDetailBuildLinkageResponse is the response for build beta detail build relationships.
+type BuildBetaDetailBuildLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetBuildBetaDetailBuildRelationship retrieves the build linkage for a build beta detail.
+func (c *Client) GetBuildBetaDetailBuildRelationship(ctx context.Context, detailID string) (*BuildBetaDetailBuildLinkageResponse, error) {
+	detailID = strings.TrimSpace(detailID)
+	if detailID == "" {
+		return nil, fmt.Errorf("detailID is required")
+	}
+
+	path := fmt.Sprintf("/v1/buildBetaDetails/%s/relationships/build", detailID)
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildBetaDetailBuildLinkageResponse
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}


### PR DESCRIPTION
## Summary

Implements the missing builds/TestFlight relationship endpoints listed in #621 (GET + relationship mutations) and adds request-shaping tests.

### Endpoints
- DELETE /v1/betaGroups/{id}/relationships/builds
- GET /v1/betaAppLocalizations/{id}/relationships/app
- GET /v1/betaAppReviewDetails/{id}/relationships/app
- GET /v1/betaAppReviewSubmissions/{id}/relationships/build
- GET /v1/betaBuildLocalizations/{id}/relationships/build
- GET /v1/betaFeedbackCrashSubmissions/{id}/relationships/crashLog
- GET /v1/betaGroups/{id}/relationships/app
- GET /v1/betaGroups/{id}/relationships/betaRecruitmentCriteria
- GET /v1/betaGroups/{id}/relationships/betaRecruitmentCriterionCompatibleBuildCheck
- GET /v1/buildBetaDetails/{id}/relationships/build
- GET /v1/buildBundles/{id}/relationships/appClipDomainCacheStatus
- GET /v1/buildBundles/{id}/relationships/appClipDomainDebugStatus
- GET /v1/buildBundles/{id}/relationships/betaAppClipInvocations
- GET /v1/buildBundles/{id}/relationships/buildBundleFileSizes
- GET /v1/buildUploads/{id}/relationships/buildUploadFiles
- GET /v1/builds/{id}/relationships/appEncryptionDeclaration
- GET /v1/builds/{id}/relationships/betaAppReviewSubmission
- PATCH /v1/builds/{id}/relationships/appEncryptionDeclaration
- POST /v1/betaGroups/{id}/relationships/builds

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

Fixes #621