### PR TITLE
refactor: finish builds test-notes canonical migration

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -88,7 +88,6 @@ asc <subcommand> [flags]
 - `pre-release-versions` - Manage TestFlight pre-release versions.
 - `build-localizations` - Manage build release notes localizations.
 - `beta-app-localizations` - Manage TestFlight beta app localizations.
-- `beta-build-localizations` - Manage TestFlight beta build localizations.
 - `sandbox` - Manage sandbox testers in App Store Connect.
 
 ### Review and Release

--- a/internal/cli/betabuildlocalizations/beta_build_localizations.go
+++ b/internal/cli/betabuildlocalizations/beta_build_localizations.go
@@ -20,28 +20,53 @@ func BetaBuildLocalizationsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "beta-build-localizations",
 		ShortUsage: "asc beta-build-localizations <subcommand> [flags]",
-		ShortHelp:  "Manage TestFlight beta build localizations.",
-		LongHelp: `Manage TestFlight beta build localizations ("What to Test" notes).
+		ShortHelp:  "DEPRECATED: use `asc builds test-notes ...`.",
+		LongHelp: `Deprecated compatibility layer for TestFlight What to Test notes.
 
-Deprecated: prefer "asc builds test-notes ..." for the same What to Test functionality.
-This command group remains available for compatibility.
+Canonical build-scoped workflows now live under ` + "`asc builds test-notes ...`" + `.
+
+Legacy-only behaviors still remain here during the transition:
+- ` + "`beta-build-localizations list --global`" + `
+- ` + "`beta-build-localizations get --app ... --latest`" + `
+- ` + "`beta-build-localizations create --app ... --latest`" + `
+- ` + "`beta-build-localizations build get`" + `
 
 Examples:
-  asc beta-build-localizations list --build "BUILD_ID"
-  asc beta-build-localizations list --global
-  asc beta-build-localizations list --global --paginate
-  asc beta-build-localizations create --build "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`,
+  asc builds test-notes list --build "BUILD_ID"
+  asc builds test-notes view --id "LOCALIZATION_ID"
+  asc builds test-notes create --build "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`,
 		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
+		UsageFunc: shared.DeprecatedUsageFunc,
 		Subcommands: []*ffcli.Command{
-			BetaBuildLocalizationsListCommand(),
-			BetaBuildLocalizationsGetCommand(),
+			deprecatedBetaBuildLocalizationsLeafCommand(
+				BetaBuildLocalizationsListCommand(),
+				"asc builds test-notes list",
+				"Warning: `asc beta-build-localizations list` is deprecated. Use `asc builds test-notes list` for build-scoped workflows. `--global` remains legacy-only during transition.",
+			),
+			deprecatedBetaBuildLocalizationsLeafCommand(
+				BetaBuildLocalizationsGetCommand(),
+				"asc builds test-notes view",
+				"Warning: `asc beta-build-localizations get` is deprecated. Use `asc builds test-notes view` for ID-based lookups. `--latest` remains legacy-only during transition.",
+			),
 			BetaBuildLocalizationsBuildCommand(),
-			BetaBuildLocalizationsCreateCommand(),
-			BetaBuildLocalizationsUpdateCommand(),
-			BetaBuildLocalizationsDeleteCommand(),
+			deprecatedBetaBuildLocalizationsLeafCommand(
+				BetaBuildLocalizationsCreateCommand(),
+				"asc builds test-notes create",
+				"Warning: `asc beta-build-localizations create` is deprecated. Use `asc builds test-notes create` for build-scoped workflows. `--latest` remains legacy-only during transition.",
+			),
+			deprecatedBetaBuildLocalizationsLeafCommand(
+				BetaBuildLocalizationsUpdateCommand(),
+				"asc builds test-notes update",
+				"Warning: `asc beta-build-localizations update` is deprecated. Use `asc builds test-notes update`.",
+			),
+			deprecatedBetaBuildLocalizationsLeafCommand(
+				BetaBuildLocalizationsDeleteCommand(),
+				"asc builds test-notes delete",
+				"Warning: `asc beta-build-localizations delete` is deprecated. Use `asc builds test-notes delete`.",
+			),
 		},
 		Exec: func(ctx context.Context, args []string) error {
+			fmt.Fprintln(os.Stderr, "Warning: `asc beta-build-localizations` is deprecated. Use `asc builds test-notes ...` for canonical build-scoped workflows.")
 			return flag.ErrHelp
 		},
 	}

