### PR TITLE
apps wall: add Don't Spiral: ROCD & Anxiety

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -152,6 +152,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Don't Spiral: ROCD & Anxiety",
+    "link": "https://apps.apple.com/us/app/dont-spiral-rocd-anxiety/id6758227509?uo=4",
+    "creator": "escamoteur",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c6/e9/77/c6e977ac-bc3b-5f1c-fbdb-e7f46ae3e467/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "DoubleMemory",
     "link": "https://apps.apple.com/app/id6737529034",
     "creator": "randomor",


### PR DESCRIPTION
## Summary

- add `Don't Spiral: ROCD & Anxiety` to the Wall of Apps

## Entry

- App ID: 6758227509
- App: Don't Spiral: ROCD & Anxiety
- Link: https://apps.apple.com/us/app/dont-spiral-rocd-anxiety/id6758227509?uo=4
- Creator: escamoteur
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
