### PR TITLE
feat: validate release configuration (type and scheduled date)

### DIFF
--- a/internal/asc/client_versions.go
+++ b/internal/asc/client_versions.go
@@ -9,11 +9,13 @@ import (
 
 // AppStoreVersionAttributes describes app store version metadata.
 type AppStoreVersionAttributes struct {
-	Platform        Platform `json:"platform,omitempty"`
-	VersionString   string   `json:"versionString,omitempty"`
-	AppStoreState   string   `json:"appStoreState,omitempty"`
-	AppVersionState string   `json:"appVersionState,omitempty"`
-	CreatedDate     string   `json:"createdDate,omitempty"`
+	Platform            Platform `json:"platform,omitempty"`
+	VersionString       string   `json:"versionString,omitempty"`
+	AppStoreState       string   `json:"appStoreState,omitempty"`
+	AppVersionState     string   `json:"appVersionState,omitempty"`
+	CreatedDate         string   `json:"createdDate,omitempty"`
+	ReleaseType         string   `json:"releaseType,omitempty"`
+	EarliestReleaseDate string   `json:"earliestReleaseDate,omitempty"`
 }
 
 // AppStoreVersionCreateAttributes describes app store version create payload attributes.

--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -1683,3 +1683,67 @@ func TestValidateNoIAPChecksWhenAppHasNoIAPs(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateWarnsScheduledReleaseDateInPast(t *testing.T) {
+	fixture := validValidateFixture()
+	fixture.version = `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0","appVersionState":"PREPARE_FOR_SUBMISSION","releaseType":"SCHEDULED","earliestReleaseDate":"2020-01-01T00:00:00+00:00"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`
+
+	client := newValidateTestClient(t, fixture)
+	restore := validate.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	defer restore()
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("expected no blocking errors, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var report validation.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("failed to parse JSON output: %v", err)
+	}
+	if !hasCheckWithID(report.Checks, "release.scheduled_date_past") {
+		t.Fatalf("expected release.scheduled_date_past warning, got %+v", report.Checks)
+	}
+}
+
+func TestValidateShowsManualReleaseInfo(t *testing.T) {
+	fixture := validValidateFixture()
+	fixture.version = `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0","appVersionState":"PREPARE_FOR_SUBMISSION","releaseType":"MANUAL"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`
+
+	client := newValidateTestClient(t, fixture)
+	restore := validate.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	defer restore()
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("expected no blocking errors, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var report validation.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("failed to parse JSON output: %v", err)
+	}
+	if !hasCheckWithID(report.Checks, "release.type_manual") {
+		t.Fatalf("expected release.type_manual info check, got %+v", report.Checks)
+	}
+}

--- a/internal/cli/validate/readiness.go
+++ b/internal/cli/validate/readiness.go
@@ -267,6 +267,8 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 		IAPs:                        iaps,
 		IAPFetchSkipReason:          iapFetchSkipReason,
 		AgeRatingDeclaration:        ageRatingDecl,
+		ReleaseType:                 versionResp.Data.Attributes.ReleaseType,
+		EarliestReleaseDate:         versionResp.Data.Attributes.EarliestReleaseDate,
 	}, opts.Strict)
 
 	return report, nil

--- a/internal/validation/release.go
+++ b/internal/validation/release.go
@@ -1,0 +1,45 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// releaseChecks validates the version release configuration.
+func releaseChecks(releaseType, earliestReleaseDate string) []CheckResult {
+	rt := strings.ToUpper(strings.TrimSpace(releaseType))
+	if rt == "" {
+		return nil
+	}
+
+	var checks []CheckResult
+
+	if rt == "SCHEDULED" {
+		date := strings.TrimSpace(earliestReleaseDate)
+		if date != "" {
+			parsed, err := time.Parse(time.RFC3339, date)
+			if err == nil && parsed.Before(time.Now()) {
+				checks = append(checks, CheckResult{
+					ID:          "release.scheduled_date_past",
+					Severity:    SeverityWarning,
+					Field:       "earliestReleaseDate",
+					Message:     fmt.Sprintf("Scheduled release date %s is in the past; the app will be released immediately after approval", date),
+					Remediation: "Update the earliest release date to a future date using `asc versions update --version-id VERSION --earliest-release-date DATE` or change the release type",
+				})
+			}
+		}
+	}
+
+	if rt == "MANUAL" {
+		checks = append(checks, CheckResult{
+			ID:          "release.type_manual",
+			Severity:    SeverityInfo,
+			Field:       "releaseType",
+			Message:     "Release type is MANUAL — the app will not be released automatically after approval",
+			Remediation: "After approval, release manually using `asc versions release --version-id VERSION --confirm` or change the release type to AFTER_APPROVAL",
+		})
+	}
+
+	return checks
+}

