### PR TITLE
docs: normalize Wall of Apps snippet spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ asc apps list --output table
 ## Wall of Apps
 
 **38 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->
 


### PR DESCRIPTION
## Summary
- sync the generated Wall of Apps snippet formatting in `README.md`
- restore the blank line after the Wall of Apps count line
- fix `Main Branch (with integration tests)` failure in `format-and-lint` (Check Wall of Apps generation)

## Test plan
- [x] `make update-wall-of-apps`
- [x] pre-commit checks ran on commit (format/lint/short tests)