### PR TITLE
guard remote webhook binds and symlinked asset paths

### DIFF
--- a/internal/asc/assets_upload.go
+++ b/internal/asc/assets_upload.go
@@ -21,7 +21,7 @@ const maxAssetFileSize = int64(1024 * 1024 * 1024) // 1GB safety guardrail
 
 // UploadAsset uploads a file using the provided upload operations.
 func UploadAsset(ctx context.Context, filePath string, operations []UploadOperation) error {
-	file, err := os.Open(filePath)
+	file, err := openUploadSourceFile(filePath)
 	if err != nil {
 		return err
 	}

--- a/internal/asc/assets_upload_test.go
+++ b/internal/asc/assets_upload_test.go
@@ -46,6 +46,59 @@ func TestValidateAssetFileRejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestUploadAssetRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.bin")
+	if err := os.WriteFile(target, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	link := filepath.Join(dir, "link.bin")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := UploadAsset(context.Background(), link, []UploadOperation{
+		{Method: http.MethodPut, URL: server.URL + "/part1", Length: 3, Offset: 0},
+	})
+	if err == nil {
+		t.Fatal("expected symlink upload to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 0 {
+		t.Fatalf("expected no upload requests, got %d", calls)
+	}
+}
+
+func TestComputeFileChecksumRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.bin")
+	if err := os.WriteFile(target, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	link := filepath.Join(dir, "link.bin")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	_, err := ComputeFileChecksum(link, ChecksumAlgorithmMD5)
+	if err == nil {
+		t.Fatal("expected symlink checksum to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}
+
 func TestValidateImageFileRejectsOversize(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "large.bin")

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -277,7 +277,7 @@ func VerifySourceFileChecksums(filePath string, expected *Checksums) (*Checksums
 
 // ComputeFileChecksum computes the checksum for a file using the provided algorithm.
 func ComputeFileChecksum(filePath string, algorithm ChecksumAlgorithm) (*Checksum, error) {
-	file, err := os.Open(filePath)
+	file, err := openUploadSourceFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("open file for checksum: %w", err)
 	}

--- a/internal/cli/webhooks/webhooks_serve.go
+++ b/internal/cli/webhooks/webhooks_serve.go
@@ -73,6 +73,7 @@ func WebhooksServeCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 
 	host := fs.String("host", webhooksServeDefaultHost, "Host to bind the local webhook receiver")
+	allowRemote := fs.Bool("allow-remote", false, "Allow binding to non-loopback hosts")
 	port := fs.Int("port", webhooksServeDefaultPort, "Port to bind the local webhook receiver (0-65535)")
 	dir := fs.String("dir", "", "Optional directory to write one JSON payload file per event")
 	execCommand := fs.String("exec", "", "Optional command to execute per event (payload JSON is piped on stdin)")
@@ -84,6 +85,11 @@ func WebhooksServeCommand() *ffcli.Command {
 		ShortUsage: "asc webhooks serve [flags]",
 		ShortHelp:  "Run a local webhook receiver for testing and automation.",
 		LongHelp: `Run a local webhook receiver for testing and automation.
+
+Security note:
+  The default host is loopback-only.
+  Binding to non-loopback hosts requires --allow-remote.
+  If you expose this server remotely, treat --exec like local automation with network trigger access.
 
 Examples:
   asc webhooks serve --port 8787
@@ -101,6 +107,9 @@ Examples:
 			if bindHost == "" {
 				fmt.Fprintln(os.Stderr, "Error: --host is required")
 				return flag.ErrHelp
+			}
+			if !*allowRemote && !isLoopbackWebhookBindHost(bindHost) {
+				return shared.UsageErrorf("binding to non-loopback host %q requires --allow-remote", bindHost)
 			}
 			if *port < 0 || *port > 65535 {
 				fmt.Fprintln(os.Stderr, "Error: --port must be between 0 and 65535")
@@ -515,4 +524,16 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func isLoopbackWebhookBindHost(host string) bool {
+	normalized := strings.TrimSpace(host)
+	if normalized == "" {
+		return false
+	}
+	if strings.EqualFold(normalized, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(strings.Trim(normalized, "[]"))
+	return ip != nil && ip.IsLoopback()
 }

--- a/internal/cli/webhooks/webhooks_serve_test.go
+++ b/internal/cli/webhooks/webhooks_serve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -85,6 +86,51 @@ func TestWebhooksServeExecReceivesPayload(t *testing.T) {
 	}
 
 	waitForFileContains(t, outPath, `"id":"evt-exec-1"`)
+}
+
+func TestWebhooksServeRejectsNonLoopbackWithoutAllowRemote(t *testing.T) {
+	cmd := WebhooksServeCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.Parse([]string{
+		"--host", "0.0.0.0",
+		"--port", "0",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := cmd.Run(ctx)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp for non-loopback bind without --allow-remote, got %v", err)
+	}
+}
+
+func TestWebhooksServeAllowsNonLoopbackWithAllowRemote(t *testing.T) {
+	port := freeLocalPort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	cmd := WebhooksServeCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.Parse([]string{
+		"--host", "0.0.0.0",
+		"--port", fmt.Sprintf("%d", port),
+		"--allow-remote",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	go func() {
+		errCh <- cmd.Run(ctx)
+	}()
+	defer shutdownServeCommand(t, cancel, errCh)
+
+	statusCode := postJSONWithRetry(t, fmt.Sprintf("http://127.0.0.1:%d", port), `{"id":"evt-remote-1","eventType":"REMOTE_EVENT"}`)
+	if statusCode != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, statusCode)
+	}
 }
 
 func TestReadWebhookServeJSONPayloadAllowsMaxInt64Limit(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -126,6 +126,30 @@ func TestSaveAtOverwritesExistingFile(t *testing.T) {
 	}
 }
 
+func TestSaveAtRestoresSecurePermissionsOnOverwrite(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "config.json")
+
+	if err := SaveAt(path, &Config{KeyID: "OLD_KEY"}); err != nil {
+		t.Fatalf("SaveAt(initial) error: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod() error: %v", err)
+	}
+
+	if err := SaveAt(path, &Config{KeyID: "NEW_KEY"}); err != nil {
+		t.Fatalf("SaveAt(updated) error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected permissions 0600, got %#o", got)
+	}
+}
+
 func TestSaveAtRejectsSymlinkPath(t *testing.T) {
 	tempDir := t.TempDir()
 	target := filepath.Join(tempDir, "target.json")


### PR DESCRIPTION
## Summary
- require an explicit `--allow-remote` opt-in before `asc webhooks serve` can bind to non-loopback hosts, and document the remote exposure risk around `--exec`
- reuse the existing no-follow file opener for path-based asset uploads and checksum reads so symlinked paths are rejected before any network request or checksum calculation
- add regression coverage for webhook bind gating, symlinked asset path rejection, and secure config overwrite permissions

## Test plan
- [x] `make format`
- [x] `make generate-command-docs`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`