### PR TITLE
Add Voice Do to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**58 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**59 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -368,6 +368,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Voice Do",
+    "link": "https://apps.apple.com/us/app/voice-do-task-manager/id6746357453",
+    "creator": "maail",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/db/38/3a/db383add-39de-00cd-d079-319f7245b43c/Placeholder.mill/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Weather mini - Trip Forecasts",
     "link": "https://apps.apple.com/us/app/weather-mini-trip-forecasts/id892589817",
     "creator": "Kai Luo",


### PR DESCRIPTION
Adds [Voice Do](https://apps.apple.com/us/app/voice-do-task-manager/id6746357453) to the Wall of Apps.

- Updated `docs/wall-of-apps.json` with Voice Do entry (iOS, creator: maail)
- Bumped app count from 58 → 59 in `README.md`