### PR TITLE
fix: preserve screenshot order after uploads

### DIFF
--- a/internal/cli/assets/assets_screenshot_order.go
+++ b/internal/cli/assets/assets_screenshot_order.go
@@ -1,0 +1,113 @@
+package assets
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// UploadScreenshotsToSet uploads screenshots in the provided file order and then
+// applies that order to the remote screenshot set.
+func UploadScreenshotsToSet(ctx context.Context, client *asc.Client, setID string, files []string, preserveExistingOrder bool) ([]asc.AssetUploadResultItem, error) {
+	orderedIDs := make([]string, 0, len(files))
+	if preserveExistingOrder {
+		existingIDs, err := GetOrderedAppScreenshotIDs(ctx, client, setID)
+		if err != nil {
+			return nil, err
+		}
+		orderedIDs = append(orderedIDs, existingIDs...)
+	}
+
+	results := make([]asc.AssetUploadResultItem, 0, len(files))
+	for _, filePath := range files {
+		item, err := uploadScreenshotAsset(ctx, client, setID, filePath)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, item)
+		orderedIDs = appendUniqueScreenshotID(orderedIDs, item.AssetID)
+	}
+
+	if len(results) == 0 {
+		return results, nil
+	}
+	if err := SetOrderedAppScreenshots(ctx, client, setID, orderedIDs); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// GetOrderedAppScreenshotIDs returns screenshot IDs in the current remote order.
+func GetOrderedAppScreenshotIDs(ctx context.Context, client *asc.Client, setID string) ([]string, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+
+	firstPage, err := client.GetAppScreenshotSetAppScreenshotsRelationships(ctx, setID, asc.WithLinkagesLimit(200))
+	if err != nil {
+		return nil, err
+	}
+
+	orderedIDs := make([]string, 0, len(firstPage.Data))
+	err = asc.PaginateEach(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetAppScreenshotSetAppScreenshotsRelationships(ctx, "", asc.WithLinkagesNextURL(nextURL))
+	}, func(page asc.PaginatedResponse) error {
+		linkages, ok := page.(*asc.LinkagesResponse)
+		if !ok {
+			return fmt.Errorf("unexpected screenshot relationship response type %T", page)
+		}
+		for _, item := range linkages.Data {
+			orderedIDs = appendUniqueScreenshotID(orderedIDs, item.ID)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return orderedIDs, nil
+}
+
+// SetOrderedAppScreenshots replaces the screenshot relationships for a set in the provided order.
+func SetOrderedAppScreenshots(ctx context.Context, client *asc.Client, setID string, orderedIDs []string) error {
+	if client == nil {
+		return fmt.Errorf("client is required")
+	}
+	return client.UpdateAppScreenshotSetAppScreenshotsRelationship(ctx, setID, normalizeScreenshotIDs(orderedIDs))
+}
+
+func normalizeScreenshotIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+	normalized := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+	return normalized
+}
+
+func appendUniqueScreenshotID(ids []string, id string) []string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ids
+	}
+	for _, existing := range ids {
+		if existing == id {
+			return ids
+		}
+	}
+	return append(ids, id)
+}

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -212,13 +212,9 @@ Examples:
 				return fmt.Errorf("screenshots upload: %w", err)
 			}
 
