### PR TITLE
Add TickerPad to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**47 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**48 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -257,6 +257,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "TickerPad",
+    "link": "https://apps.apple.com/app/id1578860989",
+    "creator": "daimajia",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3f/a0/10/3fa0108a-9671-6045-d0bb-a546a27645f5/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.jpg",
+    "platform": ["macOS"]
+  },
+  {
     "app": "Timefall",
     "link": "https://apps.apple.com/app/id6757712804",
     "creator": "vatrueshka",


### PR DESCRIPTION
## Summary

Add TickerPad to wall of apps.  

[TickerPad](https://tickerpad.app) : Real-time crypto prices in your macOS menu bar. 

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
    "app": "TickerPad",
    "link": "https://apps.apple.com/app/id1578860989",
    "creator": "daimajia",
    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3f/a0/10/3fa0108a-9671-6045-d0bb-a546a27645f5/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.jpg",
    "platform": ["macOS"]
  }
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
