### PR TITLE
fix(asc): encode empty relationship list as []

### DIFF
--- a/internal/asc/client_http_issue_616_game_center_detail_group_relationships_test.go
+++ b/internal/asc/client_http_issue_616_game_center_detail_group_relationships_test.go
@@ -324,6 +324,15 @@ func TestIssue616_GameCenterDetailAndGroupRelationshipEndpoints_PATCH(t *testing
 			},
 		},
 		{
+			name:     "UpdateGameCenterDetailGameCenterLeaderboardsRelationship empty clears relationship",
+			wantPath: "/v1/gameCenterDetails/detail-1/relationships/gameCenterLeaderboards",
+			wantType: ResourceTypeGameCenterLeaderboards,
+			wantIDs:  []string{},
+			call: func(client *Client) error {
+				return client.UpdateGameCenterDetailGameCenterLeaderboardsRelationship(ctx, "detail-1", nil)
+			},
+		},
+		{
 			name:     "UpdateGameCenterDetailGameCenterLeaderboardsV2Relationship",
 			wantPath: "/v1/gameCenterDetails/detail-1/relationships/gameCenterLeaderboardsV2",
 			wantType: ResourceTypeGameCenterLeaderboards,
@@ -370,6 +379,11 @@ func TestIssue616_GameCenterDetailAndGroupRelationshipEndpoints_PATCH(t *testing
 				var got RelationshipRequest
 				if err := json.Unmarshal(body, &got); err != nil {
 					t.Fatalf("unmarshal body: %v", err)
+				}
+				// For to-many relationship replace requests, "data" must be an array.
+				// Ensure we don't send {"data":null} when clearing a relationship.
+				if len(tt.wantIDs) == 0 && got.Data == nil {
+					t.Fatalf("expected empty relationship data array, got null")
 				}
 				if len(got.Data) != len(tt.wantIDs) {
 					t.Fatalf("expected %d relationship items, got %d", len(tt.wantIDs), len(got.Data))

--- a/internal/asc/types/resources.go
+++ b/internal/asc/types/resources.go
@@ -312,6 +312,19 @@ type RelationshipRequest struct {
 	Data []RelationshipData `json:"data"`
 }
 
+// MarshalJSON ensures relationship list payloads always encode `data` as an array.
+//
+// In JSON:API, to-many relationship payloads use `data: []` to represent an empty
+// set. Go's `encoding/json` encodes nil slices as `null`, which is not a valid
+// representation for a relationship list.
+func (r RelationshipRequest) MarshalJSON() ([]byte, error) {
+	if r.Data == nil {
+		r.Data = []RelationshipData{}
+	}
+	type alias RelationshipRequest
+	return json.Marshal(alias(r))
+}
+
 // RelationshipData represents data in a relationship payload.
 type RelationshipData struct {
 	Type ResourceType `json:"type"`

--- a/internal/asc/types/resources_test.go
+++ b/internal/asc/types/resources_test.go
@@ -1,6 +1,9 @@
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestResponseAccessors(t *testing.T) {
 	r := &Response[struct{ Name string }]{
@@ -66,5 +69,25 @@ func TestTypeConstants(t *testing.T) {
 	}
 	if UTIIPA != "com.apple.ipa" || UTIPKG != "com.apple.installer-package-archive" {
 		t.Fatalf("unexpected UTI constants: %q %q", UTIIPA, UTIPKG)
+	}
+}
+
+func TestRelationshipRequest_MarshalJSON_EncodesEmptyArray(t *testing.T) {
+	// RelationshipRequest represents a to-many relationship payload. In JSON:API, an empty
+	// relationship list is encoded as {"data":[]} (not {"data":null}).
+	body, err := json.Marshal(RelationshipRequest{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got RelationshipRequest
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Data == nil {
+		t.Fatalf("expected data to decode as an empty array, got nil (body=%q)", string(body))
+	}
+	if len(got.Data) != 0 {
+		t.Fatalf("expected empty data array, got %d items", len(got.Data))
 	}
 }


### PR DESCRIPTION
## What
- Ensure to-many relationship payloads always encode `data` as an array (`[]`) instead of `null`.
- Add regression tests for `RelationshipRequest` marshaling.
- Add a request-shaping test that exercises clearing a to-many relationship.

## Why
Go encodes nil slices as `null`, but JSON:API relationship lists use `data: []` to represent an empty set. Sending `data: null` can make relationship replace requests behave unexpectedly (especially when attempting to clear a relationship).

## Test Plan
- `make format`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`