### PR TITLE
Add 5 apps to Wall of Apps (amahanti)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ asc apps list --output json
 <!-- WALL-OF-APPS:START -->
 ## Wall of Apps
 
-**73 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
+**78 apps ship with asc.** [See the Wall of Apps →](https://asccli.sh/#wall-of-apps)
 
 Want to add yours? [Open a PR](https://github.com/rudrankriyam/App-Store-Connect-CLI/pulls).
 <!-- WALL-OF-APPS:END -->

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -7,6 +7,19 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Airmail AI",
+    "link": "https://apps.apple.com/app/id6760087450",
+    "creator": "amahanti",
+    "platform": ["iOS", "macOS"]
+  },
+  {
+    "app": "Airtist",
+    "link": "https://apps.apple.com/app/id6745053878",
+    "creator": "amahanti",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a1/85/81/a185815f-0e82-98b4-ac37-aed44c57d719/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "macOS"]
+  },
+  {
     "app": "Audio Horoscope · Astrologica",
     "link": "https://apps.apple.com/app/id6754387408",
     "creator": "supnim",
@@ -141,7 +154,7 @@
     "app": "Fuel: AI Nutrition",
     "link": "https://apps.apple.com/app/id6748624107",
     "creator": "0xSMW",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/9b/de/52/9bde5223-b760-c9c7-3d31-2dcca6bd14fa/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/52/0e/ed/520eed9c-d3f0-5d0e-3e68-5b6e698e5efc/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {
@@ -162,7 +175,7 @@
     "app": "Inkput",
     "link": "https://apps.apple.com/app/id6758570182",
     "creator": "funclosure",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0f/2b/44/0f2b4498-ed4f-3b6a-a280-5e20e1b7f047/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/83/e2/68/83e26872-d3d5-ab92-7164-673371673443/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
     "platform": ["iOS", "macOS"]
   },
   {
@@ -176,7 +189,7 @@
     "app": "kora: Music Reviews & Ratings",
     "link": "https://apps.apple.com/app/id6502549140",
     "creator": "adamjhf",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/86/c1/29/86c12949-457e-ab7b-a2b0-bce6723ecee3/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/48/70/77/487077dc-caef-0687-6ccf-48daffa9cf5b/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {
@@ -312,6 +325,13 @@
     "platform": ["iOS", "watchOS"]
   },
   {
+    "app": "Prolific",
+    "link": "https://apps.apple.com/app/id1666347084",
+    "creator": "amahanti",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/72/f7/f5/72f7f5de-2856-e0c4-e453-112ad3ad4e30/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "macOS"]
+  },
+  {
     "app": "Quietude",
     "link": "https://apps.apple.com/app/id6758955377",
     "creator": "vatrueshka",
@@ -343,7 +363,7 @@
     "app": "Siraj — Your Ramadan Light",
     "link": "https://apps.apple.com/app/id6759178047",
     "creator": "SwifAI",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6b/35/9d/6b359d31-4d98-e089-1145-efbc57acb4b3/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/9c/1d/75/9c1d7502-e0d7-0db1-bb9e-e9f9edd2c6da/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {
@@ -359,6 +379,20 @@
     "creator": "TomLiu",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c3/87/7c/c3877c8c-bac8-537d-453e-98ba2e171fe1/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg",
     "platform": ["iOS"]
+  },
+  {
+    "app": "Soundbooth",
+    "link": "https://apps.apple.com/app/id1341485079",
+    "creator": "amahanti",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/87/cf/44/87cf44ee-79ee-1a91-3edc-d195ad86582b/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "macOS"]
+  },
+  {
+    "app": "SpeedReader",
+    "link": "https://apps.apple.com/app/id6757832936",
+    "creator": "amahanti",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/90/bc/20/90bc2003-d998-ba7a-ce45-66d846d7685f/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "macOS"]
   },
   {
     "app": "Steps: Workout & Pedometer",
@@ -469,14 +503,14 @@
     "app": "Weather mini - Trip Forecasts",
     "link": "https://apps.apple.com/us/app/weather-mini-trip-forecasts/id892589817",
     "creator": "Kai Luo",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d7/cf/fb/d7cffb54-2e0d-f5c4-41ed-b583347b7393/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3c/c6/c1/3cc6c19c-acec-fb4d-ee88-63a1bfc422c4/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg",
     "platform": ["iOS", "macOS", "visionOS"]
   },
   {
     "app": "Wozi Vocabulary Builder",
     "link": "https://apps.apple.com/app/id1536585848",
     "creator": "wozi-x",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/54/66/dd/5466ddfe-7358-aafe-8f0d-5fd06a13f3ed/WoziAppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cd/33/e3/cd33e3a5-2c7d-34e8-5c22-07bca8f44d7d/WoziAppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg",
     "platform": ["iOS"]
   },
   {


### PR DESCRIPTION
## Summary

Adding 5 published apps to the Wall of Apps:

| App | Platform | App Store |
|-----|----------|-----------|
| Prolific | iOS, macOS | [Link](https://apps.apple.com/app/id1666347084) |
| SpeedReader | iOS, macOS | [Link](https://apps.apple.com/app/id6757832936) |
| Soundbooth | iOS, macOS | [Link](https://apps.apple.com/app/id1341485079) |
| Airtist | iOS, macOS | [Link](https://apps.apple.com/app/id6745053878) |
| Airmail AI | iOS, macOS | [Link](https://apps.apple.com/app/id6760087450) |

All entries generated via `make generate app`. JSON and README snippet updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)