-			results := make([]asc.AssetUploadResultItem, 0, len(files))
-			for _, filePath := range files {
-				item, err := uploadScreenshotAsset(requestCtx, client, set.ID, filePath)
-				if err != nil {
-					return fmt.Errorf("screenshots upload: %w", err)
-				}
-				results = append(results, item)
+			results, err := UploadScreenshotsToSet(requestCtx, client, set.ID, files, true)
+			if err != nil {
+				return fmt.Errorf("screenshots upload: %w", err)
 			}
 
 			result := asc.AppScreenshotUploadResult{

--- a/internal/cli/assets/assets_upload_order_test.go
+++ b/internal/cli/assets/assets_upload_order_test.go
@@ -1,0 +1,175 @@
+package assets
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type assetsUploadRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn assetsUploadRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestUploadScreenshotsToSet_PreservesExistingOrderAndAppendsNewUploads(t *testing.T) {
+	fileA := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
+	fileB := writeAssetsTestPNG(t, t.TempDir(), "02-settings.png")
+	files := []string{fileA, fileB}
+	sizes := []int64{fileSize(t, fileA), fileSize(t, fileB)}
+	relationshipPatchCalled := false
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1"},{"type":"appScreenshots","id":"old-2"}],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read create screenshot body: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode create screenshot body: %v", err)
+			}
+			id := "new-1"
+			size := sizes[0]
+			if strings.Contains(string(body), "02-settings.png") {
+				id = "new-2"
+				size = sizes[1]
+			}
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/%s","length":%d,"offset":0}]}}}`, id, id, size))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/appScreenshots/"):
+			id := strings.TrimPrefix(req.URL.Path, "/v1/appScreenshots/")
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"uploaded":true}}}`, id))
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/appScreenshots/"):
+			id := strings.TrimPrefix(req.URL.Path, "/v1/appScreenshots/")
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`, id))
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			wantIDs := []string{"old-1", "old-2", "new-1", "new-2"}
+			if !reflect.DeepEqual(gotIDs, wantIDs) {
+				t.Fatalf("relationship order = %v, want %v", gotIDs, wantIDs)
+			}
+			relationshipPatchCalled = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	results, err := UploadScreenshotsToSet(context.Background(), client, "set-1", files, true)
+	if err != nil {
+		t.Fatalf("UploadScreenshotsToSet() error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 uploaded screenshots, got %d", len(results))
+	}
+	if results[0].AssetID != "new-1" || results[1].AssetID != "new-2" {
+		t.Fatalf("unexpected uploaded asset IDs: %#v", results)
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected screenshot relationship reorder PATCH to be called")
+	}
+}
+
+func newAssetsUploadTestClient(t *testing.T) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if pemBytes == nil {
+		t.Fatal("encode pem: nil")
+	}
+
+	client, err := asc.NewClientFromPEM("KEY_ID", "ISSUER_ID", string(pemBytes))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client
+}
+
+func assetsJSONResponse(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func writeAssetsTestPNG(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create png: %v", err)
+	}
+	defer file.Close()
+
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			img.Set(x, y, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+		}
+	}
+	if err := png.Encode(file, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return path
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	return info.Size()
+}

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/migrate"
 )
 
@@ -262,6 +263,7 @@ func TestMigrateImportUploadsAndSkipsExistingScreenshots(t *testing.T) {
 	})
 
 	requestedUploads := 0
+	relationshipPatchCalled := false
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "upload.example.com" {
 			requestedUploads++
@@ -294,6 +296,9 @@ func TestMigrateImportUploadsAndSkipsExistingScreenshots(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
 			body := `{"data":[{"type":"appScreenshots","id":"shot-existing","attributes":{"fileName":"iphone_65_existing.png"}}]}`
 			return migrateJSONResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body := `{"data":[{"type":"appScreenshots","id":"shot-existing"}],"links":{}}`
+			return migrateJSONResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
 			resp := `{"data":{"type":"appScreenshots","id":"shot-new","attributes":{"fileName":"iphone_65_new.png","fileSize":1234,"uploadOperations":[{"method":"PUT","url":"https://upload.example.com/upload/shot-new","length":1234,"offset":0}]}}}`
 			return migrateJSONResponse(http.StatusCreated, resp), nil
@@ -302,6 +307,20 @@ func TestMigrateImportUploadsAndSkipsExistingScreenshots(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/shot-new":
 			body := `{"data":{"type":"appScreenshots","id":"shot-new","attributes":{"fileName":"iphone_65_new.png","assetDeliveryState":{"state":"COMPLETE"}}}}`
 			return migrateJSONResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("unmarshal relationship patch body: %v", err)
+			}
+			if len(payload.Data) != 2 || payload.Data[0].ID != "shot-existing" || payload.Data[1].ID != "shot-new" {
+				t.Fatalf("unexpected relationship patch payload: %#v", payload.Data)
+			}
+			relationshipPatchCalled = true
+			return migrateJSONResponse(http.StatusNoContent, ""), nil
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
@@ -329,6 +348,9 @@ func TestMigrateImportUploadsAndSkipsExistingScreenshots(t *testing.T) {
 	}
 	if requestedUploads != 1 {
 		t.Fatalf("expected 1 upload request, got %d", requestedUploads)
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected screenshot relationship reorder patch")
 	}
 
 	var result migrate.MigrateImportResult

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -295,20 +295,32 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 		}
 		setByType := make(map[string]string)
 		existingFiles := make(map[string]map[string]bool)
+		existingIDsByName := make(map[string]map[string]string)
+		existingOrderByType := make(map[string][]string)
 		for _, set := range existingSets.Data {
 			setByType[set.Attributes.ScreenshotDisplayType] = set.ID
+			orderedIDs, err := assets.GetOrderedAppScreenshotIDs(uploadCtx, client, set.ID)
+			if err != nil {
+				return nil, fmt.Errorf("migrate import: failed to fetch screenshot relationship order for %s: %w", set.ID, err)
+			}
+			existingOrderByType[set.Attributes.ScreenshotDisplayType] = orderedIDs
 			screenshots, err := client.GetAppScreenshots(uploadCtx, set.ID)
 			if err != nil {
 				return nil, fmt.Errorf("migrate import: failed to fetch screenshots for %s: %w", set.ID, err)
 			}
 			fileNames := make(map[string]bool)
+			fileIDs := make(map[string]string)
 			for _, shot := range screenshots.Data {
 				name := strings.TrimSpace(shot.Attributes.FileName)
 				if name != "" {
 					fileNames[name] = true
+					if fileIDs[name] == "" {
+						fileIDs[name] = shot.ID
+					}
 				}
 			}
 			existingFiles[set.Attributes.ScreenshotDisplayType] = fileNames
+			existingIDsByName[set.Attributes.ScreenshotDisplayType] = fileIDs
 		}
 
 		for _, plan := range localePlans {
@@ -322,6 +334,8 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 				setID = set.Data.ID
 				setByType[canonicalDisplayType] = setID
 				existingFiles[canonicalDisplayType] = make(map[string]bool)
+				existingIDsByName[canonicalDisplayType] = make(map[string]string)
+				existingOrderByType[canonicalDisplayType] = nil
 			}
 
 			fileNames := existingFiles[canonicalDisplayType]
@@ -329,11 +343,17 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 				fileNames = make(map[string]bool)
 				existingFiles[canonicalDisplayType] = fileNames
 			}
