### PR TITLE
fix: sync wall of apps count for main CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**36 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**37 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->


### PR DESCRIPTION
## Summary
- regenerate the Wall of Apps snippet in `README.md`
- update the stale app count from 36 to 37 to match `docs/wall-of-apps.json`
- unblock `Main Branch (with integration tests)` format-and-lint check on `main`

## Test plan
- [x] `make update-wall-of-apps`
- [x] `make format`
- [x] `make lint`
- [x] pre-commit short test suite ran during commit