### PR TITLE
apps wall: add Box Box Club: Formula Widgets

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -49,6 +49,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/fe/a3/9d/fea39d77-422f-d815-5af9-c0ee518f5b97/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Box Box Club: Formula Widgets",
+    "link": "https://apps.apple.com/us/app/box-box-club-formula-widgets/id1621241916?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f9/73/48/f9734812-afa3-83b4-4862-a9331863f84b/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "BuddyTask: AI To Do List",
     "link": "https://apps.apple.com/us/app/buddytask-ai-to-do-list/id6758902036?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/80/f5/84/80f584d0-6956-72b2-1294-8a5157c450b9/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Box Box Club: Formula Widgets` to the Wall of Apps

## Entry

- App ID: 1621241916
- App: Box Box Club: Formula Widgets
- Link: https://apps.apple.com/us/app/box-box-club-formula-widgets/id1621241916?uo=4

## Notes

- Submitted via `asc apps wall submit`
