### PR TITLE
Add localizations update subcommand for direct field updates

### DIFF
--- a/internal/cli/cmdtest/localizations_update_test.go
+++ b/internal/cli/cmdtest/localizations_update_test.go
@@ -1,0 +1,175 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type locUpdateRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn locUpdateRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func setupLocUpdateAuth(t *testing.T) {
+	t.Helper()
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "TEST_KEY")
+	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
+}
+
+func locUpdateJSONResponse(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func TestLocalizationsUpdateRequiresLocale(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "update", "--version", "ver-1", "--description", "test"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "--locale is required") {
+		t.Fatalf("expected locale required error, got: %q", stderr)
+	}
+}
+
+func TestLocalizationsUpdateRequiresAtLeastOneField(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "update", "--version", "ver-1", "--locale", "en-US"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "at least one version field") {
+		t.Fatalf("expected field required error, got: %q", stderr)
+	}
+}
+
+func TestLocalizationsUpdateAppInfoRequiresApp(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "update", "--type", "app-info", "--locale", "en-US", "--subtitle", "test"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "--app is required") {
+		t.Fatalf("expected app required error, got: %q", stderr)
+	}
+}
+
+func TestLocalizationsUpdateVersionRequiresVersion(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "update", "--locale", "en-US", "--description", "test"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "--version is required") {
+		t.Fatalf("expected version required error, got: %q", stderr)
+	}
+}
+
+func TestLocalizationsUpdateAppInfoSubtitle(t *testing.T) {
+	setupLocUpdateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var patchBody string
+	http.DefaultTransport = locUpdateRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		// Resolve app info ID
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appInfos":
+			return locUpdateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{}}]}`)
+
+		// List existing localizations
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return locUpdateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"MyApp","subtitle":"Old"}}],"links":{}}`)
+
+		// Update localization
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/loc-en":
+			body, _ := io.ReadAll(req.Body)
+			patchBody = string(body)
+			return locUpdateJSONResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"MyApp","subtitle":"New Subtitle"}}}`)
+
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"localizations", "update",
+			"--type", "app-info",
+			"--app", "app-1",
+			"--locale", "en-US",
+			"--subtitle", "New Subtitle",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	// Verify the PATCH body contains subtitle
+	if !strings.Contains(patchBody, "New Subtitle") {
+		t.Fatalf("expected subtitle in PATCH body, got: %s", patchBody)
+	}
+
+	// Verify JSON output
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v (stdout=%q)", err, stdout)
+	}
+}

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -35,6 +35,7 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			LocalizationsListCommand(),
+			LocalizationsUpdateCommand(),
 			LocalizationsSearchKeywordsCommand(),
 			LocalizationsPreviewSetsCommand(),
 			LocalizationsScreenshotSetsCommand(),

--- a/internal/cli/localizations/update.go
+++ b/internal/cli/localizations/update.go
@@ -1,0 +1,232 @@
+package localizations
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// LocalizationsUpdateCommand returns the update localizations subcommand.
+func LocalizationsUpdateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+
+	versionID := fs.String("version", "", "App Store version ID (for version localizations)")
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID, for app-info localizations)")
+	appInfoID := fs.String("app-info", "", "App Info ID (optional override)")
+	locType := fs.String("type", shared.LocalizationTypeVersion, "Localization type: version (default) or app-info")
+	locale := fs.String("locale", "", "Locale to update (required, e.g., en-US)")
+
+	// App-info fields
+	name := fs.String("name", "", "App name (app-info)")
+	subtitle := fs.String("subtitle", "", "App subtitle (app-info)")
+	privacyPolicyURL := fs.String("privacy-policy-url", "", "Privacy policy URL (app-info)")
+	privacyChoicesURL := fs.String("privacy-choices-url", "", "Privacy choices URL (app-info)")
+	privacyPolicyText := fs.String("privacy-policy-text", "", "Privacy policy text (app-info)")
+
+	// Version fields
+	description := fs.String("description", "", "App description (version)")
+	keywords := fs.String("keywords", "", "Search keywords (version)")
+	whatsNew := fs.String("whats-new", "", "What's new text (version)")
+	promotionalText := fs.String("promotional-text", "", "Promotional text (version)")
+	supportURL := fs.String("support-url", "", "Support URL (version)")
+	marketingURL := fs.String("marketing-url", "", "Marketing URL (version)")
+
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "update",
+		ShortUsage: "asc localizations update [flags]",
+		ShortHelp:  "Update localization fields directly.",
+		LongHelp: `Update localization fields directly without file preparation.
+
+For app-info localizations (name, subtitle, privacy URLs):
+  asc localizations update --app "APP_ID" --type app-info --locale "en-US" --subtitle "My App"
+
+For version localizations (description, keywords, whatsNew):
+  asc localizations update --version "VERSION_ID" --locale "en-US" --description "Updated description"
+
+At least one field flag must be provided.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			normalizedType, err := shared.NormalizeLocalizationType(*locType)
+			if err != nil {
+				return fmt.Errorf("localizations update: %w", err)
+			}
+
+			localeValue := strings.TrimSpace(*locale)
+			if localeValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --locale is required")
+				return flag.ErrHelp
+			}
+
+			switch normalizedType {
+			case shared.LocalizationTypeAppInfo:
+				return updateAppInfoLocalization(ctx, updateAppInfoParams{
+					appID:             *appID,
+					appInfoID:         *appInfoID,
+					locale:            localeValue,
+					name:              *name,
+					subtitle:          *subtitle,
+					privacyPolicyURL:  *privacyPolicyURL,
+					privacyChoicesURL: *privacyChoicesURL,
+					privacyPolicyText: *privacyPolicyText,
+					output:            output,
+				})
+			case shared.LocalizationTypeVersion:
+				return updateVersionLocalization(ctx, updateVersionParams{
+					versionID:       *versionID,
+					locale:          localeValue,
+					description:     *description,
+					keywords:        *keywords,
+					whatsNew:        *whatsNew,
+					promotionalText: *promotionalText,
+					supportURL:      *supportURL,
+					marketingURL:    *marketingURL,
+					output:          output,
+				})
+			default:
+				return fmt.Errorf("localizations update: unsupported type %q", normalizedType)
+			}
+		},
+	}
+}
+
+type updateAppInfoParams struct {
+	appID, appInfoID, locale                                               string
+	name, subtitle, privacyPolicyURL, privacyChoicesURL, privacyPolicyText string
+	output                                                                 shared.OutputFlags
+}
+
+func updateAppInfoLocalization(ctx context.Context, p updateAppInfoParams) error {
+	if !hasAnyAppInfoField(p) {
+		fmt.Fprintln(os.Stderr, "Error: at least one app-info field is required (--name, --subtitle, --privacy-policy-url, --privacy-choices-url, --privacy-policy-text)")
+		return flag.ErrHelp
+	}
+
+	resolvedAppID := shared.ResolveAppID(p.appID)
+	if resolvedAppID == "" {
+		fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations (or set ASC_APP_ID)")
+		return flag.ErrHelp
+	}
+
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("localizations update: %w", err)
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+
+	appInfo, err := shared.ResolveAppInfoID(requestCtx, client, resolvedAppID, strings.TrimSpace(p.appInfoID))
+	if err != nil {
+		return fmt.Errorf("localizations update: %w", err)
+	}
+
+	// Find existing localization ID for the locale
+	existing, err := client.GetAppInfoLocalizations(requestCtx, appInfo, asc.WithAppInfoLocalizationsLimit(200))
+	if err != nil {
+		return fmt.Errorf("localizations update: failed to fetch localizations: %w", err)
+	}
+
+	var localizationID string
+	for _, item := range existing.Data {
+		if strings.EqualFold(strings.TrimSpace(item.Attributes.Locale), p.locale) {
+			localizationID = item.ID
+			break
+		}
+	}
+	if localizationID == "" {
+		return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
+	}
+
+	attrs := asc.AppInfoLocalizationAttributes{
+		Name:              p.name,
+		Subtitle:          p.subtitle,
+		PrivacyPolicyURL:  p.privacyPolicyURL,
+		PrivacyChoicesURL: p.privacyChoicesURL,
+		PrivacyPolicyText: p.privacyPolicyText,
+	}
+
+	resp, err := client.UpdateAppInfoLocalization(requestCtx, localizationID, attrs)
+	if err != nil {
+		return fmt.Errorf("localizations update: %w", err)
+	}
+
+	return shared.PrintOutput(resp, *p.output.Output, *p.output.Pretty)
+}
+
+func hasAnyAppInfoField(p updateAppInfoParams) bool {
+	return p.name != "" || p.subtitle != "" || p.privacyPolicyURL != "" || p.privacyChoicesURL != "" || p.privacyPolicyText != ""
+}
+
+type updateVersionParams struct {
+	versionID, locale                                                   string
+	description, keywords, whatsNew, promotionalText, supportURL, marketingURL string
+	output                                                              shared.OutputFlags
+}
+
+func updateVersionLocalization(ctx context.Context, p updateVersionParams) error {
+	if !hasAnyVersionField(p) {
+		fmt.Fprintln(os.Stderr, "Error: at least one version field is required (--description, --keywords, --whats-new, --promotional-text, --support-url, --marketing-url)")
+		return flag.ErrHelp
+	}
+
+	vid := strings.TrimSpace(p.versionID)
+	if vid == "" {
+		fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
+		return flag.ErrHelp
+	}
+
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("localizations update: %w", err)
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+
+	// Find existing localization ID for the locale
+	existing, err := client.GetAppStoreVersionLocalizations(requestCtx, vid, asc.WithAppStoreVersionLocalizationsLimit(200))
+	if err != nil {
+		return fmt.Errorf("localizations update: failed to fetch localizations: %w", err)
+	}
+
+	var localizationID string
+	for _, item := range existing.Data {
+		if strings.EqualFold(strings.TrimSpace(item.Attributes.Locale), p.locale) {
+			localizationID = item.ID
+			break
+		}
+	}
+	if localizationID == "" {
+		return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
+	}
+
+	attrs := asc.AppStoreVersionLocalizationAttributes{
+		Description:     p.description,
+		Keywords:        p.keywords,
+		WhatsNew:        p.whatsNew,
+		PromotionalText: p.promotionalText,
+		SupportURL:      p.supportURL,
+		MarketingURL:    p.marketingURL,
+	}
+
+	resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, localizationID, attrs)
+	if err != nil {
+		return fmt.Errorf("localizations update: %w", err)
+	}
+
+	return shared.PrintOutput(resp, *p.output.Output, *p.output.Pretty)
+}
+
+func hasAnyVersionField(p updateVersionParams) bool {
+	return p.description != "" || p.keywords != "" || p.whatsNew != "" || p.promotionalText != "" || p.supportURL != "" || p.marketingURL != ""
+}


