### PR TITLE
apps wall: add DreamWhisper: Sleep Stories

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -133,6 +133,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/65/58/32/6558325e-7e32-4385-90a8-454c6b80e373/DoubleMemory-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "DreamWhisper: Sleep Stories",
+    "link": "https://apps.apple.com/us/app/dreamwhisper-sleep-stories/id6746324271?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f5/89/fb/f589fb1e-656e-3c59-6f4d-4c397f0a63ad/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Dripped",
     "link": "https://apps.apple.com/app/id6749790183",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/45/67/fd/4567fd8b-feb1-c665-e8e0-4b05a3016150/DrippedIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `DreamWhisper: Sleep Stories` to the Wall of Apps

## Entry

- App ID: 6746324271
- App: DreamWhisper: Sleep Stories
- Link: https://apps.apple.com/us/app/dreamwhisper-sleep-stories/id6746324271?uo=4

## Notes

- Submitted via `asc apps wall submit`
