### PR TITLE
auth: harden finance capability probing

### DIFF
--- a/internal/cli/auth/auth_capabilities.go
+++ b/internal/cli/auth/auth_capabilities.go
@@ -412,15 +412,16 @@ func authFinanceCapabilityCheck(parent context.Context, client authCapabilitiesC
 		)
 	}
 
-	return authSkippedCapabilityCheck(
-		"finance",
-		"vendor",
-		fmt.Sprintf(
-			"could not verify finance access for vendor %s because no recent finance reports were available for %s; finance reports use Apple fiscal months",
+	return authCapabilityCheck{
+		Name:   "finance",
+		Scope:  "vendor",
+		Status: "inconclusive",
+		Message: fmt.Sprintf(
+			"could not verify finance access for vendor %s because recent finance report probes for %s returned not found; finance reports use Apple fiscal months",
 			vendorNumber,
 			strings.Join(unavailableDates, ", "),
 		),
-	)
+	}
 }
 
 func authCapabilityCheckFromError(name, scope string, err error, successMessage, unavailableMessage, inconclusivePrefix string) authCapabilityCheck {

--- a/internal/cli/auth/auth_capabilities_test.go
+++ b/internal/cli/auth/auth_capabilities_test.go
@@ -364,7 +364,7 @@ func TestAuthFinanceCapabilityCheck_TriesRecentMonthsBeforeGivingUp(t *testing.T
 	}
 }
 
-func TestAuthFinanceCapabilityCheck_SkipsWhenRecentReportsUnavailable(t *testing.T) {
+func TestAuthFinanceCapabilityCheck_KeepsRecentNotFoundsInconclusive(t *testing.T) {
 	prevNow := authCapabilitiesNow
 	authCapabilitiesNow = func() time.Time { return time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC) }
 	t.Cleanup(func() {
@@ -380,11 +380,14 @@ func TestAuthFinanceCapabilityCheck_SkipsWhenRecentReportsUnavailable(t *testing
 	}
 
 	check := authFinanceCapabilityCheck(context.Background(), stub, "98765432")
-	if check.Status != "skipped" {
-		t.Fatalf("status = %q, want skipped (%+v)", check.Status, check)
+	if check.Status != "inconclusive" {
+		t.Fatalf("status = %q, want inconclusive (%+v)", check.Status, check)
 	}
 	if !strings.Contains(check.Message, "Apple fiscal months") {
 		t.Fatalf("message = %q, want Apple fiscal months guidance", check.Message)
+	}
+	if !strings.Contains(check.Message, "returned not found") {
+		t.Fatalf("message = %q, want not found guidance", check.Message)
 	}
 	if got, want := stub.financeReportDates, []string{"2026-02", "2026-01", "2025-12"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 		t.Fatalf("finance report dates = %v, want %v", got, want)


### PR DESCRIPTION
## Summary
- harden both sales and finance capability probes to retry a short window of recent report dates instead of relying on a single date
- avoid false negatives from report availability timing by treating repeated not-found responses as skipped verification guidance rather than auth failure
- add regression coverage for sales retry/skip behavior, finance retry/skip behavior, and recent report date selection

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/auth ./internal/cli/cmdtest -run AuthCapabilities -count=1`
- [x] `go run . auth capabilities --output json` with configured live `ASC_APP_ID` and `ASC_VENDOR_NUMBER`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`