### PR TITLE
fix(asc): validate relationship mutation inputs

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -736,7 +736,14 @@ func (c *Client) DeleteBetaGroup(ctx context.Context, groupID string) error {
 
 // AddBetaTestersToGroup adds testers to a beta group.
 func (c *Client) AddBetaTestersToGroup(ctx context.Context, groupID string, testerIDs []string) error {
+	groupID = strings.TrimSpace(groupID)
 	testerIDs = normalizeList(testerIDs)
+	if groupID == "" {
+		return fmt.Errorf("groupID is required")
+	}
+	if len(testerIDs) == 0 {
+		return fmt.Errorf("testerIDs are required")
+	}
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, 0, len(testerIDs)),
 	}
@@ -759,7 +766,14 @@ func (c *Client) AddBetaTestersToGroup(ctx context.Context, groupID string, test
 
 // RemoveBetaTestersFromGroup removes testers from a beta group.
 func (c *Client) RemoveBetaTestersFromGroup(ctx context.Context, groupID string, testerIDs []string) error {
+	groupID = strings.TrimSpace(groupID)
 	testerIDs = normalizeList(testerIDs)
+	if groupID == "" {
+		return fmt.Errorf("groupID is required")
+	}
+	if len(testerIDs) == 0 {
+		return fmt.Errorf("testerIDs are required")
+	}
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, 0, len(testerIDs)),
 	}

--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -322,6 +322,15 @@ func (c *Client) AddBetaGroupsToBuild(ctx context.Context, buildID string, group
 
 // AddBetaGroupsToBuildWithNotify adds beta groups to a build with optional notifications.
 func (c *Client) AddBetaGroupsToBuildWithNotify(ctx context.Context, buildID string, groupIDs []string, notify bool) error {
+	buildID = strings.TrimSpace(buildID)
+	groupIDs = normalizeList(groupIDs)
+	if buildID == "" {
+		return fmt.Errorf("buildID is required")
+	}
+	if len(groupIDs) == 0 {
+		return fmt.Errorf("groupIDs are required")
+	}
+
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, len(groupIDs)),
 	}
@@ -349,6 +358,15 @@ func (c *Client) AddBetaGroupsToBuildWithNotify(ctx context.Context, buildID str
 
 // RemoveBetaGroupsFromBuild removes beta groups from a build.
 func (c *Client) RemoveBetaGroupsFromBuild(ctx context.Context, buildID string, groupIDs []string) error {
+	buildID = strings.TrimSpace(buildID)
+	groupIDs = normalizeList(groupIDs)
+	if buildID == "" {
+		return fmt.Errorf("buildID is required")
+	}
+	if len(groupIDs) == 0 {
+		return fmt.Errorf("groupIDs are required")
+	}
+
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, len(groupIDs)),
 	}

