### PR TITLE
feat: add --platform filter to builds list

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -484,11 +484,13 @@ Examples:
 				return fmt.Errorf("builds: %w", err)
 			}
 
-			platformValue := strings.ToUpper(strings.TrimSpace(*platform))
-			if platformValue != "" {
-				if _, err := shared.NormalizePlatform(platformValue); err != nil {
-					return fmt.Errorf("builds: %w", err)
+			platformValue := ""
+			if strings.TrimSpace(*platform) != "" {
+				normalizedPlatform, err := shared.NormalizePlatform(*platform)
+				if err != nil {
+					return shared.UsageError(err.Error())
 				}
+				platformValue = string(normalizedPlatform)
 			}
 
 			versionValue := strings.TrimSpace(*version)

--- a/internal/cli/cmdtest/builds_list_platform_test.go
+++ b/internal/cli/cmdtest/builds_list_platform_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -103,6 +105,89 @@ func TestBuildsListPlatformFilterCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestBuildsListPlatformFilterWithVersionLookup(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/preReleaseVersions" {
+				t.Fatalf("expected /v1/preReleaseVersions path, got %q", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if query.Get("filter[app]") != "123456789" {
+				t.Fatalf("expected filter[app]=123456789, got %q", query.Get("filter[app]"))
+			}
+			if query.Get("filter[version]") != "1.2.3" {
+				t.Fatalf("expected filter[version]=1.2.3, got %q", query.Get("filter[version]"))
+			}
+			body := `{"data":[{"type":"preReleaseVersions","id":"prv-ios"},{"type":"preReleaseVersions","id":"prv-vision"}],"links":{"next":""}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/builds" {
+				t.Fatalf("expected /v1/builds path, got %q", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if query.Get("filter[app]") != "123456789" {
+				t.Fatalf("expected filter[app]=123456789, got %q", query.Get("filter[app]"))
+			}
+			if query.Get("filter[preReleaseVersion]") != "prv-ios,prv-vision" {
+				t.Fatalf("expected filter[preReleaseVersion]=prv-ios,prv-vision, got %q", query.Get("filter[preReleaseVersion]"))
+			}
+			if query.Get("filter[preReleaseVersion.platform]") != "IOS" {
+				t.Fatalf("expected filter[preReleaseVersion.platform]=IOS, got %q", query.Get("filter[preReleaseVersion.platform]"))
+			}
+			body := `{"data":[{"type":"builds","id":"build-ios-1"}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "list", "--app", "123456789", "--version", "1.2.3", "--platform", "ios"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"build-ios-1"`) {
+		t.Fatalf("expected build output, got %q", stdout)
+	}
+}
+
 func TestBuildsListPlatformFilterRejectsInvalid(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -111,17 +196,20 @@ func TestBuildsListPlatformFilterRejectsInvalid(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	var runErr error
-	captureOutput(t, func() {
+	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{"builds", "list", "--app", "123456789", "--platform", "ANDROID"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())
 	})
 
-	if runErr == nil {
-		t.Fatal("expected platform validation error")
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp usage error, got %v", runErr)
 	}
-	if !strings.Contains(runErr.Error(), "--platform must be one of") {
-		t.Fatalf("expected platform validation error, got %v", runErr)
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --platform must be one of: IOS, MAC_OS, TV_OS, VISION_OS") {
+		t.Fatalf("expected platform validation stderr, got %q", stderr)
 	}
 }

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -229,6 +229,11 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			wantErr: "--processing-state must be one of",
 		},
 		{
+			name:    "builds list invalid platform",
+			args:    []string{"builds", "list", "--app", "APP_123", "--platform", "ANDROID"},
+			wantErr: "--platform must be one of",
+		},
+		{
 			name:    "builds wait missing selector",
 			args:    []string{"builds", "wait"},
 			wantErr: "--app is required when --build is not provided",


### PR DESCRIPTION
## Summary

- Adds `--platform` flag to `asc builds list` (accepts `IOS`, `MAC_OS`, `TV_OS`, `VISION_OS`, case-insensitive)
- The API layer already supports `filter[preReleaseVersion.platform]` via `WithBuildsPreReleaseVersionPlatforms` — this just surfaces it as a CLI flag
- Validates via `shared.NormalizePlatform`, consistent with `builds latest` and other commands

## Motivation

Multi-platform apps (e.g. iOS + tvOS) currently have no way to filter `builds list` by platform. You have to list all builds and filter manually. `builds latest` already has `--platform`; this brings parity to `builds list`.

## Test plan

- [x] `TestBuildsListPlatformFilter` — verifies `--platform TV_OS` sends `filter[preReleaseVersion.platform]=TV_OS` to the API
- [x] `TestBuildsListPlatformFilterCaseInsensitive` — verifies `--platform ios` normalizes to `IOS`
- [x] `TestBuildsListPlatformFilterRejectsInvalid` — verifies `--platform ANDROID` returns validation error
- [x] All 20 existing `TestBuildsList*` tests pass unchanged