+			fileIDs := existingIDsByName[canonicalDisplayType]
+			if fileIDs == nil {
+				fileIDs = make(map[string]string)
+				existingIDsByName[canonicalDisplayType] = fileIDs
+			}
 
 			result := ScreenshotUploadResult{
 				Locale:      plan.Locale,
 				DisplayType: canonicalDisplayType,
 			}
+			uploadedIDsByName := make(map[string]string)
 
 			for _, filePath := range plan.Files {
 				name := filepath.Base(filePath)
@@ -349,7 +369,18 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 					return nil, fmt.Errorf("migrate import: failed to upload screenshot %s: %w", filePath, err)
 				}
 				fileNames[name] = true
+				uploadedIDsByName[name] = item.AssetID
 				result.Uploaded = append(result.Uploaded, item)
+			}
+			orderedIDs := buildPlannedScreenshotOrder(plan.Files, existingOrderByType[canonicalDisplayType], fileIDs, uploadedIDsByName)
+			if err := assets.SetOrderedAppScreenshots(uploadCtx, client, setID, orderedIDs); err != nil {
+				return nil, fmt.Errorf("migrate import: failed to reorder screenshots for %s: %w", setID, err)
+			}
+			existingOrderByType[canonicalDisplayType] = orderedIDs
+			for name, id := range uploadedIDsByName {
+				if strings.TrimSpace(id) != "" {
+					fileIDs[name] = id
+				}
 			}
 
 			results = append(results, result)
@@ -363,6 +394,37 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 		return results[i].Locale < results[j].Locale
 	})
 	return results, nil
