### PR TITLE
refactor(cli): standardize usage errors and pagination loops

### DIFF
--- a/internal/cli/iap/prices.go
+++ b/internal/cli/iap/prices.go
@@ -443,49 +443,57 @@ func fetchManualSchedulePricePointValues(
 	scheduleID string,
 	territoryID string,
 ) (map[string]iapPricePointValue, string, error) {
-	page, err := client.GetInAppPurchasePriceScheduleManualPrices(
-		ctx,
-		scheduleID,
-		asc.WithIAPPriceSchedulePricesInclude([]string{"inAppPurchasePricePoint", "territory"}),
-		asc.WithIAPPriceSchedulePricesFields([]string{"manual", "inAppPurchasePricePoint", "territory"}),
-		asc.WithIAPPriceSchedulePricesPricePointFields([]string{"customerPrice", "proceeds", "territory"}),
-		asc.WithIAPPriceSchedulePricesTerritoryFields([]string{"currency"}),
-		asc.WithIAPPriceSchedulePricesLimit(200),
-	)
+	values := make(map[string]iapPricePointValue)
+	currency := ""
+
+	fetchPage := func(nextURL string) (*asc.InAppPurchasePricesResponse, error) {
+		if strings.TrimSpace(nextURL) == "" {
+			return client.GetInAppPurchasePriceScheduleManualPrices(
+				ctx,
+				scheduleID,
+				asc.WithIAPPriceSchedulePricesInclude([]string{"inAppPurchasePricePoint", "territory"}),
+				asc.WithIAPPriceSchedulePricesFields([]string{"manual", "inAppPurchasePricePoint", "territory"}),
+				asc.WithIAPPriceSchedulePricesPricePointFields([]string{"customerPrice", "proceeds", "territory"}),
+				asc.WithIAPPriceSchedulePricesTerritoryFields([]string{"currency"}),
+				asc.WithIAPPriceSchedulePricesLimit(200),
+			)
+		}
+		return client.GetInAppPurchasePriceScheduleManualPrices(
+			ctx,
+			scheduleID,
+			asc.WithIAPPriceSchedulePricesNextURL(nextURL),
+		)
+	}
+
+	firstPage, err := fetchPage("")
 	if err != nil {
 		return nil, "", fmt.Errorf("fetch manual schedule price point values: %w", err)
 	}
 
-	values := make(map[string]iapPricePointValue)
-	currency := ""
-	seenNext := make(map[string]struct{})
+	if err := asc.PaginateEach(
+		ctx,
+		firstPage,
+		func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return fetchPage(nextURL)
+		},
+		func(page asc.PaginatedResponse) error {
+			typed, ok := page.(*asc.InAppPurchasePricesResponse)
+			if !ok {
+				return fmt.Errorf("unexpected response type %T", page)
+			}
 
-	for {
-		pageValues, pageCurrency, err := parseManualSchedulePricePointValues(page.Included, territoryID)
-		if err != nil {
-			return nil, "", err
-		}
-		maps.Copy(values, pageValues)
-		if currency == "" && pageCurrency != "" {
-			currency = pageCurrency
-		}
-
-		if page.Links.Next == "" {
-			break
-		}
-		if _, exists := seenNext[page.Links.Next]; exists {
-			return nil, "", fmt.Errorf("paginate manual schedule price point values: %w", asc.ErrRepeatedPaginationURL)
-		}
-		seenNext[page.Links.Next] = struct{}{}
-
-		page, err = client.GetInAppPurchasePriceScheduleManualPrices(
-			ctx,
-			scheduleID,
-			asc.WithIAPPriceSchedulePricesNextURL(page.Links.Next),
-		)
-		if err != nil {
-			return nil, "", fmt.Errorf("paginate manual schedule price point values: %w", err)
-		}
+			pageValues, pageCurrency, err := parseManualSchedulePricePointValues(typed.Included, territoryID)
+			if err != nil {
+				return err
+			}
+			maps.Copy(values, pageValues)
+			if currency == "" && pageCurrency != "" {
+				currency = pageCurrency
+			}
+			return nil
+		},
+	); err != nil {
+		return nil, "", fmt.Errorf("paginate manual schedule price point values: %w", err)
 	}
 
 	return values, currency, nil

--- a/internal/cli/shared/command_builders.go
+++ b/internal/cli/shared/command_builders.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -60,8 +59,7 @@ func BuildIDGetCommand(config IDGetCommandConfig) *ffcli.Command {
 		Exec: func(ctx context.Context, args []string) error {
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
-				fmt.Fprintf(os.Stderr, "Error: --%s is required\n", idFlagName)
-				return flag.ErrHelp
+				return UsageErrorf("--%s is required", idFlagName)
 			}
 
 			client, err := GetASCClient()
@@ -148,8 +146,7 @@ func BuildPaginatedListCommand(config PaginatedListCommandConfig) *ffcli.Command
 
 			resolvedParentID := strings.TrimSpace(*parentID)
 			if resolvedParentID == "" && strings.TrimSpace(*next) == "" {
-				fmt.Fprintf(os.Stderr, "Error: --%s is required\n", parentFlagName)
-				return flag.ErrHelp
+				return UsageErrorf("--%s is required", parentFlagName)
 			}
 
 			client, err := GetASCClient()
@@ -238,12 +235,10 @@ func BuildConfirmDeleteCommand(config ConfirmDeleteCommandConfig) *ffcli.Command
 		Exec: func(ctx context.Context, args []string) error {
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
-				fmt.Fprintf(os.Stderr, "Error: --%s is required\n", idFlagName)
-				return flag.ErrHelp
+				return UsageErrorf("--%s is required", idFlagName)
 			}
 			if !*confirm {
-				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return UsageError("--confirm is required")
 			}
 
 			client, err := GetASCClient()

--- a/internal/cli/shared/command_builders_test.go
+++ b/internal/cli/shared/command_builders_test.go
@@ -1,0 +1,107 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type testPaginatedResponse struct{}
+
+func (r *testPaginatedResponse) GetLinks() *asc.Links {
+	return &asc.Links{}
+}
+
+func (r *testPaginatedResponse) GetData() any {
+	return nil
+}
+
+func TestBuildIDGetCommand_MissingIDReturnsUsageError(t *testing.T) {
+	cmd := BuildIDGetCommand(IDGetCommandConfig{
+		FlagSetName: "test-id-get",
+		Name:        "get",
+		ShortUsage:  "test get",
+		ShortHelp:   "test",
+		ErrorPrefix: "test get",
+		Fetch:       func(context.Context, *asc.Client, string) (any, error) { return nil, nil },
+		ContextTimeout: func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return context.WithCancel(ctx)
+		},
+	})
+
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --id is required") {
+		t.Fatalf("expected missing id usage error, got %q", stderr)
+	}
+}
+
+func TestBuildPaginatedListCommand_MissingParentIDReturnsUsageError(t *testing.T) {
+	cmd := BuildPaginatedListCommand(PaginatedListCommandConfig{
+		FlagSetName: "test-list",
+		Name:        "list",
+		ShortUsage:  "test list",
+		ShortHelp:   "test",
+		ParentFlag:  "app-id",
+		ErrorPrefix: "test list",
+		FetchPage: func(context.Context, *asc.Client, string, int, string) (asc.PaginatedResponse, error) {
+			return &testPaginatedResponse{}, nil
+		},
+		ContextTimeout: func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return context.WithCancel(ctx)
+		},
+	})
+
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --app-id is required") {
+		t.Fatalf("expected missing app-id usage error, got %q", stderr)
+	}
+}
+
+func TestBuildConfirmDeleteCommand_MissingConfirmReturnsUsageError(t *testing.T) {
+	cmd := BuildConfirmDeleteCommand(ConfirmDeleteCommandConfig{
+		FlagSetName: "test-delete",
+		Name:        "delete",
+		ShortUsage:  "test delete",
+		ShortHelp:   "test",
+		ErrorPrefix: "test delete",
+		Delete:      func(context.Context, *asc.Client, string) error { return nil },
+		Result:      func(string) any { return map[string]string{"status": "ok"} },
+		ContextTimeout: func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return context.WithCancel(ctx)
+		},
+	})
+
+	if err := cmd.FlagSet.Parse([]string{"--id", "abc"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --confirm is required") {
+		t.Fatalf("expected missing confirm usage error, got %q", stderr)
+	}
+}

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -90,8 +90,7 @@ Examples:
 				return fmt.Errorf("subscriptions price-points list: %w", err)
 			}
 			if *stream && !*paginate {
-				fmt.Fprintln(os.Stderr, "Error: --stream requires --paginate")
-				return flag.ErrHelp
+				return shared.UsageError("--stream requires --paginate")
 			}
 
 			priceFilter := shared.PriceFilter{
@@ -103,14 +102,12 @@ Examples:
 				return shared.UsageError(err.Error())
 			}
 			if priceFilter.HasFilter() && *stream {
-				fmt.Fprintln(os.Stderr, "Error: price filtering is not supported with --stream")
-				return flag.ErrHelp
+				return shared.UsageError("price filtering is not supported with --stream")
 			}
 
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.UsageError("--subscription-id is required")
 			}
 
 			client, err := shared.GetASCClient()
