### PR TITLE
docs: add Zenther to wall of apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -590,6 +590,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Zenther: AI Calorie Tracker",
+    "link": "https://apps.apple.com/us/app/zenther-ai-calorie-tracker/id6748252780?uo=4",
+    "creator": "rudrankriyam",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c6/49/14/c6491404-390d-82e2-3c3c-1b6053594311/Zenther-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "시선 - 사진 한 장, 시 한 줄",
     "link": "https://apps.apple.com/app/id6748271659",
     "creator": "evanyi",


### PR DESCRIPTION
## Summary
- add Zenther: AI Calorie Tracker to `docs/wall-of-apps.json`
- include the public App Store URL, icon URL, creator, and iOS platform metadata

## Test plan
- [x] verify Zenther is not already listed in the wall JSON
- [x] verify the App Store metadata matches the public listing
- [x] confirm the JSON diff only adds one new entry