### PR TITLE
App-scoped build wait

### DIFF
--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -196,9 +196,9 @@ func (c *Client) GetBuilds(ctx context.Context, appID string, opts ...BuildsOpti
 	} else {
 		values := url.Values{}
 		// Use /v1/builds endpoint when sorting, limiting, or filtering by
-		// version/processingState/preReleaseVersion/platform/expired,
+		// version/preReleaseVersion.version/processingState/preReleaseVersion/platform/expired,
 		// since /v1/apps/{id}/builds doesn't support these
-		if query.sort != "" || query.limit > 0 || query.version != "" || len(query.processingStates) > 0 || len(query.preReleasePlatforms) > 0 || len(query.preReleaseVersionIDs) > 0 || query.expired != nil {
+		if query.sort != "" || query.limit > 0 || query.version != "" || query.preReleaseVersion != "" || len(query.processingStates) > 0 || len(query.preReleasePlatforms) > 0 || len(query.preReleaseVersionIDs) > 0 || query.expired != nil {
 			path = "/v1/builds"
 			values.Set("filter[app]", appID)
 			if query.sort != "" {
@@ -209,6 +209,9 @@ func (c *Client) GetBuilds(ctx context.Context, appID string, opts ...BuildsOpti
 			}
 			if query.version != "" {
 				values.Set("filter[version]", query.version)
+			}
+			if query.preReleaseVersion != "" {
+				values.Set("filter[preReleaseVersion.version]", query.preReleaseVersion)
 			}
 			if len(query.processingStates) > 0 {
 				values.Set("filter[processingState]", strings.Join(query.processingStates, ","))

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -936,6 +936,40 @@ func TestGetBuilds_WithVersionFilter(t *testing.T) {
 	}
 }
 
+func TestGetBuilds_WithPreReleaseVersionVersionFilter(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-24","attributes":{"version":"2","uploadedDate":"2026-03-02T18:01:00Z"}}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/builds" {
+			t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("filter[app]") != "123" {
+			t.Fatalf("expected filter[app]=123, got %q", values.Get("filter[app]"))
+		}
+		if values.Get("filter[preReleaseVersion.version]") != "2.4.0" {
+			t.Fatalf(
+				"expected filter[preReleaseVersion.version]=2.4.0, got %q",
+				values.Get("filter[preReleaseVersion.version]"),
+			)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	builds, err := client.GetBuilds(context.Background(), "123", WithBuildsPreReleaseVersionVersion("2.4.0"))
+	if err != nil {
+		t.Fatalf("GetBuilds() error: %v", err)
+	}
+	if len(builds.Data) != 1 {
+		t.Fatalf("expected 1 build, got %d", len(builds.Data))
+	}
+	if builds.Data[0].ID != "build-24" {
+		t.Fatalf("expected build ID build-24, got %s", builds.Data[0].ID)
+	}
+}
+
 func TestGetBuilds_WithProcessingStateFilter(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-processing","attributes":{"version":"42","processingState":"PROCESSING","uploadedDate":"2026-01-20T00:00:00Z"}}]}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -1434,6 +1434,16 @@ func WithBuildsVersion(version string) BuildsOption {
 	}
 }
 
+// WithBuildsPreReleaseVersionVersion filters builds by marketing version
+// (CFBundleShortVersionString) via filter[preReleaseVersion.version].
+func WithBuildsPreReleaseVersionVersion(version string) BuildsOption {
+	return func(q *buildsQuery) {
+		if strings.TrimSpace(version) != "" {
+			q.preReleaseVersion = strings.TrimSpace(version)
+		}
+	}
+}
+
 // WithBuildsBuildNumber filters builds by build number.
 // App Store Connect models build number as build version, so this maps to filter[version].
 func WithBuildsBuildNumber(buildNumber string) BuildsOption {

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -111,6 +111,7 @@ type buildsQuery struct {
 	listQuery
 	sort                 string
 	version              string
+	preReleaseVersion    string
 	processingStates     []string
 	preReleasePlatforms  []string
 	preReleaseVersionIDs []string

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -1275,6 +1275,7 @@ func TestBuildBuildsQuery(t *testing.T) {
 		WithBuildsNextURL("https://api.appstoreconnect.apple.com/v1/apps/123/builds?cursor=abc"),
 		WithBuildsSort("-uploadedDate"),
 		WithBuildsVersion("42"),
+		WithBuildsPreReleaseVersionVersion("2.4.0"),
 	}
 	for _, opt := range opts {
 		opt(query)
@@ -1291,6 +1292,9 @@ func TestBuildBuildsQuery(t *testing.T) {
 	}
 	if query.version != "42" {
 		t.Fatalf("expected version=42, got %q", query.version)
+	}
+	if query.preReleaseVersion != "2.4.0" {
+		t.Fatalf("expected preReleaseVersion=2.4.0, got %q", query.preReleaseVersion)
 	}
 }
 

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -381,6 +381,7 @@ Examples:
   asc builds latest --app "123456789"
   asc builds find --app "123456789" --build-number "42"
   asc builds wait --build "BUILD_ID"
+  asc builds wait --app "123456789" --newest
   asc builds info --build "BUILD_ID"
   asc builds expire --build "BUILD_ID"
   asc builds expire-all --app "123456789" --older-than 90d --dry-run

--- a/internal/cli/builds/builds_wait.go
+++ b/internal/cli/builds/builds_wait.go
@@ -25,9 +25,12 @@ func BuildsWaitCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("wait", flag.ExitOnError)
 
 	buildID := fs.String("build", "", "Build ID to wait for")
-	appID := fs.String("app", "", "App Store Connect app ID, bundle ID, or exact app name (required with --build-number)")
-	buildNumber := fs.String("build-number", "", "Build number (CFBundleVersion) to resolve and wait for (requires --app)")
-	platform := fs.String("platform", "IOS", "Platform filter for --app/--build-number: IOS, MAC_OS, TV_OS, VISION_OS")
+	appID := fs.String("app", "", "App Store Connect app ID, bundle ID, or exact app name (required when --build is not provided)")
+	newest := fs.Bool("newest", false, "Wait for the newest matching build for --app context")
+	version := fs.String("version", "", "Optional marketing version filter (CFBundleShortVersionString) for --app")
+	buildNumber := fs.String("build-number", "", "Optional build number filter (CFBundleVersion) for --app")
+	since := fs.String("since", "", "Only consider builds uploaded on or after this RFC3339 timestamp")
+	platform := fs.String("platform", "", "Optional platform filter for --app selectors: IOS, MAC_OS, TV_OS, VISION_OS")
 	timeout := fs.Duration("timeout", buildsWaitDefaultTimeout, "Maximum time to wait for build processing")
 	pollInterval := fs.Duration("poll-interval", buildsWaitDefaultPollInterval, "Polling interval for build status checks")
 	failOnInvalid := fs.Bool("fail-on-invalid", false, "Exit non-zero if build reaches INVALID")
@@ -46,20 +49,29 @@ This command polls build processing state until a terminal condition:
 
 Build selector modes (mutually exclusive):
   - --build BUILD_ID
-  - --app APP_ID --build-number NUMBER [--platform IOS]
+  - --app APP_ID with app-scoped selectors:
+      --newest
+      [--version VERSION] [--build-number NUMBER] [--since RFC3339] [--platform IOS]
 
 Examples:
   asc builds wait --build "BUILD_ID"
   asc builds wait --build "BUILD_ID" --timeout 20m --poll-interval 15s
-  asc builds wait --app "123456789" --build-number "42"
+  asc builds wait --app "1500196580" --newest
+  asc builds wait --app "1500196580" --version "2.4.0" --build-number "2"
+  asc builds wait --app "1500196580" --since "2026-03-02T18:00:00Z"
   asc builds wait --app "123456789" --build-number "42" --platform MAC_OS --fail-on-invalid`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			started := time.Now()
 			buildValue := strings.TrimSpace(*buildID)
-			buildNumberValue := strings.TrimSpace(*buildNumber)
 			appInputProvided := strings.TrimSpace(*appID) != ""
-			buildNumberProvided := buildNumberValue != ""
+			resolvedAppID := shared.ResolveAppID(*appID)
+			versionValue := strings.TrimSpace(*version)
+			buildNumberValue := strings.TrimSpace(*buildNumber)
+			sinceValue := strings.TrimSpace(*since)
+			platformValue := strings.TrimSpace(*platform)
+			appScopedFlagsUsed := appInputProvided || *newest || versionValue != "" || buildNumberValue != "" || sinceValue != "" || platformValue != ""
 
 			if *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
@@ -69,19 +81,34 @@ Examples:
 			}
 
 			if buildValue != "" {
-				if appInputProvided || buildNumberProvided {
-					return shared.UsageError("--build is mutually exclusive with --app/--build-number")
+				if appScopedFlagsUsed {
+					return shared.UsageError("--build is mutually exclusive with app-scoped selectors (--app, --newest, --version, --build-number, --since, --platform)")
 				}
 			} else {
-				resolvedAppID := shared.ResolveAppID(*appID)
-				if resolvedAppID == "" || buildNumberValue == "" {
-					return shared.UsageError("--build is required, or provide --app and --build-number")
+				if resolvedAppID == "" {
+					return shared.UsageError("--app is required when --build is not provided")
+				}
+				if !*newest && versionValue == "" && buildNumberValue == "" && sinceValue == "" {
+					return shared.UsageError("provide at least one app-scoped selector: --newest, --version, --build-number, or --since")
 				}
 			}
 
-			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
-			if err != nil {
-				return shared.UsageError(err.Error())
+			var normalizedPlatform string
+			if platformValue != "" {
+				var err error
+				normalizedPlatform, err = shared.NormalizeAppStoreVersionPlatform(platformValue)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
+			}
+
+			var sinceTime *time.Time
+			if sinceValue != "" {
+				parsedSince, err := parseBuildsWaitTimestamp(sinceValue)
+				if err != nil {
+					return shared.UsageError("--since must be an RFC3339 timestamp (e.g., 2026-03-02T18:00:00Z)")
+				}
+				sinceTime = &parsedSince
 			}
 
 			client, err := shared.GetASCClient()
@@ -92,12 +119,32 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeoutDuration(ctx, *timeout)
 			defer cancel()
 
-			buildResp, err := resolveBuildForWait(requestCtx, client, buildValue, shared.ResolveAppID(*appID), buildNumberValue, normalizedPlatform)
-			if err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					return fmt.Errorf("builds wait: timed out resolving build selector after %s", (*timeout).Round(time.Second))
+			var buildResp *asc.BuildResponse
+			if buildValue != "" {
+				buildResp = &asc.BuildResponse{
+					Data: asc.Resource[asc.BuildAttributes]{
+						ID: buildValue,
+					},
 				}
-				return fmt.Errorf("builds wait: %w", err)
+			} else {
+				lookupAppID, err := shared.ResolveAppIDWithLookup(requestCtx, client, resolvedAppID)
+				if err != nil {
+					return fmt.Errorf("builds wait: %w", err)
+				}
+
+				buildResp, err = waitForBuildDiscovery(requestCtx, client, appBuildWaitSelector{
+					AppID:       lookupAppID,
+					Version:     versionValue,
+					BuildNumber: buildNumberValue,
+					Platform:    normalizedPlatform,
+					Since:       sinceTime,
+				}, *pollInterval)
+				if err != nil {
+					if errors.Is(err, context.DeadlineExceeded) {
+						return fmt.Errorf("builds wait: timed out resolving build selector after %s", (*timeout).Round(time.Second))
+					}
+					return fmt.Errorf("builds wait: %w", err)
+				}
 			}
 
 			waitBuildID := buildResp.Data.ID
@@ -109,8 +156,138 @@ Examples:
 				return fmt.Errorf("builds wait: %w", err)
 			}
 
-			return shared.PrintOutput(buildResp, *output.Output, *output.Pretty)
+			format, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty)
+			if err != nil {
+				return err
+			}
+
+			processingState := strings.ToUpper(strings.TrimSpace(buildResp.Data.Attributes.ProcessingState))
+			if processingState == "" {
+				processingState = "UNKNOWN"
+			}
+			result := &buildWaitResult{
+				Data:            buildResp.Data,
+				Links:           buildResp.Links,
+				BuildID:         strings.TrimSpace(buildResp.Data.ID),
+				BuildNumber:     strings.TrimSpace(buildResp.Data.Attributes.Version),
+				ProcessingState: processingState,
+				Elapsed:         time.Since(started).Round(time.Second).String(),
+			}
+			if versionValue != "" {
+				result.Version = versionValue
+			}
+
+			if format == "json" {
+				return shared.PrintOutput(result, format, *output.Pretty)
+			}
+			return shared.PrintOutput(buildResp, format, *output.Pretty)
 		},
+	}
+}
+
+type appBuildWaitSelector struct {
+	AppID       string
+	Version     string
+	BuildNumber string
+	Platform    string
+	Since       *time.Time
+}
+
+type buildWaitResult struct {
+	Data            asc.Resource[asc.BuildAttributes] `json:"data"`
+	Links           asc.Links                         `json:"links,omitempty"`
+	BuildID         string                            `json:"buildId"`
+	Version         string                            `json:"version,omitempty"`
+	BuildNumber     string                            `json:"buildNumber,omitempty"`
+	ProcessingState string                            `json:"processingState"`
+	Elapsed         string                            `json:"elapsed"`
+}
+
+func waitForBuildDiscovery(
+	ctx context.Context,
+	client *asc.Client,
+	selector appBuildWaitSelector,
+	pollInterval time.Duration,
+) (*asc.BuildResponse, error) {
+	started := time.Now()
+	return asc.PollUntil(ctx, pollInterval, func(ctx context.Context) (*asc.BuildResponse, bool, error) {
+		buildResp, err := resolveLatestBuildForAppWait(ctx, client, selector)
+		if err != nil {
+			return nil, false, err
+		}
+		if buildResp != nil {
+			return buildResp, true, nil
+		}
+
+		fmt.Fprintf(
+			os.Stderr,
+			"Waiting for build discovery... (%s elapsed)\n",
+			time.Since(started).Round(time.Second),
+		)
+		return nil, false, nil
+	})
+}
+
+func resolveLatestBuildForAppWait(
+	ctx context.Context,
+	client *asc.Client,
+	selector appBuildWaitSelector,
+) (*asc.BuildResponse, error) {
+	opts := []asc.BuildsOption{
+		asc.WithBuildsSort("-uploadedDate"),
+		asc.WithBuildsLimit(1),
+		asc.WithBuildsProcessingStates(buildsWaitProcessingStates()),
+	}
+	if selector.BuildNumber != "" {
+		opts = append(opts, asc.WithBuildsBuildNumber(selector.BuildNumber))
+	}
+	if selector.Version != "" {
+		opts = append(opts, asc.WithBuildsPreReleaseVersionVersion(selector.Version))
+	}
+	if selector.Platform != "" {
+		opts = append(opts, asc.WithBuildsPreReleaseVersionPlatforms([]string{selector.Platform}))
+	}
+
+	buildsResp, err := client.GetBuilds(ctx, selector.AppID, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(buildsResp.Data) == 0 {
+		return nil, nil
+	}
+
+	candidate := buildsResp.Data[0]
+	if selector.Since != nil {
+		uploadedAt, err := parseBuildsWaitTimestamp(candidate.Attributes.UploadedDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse uploadedDate for build %s: %w", candidate.ID, err)
+		}
+		if uploadedAt.Before(selector.Since.UTC()) {
+			return nil, nil
+		}
+	}
+
+	return &asc.BuildResponse{Data: candidate, Links: buildsResp.Links}, nil
+}
+
+func parseBuildsWaitTimestamp(raw string) (time.Time, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return time.Time{}, fmt.Errorf("timestamp is required")
+	}
+	timestamp, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return timestamp.UTC(), nil
+}
+
+func buildsWaitProcessingStates() []string {
+	return []string{
+		asc.BuildProcessingStateProcessing,
+		asc.BuildProcessingStateFailed,
+		asc.BuildProcessingStateInvalid,
+		asc.BuildProcessingStateValid,
 	}
 }
 
@@ -145,12 +322,7 @@ func resolveBuildForWait(
 		asc.WithBuildsBuildNumber(buildNumber),
 		asc.WithBuildsSort("-uploadedDate"),
 		asc.WithBuildsLimit(1),
-		asc.WithBuildsProcessingStates([]string{
-			asc.BuildProcessingStateProcessing,
-			asc.BuildProcessingStateFailed,
-			asc.BuildProcessingStateInvalid,
-			asc.BuildProcessingStateValid,
-		}),
+		asc.WithBuildsProcessingStates(buildsWaitProcessingStates()),
 	}
 	if strings.TrimSpace(platform) != "" {
 		opts = append(opts, asc.WithBuildsPreReleaseVersionPlatforms([]string{platform}))

--- a/internal/cli/cmdtest/builds_wait_test.go
+++ b/internal/cli/cmdtest/builds_wait_test.go
@@ -2,6 +2,7 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -56,6 +57,19 @@ func TestBuildsWaitByBuildIDPollsUntilValid(t *testing.T) {
 
 	if !strings.Contains(stdout, `"id":"build-1"`) {
 		t.Fatalf("expected build output, got %q", stdout)
+	}
+	waitResult := parseBuildsWaitJSON(t, stdout)
+	if waitResult.BuildID != "build-1" {
+		t.Fatalf("expected buildId=build-1, got %q", waitResult.BuildID)
+	}
+	if waitResult.BuildNumber != "42" {
+		t.Fatalf("expected buildNumber=42, got %q", waitResult.BuildNumber)
+	}
+	if waitResult.ProcessingState != "VALID" {
+		t.Fatalf("expected processingState=VALID, got %q", waitResult.ProcessingState)
+	}
+	if strings.TrimSpace(waitResult.Elapsed) == "" {
+		t.Fatalf("expected non-empty elapsed in output, got %q", waitResult.Elapsed)
 	}
 	if !strings.Contains(stderr, "Waiting for build build-1... (PROCESSING") {
 		t.Fatalf("expected processing progress output, got %q", stderr)
@@ -149,8 +163,250 @@ func TestBuildsWaitByAppAndBuildNumberResolvesThenWaits(t *testing.T) {
 	if !strings.Contains(stdout, `"id":"build-42"`) {
 		t.Fatalf("expected build output, got %q", stdout)
 	}
+	waitResult := parseBuildsWaitJSON(t, stdout)
+	if waitResult.BuildID != "build-42" {
+		t.Fatalf("expected buildId=build-42, got %q", waitResult.BuildID)
+	}
+	if waitResult.BuildNumber != "42" {
+		t.Fatalf("expected buildNumber=42, got %q", waitResult.BuildNumber)
+	}
+	if waitResult.ProcessingState != "VALID" {
+		t.Fatalf("expected processingState=VALID, got %q", waitResult.ProcessingState)
+	}
 	if !strings.Contains(stderr, "Waiting for build build-42... (VALID") {
 		t.Fatalf("expected wait progress output, got %q", stderr)
+	}
+}
+
+func TestBuildsWaitByAppNewestDiscoversThenWaits(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.URL.Path != "/v1/builds" {
+				t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if query.Get("filter[app]") != "123456789" {
+				t.Fatalf("expected filter[app]=123456789, got %q", query.Get("filter[app]"))
+			}
+			if query.Get("sort") != "-uploadedDate" {
+				t.Fatalf("expected sort=-uploadedDate, got %q", query.Get("sort"))
+			}
+			if query.Get("limit") != "1" {
+				t.Fatalf("expected limit=1, got %q", query.Get("limit"))
+			}
+			body := `{"data":[]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.URL.Path != "/v1/builds" {
+				t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+			}
+			body := `{"data":[{"type":"builds","id":"build-99","attributes":{"uploadedDate":"2026-03-02T18:01:00Z","processingState":"PROCESSING","version":"99"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 3:
+			if req.URL.Path != "/v1/builds/build-99" {
+				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+			}
+			body := `{"data":{"type":"builds","id":"build-99","attributes":{"processingState":"VALID","version":"99"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "wait",
+			"--app", "123456789",
+			"--newest",
+			"--poll-interval", "1ms",
+			"--timeout", "250ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	waitResult := parseBuildsWaitJSON(t, stdout)
+	if waitResult.BuildID != "build-99" {
+		t.Fatalf("expected buildId=build-99, got %q", waitResult.BuildID)
+	}
+	if waitResult.BuildNumber != "99" {
+		t.Fatalf("expected buildNumber=99, got %q", waitResult.BuildNumber)
+	}
+	if waitResult.ProcessingState != "VALID" {
+		t.Fatalf("expected processingState=VALID, got %q", waitResult.ProcessingState)
+	}
+	if !strings.Contains(stderr, "Waiting for build discovery") {
+		t.Fatalf("expected discovery progress output, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Waiting for build build-99... (VALID") {
+		t.Fatalf("expected wait progress output, got %q", stderr)
+	}
+}
+
+func TestBuildsWaitByAppWithSinceSkipsOlderMatch(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.URL.Path != "/v1/builds" {
+				t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if query.Get("filter[preReleaseVersion.version]") != "2.4.0" {
+				t.Fatalf("expected filter[preReleaseVersion.version]=2.4.0, got %q", query.Get("filter[preReleaseVersion.version]"))
+			}
+			if query.Get("filter[version]") != "2" {
+				t.Fatalf("expected filter[version]=2, got %q", query.Get("filter[version]"))
+			}
+			body := `{"data":[{"type":"builds","id":"build-old","attributes":{"uploadedDate":"2026-03-02T17:59:00Z","processingState":"PROCESSING","version":"2"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.URL.Path != "/v1/builds" {
+				t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+			}
+			body := `{"data":[{"type":"builds","id":"build-new","attributes":{"uploadedDate":"2026-03-02T18:01:00Z","processingState":"PROCESSING","version":"2"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 3:
+			if req.URL.Path != "/v1/builds/build-new" {
+				t.Fatalf("expected path /v1/builds/build-new, got %s", req.URL.Path)
+			}
+			body := `{"data":{"type":"builds","id":"build-new","attributes":{"processingState":"VALID","version":"2"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "wait",
+			"--app", "123456789",
+			"--version", "2.4.0",
+			"--build-number", "2",
+			"--since", "2026-03-02T18:00:00Z",
+			"--poll-interval", "1ms",
+			"--timeout", "250ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	waitResult := parseBuildsWaitJSON(t, stdout)
+	if waitResult.BuildID != "build-new" {
+		t.Fatalf("expected buildId=build-new, got %q", waitResult.BuildID)
+	}
+	if waitResult.BuildNumber != "2" {
+		t.Fatalf("expected buildNumber=2, got %q", waitResult.BuildNumber)
+	}
+}
+
+func TestBuildsWaitByAppDiscoveryTimeoutReturnsError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/builds" {
+			t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+		}
+		body := `{"data":[]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "wait",
+			"--app", "123456789",
+			"--newest",
+			"--poll-interval", "1ms",
+			"--timeout", "10ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(runErr.Error(), "timed out resolving build selector") {
+		t.Fatalf("expected timeout resolving selector error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout on timeout, got %q", stdout)
 	}
 }
 
@@ -204,4 +460,28 @@ func TestBuildsWaitFailOnInvalidReturnsError(t *testing.T) {
 	if !strings.Contains(stderr, "Waiting for build build-1... (INVALID") {
 		t.Fatalf("expected progress output on stderr, got %q", stderr)
 	}
+}
+
+type buildsWaitJSONResult struct {
+	Data struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			Version         string `json:"version"`
+			ProcessingState string `json:"processingState"`
+		} `json:"attributes"`
+	} `json:"data"`
+	BuildID         string `json:"buildId"`
+	BuildNumber     string `json:"buildNumber"`
+	ProcessingState string `json:"processingState"`
+	Elapsed         string `json:"elapsed"`
+}
+
+func parseBuildsWaitJSON(t *testing.T, stdout string) buildsWaitJSONResult {
+	t.Helper()
+
+	var parsed buildsWaitJSONResult
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("failed to parse builds wait output JSON %q: %v", stdout, err)
+	}
+	return parsed
 }

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -453,6 +453,8 @@ func TestBuildsGroupValidationErrors(t *testing.T) {
 }
 
 func TestBuildsWaitValidationErrors(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
 	tests := []struct {
 		name    string
 		args    []string
@@ -461,12 +463,17 @@ func TestBuildsWaitValidationErrors(t *testing.T) {
 		{
 			name:    "builds wait missing selectors",
 			args:    []string{"builds", "wait"},
-			wantErr: "Error: --build is required, or provide --app and --build-number",
+			wantErr: "Error: --app is required when --build is not provided",
+		},
+		{
+			name:    "builds wait app missing selector hints",
+			args:    []string{"builds", "wait", "--app", "APP_123"},
+			wantErr: "provide at least one app-scoped selector",
 		},
 		{
 			name:    "builds wait selectors mutually exclusive",
 			args:    []string{"builds", "wait", "--build", "BUILD_123", "--app", "APP_123", "--build-number", "42"},
-			wantErr: "--build is mutually exclusive with --app/--build-number",
+			wantErr: "--build is mutually exclusive with app-scoped selectors",
 		},
 		{
 			name:    "builds wait invalid poll interval",
@@ -477,6 +484,11 @@ func TestBuildsWaitValidationErrors(t *testing.T) {
 			name:    "builds wait invalid timeout",
 			args:    []string{"builds", "wait", "--build", "BUILD_123", "--timeout", "0s"},
 			wantErr: "--timeout must be greater than 0",
+		},
+		{
+			name:    "builds wait invalid since timestamp",
+			args:    []string{"builds", "wait", "--app", "APP_123", "--newest", "--since", "nope"},
+			wantErr: "--since must be an RFC3339 timestamp",
 		},
 	}
 

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -226,7 +226,7 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 		{
 			name:    "builds wait missing selector",
 			args:    []string{"builds", "wait"},
-			wantErr: "--build is required, or provide --app and --build-number",
+			wantErr: "--app is required when --build is not provided",
 		},
 		{
 			name:    "builds find missing build-number",


### PR DESCRIPTION
## Summary

- Enhanced `asc builds wait` to support app-scoped build discovery and waiting without a specific build ID.
- Added new flags: `--app` (required for discovery), `--newest`, `--version`, `--build-number`, `--since`, and `--platform` for narrowing build selection.
- Introduced deterministic JSON output fields (`buildId`, `buildNumber`, `processingState`, `elapsed`) while maintaining compatibility with existing `data` field.
- Updated command help and examples.

## Validation

- [x] `make format`
- [x] `make lint` (used `go vet` due to `golangci-lint` toolchain mismatch)
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

---
<p><a href="https://cursor.com/agents/bc-7c482fff-c456-482e-8f87-2eecdb9dbffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c482fff-c456-482e-8f87-2eecdb9dbffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

