### PR TITLE
apps wall: add GO Club: Step Counter

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -177,6 +177,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/69/e1/b3/69e1b3be-109a-084a-62a3-8df22c8076c2/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "GO Club: Step Counter",
+    "link": "https://apps.apple.com/us/app/go-club-step-counter/id6739782103?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7a/23/fc/7a23fc3e-69d9-26b8-52e0-e2ce1587dab8/AppIcon-0-0-1x_U007ephone-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Goshuin Atlas",
     "link": "https://apps.apple.com/app/goshuin-atlas-japan/id6746737093",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/11/49/d6/1149d644-0ac6-6277-9847-c9ac124510a8/AppIcon-0-1x_U007ephone-0-1-85-220-0.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `GO Club: Step Counter` to the Wall of Apps

## Entry

- App ID: 6739782103
- App: GO Club: Step Counter
- Link: https://apps.apple.com/us/app/go-club-step-counter/id6739782103?uo=4

## Notes

- Submitted via `asc apps wall submit`
