### PR TITLE
Version metadata carry-forward

### DIFF
--- a/internal/asc/output_versions.go
+++ b/internal/asc/output_versions.go
@@ -34,13 +34,24 @@ type AppStoreVersionSubmissionCancelResult struct {
 
 // AppStoreVersionDetailResult represents CLI output for version details.
 type AppStoreVersionDetailResult struct {
-	ID            string `json:"id"`
-	VersionString string `json:"versionString,omitempty"`
-	Platform      string `json:"platform,omitempty"`
-	State         string `json:"state,omitempty"`
-	BuildID       string `json:"buildId,omitempty"`
-	BuildVersion  string `json:"buildVersion,omitempty"`
-	SubmissionID  string `json:"submissionId,omitempty"`
+	ID            string                              `json:"id"`
+	VersionString string                              `json:"versionString,omitempty"`
+	Platform      string                              `json:"platform,omitempty"`
+	State         string                              `json:"state,omitempty"`
+	BuildID       string                              `json:"buildId,omitempty"`
+	BuildVersion  string                              `json:"buildVersion,omitempty"`
+	SubmissionID  string                              `json:"submissionId,omitempty"`
+	MetadataCopy  *AppStoreVersionMetadataCopySummary `json:"metadataCopy,omitempty"`
+}
+
+// AppStoreVersionMetadataCopySummary represents metadata carry-forward details during version creation.
+type AppStoreVersionMetadataCopySummary struct {
+	SourceVersion      string   `json:"sourceVersion"`
+	SourceVersionID    string   `json:"sourceVersionId,omitempty"`
+	SelectedFields     []string `json:"selectedFields,omitempty"`
+	CopiedLocales      int      `json:"copiedLocales"`
+	CopiedFieldUpdates int      `json:"copiedFieldUpdates"`
+	SkippedLocales     []string `json:"skippedLocales,omitempty"`
 }
 
 // AppStoreVersionAttachBuildResult represents CLI output for build attachment.

--- a/internal/cli/cmdtest/versions_create_copy_metadata_test.go
+++ b/internal/cli/cmdtest/versions_create_copy_metadata_test.go
@@ -1,0 +1,343 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVersionsCreateCopyMetadataAppliesSelectedFields(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			body := `{"data":{"type":"appStoreVersions","id":"ver-new","attributes":{"platform":"IOS","versionString":"2.4.0","appVersionState":"PREPARE_FOR_SUBMISSION"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/appStoreVersions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			if req.URL.Query().Get("filter[versionString]") != "2.3.2" {
+				t.Fatalf("expected filter[versionString]=2.3.2, got %q", req.URL.Query().Get("filter[versionString]"))
+			}
+			if req.URL.Query().Get("filter[platform]") != "IOS" {
+				t.Fatalf("expected filter[platform]=IOS, got %q", req.URL.Query().Get("filter[platform]"))
+			}
+			body := `{"data":[{"type":"appStoreVersions","id":"ver-source","attributes":{"platform":"IOS","versionString":"2.3.2","appVersionState":"READY_FOR_SALE"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/ver-source/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			body := `{"data":[{"type":"appStoreVersionLocalizations","id":"src-en","attributes":{"locale":"en-US","description":"English description","keywords":"en,keywords","whatsNew":"ignored"}},{"type":"appStoreVersionLocalizations","id":"src-fr","attributes":{"locale":"fr-FR","description":"Description FR","keywords":"fr,motscles","whatsNew":"ignored"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/ver-new/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			body := `{"data":[{"type":"appStoreVersionLocalizations","id":"dst-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"dst-fr","attributes":{"locale":"fr-FR"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 5:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/dst-en" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read payload: %v", err)
+			}
+			bodyText := string(payload)
+			if !strings.Contains(bodyText, `"description":"English description"`) {
+				t.Fatalf("expected description in payload, got %s", bodyText)
+			}
+			if !strings.Contains(bodyText, `"keywords":"en,keywords"`) {
+				t.Fatalf("expected keywords in payload, got %s", bodyText)
+			}
+			if strings.Contains(bodyText, `"whatsNew"`) {
+				t.Fatalf("did not expect whatsNew in payload, got %s", bodyText)
+			}
+			body := `{"data":{"type":"appStoreVersionLocalizations","id":"dst-en","attributes":{"locale":"en-US","description":"English description","keywords":"en,keywords"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 6:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/dst-fr" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read payload: %v", err)
+			}
+			bodyText := string(payload)
+			if !strings.Contains(bodyText, `"description":"Description FR"`) {
+				t.Fatalf("expected description in payload, got %s", bodyText)
+			}
+			if !strings.Contains(bodyText, `"keywords":"fr,motscles"`) {
+				t.Fatalf("expected keywords in payload, got %s", bodyText)
+			}
+			if strings.Contains(bodyText, `"whatsNew"`) {
+				t.Fatalf("did not expect whatsNew in payload, got %s", bodyText)
+			}
+			body := `{"data":{"type":"appStoreVersionLocalizations","id":"dst-fr","attributes":{"locale":"fr-FR","description":"Description FR","keywords":"fr,motscles"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "create",
+			"--app", "app-1",
+			"--version", "2.4.0",
+			"--platform", "IOS",
+			"--copy-metadata-from", "2.3.2",
+			"--copy-fields", "description,keywords,whatsNew",
+			"--exclude-fields", "whatsNew",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"ver-new"`) {
+		t.Fatalf("expected created version id in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"metadataCopy"`) {
+		t.Fatalf("expected metadata copy summary in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"copiedLocales":2`) {
+		t.Fatalf("expected copied locale count in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"copiedFieldUpdates":4`) {
+		t.Fatalf("expected copied field count in output, got %q", stdout)
+	}
+}
+
+func TestVersionsCreateCopyMetadataSkipsSourceLocalesMissingOnDestination(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			body := `{"data":{"type":"appStoreVersions","id":"ver-new","attributes":{"platform":"IOS","versionString":"2.4.0","appVersionState":"PREPARE_FOR_SUBMISSION"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			body := `{"data":[{"type":"appStoreVersions","id":"ver-source","attributes":{"platform":"IOS","versionString":"2.3.2","appVersionState":"READY_FOR_SALE"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 3:
+			body := `{"data":[{"type":"appStoreVersionLocalizations","id":"src-en","attributes":{"locale":"en-US","description":"English description"}},{"type":"appStoreVersionLocalizations","id":"src-fr","attributes":{"locale":"fr-FR","description":"Description FR"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 4:
+			body := `{"data":[{"type":"appStoreVersionLocalizations","id":"dst-en","attributes":{"locale":"en-US"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 5:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/dst-en" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			body := `{"data":{"type":"appStoreVersionLocalizations","id":"dst-en","attributes":{"locale":"en-US","description":"English description"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "create",
+			"--app", "app-1",
+			"--version", "2.4.0",
+			"--platform", "IOS",
+			"--copy-metadata-from", "2.3.2",
+			"--copy-fields", "description",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "Warning: skipped source locales not enabled on destination: fr-FR") {
+		t.Fatalf("expected skip warning in stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"copiedLocales":1`) {
+		t.Fatalf("expected copied locale count in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"skippedLocales":["fr-FR"]`) {
+		t.Fatalf("expected skipped locale summary in output, got %q", stdout)
+	}
+}
+
+func TestVersionsCreateCopyMetadataRejectsInvalidCopyField(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "create",
+			"--app", "app-1",
+			"--version", "2.4.0",
+			"--copy-metadata-from", "2.3.2",
+			"--copy-fields", "description,invalidField",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--copy-fields must be one of:") {
+		t.Fatalf("expected copy-fields usage error, got %q", stderr)
+	}
+}
+
+func TestVersionsCreateCopyMetadataRequiresCopySource(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "create",
+			"--app", "app-1",
+			"--version", "2.4.0",
+			"--copy-fields", "description",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --copy-metadata-from is required when using --copy-fields or --exclude-fields") {
+		t.Fatalf("expected copy source usage error, got %q", stderr)
+	}
+}
+
+func TestVersionsCreateCopyMetadataRejectsInvalidExcludeField(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "create",
+			"--app", "app-1",
+			"--version", "2.4.0",
+			"--copy-metadata-from", "2.3.2",
+			"--exclude-fields", "description,invalidField",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--exclude-fields must be one of:") {
+		t.Fatalf("expected exclude-fields usage error, got %q", stderr)
+	}
+}

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -232,6 +232,9 @@ func VersionsCreateCommand() *ffcli.Command {
 	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	copyright := fs.String("copyright", "", "Copyright text (e.g., '2026 My Company')")
 	releaseType := fs.String("release-type", "", "Release type: MANUAL, AFTER_APPROVAL, SCHEDULED")
+	copyMetadataFrom := fs.String("copy-metadata-from", "", "Copy localization metadata from this source version string")
+	copyFields := fs.String("copy-fields", "", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
+	excludeFields := fs.String("exclude-fields", "", "Comma-separated metadata fields to exclude from copy")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -243,7 +246,9 @@ func VersionsCreateCommand() *ffcli.Command {
 Examples:
   asc versions create --app "123456789" --version "2.0.0"
   asc versions create --app "123456789" --version "2.0.0" --platform IOS
-  asc versions create --app "123456789" --version "2.0.0" --copyright "2026 My Company" --release-type MANUAL`,
+  asc versions create --app "123456789" --version "2.0.0" --copyright "2026 My Company" --release-type MANUAL
+  asc versions create --app "123456789" --version "2.4.0" --platform IOS --copy-metadata-from "2.3.2"
+  asc versions create --app "123456789" --version "2.4.0" --copy-metadata-from "2.3.2" --copy-fields "description,keywords,supportUrl" --exclude-fields "whatsNew"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -261,6 +266,31 @@ Examples:
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return flag.ErrHelp
+			}
+
+			copyMetadataFromValue := strings.TrimSpace(*copyMetadataFrom)
+			copyFieldsValue, err := normalizeVersionMetadataCopyFields(*copyFields, "--copy-fields")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				return flag.ErrHelp
+			}
+			excludeFieldsValue, err := normalizeVersionMetadataCopyFields(*excludeFields, "--exclude-fields")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				return flag.ErrHelp
+			}
+			if copyMetadataFromValue == "" && (len(copyFieldsValue) > 0 || len(excludeFieldsValue) > 0) {
+				fmt.Fprintln(os.Stderr, "Error: --copy-metadata-from is required when using --copy-fields or --exclude-fields")
+				return flag.ErrHelp
+			}
+
+			selectedCopyFields := []string(nil)
+			if copyMetadataFromValue != "" {
+				selectedCopyFields, err = resolveVersionMetadataCopyFields(copyFieldsValue, excludeFieldsValue)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					return flag.ErrHelp
+				}
 			}
 
 			client, err := shared.GetASCClient()
@@ -292,6 +322,24 @@ Examples:
 				VersionString: resp.Data.Attributes.VersionString,
 				Platform:      string(resp.Data.Attributes.Platform),
 				State:         shared.ResolveAppStoreVersionState(resp.Data.Attributes),
+			}
+			if copyMetadataFromValue != "" {
+				copySummary, err := copyVersionMetadataFromSource(
+					requestCtx,
+					client,
+					resolvedAppID,
+					normalizedPlatform,
+					copyMetadataFromValue,
+					resp.Data.ID,
+					selectedCopyFields,
+				)
+				if err != nil {
+					return fmt.Errorf("versions create: %w", err)
+				}
+				if len(copySummary.SkippedLocales) > 0 {
+					fmt.Fprintf(os.Stderr, "Warning: skipped source locales not enabled on destination: %s\n", strings.Join(copySummary.SkippedLocales, ", "))
+				}
+				result.MetadataCopy = copySummary
 			}
 
 			return shared.PrintOutput(result, *output.Output, *output.Pretty)

--- a/internal/cli/versions/versions_create_copy_metadata.go
+++ b/internal/cli/versions/versions_create_copy_metadata.go
@@ -1,0 +1,243 @@
+package versions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func versionMetadataCopyFieldList() []string {
+	return shared.VersionLocalizationKeys()
+}
+
+func normalizeVersionMetadataCopyFields(value, flagName string) ([]string, error) {
+	fields := shared.SplitUniqueCSV(value)
+	if len(fields) == 0 {
+		return nil, nil
+	}
+
+	allowed := make(map[string]struct{}, len(versionMetadataCopyFieldList()))
+	for _, field := range versionMetadataCopyFieldList() {
+		allowed[field] = struct{}{}
+	}
+	for _, field := range fields {
+		if _, ok := allowed[field]; !ok {
+			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(versionMetadataCopyFieldList(), ", "))
+		}
+	}
+
+	return fields, nil
+}
+
+func resolveVersionMetadataCopyFields(copyFields, excludeFields []string) ([]string, error) {
+	selected := make([]string, 0, len(versionMetadataCopyFieldList()))
+	if len(copyFields) == 0 {
+		selected = append(selected, versionMetadataCopyFieldList()...)
+	} else {
+		selected = append(selected, copyFields...)
+	}
+
+	if len(excludeFields) > 0 {
+		excluded := make(map[string]struct{}, len(excludeFields))
+		for _, field := range excludeFields {
+			excluded[field] = struct{}{}
+		}
+
+		filtered := make([]string, 0, len(selected))
+		for _, field := range selected {
+			if _, skip := excluded[field]; skip {
+				continue
+			}
+			filtered = append(filtered, field)
+		}
+		selected = filtered
+	}
+
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no metadata fields selected after applying --copy-fields and --exclude-fields")
+	}
+
+	return selected, nil
+}
+
+func copyVersionMetadataFromSource(
+	ctx context.Context,
+	client *asc.Client,
+	appID string,
+	platform string,
+	sourceVersionString string,
+	destinationVersionID string,
+	selectedFields []string,
+) (*asc.AppStoreVersionMetadataCopySummary, error) {
+	sourceVersion, err := findSourceAppStoreVersion(ctx, client, appID, platform, sourceVersionString, destinationVersionID)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceLocalizations, err := listAllAppStoreVersionLocalizations(ctx, client, sourceVersion.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list source localizations: %w", err)
+	}
+	destinationLocalizations, err := listAllAppStoreVersionLocalizations(ctx, client, destinationVersionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list destination localizations: %w", err)
+	}
+
+	destinationByLocale := make(map[string]string, len(destinationLocalizations))
+	for _, item := range destinationLocalizations {
+		locale := strings.TrimSpace(item.Attributes.Locale)
+		if locale == "" {
+			continue
+		}
+		destinationByLocale[locale] = item.ID
+	}
+
+	summary := &asc.AppStoreVersionMetadataCopySummary{
+		SourceVersion:   strings.TrimSpace(sourceVersionString),
+		SourceVersionID: sourceVersion.ID,
+		SelectedFields:  append([]string(nil), selectedFields...),
+	}
+
+	for _, sourceLocalization := range sourceLocalizations {
+		locale := strings.TrimSpace(sourceLocalization.Attributes.Locale)
+		if locale == "" {
+			continue
+		}
+
+		destinationLocalizationID, ok := destinationByLocale[locale]
+		if !ok {
+			summary.SkippedLocales = append(summary.SkippedLocales, locale)
+			continue
+		}
+
+		attributes, copiedFields := buildMetadataCopyAttributes(sourceLocalization.Attributes, selectedFields)
+		if copiedFields == 0 {
+			continue
+		}
+
+		if _, err := client.UpdateAppStoreVersionLocalization(ctx, destinationLocalizationID, attributes); err != nil {
+			return nil, fmt.Errorf("failed to copy metadata for locale %q: %w", locale, err)
+		}
+		summary.CopiedLocales++
+		summary.CopiedFieldUpdates += copiedFields
+	}
+
+	return summary, nil
+}
+
+func findSourceAppStoreVersion(
+	ctx context.Context,
+	client *asc.Client,
+	appID string,
+	platform string,
+	sourceVersionString string,
+	excludeVersionID string,
+) (*asc.Resource[asc.AppStoreVersionAttributes], error) {
+	versionValue := strings.TrimSpace(sourceVersionString)
+	platformValue := strings.TrimSpace(platform)
+
+	resp, err := client.GetAppStoreVersions(
+		ctx,
+		appID,
+		asc.WithAppStoreVersionsVersionStrings([]string{versionValue}),
+		asc.WithAppStoreVersionsPlatforms([]string{platformValue}),
+		asc.WithAppStoreVersionsLimit(200),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup source version %q: %w", versionValue, err)
+	}
+
+	matches := make([]asc.Resource[asc.AppStoreVersionAttributes], 0, len(resp.Data))
+	for _, version := range resp.Data {
+		if strings.TrimSpace(version.ID) == strings.TrimSpace(excludeVersionID) {
+			continue
+		}
+		if strings.TrimSpace(version.Attributes.VersionString) != versionValue {
+			continue
+		}
+		if strings.TrimSpace(string(version.Attributes.Platform)) != platformValue {
+			continue
+		}
+		matches = append(matches, version)
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("source version %q not found for platform %s", versionValue, platformValue)
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("source version %q is ambiguous for platform %s", versionValue, platformValue)
+	}
+
+	return &matches[0], nil
+}
+
+func listAllAppStoreVersionLocalizations(
+	ctx context.Context,
+	client *asc.Client,
+	versionID string,
+) ([]asc.Resource[asc.AppStoreVersionLocalizationAttributes], error) {
+	firstPage, err := client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	if err != nil {
+		return nil, err
+	}
+	allPages, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	allLocalizations, ok := allPages.(*asc.AppStoreVersionLocalizationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected localizations response type: %T", allPages)
+	}
+	return allLocalizations.Data, nil
+}
+
+func buildMetadataCopyAttributes(
+	source asc.AppStoreVersionLocalizationAttributes,
+	selectedFields []string,
+) (asc.AppStoreVersionLocalizationAttributes, int) {
+	attrs := asc.AppStoreVersionLocalizationAttributes{}
+	copiedFields := 0
+
+	for _, field := range selectedFields {
+		switch field {
+		case "description":
+			if strings.TrimSpace(source.Description) != "" {
+				attrs.Description = source.Description
+				copiedFields++
+			}
+		case "keywords":
+			if strings.TrimSpace(source.Keywords) != "" {
+				attrs.Keywords = source.Keywords
+				copiedFields++
+			}
+		case "marketingUrl":
+			if strings.TrimSpace(source.MarketingURL) != "" {
+				attrs.MarketingURL = source.MarketingURL
+				copiedFields++
+			}
+		case "promotionalText":
+			if strings.TrimSpace(source.PromotionalText) != "" {
+				attrs.PromotionalText = source.PromotionalText
+				copiedFields++
+			}
+		case "supportUrl":
+			if strings.TrimSpace(source.SupportURL) != "" {
+				attrs.SupportURL = source.SupportURL
+				copiedFields++
+			}
+		case "whatsNew":
+			if strings.TrimSpace(source.WhatsNew) != "" {
+				attrs.WhatsNew = source.WhatsNew
+				copiedFields++
+			}
+		}
+	}
+
+	return attrs, copiedFields
+}


### PR DESCRIPTION
## Summary

- Implements metadata carry-forward for `asc versions create` using new flags: `--copy-metadata-from`, `--copy-fields`, and `--exclude-fields`.
- Enables copying localization metadata (e.g., description, keywords) from an existing App Store Version to a newly created one.
- Ensures idempotent updates to destination localizations and graceful handling of missing locales.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`
- Added new command tests in `internal/cli/cmdtest/versions_create_copy_metadata_test.go` covering happy path, field filtering, and error handling.
- Verified usage error exit codes for invalid flag combinations.

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.

---
<p><a href="https://cursor.com/agents/bc-ac324015-9cad-4fdd-af15-5f9d17cd0e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac324015-9cad-4fdd-af15-5f9d17cd0e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

