### PR TITLE
feat(auth): add table/json output for auth status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Agent Skills for automating `asc` workflows including builds, TestFlight, metada
 ## Core Principles
 
 - **Explicit flags**: Use long-form flags in docs/tests/examples (`--app`, `--output`) for clarity
-- **JSON-first**: Minified JSON by default (saves tokens), `--output table/markdown` for humans
+- **TTY-aware output defaults**: `table` in interactive terminals, `json` for pipes/CI; use `--output` for explicit formats
 - **No interactive prompts**: Use `--confirm` flags for destructive operations
 - **Pagination**: `--paginate` fetches all pages automatically
 
@@ -180,7 +180,8 @@ API keys are generated at https://appstoreconnect.apple.com/access/integrations/
 | `ASC_DEBUG` | Enable debug logging (set to `api` for HTTP requests/responses) |
 | `ASC_DEFAULT_OUTPUT` | Default output format: `json`, `table`, `markdown`, or `md` |
 
-Explicit `--output` flags always override `ASC_DEFAULT_OUTPUT`.
+When `ASC_DEFAULT_OUTPUT` is unset, defaults are TTY-aware (`table` in terminals, `json` for non-interactive output).
+Explicit `--output` flags always override `ASC_DEFAULT_OUTPUT` and TTY-aware defaults.
 
 ## References
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -621,6 +621,7 @@ Examples:
 // AuthStatus command factory
 func AuthStatusCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("auth status", flag.ExitOnError)
+	output := shared.BindOutputFlagsWith(fs, "output", "table", "Output format: table (default), json")
 	verbose := fs.Bool("verbose", false, "Show detailed storage information")
 	validate := fs.Bool("validate", false, "Validate stored credentials via network")
 
@@ -635,11 +636,17 @@ Add --validate to perform a network validation for each stored credential.
 
 Examples:
   asc auth status
+  asc auth status --output json
   asc auth status --verbose
   asc auth status --validate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			normalizedOutput, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "table", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
 			credentials, err := authsvc.ListCredentials()
 			var listWarning *authsvc.CredentialsWarning
 			if err != nil {
@@ -691,45 +698,69 @@ Examples:
 				warnings = append(warnings, "Some credentials are stored in config file (less secure).")
 			}
 
