### PR TITLE
Add Tamloot to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**45 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**46 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -250,6 +250,13 @@
     "platform": ["macOS"]
   },
   {
+    "app": "Tamloot",
+    "link": "https://apps.apple.com/il/app/tamloot/id6758220887",
+    "creator": "shalomma",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/26/a3/f7/26a3f7f9-3cb6-dc8e-fcbd-0fc93630dd4c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Timefall",
     "link": "https://apps.apple.com/app/id6757712804",
     "creator": "vatrueshka",


### PR DESCRIPTION
Adds [Tamloot](https://apps.apple.com/il/app/tamloot/id6758220887) to the Wall of Apps.

Tamloot is a SaaS for therapists — it records and transcribes Zoom and Google Meet sessions, then generates AI-powered session notes.

- Updated `docs/wall-of-apps.json` with the new entry (alphabetical order)
- Bumped the app count in `README.md` from 45 → 46