### PR TITLE
docs(wall): add Bobbin to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1762,6 +1762,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | App | Link | Creator | Platform |
 |:----|:-----|:--------|:---------|
 | bijou.fm | [Open](https://apps.apple.com/us/app/bijou-fm-for-last-fm/id6450460066) | zchwyng | iOS, macOS, tvOS, visionOS |
+| Bobbin | [Open](https://apps.apple.com/us/app/threads-growth-bobbin/id6756035789) | ljyjeffrey | iOS |
 | CodexMonitor | [Open](https://github.com/Dimillian/CodexMonitor) | Dimillian | macOS, iOS |
 | Dandelion | [Open](https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901) | joeycast | iOS, macOS |
 | DoubleMemory | [Open](https://apps.apple.com/app/id6737529034) | randomor | iOS, macOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -112,5 +112,11 @@
     "link": "https://apps.apple.com/app/id6756911679",
     "creator": "OscarGorog",
     "platform": ["iOS"]
+  },
+  {
+    "app": "Bobbin",
+    "link": "https://apps.apple.com/us/app/threads-growth-bobbin/id6756035789",
+    "creator": "ljyjeffrey",
+    "platform": ["iOS"]
   }
 ]


### PR DESCRIPTION
## Summary
- Add **Bobbin** (Threads Growth tracker) to the Wall of Apps
- Updated both `docs/wall-of-apps.json` and the generated table in `README.md`
- App Store URL cleaned of tracking query parameters to match existing style

## Test plan
- [x] `docs/wall-of-apps.json` validates as valid JSON (`python3 -m json.tool`)
- [x] README table row inserted in correct alphabetical position (between bijou.fm and CodexMonitor)
- [x] Both source JSON and generated README table updated together per CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)