### PR TITLE
feat(ci): scaffold setup-asc Bitrise step and CI validation

### DIFF
--- a/.github/workflows/bitrise-step-setup-asc.yml
+++ b/.github/workflows/bitrise-step-setup-asc.yml
@@ -1,0 +1,65 @@
+name: Bitrise Step (setup-asc)
+
+on:
+  pull_request:
+    paths:
+      - "integrations/bitrise/steps-setup-asc/**"
+      - ".github/workflows/bitrise-step-setup-asc.yml"
+  push:
+    branches: [main]
+    paths:
+      - "integrations/bitrise/steps-setup-asc/**"
+      - ".github/workflows/bitrise-step-setup-asc.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    env:
+      BITRISE_ANALYTICS_DISABLED: "true"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+
+      - name: Install Bitrise CLI
+        run: |
+          go install github.com/bitrise-io/bitrise/v2@v2.38.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install Bitrise dependencies
+        run: bitrise setup --minimal
+
+      - name: Verify tool versions
+        run: |
+          bitrise --version
+          ~/.bitrise/tools/stepman --version
+          ~/.bitrise/tools/envman --version
+
+      - name: Stepman audit
+        working-directory: integrations/bitrise/steps-setup-asc
+        run: ~/.bitrise/tools/stepman audit --step-yml ./step.yml
+
+      - name: Run Bitrise workflow (audit-this-step)
+        working-directory: integrations/bitrise/steps-setup-asc
+        run: bitrise run audit-this-step
+
+      - name: Run Bitrise workflow (test-install)
+        working-directory: integrations/bitrise/steps-setup-asc
+        run: bitrise run test-install
+
+      - name: Run Bitrise workflow (test-run-help)
+        working-directory: integrations/bitrise/steps-setup-asc
+        run: bitrise run test-run-help

--- a/docs/ci/bitrise-step-checklist.md
+++ b/docs/ci/bitrise-step-checklist.md
@@ -1,0 +1,64 @@
+# Bitrise Step Checklist (`#712`)
+
+Issue: https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/712
+
+## Naming Decision
+
+- [x] Select canonical naming aligned with other CI integration issues.
+  - Step repository: `rudrankriyam/steps-setup-asc`
+  - Step ID (StepLib): `setup-asc`
+  - Step title: `Setup asc CLI`
+  - Rationale: aligns with existing `setup-asc` branding, stays short in Workflow Editor, and still supports both install-only and install+run modes.
+
+## v1 Functional Scope
+
+- [x] Define v1 behavior modes.
+  - `mode=install` installs `asc` and exports outputs.
+  - `mode=run` installs `asc`, sets optional auth env vars, runs provided command.
+- [x] Define minimum required inputs.
+  - `version`, `mode`, `command`, `working_dir`, `profile`, `debug`
+- [x] Define optional auth inputs.
+  - `key_id`, `issuer_id`, `private_key_path`, `private_key`, `bypass_keychain`
+- [x] Define minimum outputs.
+  - `ASC_CLI_PATH`, `ASC_CLI_VERSION`, `ASC_COMMAND_EXIT_CODE`
+
+## Implementation Tasks
+
+- [x] Scaffold Step repository files.
+  - `step.yml`
+  - `step.sh`
+  - `README.md`
+  - `bitrise.yml`
+- [x] Implement deterministic installer logic.
+  - Resolve `latest` tag from GitHub releases redirect.
+  - Support pinned versions with and without `v` prefix.
+  - Detect OS/arch for release asset selection.
+  - Verify SHA-256 using release checksums.
+- [x] Implement command execution mode.
+  - Validate `command` is present when `mode=run`.
+  - Execute from `working_dir` (default `$BITRISE_SOURCE_DIR`).
+  - Export `ASC_COMMAND_EXIT_CODE` before exit.
+
+## Security and UX
+
+- [x] Mark secret-capable inputs as `is_sensitive` in `step.yml`.
+- [x] Avoid echoing secret values in logs.
+- [x] Keep defaults CI-safe and idempotent.
+- [x] Expose clean and descriptive input docs for Workflow Editor.
+
+## Test and Release Checklist
+
+- [x] Add CI workflow automation for cross-platform validation.
+  - GitHub Actions matrix: `ubuntu-latest` and `macos-latest`
+  - Runs `stepman audit` and Bitrise workflows (`audit-this-step`, `test-install`, `test-run-help`)
+- [x] Run local shell smoke tests on macOS host.
+  - `mode=install` works and installs `asc`.
+  - `mode=run` works and executes `asc --help`.
+- [x] Run local audit workflow (`stepman audit --step-yml ./step.yml`).
+- [ ] Validate `mode=install` on Linux stack.
+- [x] Validate `mode=install` on macOS stack.
+- [x] Validate `mode=run` with harmless command (`asc --help`).
+- [ ] Tag and publish first release in `steps-setup-asc`.
+- [ ] Submit StepLib PR with one new Step.
+- [ ] Add usage snippet in main `asc` docs after StepLib publish.
+