@@ -136,27 +133,23 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("subscriptions price-points list: failed to fetch: %w", err)
 				}
-
-				seenNext := make(map[string]struct{})
-				for {
-					if err := shared.PrintStreamPage(page); err != nil {
-						return fmt.Errorf("subscriptions price-points list: write stream page: %w", err)
-					}
-
-					if page.Links.Next == "" {
-						break
-					}
-					if _, exists := seenNext[page.Links.Next]; exists {
-						return fmt.Errorf("subscriptions price-points list: %w", asc.ErrRepeatedPaginationURL)
-					}
-					seenNext[page.Links.Next] = struct{}{}
-
-					pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-					page, err = client.GetSubscriptionPricePoints(pageCtx, id, asc.WithSubscriptionPricePointsNextURL(page.Links.Next))
-					pageCancel()
-					if err != nil {
-						return fmt.Errorf("subscriptions price-points list: %w", err)
-					}
+				if err := asc.PaginateEach(
+					ctx,
+					page,
+					func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+						pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
+						defer pageCancel()
+						return client.GetSubscriptionPricePoints(pageCtx, id, asc.WithSubscriptionPricePointsNextURL(nextURL))
+					},
+					func(page asc.PaginatedResponse) error {
+						typed, ok := page.(*asc.SubscriptionPricePointsResponse)
+						if !ok {
+							return fmt.Errorf("unexpected pagination response type %T", page)
+						}
+						return shared.PrintStreamPage(typed)
+					},
+				); err != nil {
+					return fmt.Errorf("subscriptions price-points list: %w", err)
 				}
 				return nil
 			}

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -498,54 +498,57 @@ func fetchSubscriptionPricePointsByTerritory(
 	territoryID string,
 ) (map[string][]string, error) {
 	priceByAmount := make(map[string][]string)
-	seenNext := make(map[string]struct{})
-	nextURL := ""
-
-	for {
+	fetchPage := func(nextURL string) (*asc.SubscriptionPricePointsResponse, error) {
 		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		var (
-			resp *asc.SubscriptionPricePointsResponse
-			err  error
-		)
+		defer pageCancel()
+
 		if nextURL == "" {
-			resp, err = client.GetSubscriptionPricePoints(
+			return client.GetSubscriptionPricePoints(
 				pageCtx,
 				subscriptionID,
 				asc.WithSubscriptionPricePointsTerritory(territoryID),
 				asc.WithSubscriptionPricePointsLimit(200),
 			)
 		} else {
-			resp, err = client.GetSubscriptionPricePoints(
+			return client.GetSubscriptionPricePoints(
 				pageCtx,
 				subscriptionID,
 				asc.WithSubscriptionPricePointsNextURL(nextURL),
 			)
 		}
-		pageCancel()
-		if err != nil {
-			return nil, fmt.Errorf("resolve price points for territory %q: %w", territoryID, err)
-		}
+	}
 
-		for _, pricePoint := range resp.Data {
-			priceKey, priceErr := normalizeSubscriptionPriceImportPrice(pricePoint.Attributes.CustomerPrice)
-			if priceErr != nil {
-				continue
-			}
-			id := strings.TrimSpace(pricePoint.ID)
-			if id == "" {
-				continue
-			}
-			priceByAmount[priceKey] = appendUniqueString(priceByAmount[priceKey], id)
-		}
+	firstPage, err := fetchPage("")
+	if err != nil {
+		return nil, fmt.Errorf("resolve price points for territory %q: %w", territoryID, err)
+	}
 
-		if strings.TrimSpace(resp.Links.Next) == "" {
-			break
-		}
-		if _, seen := seenNext[resp.Links.Next]; seen {
-			return nil, fmt.Errorf("resolve price points for territory %q: repeated next URL", territoryID)
-		}
-		seenNext[resp.Links.Next] = struct{}{}
-		nextURL = resp.Links.Next
+	if err := asc.PaginateEach(
+		ctx,
+		firstPage,
+		func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return fetchPage(nextURL)
+		},
+		func(page asc.PaginatedResponse) error {
+			resp, ok := page.(*asc.SubscriptionPricePointsResponse)
+			if !ok {
+				return fmt.Errorf("unexpected response type %T", page)
+			}
+			for _, pricePoint := range resp.Data {
+				priceKey, priceErr := normalizeSubscriptionPriceImportPrice(pricePoint.Attributes.CustomerPrice)
+				if priceErr != nil {
+					continue
+				}
+				id := strings.TrimSpace(pricePoint.ID)
+				if id == "" {
+					continue
+				}
+				priceByAmount[priceKey] = appendUniqueString(priceByAmount[priceKey], id)
+			}
+			return nil
+		},
+	); err != nil {
+		return nil, fmt.Errorf("resolve price points for territory %q: %w", territoryID, err)
 	}
 
 	return priceByAmount, nil


### PR DESCRIPTION
## Summary
- route shared command-builder required-flag failures through `shared.UsageError*` so usage-class stderr formatting is consistent
- replace duplicated next-link pagination loops with `asc.PaginateEach` in subscription and IAP pricing pagination paths while preserving existing behavior
- add focused tests for `BuildIDGetCommand`, `BuildPaginatedListCommand`, and `BuildConfirmDeleteCommand` usage-error behavior

## Test plan
- [x] `go test ./internal/cli/shared -run 'CommandBuilder|BuildIDGet|BuildPaginatedList|BuildConfirmDelete'`
- [x] `go test ./internal/cli/subscriptions -run 'PricePoints|PricesImport'`
- [x] `go test ./internal/cli/iap -run 'Prices|PriceSchedules'`
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`