### PR TITLE
ci: add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Run weekly so long-lived code paths are rescanned even without new PRs.
+    - cron: "31 4 * * 3"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Go code
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
+        with:
+          languages: go
+          build-mode: manual
+
+      - name: Build Go packages
+        run: go build ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow for Go code scanning on pull requests, `main` pushes, manual dispatches, and a weekly schedule
- pin `actions/checkout`, `actions/setup-go`, and `github/codeql-action` refs to immutable SHAs
- use an explicit `go build ./...` step so the analysis follows the repository's Go toolchain and build graph predictably

## Test plan
- [x] Parse `.github/workflows/codeql.yml` locally with Ruby `YAML.load_file`
- [x] Let the local pre-commit hook run formatting, lint, and short tests during commit