### PR TITLE
ci: don't fail release when tap token invalid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           SHA256=$(shasum -a 256 release/asc_${VERSION}_macOS_arm64 | cut -d ' ' -f 1)
 
           # Clone the tap repo
-          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/rudrankriyam/tap.git homebrew-tap || {
+          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/rudrankriyam/homebrew-tap.git homebrew-tap || {
             echo "Homebrew tap update failed (auth/permissions). Skipping."
             exit 0
           }


### PR DESCRIPTION
## Summary
- Prevent the Release workflow from failing when `TAP_GITHUB_TOKEN` is set but invalid.
- If cloning or pushing the tap repo fails, log a warning and skip the tap update.

## Why
Releases should still publish artifacts even if Homebrew tap automation fails.

## Test plan
- `make format`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`