### PR TITLE
docs(wall): add Bloom to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ https://github.com/rudrankriyam/app-store-connect-cli-skills
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**30 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**31 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -7,6 +7,13 @@
     "platform": ["iOS", "macOS", "tvOS", "visionOS"]
   },
   {
+    "app": "Bloom",
+    "link": "https://apps.apple.com/app/id6739955926",
+    "creator": "mpdifran",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f0/29/db/f029dba4-b00f-69fb-c696-e1241281b12d/Blueberry-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS", "watchOS"]
+  },
+  {
     "app": "Bobbin",
     "link": "https://apps.apple.com/us/app/threads-growth-bobbin/id6756035789",
     "creator": "ljyjeffrey",


### PR DESCRIPTION
## Summary
- Add Bloom (iOS, watchOS) to the Wall of Apps
- Updates app count from 30 to 31

## Test plan
- [x] Generated entry via `make generate app`
- [x] Verified alphabetical ordering in `docs/wall-of-apps.json`
- [x] Verified README app count updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)