### PR TITLE
Main branch failure fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**39 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**40 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->


### PR DESCRIPTION
## Summary

- Fixes `main` CI failure caused by an out-of-sync "Wall of Apps" count in `README.md`. Regenerated `README.md` to reflect the correct number of apps.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`
- [x] `make update-wall-of-apps` (verified no diff after running locally)
- [x] Cross-platform builds (verified locally)

## Wall of Apps (only if this PR adds/updates a Wall app)

- This PR fixes a generation issue in `README.md` and does not add or update a Wall app entry.

---
<p><a href="https://cursor.com/agents/bc-7518b654-d119-46b1-b58e-3bdf3b075a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7518b654-d119-46b1-b58e-3bdf3b075a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

