### PR TITLE
docs: add Peakme to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**61 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**62 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -200,6 +200,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Peakme: Hike, Track, Explore",
+    "link": "https://apps.apple.com/app/id6733216670",
+    "creator": "leszko11",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/22/a4/41/22a441e6-20c5-a464-2b0f-3db405633856/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Pickle Rite",
     "link": "https://apps.apple.com/us/app/pickle-rite/id6754095362",
     "creator": "Badarinath Venkatnarayansetty",


### PR DESCRIPTION
## Summary

- Add Peakme to the Wall of Apps.
- Source app details fetched via `asc --profile "Swiftoletz Brothers"` (`apps list --name "Peakme"`).
- Added entry:
  - app: `Peakme: Hike, Track, Explore`
  - link: `https://apps.apple.com/app/id6733216670`
  - creator: `leszko11`
  - platform: `iOS`

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I ran `make generate app APP="Peakme: Hike, Track, Explore" LINK="https://apps.apple.com/app/id6733216670" CREATOR="leszko11" PLATFORM="iOS"` (then kept only the Peakme entry and snippet count update)
- [x] I committed all generated files:
  - `docs/wall-of-apps.json`
  - `README.md`

Entry template:

```json
{
  "app": "Peakme: Hike, Track, Explore",
  "link": "https://apps.apple.com/app/id6733216670",
  "creator": "leszko11",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
