### PR TITLE
docs: replace invalid submit examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ asc testflight builds list --app "123456789" --output table
 
 ```bash
 asc validate --app "123456789" --version "1.2.3"
-asc submit --app "123456789" --version "1.2.3"
+asc submit create --app "123456789" --version "1.2.3" --build "BUILD_ID" --confirm
 ```
 
 ### Metadata and localization

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -172,7 +172,7 @@ asc builds upload --app "123456789" --ipa "/path/to/MyApp.ipa"
 
 # Validate and submit an App Store version
 asc validate --app "123456789" --version "1.2.3"
-asc submit --app "123456789" --version "1.2.3"
+asc submit create --app "123456789" --version "1.2.3" --build "BUILD_ID" --confirm
 
 # Run a local automation workflow
 asc workflow run release

--- a/llms.txt
+++ b/llms.txt
@@ -51,7 +51,7 @@ https://appstoreconnect.apple.com/access/integrations/api
   - `asc testflight builds list --app "123456789" --output table`
 - Validate and submit:
   - `asc validate --app "123456789" --version "1.2.3"`
-  - `asc submit --app "123456789" --version "1.2.3"`
+  - `asc submit create --app "123456789" --version "1.2.3" --build "BUILD_ID" --confirm`
 - Metadata/localization:
   - `asc localizations list --app "123456789"`
   - `asc app-info get --app "123456789" --output json --pretty`

--- a/scripts/generate-command-docs.py
+++ b/scripts/generate-command-docs.py
@@ -145,7 +145,7 @@ def render(usage: str, flags: list[tuple[str, str]], groups: list[tuple[str, lis
             "",
             "# Validate and submit an App Store version",
             "asc validate --app \"123456789\" --version \"1.2.3\"",
-            "asc submit --app \"123456789\" --version \"1.2.3\"",
+            "asc submit create --app \"123456789\" --version \"1.2.3\" --build \"BUILD_ID\" --confirm",
             "",
             "# Run a local automation workflow",
             "asc workflow run release",


### PR DESCRIPTION
## Summary
- replace bare `asc submit --app ... --version ...` examples with the live `asc submit create ... --build ... --confirm` form
- update the command docs generator input so regenerated docs stay aligned with the checked-in examples
- keep the broader canonical review/release storytelling work out of scope for a separate follow-up

## Why this approach
These examples are objectively invalid against the current CLI surface, so fixing them independently removes command drift without prematurely choosing between the higher-level `release` path and the lower-level `submit create` path.

## Test plan
- `make generate-command-docs`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Follow-up
- Leaves the remaining phase-2 docs/help alignment work to `#891`