### PR TITLE
docs(wall): add Prickly Pear: Brain & Hormones

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**64 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**65 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -263,6 +263,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Prickly Pear: Brain & Hormones",
+    "link": "https://apps.apple.com/app/id6654889896",
+    "creator": "vishrutkmr7",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7a/04/14/7a04148e-e548-f6bf-8c0e-c26b9157a7cb/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Progressio: Habit Tracker",
     "link": "https://apps.apple.com/app/progressio-habit-tracker/id6740454461",
     "creator": "truongduy2611",


### PR DESCRIPTION
## Summary
- Adds **Prickly Pear: Brain & Hormones** to the Wall of Apps (iOS, App Store ID `6654889896`)
- Ran `make update-wall-of-apps` to bump the README count from 64 to 65

## Test plan
- [x] JSON valid
- [x] `make update-wall-of-apps` synced README snippet