### PR TITLE
Incorrect account context

### DIFF
--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -627,6 +627,70 @@ func TestResolvePrivateKeyPathFromRawValue(t *testing.T) {
 	}
 }
 
+func TestResolvePrivateKeyPathRefreshesWhenRawValueChanges(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	t.Setenv("ASC_PRIVATE_KEY", "account-a-key")
+	firstPath, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() first call error: %v", err)
+	}
+	firstData, err := os.ReadFile(firstPath)
+	if err != nil {
+		t.Fatalf("ReadFile(firstPath) error: %v", err)
+	}
+	if string(firstData) != "account-a-key" {
+		t.Fatalf("expected first key data %q, got %q", "account-a-key", string(firstData))
+	}
+
+	t.Setenv("ASC_PRIVATE_KEY", "account-b-key")
+	secondPath, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() second call error: %v", err)
+	}
+	secondData, err := os.ReadFile(secondPath)
+	if err != nil {
+		t.Fatalf("ReadFile(secondPath) error: %v", err)
+	}
+	if string(secondData) != "account-b-key" {
+		t.Fatalf("expected updated key data %q, got %q", "account-b-key", string(secondData))
+	}
+}
+
+func TestResolvePrivateKeyPathRefreshesWhenBase64ValueChanges(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	t.Setenv("ASC_PRIVATE_KEY_B64", base64.StdEncoding.EncodeToString([]byte("account-a-key")))
+	firstPath, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() first call error: %v", err)
+	}
+	firstData, err := os.ReadFile(firstPath)
+	if err != nil {
+		t.Fatalf("ReadFile(firstPath) error: %v", err)
+	}
+	if string(firstData) != "account-a-key" {
+		t.Fatalf("expected first key data %q, got %q", "account-a-key", string(firstData))
+	}
+
+	t.Setenv("ASC_PRIVATE_KEY_B64", base64.StdEncoding.EncodeToString([]byte("account-b-key")))
+	secondPath, err := resolvePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolvePrivateKeyPath() second call error: %v", err)
+	}
+	secondData, err := os.ReadFile(secondPath)
+	if err != nil {
+		t.Fatalf("ReadFile(secondPath) error: %v", err)
+	}
+	if string(secondData) != "account-b-key" {
+		t.Fatalf("expected updated key data %q, got %q", "account-b-key", string(secondData))
+	}
+}
+
 func TestCleanupTempPrivateKeysRemovesFile(t *testing.T) {
 	resetPrivateKeyTemp(t)
 	t.Setenv("ASC_PRIVATE_KEY_PATH", "")


### PR DESCRIPTION
## Summary

- Fixed an issue where private key material from `ASC_PRIVATE_KEY` or `ASC_PRIVATE_KEY_B64` environment variables was cached globally and could lead to stale key reuse when switching accounts within the same process. The temporary key cache is now keyed by the hashed content of the private key, ensuring fresh key resolution on environment variable changes.
- Added regression tests to verify that private key material is correctly refreshed when `ASC_PRIVATE_KEY` and `ASC_PRIVATE_KEY_B64` values change.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.

---
<p><a href="https://cursor.com/agents/bc-32429de6-4743-4272-b62f-e48e9d91f71f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32429de6-4743-4272-b62f-e48e9d91f71f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

