### PR TITLE
apps wall: add Cal AI - Calorie Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -76,6 +76,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Cal AI - Calorie Tracker",
+    "link": "https://apps.apple.com/us/app/cal-ai-calorie-tracker/id6480417616?uo=4",
+    "creator": "Aayush9029",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5e/5d/e9/5e5de9bc-18ef-3c07-79f0-e0a9e3009629/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Cat on Chair",
     "link": "https://apps.apple.com/ca/app/cat-on-chair-focus-timer/id6746562271",
     "creator": "Ryan Yao",


### PR DESCRIPTION
## Summary

- add `Cal AI - Calorie Tracker` to the Wall of Apps

## Entry

- App ID: 6480417616
- App: Cal AI - Calorie Tracker
- Link: https://apps.apple.com/us/app/cal-ai-calorie-tracker/id6480417616?uo=4
- Creator: Aayush9029
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
