### PR TITLE
Add Cat on Chair to Wall of Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**65 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**66 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -28,6 +28,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Cat on Chair",
+    "link": "https://apps.apple.com/ca/app/cat-on-chair-focus-timer/id6746562271",
+    "creator": "Ryan Yao",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/db/f5/df/dbf5dfa9-9f01-90d2-fce9-69e1c387c024/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "CodexMonitor",
     "link": "https://github.com/Dimillian/CodexMonitor",
     "creator": "Dimillian",


### PR DESCRIPTION
## Summary\n- add Cat on Chair to the Wall of Apps data\n- refresh the README wall snippet count\n\n## App\n- Name: Cat on Chair\n- Link: https://apps.apple.com/ca/app/cat-on-chair-focus-timer/id6746562271\n- Creator: Ryan Yao\n- Platform: iOS