--- a/internal/asc/client_game_center_activities.go
+++ b/internal/asc/client_game_center_activities.go
@@ -146,6 +146,15 @@ func (c *Client) DeleteGameCenterActivity(ctx context.Context, activityID string
 
 // AddGameCenterActivityAchievements adds achievements to an activity.
 func (c *Client) AddGameCenterActivityAchievements(ctx context.Context, activityID string, achievementIDs []string) error {
+	activityID = strings.TrimSpace(activityID)
+	achievementIDs = normalizeList(achievementIDs)
+	if activityID == "" {
+		return fmt.Errorf("activityID is required")
+	}
+	if len(achievementIDs) == 0 {
+		return fmt.Errorf("achievementIDs are required")
+	}
+
 	payload := RelationshipRequest{
 		Data: buildRelationshipData(ResourceTypeGameCenterAchievements, achievementIDs),
 	}
@@ -154,13 +163,22 @@ func (c *Client) AddGameCenterActivityAchievements(ctx context.Context, activity
 		return err
 	}
 
-	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/achievements", strings.TrimSpace(activityID))
+	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/achievements", activityID)
 	_, err = c.do(ctx, http.MethodPost, path, body)
 	return err
 }
 
 // RemoveGameCenterActivityAchievements removes achievements from an activity.
 func (c *Client) RemoveGameCenterActivityAchievements(ctx context.Context, activityID string, achievementIDs []string) error {
+	activityID = strings.TrimSpace(activityID)
+	achievementIDs = normalizeList(achievementIDs)
+	if activityID == "" {
+		return fmt.Errorf("activityID is required")
+	}
+	if len(achievementIDs) == 0 {
+		return fmt.Errorf("achievementIDs are required")
+	}
+
 	payload := RelationshipRequest{
 		Data: buildRelationshipData(ResourceTypeGameCenterAchievements, achievementIDs),
 	}
@@ -169,13 +187,22 @@ func (c *Client) RemoveGameCenterActivityAchievements(ctx context.Context, activ
 		return err
 	}
 
-	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/achievements", strings.TrimSpace(activityID))
+	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/achievements", activityID)
 	_, err = c.do(ctx, http.MethodDelete, path, body)
 	return err
 }
 
 // AddGameCenterActivityLeaderboards adds leaderboards to an activity.
 func (c *Client) AddGameCenterActivityLeaderboards(ctx context.Context, activityID string, leaderboardIDs []string) error {
+	activityID = strings.TrimSpace(activityID)
+	leaderboardIDs = normalizeList(leaderboardIDs)
+	if activityID == "" {
+		return fmt.Errorf("activityID is required")
+	}
+	if len(leaderboardIDs) == 0 {
+		return fmt.Errorf("leaderboardIDs are required")
+	}
+
 	payload := RelationshipRequest{
 		Data: buildRelationshipData(ResourceTypeGameCenterLeaderboards, leaderboardIDs),
 	}
@@ -184,13 +211,22 @@ func (c *Client) AddGameCenterActivityLeaderboards(ctx context.Context, activity
 		return err
 	}
 
-	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/leaderboards", strings.TrimSpace(activityID))
+	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/leaderboards", activityID)
 	_, err = c.do(ctx, http.MethodPost, path, body)
 	return err
 }
 
 // RemoveGameCenterActivityLeaderboards removes leaderboards from an activity.
 func (c *Client) RemoveGameCenterActivityLeaderboards(ctx context.Context, activityID string, leaderboardIDs []string) error {
+	activityID = strings.TrimSpace(activityID)
+	leaderboardIDs = normalizeList(leaderboardIDs)
+	if activityID == "" {
+		return fmt.Errorf("activityID is required")
+	}
+	if len(leaderboardIDs) == 0 {
+		return fmt.Errorf("leaderboardIDs are required")
+	}
+
 	payload := RelationshipRequest{
 		Data: buildRelationshipData(ResourceTypeGameCenterLeaderboards, leaderboardIDs),
 	}
@@ -199,7 +235,7 @@ func (c *Client) RemoveGameCenterActivityLeaderboards(ctx context.Context, activ
 		return err
 	}
 
-	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/leaderboards", strings.TrimSpace(activityID))
+	path := fmt.Sprintf("/v1/gameCenterActivities/%s/relationships/leaderboards", activityID)
 	_, err = c.do(ctx, http.MethodDelete, path, body)
 	return err
 }

--- a/internal/asc/client_relationship_mutations_validation_test.go
+++ b/internal/asc/client_relationship_mutations_validation_test.go
@@ -1,0 +1,198 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRelationshipMutationValidationErrors(t *testing.T) {
+	ctx := context.Background()
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+
+	tests := []struct {
+		name    string
+		wantErr string
+		call    func(*Client) error
+	}{
+		{
+			name:    "AddBetaGroupsToBuildWithNotify missing buildID",
+			wantErr: "buildID is required",
+			call: func(client *Client) error {
+				return client.AddBetaGroupsToBuildWithNotify(ctx, "", []string{"group-1"}, false)
+			},
+		},
+		{
+			name:    "AddBetaGroupsToBuildWithNotify missing groupIDs",
+			wantErr: "groupIDs are required",
+			call: func(client *Client) error {
+				return client.AddBetaGroupsToBuildWithNotify(ctx, "build-1", []string{" ", ""}, false)
+			},
+		},
+		{
+			name:    "RemoveBetaGroupsFromBuild missing buildID",
+			wantErr: "buildID is required",
+			call: func(client *Client) error {
+				return client.RemoveBetaGroupsFromBuild(ctx, " ", []string{"group-1"})
+			},
+		},
+		{
+			name:    "RemoveBetaGroupsFromBuild missing groupIDs",
+			wantErr: "groupIDs are required",
+			call: func(client *Client) error {
+				return client.RemoveBetaGroupsFromBuild(ctx, "build-1", nil)
+			},
+		},
+		{
+			name:    "AddBetaTestersToGroup missing groupID",
+			wantErr: "groupID is required",
+			call: func(client *Client) error {
+				return client.AddBetaTestersToGroup(ctx, "", []string{"tester-1"})
+			},
+		},
+		{
+			name:    "AddBetaTestersToGroup missing testerIDs",
+			wantErr: "testerIDs are required",
+			call: func(client *Client) error {
+				return client.AddBetaTestersToGroup(ctx, "group-1", []string{" ", ""})
+			},
+		},
+		{
+			name:    "RemoveBetaTestersFromGroup missing groupID",
+			wantErr: "groupID is required",
+			call: func(client *Client) error {
+				return client.RemoveBetaTestersFromGroup(ctx, " ", []string{"tester-1"})
+			},
+		},
+		{
+			name:    "RemoveBetaTestersFromGroup missing testerIDs",
+			wantErr: "testerIDs are required",
+			call: func(client *Client) error {
+				return client.RemoveBetaTestersFromGroup(ctx, "group-1", nil)
+			},
+		},
+		{
+			name:    "GetUserVisibleAppsRelationships missing userID",
+			wantErr: "userID is required",
+			call: func(client *Client) error {
+				_, err := client.GetUserVisibleAppsRelationships(ctx, "")
+				return err
+			},
+		},
+		{
+			name:    "AddUserVisibleApps missing userID",
+			wantErr: "userID is required",
+			call: func(client *Client) error {
+				return client.AddUserVisibleApps(ctx, "", []string{"app-1"})
+			},
+		},
+		{
+			name:    "AddUserVisibleApps missing appIDs",
+			wantErr: "appIDs are required",
+			call: func(client *Client) error {
+				return client.AddUserVisibleApps(ctx, "user-1", []string{" "})
+			},
+		},
+		{
+			name:    "RemoveUserVisibleApps missing userID",
+			wantErr: "userID is required",
+			call: func(client *Client) error {
+				return client.RemoveUserVisibleApps(ctx, " ", []string{"app-1"})
+			},
+		},
+		{
+			name:    "RemoveUserVisibleApps missing appIDs",
+			wantErr: "appIDs are required",
+			call: func(client *Client) error {
+				return client.RemoveUserVisibleApps(ctx, "user-1", nil)
+			},
+		},
+		{
+			name:    "SetUserVisibleApps missing userID",
+			wantErr: "userID is required",
+			call: func(client *Client) error {
+				return client.SetUserVisibleApps(ctx, "", []string{"app-1"})
+			},
+		},
+		{
+			name:    "AddBuildsToAppEncryptionDeclaration missing buildIDs",
+			wantErr: "buildIDs are required",
+			call: func(client *Client) error {
+				return client.AddBuildsToAppEncryptionDeclaration(ctx, "dec-1", []string{" "})
+			},
+		},
+		{
+			name:    "AddGameCenterActivityAchievements missing activityID",
+			wantErr: "activityID is required",
+			call: func(client *Client) error {
+				return client.AddGameCenterActivityAchievements(ctx, "", []string{"ach-1"})
+			},
+		},
+		{
+			name:    "AddGameCenterActivityAchievements missing achievementIDs",
+			wantErr: "achievementIDs are required",
+			call: func(client *Client) error {
+				return client.AddGameCenterActivityAchievements(ctx, "act-1", []string{" "})
+			},
+		},
+		{
+			name:    "RemoveGameCenterActivityAchievements missing activityID",
+			wantErr: "activityID is required",
+			call: func(client *Client) error {
+				return client.RemoveGameCenterActivityAchievements(ctx, " ", []string{"ach-1"})
+			},
+		},
+		{
+			name:    "RemoveGameCenterActivityAchievements missing achievementIDs",
+			wantErr: "achievementIDs are required",
+			call: func(client *Client) error {
+				return client.RemoveGameCenterActivityAchievements(ctx, "act-1", nil)
+			},
+		},
+		{
+			name:    "AddGameCenterActivityLeaderboards missing activityID",
+			wantErr: "activityID is required",
+			call: func(client *Client) error {
+				return client.AddGameCenterActivityLeaderboards(ctx, "", []string{"lb-1"})
+			},
+		},
+		{
+			name:    "AddGameCenterActivityLeaderboards missing leaderboardIDs",
+			wantErr: "leaderboardIDs are required",
+			call: func(client *Client) error {
+				return client.AddGameCenterActivityLeaderboards(ctx, "act-1", []string{" "})
+			},
+		},
+		{
+			name:    "RemoveGameCenterActivityLeaderboards missing activityID",
+			wantErr: "activityID is required",
+			call: func(client *Client) error {
+				return client.RemoveGameCenterActivityLeaderboards(ctx, " ", []string{"lb-1"})
+			},
+		},
+		{
+			name:    "RemoveGameCenterActivityLeaderboards missing leaderboardIDs",
+			wantErr: "leaderboardIDs are required",
+			call: func(client *Client) error {
+				return client.RemoveGameCenterActivityLeaderboards(ctx, "act-1", nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}, response)
+
+			err := test.call(client)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected error to contain %q, got %v", test.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/asc/client_users.go
+++ b/internal/asc/client_users.go
@@ -244,6 +244,9 @@ func (c *Client) GetUserVisibleAppsRelationships(ctx context.Context, userID str
 	for _, opt := range opts {
 		opt(query)
 	}
+	if query.nextURL == "" && userID == "" {
+		return nil, fmt.Errorf("userID is required")
+	}
 
 	path := fmt.Sprintf("/v1/users/%s/relationships/visibleApps", userID)
 	if query.nextURL != "" {
@@ -272,6 +275,12 @@ func (c *Client) GetUserVisibleAppsRelationships(ctx context.Context, userID str
 func (c *Client) AddUserVisibleApps(ctx context.Context, userID string, appIDs []string) error {
 	userID = strings.TrimSpace(userID)
 	appIDs = normalizeList(appIDs)
+	if userID == "" {
+		return fmt.Errorf("userID is required")
+	}
+	if len(appIDs) == 0 {
+		return fmt.Errorf("appIDs are required")
+	}
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, 0, len(appIDs)),
 	}
@@ -296,6 +305,12 @@ func (c *Client) AddUserVisibleApps(ctx context.Context, userID string, appIDs [
 func (c *Client) RemoveUserVisibleApps(ctx context.Context, userID string, appIDs []string) error {
 	userID = strings.TrimSpace(userID)
 	appIDs = normalizeList(appIDs)
+	if userID == "" {
+		return fmt.Errorf("userID is required")
+	}
+	if len(appIDs) == 0 {
+		return fmt.Errorf("appIDs are required")
+	}
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, 0, len(appIDs)),
 	}
@@ -320,6 +335,9 @@ func (c *Client) RemoveUserVisibleApps(ctx context.Context, userID string, appID
 func (c *Client) SetUserVisibleApps(ctx context.Context, userID string, appIDs []string) error {
 	userID = strings.TrimSpace(userID)
 	appIDs = normalizeList(appIDs)
+	if userID == "" {
+		return fmt.Errorf("userID is required")
+	}
 	payload := RelationshipRequest{
 		Data: make([]RelationshipData, 0, len(appIDs)),
 	}

--- a/internal/asc/encryption.go
+++ b/internal/asc/encryption.go
@@ -230,8 +230,12 @@ func (c *Client) CreateAppEncryptionDeclaration(ctx context.Context, appID strin
 // AddBuildsToAppEncryptionDeclaration assigns builds to a declaration.
 func (c *Client) AddBuildsToAppEncryptionDeclaration(ctx context.Context, declarationID string, buildIDs []string) error {
 	declarationID = strings.TrimSpace(declarationID)
+	buildIDs = normalizeList(buildIDs)
 	if declarationID == "" {
 		return fmt.Errorf("declarationID is required")
+	}
+	if len(buildIDs) == 0 {
+		return fmt.Errorf("buildIDs are required")
 	}
 
 	payload := RelationshipRequest{


### PR DESCRIPTION
## What
Add input validation to relationship mutation helpers so they fail fast when required IDs/lists are missing (instead of issuing malformed requests).

Touched areas:
- Build ↔ betaGroups relationship mutations
- Beta group ↔ betaTesters relationship mutations
- User ↔ visibleApps relationship mutations (+ relationship list validation)
- Encryption declaration ↔ builds relationship mutation
- Game Center activity ↔ achievements/leaderboards relationship mutations

Adds a regression test to ensure invalid inputs return errors without making any HTTP requests.

## Why
Enterprise/CI usage benefits from predictable, local validation and avoids confusing server-side errors caused by empty path segments or empty linkage payloads.

## Test Plan
- `make format`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`