### PR TITLE
Add Reps: AI Fitness & Recovery to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ https://github.com/rudrankriyam/app-store-connect-cli-skills
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**31 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**32 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -138,6 +138,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Reps: AI Fitness & Recovery",
+    "link": "https://apps.apple.com/app/id6746460451",
+    "creator": "sidbmw",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0d/32/7e/0d327e27-4d64-63f5-9b05-70a0a4f58bf6/Reps_AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "watchOS"]
+  },
+  {
     "app": "Repetti",
     "link": "https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413",
     "creator": "rursache",


### PR DESCRIPTION
## Summary
- Adds **Reps: AI Fitness & Recovery** to the Wall of Apps
- Available on iOS and watchOS
- App Store: https://apps.apple.com/app/id6746460451

## Changes
- Added entry to `docs/wall-of-apps.json` (alphabetical order)
- Updated app count in `README.md` (31 → 32)

We use `asc` for our TestFlight workflow — love the tool!