### PR TITLE
apps wall: add PaperlessHero – AI Mail Task

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -326,6 +326,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "PaperlessHero – AI Mail Task",
+    "link": "https://apps.apple.com/us/app/paperlesshero-ai-mail-task/id6758307043?uo=4",
+    "creator": "swdevpa",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/48/94/45/48944583-bcb5-a4e8-a1d1-9442a0b79676/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Parsely",
     "link": "https://testflight.apple.com/join/HjUZtzVm",
     "creator": "sambitcreate",


### PR DESCRIPTION
## Summary

- add `PaperlessHero – AI Mail Task` to the Wall of Apps

## Entry

- App ID: 6758307043
- App: PaperlessHero – AI Mail Task
- Link: https://apps.apple.com/us/app/paperlesshero-ai-mail-task/id6758307043?uo=4
- Creator: swdevpa
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
