### PR TITLE
apps wall: add Photo2Calendar Scanner Planner

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -353,6 +353,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Photo2Calendar Scanner Planner",
+    "link": "https://apps.apple.com/us/app/photo2calendar-scanner-planner/id6736373394?uo=4",
+    "creator": "swdevpa",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6c/e0/2f/6ce02fb3-6c3a-902e-3e15-ca189da30cfe/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Pickle Rite",
     "link": "https://apps.apple.com/us/app/pickle-rite/id6754095362",
     "creator": "Badarinath Venkatnarayansetty",


### PR DESCRIPTION
## Summary

- add `Photo2Calendar Scanner Planner` to the Wall of Apps

## Entry

- App ID: 6736373394
- App: Photo2Calendar Scanner Planner
- Link: https://apps.apple.com/us/app/photo2calendar-scanner-planner/id6736373394?uo=4
- Creator: swdevpa
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
