### PR TITLE
Add Deep Hour - Deep Focus Ritual to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ https://github.com/rudrankriyam/app-store-connect-cli-skills
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**31 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**32 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -34,6 +34,13 @@
     "platform": ["iOS", "macOS"]
   },
   {
+    "app": "Deep Hour - Deep Focus Ritual",
+    "link": "https://apps.apple.com/app/id6758889630",
+    "creator": "Gurfus",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/55/90/80/55908099-0de3-f577-f029-7e76d29e3481/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "DoubleMemory",
     "link": "https://apps.apple.com/app/id6737529034",
     "creator": "randomor",


### PR DESCRIPTION
## Summary
- add **Deep Hour - Deep Focus Ritual** to docs/wall-of-apps.json
- update Wall of Apps count in README from 31 to 32

## Details
- App: Deep Hour - Deep Focus Ritual
- Link: https://apps.apple.com/app/id6758889630
- Creator: @Gurfus
- Platform: iOS

Built and shipped using asc CLI.