### PR TITLE
apps wall: add QuitNicPouches Pouch Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -437,6 +437,13 @@
     "platform": ["iOS", "macOS"]
   },
   {
+    "app": "QuitNicPouches Pouch Tracker",
+    "link": "https://apps.apple.com/us/app/quitnicpouches-pouch-tracker/id6753104415?uo=4",
+    "creator": "swdevpa",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/99/f4/3b/99f43be3-8cd4-448c-26db-bbe190492794/AppIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Reloop - AI Transcribe & Speak",
     "link": "https://apps.apple.com/us/app/reloop-ai-transcribe-speak/id6752853818",
     "creator": "wuqinqiang",


### PR DESCRIPTION
## Summary

- add `QuitNicPouches Pouch Tracker` to the Wall of Apps

## Entry

- App ID: 6753104415
- App: QuitNicPouches Pouch Tracker
- Link: https://apps.apple.com/us/app/quitnicpouches-pouch-tracker/id6753104415?uo=4
- Creator: swdevpa
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
