### PR TITLE
apps wall: add Smart Music Stations: Wavyy

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -374,6 +374,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Smart Music Stations: Wavyy",
+    "link": "https://apps.apple.com/us/app/smart-music-stations-wavyy/id6458877273?uo=4",
+    "creator": "rudrankriyam",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5a/c6/8d/5ac68df8-3d3f-4bf4-984c-06554678468d/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "SnaPOP: Screenshot Editor",
     "link": "https://apps.apple.com/app/snapop/id6756635978",
     "creator": "randomor",


### PR DESCRIPTION
## Summary

- add `Smart Music Stations: Wavyy` to the Wall of Apps

## Entry

- App ID: 6458877273
- App: Smart Music Stations: Wavyy
- Link: https://apps.apple.com/us/app/smart-music-stations-wavyy/id6458877273?uo=4
- Creator: rudrankriyam
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
