### PR TITLE
fix(bench): parse low-sample benchstat output in benchmark comments

### DIFF
--- a/scripts/bench-comment.js
+++ b/scripts/bench-comment.js
@@ -80,7 +80,7 @@ for (const line of lines) {
     }
   }
 
-  results.push({ icon, name, change, deltaDisplay, pValue, verdict });
+  results.push({ icon, name, deltaDisplay, pValue, verdict });
 }
 
 let body;


### PR DESCRIPTION
## Summary
- fix benchmark comment parsing to handle benchstat rows that use `±∞`/footnoted confidence output when sample count is low
- parse only `sec/op` sections and skip `B/op` + `allocs/op` rows to avoid duplicate benchmark entries
- keep fallback raw output rendering unchanged when parsing truly fails

## Test plan
- [x] `mkdir -p .perf && bash scripts/bench-ci.sh .perf/base.txt 1`
- [x] `bash scripts/bench-ci.sh .perf/pr.txt 1`
- [x] `PATH="$(go env GOPATH)/bin:$PATH" node scripts/bench-comment.js .perf/base.txt .perf/pr.txt .perf/comment.md`
- [x] verified `.perf/comment.md` contains parsed benchmark table instead of "No benchmark results could be parsed"