### PR TITLE
versions: add phased release progress output

### DIFF
--- a/internal/asc/output_versions.go
+++ b/internal/asc/output_versions.go
@@ -142,13 +142,14 @@ func appStoreVersionDetailRows(result *AppStoreVersionDetailResult) ([]string, [
 }
 
 func appStoreVersionPhasedReleaseRows(resp *AppStoreVersionPhasedReleaseResponse) ([]string, [][]string) {
-	headers := []string{"Phased Release ID", "State", "Start Date", "Current Day", "Total Pause Duration"}
+	headers := []string{"Phased Release ID", "State", "Start Date", "Current Day", "Progress", "Total Pause Duration"}
 	attrs := resp.Data.Attributes
 	rows := [][]string{{
 		resp.Data.ID,
 		string(attrs.PhasedReleaseState),
 		attrs.StartDate,
 		fmt.Sprintf("%d", attrs.CurrentDayNumber),
+		FormatPhasedReleaseProgressBar(attrs.CurrentDayNumber),
 		fmt.Sprintf("%d", attrs.TotalPauseDuration),
 	}}
 	return headers, rows

--- a/internal/asc/output_versions_test.go
+++ b/internal/asc/output_versions_test.go
@@ -1,0 +1,56 @@
+package asc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrintTable_AppStoreVersionPhasedReleaseIncludesProgress(t *testing.T) {
+	resp := &AppStoreVersionPhasedReleaseResponse{
+		Data: Resource[AppStoreVersionPhasedReleaseAttributes]{
+			ID: "phase-1",
+			Attributes: AppStoreVersionPhasedReleaseAttributes{
+				PhasedReleaseState: PhasedReleaseStateActive,
+				StartDate:          "2026-02-20",
+				CurrentDayNumber:   3,
+				TotalPauseDuration: 0,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "Progress") {
+		t.Fatalf("expected progress header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "[####------] 3/7") {
+		t.Fatalf("expected progress bar in output, got: %s", output)
+	}
+}
+
+func TestPrintMarkdown_AppStoreVersionPhasedReleaseIncludesProgress(t *testing.T) {
+	resp := &AppStoreVersionPhasedReleaseResponse{
+		Data: Resource[AppStoreVersionPhasedReleaseAttributes]{
+			ID: "phase-1",
+			Attributes: AppStoreVersionPhasedReleaseAttributes{
+				PhasedReleaseState: PhasedReleaseStateActive,
+				StartDate:          "2026-02-20",
+				CurrentDayNumber:   3,
+				TotalPauseDuration: 0,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(resp)
+	})
+
+	if !strings.Contains(output, "Progress") {
+		t.Fatalf("expected progress header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "[####------] 3/7") {
+		t.Fatalf("expected progress bar in output, got: %s", output)
+	}
+}

--- a/internal/asc/phased_release.go
+++ b/internal/asc/phased_release.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // PhasedReleaseState represents the state of a phased release.
@@ -77,6 +78,29 @@ type AppStoreVersionPhasedReleaseUpdateAttributes struct {
 type AppStoreVersionPhasedReleaseDeleteResult struct {
 	ID      string `json:"id"`
 	Deleted bool   `json:"deleted"`
+}
+
+// FormatPhasedReleaseProgressBar renders the phased release day as a deterministic
+// seven-step ASCII progress bar for human-facing outputs.
+func FormatPhasedReleaseProgressBar(currentDayNumber int) string {
+	day := currentDayNumber
+	if day < 0 {
+		day = 0
+	}
+	if day > 7 {
+		day = 7
+	}
+
+	const barWidth = 10
+	filled := (day * barWidth) / 7
+	if day > 0 && filled == 0 {
+		filled = 1
+	}
+	if filled > barWidth {
+		filled = barWidth
+	}
+
+	return fmt.Sprintf("[%s%s] %d/7", strings.Repeat("#", filled), strings.Repeat("-", barWidth-filled), day)
 }
 
 // GetAppStoreVersionPhasedRelease fetches the phased release for an app store version.

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -791,25 +791,7 @@ func phasedReleaseProgressBar(phased *phasedReleaseSection) string {
 	if !phased.Configured {
 		return "not configured"
 	}
-
-	day := phased.CurrentDayNumber
-	if day < 0 {
-		day = 0
-	}
-	if day > 7 {
-		day = 7
-	}
-
-	const barWidth = 10
-	filled := (day * barWidth) / 7
-	if day > 0 && filled == 0 {
-		filled = 1
-	}
-	if filled > barWidth {
-		filled = barWidth
-	}
-
-	return fmt.Sprintf("[%s%s] %d/7", strings.Repeat("#", filled), strings.Repeat("-", barWidth-filled), day)
+	return asc.FormatPhasedReleaseProgressBar(phased.CurrentDayNumber)
 }
 
 func renderTable(resp *dashboardResponse) {


### PR DESCRIPTION
## Summary
- add a human-readable phased release progress column to `asc versions phased-release get` table and markdown output
- share the phased release progress bar formatter between the versions output and the status dashboard
- cover the new human output with table and markdown renderer tests while leaving JSON behavior unchanged

## Test plan
- [x] `go test ./internal/asc ./internal/cli/status`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`