### PR TITLE
fix(review): align items-add with documented submission item types

### DIFF
--- a/internal/asc/review_submission_items.go
+++ b/internal/asc/review_submission_items.go
@@ -16,6 +16,12 @@ const (
 	ReviewSubmissionItemTypeAppEvent                           ReviewSubmissionItemType = "appEvents"
 	ReviewSubmissionItemTypeAppStoreVersionExperiment          ReviewSubmissionItemType = "appStoreVersionExperiments"
 	ReviewSubmissionItemTypeAppStoreVersionExperimentTreatment ReviewSubmissionItemType = "appStoreVersionExperimentTreatments"
+	ReviewSubmissionItemTypeBackgroundAssetVersion             ReviewSubmissionItemType = "backgroundAssetVersions"
+	ReviewSubmissionItemTypeGameCenterAchievementVersion       ReviewSubmissionItemType = "gameCenterAchievementVersions"
+	ReviewSubmissionItemTypeGameCenterActivityVersion          ReviewSubmissionItemType = "gameCenterActivityVersions"
+	ReviewSubmissionItemTypeGameCenterChallengeVersion         ReviewSubmissionItemType = "gameCenterChallengeVersions"
+	ReviewSubmissionItemTypeGameCenterLeaderboardSetVersion    ReviewSubmissionItemType = "gameCenterLeaderboardSetVersions"
+	ReviewSubmissionItemTypeGameCenterLeaderboardVersion       ReviewSubmissionItemType = "gameCenterLeaderboardVersions"
 )
 
 // ReviewSubmissionItemAttributes describes review submission item attributes.
@@ -79,6 +85,12 @@ type ReviewSubmissionItemCreateRelationships struct {
 	AppEvent                           *Relationship `json:"appEvent,omitempty"`
 	AppStoreVersionExperiment          *Relationship `json:"appStoreVersionExperiment,omitempty"`
 	AppStoreVersionExperimentTreatment *Relationship `json:"appStoreVersionExperimentTreatment,omitempty"`
+	BackgroundAssetVersion             *Relationship `json:"backgroundAssetVersion,omitempty"`
+	GameCenterAchievementVersion       *Relationship `json:"gameCenterAchievementVersion,omitempty"`
+	GameCenterActivityVersion          *Relationship `json:"gameCenterActivityVersion,omitempty"`
+	GameCenterChallengeVersion         *Relationship `json:"gameCenterChallengeVersion,omitempty"`
+	GameCenterLeaderboardSetVersion    *Relationship `json:"gameCenterLeaderboardSetVersion,omitempty"`
+	GameCenterLeaderboardVersion       *Relationship `json:"gameCenterLeaderboardVersion,omitempty"`
 }
 
 // ReviewSubmissionItemCreateData is the data portion of a review submission item create request.
@@ -218,6 +230,30 @@ func (c *Client) CreateReviewSubmissionItem(ctx context.Context, submissionID st
 	case ReviewSubmissionItemTypeAppStoreVersionExperimentTreatment:
 		relationships.AppStoreVersionExperimentTreatment = &Relationship{
 			Data: ResourceData{Type: ResourceTypeAppStoreVersionExperimentTreatments, ID: itemID},
+		}
+	case ReviewSubmissionItemTypeBackgroundAssetVersion:
+		relationships.BackgroundAssetVersion = &Relationship{
+			Data: ResourceData{Type: ResourceTypeBackgroundAssetVersions, ID: itemID},
+		}
+	case ReviewSubmissionItemTypeGameCenterAchievementVersion:
+		relationships.GameCenterAchievementVersion = &Relationship{
+			Data: ResourceData{Type: ResourceTypeGameCenterAchievementVersions, ID: itemID},
+		}
+	case ReviewSubmissionItemTypeGameCenterActivityVersion:
+		relationships.GameCenterActivityVersion = &Relationship{
+			Data: ResourceData{Type: ResourceTypeGameCenterActivityVersions, ID: itemID},
+		}
+	case ReviewSubmissionItemTypeGameCenterChallengeVersion:
+		relationships.GameCenterChallengeVersion = &Relationship{
+			Data: ResourceData{Type: ResourceTypeGameCenterChallengeVersions, ID: itemID},
+		}
+	case ReviewSubmissionItemTypeGameCenterLeaderboardSetVersion:
+		relationships.GameCenterLeaderboardSetVersion = &Relationship{
+			Data: ResourceData{Type: ResourceTypeGameCenterLeaderboardSetVersions, ID: itemID},
+		}
+	case ReviewSubmissionItemTypeGameCenterLeaderboardVersion:
+		relationships.GameCenterLeaderboardVersion = &Relationship{
+			Data: ResourceData{Type: ResourceTypeGameCenterLeaderboardVersions, ID: itemID},
 		}
 	default:
 		return nil, fmt.Errorf("unsupported itemType: %s", itemType)

--- a/internal/asc/review_submissions_test.go
+++ b/internal/asc/review_submissions_test.go
@@ -244,6 +244,138 @@ func TestCreateReviewSubmissionItem(t *testing.T) {
 	}
 }
 
