### PR TITLE
Add mojo - GLP-1 Weight Tracker to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -262,6 +262,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/71/af/7f/71af7f55-1c60-1638-6161-8491e23edd0e/AppIcon-0-0-1x_U007ephone-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "mojo - GLP-1 Weight Tracker",
+    "link": "https://apps.apple.com/app/id6751704399",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ee/00/84/ee008451-9632-a851-0da8-6a69caab37a5/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Morning Pages",
     "link": "https://apps.apple.com/us/app/morning-pages/id6738604034",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c5/ec/37/c5ec371e-e920-33ec-1541-74d05fc067c2/app-icon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
@@ -578,11 +583,5 @@
     "app": "시선 - 사진 한 장, 시 한 줄",
     "link": "https://apps.apple.com/app/id6748271659",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4e/a3/3b/4ea33b80-8dcb-11ec-4699-6ccff7efcfa9/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
-  },
-  {
-    "app": "mojo - GLP-1 Weight Tracker",
-    "link": "https://apps.apple.com/app/id6751704399",
-    "creator": "hanamizuki",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ee/00/84/ee008451-9632-a851-0da8-6a69caab37a5/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"
   }
 ]


### PR DESCRIPTION
## Summary

- Add **mojo - GLP-1 Weight Tracker** to the Wall of Apps
- App Store: https://apps.apple.com/app/id6751704399

## Changes

- Updated `docs/wall-of-apps.json` with new entry