### PR TITLE
feat: Support selecting price points by customer price in schedule creation

### DIFF
--- a/internal/cli/cmdtest/pricing_schedule_create_price_test.go
+++ b/internal/cli/cmdtest/pricing_schedule_create_price_test.go
@@ -1,0 +1,166 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPricingScheduleCreatePriceValidationError(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "schedule", "create",
+			"--app", "app-1",
+			"--price", "abc",
+			"--base-territory", "USA",
+			"--start-date", "2026-03-01",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --price must be a number") {
+		t.Fatalf("expected invalid number error, got %q", stderr)
+	}
+}
+
+func TestPricingScheduleCreatePriceValidationFiniteError(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "schedule", "create",
+			"--app", "app-1",
+			"--price", "NaN",
+			"--base-territory", "USA",
+			"--start-date", "2026-03-01",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --price must be a finite number") {
+		t.Fatalf("expected finite-number error, got %q", stderr)
+	}
+}
+
+func TestPricingScheduleCreateResolvesPriceUsingNumericMatch(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var pricePointsCalls int
+	var resolvedPricePointID string
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appPricePoints":
+			pricePointsCalls++
+			if got := req.URL.Query().Get("filter[territory]"); got != "USA" {
+				t.Fatalf("expected filter[territory]=USA, got %q", got)
+			}
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected limit=200, got %q", got)
+			}
+			body := `{
+				"data":[
+					{"type":"appPricePoints","id":"pp-099","attributes":{"customerPrice":"0.99"}}
+				],
+				"links":{"next":""}
+			}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appPriceSchedules":
+			var payload struct {
+				Included []struct {
+					Relationships struct {
+						AppPricePoint struct {
+							Data struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"appPricePoint"`
+					} `json:"relationships"`
+				} `json:"included"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode create payload: %v", err)
+			}
+			if len(payload.Included) == 0 {
+				t.Fatalf("expected included app price data in create payload")
+			}
+			resolvedPricePointID = payload.Included[0].Relationships.AppPricePoint.Data.ID
+
+			body := `{"data":{"type":"appPriceSchedules","id":"sched-1","attributes":{}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "schedule", "create",
+			"--app", "app-1",
+			"--price", "0.990",
+			"--base-territory", "USA",
+			"--start-date", "2026-03-01",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if pricePointsCalls != 1 {
+		t.Fatalf("expected one price-point lookup call, got %d", pricePointsCalls)
+	}
+	if resolvedPricePointID != "pp-099" {
+		t.Fatalf("expected resolved price point pp-099, got %q", resolvedPricePointID)
+	}
+	if !strings.Contains(stdout, `"id":"sched-1"`) {
+		t.Fatalf("expected schedule id in output, got %q", stdout)
+	}
+}

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -122,6 +122,47 @@ func TestPricingScheduleCreateCommand_MissingFlags(t *testing.T) {
 	}
 }
 
+func TestPricingScheduleCreateCommand_MutuallyExclusivePriceInputs(t *testing.T) {
+	cmd := PricingScheduleCreateCommand()
+
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "APP",
+		"--price-point", "PP",
+		"--price", "0.99",
+		"--base-territory", "USA",
+		"--start-date", "2024-03-01",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp when --price-point and --price are both set, got %v", err)
+	}
+}
+
+func TestPricingScheduleCreateCommand_InvalidPriceValue(t *testing.T) {
+	tests := []string{"abc", "NaN"}
+
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			cmd := PricingScheduleCreateCommand()
+
+			if err := cmd.FlagSet.Parse([]string{
+				"--app", "APP",
+				"--price", value,
+				"--base-territory", "USA",
+				"--start-date", "2024-03-01",
+			}); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp for invalid --price value %q, got %v", value, err)
+			}
+		})
+	}
+}
+
 func TestPricingScheduleCreateCommand_InvalidDate(t *testing.T) {
 	cmd := PricingScheduleCreateCommand()
 


### PR DESCRIPTION
This PR adds a `--price` flag to the `pricing schedule create` command, allowing users to select a price point by its customer price value (e.g., "0.99") instead of the opaque Price Point ID.\n\nWhen `--price` is provided:\n1. The CLI fetches all price points for the specified base territory.\n2. It finds the price point with a matching `customerPrice`.\n3. It uses that price point's ID to create the schedule.\n\nThis resolves #649 by providing a more user-friendly way to set prices, aligning with the "tier-based" selection request (as tiers map to prices).\n\nUsage:\n`asc pricing schedule create --app <ID> --base-territory USA --price "0.99" --start-date "2026-03-01"`