+}
+
+func buildPlannedScreenshotOrder(planFiles []string, existingOrder []string, existingIDsByName map[string]string, uploadedIDsByName map[string]string) []string {
+	orderedIDs := make([]string, 0, len(planFiles)+len(existingOrder))
+	seen := make(map[string]struct{}, len(planFiles)+len(existingOrder))
+	appendUnique := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, exists := seen[id]; exists {
+			return
+		}
+		seen[id] = struct{}{}
+		orderedIDs = append(orderedIDs, id)
+	}
+
+	for _, filePath := range planFiles {
+		name := filepath.Base(filePath)
+		if id := uploadedIDsByName[name]; strings.TrimSpace(id) != "" {
+			appendUnique(id)
+			continue
+		}
+		appendUnique(existingIDsByName[name])
+	}
+
+	for _, id := range existingOrder {
+		appendUnique(id)
+	}
+
+	return orderedIDs
 }
 
 func isNotFoundReviewDetail(err error) bool {

--- a/internal/cli/migrate/import_helpers_test.go
+++ b/internal/cli/migrate/import_helpers_test.go
@@ -1,0 +1,176 @@
+package migrate
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type migrateUploadRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn migrateUploadRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestUploadScreenshots_ReordersPlannedFilesBeforeUntouchedRemoteExtras(t *testing.T) {
+	dir := t.TempDir()
+	existingFile := writeMigrateTestPNG(t, dir, "01-home.png")
+	newFile := writeMigrateTestPNG(t, dir, "02-settings.png")
+	newFileSize := migrateFileSize(t, newFile)
+	relationshipPatchCalled := false
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = migrateUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-1/appScreenshotSets":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return migrateJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"old-home","attributes":{"fileName":"%s"}},{"type":"appScreenshots","id":"old-extra","attributes":{"fileName":"99-legacy.png"}}]}`, filepath.Base(existingFile)))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-extra"},{"type":"appScreenshots","id":"old-home"}],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			return migrateJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"new-settings","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/new-settings","length":%d,"offset":0}]}}}`, newFileSize))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return migrateJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/new-settings":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"new-settings","attributes":{"uploaded":true}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/new-settings":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"new-settings","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			wantIDs := []string{"old-home", "new-settings", "old-extra"}
+			if !reflect.DeepEqual(gotIDs, wantIDs) {
+				t.Fatalf("relationship order = %v, want %v", gotIDs, wantIDs)
+			}
+			relationshipPatchCalled = true
+			return migrateJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newMigrateUploadTestClient(t)
+	results, err := uploadScreenshots(
+		context.Background(),
+		client,
+		"version-1",
+		map[string]string{"en-US": "loc-1"},
+		[]ScreenshotPlan{{
+			Locale:      "en-US",
+			DisplayType: "APP_IPHONE_65",
+			Files:       []string{existingFile, newFile},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("uploadScreenshots() error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 screenshot result, got %d", len(results))
+	}
+	if len(results[0].Skipped) != 1 || results[0].Skipped[0].Path != existingFile {
+		t.Fatalf("expected existing file to be skipped, got %#v", results[0].Skipped)
+	}
+	if len(results[0].Uploaded) != 1 || results[0].Uploaded[0].AssetID != "new-settings" {
+		t.Fatalf("expected uploaded screenshot new-settings, got %#v", results[0].Uploaded)
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected screenshot relationship reorder PATCH to be called")
+	}
+}
+
+func newMigrateUploadTestClient(t *testing.T) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if pemBytes == nil {
+		t.Fatal("encode pem: nil")
+	}
+
+	client, err := asc.NewClientFromPEM("KEY_ID", "ISSUER_ID", string(pemBytes))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client
+}
+
+func migrateJSONResponse(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func writeMigrateTestPNG(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create png: %v", err)
+	}
+	defer file.Close()
+
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			img.Set(x, y, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+		}
+	}
+	if err := png.Encode(file, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return path
+}
+
+func migrateFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	return info.Size()
+}

--- a/internal/cli/productpages/custom_page_localization_media_upload.go
+++ b/internal/cli/productpages/custom_page_localization_media_upload.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+var customPageMediaClientFactory = shared.GetASCClient
+
 // CustomPageLocalizationsScreenshotSetsUploadCommand returns the screenshot sets upload subcommand.
 func CustomPageLocalizationsScreenshotSetsUploadCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("custom-page-localizations screenshot-sets upload", flag.ExitOnError)
@@ -181,7 +183,7 @@ func executeCustomPageScreenshotUpload(
 		return nil, err
 	}
 
-	client, err := shared.GetASCClient()
+	client, err := customPageMediaClientFactory()
 	if err != nil {
 		return nil, err
 	}
@@ -199,13 +201,9 @@ func executeCustomPageScreenshotUpload(
 		}
 	}
 
-	results := make([]asc.AssetUploadResultItem, 0, len(files))
-	for _, filePath := range files {
-		item, err := uploadCustomPageScreenshotAsset(requestCtx, client, set.ID, filePath)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, item)
+	results, err := assets.UploadScreenshotsToSet(requestCtx, client, set.ID, files, !sync)
+	if err != nil {
+		return nil, err
 	}
 
 	return &asc.CustomProductPageScreenshotUploadResult{
@@ -246,7 +244,7 @@ func executeCustomPagePreviewUpload(
 		return nil, err
 	}
 
-	client, err := shared.GetASCClient()
+	client, err := customPageMediaClientFactory()
 	if err != nil {
 		return nil, err
 	}
@@ -347,10 +345,6 @@ func deleteAllPreviewsInSet(ctx context.Context, client *asc.Client, setID strin
 		}
 	}
 	return nil
-}
-
-func uploadCustomPageScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, error) {
-	return assets.UploadScreenshotAsset(ctx, client, setID, filePath)
 }
 
 func uploadCustomPagePreviewAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, error) {

--- a/internal/cli/productpages/custom_page_localization_media_upload_test.go
+++ b/internal/cli/productpages/custom_page_localization_media_upload_test.go
@@ -1,0 +1,186 @@
+package productpages
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type customPageUploadRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn customPageUploadRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestExecuteCustomPageScreenshotUpload_SyncDeletesExistingScreenshotsAndReordersUploads(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeCustomPageTestPNG(t, dir, "01-home.png", 1242, 2688)
+	fileB := writeCustomPageTestPNG(t, dir, "02-settings.png", 1242, 2688)
+	sizes := map[string]int64{
+		"new-1": customPageFileSize(t, fileA),
+		"new-2": customPageFileSize(t, fileB),
+	}
+
+	deletedExisting := false
+	relationshipPatchCalled := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = customPageUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appCustomProductPageLocalizations/loc-1/appScreenshotSets":
+			return customPageJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return customPageJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1","attributes":{"fileName":"legacy.png"}}]}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/appScreenshots/old-1":
+			deletedExisting = true
+			return customPageJSONResponse(http.StatusNoContent, "")
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read create screenshot body: %v", err)
+			}
+			id := "new-1"
+			if strings.Contains(string(body), "02-settings.png") {
+				id = "new-2"
+			}
+			return customPageJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/%s","length":%d,"offset":0}]}}}`, id, id, sizes[id]))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return customPageJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/appScreenshots/"):
+			id := strings.TrimPrefix(req.URL.Path, "/v1/appScreenshots/")
+			return customPageJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"uploaded":true}}}`, id))
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/appScreenshots/"):
+			id := strings.TrimPrefix(req.URL.Path, "/v1/appScreenshots/")
+			return customPageJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`, id))
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			wantIDs := []string{"new-1", "new-2"}
+			if !reflect.DeepEqual(gotIDs, wantIDs) {
+				t.Fatalf("relationship order = %v, want %v", gotIDs, wantIDs)
+			}
+			relationshipPatchCalled = true
+			return customPageJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newCustomPageTestClient(t)
+	origFactory := customPageMediaClientFactory
+	customPageMediaClientFactory = func() (*asc.Client, error) { return client, nil }
+	t.Cleanup(func() {
+		customPageMediaClientFactory = origFactory
+	})
+
+	result, err := executeCustomPageScreenshotUpload(context.Background(), "loc-1", dir, "IPHONE_65", true)
+	if err != nil {
+		t.Fatalf("executeCustomPageScreenshotUpload() error: %v", err)
+	}
+	if result.SetID != "set-1" {
+		t.Fatalf("expected set ID set-1, got %q", result.SetID)
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("expected 2 uploaded screenshots, got %d", len(result.Results))
+	}
+	if !deletedExisting {
+		t.Fatal("expected sync to delete existing screenshots before upload")
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected screenshot relationship reorder PATCH to be called")
+	}
+}
+
+func newCustomPageTestClient(t *testing.T) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if pemBytes == nil {
+		t.Fatal("encode pem: nil")
+	}
+
+	client, err := asc.NewClientFromPEM("KEY_ID", "ISSUER_ID", string(pemBytes))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client
+}
+
+func customPageJSONResponse(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func writeCustomPageTestPNG(t *testing.T, dir, name string, width, height int) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create png: %v", err)
+	}
+	defer file.Close()
+
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+		}
+	}
+	if err := png.Encode(file, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return path
+}
+
+func customPageFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	return info.Size()
+}


### PR DESCRIPTION
## Summary
- reorder screenshot sets with the relationship PATCH endpoint after standard screenshot uploads so App Store Connect reflects the local file order instead of upload timing
- apply the same deterministic ordering to custom product page screenshot sync/upload flows and to migrate import, preserving untouched remote extras after planned files for migrate
- add targeted tests for the shared upload helper, custom page sync, migrate import ordering, and update the migrate cmdtest fixture for the new relationship calls

## Test plan
- [x] `go run . screenshots --help`
- [x] `go run . product-pages custom-pages localizations screenshot-sets --help`
- [x] `go run . migrate import --help`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets ./internal/cli/productpages ./internal/cli/migrate`
- [x] `go build -o /tmp/asc .`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`