### PR TITLE
fix(screenshots): focus default sizes on iOS submission slots

### DIFF
--- a/internal/asc/screenshot_sizes.go
+++ b/internal/asc/screenshot_sizes.go
@@ -85,7 +85,10 @@ var (
 		portraitLandscape(1179, 2556),
 		portraitLandscape(1170, 2532),
 	)
-	iphone65Dimensions = portraitLandscape(1242, 2688)
+	iphone65Dimensions = combineDimensions(
+		portraitLandscape(1242, 2688),
+		portraitLandscape(1284, 2778),
+	)
 	iphone58Dimensions = portraitLandscape(1125, 2436)
 	iphone55Dimensions = portraitLandscape(1242, 2208)
 	iphone47Dimensions = portraitLandscape(750, 1334)

--- a/internal/asc/screenshot_sizes_test.go
+++ b/internal/asc/screenshot_sizes_test.go
@@ -68,6 +68,31 @@ func TestValidateScreenshotDimensionsAcceptsLatestLargeIPhoneSizes(t *testing.T)
 	}
 }
 
+func TestValidateScreenshotDimensionsAcceptsIPhone65ConsolidatedSlotSizes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{name: "1242x2688 portrait", width: 1242, height: 2688},
+		{name: "2688x1242 landscape", width: 2688, height: 1242},
+		{name: "1284x2778 portrait", width: 1284, height: 2778},
+		{name: "2778x1284 landscape", width: 2778, height: 1284},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "iphone65-consolidated.png")
+			writePNG(t, path, tc.width, tc.height)
+
+			if err := ValidateScreenshotDimensions(path, "APP_IPHONE_65"); err != nil {
+				t.Fatalf("expected dimensions %dx%d to be valid for APP_IPHONE_65, got %v", tc.width, tc.height, err)
+			}
+		})
+	}
+}
+
 func TestScreenshotDisplayTypesMatchOpenAPI(t *testing.T) {
 	specTypes := openAPIScreenshotDisplayTypes(t)
 	codeTypes := ScreenshotDisplayTypes()
@@ -103,6 +128,25 @@ func TestScreenshotSizeEntryIncludesLatestLargeIPhoneDimensions(t *testing.T) {
 	for _, dim := range expected {
 		if !containsScreenshotDimension(entry.Dimensions, dim) {
 			t.Fatalf("expected APP_IPHONE_67 to include %s, got %v", dim.String(), entry.Dimensions)
+		}
+	}
+}
+
+func TestScreenshotSizeEntryIncludesIPhone65ConsolidatedDimensions(t *testing.T) {
+	entry, ok := ScreenshotSizeEntryForDisplayType("APP_IPHONE_65")
+	if !ok {
+		t.Fatal("expected APP_IPHONE_65 entry in screenshot size catalog")
+	}
+
+	expected := []ScreenshotDimension{
+		{Width: 1242, Height: 2688},
+		{Width: 2688, Height: 1242},
+		{Width: 1284, Height: 2778},
+		{Width: 2778, Height: 1284},
+	}
+	for _, dim := range expected {
+		if !containsScreenshotDimension(entry.Dimensions, dim) {
+			t.Fatalf("expected APP_IPHONE_65 to include %s, got %v", dim.String(), entry.Dimensions)
 		}
 	}
 }

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -15,6 +15,26 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+var focusedScreenshotDisplayTypes = []string{
+	"APP_IPHONE_65",
+	"APP_IPAD_PRO_3GEN_129",
+}
+
+func focusedScreenshotSizeCatalog() []asc.ScreenshotSizeEntry {
+	focused := make([]asc.ScreenshotSizeEntry, 0, len(focusedScreenshotDisplayTypes))
+	for _, displayType := range focusedScreenshotDisplayTypes {
+		entry, ok := asc.ScreenshotSizeEntryForDisplayType(displayType)
+		if !ok {
+			continue
+		}
+		focused = append(focused, entry)
+	}
+	if len(focused) == 0 {
+		return asc.ScreenshotSizeCatalog()
+	}
+	return focused
+}
+
 // AssetsScreenshotsCommand returns the screenshots subcommand group.
 func AssetsScreenshotsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("screenshots", flag.ExitOnError)
@@ -27,10 +47,16 @@ func AssetsScreenshotsCommand() *ffcli.Command {
 
 Examples:
   asc screenshots list --version-localization "LOC_ID"
-  asc screenshots sizes --display-type "APP_IPHONE_65"
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_65"
+  asc screenshots sizes
+  asc screenshots sizes --all
+  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/iphone" --device-type "IPHONE_65"
+  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/ipad" --device-type "IPAD_PRO_3GEN_129"
   asc screenshots download --version-localization "LOC_ID" --output-dir "./screenshots/downloaded"
-  asc screenshots delete --id "SCREENSHOT_ID" --confirm`,
+  asc screenshots delete --id "SCREENSHOT_ID" --confirm
+
+By default, "asc screenshots sizes" focuses on one iPhone set (IPHONE_65)
+and one iPad set (IPAD_PRO_3GEN_129). Use --all to list every supported
+display type.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -109,25 +135,32 @@ func AssetsScreenshotsSizesCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("sizes", flag.ExitOnError)
 
 	displayType := fs.String("display-type", "", "Filter by screenshot display type (e.g., APP_IPHONE_65)")
+	all := fs.Bool("all", false, "List all supported screenshot display types")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "sizes",
-		ShortUsage: "asc screenshots sizes [--display-type \"APP_IPHONE_65\"]",
+		ShortUsage: "asc screenshots sizes [--display-type \"APP_IPHONE_65\" | --all]",
 		ShortHelp:  "List supported screenshot display sizes.",
 		LongHelp: `List supported screenshot display sizes.
 
+By default this command focuses on common iOS submission slots:
+APP_IPHONE_65 and APP_IPAD_PRO_3GEN_129.
+
 Examples:
   asc screenshots sizes
+  asc screenshots sizes --all
   asc screenshots sizes --display-type "APP_IPHONE_65"
   asc screenshots sizes --output table`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			filter := strings.TrimSpace(*displayType)
-			result := asc.ScreenshotSizesResult{
-				Sizes: asc.ScreenshotSizeCatalog(),
+			if filter != "" && *all {
+				return shared.UsageError("--display-type and --all are mutually exclusive")
 			}
+
+			result := asc.ScreenshotSizesResult{}
 
 			if filter != "" {
 				normalized, err := normalizeScreenshotDisplayType(filter)
@@ -139,6 +172,10 @@ Examples:
 					return fmt.Errorf("screenshots sizes: unsupported screenshot display type %q", normalized)
 				}
 				result.Sizes = []asc.ScreenshotSizeEntry{entry}
+			} else if *all {
+				result.Sizes = asc.ScreenshotSizeCatalog()
+			} else {
+				result.Sizes = focusedScreenshotSizeCatalog()
 			}
 
 			return shared.PrintOutput(&result, *output.Output, *output.Pretty)
@@ -152,7 +189,7 @@ func AssetsScreenshotsUploadCommand() *ffcli.Command {
 
 	localizationID := fs.String("version-localization", "", "App Store version localization ID")
 	path := fs.String("path", "", "Path to screenshot file or directory")
-	deviceType := fs.String("device-type", "", "Device type (e.g., IPHONE_65)")
+	deviceType := fs.String("device-type", "", "Device type (e.g., IPHONE_65 or IPAD_PRO_3GEN_129)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -163,6 +200,7 @@ func AssetsScreenshotsUploadCommand() *ffcli.Command {
 
 Examples:
   asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_65"
+  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPAD_PRO_3GEN_129"
   asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/en-US.png" --device-type "IPHONE_65"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -3,12 +3,48 @@ package assets
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"flag"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
+
+func TestAssetsScreenshotsSizesCommandDefaultFocused(t *testing.T) {
+	cmd := AssetsScreenshotsSizesCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), cmd.FlagSet.Args()); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result asc.ScreenshotSizesResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(result.Sizes) != 2 {
+		t.Fatalf("expected 2 default focused entries, got %d", len(result.Sizes))
+	}
+
+	if result.Sizes[0].DisplayType != "APP_IPHONE_65" {
+		t.Fatalf("expected first focused type APP_IPHONE_65, got %q", result.Sizes[0].DisplayType)
+	}
+	if result.Sizes[1].DisplayType != "APP_IPAD_PRO_3GEN_129" {
+		t.Fatalf("expected second focused type APP_IPAD_PRO_3GEN_129, got %q", result.Sizes[1].DisplayType)
+	}
+}
 
 func TestAssetsScreenshotsSizesCommandFilter(t *testing.T) {
 	cmd := AssetsScreenshotsSizesCommand()
@@ -94,6 +130,66 @@ func TestAssetsScreenshotsSizesCommandSupportsIMessageIPhone69Alias(t *testing.T
 	}
 	if result.Sizes[0].DisplayType != "IMESSAGE_APP_IPHONE_69" {
 		t.Fatalf("expected IMESSAGE_APP_IPHONE_69, got %q", result.Sizes[0].DisplayType)
+	}
+}
+
+func TestAssetsScreenshotsSizesCommandAllIncludesNonFocusedTypes(t *testing.T) {
+	cmd := AssetsScreenshotsSizesCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{"--all"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), cmd.FlagSet.Args()); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result asc.ScreenshotSizesResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(result.Sizes) <= 2 {
+		t.Fatalf("expected --all to return more than focused entries, got %d", len(result.Sizes))
+	}
+
+	foundDesktop := false
+	for _, entry := range result.Sizes {
+		if entry.DisplayType == "APP_DESKTOP" {
+			foundDesktop = true
+			break
+		}
+	}
+	if !foundDesktop {
+		t.Fatal("expected APP_DESKTOP in --all sizes output")
+	}
+}
+
+func TestAssetsScreenshotsSizesCommandRejectsAllWithDisplayType(t *testing.T) {
+	cmd := AssetsScreenshotsSizesCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{"--all", "--display-type", "APP_IPHONE_65"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), cmd.FlagSet.Args())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "--display-type and --all are mutually exclusive") {
+		t.Fatalf("expected mutually exclusive error in stderr, got %q", stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/assets_screenshots_sizes_test.go
+++ b/internal/cli/cmdtest/assets_screenshots_sizes_test.go
@@ -3,6 +3,8 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"flag"
 	"fmt"
 	"image"
 	"image/png"
@@ -38,18 +40,20 @@ func TestAssetsScreenshotsSizesOutput(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("decode output: %v", err)
 	}
-	if len(result.Sizes) == 0 {
-		t.Fatal("expected sizes output, got empty list")
+	if len(result.Sizes) != 2 {
+		t.Fatalf("expected 2 focused entries by default, got %d", len(result.Sizes))
 	}
-	found := false
+
+	if result.Sizes[0].DisplayType != "APP_IPHONE_65" {
+		t.Fatalf("expected first focused type APP_IPHONE_65, got %q", result.Sizes[0].DisplayType)
+	}
+	if result.Sizes[1].DisplayType != "APP_IPAD_PRO_3GEN_129" {
+		t.Fatalf("expected second focused type APP_IPAD_PRO_3GEN_129, got %q", result.Sizes[1].DisplayType)
+	}
 	for _, entry := range result.Sizes {
-		if entry.DisplayType == "APP_IPHONE_65" {
-			found = true
-			break
+		if entry.DisplayType == "APP_DESKTOP" {
+			t.Fatal("did not expect APP_DESKTOP in default focused output")
 		}
-	}
-	if !found {
-		t.Fatal("expected APP_IPHONE_65 in sizes output")
 	}
 }
 
@@ -116,7 +120,7 @@ func TestAssetsScreenshotsSizesOutputIncludesMacWatchTVAndVisionDimensions(t *te
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"screenshots", "sizes", "--output", "json"}); err != nil {
+		if err := root.Parse([]string{"screenshots", "sizes", "--all", "--output", "json"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -178,6 +182,34 @@ func TestAssetsScreenshotsSizesOutputIncludesMacWatchTVAndVisionDimensions(t *te
 				t.Fatalf("expected %s to include %dx%d, got %v", tc.displayType, dim.Width, dim.Height, entry.Dimensions)
 			}
 		}
+	}
+}
+
+func TestAssetsScreenshotsSizesRejectsAllWithDisplayType(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"screenshots", "sizes",
+			"--all",
+			"--display-type", "APP_IPHONE_65",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--display-type and --all are mutually exclusive") {
+		t.Fatalf("expected mutually exclusive error in stderr, got %q", stderr)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
 	}
 }
 

--- a/internal/cli/screenshots/screenshots.go
+++ b/internal/cli/screenshots/screenshots.go
@@ -36,10 +36,16 @@ Local workflow (experimental):
 
 App Store workflow:
   asc screenshots list --version-localization "LOC_ID"
-  asc screenshots sizes --display-type "APP_IPHONE_69"
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_69"
+  asc screenshots sizes
+  asc screenshots sizes --all
+  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/iphone" --device-type "IPHONE_65"
+  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/ipad" --device-type "IPAD_PRO_3GEN_129"
   asc screenshots download --version-localization "LOC_ID" --output-dir "./screenshots/downloaded"
-  asc screenshots delete --id "SCREENSHOT_ID" --confirm`,
+  asc screenshots delete --id "SCREENSHOT_ID" --confirm
+
+For most iOS submissions, one iPhone set (IPHONE_65) and one iPad set
+(IPAD_PRO_3GEN_129) are enough. "asc screenshots sizes" focuses on these by
+default; use --all only when you need the full matrix.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{

--- a/internal/validation/screenshot_test.go
+++ b/internal/validation/screenshot_test.go
@@ -38,6 +38,25 @@ func TestScreenshotChecks_Pass(t *testing.T) {
 	}
 }
 
+func TestScreenshotChecks_PassIPhone65ConsolidatedSlot(t *testing.T) {
+	sets := []ScreenshotSet{
+		{
+			ID:          "set-1",
+			DisplayType: "APP_IPHONE_65",
+			Locale:      "en-US",
+			Screenshots: []Screenshot{
+				{ID: "shot-1", FileName: "shot-1.png", Width: 1242, Height: 2688},
+				{ID: "shot-2", FileName: "shot-2.png", Width: 1284, Height: 2778},
+			},
+		},
+	}
+
+	checks := screenshotChecks("IOS", sets)
+	if len(checks) != 0 {
+		t.Fatalf("expected no checks, got %d (%v)", len(checks), checks)
+	}
+}
+
 func TestScreenshotChecks_PassLatestLargeIPhoneSizes(t *testing.T) {
 	sets := []ScreenshotSet{
 		{

--- a/internal/validation/screenshots.go
+++ b/internal/validation/screenshots.go
@@ -23,7 +23,10 @@ var screenshotSizeCatalog = map[string][]screenshotSize{
 		{Width: 1320, Height: 2868},
 		{Width: 1284, Height: 2778},
 	},
-	"APP_IPHONE_65": {{Width: 1242, Height: 2688}},
+	"APP_IPHONE_65": {
+		{Width: 1242, Height: 2688},
+		{Width: 1284, Height: 2778},
+	},
 	"APP_IPHONE_61": {{Width: 1179, Height: 2556}, {Width: 1170, Height: 2532}},
 	"APP_IPHONE_58": {{Width: 1125, Height: 2436}},
 	"APP_IPHONE_55": {{Width: 1242, Height: 2208}},


### PR DESCRIPTION
## Summary
- Default `asc screenshots sizes` to the focused iOS submission slots (`APP_IPHONE_65` and `APP_IPAD_PRO_3GEN_129`) and add `--all` for the full matrix.
- Update screenshot command help/examples to guide users toward one iPhone and one iPad set by default, with explicit opt-in for all sizes.
- Accept `1284x2778` as a valid `APP_IPHONE_65` size and align both validation paths and tests with the consolidated App Store Connect slot behavior.

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go test ./internal/cli/assets ./internal/cli/cmdtest ./internal/cli/screenshots`
- [x] `go run . screenshots sizes --output table`
- [x] `go run . screenshots sizes --all --output table`