### PR TITLE
apps wall: add rawcast — Terminal Weather

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -465,6 +465,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "rawcast — Terminal Weather",
+    "link": "https://apps.apple.com/us/app/rawcast-terminal-weather/id6760224045?uo=4",
+    "creator": "juergen-kc",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7b/a4/47/7ba447d5-d934-754b-3f42-2b03670f82b7/AppIcon-0-0-1x_U007epad-0-5-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Reloop - AI Transcribe & Speak",
     "link": "https://apps.apple.com/us/app/reloop-ai-transcribe-speak/id6752853818",
     "creator": "wuqinqiang",


### PR DESCRIPTION
## Summary

- add `rawcast — Terminal Weather` to the Wall of Apps

## Entry

- App ID: 6760224045
- App: rawcast — Terminal Weather
- Link: https://apps.apple.com/us/app/rawcast-terminal-weather/id6760224045?uo=4
- Creator: juergen-kc
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
