### PR TITLE
fix(subscriptions): use PATCH with inline prices for initial subscription pricing

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6919,6 +6919,77 @@ func TestDeleteSubscription(t *testing.T) {
 	}
 }
 
+func TestSetSubscriptionInitialPrice(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.sub.monthly"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptions/sub-1" {
+			t.Fatalf("expected path /v1/subscriptions/sub-1, got %s", req.URL.Path)
+		}
+
+		var payload SubscriptionUpdateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if payload.Data.Type != ResourceTypeSubscriptions {
+			t.Fatalf("expected type subscriptions, got %q", payload.Data.Type)
+		}
+		if payload.Data.ID != "sub-1" {
+			t.Fatalf("expected subscription ID sub-1, got %q", payload.Data.ID)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.Prices == nil {
+			t.Fatalf("expected prices relationship in payload")
+		}
+		if len(payload.Data.Relationships.Prices.Data) != 1 {
+			t.Fatalf("expected one relationship price item, got %d", len(payload.Data.Relationships.Prices.Data))
+		}
+		if payload.Data.Relationships.Prices.Data[0].Type != ResourceTypeSubscriptionPrices || payload.Data.Relationships.Prices.Data[0].ID != "${price-1}" {
+			t.Fatalf("unexpected relationships.prices item: %+v", payload.Data.Relationships.Prices.Data[0])
+		}
+		if len(payload.Included) != 1 {
+			t.Fatalf("expected one included item, got %d", len(payload.Included))
+		}
+
+		included := payload.Included[0]
+		if included.Type != ResourceTypeSubscriptionPrices || included.ID != "${price-1}" {
+			t.Fatalf("unexpected included item: %+v", included)
+		}
+		if included.Attributes == nil {
+			t.Fatal("expected included attributes to be present")
+		}
+		if included.Attributes.StartDate != "2026-01-01" {
+			t.Fatalf("expected startDate 2026-01-01, got %q", included.Attributes.StartDate)
+		}
+		if included.Attributes.Preserved == nil || !*included.Attributes.Preserved {
+			t.Fatalf("expected preserveCurrentPrice=true, got %+v", included.Attributes.Preserved)
+		}
+		if included.Relationships.Subscription.Data.Type != ResourceTypeSubscriptions || included.Relationships.Subscription.Data.ID != "sub-1" {
+			t.Fatalf("unexpected included subscription relationship: %+v", included.Relationships.Subscription.Data)
+		}
+		if included.Relationships.SubscriptionPricePoint.Data.Type != ResourceTypeSubscriptionPricePoints || included.Relationships.SubscriptionPricePoint.Data.ID != "price-point-1" {
+			t.Fatalf("unexpected included subscriptionPricePoint relationship: %+v", included.Relationships.SubscriptionPricePoint.Data)
+		}
+		if included.Relationships.Territory == nil {
+			t.Fatal("expected included territory relationship")
+		}
+		if included.Relationships.Territory.Data.Type != ResourceTypeTerritories || included.Relationships.Territory.Data.ID != "USA" {
+			t.Fatalf("unexpected included territory relationship: %+v", included.Relationships.Territory.Data)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	preserved := true
+	attrs := SubscriptionPriceCreateAttributes{
+		StartDate: "2026-01-01",
+		Preserved: &preserved,
+	}
+	if _, err := client.SetSubscriptionInitialPrice(context.Background(), "sub-1", "price-point-1", "USA", attrs); err != nil {
+		t.Fatalf("SetSubscriptionInitialPrice() error: %v", err)
+	}
+}
+
 func TestCreateSubscriptionPrice(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01","preserved":true}}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -241,11 +241,30 @@ func (c *Client) UpdateSubscription(ctx context.Context, subID string, attrs Sub
 // SubscriptionPriceInlineCreate resources, which is the only supported method
 // for setting the first price on a new subscription. POST /v1/subscriptionPrices
 // only works for price *changes* on subscriptions that already have a price.
-func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePointID string) (*SubscriptionResponse, error) {
+func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePointID, territoryID string, attrs SubscriptionPriceCreateAttributes) (*SubscriptionResponse, error) {
 	subID = strings.TrimSpace(subID)
 	pricePointID = strings.TrimSpace(pricePointID)
+	territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
 	if subID == "" || pricePointID == "" {
 		return nil, fmt.Errorf("subscription ID and price point ID are required")
+	}
+
+	var attributes *SubscriptionPriceCreateAttributes
+	if attrs.StartDate != "" || attrs.Preserved != nil {
+		attributes = &attrs
+	}
+
+	relationships := SubscriptionPriceInlineRelationships{
+		Subscription:           Relationship{Data: ResourceData{Type: ResourceTypeSubscriptions, ID: subID}},
+		SubscriptionPricePoint: Relationship{Data: ResourceData{Type: ResourceTypeSubscriptionPricePoints, ID: pricePointID}},
+	}
+	if territoryID != "" {
+		relationships.Territory = &Relationship{
+			Data: ResourceData{
+				Type: ResourceTypeTerritories,
+				ID:   territoryID,
+			},
+		}
 	}
 
 	inlinePriceID := "${price-1}"
@@ -263,12 +282,10 @@ func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePo
 		},
 		Included: []SubscriptionPriceInlineCreate{
 			{
-				Type: ResourceTypeSubscriptionPrices,
-				ID:   inlinePriceID,
-				Relationships: SubscriptionPriceInlineRelationships{
-					Subscription:           Relationship{Data: ResourceData{Type: ResourceTypeSubscriptions, ID: subID}},
-					SubscriptionPricePoint: Relationship{Data: ResourceData{Type: ResourceTypeSubscriptionPricePoints, ID: pricePointID}},
-				},
+				Type:          ResourceTypeSubscriptionPrices,
+				ID:            inlinePriceID,
+				Attributes:    attributes,
+				Relationships: relationships,
 			},
 		},
 	}

--- a/internal/asc/subscriptions.go
+++ b/internal/asc/subscriptions.go
@@ -124,13 +124,15 @@ type SubscriptionUpdateRequest struct {
 type SubscriptionPriceInlineCreate struct {
 	Type          ResourceType                         `json:"type"`
 	ID            string                               `json:"id"`
+	Attributes    *SubscriptionPriceCreateAttributes   `json:"attributes,omitempty"`
 	Relationships SubscriptionPriceInlineRelationships `json:"relationships"`
 }
 
 // SubscriptionPriceInlineRelationships describes relationships for an inline price create.
 type SubscriptionPriceInlineRelationships struct {
-	Subscription           Relationship `json:"subscription"`
-	SubscriptionPricePoint Relationship `json:"subscriptionPricePoint"`
+	Subscription           Relationship  `json:"subscription"`
+	SubscriptionPricePoint Relationship  `json:"subscriptionPricePoint"`
+	Territory              *Relationship `json:"territory,omitempty"`
 }
 
 // SubscriptionPriceAttributes describes a subscription price resource.

--- a/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
@@ -2,6 +2,7 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -112,6 +113,158 @@ func TestSubscriptionsPricesAdd_TierUsesSubscriptionPricePoints(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"sub-price-1"`) {
 		t.Fatalf("expected create output, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsPricesAdd_ProbeErrorReturnsWithoutWrite(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/relationships/prices"):
+			body := `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"An unexpected error occurred.","detail":"An unexpected error occurred on the server side."}]}`
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPatch && strings.Contains(req.URL.Path, "/v1/subscriptions/"):
+			t.Fatalf("unexpected PATCH write request after failed probe: %s", req.URL.Path)
+			return nil, nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/subscriptionPrices"):
+			t.Fatalf("unexpected POST write request after failed probe: %s", req.URL.Path)
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "prices", "add",
+			"--id", "SUB_ID",
+			"--price-point", "PP_ID",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected command to fail when prices probe fails")
+		}
+		if !strings.Contains(err.Error(), "failed to check existing prices") {
+			t.Fatalf("expected probe error message, got %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsPricesAdd_InitialPriceForwardsAttributes(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/relationships/prices"):
+			body := `{"data":[],"links":{}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPatch && strings.Contains(req.URL.Path, "/v1/subscriptions/SUB_ID"):
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode patch payload: %v", err)
+			}
+
+			includedAny, ok := payload["included"].([]any)
+			if !ok || len(includedAny) != 1 {
+				t.Fatalf("expected one included resource, got %#v", payload["included"])
+			}
+			included, ok := includedAny[0].(map[string]any)
+			if !ok {
+				t.Fatalf("expected included resource object, got %#v", includedAny[0])
+			}
+
+			attrs, ok := included["attributes"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected included attributes object, got %#v", included["attributes"])
+			}
+			if attrs["startDate"] != "2026-05-01" {
+				t.Fatalf("expected startDate 2026-05-01, got %#v", attrs["startDate"])
+			}
+			if attrs["preserveCurrentPrice"] != true {
+				t.Fatalf("expected preserveCurrentPrice true, got %#v", attrs["preserveCurrentPrice"])
+			}
+
+			relationships, ok := included["relationships"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected included relationships object, got %#v", included["relationships"])
+			}
+			territory, ok := relationships["territory"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected territory relationship object, got %#v", relationships["territory"])
+			}
+			territoryData, ok := territory["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected territory.data object, got %#v", territory["data"])
+			}
+			if territoryData["id"] != "USA" {
+				t.Fatalf("expected territory id USA, got %#v", territoryData["id"])
+			}
+
+			resp := `{"data":{"type":"subscriptions","id":"SUB_ID","attributes":{"name":"Monthly","productId":"com.example.sub.monthly"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(resp)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/subscriptionPrices"):
+			t.Fatalf("unexpected POST request; initial pricing should use PATCH flow")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "prices", "add",
+			"--id", "SUB_ID",
+			"--price-point", "PP_ID",
+			"--territory", "USA",
+			"--start-date", "2026-05-01",
+			"--preserved",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"SUB_ID"`) {
+		t.Fatalf("expected subscription response in stdout, got %q", stdout)
 	}
 }
 

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -886,19 +886,6 @@ Examples:
 			}
 			hasExistingPrices := len(existingPrices.Data) > 0
 