+func TestCreateReviewSubmissionItemDocumentedAdditionalTypes(t *testing.T) {
+	tests := []struct {
+		name                 string
+		itemType             string
+		expectedRelationship string
+		expectedResourceType string
+	}{
+		{
+			name:                 "background asset version",
+			itemType:             "backgroundAssetVersions",
+			expectedRelationship: "backgroundAssetVersion",
+			expectedResourceType: "backgroundAssetVersions",
+		},
+		{
+			name:                 "game center achievement version",
+			itemType:             "gameCenterAchievementVersions",
+			expectedRelationship: "gameCenterAchievementVersion",
+			expectedResourceType: "gameCenterAchievementVersions",
+		},
+		{
+			name:                 "game center activity version",
+			itemType:             "gameCenterActivityVersions",
+			expectedRelationship: "gameCenterActivityVersion",
+			expectedResourceType: "gameCenterActivityVersions",
+		},
+		{
+			name:                 "game center challenge version",
+			itemType:             "gameCenterChallengeVersions",
+			expectedRelationship: "gameCenterChallengeVersion",
+			expectedResourceType: "gameCenterChallengeVersions",
+		},
+		{
+			name:                 "game center leaderboard set version",
+			itemType:             "gameCenterLeaderboardSetVersions",
+			expectedRelationship: "gameCenterLeaderboardSetVersion",
+			expectedResourceType: "gameCenterLeaderboardSetVersions",
+		},
+		{
+			name:                 "game center leaderboard version",
+			itemType:             "gameCenterLeaderboardVersions",
+			expectedRelationship: "gameCenterLeaderboardVersion",
+			expectedResourceType: "gameCenterLeaderboardVersions",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := reviewSubmissionsJSONResponse(http.StatusCreated, `{
+				"data": {
+					"type": "reviewSubmissionItems",
+					"id": "item-123",
+					"attributes": {
+						"state": "READY_FOR_REVIEW"
+					}
+				}
+			}`)
+
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodPost {
+					t.Fatalf("expected POST, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/reviewSubmissionItems" {
+					t.Fatalf("expected path /v1/reviewSubmissionItems, got %s", req.URL.Path)
+				}
+
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+
+				var payload struct {
+					Data struct {
+						Type          string `json:"type"`
+						Relationships map[string]struct {
+							Data struct {
+								Type string `json:"type"`
+								ID   string `json:"id"`
+							} `json:"data"`
+						} `json:"relationships"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("failed to unmarshal request body: %v", err)
+				}
+
+				if payload.Data.Type != string(ResourceTypeReviewSubmissionItems) {
+					t.Fatalf("expected type reviewSubmissionItems, got %s", payload.Data.Type)
+				}
+
+				reviewSubmission, ok := payload.Data.Relationships["reviewSubmission"]
+				if !ok {
+					t.Fatal("expected reviewSubmission relationship to be set")
+				}
+				if reviewSubmission.Data.Type != string(ResourceTypeReviewSubmissions) {
+					t.Fatalf("expected review submission type reviewSubmissions, got %s", reviewSubmission.Data.Type)
+				}
+				if reviewSubmission.Data.ID != "submission-123" {
+					t.Fatalf("expected submission ID submission-123, got %s", reviewSubmission.Data.ID)
+				}
+
+				relationship, ok := payload.Data.Relationships[test.expectedRelationship]
+				if !ok {
+					t.Fatalf("expected %s relationship to be set", test.expectedRelationship)
+				}
+				if relationship.Data.Type != test.expectedResourceType {
+					t.Fatalf("expected %s type %s, got %s", test.expectedRelationship, test.expectedResourceType, relationship.Data.Type)
+				}
+				if relationship.Data.ID != "resource-123" {
+					t.Fatalf("expected %s ID resource-123, got %s", test.expectedRelationship, relationship.Data.ID)
+				}
+			}, response)
+
+			resp, err := client.CreateReviewSubmissionItem(
+				context.Background(),
+				"submission-123",
+				ReviewSubmissionItemType(test.itemType),
+				"resource-123",
+			)
+			if err != nil {
+				t.Fatalf("CreateReviewSubmissionItem() error: %v", err)
+			}
+
+			if resp.Data.ID != "item-123" {
+				t.Fatalf("expected ID item-123, got %s", resp.Data.ID)
+			}
+			if resp.Data.Attributes.State != "READY_FOR_REVIEW" {
+				t.Fatalf("expected state READY_FOR_REVIEW, got %s", resp.Data.Attributes.State)
+			}
+		})
+	}
+}
+
 func TestUpdateReviewSubmissionItem(t *testing.T) {
 	response := reviewSubmissionsJSONResponse(http.StatusOK, `{
 		"data": {

--- a/internal/cli/cmdtest/review_items_add_test.go
+++ b/internal/cli/cmdtest/review_items_add_test.go
@@ -1,0 +1,88 @@
+package cmdtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func reviewItemsAddJSONResponse(status int, body string) (*http.Response, error) {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func TestReviewItemsAddAcceptsDocumentedAdditionalItemTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		itemType string
+	}{
+		{name: "background asset versions", itemType: "backgroundAssetVersions"},
+		{name: "game center achievement versions", itemType: "gameCenterAchievementVersions"},
+		{name: "game center activity versions", itemType: "gameCenterActivityVersions"},
+		{name: "game center challenge versions", itemType: "gameCenterChallengeVersions"},
+		{name: "game center leaderboard set versions", itemType: "gameCenterLeaderboardSetVersions"},
+		{name: "game center leaderboard versions", itemType: "gameCenterLeaderboardVersions"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+			t.Setenv("ASC_APP_ID", "")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+			})
+
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodPost {
+					t.Fatalf("expected POST, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/reviewSubmissionItems" {
+					t.Fatalf("expected path /v1/reviewSubmissionItems, got %s", req.URL.Path)
+				}
+
+				return reviewItemsAddJSONResponse(http.StatusCreated, `{
+					"data": {
+						"type": "reviewSubmissionItems",
+						"id": "item-123"
+					}
+				}`)
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"review", "items-add",
+					"--submission", "submission-123",
+					"--item-type", test.itemType,
+					"--item-id", "resource-123",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			if stdout == "" {
+				t.Fatal("expected JSON output on stdout")
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/review_submissions_test.go
+++ b/internal/cli/cmdtest/review_submissions_test.go
@@ -166,14 +166,39 @@ func TestReviewCommandItemsInvalidItemType(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
-	if err := root.Parse([]string{"review", "items-add", "--submission", "SUBMISSION_ID", "--item-type", "nope", "--item-id", "ITEM_ID"}); err != nil {
-		t.Fatalf("parse error: %v", err)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"review", "items-add", "--submission", "SUBMISSION_ID", "--item-type", "nope", "--item-id", "ITEM_ID"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	err := root.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	if !strings.Contains(stderr, "--item-type must be one of:") {
+		t.Fatalf("expected invalid item type guidance, got %q", stderr)
 	}
-	t.Logf("got expected error: %v", err)
+
+	wantSupportedTypes := []string{
+		"backgroundAssetVersions",
+		"gameCenterAchievementVersions",
+		"gameCenterActivityVersions",
+		"gameCenterChallengeVersions",
+		"gameCenterLeaderboardSetVersions",
+		"gameCenterLeaderboardVersions",
+	}
+	for _, supportedType := range wantSupportedTypes {
+		if !strings.Contains(stderr, supportedType) {
+			t.Fatalf("expected stderr to list %s, got %q", supportedType, stderr)
+		}
+	}
+	if strings.Contains(stderr, "gameCenterLeaderboardReleases") {
+		t.Fatalf("did not expect undocumented leaderboard release type in stderr, got %q", stderr)
+	}
 }
 
 func TestReviewCommandItemsInvalidState(t *testing.T) {

--- a/internal/cli/reviews/review_items.go
+++ b/internal/cli/reviews/review_items.go
@@ -133,7 +133,7 @@ func ReviewItemsAddCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("items-add", flag.ExitOnError)
 
 	submissionID := fs.String("submission", "", "Review submission ID (required)")
-	itemType := fs.String("item-type", "", "Item type: appStoreVersions, appCustomProductPages, appEvents, appStoreVersionExperiments, appStoreVersionExperimentTreatments (required)")
+	itemType := fs.String("item-type", "", fmt.Sprintf("Item type: %s (required)", strings.Join(reviewSubmissionItemTypeList(), ", ")))
 	itemID := fs.String("item-id", "", "Item ID (required)")
 	output := shared.BindOutputFlags(fs)
 
@@ -163,7 +163,7 @@ Examples:
 
 			normalizedType, err := normalizeReviewSubmissionItemType(*itemType)
 			if err != nil {
-				return fmt.Errorf("review items-add: %w", err)
+				return shared.UsageError(err.Error())
 			}
 
 			client, err := shared.GetASCClient()
@@ -307,6 +307,12 @@ func reviewSubmissionItemTypeList() []string {
 		"appEvents",
 		"appStoreVersionExperiments",
 		"appStoreVersionExperimentTreatments",
+		"backgroundAssetVersions",
+		"gameCenterAchievementVersions",
+		"gameCenterActivityVersions",
+		"gameCenterChallengeVersions",
+		"gameCenterLeaderboardSetVersions",
+		"gameCenterLeaderboardVersions",
 	}
 }
 
@@ -337,6 +343,12 @@ var reviewSubmissionItemTypes = map[string]asc.ReviewSubmissionItemType{
 	"appEvents":                           asc.ReviewSubmissionItemTypeAppEvent,
 	"appStoreVersionExperiments":          asc.ReviewSubmissionItemTypeAppStoreVersionExperiment,
 	"appStoreVersionExperimentTreatments": asc.ReviewSubmissionItemTypeAppStoreVersionExperimentTreatment,
+	"backgroundAssetVersions":             asc.ReviewSubmissionItemTypeBackgroundAssetVersion,
+	"gameCenterAchievementVersions":       asc.ReviewSubmissionItemTypeGameCenterAchievementVersion,
+	"gameCenterActivityVersions":          asc.ReviewSubmissionItemTypeGameCenterActivityVersion,
+	"gameCenterChallengeVersions":         asc.ReviewSubmissionItemTypeGameCenterChallengeVersion,
+	"gameCenterLeaderboardSetVersions":    asc.ReviewSubmissionItemTypeGameCenterLeaderboardSetVersion,
+	"gameCenterLeaderboardVersions":       asc.ReviewSubmissionItemTypeGameCenterLeaderboardVersion,
 }
 
 var reviewSubmissionItemStates = map[string]struct{}{


### PR DESCRIPTION
## Summary
- expand `asc review items-add --item-type` to accept the documented background asset and Game Center version resource types supported by `ReviewSubmissionItemCreateRequest`
- map those new item types to the correct review submission item relationships and treat invalid `--item-type` values as usage errors so the CLI exits with code `2`
- add client and CLI regression coverage for the new relationship mappings and the expanded validation message

## Test plan
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go build -o /tmp/asc-pr-989 .`
- [x] `"/tmp/asc-pr-989" review items-add --submission SUBMISSION_ID --item-type nope --item-id ITEM_ID` prints the expanded validation message and exits with code `2`

## Audit note
Issue `#989` reports `gameCenterLeaderboardReleases`, but the repository's offline OpenAPI snapshot and the live App Store Connect docs both document `gameCenterLeaderboardVersions` for `reviewSubmissionItems` create relationships. This PR follows the documented API contract while also covering the related `gameCenterChallengeVersions` gap from `#988`.