### PR TITLE
Add Plinth.IT to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**57 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**58 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -214,6 +214,13 @@
     "platform": ["iOS", "macOS"]
   },
   {
+    "app": "Plinth.IT",
+    "link": "https://apps.apple.com/us/app/plinth-it/id6746931219",
+    "creator": "lanxinger",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2f/57/02/2f570236-cd2e-4d0b-a797-1130d5b68c19/AppIcon-0-1x_U007emarketing-0-11-0-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Popcorn Stack: Track Watchlist",
     "link": "https://apps.apple.com/app/id6759187614",
     "creator": "maail",


### PR DESCRIPTION
## Summary

- Adds [Plinth.IT](https://apps.apple.com/us/app/plinth-it/id6746931219) to the Wall of Apps.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps

- [x] Manually edited `docs/wall-of-apps.json` and ran `make update-wall-of-apps`
- [x] Committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry:

\`\`\`json
{
  "app": "Plinth.IT",
  "link": "https://apps.apple.com/us/app/plinth-it/id6746931219",
  "creator": "lanxinger",
  "platform": ["iOS"]
}
\`\`\`