-			if !hasExistingPrices {
-				if strings.TrimSpace(*startDate) != "" || *preserved {
-					fmt.Fprintln(os.Stderr, "Note: --start-date and --preserved are ignored when setting the initial price")
-				}
-				// Initial price: use PATCH with inline resources
-				subResp, err := client.SetSubscriptionInitialPrice(requestCtx, id, pricePoint)
-				if err != nil {
-					return fmt.Errorf("subscriptions prices add: failed to set initial price: %w", err)
-				}
-				return shared.PrintOutput(subResp, *output.Output, *output.Pretty)
-			}
-
-			// Existing prices: use POST /v1/subscriptionPrices for a price change
 			attrs := asc.SubscriptionPriceCreateAttributes{
 				StartDate: strings.TrimSpace(*startDate),
 			}
@@ -906,6 +893,16 @@ Examples:
 				attrs.Preserved = preserved
 			}
 
+			if !hasExistingPrices {
+				// Initial price: use PATCH with inline resources
+				subResp, err := client.SetSubscriptionInitialPrice(requestCtx, id, pricePoint, territoryID, attrs)
+				if err != nil {
+					return fmt.Errorf("subscriptions prices add: failed to set initial price: %w", err)
+				}
+				return shared.PrintOutput(subResp, *output.Output, *output.Pretty)
+			}
+
+			// Existing prices: use POST /v1/subscriptionPrices for a price change
 			resp, err := client.CreateSubscriptionPrice(requestCtx, id, pricePoint, territoryID, attrs)
 			if err != nil {
 				return fmt.Errorf("subscriptions prices add: failed to create: %w", err)


### PR DESCRIPTION
## Summary

- **`POST /v1/subscriptionPrices`** is Apple's "Create a Subscription Price Change" endpoint — it only works on subscriptions that already have at least one price. For new subscriptions, it returns a `500 UNEXPECTED_ERROR`.
- The correct way to set the **initial base price** on a new subscription is via **`PATCH /v1/subscriptions/{id}`** with inline `SubscriptionPriceInlineCreate` resources in the `included` array (same pattern as IAP pricing via `inAppPurchasePriceSchedules`).
- `asc subscriptions prices add` now **auto-detects** whether the subscription has existing prices and routes to the correct endpoint automatically — no flags or user action needed.

### Changes

1. **`internal/asc/subscriptions.go`** — Added `SubscriptionPriceInlineCreate`, `SubscriptionPriceInlineRelationships`, and `SubscriptionUpdateRelationships` types; updated `SubscriptionUpdateData` and `SubscriptionUpdateRequest` to support the `included` array.
2. **`internal/asc/client_subscriptions.go`** — Added `SetSubscriptionInitialPrice` method that builds the PATCH payload with inline price resources.
3. **`internal/cli/subscriptions/subscriptions.go`** — Added auto-detection in the `prices add` command: checks `GetSubscriptionPricesRelationships` to see if prices exist, then routes to `SetSubscriptionInitialPrice` (initial) or `CreateSubscriptionPrice` (change).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/asc/... ./internal/cli/subscriptions/...` passes
- [x] Manually tested against App Store Connect: successfully set initial prices on two new subscriptions (monthly $2.99, yearly $19.99) that previously failed with 500 errors
- [ ] Verify price change flow still works on subscriptions with existing prices

Fixes #828