### PR TITLE
apps wall: add Cloak: App Locker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -83,6 +83,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Cloak: App Locker",
+    "link": "https://apps.apple.com/us/app/cloak-app-locker/id6451156267?uo=4",
+    "creator": "Ailton vieira",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/eb/b9/c4/ebb9c4be-fd15-228d-dd9a-05bfc5fa37ad/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg",
+    "platform": ["iOS", "tvOS", "watchOS"]
+  },
+  {
     "app": "CodexMonitor",
     "link": "https://github.com/Dimillian/CodexMonitor",
     "creator": "Dimillian",


### PR DESCRIPTION
## Summary

- add `Cloak: App Locker` to the Wall of Apps

## Entry

- App ID: 6451156267
- App: Cloak: App Locker
- Link: https://apps.apple.com/us/app/cloak-app-locker/id6451156267?uo=4
- Creator: Ailton vieira
- Platform: iOS, tvOS, watchOS

## Notes

- Submitted via `asc apps wall submit`
