### PR TITLE
test(cli): add critical delete-path coverage

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -1135,6 +1135,23 @@ func TestCreateAppStoreVersion(t *testing.T) {
 	}
 }
 
+func TestDeleteAppStoreVersion(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersions/VERSION_123" {
+			t.Fatalf("expected path /v1/appStoreVersions/VERSION_123, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteAppStoreVersion(context.Background(), "VERSION_123"); err != nil {
+		t.Fatalf("DeleteAppStoreVersion() error: %v", err)
+	}
+}
+
 func TestAttachBuildToVersion(t *testing.T) {
 	response := jsonResponse(http.StatusNoContent, ``)
 	client := newTestClient(t, func(req *http.Request) {
@@ -6505,6 +6522,23 @@ func TestUpdateSubscriptionGroup(t *testing.T) {
 	}
 }
 
+func TestDeleteSubscriptionGroup(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptionGroups/group-1" {
+			t.Fatalf("expected path /v1/subscriptionGroups/group-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteSubscriptionGroup(context.Background(), "group-1"); err != nil {
+		t.Fatalf("DeleteSubscriptionGroup() error: %v", err)
+	}
+}
+
 func TestGetSubscriptions_WithLimit(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.sub.monthly"}}]}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -6559,6 +6593,23 @@ func TestCreateSubscription(t *testing.T) {
 	}
 	if _, err := client.CreateSubscription(context.Background(), "group-1", createSubAttrs); err != nil {
 		t.Fatalf("CreateSubscription() error: %v", err)
+	}
+}
+
+func TestDeleteSubscription(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptions/sub-1" {
+			t.Fatalf("expected path /v1/subscriptions/sub-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteSubscription(context.Background(), "sub-1"); err != nil {
+		t.Fatalf("DeleteSubscription() error: %v", err)
 	}
 }
 
@@ -6708,6 +6759,23 @@ func TestUpdateUser_SendsRequest(t *testing.T) {
 		AllAppsVisible: &allAppsVisible,
 	}); err != nil {
 		t.Fatalf("UpdateUser() error: %v", err)
+	}
+}
+
+func TestDeleteUser_SendsRequest(t *testing.T) {
+	response := jsonResponse(http.StatusNoContent, ``)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/users/user-1" {
+			t.Fatalf("expected path /v1/users/user-1, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if err := client.DeleteUser(context.Background(), "user-1"); err != nil {
+		t.Fatalf("DeleteUser() error: %v", err)
 	}
 }
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3053,6 +3053,16 @@ func TestLocalizationsValidationErrors(t *testing.T) {
 			args:    []string{"localizations", "upload", "--type", "app-info", "--path", "localizations"},
 			wantErr: "--app is required",
 		},
+		{
+			name:    "localizations screenshot-sets delete missing id",
+			args:    []string{"localizations", "screenshot-sets", "delete", "--confirm"},
+			wantErr: "Error: --id is required",
+		},
+		{
+			name:    "localizations screenshot-sets delete missing confirm",
+			args:    []string{"localizations", "screenshot-sets", "delete", "--id", "SET_ID"},
+			wantErr: "Error: --confirm is required to delete",
+		},
 	}
 
 	for _, test := range tests {
@@ -3624,6 +3634,16 @@ func TestVersionsValidationErrors(t *testing.T) {
 			name:    "release missing confirm",
 			args:    []string{"versions", "release", "--version-id", "VERSION_123"},
 			wantErr: "Error: --confirm is required to release a version",
+		},
+		{
+			name:    "delete missing version id",
+			args:    []string{"versions", "delete", "--confirm"},
+			wantErr: "Error: --version-id is required",
+		},
+		{
+			name:    "delete missing confirm",
+			args:    []string{"versions", "delete", "--version-id", "VERSION_123"},
+			wantErr: "Error: --confirm is required to delete a version",
 		},
 	}
 

--- a/internal/cli/cmdtest/delete_commands_output_test.go
+++ b/internal/cli/cmdtest/delete_commands_output_test.go
@@ -1,0 +1,196 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalizationsScreenshotSetsDeleteOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appScreenshotSets/set-1" {
+			t.Fatalf("expected path /v1/appScreenshotSets/set-1, got %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "screenshot-sets", "delete", "--id", "set-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"set-1"`) {
+		t.Fatalf("expected set id in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"deleted":true`) {
+		t.Fatalf("expected deleted true in output, got %q", stdout)
+	}
+}
+
+func TestLocalizationsScreenshotSetsDeleteAPIError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body: io.NopCloser(strings.NewReader(
+				`{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found","detail":"Resource does not exist"}]}`,
+			)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "screenshot-sets", "delete", "--id", "missing-set", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(runErr.Error(), "localizations screenshot-sets delete:") {
+		t.Fatalf("expected wrapped localizations delete error, got %v", runErr)
+	}
+	if !strings.Contains(strings.ToLower(runErr.Error()), "not found") {
+		t.Fatalf("expected not-found details, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
+func TestVersionsDeleteOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/appStoreVersions/ver-1" {
+			t.Fatalf("expected path /v1/appStoreVersions/ver-1, got %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"versions", "delete", "--version-id", "ver-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"versionId":"ver-1"`) {
+		t.Fatalf("expected version id in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"deleted":true`) {
+		t.Fatalf("expected deleted true in output, got %q", stdout)
+	}
+}
+
+func TestVersionsDeleteAPIError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body: io.NopCloser(strings.NewReader(
+				`{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found","detail":"Resource does not exist"}]}`,
+			)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"versions", "delete", "--version-id", "missing-ver", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(runErr.Error(), "versions delete:") {
+		t.Fatalf("expected wrapped versions delete error, got %v", runErr)
+	}
+	if !strings.Contains(strings.ToLower(runErr.Error()), "not found") {
+		t.Fatalf("expected not-found details, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- Add missing cmdtest coverage for `localizations screenshot-sets delete` and `versions delete` (required flag validation, success output, and API error propagation).
- Extend central validation tests to assert missing `--id` / `--confirm` cases for the new and existing destructive commands.
- Add HTTP contract tests for high-risk delete client methods: `DeleteAppStoreVersion`, `DeleteSubscriptionGroup`, `DeleteSubscription`, and `DeleteUser`.

## Test plan
- [x] `go test ./internal/cli/cmdtest -run "LocalizationsScreenshotSetsDelete|VersionsDelete|LocalizationsValidationErrors|VersionsValidationErrors" -count=1`
- [x] `go test ./internal/asc -run "DeleteAppStoreVersion|DeleteSubscriptionGroup|DeleteSubscription|DeleteUser_SendsRequest" -count=1`
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`