### PR TITLE
Add FPLai: FPL AI Assistant to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**62 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**63 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -96,6 +96,13 @@
     "platform": ["iOS", "macOS"]
   },
   {
+    "app": "FPLai: FPL AI Assistant",
+    "link": "https://apps.apple.com/app/id6757015527",
+    "creator": "Yago Martinez",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a3/a3/19/a3a31917-1ef0-2d81-3150-65391212a1bd/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Fuel: AI Nutrition",
     "link": "https://apps.apple.com/app/id6748624107",
     "creator": "0xSMW",


### PR DESCRIPTION
Adds FPLai: FPL AI Assistant to the Wall of Apps.

- App: FPLai: FPL AI Assistant
- Link: https://apps.apple.com/app/id6757015527
- Creator: Yago Martinez
- Platform: iOS