### PR TITLE
fix(web): dedupe URL redaction and avoid prompt timeout regression

### DIFF
--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -160,13 +160,13 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
-			session, source, err := resolveSessionFn(requestCtx, *appleID, "", *twoFactorCode, *passwordStdin)
+			session, source, err := resolveSessionFn(ctx, *appleID, "", *twoFactorCode, *passwordStdin)
 			if err != nil {
 				return err
 			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
 			if source == "fresh" {
 				fmt.Fprintln(os.Stderr, "Authenticated via fresh web login.")
 			} else {

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -59,3 +59,35 @@ func TestWebAppsCreateDefersPasswordResolutionToResolveSession(t *testing.T) {
 		t.Fatalf("expected empty password argument, got %q", receivedPass)
 	}
 }
+
+func TestWebAppsCreateResolvesSessionBeforeTimeoutContext(t *testing.T) {
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+	})
+
+	resolveErr := errors.New("stop before network call")
+	hadDeadline := false
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string, usePasswordStdin bool) (*webcore.AuthSession, string, error) {
+		_, hadDeadline = ctx.Deadline()
+		return nil, "", resolveErr
+	}
+
+	cmd := WebAppsCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--name", "My App",
+		"--bundle-id", "com.example.app",
+		"--sku", "SKU123",
+		"--apple-id", "user@example.com",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, resolveErr) {
+		t.Fatalf("expected resolveSession error %v, got %v", resolveErr, err)
+	}
+	if hadDeadline {
+		t.Fatal("expected resolveSession to run before timeout context creation")
+	}
+}

--- a/internal/urlsanitize/urlsanitize.go
+++ b/internal/urlsanitize/urlsanitize.go
@@ -1,0 +1,117 @@
+package urlsanitize
+
+import (
+	"net/url"
+	"strings"
+)
+
+// DefaultSignedQueryKeys identifies query params that indicate signed URLs.
+var DefaultSignedQueryKeys = map[string]struct{}{
+	"x-amz-signature":     {},
+	"x-amz-credential":    {},
+	"x-amz-algorithm":     {},
+	"x-amz-signedheaders": {},
+	"signature":           {},
+	"key-pair-id":         {},
+	"policy":              {},
+	"sig":                 {},
+}
+
+// DefaultSensitiveQueryKeys identifies params that should be redacted in logs.
+var DefaultSensitiveQueryKeys = map[string]struct{}{
+	"x-amz-signature":      {},
+	"x-amz-credential":     {},
+	"x-amz-algorithm":      {},
+	"x-amz-signedheaders":  {},
+	"x-amz-security-token": {},
+	"signature":            {},
+	"key-pair-id":          {},
+	"policy":               {},
+	"sig":                  {},
+	"token":                {},
+	"access_token":         {},
+	"id_token":             {},
+	"refresh_token":        {},
+}
+
+// CopyKeySet returns a shallow copy of a key set map.
+func CopyKeySet(source map[string]struct{}) map[string]struct{} {
+	if len(source) == 0 {
+		return map[string]struct{}{}
+	}
+	cloned := make(map[string]struct{}, len(source))
+	for key := range source {
+		cloned[key] = struct{}{}
+	}
+	return cloned
+}
+
+// MergeKeySets returns a merged copy of all provided key sets.
+func MergeKeySets(sets ...map[string]struct{}) map[string]struct{} {
+	merged := make(map[string]struct{})
+	for _, set := range sets {
+		for key := range set {
+			merged[strings.ToLower(strings.TrimSpace(key))] = struct{}{}
+		}
+	}
+	return merged
+}
+
+// HasSignedQuery returns true when query contains a non-empty signing key value.
+func HasSignedQuery(values url.Values, signedKeys map[string]struct{}) bool {
+	if len(values) == 0 || len(signedKeys) == 0 {
+		return false
+	}
+	for key, vals := range values {
+		if _, ok := signedKeys[strings.ToLower(key)]; ok && hasNonEmptyValue(vals) {
+			return true
+		}
+	}
+	return false
+}
+
+// SanitizeURLForLog redacts sensitive URL fields while preserving shape.
+func SanitizeURLForLog(rawURL string, signedKeys, sensitiveKeys map[string]struct{}) string {
+	if rawURL == "" {
+		return ""
+	}
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if parsedURL.User != nil {
+		parsedURL.User = url.User("[REDACTED]")
+	}
+	values := parsedURL.Query()
+	if len(values) == 0 {
+		return parsedURL.String()
+	}
+	redactAll := HasSignedQuery(values, signedKeys)
+	for key, vals := range values {
+		if redactAll || isSensitiveQueryKey(key, sensitiveKeys) {
+			for i := range vals {
+				vals[i] = "[REDACTED]"
+			}
+			values[key] = vals
+		}
+	}
+	parsedURL.RawQuery = values.Encode()
+	return parsedURL.String()
+}
+
+func isSensitiveQueryKey(key string, sensitiveKeys map[string]struct{}) bool {
+	if len(sensitiveKeys) == 0 {
+		return false
+	}
+	_, ok := sensitiveKeys[strings.ToLower(key)]
+	return ok
+}
+
+func hasNonEmptyValue(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- extract URL redaction into a shared `internal/urlsanitize` helper and reuse it in both `internal/asc` and `internal/web` to remove duplicated sanitization logic
- align web auth signed-query detection with the shared default key set (including `x-amz-algorithm` and `x-amz-signedheaders`) to avoid drift
- move `web apps create` timeout-context creation after session resolution so interactive password entry no longer consumes the request timeout budget

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/urlsanitize ./internal/asc ./internal/web ./internal/cli/web ./internal/cli/cmdtest`
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`