### PR TITLE
Add LilyFM to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**38 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**39 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -90,6 +90,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "LilyFM",
+    "link": "https://apps.apple.com/app/id6745472149",
+    "creator": "Clark Zhou",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c0/43/6e/c0436e71-e3cc-763c-4ece-98ef2adae0da/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Lumical: Scan to Calendar",
     "link": "https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309",
     "creator": "arunavo4",


### PR DESCRIPTION
## Summary

- Add **LilyFM** to the Wall of Apps
- LilyFM is an AI-powered podcast app that converts web articles into high-quality audio podcasts
- Platform: iOS
- App Store: https://apps.apple.com/app/id6745472149

Generated using `make generate-app`.