### PR TITLE
feat: add 시선 app to wall of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**48 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**49 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -332,5 +332,12 @@
     "creator": "arunavo4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d7/4d/4c/d74d4c07-c147-fa7e-86fe-cff01727629b/XO-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
+  },
+  {
+    "app": "시선 - 사진 한 장, 시 한 줄",
+    "link": "https://apps.apple.com/app/id6748271659",
+    "creator": "evanyi",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/61/84/82/61848267-44c7-31d7-a46e-250c2bc09495/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
   }
 ]


### PR DESCRIPTION
## Summary

  - Add "시선 - 사진 한 장, 시 한 줄" to Wall of Apps (`docs/wall-of-apps.json`)
  - Update Wall of Apps count in `README.md` from 48 to 49

## Validation

- [ ] `make format`
- [ ] `make lint`
- [ ] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
  {
    "app": "시선 - 사진 한 장, 시 한 줄",
    "link": "https://apps.apple.com/app/id6748271659",
    "creator": "evanyi",
    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/61/84/82/61848267-44c7-31d7-a46e-250c2bc09495/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg",
    "platform": ["iOS"]
  }
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