--- a/integrations/bitrise/steps-setup-asc/README.md
+++ b/integrations/bitrise/steps-setup-asc/README.md
@@ -1,0 +1,59 @@
+# Setup asc CLI (Bitrise Step Prototype)
+
+This folder contains a first-pass implementation for issue `#712`:
+https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/712
+
+Recommended Step naming from cross-issue alignment:
+
+- Step repository: `rudrankriyam/steps-setup-asc`
+- Step ID: `setup-asc`
+- Step title: `Setup asc CLI`
+
+## What v1 does
+
+- `mode=install`: installs `asc` from GitHub Releases and exports:
+  - `ASC_CLI_PATH`
+  - `ASC_CLI_VERSION`
+- `mode=run`: installs `asc`, sets optional `ASC_*` auth environment variables, runs a command, and exports:
+  - `ASC_COMMAND_EXIT_CODE`
+
+## Example usage in a Bitrise workflow
+
+```yaml
+workflows:
+  primary:
+    steps:
+    - setup-asc:
+        inputs:
+        - mode: install
+        - version: latest
+    - script:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euo pipefail
+            "${ASC_CLI_PATH}" --help
+```
+
+Install + run in one step:
+
+```yaml
+workflows:
+  primary:
+    steps:
+    - setup-asc:
+        inputs:
+        - mode: run
+        - version: latest
+        - command: asc --help
+```
+
+## Local validation
+
+From this directory:
+
+```bash
+bitrise run audit-this-step
+bitrise run test-install
+bitrise run test-run-help
+```

--- a/integrations/bitrise/steps-setup-asc/bitrise.yml
+++ b/integrations/bitrise/steps-setup-asc/bitrise.yml
@@ -1,0 +1,53 @@
+format_version: 1.1.0
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+workflows:
+  test-install:
+    steps:
+    - path::./:
+        title: Test install mode
+        inputs:
+        - mode: install
+        - version: latest
+
+  test-run-help:
+    steps:
+    - path::./:
+        title: Test run mode
+        inputs:
+        - mode: run
+        - version: latest
+        - command: asc --help
+        - working_dir: $BITRISE_SOURCE_DIR
+
+  audit-this-step:
+    steps:
+    - script:
+        title: Audit step definition
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euo pipefail
+            stepman audit --step-yml ./step.yml
+
+  share-this-step:
+    envs:
+    - MY_STEPLIB_REPO_FORK_GIT_URL:
+    - STEP_ID_IN_STEPLIB: setup-asc
+    - STEP_GIT_VERSION_TAG_TO_SHARE:
+    - STEP_GIT_CLONE_URL:
+    before_run:
+    - audit-this-step
+    steps:
+    - script:
+        title: Share step to StepLib fork
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euo pipefail
+            bitrise share start -c "${MY_STEPLIB_REPO_FORK_GIT_URL}"
+            bitrise share create \
+              --stepid "${STEP_ID_IN_STEPLIB}" \
+              --tag "${STEP_GIT_VERSION_TAG_TO_SHARE}" \
+              --git "${STEP_GIT_CLONE_URL}"
+            bitrise share finish

