### PR TITLE
fix: exclude territory resources from included array during availability create

### DIFF
--- a/internal/asc/client_pricing.go
+++ b/internal/asc/client_pricing.go
@@ -525,7 +525,8 @@ func (c *Client) GetAppAvailabilityV2TerritoryAvailabilitiesRelationships(ctx co
 	return &response, nil
 }
 
-// CreateAppAvailabilityV2 creates or updates app availability.
+// CreateAppAvailabilityV2 calls POST /v2/appAvailabilities.
+// Apple documents this endpoint as app pre-order creation, not generic app-availability bootstrap.
 func (c *Client) CreateAppAvailabilityV2(ctx context.Context, appID string, attrs AppAvailabilityV2CreateAttributes) (*AppAvailabilityV2Response, error) {
 	appID = strings.TrimSpace(appID)
 	if appID == "" {
@@ -575,7 +576,8 @@ func (c *Client) CreateAppAvailabilityV2(ctx context.Context, appID string, attr
 			Data: relationshipData,
 		}
 	} else if len(attrs.TerritoryAvailabilities) > 0 {
-		payload.Included = make([]AppAvailabilityV2IncludedResource, 0, len(attrs.TerritoryAvailabilities))
+		payload.Included = make([]AppAvailabilityV2IncludedResource, 0, len(attrs.TerritoryAvailabilities)*2)
+		includedTerritories := make(map[string]struct{}, len(attrs.TerritoryAvailabilities))
 		relationshipData := make([]ResourceData, 0, len(attrs.TerritoryAvailabilities))
 		for _, availability := range attrs.TerritoryAvailabilities {
 			territoryID := strings.ToUpper(strings.TrimSpace(availability.TerritoryID))
@@ -600,15 +602,19 @@ func (c *Client) CreateAppAvailabilityV2(ctx context.Context, appID string, attr
 					},
 				},
 			}
-			// Only include the inline-created territoryAvailabilities resources.
-			// Territories are existing resources referenced via relationship — they
-			// must NOT appear in included, or Apple rejects them for lacking a local-id.
 			payload.Included = append(payload.Included, AppAvailabilityV2IncludedResource{
 				Type:          ResourceTypeTerritoryAvailabilities,
 				ID:            resourceID,
 				Attributes:    attributes,
 				Relationships: relationships,
 			})
+			if _, exists := includedTerritories[territoryID]; !exists {
+				payload.Included = append(payload.Included, AppAvailabilityV2IncludedResource{
+					Type: ResourceTypeTerritories,
+					ID:   territoryID,
+				})
+				includedTerritories[territoryID] = struct{}{}
+			}
 		}
 		payload.Data.Relationships.TerritoryAvailabilities = &RelationshipList{
 			Data: relationshipData,

--- a/internal/asc/pricing.go
+++ b/internal/asc/pricing.go
@@ -86,7 +86,8 @@ type AppPriceRelationships struct {
 	AppPricePoint Relationship `json:"appPricePoint"`
 }
 
-// AppAvailabilityV2CreateAttributes defines inputs for app availability.
+// AppAvailabilityV2CreateAttributes defines inputs for POST /v2/appAvailabilities.
+// Apple documents this endpoint as app pre-order creation, not generic app-availability bootstrap.
 type AppAvailabilityV2CreateAttributes struct {
 	AvailableInNewTerritories *bool                         `json:"availableInNewTerritories,omitempty"`
 	TerritoryAvailabilityIDs  []string                      `json:"-"`
@@ -101,7 +102,7 @@ type TerritoryAvailabilityCreate struct {
 	PreOrderEnabled *bool
 }
 
-// AppAvailabilityV2CreateRequest is a request to create app availability.
+// AppAvailabilityV2CreateRequest is the payload for POST /v2/appAvailabilities.
 type AppAvailabilityV2CreateRequest struct {
 	Data     AppAvailabilityV2CreateData         `json:"data"`
 	Included []AppAvailabilityV2IncludedResource `json:"included,omitempty"`

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -317,7 +317,10 @@ func AppSetupAvailabilitySetCommand() *ffcli.Command {
 		LongHelp: `Set app availability for territories.
 
 Examples:
-  asc app-setup availability set --app "123456789" --territory "USA,GBR" --available true --available-in-new-territories true`,
+  asc app-setup availability set --app "123456789" --territory "USA,GBR" --available true --available-in-new-territories true
+
+Note:
+  This command only updates an existing app availability. If the app has no availability record yet, initialize availability in App Store Connect first.`,
 		ErrorPrefix:                      "app-setup availability set",
 		IncludeAvailableInNewTerritories: true,
 	})

--- a/internal/cli/cmdtest/pricing_availability_set_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_set_create_test.go
@@ -1,0 +1,93 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantPrefix string
+	}{
+		{
+			name: "pricing availability set",
+			args: []string{
+				"pricing", "availability", "set",
+				"--app", "app-1",
+				"--territory", "usa,gbr",
+				"--available", "true",
+				"--available-in-new-territories", "false",
+				"--output", "json",
+			},
+			wantPrefix: `pricing availability set: app availability not found for app "app-1"; this command only updates existing app availability`,
+		},
+		{
+			name: "app-setup availability set",
+			args: []string{
+				"app-setup", "availability", "set",
+				"--app", "app-1",
+				"--territory", "usa,gbr",
+				"--available", "true",
+				"--available-in-new-territories", "false",
+				"--output", "json",
+			},
+			wantPrefix: `app-setup availability set: app availability not found for app "app-1"; this command only updates existing app availability`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+			})
+
+			requestCount := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requestCount++
+				if requestCount > 1 {
+					t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.Path)
+				}
+				if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/appAvailabilityV2" {
+					t.Fatalf("unexpected initial availability request: %s %s", req.Method, req.URL.Path)
+				}
+				return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"not found","detail":"missing"}]}`), nil
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(tc.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if err == nil {
+					t.Fatal("expected missing-availability error")
+				}
+				if !strings.Contains(err.Error(), tc.wantPrefix) {
+					t.Fatalf("expected update-only error, got %q", err.Error())
+				}
+			})
+
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if requestCount != 1 {
+				t.Fatalf("expected only the missing-availability lookup request, got %d requests", requestCount)
+			}
+		})
+	}
+}

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -629,7 +629,10 @@ func PricingAvailabilitySetCommand() *ffcli.Command {
 		LongHelp: `Set app availability for territories.
 
 Examples:
-  asc pricing availability set --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true`,
+  asc pricing availability set --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
+
+Note:
+  This command only updates an existing app availability. If the app has no availability record yet, initialize availability in App Store Connect first.`,
 		ErrorPrefix:                      "pricing availability set",
 		IncludeAvailableInNewTerritories: true,
 	})

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -71,7 +71,6 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				return flag.ErrHelp
 			}
 			availableValue := available.Value()
-			availabilityExists := true
 
 			client, err := getASCClient()
 			if err != nil {
@@ -84,28 +83,13 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 			resp, err := client.GetAppAvailabilityV2(requestCtx, resolvedAppID)
 			if err != nil {
 				if isAppAvailabilityMissing(err) {
-					availabilityExists = false
-					requestedTerritoryAvailabilities := make([]asc.TerritoryAvailabilityCreate, 0, len(territories))
-					for _, territoryID := range territories {
-						requestedTerritoryAvailabilities = append(requestedTerritoryAvailabilities, asc.TerritoryAvailabilityCreate{
-							TerritoryID: territoryID,
-							Available:   availableValue,
-						})
-					}
-					createAttrs := asc.AppAvailabilityV2CreateAttributes{
-						TerritoryAvailabilities: requestedTerritoryAvailabilities,
-					}
-					if config.IncludeAvailableInNewTerritories {
-						availableInNewTerritoriesValue := availableInNewTerritories.Value()
-						createAttrs.AvailableInNewTerritories = &availableInNewTerritoriesValue
-					}
-					resp, err = client.CreateAppAvailabilityV2(requestCtx, resolvedAppID, createAttrs)
-					if err != nil {
-						return fmt.Errorf("%s: app availability not found for app %q and failed to create: %w", config.ErrorPrefix, resolvedAppID, err)
-					}
-				} else {
-					return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
+					return fmt.Errorf(
+						"%s: app availability not found for app %q; this command only updates existing app availability, so initialize availability in App Store Connect first",
+						config.ErrorPrefix,
+						resolvedAppID,
+					)
 				}
+				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
 			}
 			availabilityID := strings.TrimSpace(resp.Data.ID)
 			if availabilityID == "" {
@@ -127,7 +111,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				return fmt.Errorf("%s: unexpected territory availabilities response", config.ErrorPrefix)
 			}
 
-			if availabilityExists && config.IncludeAvailableInNewTerritories {
+			if config.IncludeAvailableInNewTerritories {
 				availableInNewTerritoriesValue := availableInNewTerritories.Value()
 				if resp.Data.Attributes.AvailableInNewTerritories != availableInNewTerritoriesValue {
 					return fmt.Errorf(


### PR DESCRIPTION
## Problem

`asc pricing availability set` (and `asc app-setup availability set`) fails when creating availability for apps that don't have an existing availability record.

**Error:**
```
The provided included entity id 'AFG' has invalid format.
For inline creation, the id must be a local id with the format '${local-id}'.
```

## Root Cause

The `CreateAppAvailabilityV2` function adds bare territory resources (`{type: "territories", id: "AFG"}`) to the `included` array. Apple's v2 API rejects non-local IDs in `included` during inline creation.

Territories are existing resources — they should only be referenced via the `territory` relationship inside the inline-created `territoryAvailability` resources, not included separately.

## Fix

Remove the territory resources from the `included` array. The territory availabilities already reference territories via their nested `relationships.territory.data` — that's sufficient for the API.

## Testing

Tested against a real app (`6759846474`) that had no prior availability record:
- Before fix: fails with `invalid format` error
- After fix: successfully creates availability for all 175 territories

Fixes #998