### PR TITLE
docs: require issue triage labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,21 @@ Canonical test rule: all test runs must use `ASC_BYPASS_KEYCHAIN=1` to avoid hos
 - CI must enforce formatting + lint + tests on both PR and `main` workflows.
 - Remove unused shared wrappers/helpers when commands are refactored.
 
+## Issue Triage & Labeling
+
+- When creating or triaging a GitHub issue, ensure it ends the task with exactly one label
+  from each of these buckets:
+  - type: `bug`, `enhancement`, or `question`
+  - priority: `p0`, `p1`, `p2`, or `p3`
+  - difficulty: `easy`, `medium`, or `hard`
+- If an issue is created without labels, add the missing labels immediately as part of the
+  same task.
+- Use priority for urgency and user impact, not implementation size.
+- Use difficulty for implementation scope/risk, not urgency.
+- Do not leave newly created issues without a type, priority, and difficulty label.
+- If the exact label is ambiguous, prefer the lower priority/difficulty and note the
+  assumption in the handoff.
+
 ## Testing Discipline
 
 - Use TDD for behavior changes: bugs, refactors that alter behavior, and new features.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,32 @@ make build               # Build binary
 - Update `README.md` if behavior or scope changes.
 - Avoid committing any credentials or `.p8` files.
 
+## Issue Triage Labels
+
+Every newly created GitHub issue should leave initial triage with exactly one label from
+each of these buckets:
+
+- Type: `bug`, `enhancement`, or `question`
+- Priority: `p0`, `p1`, `p2`, or `p3`
+- Difficulty: `easy`, `medium`, or `hard`
+
+Label meanings:
+
+- `bug`: broken behavior, regression, incorrect output, or misleading UX
+- `enhancement`: new feature, workflow improvement, or behavior expansion
+- `question`: clarification or discussion where the work is not yet well-defined
+- `p0`: release-blocking, security-sensitive, data-loss, or core workflow outage
+- `p1`: high-impact bug or important near-term work
+- `p2`: normal roadmap work or a bug with a reasonable workaround or limited blast radius
+- `p3`: longer-horizon, convenience, exploratory, or low-urgency work
+- `easy`: small, low-risk, localized change
+- `medium`: moderate cross-file change or some product/UX/design work
+- `hard`: large, high-risk, or architecture-heavy change
+
+External contributors may not have permission to label issues directly. Maintainers and
+agents should add any missing labels during first triage, and new issues should not be left
+without a type, priority, and difficulty label set.
+
 ## Security
 
 If you find a security issue, please report it responsibly by opening a private issue


### PR DESCRIPTION
## Summary
- document that every new issue should receive exactly one type, one priority, and one difficulty label during first triage
- define the meaning of the `bug`/`enhancement`/`question`, `p0`-`p3`, and `easy`/`medium`/`hard` label families
- tell maintainers and agents to backfill missing labels immediately instead of leaving new issues partially triaged

## Test plan
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`