### PR DESCRIPTION
## Summary
- Adds `asc localizations update` for directly updating localization fields without preparing JSON or .strings files
- Supports both `--type app-info` and `--type version` localization types
- Resolves existing localization by `--locale`, then PATCHes only the specified fields

## Usage
```bash
# Set subtitle for a locale
asc localizations update --app APP_ID --type app-info --locale en-US --subtitle "My Subtitle"

# Update version description
asc localizations update --version-id VER_ID --type version --locale en-US --description "New description"
```

## Supported flags
**App-info type:** `--name`, `--subtitle`, `--privacy-policy-url`, `--privacy-choices-url`, `--privacy-policy-text`
**Version type:** `--description`, `--keywords`, `--whats-new`, `--promotional-text`, `--support-url`, `--marketing-url`

## Files changed
- `internal/cli/localizations/update.go` — `LocalizationsUpdateCommand()` (~232 lines)
- `internal/cli/localizations/localizations.go` — registers new subcommand (+1 line)
- `internal/cli/cmdtest/localizations_update_test.go` — 5 tests including HTTP mock integration

## Test plan
- [x] `TestLocalizationsUpdateRequiresLocale` — validates --locale is required
- [x] `TestLocalizationsUpdateRequiresAtLeastOneField` — validates at least one field flag
- [x] `TestLocalizationsUpdateAppInfoRequiresApp` — validates --app for app-info type
- [x] `TestLocalizationsUpdateVersionRequiresVersion` — validates --version/--version-id for version type
- [x] `TestLocalizationsUpdateAppInfoSubtitle` — full HTTP mock integration test
- [x] `ASC_BYPASS_KEYCHAIN=1 make test` — all tests pass