### PR TITLE
Add Meshing to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1784,6 +1784,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | Inkput | [Open](https://apps.apple.com/app/id6758570182) | funclosure | iOS, macOS |
 | kora: Music Reviews & Ratings | [Open](https://apps.apple.com/app/id6502549140) | adamjhf | iOS |
 | Lumical: Scan to Calendar | [Open](https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309) | arunavo4 | iOS |
+| Meshing | [Open](https://apps.apple.com/app/id6567933550) | rudrankriyam | iOS, macOS |
 | MileIO | [Open](https://apps.apple.com/app/id6758225631) | Juergen | iOS |
 | Mixtape | [Open](https://apps.apple.com/us/app/mixtape-personal-music-gift/id6756442910) | jimripple | iOS |
 | Morning Pages | [Open](https://apps.apple.com/us/app/morning-pages/id6738604034) | zchwyng | iOS, macOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -136,5 +136,11 @@
     "link": "https://apps.apple.com/app/id6758570182",
     "creator": "funclosure",
     "platform": ["iOS", "macOS"]
+  },
+  {
+    "app": "Meshing",
+    "link": "https://apps.apple.com/app/id6567933550",
+    "creator": "rudrankriyam",
+    "platform": ["iOS", "macOS"]
   }
 ]


### PR DESCRIPTION
## Summary

- Add Meshing (AI mesh gradient tool by rudrankriyam) to the Wall of Apps

## Validation

- [ ] `make format`
- [ ] `make lint`
- [ ] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make update-wall-of-apps` after editing `docs/wall-of-apps.json`
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry added:

```json
{
  "app": "Meshing",
  "link": "https://apps.apple.com/app/id6567933550",
  "creator": "rudrankriyam",
  "platform": ["iOS", "macOS"]
}
```