### PR TITLE
apps wall: add FocusAir: Deep Focus Timer

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -163,6 +163,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a1/e6/4f/a1e64f9f-de99-5fc1-f7e0-7ecbe7fafedb/AppIcon-0-1x_U007emarketing-0-11-0-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "FocusAir: Deep Focus Timer",
+    "link": "https://apps.apple.com/us/app/focusair-deep-focus-timer/id6756526902?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/09/e1/ad/09e1adab-b9fd-1707-57fc-387a7e19a7d0/AppIcon-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Foundation Lab",
     "link": "https://testflight.apple.com/join/JWR9FpP3"
   },


### PR DESCRIPTION
## Summary

- add `FocusAir: Deep Focus Timer` to the Wall of Apps

## Entry

- App ID: 6756526902
- App: FocusAir: Deep Focus Timer
- Link: https://apps.apple.com/us/app/focusair-deep-focus-timer/id6756526902?uo=4

## Notes

- Submitted via `asc apps wall submit`
