### PR TITLE
apps wall: add Sona · AI Journal & Companion

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -479,6 +479,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Sona · AI Journal & Companion",
+    "link": "https://apps.apple.com/us/app/sona-ai-journal-companion/id6759681212?uo=4",
+    "creator": "Aayush9029",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/3c/c2/d8/3cc2d877-adb5-24ea-440b-061d98acedd7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Soundbooth",
     "link": "https://apps.apple.com/app/id1341485079",
     "creator": "amahanti",


### PR DESCRIPTION
## Summary

- add `Sona · AI Journal & Companion` to the Wall of Apps

## Entry

- App ID: 6759681212
- App: Sona · AI Journal & Companion
- Link: https://apps.apple.com/us/app/sona-ai-journal-companion/id6759681212?uo=4
- Creator: Aayush9029
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
