### PR TITLE
feat: wire --family-sharable flag for IAP and subscription create/update

### DIFF
--- a/internal/cli/cmdtest/iap_family_sharable_test.go
+++ b/internal/cli/cmdtest/iap_family_sharable_test.go
@@ -1,0 +1,131 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestIAPCreateFamilySharable(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var capturedBody string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPost && req.URL.Path == "/v2/inAppPurchases" {
+			bodyBytes, _ := io.ReadAll(req.Body)
+			capturedBody = string(bodyBytes)
+			resp := `{"data":{"type":"inAppPurchases","id":"new-iap","attributes":{"name":"Pro","productId":"com.example.pro","inAppPurchaseType":"CONSUMABLE","familySharable":true}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(resp)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"status":"404"}]}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"iap", "create", "--app", "APP1", "--type", "CONSUMABLE", "--ref-name", "Pro", "--product-id", "com.example.pro", "--family-sharable"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	// Verify the request body contains familySharable: true
+	var req asc.InAppPurchaseV2CreateRequest
+	if err := json.Unmarshal([]byte(capturedBody), &req); err != nil {
+		t.Fatalf("failed to parse request body: %v\nbody: %s", err, capturedBody)
+	}
+	if !req.Data.Attributes.FamilySharable {
+		t.Fatalf("expected familySharable=true in request, got %+v", req.Data.Attributes)
+	}
+
+	// Verify output contains the response
+	if !strings.Contains(stdout, `"familySharable":true`) {
+		t.Fatalf("expected familySharable in output, got %q", stdout)
+	}
+}
+
+func TestIAPUpdateFamilySharableAsSoleFlag(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var capturedBody string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPatch && strings.Contains(req.URL.Path, "/inAppPurchases/") {
+			bodyBytes, _ := io.ReadAll(req.Body)
+			capturedBody = string(bodyBytes)
+			resp := `{"data":{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Pro","productId":"com.example.pro","inAppPurchaseType":"CONSUMABLE","familySharable":true}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(resp)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"status":"404"}]}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"iap", "update", "--id", "iap-1", "--family-sharable"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	// Verify the request body contains familySharable: true
+	var req asc.InAppPurchaseV2UpdateRequest
+	if err := json.Unmarshal([]byte(capturedBody), &req); err != nil {
+		t.Fatalf("failed to parse request body: %v\nbody: %s", err, capturedBody)
+	}
+	if req.Data.Attributes == nil || req.Data.Attributes.FamilySharable == nil || !*req.Data.Attributes.FamilySharable {
+		t.Fatalf("expected familySharable=true in request, got %+v", req.Data.Attributes)
+	}
+	// Name should not be set when only --family-sharable is provided
+	if req.Data.Attributes.Name != nil {
+		t.Fatalf("expected Name to be nil when only --family-sharable is passed, got %q", *req.Data.Attributes.Name)
+	}
+
+	if !strings.Contains(stdout, `"familySharable":true`) {
+		t.Fatalf("expected familySharable in output, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_family_sharable_test.go
+++ b/internal/cli/cmdtest/subscriptions_family_sharable_test.go
@@ -1,0 +1,131 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestSubscriptionsCreateFamilySharable(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var capturedBody string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/subscriptions") {
+			bodyBytes, _ := io.ReadAll(req.Body)
+			capturedBody = string(bodyBytes)
+			resp := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Family","productId":"com.example.sub.family","familySharable":true}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(resp)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"status":"404"}]}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "create", "--group", "GRP1", "--ref-name", "Family", "--product-id", "com.example.sub.family", "--family-sharable"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var req asc.SubscriptionCreateRequest
+	if err := json.Unmarshal([]byte(capturedBody), &req); err != nil {
+		t.Fatalf("failed to parse request body: %v\nbody: %s", err, capturedBody)
+	}
+	if req.Data.Attributes.FamilySharable == nil || !*req.Data.Attributes.FamilySharable {
+		t.Fatalf("expected familySharable=true in request, got %+v", req.Data.Attributes)
+	}
+
+	if !strings.Contains(stdout, `"familySharable":true`) {
+		t.Fatalf("expected familySharable in output, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsUpdateFamilySharableAsSoleFlag(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var capturedBody string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPatch && strings.Contains(req.URL.Path, "/subscriptions/") {
+			bodyBytes, _ := io.ReadAll(req.Body)
+			capturedBody = string(bodyBytes)
+			resp := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.sub.monthly","familySharable":true}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(resp)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"status":"404"}]}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "update", "--id", "sub-1", "--family-sharable"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var req asc.SubscriptionUpdateRequest
+	if err := json.Unmarshal([]byte(capturedBody), &req); err != nil {
+		t.Fatalf("failed to parse request body: %v\nbody: %s", err, capturedBody)
+	}
+	if req.Data.Attributes.FamilySharable == nil || !*req.Data.Attributes.FamilySharable {
+		t.Fatalf("expected familySharable=true in request, got %+v", req.Data.Attributes)
+	}
+	// Name and period should not be set when only --family-sharable is provided
+	if req.Data.Attributes.Name != nil {
+		t.Fatalf("expected Name to be nil when only --family-sharable is passed, got %q", *req.Data.Attributes.Name)
+	}
+	if req.Data.Attributes.SubscriptionPeriod != nil {
+		t.Fatalf("expected SubscriptionPeriod to be nil when only --family-sharable is passed, got %q", *req.Data.Attributes.SubscriptionPeriod)
+	}
+
+	if !strings.Contains(stdout, `"familySharable":true`) {
+		t.Fatalf("expected familySharable in output, got %q", stdout)
+	}
+}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -450,6 +450,7 @@ func SubscriptionsCreateCommand() *ffcli.Command {
 	refName := fs.String("ref-name", "", "Reference name")
 	productID := fs.String("product-id", "", "Product ID (e.g., com.example.sub)")
 	subscriptionPeriod := fs.String("subscription-period", "", "Subscription period: "+strings.Join(subscriptionPeriodValues, ", "))
+	familySharable := fs.Bool("family-sharable", false, "Enable Family Sharing (cannot be undone)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -460,7 +461,8 @@ func SubscriptionsCreateCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions create --group "GROUP_ID" --ref-name "Monthly" --product-id "com.example.sub.monthly"
-  asc subscriptions create --group "GROUP_ID" --ref-name "Monthly" --product-id "com.example.sub.monthly" --subscription-period ONE_MONTH`,
+  asc subscriptions create --group "GROUP_ID" --ref-name "Monthly" --product-id "com.example.sub.monthly" --subscription-period ONE_MONTH
+  asc subscriptions create --group "GROUP_ID" --ref-name "Family" --product-id "com.example.sub.family" --family-sharable`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -502,6 +504,10 @@ Examples:
 			}
 			if period != "" {
 				attrs.SubscriptionPeriod = string(period)
+			}
+			if *familySharable {
+				val := true
+				attrs.FamilySharable = &val
 			}
 
 			resp, err := client.CreateSubscription(requestCtx, group, attrs)
@@ -563,6 +569,7 @@ func SubscriptionsUpdateCommand() *ffcli.Command {
 	subID := fs.String("id", "", "Subscription ID")
 	refName := fs.String("ref-name", "", "Reference name")
 	subscriptionPeriod := fs.String("subscription-period", "", "Subscription period: "+strings.Join(subscriptionPeriodValues, ", "))
+	familySharable := fs.Bool("family-sharable", false, "Enable Family Sharing (cannot be undone)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -573,7 +580,8 @@ func SubscriptionsUpdateCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions update --id "SUB_ID" --ref-name "New Name"
-  asc subscriptions update --id "SUB_ID" --subscription-period ONE_YEAR`,
+  asc subscriptions update --id "SUB_ID" --subscription-period ONE_YEAR
+  asc subscriptions update --id "SUB_ID" --family-sharable`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -589,7 +597,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp
 			}
-			if name == "" && period == "" {
+			if name == "" && period == "" && !*familySharable {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
 				return flag.ErrHelp
 			}
@@ -609,6 +617,10 @@ Examples:
 			if period != "" {
 				periodValue := string(period)
 				attrs.SubscriptionPeriod = &periodValue
+			}
+			if *familySharable {
+				val := true
+				attrs.FamilySharable = &val
 			}
 
 			resp, err := client.UpdateSubscription(requestCtx, id, attrs)


### PR DESCRIPTION
## Summary

- Expose `familySharable` API field as `--family-sharable` CLI flag on `iap create`, `iap update`, `subscriptions create`, and `subscriptions update`
- Update commands accept `--family-sharable` as a sole update flag (no "at least one update flag" error)
- Apple states family sharing cannot be disabled once enabled, so the flag is one-way (present = enable, absent = no change)

## Test plan

- [x] `TestIAPCreateFamilySharable` — verifies request body contains `"familySharable":true`
- [x] `TestIAPUpdateFamilySharableAsSoleFlag` — verifies `--family-sharable` alone is sufficient, no other attrs set
- [x] `TestSubscriptionsCreateFamilySharable` — same for subscriptions create
- [x] `TestSubscriptionsUpdateFamilySharableAsSoleFlag` — same for subscriptions update
- [x] `ASC_BYPASS_KEYCHAIN=1 make test` — full suite green
- [x] `make format` — clean
- [x] Help output verified: `asc iap create --help | grep family` etc.