### PR TITLE
Add Sunbreak: Nightly App Blocker to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -444,6 +444,12 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Sunbreak: Nightly App Blocker",
+    "link": "https://apps.apple.com/us/app/sunbreak-nightly-app-blocker/id6752121964",
+    "creator": "WilsonLimSet",
+    "platform": ["iOS"]
+  },
+  {
     "app": "SwiftBiu",
     "link": "https://apps.apple.com/app/swiftbiu/id6754772331",
     "creator": "SwiftBiu",


### PR DESCRIPTION
## Summary
- Adds Sunbreak: Nightly App Blocker to the Wall of Apps
- Platform: iOS
- App Store: https://apps.apple.com/us/app/sunbreak-nightly-app-blocker/id6752121964