### PR TITLE
Add SajdaTV to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -402,6 +402,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "SajdaTV",
+    "link": "https://apps.apple.com/us/app/sajdatv/id6759179587",
+    "creator": "Abdo-codes",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/86/a6/a286a647-d984-7f1d-6f2b-7d4fda64c3e2/App_Icon-marketing.lsr/512x512bb.jpg",
+    "platform": ["tvOS"]
+  },
+  {
     "app": "Siraj — Your Ramadan Light",
     "link": "https://apps.apple.com/app/id6759178047",
     "creator": "SwifAI",


### PR DESCRIPTION
## Summary

- Adds **SajdaTV** to `docs/wall-of-apps.json`
- Quran app for Apple TV (tvOS) — 200+ reciters, verse-by-verse sync, prayer times, athan alerts, Qibla direction
- Free to download: https://apps.apple.com/us/app/sajdatv/id6759179587
- Platform: tvOS