### PR TITLE
ci: add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,27 @@
+name: Govulncheck
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Run weekly to catch newly disclosed vulnerabilities in existing dependencies.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Run govulncheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Scan Go dependencies and reachable code paths
+        id: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+          go-package: ./...


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for `govulncheck`
- scan the repository on pull requests, `main` pushes, manual dispatches, and a weekly schedule
- pin the `golang/govulncheck-action` ref from the start so the new security check is reproducible

## Test plan
- [x] Parse `.github/workflows/govulncheck.yml` locally with Ruby `YAML.load_file`
- [x] Let the local pre-commit hook run formatting, lint, and short tests during commit