### PR TITLE
apps wall: add Notch: Target Scoring Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -347,6 +347,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Notch: Target Scoring Tracker",
+    "link": "https://apps.apple.com/us/app/notch-target-scoring-tracker/id6747980153?uo=4",
+    "creator": "valzevul",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d7/83/48/d783480d-74fa-4033-44ce-f4154c3ab7de/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Palabros - Diccionario",
     "link": "https://apps.apple.com/us/app/palabros-diccionario/id6758098070?uo=4",
     "creator": "nachocerrato",


### PR DESCRIPTION
## Summary

- add `Notch: Target Scoring Tracker` to the Wall of Apps

## Entry

- App ID: 6747980153
- App: Notch: Target Scoring Tracker
- Link: https://apps.apple.com/us/app/notch-target-scoring-tracker/id6747980153?uo=4
- Creator: valzevul
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
