### PR TITLE
apps wall: add Visa Day Tracker: Residency

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -716,6 +716,13 @@
     "platform": ["iOS"]
   },
   {
+    "app": "Visa Day Tracker: Residency",
+    "link": "https://apps.apple.com/us/app/visa-day-tracker-residency/id6749048224?uo=4",
+    "creator": "valzevul",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/73/d0/88/73d088d4-104c-b8ea-4b0d-863da7932f6d/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Voice Do",
     "link": "https://apps.apple.com/us/app/voice-do-task-manager/id6746357453",
     "creator": "maail",


### PR DESCRIPTION
## Summary

- add `Visa Day Tracker: Residency` to the Wall of Apps

## Entry

- App ID: 6749048224
- App: Visa Day Tracker: Residency
- Link: https://apps.apple.com/us/app/visa-day-tracker-residency/id6749048224?uo=4
- Creator: valzevul
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
