### PR TITLE
docs(wall): add Foundation Lab TestFlight entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asc apps list --output table
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**51 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**52 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -76,6 +76,12 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Foundation Lab",
+    "link": "https://testflight.apple.com/join/JWR9FpP3",
+    "creator": "rudrankriyam",
+    "platform": ["iOS", "macOS"]
+  },
+  {
     "app": "Fuel: AI Nutrition",
     "link": "https://apps.apple.com/app/id6748624107",
     "creator": "0xSMW",


### PR DESCRIPTION
## Summary
- add Foundation Lab to the Wall of Apps
- use the TestFlight link from the Foundation Models Framework Example README

## App entry
- app: Foundation Lab
- link: https://testflight.apple.com/join/JWR9FpP3
- creator: rudrankriyam
- platform: iOS, macOS
