### PR TITLE
coverage: add missing Game Center leaderboard relationships

### DIFF
--- a/internal/asc/client_game_center_leaderboards_relationships.go
+++ b/internal/asc/client_game_center_leaderboards_relationships.go
@@ -1,0 +1,300 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse is the response for groupLeaderboardSet relationships.
+type GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GameCenterLeaderboardGroupLeaderboardLinkageResponse is the response for groupLeaderboard relationships.
+type GameCenterLeaderboardGroupLeaderboardLinkageResponse struct {
+	Data  ResourceData `json:"data"`
+	Links Links        `json:"links"`
+}
+
+// GetGameCenterLeaderboardSetMembersRelationships retrieves leaderboard linkages for a leaderboard set.
+func (c *Client) GetGameCenterLeaderboardSetMembersRelationships(ctx context.Context, setID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardSetLinkages(ctx, setID, "gameCenterLeaderboards", opts...)
+}
+
+// GetGameCenterLeaderboardSetGroupLeaderboardSetRelationship retrieves the group leaderboard set linkage for a leaderboard set.
+func (c *Client) GetGameCenterLeaderboardSetGroupLeaderboardSetRelationship(ctx context.Context, setID string) (*GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse, error) {
+	setID = strings.TrimSpace(setID)
+	if setID == "" {
+		return nil, fmt.Errorf("setID is required")
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardSets/%s/relationships/groupLeaderboardSet", setID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
+// GetGameCenterLeaderboardSetLocalizationsRelationships retrieves localization linkages for a leaderboard set.
+func (c *Client) GetGameCenterLeaderboardSetLocalizationsRelationships(ctx context.Context, setID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardSetLinkages(ctx, setID, "localizations", opts...)
+}
+
+// GetGameCenterLeaderboardSetReleasesRelationships retrieves release linkages for a leaderboard set.
+func (c *Client) GetGameCenterLeaderboardSetReleasesRelationships(ctx context.Context, setID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardSetLinkages(ctx, setID, "releases", opts...)
+}
+
+// AddGameCenterLeaderboardSetMembers adds leaderboards to a leaderboard set.
+func (c *Client) AddGameCenterLeaderboardSetMembers(ctx context.Context, setID string, leaderboardIDs []string) error {
+	payload := RelationshipRequest{
+		Data: buildRelationshipData(ResourceTypeGameCenterLeaderboards, leaderboardIDs),
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardSets/%s/relationships/gameCenterLeaderboards", strings.TrimSpace(setID))
+	_, err = c.do(ctx, http.MethodPost, path, body)
+	return err
+}
+
+// RemoveGameCenterLeaderboardSetMembers removes leaderboards from a leaderboard set.
+func (c *Client) RemoveGameCenterLeaderboardSetMembers(ctx context.Context, setID string, leaderboardIDs []string) error {
+	payload := RelationshipRequest{
+		Data: buildRelationshipData(ResourceTypeGameCenterLeaderboards, leaderboardIDs),
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardSets/%s/relationships/gameCenterLeaderboards", strings.TrimSpace(setID))
+	_, err = c.do(ctx, http.MethodDelete, path, body)
+	return err
+}
+
+// UpdateGameCenterLeaderboardSetGroupLeaderboardSetRelationship updates the groupLeaderboardSet relationship on a leaderboard set.
+func (c *Client) UpdateGameCenterLeaderboardSetGroupLeaderboardSetRelationship(ctx context.Context, setID, groupSetID string) error {
+	setID = strings.TrimSpace(setID)
+	groupSetID = strings.TrimSpace(groupSetID)
+	if setID == "" {
+		return fmt.Errorf("setID is required")
+	}
+	if groupSetID == "" {
+		return fmt.Errorf("groupSetID is required")
+	}
+
+	payload := struct {
+		Data ResourceData `json:"data"`
+	}{
+		Data: ResourceData{
+			Type: ResourceTypeGameCenterLeaderboardSets,
+			ID:   groupSetID,
+		},
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardSets/%s/relationships/groupLeaderboardSet", setID)
+	_, err = c.do(ctx, http.MethodPatch, path, body)
+	return err
+}
+
+// GetGameCenterLeaderboardGroupLeaderboardRelationship retrieves the group leaderboard linkage for a leaderboard.
+func (c *Client) GetGameCenterLeaderboardGroupLeaderboardRelationship(ctx context.Context, leaderboardID string) (*GameCenterLeaderboardGroupLeaderboardLinkageResponse, error) {
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	if leaderboardID == "" {
+		return nil, fmt.Errorf("leaderboardID is required")
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboards/%s/relationships/groupLeaderboard", leaderboardID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GameCenterLeaderboardGroupLeaderboardLinkageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
+// GetGameCenterLeaderboardLocalizationsRelationships retrieves localization linkages for a leaderboard.
+func (c *Client) GetGameCenterLeaderboardLocalizationsRelationships(ctx context.Context, leaderboardID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardLinkages(ctx, leaderboardID, "localizations", opts...)
+}
+
+// GetGameCenterLeaderboardReleasesRelationships retrieves release linkages for a leaderboard.
+func (c *Client) GetGameCenterLeaderboardReleasesRelationships(ctx context.Context, leaderboardID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardLinkages(ctx, leaderboardID, "releases", opts...)
+}
+
+// UpdateGameCenterLeaderboardActivityRelationship updates the activity relationship on a leaderboard.
+func (c *Client) UpdateGameCenterLeaderboardActivityRelationship(ctx context.Context, leaderboardID, activityID string) error {
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	activityID = strings.TrimSpace(activityID)
+	if leaderboardID == "" {
+		return fmt.Errorf("leaderboardID is required")
+	}
+	if activityID == "" {
+		return fmt.Errorf("activityID is required")
+	}
+
+	payload := struct {
+		Data ResourceData `json:"data"`
+	}{
+		Data: ResourceData{
+			Type: ResourceTypeGameCenterActivities,
+			ID:   activityID,
+		},
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboards/%s/relationships/activity", leaderboardID)
+	_, err = c.do(ctx, http.MethodPatch, path, body)
+	return err
+}
+
+// UpdateGameCenterLeaderboardChallengeRelationship updates the challenge relationship on a leaderboard.
+func (c *Client) UpdateGameCenterLeaderboardChallengeRelationship(ctx context.Context, leaderboardID, challengeID string) error {
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	challengeID = strings.TrimSpace(challengeID)
+	if leaderboardID == "" {
+		return fmt.Errorf("leaderboardID is required")
+	}
+	if challengeID == "" {
+		return fmt.Errorf("challengeID is required")
+	}
+
+	payload := struct {
+		Data ResourceData `json:"data"`
+	}{
+		Data: ResourceData{
+			Type: ResourceTypeGameCenterChallenges,
+			ID:   challengeID,
+		},
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboards/%s/relationships/challenge", leaderboardID)
+	_, err = c.do(ctx, http.MethodPatch, path, body)
+	return err
+}
+
+// UpdateGameCenterLeaderboardGroupLeaderboardRelationship updates the groupLeaderboard relationship on a leaderboard.
+func (c *Client) UpdateGameCenterLeaderboardGroupLeaderboardRelationship(ctx context.Context, leaderboardID, groupLeaderboardID string) error {
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	groupLeaderboardID = strings.TrimSpace(groupLeaderboardID)
+	if leaderboardID == "" {
+		return fmt.Errorf("leaderboardID is required")
+	}
+	if groupLeaderboardID == "" {
+		return fmt.Errorf("groupLeaderboardID is required")
+	}
+
+	payload := struct {
+		Data ResourceData `json:"data"`
+	}{
+		Data: ResourceData{
+			Type: ResourceTypeGameCenterLeaderboards,
+			ID:   groupLeaderboardID,
+		},
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboards/%s/relationships/groupLeaderboard", leaderboardID)
+	_, err = c.do(ctx, http.MethodPatch, path, body)
+	return err
+}
+
+func (c *Client) getGameCenterLeaderboardSetLinkages(ctx context.Context, setID, relationship string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	setID = strings.TrimSpace(setID)
+	if query.nextURL == "" && setID == "" {
+		return nil, fmt.Errorf("setID is required")
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboardSets/%s/relationships/%s", setID, relationship)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("gameCenterLeaderboardSetRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+func (c *Client) getGameCenterLeaderboardLinkages(ctx context.Context, leaderboardID, relationship string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	if query.nextURL == "" && leaderboardID == "" {
+		return nil, fmt.Errorf("leaderboardID is required")
+	}
+
+	path := fmt.Sprintf("/v1/gameCenterLeaderboards/%s/relationships/%s", leaderboardID, relationship)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("gameCenterLeaderboardRelationships: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/client_game_center_leaderboards_relationships_v2.go
+++ b/internal/asc/client_game_center_leaderboards_relationships_v2.go
@@ -1,0 +1,180 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// GetGameCenterLeaderboardSetMembersRelationshipsV2 retrieves leaderboard linkages for a v2 leaderboard set.
+func (c *Client) GetGameCenterLeaderboardSetMembersRelationshipsV2(ctx context.Context, setID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardSetLinkagesV2(ctx, setID, "gameCenterLeaderboards", opts...)
+}
+
+// AddGameCenterLeaderboardSetMembersV2 adds leaderboards to a v2 leaderboard set.
+func (c *Client) AddGameCenterLeaderboardSetMembersV2(ctx context.Context, setID string, leaderboardIDs []string) error {
+	payload := RelationshipRequest{
+		Data: buildRelationshipData(ResourceTypeGameCenterLeaderboards, leaderboardIDs),
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v2/gameCenterLeaderboardSets/%s/relationships/gameCenterLeaderboards", strings.TrimSpace(setID))
+	_, err = c.do(ctx, http.MethodPost, path, body)
+	return err
+}
+
+// RemoveGameCenterLeaderboardSetMembersV2 removes leaderboards from a v2 leaderboard set.
+func (c *Client) RemoveGameCenterLeaderboardSetMembersV2(ctx context.Context, setID string, leaderboardIDs []string) error {
+	payload := RelationshipRequest{
+		Data: buildRelationshipData(ResourceTypeGameCenterLeaderboards, leaderboardIDs),
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v2/gameCenterLeaderboardSets/%s/relationships/gameCenterLeaderboards", strings.TrimSpace(setID))
+	_, err = c.do(ctx, http.MethodDelete, path, body)
+	return err
+}
+
+// GetGameCenterLeaderboardSetVersionsRelationships retrieves version linkages for a v2 leaderboard set.
+func (c *Client) GetGameCenterLeaderboardSetVersionsRelationships(ctx context.Context, setID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardSetLinkagesV2(ctx, setID, "versions", opts...)
+}
+
+// GetGameCenterLeaderboardVersionsRelationships retrieves version linkages for a v2 leaderboard.
+func (c *Client) GetGameCenterLeaderboardVersionsRelationships(ctx context.Context, leaderboardID string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	return c.getGameCenterLeaderboardLinkagesV2(ctx, leaderboardID, "versions", opts...)
+}
+
+// UpdateGameCenterLeaderboardActivityRelationshipV2 updates the activity relationship on a v2 leaderboard.
+func (c *Client) UpdateGameCenterLeaderboardActivityRelationshipV2(ctx context.Context, leaderboardID, activityID string) error {
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	activityID = strings.TrimSpace(activityID)
+	if leaderboardID == "" {
+		return fmt.Errorf("leaderboardID is required")
+	}
+	if activityID == "" {
+		return fmt.Errorf("activityID is required")
+	}
+
+	payload := struct {
+		Data ResourceData `json:"data"`
+	}{
+		Data: ResourceData{
+			Type: ResourceTypeGameCenterActivities,
+			ID:   activityID,
+		},
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v2/gameCenterLeaderboards/%s/relationships/activity", leaderboardID)
+	_, err = c.do(ctx, http.MethodPatch, path, body)
+	return err
+}
+
+// UpdateGameCenterLeaderboardChallengeRelationshipV2 updates the challenge relationship on a v2 leaderboard.
+func (c *Client) UpdateGameCenterLeaderboardChallengeRelationshipV2(ctx context.Context, leaderboardID, challengeID string) error {
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	challengeID = strings.TrimSpace(challengeID)
+	if leaderboardID == "" {
+		return fmt.Errorf("leaderboardID is required")
+	}
+	if challengeID == "" {
+		return fmt.Errorf("challengeID is required")
+	}
+
+	payload := struct {
+		Data ResourceData `json:"data"`
+	}{
+		Data: ResourceData{
+			Type: ResourceTypeGameCenterChallenges,
+			ID:   challengeID,
+		},
+	}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v2/gameCenterLeaderboards/%s/relationships/challenge", leaderboardID)
+	_, err = c.do(ctx, http.MethodPatch, path, body)
+	return err
+}
+
+func (c *Client) getGameCenterLeaderboardSetLinkagesV2(ctx context.Context, setID, relationship string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	setID = strings.TrimSpace(setID)
+	if query.nextURL == "" && setID == "" {
+		return nil, fmt.Errorf("setID is required")
+	}
+
+	path := fmt.Sprintf("/v2/gameCenterLeaderboardSets/%s/relationships/%s", setID, relationship)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("gameCenterLeaderboardSetRelationshipsV2: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+func (c *Client) getGameCenterLeaderboardLinkagesV2(ctx context.Context, leaderboardID, relationship string, opts ...LinkagesOption) (*LinkagesResponse, error) {
+	query := &linkagesQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	leaderboardID = strings.TrimSpace(leaderboardID)
+	if query.nextURL == "" && leaderboardID == "" {
+		return nil, fmt.Errorf("leaderboardID is required")
+	}
+
+	path := fmt.Sprintf("/v2/gameCenterLeaderboards/%s/relationships/%s", leaderboardID, relationship)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("gameCenterLeaderboardRelationshipsV2: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildLinkagesQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response LinkagesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/client_http_issue_617_game_center_leaderboards_relationships_test.go
+++ b/internal/asc/client_http_issue_617_game_center_leaderboards_relationships_test.go
@@ -1,0 +1,372 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestIssue617_GameCenterLeaderboardRelationshipEndpoints_GET(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		linkagesOK = `{"data":[{"type":"gameCenterLeaderboards","id":"lb-1"}],"links":{}}`
+		toOneOK    = `{"data":{"type":"gameCenterLeaderboards","id":"lb-1"},"links":{}}`
+	)
+
+	tests := []struct {
+		name     string
+		wantPath string
+		body     string
+		call     func(*Client) error
+	}{
+		{
+			name:     "GetGameCenterLeaderboardSetMembersRelationships",
+			wantPath: "/v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardSetMembersRelationships(ctx, "set-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardSetGroupLeaderboardSetRelationship",
+			wantPath: "/v1/gameCenterLeaderboardSets/set-1/relationships/groupLeaderboardSet",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardSetGroupLeaderboardSetRelationship(ctx, "set-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardSetLocalizationsRelationships",
+			wantPath: "/v1/gameCenterLeaderboardSets/set-1/relationships/localizations",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardSetLocalizationsRelationships(ctx, "set-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardSetReleasesRelationships",
+			wantPath: "/v1/gameCenterLeaderboardSets/set-1/relationships/releases",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardSetReleasesRelationships(ctx, "set-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardGroupLeaderboardRelationship",
+			wantPath: "/v1/gameCenterLeaderboards/lb-1/relationships/groupLeaderboard",
+			body:     toOneOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardGroupLeaderboardRelationship(ctx, "lb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardLocalizationsRelationships",
+			wantPath: "/v1/gameCenterLeaderboards/lb-1/relationships/localizations",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardLocalizationsRelationships(ctx, "lb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardReleasesRelationships",
+			wantPath: "/v1/gameCenterLeaderboards/lb-1/relationships/releases",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardReleasesRelationships(ctx, "lb-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardSetMembersRelationshipsV2",
+			wantPath: "/v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardSetMembersRelationshipsV2(ctx, "set-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardSetVersionsRelationships",
+			wantPath: "/v2/gameCenterLeaderboardSets/set-1/relationships/versions",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardSetVersionsRelationships(ctx, "set-1")
+				return err
+			},
+		},
+		{
+			name:     "GetGameCenterLeaderboardVersionsRelationships",
+			wantPath: "/v2/gameCenterLeaderboards/lb-1/relationships/versions",
+			body:     linkagesOK,
+			call: func(client *Client) error {
+				_, err := client.GetGameCenterLeaderboardVersionsRelationships(ctx, "lb-1")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != tt.wantPath {
+					t.Fatalf("expected path %s, got %s", tt.wantPath, req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			}, jsonResponse(http.StatusOK, tt.body))
+
+			if err := tt.call(client); err != nil {
+				t.Fatalf("request error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIssue617_GameCenterLeaderboardRelationshipEndpoints_Mutations(t *testing.T) {
+	ctx := context.Background()
+
+	type toOneRequest struct {
+		Data ResourceData `json:"data"`
+	}
+
+	tests := []struct {
+		name       string
+		wantMethod string
+		wantPath   string
+		wantBodyFn func(*testing.T, []byte)
+		call       func(*Client) error
+	}{
+		{
+			name:       "AddGameCenterLeaderboardSetMembers (POST v1)",
+			wantMethod: http.MethodPost,
+			wantPath:   "/v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got RelationshipRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if len(got.Data) != 2 {
+					t.Fatalf("expected 2 relationship items, got %d", len(got.Data))
+				}
+				if got.Data[0].Type != ResourceTypeGameCenterLeaderboards || got.Data[0].ID != "lb-1" {
+					t.Fatalf("unexpected first item: %#v", got.Data[0])
+				}
+				if got.Data[1].Type != ResourceTypeGameCenterLeaderboards || got.Data[1].ID != "lb-2" {
+					t.Fatalf("unexpected second item: %#v", got.Data[1])
+				}
+			},
+			call: func(client *Client) error {
+				return client.AddGameCenterLeaderboardSetMembers(ctx, "set-1", []string{"lb-1", "lb-2"})
+			},
+		},
+		{
+			name:       "RemoveGameCenterLeaderboardSetMembers (DELETE v1)",
+			wantMethod: http.MethodDelete,
+			wantPath:   "/v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got RelationshipRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if len(got.Data) != 1 {
+					t.Fatalf("expected 1 relationship item, got %d", len(got.Data))
+				}
+				if got.Data[0].Type != ResourceTypeGameCenterLeaderboards || got.Data[0].ID != "lb-1" {
+					t.Fatalf("unexpected item: %#v", got.Data[0])
+				}
+			},
+			call: func(client *Client) error {
+				return client.RemoveGameCenterLeaderboardSetMembers(ctx, "set-1", []string{"lb-1"})
+			},
+		},
+		{
+			name:       "AddGameCenterLeaderboardSetMembersV2 (POST v2)",
+			wantMethod: http.MethodPost,
+			wantPath:   "/v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got RelationshipRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if len(got.Data) != 2 {
+					t.Fatalf("expected 2 relationship items, got %d", len(got.Data))
+				}
+				if got.Data[0].Type != ResourceTypeGameCenterLeaderboards || got.Data[0].ID != "lb-1" {
+					t.Fatalf("unexpected first item: %#v", got.Data[0])
+				}
+				if got.Data[1].Type != ResourceTypeGameCenterLeaderboards || got.Data[1].ID != "lb-2" {
+					t.Fatalf("unexpected second item: %#v", got.Data[1])
+				}
+			},
+			call: func(client *Client) error {
+				return client.AddGameCenterLeaderboardSetMembersV2(ctx, "set-1", []string{"lb-1", "lb-2"})
+			},
+		},
+		{
+			name:       "RemoveGameCenterLeaderboardSetMembersV2 (DELETE v2)",
+			wantMethod: http.MethodDelete,
+			wantPath:   "/v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got RelationshipRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if len(got.Data) != 1 {
+					t.Fatalf("expected 1 relationship item, got %d", len(got.Data))
+				}
+				if got.Data[0].Type != ResourceTypeGameCenterLeaderboards || got.Data[0].ID != "lb-1" {
+					t.Fatalf("unexpected item: %#v", got.Data[0])
+				}
+			},
+			call: func(client *Client) error {
+				return client.RemoveGameCenterLeaderboardSetMembersV2(ctx, "set-1", []string{"lb-1"})
+			},
+		},
+		{
+			name:       "UpdateGameCenterLeaderboardSetGroupLeaderboardSetRelationship (PATCH v1)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v1/gameCenterLeaderboardSets/set-1/relationships/groupLeaderboardSet",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got toOneRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeGameCenterLeaderboardSets || got.Data.ID != "set-2" {
+					t.Fatalf("unexpected data: %#v", got.Data)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterLeaderboardSetGroupLeaderboardSetRelationship(ctx, "set-1", "set-2")
+			},
+		},
+		{
+			name:       "UpdateGameCenterLeaderboardActivityRelationship (PATCH v1)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v1/gameCenterLeaderboards/lb-1/relationships/activity",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got toOneRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeGameCenterActivities || got.Data.ID != "act-1" {
+					t.Fatalf("unexpected data: %#v", got.Data)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterLeaderboardActivityRelationship(ctx, "lb-1", "act-1")
+			},
+		},
+		{
+			name:       "UpdateGameCenterLeaderboardChallengeRelationship (PATCH v1)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v1/gameCenterLeaderboards/lb-1/relationships/challenge",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got toOneRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeGameCenterChallenges || got.Data.ID != "chal-1" {
+					t.Fatalf("unexpected data: %#v", got.Data)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterLeaderboardChallengeRelationship(ctx, "lb-1", "chal-1")
+			},
+		},
+		{
+			name:       "UpdateGameCenterLeaderboardGroupLeaderboardRelationship (PATCH v1)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v1/gameCenterLeaderboards/lb-1/relationships/groupLeaderboard",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got toOneRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeGameCenterLeaderboards || got.Data.ID != "lb-2" {
+					t.Fatalf("unexpected data: %#v", got.Data)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterLeaderboardGroupLeaderboardRelationship(ctx, "lb-1", "lb-2")
+			},
+		},
+		{
+			name:       "UpdateGameCenterLeaderboardActivityRelationshipV2 (PATCH v2)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v2/gameCenterLeaderboards/lb-1/relationships/activity",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got toOneRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeGameCenterActivities || got.Data.ID != "act-1" {
+					t.Fatalf("unexpected data: %#v", got.Data)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterLeaderboardActivityRelationshipV2(ctx, "lb-1", "act-1")
+			},
+		},
+		{
+			name:       "UpdateGameCenterLeaderboardChallengeRelationshipV2 (PATCH v2)",
+			wantMethod: http.MethodPatch,
+			wantPath:   "/v2/gameCenterLeaderboards/lb-1/relationships/challenge",
+			wantBodyFn: func(t *testing.T, body []byte) {
+				t.Helper()
+				var got toOneRequest
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				if got.Data.Type != ResourceTypeGameCenterChallenges || got.Data.ID != "chal-1" {
+					t.Fatalf("unexpected data: %#v", got.Data)
+				}
+			},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterLeaderboardChallengeRelationshipV2(ctx, "lb-1", "chal-1")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != tt.wantMethod {
+					t.Fatalf("expected %s, got %s", tt.wantMethod, req.Method)
+				}
+				if req.URL.Path != tt.wantPath {
+					t.Fatalf("expected path %s, got %s", tt.wantPath, req.URL.Path)
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				tt.wantBodyFn(t, body)
+				assertAuthorized(t, req)
+			}, jsonResponse(http.StatusNoContent, ""))
+
+			if err := tt.call(client); err != nil {
+				t.Fatalf("request error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the missing Game Center leaderboard + leaderboard set relationship endpoints listed in #617 and adds request-shaping tests.

### Endpoints
- DELETE /v1/gameCenterLeaderboardSets/{id}/relationships/gameCenterLeaderboards
- DELETE /v2/gameCenterLeaderboardSets/{id}/relationships/gameCenterLeaderboards
- GET /v1/gameCenterLeaderboardSets/{id}/relationships/gameCenterLeaderboards
- GET /v1/gameCenterLeaderboardSets/{id}/relationships/groupLeaderboardSet
- GET /v1/gameCenterLeaderboardSets/{id}/relationships/localizations
- GET /v1/gameCenterLeaderboardSets/{id}/relationships/releases
- GET /v1/gameCenterLeaderboards/{id}/relationships/groupLeaderboard
- GET /v1/gameCenterLeaderboards/{id}/relationships/localizations
- GET /v1/gameCenterLeaderboards/{id}/relationships/releases
- GET /v2/gameCenterLeaderboardSets/{id}/relationships/gameCenterLeaderboards
- GET /v2/gameCenterLeaderboardSets/{id}/relationships/versions
- GET /v2/gameCenterLeaderboards/{id}/relationships/versions
- PATCH /v1/gameCenterLeaderboardSets/{id}/relationships/groupLeaderboardSet
- PATCH /v1/gameCenterLeaderboards/{id}/relationships/activity
- PATCH /v1/gameCenterLeaderboards/{id}/relationships/challenge
- PATCH /v1/gameCenterLeaderboards/{id}/relationships/groupLeaderboard
- PATCH /v2/gameCenterLeaderboards/{id}/relationships/activity
- PATCH /v2/gameCenterLeaderboards/{id}/relationships/challenge
- POST /v1/gameCenterLeaderboardSets/{id}/relationships/gameCenterLeaderboards
- POST /v2/gameCenterLeaderboardSets/{id}/relationships/gameCenterLeaderboards

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

Fixes #617