### PR TITLE
refactor: make app-info list the canonical discovery path

### DIFF
--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -32,7 +32,7 @@ var rootUsageGroups = []rootCommandGroup{
 	{
 		title: "APP MANAGEMENT COMMANDS",
 		commands: []string{
-			"apps", "app-setup", "app-tags", "app-info", "app-infos", "versions",
+			"apps", "app-setup", "app-tags", "app-info", "versions",
 			"localizations", "screenshots", "video-previews", "background-assets", "product-pages",
 			"routing-coverage", "pricing", "pre-orders", "categories", "age-rating",
 			"accessibility", "encryption", "eula", "agreements", "app-clips",

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -59,7 +59,6 @@ asc <subcommand> [flags]
 - `app-setup` - Post-create app setup automation.
 - `app-tags` - Manage app tags for App Store visibility.
 - `app-info` - Manage App Store version metadata.
-- `app-infos` - List app info records for an app.
 - `versions` - Manage App Store versions.
 - `localizations` - Manage App Store localization metadata.
 - `screenshots` - Upload and manage App Store screenshots; local capture/frame workflow is [experimental].

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -30,12 +30,14 @@ func AppInfoCommand() *ffcli.Command {
 		LongHelp: `Manage App Store version metadata like description, keywords, and what's new.
 
 Examples:
+  asc app-info list --app "APP_ID"
   asc app-info get --app "APP_ID"
   asc app-info get --app "APP_ID" --version "1.2.3" --platform IOS
   asc app-info set --app "APP_ID" --locale "en-US" --whats-new "Bug fixes"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			AppInfoListCommand(),
 			AppInfoGetCommand(),
 			AppInfoSetCommand(),
 			AppInfoRelationshipsCommand(),

--- a/internal/cli/apps/app_infos.go
+++ b/internal/cli/apps/app_infos.go
@@ -11,25 +11,26 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+const appInfosDeprecationWarning = "Warning: `asc app-infos list` is deprecated. Use `asc app-info list`."
+
 // AppInfosCommand returns the app-infos command group.
 func AppInfosCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("app-infos", flag.ExitOnError)
 
 	return &ffcli.Command{
 		Name:       "app-infos",
-		ShortUsage: "asc app-infos <subcommand> [flags]",
-		ShortHelp:  "List app info records for an app.",
-		LongHelp: `List app info records for an app.
+		ShortUsage: "asc app-info list [flags]",
+		ShortHelp:  "DEPRECATED: use `asc app-info list`.",
+		LongHelp: `DEPRECATED: use ` + "`asc app-info list`" + `.
 
-An app can have multiple app info records (one per platform or state). This command
-helps you find the specific app info ID you need when commands report "multiple app
-infos found" errors.
+This compatibility alias preserves the legacy plural root while the canonical app
+info discovery workflow lives under ` + "`asc app-info list`" + `.
 
 Examples:
-  asc app-infos list --app "APP_ID"
-  asc app-infos list --app "APP_ID" --output table`,
+  asc app-info list --app "APP_ID"
+  asc app-info list --app "APP_ID" --output table`,
 		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
+		UsageFunc: shared.DeprecatedUsageFunc,
 		Subcommands: []*ffcli.Command{
 			AppInfosListCommand(),
 		},
@@ -39,30 +40,72 @@ Examples:
 	}
 }
 
-// AppInfosListCommand returns the list subcommand for app-infos.
-func AppInfosListCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("app-infos list", flag.ExitOnError)
-
-	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	output := shared.BindOutputFlags(fs)
-
-	return &ffcli.Command{
-		Name:       "list",
-		ShortUsage: "asc app-infos list [flags]",
-		ShortHelp:  "List all app info records for an app.",
-		LongHelp: `List all app info records for an app.
+// AppInfoListCommand returns the canonical list subcommand for app-info.
+func AppInfoListCommand() *ffcli.Command {
+	return newAppInfoListCommand(
+		"app-info list",
+		"list",
+		"asc app-info list [flags]",
+		"List all app info records for an app.",
+		`List all app info records for an app.
 
 An app can have multiple app info records (one per platform or state). Use this
 command to find the specific app info ID when you encounter "multiple app infos
 found" errors in other commands.
 
 Examples:
-  asc app-infos list --app "APP_ID"
-  asc app-infos list --app "APP_ID" --output table
-  asc app-infos list --app "APP_ID" --output markdown`,
-		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
+  asc app-info list --app "APP_ID"
+  asc app-info list --app "APP_ID" --output table
+  asc app-info list --app "APP_ID" --output markdown`,
+		"app-info list",
+		"",
+		shared.DefaultUsageFunc,
+	)
+}
+
+// AppInfosListCommand returns the deprecated compatibility alias for app-infos list.
+func AppInfosListCommand() *ffcli.Command {
+	return newAppInfoListCommand(
+		"app-infos list",
+		"list",
+		"asc app-info list [flags]",
+		"DEPRECATED: use `asc app-info list`.",
+		`DEPRECATED: use `+"`asc app-info list`"+`.
+
+This compatibility alias preserves the legacy plural command while the canonical
+discovery path lives under `+"`asc app-info list`"+`.
+
+Examples:
+  asc app-info list --app "APP_ID"
+  asc app-info list --app "APP_ID" --output table
+  asc app-info list --app "APP_ID" --output markdown`,
+		"app-infos list",
+		appInfosDeprecationWarning,
+		shared.DeprecatedUsageFunc,
+	)
+}
+
+func newAppInfoListCommand(
+	flagSetName, commandName, shortUsage, shortHelp, longHelp, errorPrefix, deprecatedWarning string,
+	usageFunc func(*ffcli.Command) string,
+) *ffcli.Command {
+	fs := flag.NewFlagSet(flagSetName, flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       commandName,
+		ShortUsage: shortUsage,
+		ShortHelp:  shortHelp,
+		LongHelp:   longHelp,
+		FlagSet:    fs,
+		UsageFunc:  usageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(deprecatedWarning) != "" {
+				fmt.Fprintln(os.Stderr, deprecatedWarning)
+			}
+
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if strings.TrimSpace(resolvedAppID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
@@ -71,7 +114,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("app-infos list: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -79,7 +122,7 @@ Examples:
 
 			resp, err := client.GetAppInfos(requestCtx, resolvedAppID)
 			if err != nil {
-				return fmt.Errorf("app-infos list: failed to fetch: %w", err)
+				return fmt.Errorf("%s: failed to fetch: %w", errorPrefix, err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)

--- a/internal/cli/cmdtest/app_info_canonical_surface_test.go
+++ b/internal/cli/cmdtest/app_info_canonical_surface_test.go
@@ -1,0 +1,150 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAppInfoHelpShowsCanonicalListSubcommand(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"app-info"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "list") {
+		t.Fatalf("expected app-info help to contain list subcommand, got %q", stderr)
+	}
+}
+
+func TestRootHelpHidesDeprecatedAppInfosCommand(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "  app-info:") {
+		t.Fatalf("expected root help to show app-info, got %q", stderr)
+	}
+	if strings.Contains(stderr, "  app-infos:") {
+		t.Fatalf("expected root help to hide deprecated app-infos root, got %q", stderr)
+	}
+}
+
+func TestDeprecatedAppInfosHelpPointsToCanonicalPath(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"app-infos"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "asc app-info list [flags]") {
+		t.Fatalf("expected deprecated help to point to canonical path, got %q", stderr)
+	}
+	if strings.Contains(stderr, "asc app-infos <subcommand> [flags]") {
+		t.Fatalf("expected deprecated help to hide legacy usage, got %q", stderr)
+	}
+}
+
+func TestAppInfosAliasMatchesCanonicalAppInfoListOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/appInfos" {
+			t.Fatalf("expected path /v1/apps/app-1/appInfos, got %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"data":[
+					{"type":"appInfos","id":"info-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}},
+					{"type":"appInfos","id":"info-2","attributes":{"state":"READY_FOR_DISTRIBUTION"}}
+				]
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	run := func(args []string) (string, string) {
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+
+		return captureOutput(t, func() {
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := root.Run(context.Background()); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+		})
+	}
+
+	canonicalStdout, canonicalStderr := run([]string{"app-info", "list", "--app", "app-1", "--output", "json"})
+	aliasStdout, aliasStderr := run([]string{"app-infos", "list", "--app", "app-1", "--output", "json"})
+
+	if canonicalStderr != "" {
+		t.Fatalf("expected canonical command to avoid warnings, got %q", canonicalStderr)
+	}
+	requireStderrContainsWarning(t, aliasStderr, "Warning: `asc app-infos list` is deprecated. Use `asc app-info list`.")
+
+	var canonicalPayload map[string]any
+	if err := json.Unmarshal([]byte(canonicalStdout), &canonicalPayload); err != nil {
+		t.Fatalf("parse canonical stdout: %v", err)
+	}
+
+	var aliasPayload map[string]any
+	if err := json.Unmarshal([]byte(aliasStdout), &aliasPayload); err != nil {
+		t.Fatalf("parse alias stdout: %v", err)
+	}
+
+	if canonicalStdout != aliasStdout {
+		t.Fatalf("expected canonical and alias output to match, canonical=%q alias=%q", canonicalStdout, aliasStdout)
+	}
+}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3889,6 +3889,11 @@ func TestAppInfoValidationErrors(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name:    "app-info list missing app",
+			args:    []string{"app-info", "list"},
+			wantErr: "Error: --app is required",
+		},
+		{
 			name:    "app-info get missing app",
 			args:    []string{"app-info", "get"},
 			wantErr: "--app or --app-info is required",

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -144,7 +144,6 @@ Use `asc <command> --help` for subcommands and flags.
 - `product-pages` - Manage custom product pages and product page experiments.
 - `routing-coverage` - Manage routing app coverage files.
 - `app-info` - Manage App Store version metadata.
-- `app-infos` - List app info records for an app.
 - `eula` - Manage End User License Agreements (EULA).
 - `agreements` - Manage agreements in App Store Connect.
 - `pricing` - Manage app pricing and availability.


### PR DESCRIPTION
## Summary
- add `asc app-info list` as the canonical app info discovery path under the existing `app-info` family
- keep `asc app-infos list` working as a hidden deprecated compatibility alias with the same runtime behavior and a canonical warning
- remove `app-infos` from primary root/docs discovery and add cmdtests for canonical help, hidden alias behavior, and output parity

## Test plan
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

Closes #948.