### PR TITLE
Extend Xcode Cloud run triggers and add build-runs get

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ asc bundle-ids list
 asc workflow run release
 ```
 
+### Xcode Cloud workflows and build runs
+
+```bash
+# Trigger from a pull request
+asc xcode-cloud run --workflow-id "WORKFLOW_ID" --pull-request-id "PR_ID"
+
+# Rerun from an existing build run with a clean build
+asc xcode-cloud run --source-run-id "BUILD_RUN_ID" --clean
+
+# Fetch a single build run by ID
+asc xcode-cloud build-runs get --id "BUILD_RUN_ID"
+```
+
 ## Commands and Reference
 
 Use built-in help as the source of truth:

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -4937,6 +4937,35 @@ func TestGetCiBuildRun(t *testing.T) {
 	}
 }
 
+func TestGetCiBuildRun_WithIncludeAndFields(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":1}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildRuns/run-1" {
+			t.Fatalf("expected path /v1/ciBuildRuns/run-1, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("include") != "workflow,pullRequest" {
+			t.Fatalf("expected include=workflow,pullRequest, got %q", values.Get("include"))
+		}
+		if values.Get("fields[ciBuildRuns]") != "workflow,pullRequest" {
+			t.Fatalf("expected fields[ciBuildRuns]=workflow,pullRequest, got %q", values.Get("fields[ciBuildRuns]"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetCiBuildRun(
+		context.Background(),
+		"run-1",
+		WithCiBuildRunInclude("workflow", "pullRequest"),
+		WithCiBuildRunFields("workflow", "pullRequest"),
+	); err != nil {
+		t.Fatalf("GetCiBuildRun() error: %v", err)
+	}
+}
+
 func TestGetCiBuildRunBuilds_WithLimit(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1"}]}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -4993,6 +5022,133 @@ func TestCreateCiBuildRun(t *testing.T) {
 			},
 		},
 	}
+	if _, err := client.CreateCiBuildRun(context.Background(), req); err != nil {
+		t.Fatalf("CreateCiBuildRun() error: %v", err)
+	}
+}
+
+func TestCreateCiBuildRun_WithPullRequestAndClean(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"ciBuildRuns","id":"run-pr-1","attributes":{"number":2}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildRuns" {
+			t.Fatalf("expected path /v1/ciBuildRuns, got %s", req.URL.Path)
+		}
+
+		var payload map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected data object in payload, got %#v", payload["data"])
+		}
+		attrs, ok := data["attributes"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected attributes object in payload, got %#v", data["attributes"])
+		}
+		if clean, ok := attrs["clean"].(bool); !ok || !clean {
+			t.Fatalf("expected attributes.clean=true, got %#v", attrs["clean"])
+		}
+
+		relationships, ok := data["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected relationships object in payload, got %#v", data["relationships"])
+		}
+		if _, ok := relationships["workflow"]; !ok {
+			t.Fatalf("expected workflow relationship, got %#v", relationships)
+		}
+		if _, ok := relationships["pullRequest"]; !ok {
+			t.Fatalf("expected pullRequest relationship, got %#v", relationships)
+		}
+		if _, ok := relationships["sourceBranchOrTag"]; ok {
+			t.Fatalf("did not expect sourceBranchOrTag relationship, got %#v", relationships)
+		}
+		if _, ok := relationships["buildRun"]; ok {
+			t.Fatalf("did not expect buildRun relationship, got %#v", relationships)
+		}
+
+		assertAuthorized(t, req)
+	}, response)
+
+	clean := true
+	req := CiBuildRunCreateRequest{
+		Data: CiBuildRunCreateData{
+			Type:       ResourceTypeCiBuildRuns,
+			Attributes: &CiBuildRunCreateAttributes{Clean: &clean},
+			Relationships: &CiBuildRunCreateRelationships{
+				Workflow: &Relationship{
+					Data: ResourceData{Type: ResourceTypeCiWorkflows, ID: "wf-1"},
+				},
+				PullRequest: &Relationship{
+					Data: ResourceData{Type: ResourceTypeScmPullRequests, ID: "pr-1"},
+				},
+			},
+		},
+	}
+
+	if _, err := client.CreateCiBuildRun(context.Background(), req); err != nil {
+		t.Fatalf("CreateCiBuildRun() error: %v", err)
+	}
+}
+
+func TestCreateCiBuildRun_WithSourceBuildRunOnly(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"ciBuildRuns","id":"run-rerun-1","attributes":{"number":3}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildRuns" {
+			t.Fatalf("expected path /v1/ciBuildRuns, got %s", req.URL.Path)
+		}
+
+		var payload map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected data object in payload, got %#v", payload["data"])
+		}
+		if _, ok := data["attributes"]; ok {
+			t.Fatalf("did not expect attributes in payload, got %#v", data["attributes"])
+		}
+
+		relationships, ok := data["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected relationships object in payload, got %#v", data["relationships"])
+		}
+		if _, ok := relationships["buildRun"]; !ok {
+			t.Fatalf("expected buildRun relationship, got %#v", relationships)
+		}
+		if _, ok := relationships["workflow"]; ok {
+			t.Fatalf("did not expect workflow relationship, got %#v", relationships)
+		}
+		if _, ok := relationships["sourceBranchOrTag"]; ok {
+			t.Fatalf("did not expect sourceBranchOrTag relationship, got %#v", relationships)
+		}
+		if _, ok := relationships["pullRequest"]; ok {
+			t.Fatalf("did not expect pullRequest relationship, got %#v", relationships)
+		}
+
+		assertAuthorized(t, req)
+	}, response)
+
+	req := CiBuildRunCreateRequest{
+		Data: CiBuildRunCreateData{
+			Type: ResourceTypeCiBuildRuns,
+			Relationships: &CiBuildRunCreateRelationships{
+				BuildRun: &Relationship{
+					Data: ResourceData{Type: ResourceTypeCiBuildRuns, ID: "run-1"},
+				},
+			},
+		},
+	}
+
 	if _, err := client.CreateCiBuildRun(context.Background(), req); err != nil {
 		t.Fatalf("CreateCiBuildRun() error: %v", err)
 	}

--- a/internal/asc/xcode_cloud.go
+++ b/internal/asc/xcode_cloud.go
@@ -495,16 +495,24 @@ type CiBuildRunCreateRequest struct {
 	Data CiBuildRunCreateData `json:"data"`
 }
 
+// CiBuildRunCreateAttributes are optional attributes for creating a CI build run.
+type CiBuildRunCreateAttributes struct {
+	Clean *bool `json:"clean,omitempty"`
+}
+
 // CiBuildRunCreateData is the data portion of a CI build run create request.
 type CiBuildRunCreateData struct {
 	Type          ResourceType                   `json:"type"`
-	Relationships *CiBuildRunCreateRelationships `json:"relationships"`
+	Attributes    *CiBuildRunCreateAttributes    `json:"attributes,omitempty"`
+	Relationships *CiBuildRunCreateRelationships `json:"relationships,omitempty"`
 }
 
 // CiBuildRunCreateRelationships describes relationships for creating a CI build run.
 type CiBuildRunCreateRelationships struct {
-	Workflow          *Relationship `json:"workflow"`
-	SourceBranchOrTag *Relationship `json:"sourceBranchOrTag"`
+	BuildRun          *Relationship `json:"buildRun,omitempty"`
+	Workflow          *Relationship `json:"workflow,omitempty"`
+	SourceBranchOrTag *Relationship `json:"sourceBranchOrTag,omitempty"`
+	PullRequest       *Relationship `json:"pullRequest,omitempty"`
 }
 
 // Query types for Xcode Cloud endpoints
@@ -715,6 +723,28 @@ type ciBuildRunsQuery struct {
 // CiBuildRunsOption is a functional option for GetCiBuildRuns.
 type CiBuildRunsOption func(*ciBuildRunsQuery)
 
+type ciBuildRunGetQuery struct {
+	include           []string
+	fieldsCiBuildRuns []string
+}
+
+// CiBuildRunGetOption is a functional option for GetCiBuildRun.
+type CiBuildRunGetOption func(*ciBuildRunGetQuery)
+
+// WithCiBuildRunInclude includes related resources in the build run detail response.
+func WithCiBuildRunInclude(relationships ...string) CiBuildRunGetOption {
+	return func(q *ciBuildRunGetQuery) {
+		q.include = normalizeUniqueList(append(q.include, relationships...))
+	}
+}
+
+// WithCiBuildRunFields limits returned fields for ciBuildRuns resources.
+func WithCiBuildRunFields(fields ...string) CiBuildRunGetOption {
+	return func(q *ciBuildRunGetQuery) {
+		q.fieldsCiBuildRuns = normalizeUniqueList(append(q.fieldsCiBuildRuns, fields...))
+	}
+}
+
 // WithCiBuildRunsLimit sets the max number of build runs to return.
 func WithCiBuildRunsLimit(limit int) CiBuildRunsOption {
 	return func(q *ciBuildRunsQuery) {
@@ -736,6 +766,13 @@ func WithCiBuildRunsNextURL(next string) CiBuildRunsOption {
 func buildCiBuildRunsQuery(query *ciBuildRunsQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildCiBuildRunGetQuery(query *ciBuildRunGetQuery) string {
+	values := url.Values{}
+	addCSV(values, "include", query.include)
+	addCSV(values, "fields[ciBuildRuns]", query.fieldsCiBuildRuns)
 	return values.Encode()
 }
 
@@ -1469,8 +1506,17 @@ func (c *Client) GetCiBuildRuns(ctx context.Context, workflowID string, opts ...
 }
 
 // GetCiBuildRun retrieves a CI build run by ID.
-func (c *Client) GetCiBuildRun(ctx context.Context, buildRunID string) (*CiBuildRunResponse, error) {
+func (c *Client) GetCiBuildRun(ctx context.Context, buildRunID string, opts ...CiBuildRunGetOption) (*CiBuildRunResponse, error) {
+	query := &ciBuildRunGetQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	path := fmt.Sprintf("/v1/ciBuildRuns/%s", buildRunID)
+	if queryString := buildCiBuildRunGetQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -1683,8 +1729,12 @@ type XcodeCloudRunResult struct {
 	BuildNumber       int    `json:"buildNumber,omitempty"`
 	WorkflowID        string `json:"workflowId"`
 	WorkflowName      string `json:"workflowName,omitempty"`
-	GitReferenceID    string `json:"gitReferenceId"`
+	TriggerSource     string `json:"triggerSource,omitempty"`
+	GitReferenceID    string `json:"gitReferenceId,omitempty"`
 	GitReferenceName  string `json:"gitReferenceName,omitempty"`
+	PullRequestID     string `json:"pullRequestId,omitempty"`
+	SourceRunID       string `json:"sourceRunId,omitempty"`
+	Clean             bool   `json:"clean,omitempty"`
 	ExecutionProgress string `json:"executionProgress,omitempty"`
 	CompletionStatus  string `json:"completionStatus,omitempty"`
 	StartReason       string `json:"startReason,omitempty"`

--- a/internal/asc/xcode_cloud_output.go
+++ b/internal/asc/xcode_cloud_output.go
@@ -28,14 +28,18 @@ type CiProductDeleteResult struct {
 }
 
 func xcodeCloudRunResultRows(result *XcodeCloudRunResult) ([]string, [][]string) {
-	headers := []string{"Build Run ID", "Build #", "Workflow ID", "Workflow Name", "Git Ref ID", "Git Ref Name", "Progress", "Status", "Start Reason", "Created"}
+	headers := []string{"Build Run ID", "Build #", "Workflow ID", "Workflow Name", "Trigger Source", "Git Ref ID", "Git Ref Name", "Pull Request ID", "Source Run ID", "Clean", "Progress", "Status", "Start Reason", "Created"}
 	rows := [][]string{{
 		result.BuildRunID,
 		fmt.Sprintf("%d", result.BuildNumber),
 		result.WorkflowID,
 		result.WorkflowName,
+		result.TriggerSource,
 		result.GitReferenceID,
 		result.GitReferenceName,
+		result.PullRequestID,
+		result.SourceRunID,
+		fmt.Sprintf("%t", result.Clean),
 		result.ExecutionProgress,
 		result.CompletionStatus,
 		result.StartReason,

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -43,8 +43,12 @@ func TestPrintTable_XcodeCloudRunResult(t *testing.T) {
 		BuildNumber:       42,
 		WorkflowID:        "wf-456",
 		WorkflowName:      "CI Build",
+		TriggerSource:     "branch",
 		GitReferenceID:    "ref-789",
 		GitReferenceName:  "main",
+		PullRequestID:     "",
+		SourceRunID:       "",
+		Clean:             true,
 		ExecutionProgress: "PENDING",
 		CompletionStatus:  "",
 		StartReason:       "MANUAL",
@@ -64,6 +68,15 @@ func TestPrintTable_XcodeCloudRunResult(t *testing.T) {
 	if !strings.Contains(output, "CI Build") {
 		t.Fatalf("expected workflow name in output, got: %s", output)
 	}
+	if !strings.Contains(output, "Trigger Source") {
+		t.Fatalf("expected trigger source header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "branch") {
+		t.Fatalf("expected trigger source value in output, got: %s", output)
+	}
+	if !strings.Contains(output, "true") {
+		t.Fatalf("expected clean flag value in output, got: %s", output)
+	}
 	if !strings.Contains(output, "PENDING") {
 		t.Fatalf("expected execution progress in output, got: %s", output)
 	}
@@ -75,8 +88,10 @@ func TestPrintMarkdown_XcodeCloudRunResult(t *testing.T) {
 		BuildNumber:       42,
 		WorkflowID:        "wf-456",
 		WorkflowName:      "CI Build",
+		TriggerSource:     "pull-request",
 		GitReferenceID:    "ref-789",
 		GitReferenceName:  "main",
+		PullRequestID:     "pr-1",
 		ExecutionProgress: "RUNNING",
 		CompletionStatus:  "",
 		StartReason:       "MANUAL",
@@ -92,6 +107,12 @@ func TestPrintMarkdown_XcodeCloudRunResult(t *testing.T) {
 	}
 	if !strings.Contains(output, "run-123") {
 		t.Fatalf("expected build run ID in output, got: %s", output)
+	}
+	if !strings.Contains(output, "pull-request") {
+		t.Fatalf("expected trigger source in output, got: %s", output)
+	}
+	if !strings.Contains(output, "pr-1") {
+		t.Fatalf("expected pull request ID in output, got: %s", output)
 	}
 	if !strings.Contains(output, "RUNNING") {
 		t.Fatalf("expected execution progress in output, got: %s", output)

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -4987,7 +4987,7 @@ func TestXcodeCloudValidationErrors(t *testing.T) {
 		{
 			name:    "xcode-cloud run missing branch",
 			args:    []string{"xcode-cloud", "run", "--workflow-id", "WF_ID"},
-			wantErr: "--branch or --git-reference-id is required",
+			wantErr: "--branch, --git-reference-id, or --pull-request-id is required",
 		},
 		{
 			name:    "xcode-cloud run workflow by name without app",
@@ -5048,6 +5048,11 @@ func TestXcodeCloudValidationErrors(t *testing.T) {
 			name:    "xcode-cloud build-runs missing workflow-id",
 			args:    []string{"xcode-cloud", "build-runs"},
 			wantErr: "--workflow-id is required",
+		},
+		{
+			name:    "xcode-cloud build-runs get missing id",
+			args:    []string{"xcode-cloud", "build-runs", "get"},
+			wantErr: "--id is required",
 		},
 		{
 			name:    "xcode-cloud build-runs builds missing run-id",
@@ -5211,6 +5216,16 @@ func TestXcodeCloudMutualExclusiveFlags(t *testing.T) {
 			name:    "xcode-cloud run branch and git-reference-id are mutually exclusive",
 			args:    []string{"xcode-cloud", "run", "--workflow-id", "WF_ID", "--branch", "main", "--git-reference-id", "REF_ID"},
 			wantErr: "--branch and --git-reference-id are mutually exclusive",
+		},
+		{
+			name:    "xcode-cloud run branch and pull-request-id are mutually exclusive",
+			args:    []string{"xcode-cloud", "run", "--workflow-id", "WF_ID", "--branch", "main", "--pull-request-id", "PR_ID"},
+			wantErr: "--branch, --git-reference-id, and --pull-request-id are mutually exclusive",
+		},
+		{
+			name:    "xcode-cloud run source-run-id conflicts with workflow",
+			args:    []string{"xcode-cloud", "run", "--source-run-id", "RUN_ID", "--workflow-id", "WF_ID"},
+			wantErr: "--source-run-id is mutually exclusive with --workflow and --workflow-id",
 		},
 		{
 			name:    "xcode-cloud run invalid poll-interval",

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -214,6 +214,11 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			wantErr: "--workflow and --workflow-id are mutually exclusive",
 		},
 		{
+			name:    "xcode-cloud run source-run conflicts with workflow flags",
+			args:    []string{"xcode-cloud", "run", "--source-run-id", "RUN_123", "--workflow-id", "WF_ID"},
+			wantErr: "--source-run-id is mutually exclusive with --workflow and --workflow-id",
+		},
+		{
 			name:    "publish appstore invalid timeout",
 			args:    []string{"publish", "appstore", "--app", "APP_123", "--ipa", "app.ipa", "--version", "1.0.0", "--timeout", "-1s"},
 			wantErr: "--timeout must be greater than 0",

--- a/internal/cli/cmdtest/xcode_cloud_run_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_run_test.go
@@ -1,0 +1,260 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestXcodeCloudRunWithPullRequestIDPostsExpectedPayload(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount != 1 {
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+		}
+
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildRuns" {
+			t.Fatalf("expected path /v1/ciBuildRuns, got %s", req.URL.Path)
+		}
+
+		var payload map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected data object in payload, got %#v", payload["data"])
+		}
+		relationships, ok := data["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected relationships object in payload, got %#v", data["relationships"])
+		}
+
+		if _, ok := relationships["workflow"]; !ok {
+			t.Fatalf("expected workflow relationship in payload, got %#v", relationships)
+		}
+		if _, ok := relationships["pullRequest"]; !ok {
+			t.Fatalf("expected pullRequest relationship in payload, got %#v", relationships)
+		}
+		if _, ok := relationships["sourceBranchOrTag"]; ok {
+			t.Fatalf("did not expect sourceBranchOrTag relationship in payload, got %#v", relationships)
+		}
+		if _, ok := relationships["buildRun"]; ok {
+			t.Fatalf("did not expect buildRun relationship in payload, got %#v", relationships)
+		}
+		if _, ok := data["attributes"]; ok {
+			t.Fatalf("did not expect attributes in payload, got %#v", data["attributes"])
+		}
+
+		body := `{"data":{"type":"ciBuildRuns","id":"run-pr-1","attributes":{"number":1,"executionProgress":"PENDING","startReason":"MANUAL","createdDate":"2026-03-05T10:00:00Z"}}}`
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "run", "--workflow-id", "wf-1", "--pull-request-id", "pr-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"buildRunId":"run-pr-1"`) {
+		t.Fatalf("expected build run ID in output, got %q", stdout)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected exactly one request, got %d", requestCount)
+	}
+}
+
+func TestXcodeCloudRunWithSourceRunAndCleanPostsExpectedPayload(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/ciBuildRuns/run-1" {
+				t.Fatalf("expected path /v1/ciBuildRuns/run-1, got %s", req.URL.Path)
+			}
+			values := req.URL.Query()
+			if values.Get("include") != "workflow" {
+				t.Fatalf("expected include=workflow, got %q", values.Get("include"))
+			}
+			if values.Get("fields[ciBuildRuns]") != "workflow" {
+				t.Fatalf("expected fields[ciBuildRuns]=workflow, got %q", values.Get("fields[ciBuildRuns]"))
+			}
+			body := `{"data":{"type":"ciBuildRuns","id":"run-1","relationships":{"workflow":{"data":{"type":"ciWorkflows","id":"wf-1"}}}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/ciBuildRuns" {
+				t.Fatalf("expected path /v1/ciBuildRuns, got %s", req.URL.Path)
+			}
+
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+
+			data, ok := payload["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected data object in payload, got %#v", payload["data"])
+			}
+			attributes, ok := data["attributes"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected attributes object in payload, got %#v", data["attributes"])
+			}
+			clean, ok := attributes["clean"].(bool)
+			if !ok || !clean {
+				t.Fatalf("expected attributes.clean=true in payload, got %#v", attributes["clean"])
+			}
+
+			relationships, ok := data["relationships"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected relationships object in payload, got %#v", data["relationships"])
+			}
+			if _, ok := relationships["buildRun"]; !ok {
+				t.Fatalf("expected buildRun relationship in payload, got %#v", relationships)
+			}
+			if _, ok := relationships["workflow"]; !ok {
+				t.Fatalf("expected workflow relationship in payload, got %#v", relationships)
+			}
+			if _, ok := relationships["sourceBranchOrTag"]; ok {
+				t.Fatalf("did not expect sourceBranchOrTag relationship in payload, got %#v", relationships)
+			}
+			if _, ok := relationships["pullRequest"]; ok {
+				t.Fatalf("did not expect pullRequest relationship in payload, got %#v", relationships)
+			}
+
+			body := `{"data":{"type":"ciBuildRuns","id":"run-rerun-1","attributes":{"number":2,"executionProgress":"PENDING","startReason":"MANUAL","createdDate":"2026-03-05T10:00:00Z"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+		}
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "run", "--source-run-id", "run-1", "--clean"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"buildRunId":"run-rerun-1"`) {
+		t.Fatalf("expected build run ID in output, got %q", stdout)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected exactly two requests, got %d", requestCount)
+	}
+}
+
+func TestXcodeCloudBuildRunsGetFetchesBuildRun(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount != 1 {
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+		}
+
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/ciBuildRuns/run-1" {
+			t.Fatalf("expected path /v1/ciBuildRuns/run-1, got %s", req.URL.Path)
+		}
+
+		body := `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":42,"executionProgress":"RUNNING"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "build-runs", "get", "--id", "run-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"run-1"`) {
+		t.Fatalf("expected run ID in output, got %q", stdout)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected exactly one request, got %d", requestCount)
+	}
+}

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -31,6 +31,8 @@ Examples:
   asc xcode-cloud scm providers list
   asc xcode-cloud run --app "APP_ID" --workflow "WorkflowName" --branch "main"
   asc xcode-cloud run --workflow-id "WORKFLOW_ID" --git-reference-id "REF_ID"
+  asc xcode-cloud run --workflow-id "WORKFLOW_ID" --pull-request-id "PR_ID"
+  asc xcode-cloud run --source-run-id "BUILD_RUN_ID" --clean
   asc xcode-cloud run --app "APP_ID" --workflow "Deploy" --branch "main" --wait
   asc xcode-cloud status --run-id "BUILD_RUN_ID"
   asc xcode-cloud status --run-id "BUILD_RUN_ID" --wait`,
@@ -65,6 +67,9 @@ func XcodeCloudRunCommand() *ffcli.Command {
 	workflowID := fs.String("workflow-id", "", "Workflow ID to trigger (alternative to --workflow)")
 	branch := fs.String("branch", "", "Branch or tag name to build")
 	gitReferenceID := fs.String("git-reference-id", "", "Git reference ID to build (alternative to --branch)")
+	pullRequestID := fs.String("pull-request-id", "", "Pull request ID to build")
+	sourceRunID := fs.String("source-run-id", "", "Source build run ID to rerun")
+	clean := fs.Bool("clean", false, "Request a clean build")
 	wait := fs.Bool("wait", false, "Wait for build to complete")
 	pollInterval := fs.Duration("poll-interval", 10*time.Second, "Poll interval when waiting")
 	timeout := fs.Duration("timeout", 0, "Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
@@ -76,12 +81,18 @@ func XcodeCloudRunCommand() *ffcli.Command {
 		ShortHelp:  "Trigger an Xcode Cloud workflow build.",
 		LongHelp: `Trigger an Xcode Cloud workflow build.
 
-You can specify the workflow by name (requires --app) or by ID (--workflow-id).
-You can specify the branch/tag by name (--branch) or by ID (--git-reference-id).
+Standard mode:
+- Specify workflow by name (requires --app) or by ID (--workflow-id)
+- Specify source by branch/tag (--branch or --git-reference-id) or pull request (--pull-request-id)
+
+Rerun mode:
+- Use --source-run-id to rerun from an existing build run (without workflow/source selectors)
 
 Examples:
   asc xcode-cloud run --app "123456789" --workflow "CI" --branch "main"
   asc xcode-cloud run --workflow-id "WORKFLOW_ID" --git-reference-id "REF_ID"
+  asc xcode-cloud run --workflow-id "WORKFLOW_ID" --pull-request-id "PR_ID"
+  asc xcode-cloud run --source-run-id "BUILD_RUN_ID" --clean
   asc xcode-cloud run --app "123456789" --workflow "Deploy" --branch "release/1.0" --wait
   asc xcode-cloud run --app "123456789" --workflow "CI" --branch "main" --wait --poll-interval 30s --timeout 1h`,
 		FlagSet:   fs,
@@ -92,20 +103,34 @@ Examples:
 			hasWorkflowID := strings.TrimSpace(*workflowID) != ""
 			hasBranch := strings.TrimSpace(*branch) != ""
 			hasGitRefID := strings.TrimSpace(*gitReferenceID) != ""
+			hasPullRequestID := strings.TrimSpace(*pullRequestID) != ""
+			hasSourceRunID := strings.TrimSpace(*sourceRunID) != ""
 
 			if hasWorkflowName && hasWorkflowID {
 				return shared.UsageError("--workflow and --workflow-id are mutually exclusive")
 			}
-			if !hasWorkflowName && !hasWorkflowID {
-				fmt.Fprintln(os.Stderr, "Error: --workflow or --workflow-id is required")
-				return flag.ErrHelp
-			}
 			if hasBranch && hasGitRefID {
 				return shared.UsageError("--branch and --git-reference-id are mutually exclusive")
 			}
-			if !hasBranch && !hasGitRefID {
-				fmt.Fprintln(os.Stderr, "Error: --branch or --git-reference-id is required")
-				return flag.ErrHelp
+			if (hasBranch || hasGitRefID) && hasPullRequestID {
+				return shared.UsageError("--branch, --git-reference-id, and --pull-request-id are mutually exclusive")
+			}
+			if hasSourceRunID {
+				if hasWorkflowName || hasWorkflowID {
+					return shared.UsageError("--source-run-id is mutually exclusive with --workflow and --workflow-id")
+				}
+				if hasBranch || hasGitRefID || hasPullRequestID {
+					return shared.UsageError("--source-run-id is mutually exclusive with --branch, --git-reference-id, and --pull-request-id")
+				}
+			} else {
+				if !hasWorkflowName && !hasWorkflowID {
+					fmt.Fprintln(os.Stderr, "Error: --workflow or --workflow-id is required")
+					return flag.ErrHelp
+				}
+				if !hasBranch && !hasGitRefID && !hasPullRequestID {
+					fmt.Fprintln(os.Stderr, "Error: --branch, --git-reference-id, or --pull-request-id is required")
+					return flag.ErrHelp
+				}
 			}
 			if *timeout < 0 {
 				return shared.UsageError("--timeout must be greater than or equal to 0")
@@ -115,7 +140,7 @@ Examples:
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
-			if hasWorkflowName && resolvedAppID == "" {
+			if hasWorkflowName && !hasSourceRunID && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required when using --workflow (or set ASC_APP_ID)")
 				return flag.ErrHelp
 			}
@@ -128,58 +153,105 @@ Examples:
 			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, *timeout)
 			defer cancel()
 
-			// Resolve workflow ID
 			resolvedWorkflowID := strings.TrimSpace(*workflowID)
 			var workflowNameForOutput string
-			if resolvedWorkflowID == "" {
-				// Need to resolve workflow by name
-				product, err := client.ResolveCiProductForApp(requestCtx, resolvedAppID)
-				if err != nil {
-					return fmt.Errorf("xcode-cloud run: %w", err)
-				}
-
-				workflow, err := client.ResolveCiWorkflowByName(requestCtx, product.ID, strings.TrimSpace(*workflowName))
-				if err != nil {
-					return fmt.Errorf("xcode-cloud run: %w", err)
-				}
-
-				resolvedWorkflowID = workflow.ID
-				workflowNameForOutput = workflow.Attributes.Name
-			}
-
-			// Resolve git reference ID
 			resolvedGitRefID := strings.TrimSpace(*gitReferenceID)
+			resolvedPullRequestID := strings.TrimSpace(*pullRequestID)
+			resolvedSourceRunID := strings.TrimSpace(*sourceRunID)
 			var refNameForOutput string
-			if resolvedGitRefID == "" {
-				// Need to resolve git reference by name
-				// First get the repository from the workflow
-				repo, err := client.GetCiWorkflowRepository(requestCtx, resolvedWorkflowID)
-				if err != nil {
-					return fmt.Errorf("xcode-cloud run: failed to get workflow repository: %w", err)
+			triggerSource := ""
+
+			if !hasSourceRunID {
+				// Resolve workflow ID if needed.
+				if resolvedWorkflowID == "" {
+					product, err := client.ResolveCiProductForApp(requestCtx, resolvedAppID)
+					if err != nil {
+						return fmt.Errorf("xcode-cloud run: %w", err)
+					}
+
+					workflow, err := client.ResolveCiWorkflowByName(requestCtx, product.ID, strings.TrimSpace(*workflowName))
+					if err != nil {
+						return fmt.Errorf("xcode-cloud run: %w", err)
+					}
+
+					resolvedWorkflowID = workflow.ID
+					workflowNameForOutput = workflow.Attributes.Name
 				}
 
-				gitRef, err := client.ResolveGitReferenceByName(requestCtx, repo.ID, strings.TrimSpace(*branch))
-				if err != nil {
-					return fmt.Errorf("xcode-cloud run: %w", err)
-				}
+				if resolvedPullRequestID != "" {
+					triggerSource = "pull-request"
+				} else {
+					// Resolve git reference by name if needed.
+					if resolvedGitRefID == "" {
+						repo, err := client.GetCiWorkflowRepository(requestCtx, resolvedWorkflowID)
+						if err != nil {
+							return fmt.Errorf("xcode-cloud run: failed to get workflow repository: %w", err)
+						}
 
-				resolvedGitRefID = gitRef.ID
-				refNameForOutput = gitRef.Attributes.Name
+						gitRef, err := client.ResolveGitReferenceByName(requestCtx, repo.ID, strings.TrimSpace(*branch))
+						if err != nil {
+							return fmt.Errorf("xcode-cloud run: %w", err)
+						}
+
+						resolvedGitRefID = gitRef.ID
+						refNameForOutput = gitRef.Attributes.Name
+						triggerSource = "branch"
+					} else {
+						triggerSource = "git-reference"
+					}
+				}
+			} else {
+				sourceRunResp, err := getCiBuildRunWithRetry(
+					requestCtx,
+					client,
+					resolvedSourceRunID,
+					asc.WithCiBuildRunInclude("workflow"),
+					asc.WithCiBuildRunFields("workflow"),
+				)
+				if err != nil {
+					return fmt.Errorf("xcode-cloud run: failed to resolve source run workflow: %w", err)
+				}
+				if sourceRunResp.Data.Relationships == nil || sourceRunResp.Data.Relationships.Workflow == nil || strings.TrimSpace(sourceRunResp.Data.Relationships.Workflow.Data.ID) == "" {
+					return fmt.Errorf("xcode-cloud run: source run %q does not contain a workflow relationship", resolvedSourceRunID)
+				}
+				resolvedWorkflowID = sourceRunResp.Data.Relationships.Workflow.Data.ID
+				triggerSource = "source-run"
 			}
 
-			// Create the build run
+			relationships := &asc.CiBuildRunCreateRelationships{}
+			switch {
+			case hasSourceRunID:
+				relationships.Workflow = &asc.Relationship{
+					Data: asc.ResourceData{Type: asc.ResourceTypeCiWorkflows, ID: resolvedWorkflowID},
+				}
+				relationships.BuildRun = &asc.Relationship{
+					Data: asc.ResourceData{Type: asc.ResourceTypeCiBuildRuns, ID: resolvedSourceRunID},
+				}
+			case resolvedPullRequestID != "":
+				relationships.Workflow = &asc.Relationship{
+					Data: asc.ResourceData{Type: asc.ResourceTypeCiWorkflows, ID: resolvedWorkflowID},
+				}
+				relationships.PullRequest = &asc.Relationship{
+					Data: asc.ResourceData{Type: asc.ResourceTypeScmPullRequests, ID: resolvedPullRequestID},
+				}
+			default:
+				relationships.Workflow = &asc.Relationship{
+					Data: asc.ResourceData{Type: asc.ResourceTypeCiWorkflows, ID: resolvedWorkflowID},
+				}
+				relationships.SourceBranchOrTag = &asc.Relationship{
+					Data: asc.ResourceData{Type: asc.ResourceTypeScmGitReferences, ID: resolvedGitRefID},
+				}
+			}
+
 			req := asc.CiBuildRunCreateRequest{
 				Data: asc.CiBuildRunCreateData{
-					Type: asc.ResourceTypeCiBuildRuns,
-					Relationships: &asc.CiBuildRunCreateRelationships{
-						Workflow: &asc.Relationship{
-							Data: asc.ResourceData{Type: asc.ResourceTypeCiWorkflows, ID: resolvedWorkflowID},
-						},
-						SourceBranchOrTag: &asc.Relationship{
-							Data: asc.ResourceData{Type: asc.ResourceTypeScmGitReferences, ID: resolvedGitRefID},
-						},
-					},
+					Type:          asc.ResourceTypeCiBuildRuns,
+					Relationships: relationships,
 				},
+			}
+			if *clean {
+				cleanValue := true
+				req.Data.Attributes = &asc.CiBuildRunCreateAttributes{Clean: &cleanValue}
 			}
 
 			resp, err := client.CreateCiBuildRun(requestCtx, req)
@@ -192,14 +264,29 @@ Examples:
 				BuildNumber:       resp.Data.Attributes.Number,
 				WorkflowID:        resolvedWorkflowID,
 				WorkflowName:      workflowNameForOutput,
+				TriggerSource:     triggerSource,
 				GitReferenceID:    resolvedGitRefID,
 				GitReferenceName:  refNameForOutput,
+				PullRequestID:     resolvedPullRequestID,
+				SourceRunID:       resolvedSourceRunID,
+				Clean:             *clean,
 				ExecutionProgress: string(resp.Data.Attributes.ExecutionProgress),
 				CompletionStatus:  string(resp.Data.Attributes.CompletionStatus),
 				StartReason:       resp.Data.Attributes.StartReason,
 				CreatedDate:       resp.Data.Attributes.CreatedDate,
 				StartedDate:       resp.Data.Attributes.StartedDate,
 				FinishedDate:      resp.Data.Attributes.FinishedDate,
+			}
+			if resp.Data.Relationships != nil {
+				if result.WorkflowID == "" && resp.Data.Relationships.Workflow != nil {
+					result.WorkflowID = resp.Data.Relationships.Workflow.Data.ID
+				}
+				if result.GitReferenceID == "" && resp.Data.Relationships.SourceBranchOrTag != nil {
+					result.GitReferenceID = resp.Data.Relationships.SourceBranchOrTag.Data.ID
+				}
+				if result.PullRequestID == "" && resp.Data.Relationships.PullRequest != nil {
+					result.PullRequestID = resp.Data.Relationships.PullRequest.Data.ID
+				}
 			}
 
 			if !*wait {

--- a/internal/cli/xcodecloud/xcode_cloud_build_runs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_build_runs.go
@@ -36,6 +36,7 @@ func XcodeCloudBuildRunsCommand() *ffcli.Command {
 Examples:
   asc xcode-cloud build-runs --workflow-id "WORKFLOW_ID"
   asc xcode-cloud build-runs list --workflow-id "WORKFLOW_ID"
+  asc xcode-cloud build-runs get --id "BUILD_RUN_ID"
   asc xcode-cloud build-runs builds --run-id "BUILD_RUN_ID"
   asc xcode-cloud build-runs --workflow-id "WORKFLOW_ID" --limit 50
   asc xcode-cloud build-runs --workflow-id "WORKFLOW_ID" --paginate`,
@@ -43,6 +44,7 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			XcodeCloudBuildRunsListCommand(),
+			XcodeCloudBuildRunsGetCommand(),
 			XcodeCloudBuildRunsBuildsCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -72,6 +74,29 @@ Examples:
 			return xcodeCloudBuildRunsList(ctx, *workflowID, *limit, *next, *paginate, *output, *pretty)
 		},
 	}
+}
+
+func XcodeCloudBuildRunsGetCommand() *ffcli.Command {
+	return shared.BuildIDGetCommand(shared.IDGetCommandConfig{
+		FlagSetName: "get",
+		Name:        "get",
+		ShortUsage:  "asc xcode-cloud build-runs get --id \"BUILD_RUN_ID\"",
+		ShortHelp:   "Get details for a build run.",
+		LongHelp: `Get details for a build run.
+
+Examples:
+  asc xcode-cloud build-runs get --id "BUILD_RUN_ID"
+  asc xcode-cloud build-runs get --id "BUILD_RUN_ID" --output table`,
+		IDFlag:      "id",
+		IDUsage:     "Build run ID",
+		ErrorPrefix: "xcode-cloud build-runs get",
+		ContextTimeout: func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return contextWithXcodeCloudTimeout(ctx, 0)
+		},
+		Fetch: func(ctx context.Context, client *asc.Client, id string) (any, error) {
+			return client.GetCiBuildRun(ctx, id)
+		},
+	})
 }
 
 func XcodeCloudBuildRunsBuildsCommand() *ffcli.Command {

--- a/internal/cli/xcodecloud/xcode_cloud_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_helpers.go
@@ -84,10 +84,10 @@ func contextWithXcodeCloudTimeout(ctx context.Context, timeout time.Duration) (c
 	return context.WithTimeout(ctx, timeout)
 }
 
-func getCiBuildRunWithRetry(ctx context.Context, client *asc.Client, buildRunID string) (*asc.CiBuildRunResponse, error) {
+func getCiBuildRunWithRetry(ctx context.Context, client *asc.Client, buildRunID string, opts ...asc.CiBuildRunGetOption) (*asc.CiBuildRunResponse, error) {
 	retryOpts := asc.ResolveRetryOptions()
 	return asc.WithRetry(ctx, func() (*asc.CiBuildRunResponse, error) {
-		resp, err := client.GetCiBuildRun(ctx, buildRunID)
+		resp, err := client.GetCiBuildRun(ctx, buildRunID, opts...)
 		if err != nil {
 			if isTransientNetworkError(err) {
 				return nil, &asc.RetryableError{Err: err}


### PR DESCRIPTION
## Summary

- Extend `asc xcode-cloud run` with `--pull-request-id`, `--source-run-id`, and `--clean`.
- Add `asc xcode-cloud build-runs get --id "BUILD_RUN_ID"` for direct `GET /v1/ciBuildRuns/{id}` reads.
- Expand `POST /v1/ciBuildRuns` payload support for trigger relationships (`workflow`, `sourceBranchOrTag`, `pullRequest`, `buildRun`) and `attributes.clean`.
- Add strict CLI validation/tests for new run modes and argument conflicts.
- Include trigger context fields in run output (`triggerSource`, `pullRequestId`, `sourceRunId`, `clean`) across output formats.
- Update `README.md` Xcode Cloud workflow examples.
- Live-test fix: rerun mode now resolves and sends `workflow` relationship from source build run (required by ASC API behavior).

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I ran `make generate app APP="..." LINK="..." CREATOR="..." PLATFORM="..."` (or manually edited `docs/wall-of-apps.json` + ran `make update-wall-of-apps`)
- [ ] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