--- a/internal/validation/release_test.go
+++ b/internal/validation/release_test.go
@@ -1,0 +1,72 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReleaseChecks_ScheduledDateInPast(t *testing.T) {
+	past := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
+	checks := releaseChecks("SCHEDULED", past)
+	if !hasCheckID(checks, "release.scheduled_date_past") {
+		t.Fatalf("expected scheduled_date_past check, got %v", checks)
+	}
+	if checks[0].Severity != SeverityWarning {
+		t.Fatalf("expected warning severity, got %s", checks[0].Severity)
+	}
+	if !strings.Contains(checks[0].Message, past) {
+		t.Fatalf("expected message to include the date, got %s", checks[0].Message)
+	}
+}
+
+func TestReleaseChecks_ScheduledDateInFuture(t *testing.T) {
+	future := time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339)
+	checks := releaseChecks("SCHEDULED", future)
+	if hasCheckID(checks, "release.scheduled_date_past") {
+		t.Fatalf("expected no past-date warning for future date, got %v", checks)
+	}
+}
+
+func TestReleaseChecks_ManualReleaseInfo(t *testing.T) {
+	checks := releaseChecks("MANUAL", "")
+	if !hasCheckID(checks, "release.type_manual") {
+		t.Fatalf("expected manual release info check, got %v", checks)
+	}
+	if checks[0].Severity != SeverityInfo {
+		t.Fatalf("expected info severity, got %s", checks[0].Severity)
+	}
+}
+
+func TestReleaseChecks_AfterApprovalNoChecks(t *testing.T) {
+	checks := releaseChecks("AFTER_APPROVAL", "")
+	if len(checks) != 0 {
+		t.Fatalf("expected no checks for AFTER_APPROVAL, got %d (%v)", len(checks), checks)
+	}
+}
+
+func TestReleaseChecks_EmptyReleaseTypeNoChecks(t *testing.T) {
+	checks := releaseChecks("", "")
+	if len(checks) != 0 {
+		t.Fatalf("expected no checks for empty release type, got %d (%v)", len(checks), checks)
+	}
+}
+
+func TestReleaseChecks_ScheduledCaseInsensitive(t *testing.T) {
+	past := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
+	checks := releaseChecks("scheduled", past)
+	if !hasCheckID(checks, "release.scheduled_date_past") {
+		t.Fatalf("expected case-insensitive match for SCHEDULED, got %v", checks)
+	}
+}
+
+func TestValidateIncludesReleaseChecks(t *testing.T) {
+	report := Validate(Input{
+		AppID:       "app-1",
+		VersionID:   "ver-1",
+		ReleaseType: "MANUAL",
+	}, false)
+	if !hasCheckID(report.Checks, "release.type_manual") {
+		t.Fatalf("expected release check in unified validate, got %+v", report.Checks)
+	}
+}

--- a/internal/validation/report.go
+++ b/internal/validation/report.go
@@ -19,6 +19,7 @@ func Validate(input Input, strict bool) Report {
 	checks = append(checks, iapFetchChecks(input.IAPFetchSkipReason)...)
 	checks = append(checks, iapReviewReadinessChecks(input.IAPs)...)
 	checks = append(checks, ageRatingChecks(input.AgeRatingDeclaration)...)
+	checks = append(checks, releaseChecks(input.ReleaseType, input.EarliestReleaseDate)...)
 
 	summary := summarize(checks, strict)
 

--- a/internal/validation/types.go
+++ b/internal/validation/types.go
@@ -63,6 +63,8 @@ type Input struct {
 	IAPs                        []IAP
 	IAPFetchSkipReason          string
 	AgeRatingDeclaration        *AgeRatingDeclaration
+	ReleaseType                 string
+	EarliestReleaseDate         string
 }
 
 // VersionLocalization represents version-level metadata.


### PR DESCRIPTION
## Summary

- Adds release configuration validation to `asc validate`
- `release.scheduled_date_past` (warning): catches SCHEDULED releases with an earliest release date in the past — the app would release immediately after approval instead of waiting, which may not be the developer's intent
- `release.type_manual` (info): reminds that MANUAL release requires the developer to explicitly trigger release after approval via `asc versions release`
- Adds `ReleaseType` and `EarliestReleaseDate` fields to `AppStoreVersionAttributes` so the version GET response surfaces these fields (previously only available in create/update requests)

## Test plan

- [x] Unit tests for all release check scenarios (past date, future date, manual, after_approval, empty, case-insensitive)
- [x] Integration test: `TestValidateWarnsScheduledReleaseDateInPast` — version with SCHEDULED + past date triggers warning
- [x] Integration test: `TestValidateShowsManualReleaseInfo` — version with MANUAL triggers info check
- [x] Wired through `Validate()` — `TestValidateIncludesReleaseChecks`
- [x] No regressions: full `TestValidate*` suite passes