### PR TITLE
Add Popcorn Stack to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**44 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**45 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -166,6 +166,13 @@
     "platform": ["iOS", "macOS"]
   },
   {
+    "app": "Popcorn Stack: Track Watchlist",
+    "link": "https://apps.apple.com/app/id6759187614",
+    "creator": "maail",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4f/b6/ed/4fb6edea-943d-13e3-3753-b99ee1920c7b/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Positive",
     "link": "https://apps.apple.com/us/app/positive/id653287635",
     "creator": "DanielStormApps",


### PR DESCRIPTION
Adds [Popcorn Stack: Track Watchlist](https://apps.apple.com/app/id6759187614) to the Wall of Apps.

Popcorn Stack is a personal entertainment tracker for movies, TV shows, and anime — built and shipped with `asc`.

- Updated `docs/wall-of-apps.json` with the new entry (alphabetical order)
- Bumped the app count in `README.md` from 44 → 45