### PR TITLE
apps wall: add GrowPal: Health & Fitness

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -182,6 +182,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/11/49/d6/1149d644-0ac6-6277-9847-c9ac124510a8/AppIcon-0-1x_U007ephone-0-1-85-220-0.jpeg/512x512bb.jpg"
   },
   {
+    "app": "GrowPal: Health & Fitness",
+    "link": "https://apps.apple.com/us/app/growpal-health-fitness/id1560604814?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0c/be/8b/0cbe8bfa-a36d-7ebb-6580-959481f43294/Grow-0-0-1x_U007ephone-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "HRM Battery",
     "link": "https://apps.apple.com/app/id6758920011",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7b/43/73/7b4373fc-26e2-030b-7162-2f0ab0a7681d/AppIcon-0-0-1x_U007ewatch-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `GrowPal: Health & Fitness` to the Wall of Apps

## Entry

- App ID: 1560604814
- App: GrowPal: Health & Fitness
- Link: https://apps.apple.com/us/app/growpal-health-fitness/id1560604814?uo=4

## Notes

- Submitted via `asc apps wall submit`
