### PR TITLE
apps wall: add SubList: Subscription List

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -472,6 +472,13 @@
     "platform": ["iOS", "visionOS"]
   },
   {
+    "app": "SubList: Subscription List",
+    "link": "https://apps.apple.com/us/app/sublist-subscription-list/id6757860829?uo=4",
+    "creator": "lexrus",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/45/7e/dd/457edd6b-d9f7-89a7-99b2-72a72cab212f/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "macOS"]
+  },
+  {
     "app": "Summit",
     "link": "https://apps.apple.com/app/id6756911679",
     "creator": "OscarGorog",


### PR DESCRIPTION
## Summary

- add `SubList: Subscription List` to the Wall of Apps

## Entry

- App ID: 6757860829
- App: SubList: Subscription List
- Link: https://apps.apple.com/us/app/sublist-subscription-list/id6757860829?uo=4
- Creator: lexrus
- Platform: iOS, macOS

## Notes

- Submitted via `asc apps wall submit`
