### PR TITLE
apps wall: add BuddyTask: AI To Do List

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -62,6 +62,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "BuddyTask: AI To Do List",
+    "link": "https://apps.apple.com/us/app/buddytask-ai-to-do-list/id6758902036?uo=4",
+    "creator": "IvanLohCK",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/80/f5/84/80f584d0-6956-72b2-1294-8a5157c450b9/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Cat on Chair",
     "link": "https://apps.apple.com/ca/app/cat-on-chair-focus-timer/id6746562271",
     "creator": "Ryan Yao",


### PR DESCRIPTION
## Summary

- add `BuddyTask: AI To Do List` to the Wall of Apps

## Entry

- App ID: 6758902036
- App: BuddyTask: AI To Do List
- Link: https://apps.apple.com/us/app/buddytask-ai-to-do-list/id6758902036?uo=4
- Creator: IvanLohCK
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