--- a/internal/cli/betabuildlocalizations/beta_build_localizations_build.go
+++ b/internal/cli/betabuildlocalizations/beta_build_localizations_build.go
@@ -18,17 +18,26 @@ func BetaBuildLocalizationsBuildCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "build",
 		ShortUsage: "asc beta-build-localizations build <subcommand> [flags]",
-		ShortHelp:  "View the build for a beta build localization.",
-		LongHelp: `View the build for a beta build localization.
+		ShortHelp:  "DEPRECATED: legacy-only compatibility path.",
+		LongHelp: `Deprecated compatibility path retained during migration.
+
+No canonical ` + "`asc builds test-notes ...`" + ` replacement exists for the build relationship helper yet.
+
+View the build for a beta build localization.
 
 Examples:
   asc beta-build-localizations build get --id "LOCALIZATION_ID"`,
 		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
+		UsageFunc: shared.DeprecatedUsageFunc,
 		Subcommands: []*ffcli.Command{
-			BetaBuildLocalizationsBuildGetCommand(),
+			deprecatedBetaBuildLocalizationsLeafCommand(
+				BetaBuildLocalizationsBuildGetCommand(),
+				"",
+				"Warning: `asc beta-build-localizations build get` is deprecated. No canonical replacement exists yet; this legacy helper remains available during transition.",
+			),
 		},
 		Exec: func(ctx context.Context, args []string) error {
+			fmt.Fprintln(os.Stderr, "Warning: `asc beta-build-localizations build` is deprecated. No canonical replacement exists yet; this legacy helper remains available during transition.")
 			return flag.ErrHelp
 		},
 	}

--- a/internal/cli/betabuildlocalizations/deprecated.go
+++ b/internal/cli/betabuildlocalizations/deprecated.go
@@ -1,0 +1,32 @@
+package betabuildlocalizations
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+func deprecatedBetaBuildLocalizationsLeafCommand(cmd *ffcli.Command, replacement, warning string) *ffcli.Command {
+	if cmd == nil {
+		return nil
+	}
+
+	clone := *cmd
+	if replacement != "" {
+		clone.ShortHelp = fmt.Sprintf("DEPRECATED: use `%s`.", replacement)
+		clone.LongHelp = fmt.Sprintf("Deprecated compatibility alias for `%s`.\n\n%s", replacement, cmd.LongHelp)
+	} else {
+		clone.ShortHelp = "DEPRECATED: legacy-only compatibility path."
+		clone.LongHelp = "Deprecated compatibility path retained during migration.\n\n" + cmd.LongHelp
+	}
+
+	origExec := cmd.Exec
+	clone.Exec = func(ctx context.Context, args []string) error {
+		fmt.Fprintln(os.Stderr, warning)
+		return origExec(ctx, args)
+	}
+
+	return &clone
+}

--- a/internal/cli/builds/build_test_notes.go
+++ b/internal/cli/builds/build_test_notes.go
@@ -25,15 +25,16 @@ func BuildsTestNotesCommand() *ffcli.Command {
 
 Examples:
   asc builds test-notes list --build "BUILD_ID"
-  asc builds test-notes get --id "LOCALIZATION_ID"
+  asc builds test-notes view --id "LOCALIZATION_ID"
   asc builds test-notes create --build "BUILD_ID" --locale "en-US" --whats-new "Test instructions"
   asc builds test-notes update --id "LOCALIZATION_ID" --whats-new "Updated instructions"
   asc builds test-notes delete --id "LOCALIZATION_ID" --confirm`,
 		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
+		UsageFunc: buildsVisibleUsageFunc,
 		Subcommands: []*ffcli.Command{
 			BuildsTestNotesListCommand(),
-			BuildsTestNotesGetCommand(),
+			BuildsTestNotesViewCommand(),
+			DeprecatedBuildsTestNotesGetAliasCommand(),
 			BuildsTestNotesCreateCommand(),
 			BuildsTestNotesUpdateCommand(),
 			BuildsTestNotesDeleteCommand(),
@@ -127,21 +128,21 @@ Examples:
 	}
 }
 
-// BuildsTestNotesGetCommand returns the get subcommand.
-func BuildsTestNotesGetCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("get", flag.ExitOnError)
+// BuildsTestNotesViewCommand returns the view subcommand.
+func BuildsTestNotesViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("view", flag.ExitOnError)
 
 	localizationID := fs.String("id", "", "Localization ID")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "get",
