### PR TITLE
feat(testflight): add --internal, --all-builds flags to beta-groups create

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -657,11 +657,11 @@ func (c *Client) GetBetaGroupTesters(ctx context.Context, groupID string, opts .
 }
 
 // CreateBetaGroup creates a beta group for an app.
-func (c *Client) CreateBetaGroup(ctx context.Context, appID, name string) (*BetaGroupResponse, error) {
+func (c *Client) CreateBetaGroup(ctx context.Context, appID string, attrs BetaGroupAttributes) (*BetaGroupResponse, error) {
 	payload := BetaGroupCreateRequest{
 		Data: BetaGroupCreateData{
 			Type:       ResourceTypeBetaGroups,
-			Attributes: BetaGroupAttributes{Name: name},
+			Attributes: attrs,
 			Relationships: &BetaGroupRelationships{
 				App: &Relationship{
 					Data: ResourceData{

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -1622,8 +1622,64 @@ func TestCreateBetaGroup_SendsRequest(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.CreateBetaGroup(context.Background(), "app-1", "Beta"); err != nil {
+	if _, err := client.CreateBetaGroup(context.Background(), "app-1", BetaGroupAttributes{Name: "Beta"}); err != nil {
 		t.Fatalf("CreateBetaGroup() error: %v", err)
+	}
+}
+
+func TestCreateBetaGroup_InternalGroup(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"betaGroups","id":"bg2","attributes":{"name":"Internal Team","isInternalGroup":true,"hasAccessToAllBuilds":true,"feedbackEnabled":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaGroups" {
+			t.Fatalf("expected path /v1/betaGroups, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		var payload BetaGroupCreateRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode body error: %v", err)
+		}
+		if payload.Data.Attributes.Name != "Internal Team" {
+			t.Fatalf("expected name Internal Team, got %q", payload.Data.Attributes.Name)
+		}
+		if !payload.Data.Attributes.IsInternalGroup {
+			t.Fatalf("expected isInternalGroup to be true")
+		}
+		if !payload.Data.Attributes.HasAccessToAllBuilds {
+			t.Fatalf("expected hasAccessToAllBuilds to be true")
+		}
+		if !payload.Data.Attributes.FeedbackEnabled {
+			t.Fatalf("expected feedbackEnabled to be true")
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.App == nil {
+			t.Fatalf("expected app relationship to be set")
+		}
+		if payload.Data.Relationships.App.Data.ID != "app-2" {
+			t.Fatalf("expected app id app-2, got %q", payload.Data.Relationships.App.Data.ID)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	attrs := BetaGroupAttributes{
+		Name:                 "Internal Team",
+		IsInternalGroup:      true,
+		HasAccessToAllBuilds: true,
+		FeedbackEnabled:      true,
+	}
+	resp, err := client.CreateBetaGroup(context.Background(), "app-2", attrs)
+	if err != nil {
+		t.Fatalf("CreateBetaGroup() error: %v", err)
+	}
+	if resp.Data.ID != "bg2" {
+		t.Fatalf("expected response id bg2, got %q", resp.Data.ID)
+	}
+	if !resp.Data.Attributes.IsInternalGroup {
+		t.Fatalf("expected response isInternalGroup to be true")
 	}
 }
 

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -28,6 +28,7 @@ Examples:
   asc testflight beta-groups list --global
   asc testflight beta-groups list --global --limit 50
   asc testflight beta-groups create --app "APP_ID" --name "Beta Testers"
+  asc testflight beta-groups create --app "APP_ID" --name "Internal Team" --internal
   asc testflight beta-groups app get --group-id "GROUP_ID"
   asc testflight beta-groups beta-recruitment-criteria get --group-id "GROUP_ID"
   asc testflight beta-groups beta-recruitment-criterion-compatible-build-check get --group-id "GROUP_ID"`,
@@ -171,6 +172,9 @@ func BetaGroupsCreateCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	name := fs.String("name", "", "Beta group name")
+	internal := fs.Bool("internal", false, "Create as internal group (no beta review required)")
+	allBuilds := fs.Bool("all-builds", false, "Grant access to all builds")
+	feedbackEnabled := fs.Bool("feedback-enabled", true, "Enable feedback")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -179,8 +183,14 @@ func BetaGroupsCreateCommand() *ffcli.Command {
 		ShortHelp:  "Create a TestFlight beta group.",
 		LongHelp: `Create a TestFlight beta group.
 
+By default, groups are created as external groups which require Apple's beta
+review before testers can install. Use --internal to create an internal group
+that allows immediate installation for App Store Connect team members.
+
 Examples:
-  asc testflight beta-groups create --app "APP_ID" --name "Beta Testers"`,
+  asc testflight beta-groups create --app "APP_ID" --name "Beta Testers"
+  asc testflight beta-groups create --app "APP_ID" --name "Internal Team" --internal
+  asc testflight beta-groups create --app "APP_ID" --name "QA Team" --internal --all-builds`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -194,6 +204,25 @@ Examples:
 				return flag.ErrHelp
 			}
 
+			visited := map[string]bool{}
+			fs.Visit(func(f *flag.Flag) {
+				visited[f.Name] = true
+			})
+
+			attrs := asc.BetaGroupAttributes{
+				Name: strings.TrimSpace(*name),
+			}
+
+			if visited["internal"] {
+				attrs.IsInternalGroup = *internal
+			}
+			if visited["all-builds"] {
+				attrs.HasAccessToAllBuilds = *allBuilds
+			}
+			if visited["feedback-enabled"] {
+				attrs.FeedbackEnabled = *feedbackEnabled
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("beta-groups create: %w", err)
@@ -202,7 +231,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			group, err := client.CreateBetaGroup(requestCtx, resolvedAppID, strings.TrimSpace(*name))
+			group, err := client.CreateBetaGroup(requestCtx, resolvedAppID, attrs)
 			if err != nil {
 				return fmt.Errorf("beta-groups create: failed to create: %w", err)
 			}


### PR DESCRIPTION
## Summary

- The `beta-groups create` command currently only supports `--app` and `--name`, always creating **external** beta groups that require Apple's beta review before testers can install
- Adds `--internal`, `--all-builds`, and `--feedback-enabled` flags to `beta-groups create`, following the same `fs.Visit()` pattern already used by `beta-groups update`
- Changes `CreateBetaGroup()` client method to accept a `BetaGroupAttributes` struct instead of a bare `name` string, allowing the new API fields to be passed through

## Motivation

External beta groups require Apple's beta review before testers can install builds. Internal groups allow immediate installation for App Store Connect team members — a critical workflow for indie developers and small teams doing rapid iteration. The Apple API already supports `isInternalGroup: true` in the POST body, and the Go structs already have this field, but the CLI command didn't expose it.

## Changes

### `internal/cli/testflight/beta_groups.go`
- Added `--internal` (bool, default false) — creates an internal group
- Added `--all-builds` (bool, default false) — grants access to all builds
- Added `--feedback-enabled` (bool, default true) — enables feedback
- Uses `fs.Visit()` to track explicitly-passed flags (same pattern as `update`)
- Updated help text and examples

### `internal/asc/client.go`
- Changed `CreateBetaGroup(ctx, appID, name string)` to `CreateBetaGroup(ctx, appID string, attrs BetaGroupAttributes)`
- The struct fields (`IsInternalGroup`, `HasAccessToAllBuilds`, `FeedbackEnabled`) are serialized via `omitempty`, so unset fields are excluded from the request body

### `internal/asc/client_http_test.go`
- Updated existing `TestCreateBetaGroup_SendsRequest` to use new signature
- Added `TestCreateBetaGroup_InternalGroup` verifying all new attributes are sent in the POST body and parsed in the response

## Test plan

- [x] `go test ./...` passes (all 82 packages)
- [ ] Manual test: `asc testflight beta-groups create --app APP_ID --name "Test" --internal`
- [ ] Manual test: `asc testflight beta-groups create --app APP_ID --name "Test"` (backwards-compatible, external group)