### PR TITLE
fix(web-auth): add debug diagnostics for 401 login failures

### DIFF
--- a/internal/cli/shared/debug_overrides_test.go
+++ b/internal/cli/shared/debug_overrides_test.go
@@ -1,0 +1,67 @@
+package shared
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestApplyRootLoggingOverridesDebugFalseWinsOverEnv(t *testing.T) {
+	t.Setenv("ASC_DEBUG", "1")
+	resetRootLoggingFlagsForTest()
+	asc.SetDebugOverride(nil)
+	asc.SetDebugHTTPOverride(nil)
+	asc.SetRetryLogOverride(nil)
+	t.Cleanup(func() {
+		resetRootLoggingFlagsForTest()
+		asc.SetDebugOverride(nil)
+		asc.SetDebugHTTPOverride(nil)
+		asc.SetRetryLogOverride(nil)
+	})
+
+	fs := flag.NewFlagSet("asc", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	BindRootFlags(fs)
+	if err := fs.Parse([]string{"--debug=false"}); err != nil {
+		t.Fatalf("parse root flags: %v", err)
+	}
+
+	ApplyRootLoggingOverrides()
+	if asc.ResolveDebugEnabled() {
+		t.Fatal("expected --debug=false to disable debug logging")
+	}
+}
+
+func TestApplyRootLoggingOverridesAPIDebugEnablesDebug(t *testing.T) {
+	t.Setenv("ASC_DEBUG", "")
+	resetRootLoggingFlagsForTest()
+	asc.SetDebugOverride(nil)
+	asc.SetDebugHTTPOverride(nil)
+	asc.SetRetryLogOverride(nil)
+	t.Cleanup(func() {
+		resetRootLoggingFlagsForTest()
+		asc.SetDebugOverride(nil)
+		asc.SetDebugHTTPOverride(nil)
+		asc.SetRetryLogOverride(nil)
+	})
+
+	fs := flag.NewFlagSet("asc", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	BindRootFlags(fs)
+	if err := fs.Parse([]string{"--api-debug"}); err != nil {
+		t.Fatalf("parse root flags: %v", err)
+	}
+
+	ApplyRootLoggingOverrides()
+	if !asc.ResolveDebugEnabled() {
+		t.Fatal("expected --api-debug to enable debug logging")
+	}
+}
+
+func resetRootLoggingFlagsForTest() {
+	retryLog = OptionalBool{}
+	debug = OptionalBool{}
+	apiDebug = OptionalBool{}
+}

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -399,6 +399,16 @@ func getASCClient() (*asc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	ApplyRootLoggingOverrides()
+	if strings.TrimSpace(resolved.keyPEM) != "" {
+		return asc.NewClientFromPEM(resolved.keyID, resolved.issuerID, resolved.keyPEM)
+	}
+	return asc.NewClient(resolved.keyID, resolved.issuerID, resolved.keyPath)
+}
+
+// ApplyRootLoggingOverrides applies root-level logging flag overrides
+// (--retry-log, --debug, --api-debug) into the shared ASC runtime.
+func ApplyRootLoggingOverrides() {
 	if retryLog.IsSet() {
 		value := retryLog.Value()
 		asc.SetRetryLogOverride(&value)
@@ -417,10 +427,6 @@ func getASCClient() (*asc.Client, error) {
 	} else {
 		asc.SetDebugHTTPOverride(nil)
 	}
-	if strings.TrimSpace(resolved.keyPEM) != "" {
-		return asc.NewClientFromPEM(resolved.keyID, resolved.issuerID, resolved.keyPEM)
-	}
-	return asc.NewClient(resolved.keyID, resolved.issuerID, resolved.keyPath)
 }
 
 func checkMixedCredentialSources(sources credentialSource) error {

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -121,6 +121,8 @@ func loginWithOptionalTwoFactor(ctx context.Context, appleID, password, twoFacto
 }
 
 func resolveSession(ctx context.Context, appleID, password, twoFactorCode string, usePasswordStdin bool) (*webcore.AuthSession, string, error) {
+	shared.ApplyRootLoggingOverrides()
+
 	appleID = strings.TrimSpace(appleID)
 	twoFactorCode = strings.TrimSpace(twoFactorCode)
 


### PR DESCRIPTION
## Summary
- apply root `--debug` / `--api-debug` runtime overrides to web-session auth flows so debug flags work for `asc web auth login`
- add sanitized web-auth HTTP diagnostics for each auth stage (status, request/correlation IDs, and service error codes) without leaking tokens/passwords/query secrets
- add tests for root logging override application and redaction/no-op behavior in web auth debug logging

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/web ./internal/cli/shared ./internal/cli/web ./internal/cli/cmdtest`
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

## Why this helps with 401s
- friend can run `asc --debug web auth login --apple-id \"...\"` (or `--api-debug`) and share request metadata + stage-level status/codes for diagnosis
- logs include Apple request IDs and service codes while keeping sensitive values redacted