### PR TITLE
Add Shadow: Speak & Learn Language to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -416,6 +416,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Shadow: Speak & Learn Language",
+    "link": "https://apps.apple.com/us/app/shadow-speak-learn-language/id6758269114",
+    "creator": "musakurel",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/17/4c/d9/174cd903-aeaf-d384-1eb2-e096bc7cef34/AppIcon-0-1x_U007emarketing-0-7-0-85-220-0.png/400x400ia-75.webp",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Smart Music Stations: Wavyy",
     "link": "https://apps.apple.com/us/app/smart-music-stations-wavyy/id6458877273?uo=4",
     "creator": "rudrankriyam",


### PR DESCRIPTION
Adding Shadow: Speak & Learn Language app to the Wall of Apps.

- **App**: Shadow: Speak & Learn Language
- **Creator**: musakurel
- **Platform**: iOS
- **App Store Link**: https://apps.apple.com/us/app/shadow-speak-learn-language/id6758269114

This PR adds the Shadow app to the community showcase, maintaining alphabetical order in the list.

