### PR TITLE
apps wall: add Pets Check-in - PeekaPaw

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -276,6 +276,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Pets Check-in - PeekaPaw",
+    "link": "https://apps.apple.com/us/app/pets-check-in-peekapaw/id6759892136?uo=4",
+    "creator": "Hiep Le",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c9/57/6e/c9576e6d-948b-2e9f-fded-18261f597999/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Pickle Rite",
     "link": "https://apps.apple.com/us/app/pickle-rite/id6754095362",
     "creator": "Badarinath Venkatnarayansetty",


### PR DESCRIPTION
## Summary

- add `Pets Check-in - PeekaPaw` to the Wall of Apps

## Entry

- App ID: 6759892136
- App: Pets Check-in - PeekaPaw
- Link: https://apps.apple.com/us/app/pets-check-in-peekapaw/id6759892136?uo=4
- Creator: Hiep Le
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
