### PR TITLE
apps wall: add Loverzz: Couples App & Widgets

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -221,6 +221,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Loverzz: Couples App & Widgets",
+    "link": "https://apps.apple.com/us/app/loverzz-couples-app-widgets/id6744887601?uo=4",
+    "creator": "tom-eberle",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/34/14/b8/3414b8a0-0647-c6b2-550a-e2ca1eb28e77/AppIcon-0-1x_U007ephone-0-1-0-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Lumical: Scan to Calendar",
     "link": "https://apps.apple.com/us/app/lumical-scan-to-calendar/id6753274309",
     "creator": "arunavo4",


### PR DESCRIPTION
## Summary

- add `Loverzz: Couples App & Widgets` to the Wall of Apps

## Entry

- App ID: 6744887601
- App: Loverzz: Couples App & Widgets
- Link: https://apps.apple.com/us/app/loverzz-couples-app-widgets/id6744887601?uo=4
- Creator: tom-eberle
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
