### PR TITLE
apps wall: add Klick: keyboard sounds

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -217,6 +217,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ee/f4/e6/eef4e6d4-c2af-3856-6cdf-80af085b1cb9/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Klick: keyboard sounds",
+    "link": "https://apps.apple.com/us/app/klick-keyboard-sounds/id6758880736?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d1/c0/46/d1c046e6-f966-f063-e294-0a1969396b60/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
+  },
+  {
     "app": "kora: Music Reviews & Ratings",
     "link": "https://apps.apple.com/app/id6502549140",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/48/70/77/487077dc-caef-0687-6ccf-48daffa9cf5b/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Klick: keyboard sounds` to the Wall of Apps

## Entry

- App ID: 6758880736
- App: Klick: keyboard sounds
- Link: https://apps.apple.com/us/app/klick-keyboard-sounds/id6758880736?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
