### PR TITLE
Add Inkput app to wall of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1771,6 +1771,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | DoubleMemory | [Open](https://apps.apple.com/app/id6737529034) | randomor | iOS, macOS |
 | Dripped | [Open](https://apps.apple.com/app/id6749790183) | mithileshchellapan | iOS |
 | Fisherman SMS Filtering | [Open](https://apps.apple.com/app/id6449192504) | MGidnian | iOS |
+| Inkput | [Open](https://apps.apple.com/app/id6758570182) | funclosure | iOS, macOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |
 | Lumical: Scan to Calendar | [Open](https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309) | arunavo4 | iOS |
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -130,5 +130,11 @@
     "link": "https://apps.apple.com/us/app/plinky-easily-save-links/id1597187737",
     "creator": "mergesort",
     "platform": ["iOS", "macOS"]
+  },
+    {
+    "app": "Inkput",
+    "link": "https://apps.apple.com/app/id6758570182",
+    "creator": "funclosure",
+    "platform": ["iOS", "macOS"]
   }
 ]


### PR DESCRIPTION
Thank you for creating the tool : )

## Summary

- Add Inkput to the Wall of Apps

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or
manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry added:

```json
{
  "app": "Inkput",
  "link": "https://apps.apple.com/app/id6758570182",
  "creator": "funclosure",
  "platform": ["iOS", "macOS"]
}