### PR TITLE
apps wall: add Glint: Morse Code Translator

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -242,6 +242,13 @@
     "platform": ["iOS", "macOS"]
   },
   {
+    "app": "Glint: Morse Code Translator",
+    "link": "https://apps.apple.com/us/app/glint-morse-code-translator/id6758366218?uo=4",
+    "creator": "valzevul",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/69/e1/b3/69e1b3be-109a-084a-62a3-8df22c8076c2/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg",
+    "platform": ["iOS"]
+  },
+  {
     "app": "Goshuin Atlas",
     "link": "https://apps.apple.com/app/goshuin-atlas-japan/id6746737093",
     "creator": "thedaviddias",


### PR DESCRIPTION
## Summary

- add `Glint: Morse Code Translator` to the Wall of Apps

## Entry

- App ID: 6758366218
- App: Glint: Morse Code Translator
- Link: https://apps.apple.com/us/app/glint-morse-code-translator/id6758366218?uo=4
- Creator: valzevul
- Platform: iOS

## Notes

- Submitted via `asc apps wall submit`
