### PR TITLE
Add 66-Day Streak and Thought Ease to wall of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**66 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**68 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -24,7 +24,7 @@
     "app": "Bloom",
     "link": "https://apps.apple.com/app/id6739955926",
     "creator": "mpdifran",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/df/b7/c1/dfb7c112-0edd-2a12-821a-873f7fab9d53/Blueberry-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8e/9b/52/8e9b5222-940f-0058-1528-aec270296b39/Blueberry-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg",
     "platform": ["iOS", "watchOS"]
   },
   {
@@ -38,7 +38,7 @@
     "app": "Cat on Chair",
     "link": "https://apps.apple.com/ca/app/cat-on-chair-focus-timer/id6746562271",
     "creator": "Ryan Yao",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/db/f5/df/dbf5dfa9-9f01-90d2-fce9-69e1c387c024/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/aa/9b/c7/aa9bc7c3-f8d8-2a7c-3a7b-ca7dec264363/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {
@@ -141,7 +141,7 @@
     "app": "Inkput",
     "link": "https://apps.apple.com/app/id6758570182",
     "creator": "funclosure",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/16/c2/84/16c2844a-b18c-63bd-328c-6057bc55cd62/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0f/2b/44/0f2b4498-ed4f-3b6a-a280-5e20e1b7f047/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
     "platform": ["iOS", "macOS"]
   },
   {
@@ -273,7 +273,7 @@
     "app": "Positive",
     "link": "https://apps.apple.com/us/app/positive/id653287635",
     "creator": "DanielStormApps",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/cc/4c/a8/cc4ca841-9f2f-7d04-e7ce-ad841d5d3d0c/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-P3-85-220.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ff/41/f6/ff41f60e-7df4-563f-3872-9cb6490e786f/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-P3-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {
@@ -329,7 +329,7 @@
     "app": "SnapVinyl",
     "link": "https://apps.apple.com/app/id6741057688",
     "creator": "TomLiu",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d4/c7/22/d4c722e8-7585-24a7-64b8-b83e47c93ff6/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c3/87/7c/c3877c8c-bac8-537d-453e-98ba2e171fe1/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {
@@ -375,6 +375,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Thought Ease: End Overthinking",
+    "link": "https://apps.apple.com/app/id6759291269",
+    "creator": "buraksh",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/38/89/82/3889821a-7a9e-d068-89ca-937b482923ed/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "TickerPad",
     "link": "https://apps.apple.com/app/id1578860989",
     "creator": "daimajia",
@@ -407,13 +414,6 @@
     "link": "https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903",
     "creator": "rursache",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/b8/67/43b86702-f67b-c314-f65b-cd60980205b0/Icon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
-    "platform": ["iOS"]
-  },
-  {
-    "app": "Thought Ease: End Overthinking",
-    "link": "https://apps.apple.com/us/app/thought-ease-end-overthinking/id6759291269",
-    "creator": "buraksh",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/38/89/82/3889821a-7a9e-d068-89ca-937b482923ed/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {


### PR DESCRIPTION
## Summary
- add 66-Day Streak: Habit Builder to `docs/wall-of-apps.json`
- add Thought Ease: End Overthinking to `docs/wall-of-apps.json`
- include App Store links, icons, and iOS platform metadata for both apps