### PR TITLE
docs(readme): add GitLab CI components integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1739,6 +1739,23 @@ Install `asc` in CI using the official setup action:
 For end-to-end CI examples (publish to TestFlight, upload localizations, etc.), see:
 https://github.com/rudrankriyam/setup-asc
 
+### GitLab CI/CD Components
+
+Use the official `asc-ci-components` repository:
+
+```yaml
+include:
+  - component: gitlab.com/rudrankriyam/asc-ci-components/run@main
+    inputs:
+      stage: deploy
+      job_prefix: release
+      asc_version: latest
+      command: asc --help
+```
+
+For install/run templates, self-managed examples, and release tags, see:
+https://github.com/rudrankriyam/asc-ci-components
+
 ### Bitrise (CI/CD)
 
 Use the official `setup-asc` Bitrise step repository:


### PR DESCRIPTION
## Summary
- add a new `GitLab CI/CD Components` subsection in `README.md` under Installation
- include a minimal `include: component:` example pointing to `rudrankriyam/asc-ci-components`
- link to the component repository for install/run templates, self-managed usage, and release tags

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

## Context
Complements the new GitLab component project introduced for CI integration docs.