### PR TITLE
feat: expand asc docs with embedded list/show guides

### DIFF
--- a/docs/embed.go
+++ b/docs/embed.go
@@ -1,0 +1,9 @@
+package docsembed
+
+import _ "embed"
+
+//go:embed WORKFLOWS.md
+var WorkflowsGuide string
+
+//go:embed API_NOTES.md
+var APINotesGuide string

--- a/internal/cli/cmdtest/docs_list_show_test.go
+++ b/internal/cli/cmdtest/docs_list_show_test.go
@@ -1,0 +1,189 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestDocsListOutputsEmbeddedGuidesAsJSON(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "list"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var guides []struct {
+		Slug        string `json:"slug"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &guides); err != nil {
+		t.Fatalf("failed to unmarshal guides JSON: %v\nstdout=%s", err, stdout)
+	}
+
+	if len(guides) != 3 {
+		t.Fatalf("expected 3 guides, got %d", len(guides))
+	}
+
+	expectedSlugs := []string{"workflows", "api-notes", "reference"}
+	for i, expectedSlug := range expectedSlugs {
+		if guides[i].Slug != expectedSlug {
+			t.Fatalf("expected guide %d slug %q, got %q", i, expectedSlug, guides[i].Slug)
+		}
+		if strings.TrimSpace(guides[i].Description) == "" {
+			t.Fatalf("expected guide %q to include a description", guides[i].Slug)
+		}
+	}
+}
+
+func TestDocsListSupportsMarkdownOutput(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "list", "--output", "markdown"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, slug := range []string{"workflows", "api-notes", "reference"} {
+		if !strings.Contains(stdout, slug) {
+			t.Fatalf("expected markdown output to contain %q, got %q", slug, stdout)
+		}
+	}
+}
+
+func TestDocsListSupportsTableOutput(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "list", "--output", "table"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "slug") || !strings.Contains(stdout, "description") {
+		t.Fatalf("expected table output headers, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "workflows") || !strings.Contains(stdout, "api-notes") || !strings.Contains(stdout, "reference") {
+		t.Fatalf("expected table output to include all guide slugs, got %q", stdout)
+	}
+}
+
+func TestDocsShowPrintsWorkflowsGuide(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "show", "workflows"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "# Workflows") {
+		t.Fatalf("expected workflows heading in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "asc workflow") {
+		t.Fatalf("expected workflow command documentation, got %q", stdout)
+	}
+}
+
+func TestDocsShowPrintsReferenceGuide(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "show", "reference"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "# asc cli reference") {
+		t.Fatalf("expected reference guide heading, got %q", stdout)
+	}
+}
+
+func TestDocsShowUnknownGuideReturnsUsageError(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "show", "unknown-guide"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unknown guide") {
+		t.Fatalf("expected unknown guide error message, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "workflows") || !strings.Contains(stderr, "api-notes") || !strings.Contains(stderr, "reference") {
+		t.Fatalf("expected stderr to list available guides, got %q", stderr)
+	}
+}
+
+func TestDocsShowRequiresGuideName(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"docs", "show"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}

--- a/internal/cli/docs/docs.go
+++ b/internal/cli/docs/docs.go
@@ -18,16 +18,20 @@ func DocsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "docs",
 		ShortUsage: "asc docs <subcommand> [flags]",
-		ShortHelp:  "Generate asc cli documentation helpers.",
-		LongHelp: `Generate asc cli documentation helpers.
+		ShortHelp:  "Access embedded documentation guides and reference helpers.",
+		LongHelp: `Access embedded documentation guides and reference helpers.
 
 Examples:
+  asc docs list
+  asc docs show workflows
   asc docs init
   asc docs init --path ./ASC.md
   asc docs init --force --link=false`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			DocsListCommand(),
+			DocsShowCommand(),
 			DocsInitCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/docs/docs_list.go
+++ b/internal/cli/docs/docs_list.go
@@ -1,0 +1,55 @@
+package docs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// DocsListCommand returns the docs list subcommand.
+func DocsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("docs list", flag.ExitOnError)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc docs list [flags]",
+		ShortHelp:  "List available embedded documentation guides.",
+		LongHelp: `List available embedded documentation guides.
+
+Examples:
+  asc docs list
+  asc docs list --output table`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			_ = ctx
+			if len(args) > 0 {
+				fmt.Fprintln(os.Stderr, "Error: docs list does not accept positional arguments")
+				return flag.ErrHelp
+			}
+			if err := shared.PrintOutputWithRenderers(
+				listGuideSummaries(),
+				*output.Output,
+				*output.Pretty,
+				func() error {
+					asc.RenderTable([]string{"slug", "description"}, guideRows())
+					return nil
+				},
+				func() error {
+					asc.RenderMarkdown([]string{"slug", "description"}, guideRows())
+					return nil
+				},
+			); err != nil {
+				return fmt.Errorf("docs list: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/docs/docs_show.go
+++ b/internal/cli/docs/docs_show.go
@@ -1,0 +1,58 @@
+package docs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// DocsShowCommand returns the docs show subcommand.
+func DocsShowCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("docs show", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "show",
+		ShortUsage: "asc docs show <workflows|api-notes|reference>",
+		ShortHelp:  "Print an embedded documentation guide.",
+		LongHelp: `Print an embedded documentation guide.
+
+Examples:
+  asc docs show workflows
+  asc docs show api-notes
+  asc docs show reference`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			_ = ctx
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			if len(args) > 1 {
+				fmt.Fprintln(os.Stderr, "Error: docs show accepts exactly one guide name")
+				return flag.ErrHelp
+			}
+
+			guideName := strings.TrimSpace(args[0])
+			guide, ok := findGuide(guideName)
+			if !ok {
+				safeName := shared.SanitizeTerminal(guideName)
+				fmt.Fprintf(os.Stderr, "Error: unknown guide %q\n", safeName)
+				fmt.Fprintf(os.Stderr, "Available guides: %s\n", strings.Join(guideSlugs(), ", "))
+				return flag.ErrHelp
+			}
+
+			content := guide.Content
+			if !strings.HasSuffix(content, "\n") {
+				content += "\n"
+			}
+			fmt.Fprint(os.Stdout, content)
+			return nil
+		},
+	}
+}

--- a/internal/cli/docs/guides.go
+++ b/internal/cli/docs/guides.go
@@ -1,0 +1,73 @@
+package docs
+
+import (
+	"strings"
+
+	docsembed "github.com/rudrankriyam/App-Store-Connect-CLI/docs"
+)
+
+type guideEntry struct {
+	Slug        string
+	Description string
+	Content     string
+}
+
+type guideSummary struct {
+	Slug        string `json:"slug"`
+	Description string `json:"description"`
+}
+
+var guideRegistry = []guideEntry{
+	{
+		Slug:        "workflows",
+		Description: "Workflow definition format, security model, and examples",
+		Content:     docsembed.WorkflowsGuide,
+	},
+	{
+		Slug:        "api-notes",
+		Description: "API quirks: date formats, finance reports, sandbox testers",
+		Content:     docsembed.APINotesGuide,
+	},
+	{
+		Slug:        "reference",
+		Description: "ASC CLI command reference (also available via 'asc init')",
+		Content:     ascTemplate,
+	},
+}
+
+func listGuideSummaries() []guideSummary {
+	out := make([]guideSummary, 0, len(guideRegistry))
+	for _, guide := range guideRegistry {
+		out = append(out, guideSummary{
+			Slug:        guide.Slug,
+			Description: guide.Description,
+		})
+	}
+	return out
+}
+
+func guideRows() [][]string {
+	rows := make([][]string, 0, len(guideRegistry))
+	for _, guide := range guideRegistry {
+		rows = append(rows, []string{guide.Slug, guide.Description})
+	}
+	return rows
+}
+
+func guideSlugs() []string {
+	slugs := make([]string, 0, len(guideRegistry))
+	for _, guide := range guideRegistry {
+		slugs = append(slugs, guide.Slug)
+	}
+	return slugs
+}
+
+func findGuide(slug string) (guideEntry, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(slug))
+	for _, guide := range guideRegistry {
+		if guide.Slug == normalized {
+			return guide, true
+		}
+	}
+	return guideEntry{}, false
+}


### PR DESCRIPTION
## Summary
- add embedded guide assets for `WORKFLOWS.md` and `API_NOTES.md`, plus a guide registry that includes the existing `reference` doc
- add `asc docs list` with JSON/table/markdown output and deterministic guide ordering
- add `asc docs show <name>` to print guide markdown to stdout, with usage-style validation for missing/unknown names
- add cmdtests for list/show success paths and error behavior

Closes #650.

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go test ./internal/cli/cmdtest -run Docs`
- [x] `go run . docs list --output table`
- [x] `go run . docs list --output markdown`