### PR TITLE
fix(game-center): make leaderboard-set members set work on empty sets

### DIFF
--- a/internal/asc/client_helpers.go
+++ b/internal/asc/client_helpers.go
@@ -21,6 +21,36 @@ func normalizeList(values []string) []string {
 	return normalized
 }
 
+func normalizeUniqueList(values []string) []string {
+	values = normalizeList(values)
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func sameOrderedList(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func normalizeUpperList(values []string) []string {
 	if len(values) == 0 {
 		return nil

--- a/internal/cli/cmdtest/game_center_leaderboard_set_members_mutations_test.go
+++ b/internal/cli/cmdtest/game_center_leaderboard_set_members_mutations_test.go
@@ -1,0 +1,210 @@
+package cmdtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func gcLeaderboardSetMembersJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestGameCenterLeaderboardSetMembersSetAddsMembersToEmptySet(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/gameCenterLeaderboardSets/set-1/gameCenterLeaderboards" {
+				t.Fatalf("expected path /v1/gameCenterLeaderboardSets/set-1/gameCenterLeaderboards, got %s", req.URL.Path)
+			}
+			if req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("expected limit=200, got %q", req.URL.Query().Get("limit"))
+			}
+
+			return gcLeaderboardSetMembersJSONResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards" {
+				t.Fatalf("expected path /v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards, got %s", req.URL.Path)
+			}
+
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			if !strings.Contains(string(payload), `"id":"lb-1"`) || !strings.Contains(string(payload), `"id":"lb-2"`) {
+				t.Fatalf("expected leaderboard ids lb-1/lb-2 in POST payload, got %s", string(payload))
+			}
+
+			return gcLeaderboardSetMembersJSONResponse(http.StatusNoContent, ""), nil
+		case 3:
+			if req.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards" {
+				t.Fatalf("expected path /v1/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards, got %s", req.URL.Path)
+			}
+
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			body := string(payload)
+			i1 := strings.Index(body, `"id":"lb-1"`)
+			i2 := strings.Index(body, `"id":"lb-2"`)
+			if i1 == -1 || i2 == -1 || i1 > i2 {
+				t.Fatalf("expected PATCH payload order lb-1,lb-2; got %s", body)
+			}
+
+			return gcLeaderboardSetMembersJSONResponse(http.StatusNoContent, ""), nil
+		default:
+			t.Fatalf("unexpected request #%d: %s %s", callCount, req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"game-center", "leaderboard-sets", "members", "set",
+			"--set-id", "set-1",
+			"--leaderboard-ids", "lb-1,lb-2",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"setId":"set-1"`) || !strings.Contains(stdout, `"memberCount":2`) || !strings.Contains(stdout, `"updated":true`) {
+		t.Fatalf("expected update result JSON in stdout, got %q", stdout)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 API calls, got %d", callCount)
+	}
+}
+
+func TestGameCenterLeaderboardSetMembersV2SetAddsMembersToEmptySet(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v2/gameCenterLeaderboardSets/set-1/gameCenterLeaderboards" {
+				t.Fatalf("expected path /v2/gameCenterLeaderboardSets/set-1/gameCenterLeaderboards, got %s", req.URL.Path)
+			}
+			if req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("expected limit=200, got %q", req.URL.Query().Get("limit"))
+			}
+
+			return gcLeaderboardSetMembersJSONResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards" {
+				t.Fatalf("expected path /v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards, got %s", req.URL.Path)
+			}
+
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			if !strings.Contains(string(payload), `"id":"lb-1"`) || !strings.Contains(string(payload), `"id":"lb-2"`) {
+				t.Fatalf("expected leaderboard ids lb-1/lb-2 in POST payload, got %s", string(payload))
+			}
+
+			return gcLeaderboardSetMembersJSONResponse(http.StatusNoContent, ""), nil
+		case 3:
+			if req.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", req.Method)
+			}
+			if req.URL.Path != "/v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards" {
+				t.Fatalf("expected path /v2/gameCenterLeaderboardSets/set-1/relationships/gameCenterLeaderboards, got %s", req.URL.Path)
+			}
+
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			body := string(payload)
+			i1 := strings.Index(body, `"id":"lb-1"`)
+			i2 := strings.Index(body, `"id":"lb-2"`)
+			if i1 == -1 || i2 == -1 || i1 > i2 {
+				t.Fatalf("expected PATCH payload order lb-1,lb-2; got %s", body)
+			}
+
+			return gcLeaderboardSetMembersJSONResponse(http.StatusNoContent, ""), nil
+		default:
+			t.Fatalf("unexpected request #%d: %s %s", callCount, req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"game-center", "leaderboard-sets", "v2", "members", "set",
+			"--set-id", "set-1",
+			"--leaderboard-ids", "lb-1,lb-2",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"setId":"set-1"`) || !strings.Contains(stdout, `"memberCount":2`) || !strings.Contains(stdout, `"updated":true`) {
+		t.Fatalf("expected update result JSON in stdout, got %q", stdout)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 API calls, got %d", callCount)
+	}
+}

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members.go
@@ -162,7 +162,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			if err := client.UpdateGameCenterLeaderboardSetMembers(requestCtx, id, ids); err != nil {
+			if err := client.SetGameCenterLeaderboardSetMembers(requestCtx, id, ids); err != nil {
 				return fmt.Errorf("game-center leaderboard-sets members set: failed to update: %w", err)
 			}
 

--- a/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
@@ -509,7 +509,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			if err := client.UpdateGameCenterLeaderboardSetMembersV2(requestCtx, id, ids); err != nil {
+			if err := client.SetGameCenterLeaderboardSetMembersV2(requestCtx, id, ids); err != nil {
 				return fmt.Errorf("game-center leaderboard-sets v2 members set: failed to update: %w", err)
 			}
 


### PR DESCRIPTION
## Summary
- Implement true set semantics for leaderboard-set member updates in both v1 and v2: list current members, add missing members, remove extra members, then patch to enforce final order.
- Wire `asc game-center leaderboard-sets members set` and `asc game-center leaderboard-sets v2 members set` to the new set-semantics client methods.
- Add CLI mutation tests that reproduce the empty-set population case and verify the expected GET -> POST -> PATCH flow for both v1 and v2.

Closes #800

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] Live smoke test on `ASC Test 20260216074703`:
  - create empty leaderboard set + new leaderboards
  - run `asc game-center leaderboard-sets members set --set-id ... --leaderboard-ids ...` (exit 0, members total: 0 -> 2)
  - run `asc game-center leaderboard-sets v2 members set --set-id ... --leaderboard-ids ...` (exit 0, members total: 0 -> 2)