--- a/integrations/bitrise/steps-setup-asc/step.sh
+++ b/integrations/bitrise/steps-setup-asc/step.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly STEP_NAME="setup-asc"
+readonly REPO_SLUG="rudrankriyam/App-Store-Connect-CLI"
+
+TMP_DIR=""
+RELEASE_TAG=""
+ASSET_VERSION=""
+ASSET_NAME=""
+EXPECTED_CHECKSUM=""
+CHECKSUMS_URL=""
+ASSET_URL=""
+
+log_info() {
+  printf "[%s] %s\n" "${STEP_NAME}" "$*" >&2
+}
+
+log_warn() {
+  printf "[%s] warning: %s\n" "${STEP_NAME}" "$*" >&2
+}
+
+fail() {
+  printf "[%s] error: %s\n" "${STEP_NAME}" "$*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    fail "Missing required command: ${command_name}"
+  fi
+}
+
+normalize_yes_no() {
+  local value="${1:-}"
+  local field_name="${2:-value}"
+
+  case "${value}" in
+    [Yy][Ee][Ss] | [Tt][Rr][Uu][Ee] | 1 | [Yy] | [Oo][Nn])
+      printf "yes"
+      ;;
+    [Nn][Oo] | [Ff][Aa][Ll][Ss][Ee] | 0 | [Nn] | [Oo][Ff][Ff] | "")
+      printf "no"
+      ;;
+    *)
+      fail "Invalid value for ${field_name}: ${value}. Use yes or no."
+      ;;
+  esac
+}
+
+export_output() {
+  local key="$1"
+  local value="$2"
+
+  if command -v envman >/dev/null 2>&1; then
+    envman add --key "${key}" --value "${value}" >/dev/null
+    return
+  fi
+
+  log_warn "envman not found, exporting output only for current process: ${key}"
+  export "${key}=${value}"
+}
+
+resolve_requested_version() {
+  local raw_version="${version:-latest}"
+  local latest_url
+
+  if [ -z "${raw_version}" ] || [ "${raw_version}" = "latest" ]; then
+    latest_url="$(curl -fsSL -o /dev/null -w "%{url_effective}" "https://github.com/${REPO_SLUG}/releases/latest")" \
+      || fail "Unable to resolve latest release version."
+    raw_version="${latest_url##*/}"
+  fi
+
+  raw_version="${raw_version#v}"
+  if [ -z "${raw_version}" ]; then
+    fail "Version must not be empty."
+  fi
+
+  printf "%s" "${raw_version}"
+}
+
+detect_os_arch() {
+  local os_name
+  local arch_name
+
+  os_name="$(uname -s)"
+  arch_name="$(uname -m)"
+
+  case "${os_name}" in
+    Darwin)
+      DETECTED_OS="macOS"
+      ;;
+    Linux)
+      DETECTED_OS="linux"
+      ;;
+    *)
+      fail "Unsupported operating system: ${os_name}"
+      ;;
+  esac
+
+  case "${arch_name}" in
+    x86_64 | amd64)
+      DETECTED_ARCH="amd64"
+      ;;
+    arm64 | aarch64)
+      DETECTED_ARCH="arm64"
+      ;;
+    *)
+      fail "Unsupported architecture: ${arch_name}"
+      ;;
+  esac
+}
+
+extract_expected_checksum() {
+  local checksums_file="$1"
+  local asset_name="$2"
+
+  awk -v target="${asset_name}" '
+    {
+      file_name = $2
+      gsub(/^\*/, "", file_name)
+      if (file_name == target) {
+        print $1
+        exit
+      }
+    }
+  ' "${checksums_file}" | tr -d '\r\n '
+}
+
+resolve_release_artifacts() {
+  local version_no_v="$1"
+  local os_name="$2"
+  local arch_name="$3"
+
+  local checksums_file="${TMP_DIR}/checksums.txt"
+  local candidate_tag
+  local candidate_asset_version
+  local checksums_name
+  local candidate_asset_name
+  local expected_checksum
+
+  RELEASE_TAG=""
+  ASSET_VERSION=""
+  ASSET_NAME=""
+  EXPECTED_CHECKSUM=""
+  CHECKSUMS_URL=""
+  ASSET_URL=""
+
+  for candidate_tag in "${version_no_v}" "v${version_no_v}"; do
+    for candidate_asset_version in "${version_no_v}" "v${version_no_v}"; do
+      checksums_name="asc_${candidate_asset_version}_checksums.txt"
+      CHECKSUMS_URL="https://github.com/${REPO_SLUG}/releases/download/${candidate_tag}/${checksums_name}"
+
+      if ! curl -fsSL "${CHECKSUMS_URL}" -o "${checksums_file}"; then
+        continue
+      fi
+
+      candidate_asset_name="asc_${candidate_asset_version}_${os_name}_${arch_name}"
+      expected_checksum="$(extract_expected_checksum "${checksums_file}" "${candidate_asset_name}")"
+      if [ -z "${expected_checksum}" ]; then
+        continue
+      fi
+
+      RELEASE_TAG="${candidate_tag}"
+      ASSET_VERSION="${candidate_asset_version}"
+      ASSET_NAME="${candidate_asset_name}"
+      EXPECTED_CHECKSUM="${expected_checksum}"
+      ASSET_URL="https://github.com/${REPO_SLUG}/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
+      return
+    done
+  done
+
+  fail "Could not resolve release artifacts for version ${version_no_v} (${os_name}/${arch_name})."
+}
+
+compute_sha256() {
+  local file_path="$1"
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file_path}" | awk '{print $1}' | tr -d '\r\n '
+    return
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file_path}" | awk '{print $1}' | tr -d '\r\n '
+    return
+  fi
+
+  fail "Neither shasum nor sha256sum is available for checksum verification."
+}
+
+install_asc() {
+  local install_dir_path="$1"
+  local asset_path="${TMP_DIR}/${ASSET_NAME}"
+  local actual_checksum
+  local binary_path
+
+  mkdir -p "${install_dir_path}"
+
+  log_info "Downloading ${ASSET_NAME} from release ${RELEASE_TAG}."
+  curl -fsSL "${ASSET_URL}" -o "${asset_path}" || fail "Failed to download ${ASSET_NAME}."
+
+  actual_checksum="$(compute_sha256 "${asset_path}")"
+  if [ "${actual_checksum}" != "${EXPECTED_CHECKSUM}" ]; then
+    fail "Checksum mismatch for ${ASSET_NAME}."
+  fi
+
+  binary_path="${install_dir_path}/asc"
+  cp "${asset_path}" "${binary_path}"
+  chmod +x "${binary_path}"
+
+  printf "%s" "${binary_path}"
+}
+
+configure_runtime_env() {
+  local profile_value="$1"
+  local debug_value="$2"
+  local bypass_value="$3"
+
+  if [ -n "${profile_value}" ]; then
+    export ASC_PROFILE="${profile_value}"
+  fi
+
+  if [ "${debug_value}" = "yes" ]; then
+    export ASC_DEBUG="1"
+  fi
+
+  if [ "${bypass_value}" = "yes" ]; then
+    export ASC_BYPASS_KEYCHAIN="1"
+  fi
+
+  if [ -n "${key_id:-}" ]; then
+    export ASC_KEY_ID="${key_id}"
+  fi
+
+  if [ -n "${issuer_id:-}" ]; then
+    export ASC_ISSUER_ID="${issuer_id}"
+  fi
+
+  if [ -n "${private_key_path:-}" ]; then
+    export ASC_PRIVATE_KEY_PATH="${private_key_path}"
+  fi
+
+  if [ -n "${private_key:-}" ]; then
+    export ASC_PRIVATE_KEY="${private_key}"
+  fi
+}
+
+run_user_command() {
+  local run_command="$1"
+  local working_directory="$2"
+  local command_exit_code=0
+
+  [ -d "${working_directory}" ] || fail "working_dir does not exist: ${working_directory}"
+
+  log_info "Running user command in ${working_directory}."
+  (
+    cd "${working_directory}"
+    bash -lc "${run_command}"
+  ) || command_exit_code=$?
+
+  export_output "ASC_COMMAND_EXIT_CODE" "${command_exit_code}"
+  if [ "${command_exit_code}" -ne 0 ]; then
+    fail "Command failed with exit code ${command_exit_code}."
+  fi
+}
+
+main() {
+  local mode_value
+  local requested_version
+  local install_dir_value
+  local working_dir_value
+  local profile_value
+  local debug_value
+  local bypass_value
+  local run_command
+  local asc_path
+  local reported_version
+
+  require_command curl
+
+  mode_value="$(printf "%s" "${mode:-install}" | tr '[:upper:]' '[:lower:]')"
+  case "${mode_value}" in
+    install | run)
+      ;;
+    *)
+      fail "Invalid mode: ${mode_value}. Use install or run."
+      ;;
+  esac
+
+  requested_version="$(resolve_requested_version)"
+  install_dir_value="${install_dir:-${HOME}/.local/bin}"
+  working_dir_value="${working_dir:-${BITRISE_SOURCE_DIR:-$PWD}}"
+  profile_value="${profile:-}"
+  debug_value="$(normalize_yes_no "${debug:-no}" "debug")"
+  bypass_value="$(normalize_yes_no "${bypass_keychain:-no}" "bypass_keychain")"
+  run_command="${command:-}"
+
+  if [ "${mode_value}" = "run" ] && [ -z "${run_command}" ]; then
+    fail "command is required when mode=run."
+  fi
+
+  detect_os_arch
+
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+
+  resolve_release_artifacts "${requested_version}" "${DETECTED_OS}" "${DETECTED_ARCH}"
+  asc_path="$(install_asc "${install_dir_value}")"
+  reported_version="${ASSET_VERSION#v}"
+  export PATH="$(dirname "${asc_path}"):${PATH}"
+
+  export_output "ASC_CLI_PATH" "${asc_path}"
+  export_output "ASC_CLI_VERSION" "${reported_version}"
+
+  if [ "${mode_value}" = "install" ]; then
+    log_info "Installed asc ${reported_version} at ${asc_path}."
+    exit 0
+  fi
+
+  configure_runtime_env "${profile_value}" "${debug_value}" "${bypass_value}"
+  run_user_command "${run_command}" "${working_dir_value}"
+
+  log_info "Command completed successfully."
+}
+
+main "$@"

