### PR TITLE
docs: add Timefall to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1793,6 +1793,7 @@ Apps shipping with asc-cli. [Add yours via PR](https://github.com/rudrankriyam/A
 | Repetti | [Open](https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413) | rursache | iOS |
 | Steps: Workout & Pedometer | [Open](https://apps.apple.com/us/app/steps-workout-pedometer/id6746096378) | Hieu Dinh | iOS |
 | Summit | [Open](https://apps.apple.com/app/id6756911679) | OscarGorog | iOS |
+| Timefall | [Open](https://apps.apple.com/app/id6757712804) | vatrueshka | iOS, macOS |
 | ToMe: Save to Self | [Open](https://apps.apple.com/app/id6755589008) | framara | iOS, macOS |
 | TV Show Tracker | [Open](https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903) | rursache | iOS |
 | Unlimited Clipboard History | [Open](https://apps.apple.com/us/app/unlimited-clipboard-history/id6705136056) | yspreen | macOS |

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -125,13 +125,13 @@
     "creator": "framara",
     "platform": ["iOS", "macOS"]
   },
-    {
+  {
     "app": "Plinky",
     "link": "https://apps.apple.com/us/app/plinky-easily-save-links/id1597187737",
     "creator": "mergesort",
     "platform": ["iOS", "macOS"]
   },
-    {
+  {
     "app": "Inkput",
     "link": "https://apps.apple.com/app/id6758570182",
     "creator": "funclosure",
@@ -148,5 +148,11 @@
     "link": "https://apps.apple.com/app/id6758207392",
     "creator": "evanyi",
     "platform": ["iOS"]
+  },
+  {
+    "app": "Timefall",
+    "link": "https://apps.apple.com/app/id6757712804",
+    "creator": "vatrueshka",
+    "platform": ["iOS", "macOS"]
   }
 ]


### PR DESCRIPTION
## Summary

- Thx a lot for asc - great tool!
- Add Timefall to Wall of Apps

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited [docs/wall-of-apps.json](cci:7://file:///Users/i.usatov/Documents/for_fun/App-Store-Connect-CLI/docs/wall-of-apps.json:0:0-0:0) + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - [docs/wall-of-apps.json](cci:7://file:///Users/i.usatov/Documents/for_fun/App-Store-Connect-CLI/docs/wall-of-apps.json:0:0-0:0)
  - `README.md`