-			fmt.Printf("Credential storage: %s\n", storageBackend)
-			fmt.Printf("Location: %s\n", storageLocation)
-			for _, warning := range warnings {
-				fmt.Printf("Warning: %s\n", warning)
-			}
-			if *verbose {
-				fmt.Printf("Keychain available: %t\n", keychainAvailable)
-				if keychainErr != nil {
-					fmt.Printf("Keychain error: %v\n", keychainErr)
+			if normalizedOutput == "table" {
+				fmt.Printf("Credential storage: %s\n", storageBackend)
+				fmt.Printf("Location: %s\n", storageLocation)
+				for _, warning := range warnings {
+					fmt.Printf("Warning: %s\n", warning)
 				}
-				if configErr == nil {
-					fmt.Printf("Config path: %s\n", configPath)
+				if *verbose {
+					fmt.Printf("Keychain available: %t\n", keychainAvailable)
+					if keychainErr != nil {
+						fmt.Printf("Keychain error: %v\n", keychainErr)
+					}
+					if configErr == nil {
+						fmt.Printf("Config path: %s\n", configPath)
+					}
 				}
+				fmt.Println()
 			}
-			fmt.Println()
 
 			validationFailures := 0
+			credentialOutput := make([]authStatusCredentialOutput, 0, len(credentials))
 			if len(credentials) == 0 {
-				fmt.Println("No credentials stored. Run 'asc auth login' to get started.")
+				if normalizedOutput == "table" {
+					fmt.Println("No credentials stored. Run 'asc auth login' to get started.")
+				}
 			} else {
-				fmt.Println("Stored credentials:")
+				if normalizedOutput == "table" {
+					fmt.Println("Stored credentials:")
+					asc.RenderTable(
+						[]string{"Name", "Key ID", "Default", "Stored In"},
+						buildAuthStatusCredentialRows(credentials),
+					)
+				}
 				for _, cred := range credentials {
-					active := ""
-					if cred.IsDefault {
-						active = " (default)"
+					credentialEntry := authStatusCredentialOutput{
+						Name:      cred.Name,
+						KeyID:     cred.KeyID,
+						IsDefault: cred.IsDefault,
+						StoredIn:  credentialStorageLabel(cred),
 					}
-					fmt.Printf("  - %s (Key ID: %s)%s (stored in %s)\n", cred.Name, cred.KeyID, active, credentialStorageLabel(cred))
 					if *validate {
 						if err := statusValidateCredential(ctx, cred); err != nil {
 							if _, ok := errors.AsType[*permissionWarning](err); ok {
-								fmt.Printf("    %s (Key ID: %s): works (insufficient permissions for apps list)\n", cred.Name, cred.KeyID)
+								credentialEntry.Validation = "works"
+								credentialEntry.ValidationDetail = "insufficient permissions for apps list"
+								if normalizedOutput == "table" {
+									fmt.Printf("    %s (Key ID: %s): works (insufficient permissions for apps list)\n", cred.Name, cred.KeyID)
+								}
 							} else {
 								validationFailures++
-								fmt.Printf("    %s (Key ID: %s): failed (%v)\n", cred.Name, cred.KeyID, err)
+								credentialEntry.Validation = "failed"
+								credentialEntry.ValidationError = err.Error()
+								if normalizedOutput == "table" {
+									fmt.Printf("    %s (Key ID: %s): failed (%v)\n", cred.Name, cred.KeyID, err)
+								}
 							}
 						} else {
-							fmt.Printf("    %s (Key ID: %s): works\n", cred.Name, cred.KeyID)
+							credentialEntry.Validation = "works"
+							if normalizedOutput == "table" {
+								fmt.Printf("    %s (Key ID: %s): works\n", cred.Name, cred.KeyID)
+							}
 						}
 					}
+					credentialOutput = append(credentialOutput, credentialEntry)
 				}
 			}
 
@@ -742,13 +773,44 @@ Examples:
 			envProvided := envKeyID != "" || envIssuerID != "" || hasKeyEnv
 			envComplete := envKeyID != "" && envIssuerID != "" && hasKeyEnv
 
+			environmentNote := ""
 			if profile != "" && envProvided {
-				fmt.Printf("Profile %q selected; environment credentials will be ignored.\n", profile)
+				environmentNote = fmt.Sprintf("Profile %q selected; environment credentials will be ignored.", profile)
 			} else if bypassKeychain && envComplete {
-				fmt.Println("Environment credentials detected (ASC_KEY_ID present). With ASC_BYPASS_KEYCHAIN set to 1/true/yes/on, they will be used when no profile is selected.")
+				environmentNote = "Environment credentials detected (ASC_KEY_ID present). With ASC_BYPASS_KEYCHAIN set to 1/true/yes/on, they will be used when no profile is selected."
 			} else if bypassKeychain && envProvided && !envComplete {
-				fmt.Println("Environment credentials are incomplete. Set ASC_KEY_ID, ASC_ISSUER_ID, and one of ASC_PRIVATE_KEY_PATH/ASC_PRIVATE_KEY/ASC_PRIVATE_KEY_B64.")
+				environmentNote = "Environment credentials are incomplete. Set ASC_KEY_ID, ASC_ISSUER_ID, and one of ASC_PRIVATE_KEY_PATH/ASC_PRIVATE_KEY/ASC_PRIVATE_KEY_B64."
 			}
+			if normalizedOutput == "table" && environmentNote != "" {
+				fmt.Println(environmentNote)
+			}
+
+			if normalizedOutput == "json" {
+				payload := authStatusOutput{
+					StorageBackend:                 storageBackend,
+					StorageLocation:                storageLocation,
+					Warnings:                       warnings,
+					Credentials:                    credentialOutput,
+					Profile:                        profile,
+					EnvironmentCredentialsProvided: envProvided,
+					EnvironmentCredentialsComplete: envComplete,
+					EnvironmentNote:                environmentNote,
+					ValidationFailures:             validationFailures,
+				}
+				if *verbose {
+					payload.KeychainAvailable = boolPointer(keychainAvailable)
+					if keychainErr != nil {
+						payload.KeychainError = keychainErr.Error()
+					}
+					if configErr == nil {
+						payload.ConfigPath = configPath
+					}
+				}
+				if err := shared.PrintOutput(payload, "json", *output.Pretty); err != nil {
+					return err
+				}
+			}
+
 			if *validate && validationFailures > 0 {
 				return shared.NewReportedError(fmt.Errorf("auth status: validation failed for %d credential(s)", validationFailures))
 			}
@@ -765,4 +827,51 @@ func credentialStorageLabel(cred authsvc.Credential) string {
 		return cred.Source
 	}
 	return "unknown"
+}
+
+type authStatusCredentialOutput struct {
+	Name             string `json:"name"`
+	KeyID            string `json:"keyId"`
+	IsDefault        bool   `json:"isDefault"`
+	StoredIn         string `json:"storedIn"`
+	Validation       string `json:"validation,omitempty"`
+	ValidationDetail string `json:"validationDetail,omitempty"`
+	ValidationError  string `json:"validationError,omitempty"`
+}
+
+type authStatusOutput struct {
+	StorageBackend                 string                       `json:"storageBackend"`
+	StorageLocation                string                       `json:"storageLocation"`
+	Warnings                       []string                     `json:"warnings,omitempty"`
+	Credentials                    []authStatusCredentialOutput `json:"credentials"`
+	Profile                        string                       `json:"profile,omitempty"`
+	EnvironmentCredentialsProvided bool                         `json:"environmentCredentialsProvided"`
+	EnvironmentCredentialsComplete bool                         `json:"environmentCredentialsComplete"`
+	EnvironmentNote                string                       `json:"environmentNote,omitempty"`
+	ValidationFailures             int                          `json:"validationFailures,omitempty"`
+	KeychainAvailable              *bool                        `json:"keychainAvailable,omitempty"`
+	KeychainError                  string                       `json:"keychainError,omitempty"`
+	ConfigPath                     string                       `json:"configPath,omitempty"`
+}
+
+func buildAuthStatusCredentialRows(credentials []authsvc.Credential) [][]string {
+	rows := make([][]string, 0, len(credentials))
+	for _, cred := range credentials {
+		defaultLabel := "no"
+		if cred.IsDefault {
+			defaultLabel = "yes"
+		}
+		rows = append(rows, []string{
+			cred.Name,
+			cred.KeyID,
+			defaultLabel,
+			credentialStorageLabel(cred),
+		})
+	}
+	return rows
+}
+
+func boolPointer(value bool) *bool {
+	result := value
+	return &result
 }

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -627,6 +628,101 @@ func TestAuthStatusCommand(t *testing.T) {
 		}
 		if strings.Contains(stdout, "ASC_BYPASS_KEYCHAIN=1") {
 			t.Fatalf("expected warning to avoid hardcoded '=1', got %q", stdout)
+		}
+	})
+
+	t.Run("stored credentials are rendered as table", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+		if err := authsvc.StoreCredentialsConfigAt("demo", "KEY123", "ISS123", "/tmp/AuthKey.p8", cfgPath); err != nil {
+			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+		}
+
+		cmd := AuthStatusCommand()
+		if err := cmd.FlagSet.Parse([]string{}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, _ := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+		if !strings.Contains(stdout, "Stored credentials:") {
+			t.Fatalf("expected stored credentials heading, got %q", stdout)
+		}
+		if !strings.Contains(stdout, "┌") || !strings.Contains(stdout, "│ Name ") {
+			t.Fatalf("expected table output for credentials, got %q", stdout)
+		}
+		if !strings.Contains(stdout, "demo") || !strings.Contains(stdout, "KEY123") {
+			t.Fatalf("expected credential values in table output, got %q", stdout)
+		}
+	})
+
+	t.Run("json output renders structured credentials", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+		if err := authsvc.StoreCredentialsConfigAt("demo", "KEY123", "ISS123", "/tmp/AuthKey.p8", cfgPath); err != nil {
+			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+		}
+
+		cmd := AuthStatusCommand()
+		if err := cmd.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, stderr := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("expected empty stderr, got %q", stderr)
+		}
+
+		var payload struct {
+			StorageBackend string `json:"storageBackend"`
+			Credentials    []struct {
+				Name      string `json:"name"`
+				KeyID     string `json:"keyId"`
+				IsDefault bool   `json:"isDefault"`
+				StoredIn  string `json:"storedIn"`
+			} `json:"credentials"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("failed to unmarshal auth status json: %v; stdout=%q", err, stdout)
+		}
+		if payload.StorageBackend == "" {
+			t.Fatalf("expected storage backend in json output, got %q", stdout)
+		}
+		if len(payload.Credentials) != 1 {
+			t.Fatalf("expected one credential in json output, got %d", len(payload.Credentials))
+		}
+		if payload.Credentials[0].Name != "demo" || payload.Credentials[0].KeyID != "KEY123" {
+			t.Fatalf("unexpected credential json payload: %+v", payload.Credentials[0])
+		}
+	})
+
+	t.Run("invalid output format returns usage error", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+
+		cmd := AuthStatusCommand()
+		if err := cmd.FlagSet.Parse([]string{"--output", "yaml"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if stdout != "" {
+			t.Fatalf("expected empty stdout, got %q", stdout)
+		}
+		if !strings.Contains(stderr, "unsupported format: yaml") {
+			t.Fatalf("expected unsupported format error, got %q", stderr)
 		}
 	})
 

--- a/internal/cli/cmdtest/auth_status_output_test.go
+++ b/internal/cli/cmdtest/auth_status_output_test.go
@@ -1,0 +1,90 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+func TestAuthStatusOutputJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+
+	cfg := &config.Config{
+		DefaultKeyName: "default",
+		Keys: []config.Credential{
+			{
+				Name:           "default",
+				KeyID:          "KEY123",
+				IssuerID:       "ISS456",
+				PrivateKeyPath: keyPath,
+			},
+		},
+	}
+	if err := config.SaveAt(configPath, cfg); err != nil {
+		t.Fatalf("SaveAt() error: %v", err)
+	}
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = cmd.Run([]string{"auth", "status", "--output", "json"}, "1.0.0")
+	})
+	if code != cmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, cmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		StorageBackend string `json:"storageBackend"`
+		Credentials    []struct {
+			Name      string `json:"name"`
+			KeyID     string `json:"keyId"`
+			IsDefault bool   `json:"isDefault"`
+			StoredIn  string `json:"storedIn"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to unmarshal auth status json: %v; stdout=%q", err, stdout)
+	}
+	if payload.StorageBackend != "Config File" {
+		t.Fatalf("expected storage backend %q, got %q", "Config File", payload.StorageBackend)
+	}
+	if len(payload.Credentials) != 1 {
+		t.Fatalf("expected one credential, got %d", len(payload.Credentials))
+	}
+	if payload.Credentials[0].Name != "default" || payload.Credentials[0].KeyID != "KEY123" || !payload.Credentials[0].IsDefault {
+		t.Fatalf("unexpected credential payload: %+v", payload.Credentials[0])
+	}
+}
+
+func TestAuthStatusOutputInvalidReturnsExitUsage(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	_, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"auth", "status", "--output", "yaml"}, "1.0.0")
+		if code != cmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+		}
+	})
+	if !strings.Contains(stderr, "unsupported format: yaml") {
+		t.Fatalf("expected stderr to contain unsupported format error, got %q", stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- add `--output` support to `asc auth status` with `table` (default) and `json` modes
- keep the human-friendly storage summary + credentials table for default output, and emit structured JSON for scripting/automation
- add tests for JSON output and invalid output handling (usage exit), and align `AGENTS.md` output-default guidance with TTY-aware behavior

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/auth ./internal/cli/cmdtest`
- [x] `make format`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go run . auth status --help` (verify `--output` flag)