### PR TITLE
Add Homebrew tap instruction for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Automate iOS, macOS, tvOS, and visionOS release workflows from your terminal, ID
 
 ```bash
 # Homebrew (recommended)
+brew tap rudrankriyam/tap
 brew install asc
 
 # Install script (macOS/Linux)


### PR DESCRIPTION
## Summary

- Added Homebrew tap instruction in readme file - tap installation is already mentioned in [llms.txt](https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/ebb2100519f026092916fc719df8c78158fca889/llms.txt#L23) but not in the main readme

## Validation

- [ ] `make format`
- [ ] `make lint`
- [ ] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
