### PR TITLE
apps wall: add Concert Memories 2: Countdown

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -82,6 +82,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Concert Memories 2: Countdown",
+    "link": "https://apps.apple.com/us/app/concert-memories-2-countdown/id6744301154?uo=4",
+    "creator": "Eros Bonanni",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6c/ce/a1/6ccea161-6da4-52c7-1260-f44955b0bc70/ConcertMemories2-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "macOS"]
+  },
+  {
     "app": "Contact Sheet",
     "link": "https://apps.apple.com/us/app/contact-sheet-generator/id6744368077",
     "creator": "sambitcreate",


### PR DESCRIPTION
## Summary

- add `Concert Memories 2: Countdown` to the Wall of Apps

## Entry

- App ID: 6744301154
- App: Concert Memories 2: Countdown
- Link: https://apps.apple.com/us/app/concert-memories-2-countdown/id6744301154?uo=4
- Creator: Eros Bonanni
- Platform: iOS, macOS

## Notes

- Submitted via `asc apps wall submit`
