### PR TITLE
ci: run PR checks only on pull_request events

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,10 +1,12 @@
 name: PR Checks
 
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
-    branches: ["*"]
+    branches: [main]
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   format-and-lint:


### PR DESCRIPTION
## Summary
- remove the `push` trigger from `.github/workflows/pr-checks.yml` so `PR Checks` runs only on pull requests targeting `main`
- add workflow `concurrency` with `cancel-in-progress: true` to cancel stale runs when new commits are pushed
- prevent duplicate check contexts (`(push)` and `(pull_request)`) for the same PR commit

## Test plan
- [x] Review workflow diff to confirm only `pull_request` trigger remains
- [x] Verify concurrency group is set to `pr-checks-${{ github.event.pull_request.number || github.ref }}`
- [ ] Open/update branch protection to require the `pull_request` check contexts only (no `(push)` contexts)