### PR TITLE
Codex/add writone wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1797,7 +1797,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
 | Unlimited Clipboard History | [Open](https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056) | yspreen | macOS |
 | Video Annotation | [Open](https://apps.apple.com/us/app/video-annotation/id6758316355) | antranapp | iOS |
-| Writone - Reply Assistant | [Open](https://apps.apple.com/app/id6758207392) | dukhyunlee | iOS |
+| Writone - Reply Assistant | [Open](https://apps.apple.com/app/id6758207392) | evanyi | iOS |
 | XO: Have I Ever | [Open](https://apps.apple.com/us/app/xo-have-i-ever/id6757594745) | arunavo4 | iOS |
 <!-- WALL-OF-APPS:END -->
 

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -146,7 +146,7 @@
   {
     "app": "Writone - Reply Assistant",
     "link": "https://apps.apple.com/app/id6758207392",
-    "creator": "dukhyunlee",
+    "creator": "evanyi",
     "platform": ["iOS"]
   }
 ]


### PR DESCRIPTION
## Summary

- Add **Writone - Reply Assistant** to Wall of Apps.
- Update `docs/wall-of-apps.json` and synced wall table entry in `README.md`.

## Validation

- [ ] `make format`
- [ ] `make lint`
- [ ] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Writone - Reply Assistant",
  "link": "https://apps.apple.com/app/id6758207392",
  "creator": "evanyi",
  "platform": ["iOS"]
}