-		ShortUsage: "asc builds test-notes get [flags]",
-		ShortHelp:  "Get a What to Test note by ID.",
-		LongHelp: `Get a What to Test note by ID.
+		Name:       "view",
+		ShortUsage: "asc builds test-notes view [flags]",
+		ShortHelp:  "View a What to Test note by ID.",
+		LongHelp: `View a What to Test note by ID.
 
 Examples:
-  asc builds test-notes get --id "LOCALIZATION_ID"`,
+  asc builds test-notes view --id "LOCALIZATION_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -153,7 +154,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("builds test-notes get: %w", err)
+				return fmt.Errorf("builds test-notes view: %w", err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -161,12 +162,22 @@ Examples:
 
 			resp, err := client.GetBetaBuildLocalization(requestCtx, id)
 			if err != nil {
-				return fmt.Errorf("builds test-notes get: %w", err)
+				return fmt.Errorf("builds test-notes view: %w", err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func DeprecatedBuildsTestNotesGetAliasCommand() *ffcli.Command {
+	return deprecatedBuildsAliasLeafCommand(
+		BuildsTestNotesViewCommand(),
+		"get",
+		"asc builds test-notes get [flags]",
+		"asc builds test-notes view",
+		"Warning: `asc builds test-notes get` is deprecated. Use `asc builds test-notes view`.",
+	)
 }
 
 // BuildsTestNotesCreateCommand returns the create subcommand.

--- a/internal/cli/builds/command_wrappers.go
+++ b/internal/cli/builds/command_wrappers.go
@@ -1,0 +1,51 @@
+package builds
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func buildsVisibleUsageFunc(c *ffcli.Command) string {
+	clone := *c
+	if len(c.Subcommands) > 0 {
+		visible := make([]*ffcli.Command, 0, len(c.Subcommands))
+		for _, sub := range c.Subcommands {
+			if sub == nil {
+				continue
+			}
+			if strings.HasPrefix(strings.TrimSpace(sub.ShortHelp), "DEPRECATED:") {
+				continue
+			}
+			visible = append(visible, sub)
+		}
+		clone.Subcommands = visible
+	}
+	return shared.DefaultUsageFunc(&clone)
+}
+
+func deprecatedBuildsAliasLeafCommand(cmd *ffcli.Command, name, shortUsage, newCommand, warning string) *ffcli.Command {
+	if cmd == nil {
+		return nil
+	}
+
+	clone := *cmd
+	clone.Name = name
+	clone.ShortUsage = shortUsage
+	clone.ShortHelp = fmt.Sprintf("DEPRECATED: use `%s`.", newCommand)
+	clone.LongHelp = fmt.Sprintf("Deprecated compatibility alias for `%s`.", newCommand)
+	clone.UsageFunc = shared.DeprecatedUsageFunc
+
+	origExec := cmd.Exec
+	clone.Exec = func(ctx context.Context, args []string) error {
+		fmt.Fprintln(os.Stderr, warning)
+		return origExec(ctx, args)
+	}
+
+	return &clone
+}

--- a/internal/cli/cmdtest/beta_build_localizations_global_test.go
+++ b/internal/cli/cmdtest/beta_build_localizations_global_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 )
 
+const deprecatedBetaBuildLocalizationsListWarning = "Warning: `asc beta-build-localizations list` is deprecated. Use `asc builds test-notes list`"
+
 func TestBetaBuildLocalizationsListGlobalSuccess(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_APP_ID", "")
@@ -48,8 +50,8 @@ func TestBetaBuildLocalizationsListGlobalSuccess(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsListWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"id":"bbl-1"`) {
 		t.Fatalf("expected localization id in output, got %q", stdout)
@@ -132,8 +134,8 @@ func TestBetaBuildLocalizationsListScopedStillWorks(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsListWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"id":"bbl-scoped"`) {
 		t.Fatalf("expected scoped localization in output, got %q", stdout)
@@ -175,8 +177,8 @@ func TestBetaBuildLocalizationsListNextSkipsSelector(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsListWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 }
 
@@ -229,8 +231,8 @@ func TestBetaBuildLocalizationsListGlobalPaginate(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsListWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"bbl-1"`) {
 		t.Fatalf("expected first page data in output, got %q", stdout)

--- a/internal/cli/cmdtest/beta_build_localizations_latest_selector_test.go
+++ b/internal/cli/cmdtest/beta_build_localizations_latest_selector_test.go
@@ -11,6 +11,11 @@ import (
 	"testing"
 )
 
+const (
+	deprecatedBetaBuildLocalizationsGetWarning    = "Warning: `asc beta-build-localizations get` is deprecated. Use `asc builds test-notes view`"
+	deprecatedBetaBuildLocalizationsCreateWarning = "Warning: `asc beta-build-localizations create` is deprecated. Use `asc builds test-notes create`"
+)
+
 func TestBetaBuildLocalizationsGetLatestByAppWithStateAlias(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_APP_ID", "")
@@ -84,8 +89,8 @@ func TestBetaBuildLocalizationsGetLatestByAppWithStateAlias(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsGetWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"id":"loc-1"`) {
 		t.Fatalf("expected localization output, got %q", stdout)
@@ -223,8 +228,8 @@ func TestBetaBuildLocalizationsCreateLatestByAppWithStateAlias(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsCreateWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"id":"loc-create"`) {
 		t.Fatalf("expected create output, got %q", stdout)

--- a/internal/cli/cmdtest/beta_build_localizations_upsert_test.go
+++ b/internal/cli/cmdtest/beta_build_localizations_upsert_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+const deprecatedBetaBuildLocalizationsCreateUpsertWarning = "Warning: `asc beta-build-localizations create` is deprecated. Use `asc builds test-notes create`"
+
 func TestBetaBuildLocalizationsCreateUpsertUpdatesExistingLocale(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_APP_ID", "")
@@ -77,8 +79,8 @@ func TestBetaBuildLocalizationsCreateUpsertUpdatesExistingLocale(t *testing.T) {
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsCreateUpsertWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"id":"loc-1"`) {
 		t.Fatalf("expected updated localization output, got %q", stdout)
@@ -151,8 +153,8 @@ func TestBetaBuildLocalizationsCreateUpsertCreatesWhenLocaleMissing(t *testing.T
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, deprecatedBetaBuildLocalizationsCreateUpsertWarning) {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"id":"loc-new"`) {
 		t.Fatalf("expected created localization output, got %q", stdout)

--- a/internal/cli/cmdtest/builds_test_notes_surface_test.go
+++ b/internal/cli/cmdtest/builds_test_notes_surface_test.go
@@ -1,0 +1,187 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRootHelpHidesBetaBuildLocalizationsRoot(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if strings.Contains(stderr, "  beta-build-localizations:") {
+		t.Fatalf("expected root help to hide beta-build-localizations, got %q", stderr)
+	}
+}
+
+func TestBuildsTestNotesHelpShowsViewNotGet(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "test-notes"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "view") {
+		t.Fatalf("expected builds test-notes help to contain view, got %q", stderr)
+	}
+	if strings.Contains(stderr, "\n  get ") || strings.Contains(stderr, "\n  get\t") {
+		t.Fatalf("expected builds test-notes help to hide get alias, got %q", stderr)
+	}
+}
+
+func TestDeprecatedBuildsTestNotesGetAliasWarnsAndMatchesViewOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaBuildLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/betaBuildLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"data":{"type":"betaBuildLocalizations","id":"loc-1","attributes":{"locale":"en-US","whatsNew":"Notes"}}
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	run := func(args []string) (string, string) {
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+
+		return captureOutput(t, func() {
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := root.Run(context.Background()); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+		})
+	}
+
+	canonicalStdout, canonicalStderr := run([]string{"builds", "test-notes", "view", "--id", "loc-1", "--output", "json"})
+	aliasStdout, aliasStderr := run([]string{"builds", "test-notes", "get", "--id", "loc-1", "--output", "json"})
+
+	if canonicalStderr != "" {
+		t.Fatalf("expected canonical command to avoid warnings, got %q", canonicalStderr)
+	}
+	if !strings.Contains(aliasStderr, "Warning: `asc builds test-notes get` is deprecated. Use `asc builds test-notes view`.") {
+		t.Fatalf("expected deprecation warning, got %q", aliasStderr)
+	}
+
+	var canonicalPayload map[string]any
+	if err := json.Unmarshal([]byte(canonicalStdout), &canonicalPayload); err != nil {
+		t.Fatalf("parse canonical stdout: %v", err)
+	}
+	var aliasPayload map[string]any
+	if err := json.Unmarshal([]byte(aliasStdout), &aliasPayload); err != nil {
+		t.Fatalf("parse alias stdout: %v", err)
+	}
+	if canonicalStdout != aliasStdout {
+		t.Fatalf("expected canonical and alias output to match, canonical=%q alias=%q", canonicalStdout, aliasStdout)
+	}
+}
+
+func TestDeprecatedBetaBuildLocalizationsGetWarnsAndMatchesCanonicalViewOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaBuildLocalizations/loc-1" {
+			t.Fatalf("expected path /v1/betaBuildLocalizations/loc-1, got %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"data":{"type":"betaBuildLocalizations","id":"loc-1","attributes":{"locale":"en-US","whatsNew":"Notes"}}
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	run := func(args []string) (string, string) {
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+
+		return captureOutput(t, func() {
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := root.Run(context.Background()); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+		})
+	}
+
+	canonicalStdout, canonicalStderr := run([]string{"builds", "test-notes", "view", "--id", "loc-1", "--output", "json"})
+	aliasStdout, aliasStderr := run([]string{"beta-build-localizations", "get", "--id", "loc-1", "--output", "json"})
+
+	if canonicalStderr != "" {
+		t.Fatalf("expected canonical command to avoid warnings, got %q", canonicalStderr)
+	}
+	if !strings.Contains(aliasStderr, "Warning: `asc beta-build-localizations get` is deprecated. Use `asc builds test-notes view`") {
+		t.Fatalf("expected deprecation warning, got %q", aliasStderr)
+	}
+
+	var canonicalPayload map[string]any
+	if err := json.Unmarshal([]byte(canonicalStdout), &canonicalPayload); err != nil {
+		t.Fatalf("parse canonical stdout: %v", err)
+	}
+	var aliasPayload map[string]any
+	if err := json.Unmarshal([]byte(aliasStdout), &aliasPayload); err != nil {
+		t.Fatalf("parse alias stdout: %v", err)
+	}
+	if canonicalStdout != aliasStdout {
+		t.Fatalf("expected canonical and alias output to match, canonical=%q alias=%q", canonicalStdout, aliasStdout)
+	}
+}

--- a/internal/cli/cmdtest/localizations_next_validation_phase47_test.go
+++ b/internal/cli/cmdtest/localizations_next_validation_phase47_test.go
@@ -9,6 +9,13 @@ import (
 	"testing"
 )
 
+func expectedLocalizationsStderr(argsPrefix []string) string {
+	if len(argsPrefix) >= 2 && argsPrefix[0] == "beta-build-localizations" && argsPrefix[1] == "list" {
+		return "Warning: `asc beta-build-localizations list` is deprecated. Use `asc builds test-notes list`"
+	}
+	return ""
+}
+
 func runLocalizationsInvalidNextURLCases(
 	t *testing.T,
 	argsPrefix []string,
@@ -57,7 +64,11 @@ func runLocalizationsInvalidNextURLCases(
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if stderr != "" {
+			if wantWarning := expectedLocalizationsStderr(argsPrefix); wantWarning != "" {
+				if !strings.Contains(stderr, wantWarning) {
+					t.Fatalf("expected deprecation warning %q, got %q", wantWarning, stderr)
+				}
+			} else if stderr != "" {
 				t.Fatalf("expected empty stderr, got %q", stderr)
 			}
 		})
@@ -125,7 +136,11 @@ func runLocalizationsPaginateFromNext(
 		}
 	})
 
-	if stderr != "" {
+	if wantWarning := expectedLocalizationsStderr(argsPrefix); wantWarning != "" {
+		if !strings.Contains(stderr, wantWarning) {
+			t.Fatalf("expected deprecation warning %q, got %q", wantWarning, stderr)
+		}
+	} else if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
 	for _, id := range wantIDs {

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -154,7 +154,6 @@ Use `asc <command> --help` for subcommands and flags.
 - `background-assets` - Manage background assets.
 - `build-localizations` - Manage build release notes localizations.
 - `beta-app-localizations` - Manage TestFlight beta app localizations.
-- `beta-build-localizations` - Manage TestFlight beta build localizations.
 - `sandbox` - Manage sandbox testers in App Store Connect.
 - `video-previews` - Manage App Store app preview videos.
 - `signing` - Manage signing certificates and profiles.


### PR DESCRIPTION
## Summary
- make `asc builds test-notes ...` the canonical What to Test surface and rename the canonical read path from `get` to `view`
- keep `asc builds test-notes get` and `asc beta-build-localizations ...` as deprecated compatibility aliases while hiding the legacy root from normal discovery and docs
- preserve legacy-only selectors like `--global`, `--app --latest`, and `build get` on the deprecated root during the migration window

## Test plan
- [x] `make format`
- [x] `make generate-command-docs`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

Closes #945.