--- a/integrations/bitrise/steps-setup-asc/step.yml
+++ b/integrations/bitrise/steps-setup-asc/step.yml
@@ -1,0 +1,146 @@
+title: Setup asc CLI
+summary: Install asc and optionally run an asc command.
+description: |-
+  Installs the `asc` CLI (App Store Connect CLI) from GitHub Releases and optionally runs a command.
+
+  ### Configuring the Step
+
+  1. Select mode:
+     - `install`: installs `asc` only
+     - `run`: installs `asc` and executes the provided command
+  2. Set `version` to `latest` or a pinned version (for example `0.31.5`).
+  3. If using `run` mode, provide `command`.
+  4. Optionally provide auth inputs to export `ASC_*` environment variables for command execution.
+
+  ### Useful links
+
+  - https://github.com/rudrankriyam/App-Store-Connect-CLI
+  - https://asccli.sh/
+
+website: https://github.com/rudrankriyam/steps-setup-asc
+source_code_url: https://github.com/rudrankriyam/steps-setup-asc
+support_url: https://github.com/rudrankriyam/steps-setup-asc/issues
+project_type_tags:
+- ios
+- macos
+type_tags:
+- utility
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: .IsCI
+
+inputs:
+- version: latest
+  opts:
+    title: asc version
+    summary: latest or a pinned release version
+    description: |-
+      Version to install.
+      Accepted examples: `latest`, `0.31.5`, `v0.31.5`.
+    is_required: true
+
+- mode: install
+  opts:
+    title: Mode
+    summary: install or run
+    value_options:
+    - install
+    - run
+    is_required: true
+
+- command: ""
+  opts:
+    title: Command (required for run mode)
+    summary: asc command to execute when mode is run
+    description: |-
+      Example: `asc --help` or `asc apps list --paginate`.
+      Ignored when mode is `install`.
+
+- working_dir: $BITRISE_SOURCE_DIR
+  opts:
+    title: Working directory
+    summary: working directory used in run mode
+    is_required: true
+
+- install_dir: $HOME/.local/bin
+  opts:
+    category: Install options
+    title: Install directory
+    summary: location where asc binary is installed
+    is_required: true
+
+- profile: ""
+  opts:
+    category: Runtime options
+    title: ASC profile
+    summary: optional ASC_PROFILE exported for run mode
+
+- debug: "no"
+  opts:
+    category: Runtime options
+    title: Enable debug
+    summary: exports ASC_DEBUG=1 in run mode
+    value_options:
+    - "yes"
+    - "no"
+    is_required: true
+
+- key_id: ""
+  opts:
+    category: Auth (optional)
+    title: ASC key ID
+    summary: exported as ASC_KEY_ID in run mode
+    is_sensitive: true
+
+- issuer_id: ""
+  opts:
+    category: Auth (optional)
+    title: ASC issuer ID
+    summary: exported as ASC_ISSUER_ID in run mode
+    is_sensitive: true
+
+- private_key_path: ""
+  opts:
+    category: Auth (optional)
+    title: ASC private key path
+    summary: exported as ASC_PRIVATE_KEY_PATH in run mode
+    is_sensitive: true
+
+- private_key: ""
+  opts:
+    category: Auth (optional)
+    title: ASC private key content
+    summary: exported as ASC_PRIVATE_KEY in run mode
+    description: |-
+      Raw private key content. Use a Secret Env Var.
+    is_sensitive: true
+
+- bypass_keychain: "no"
+  opts:
+    category: Auth (optional)
+    title: Bypass keychain
+    summary: exports ASC_BYPASS_KEYCHAIN=1 in run mode
+    value_options:
+    - "yes"
+    - "no"
+    is_required: true
+
+outputs:
+- ASC_CLI_PATH:
+  opts:
+    title: Installed asc binary path
+    summary: absolute path to installed asc binary
+    is_dont_change_value: true
+
+- ASC_CLI_VERSION:
+  opts:
+    title: Installed asc version
+    summary: resolved asc version that was installed
+    is_dont_change_value: true
+
+- ASC_COMMAND_EXIT_CODE:
+  opts:
+    title: asc command exit code
+    summary: exported when mode is run
+    is_dont_change_value: true


### PR DESCRIPTION
## Summary
- add a first-pass `setup-asc` Bitrise step prototype under `integrations/bitrise/steps-setup-asc` with `install` and `run` modes, secure optional auth inputs, and checksum-verified release installs
- add local validation workflows (`audit-this-step`, `test-install`, `test-run-help`) and a concrete implementation checklist in `docs/ci/bitrise-step-checklist.md`
- add a GitHub Actions matrix workflow to validate the Bitrise step behavior on both macOS and Linux

## Test plan
- [x] `stepman audit --step-yml ./step.yml` (from `integrations/bitrise/steps-setup-asc`)
- [x] `bitrise run audit-this-step`
- [x] `bitrise run test-install`
- [x] `bitrise run test-run-help`
- [ ] Verify GitHub Actions matrix passes on `ubuntu-latest` and `macos-latest`