### PR TITLE
apps wall: add Plushify

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -351,6 +351,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2f/57/02/2f570236-cd2e-4d0b-a797-1130d5b68c19/AppIcon-0-1x_U007emarketing-0-11-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Plushify",
+    "link": "https://apps.apple.com/us/app/plushify/id6758206706?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5d/49/25/5d4925ae-e8d1-6d72-5f7c-28f78c126f0f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Popcorn Stack: Track Watchlist",
     "link": "https://apps.apple.com/app/id6759187614",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/1b/9c/62/1b9c62c3-b960-84cd-77a1-f1f4a734a572/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Plushify` to the Wall of Apps

## Entry

- App ID: 6758206706
- App: Plushify
- Link: https://apps.apple.com/us/app/plushify/id6758206706?uo=4

## Notes

- Submitted via `asc apps wall submit`
