### PR TITLE
Fix code scanning alerts: add workflow permissions, dismiss false-positive crypto alerts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
     # Allow manual trigger from GitHub UI
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: macos-latest

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   format-and-lint:
     runs-on: macos-latest
@@ -69,6 +72,9 @@ jobs:
 
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-checks-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -67,6 +70,9 @@ jobs:
 
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add explicit `permissions: contents: read` at the workflow level for all three CI workflows (`integration.yml`, `main-branch.yml`, `pr-checks.yml`) to resolve 7 medium-severity `actions/missing-workflow-permissions` CodeQL alerts.
- Build jobs that use `actions/upload-artifact` get additional `actions: write` at the job level.
- Dismiss 4 high-severity `go/weak-sensitive-data-hashing` alerts as false positives — SHA-256 in `internal/web/auth.go` and `internal/iris/auth.go` is an intermediate step in Apple's SRP authentication protocol before PBKDF2 key derivation, not standalone password hashing. The algorithm is dictated by Apple's server-side SRP implementation.

## Alerts resolved

| # | Severity | Rule | File | Resolution |
|---|----------|------|------|------------|
| 1 | Medium | `actions/missing-workflow-permissions` | `integration.yml` | Added `permissions: contents: read` |
| 2 | Medium | `actions/missing-workflow-permissions` | `main-branch.yml` (job 1) | Added `permissions: contents: read` |
| 3 | Medium | `actions/missing-workflow-permissions` | `pr-checks.yml` (job 1) | Added `permissions: contents: read` |
| 4 | Medium | `actions/missing-workflow-permissions` | `main-branch.yml` (job 2) | Added `permissions: contents: read` |
| 5 | Medium | `actions/missing-workflow-permissions` | `pr-checks.yml` (job 2) | Added `permissions: contents: read` |
| 6 | Medium | `actions/missing-workflow-permissions` | `main-branch.yml` (job 3) | Added `permissions: contents: read` |
| 7 | Medium | `actions/missing-workflow-permissions` | `pr-checks.yml` (job 3) | Added `permissions: contents: read` |
| 8 | High | `go/weak-sensitive-data-hashing` | `internal/iris/auth.go:387` | Dismissed (false positive) |
| 9 | High | `go/weak-sensitive-data-hashing` | `internal/iris/auth.go:499` | Dismissed (false positive) |
| 10 | High | `go/weak-sensitive-data-hashing` | `internal/web/auth.go:527` | Dismissed (false positive) |
| 11 | High | `go/weak-sensitive-data-hashing` | `internal/web/auth.go:698` | Dismissed (false positive) |

## Test plan

- [x] `ASC_BYPASS_KEYCHAIN=1 make test` passes locally
- [ ] CI PR checks pass (format, lint, unit tests, build)
- [ ] Verify code scanning alerts page shows all 11 alerts resolved