### PR TITLE
feat: auto-select editable app info when multiple exist

### DIFF
--- a/internal/cli/cmdtest/apps_info_surface_test.go
+++ b/internal/cli/cmdtest/apps_info_surface_test.go
@@ -204,3 +204,64 @@ func TestDeprecatedAppInfosListAliasWarnsAndMatchesAppsInfoListOutput(t *testing
 		t.Fatalf("expected canonical and alias output to match, canonical=%q alias=%q", canonicalStdout, aliasStdout)
 	}
 }
+
+func TestAppsInfoViewIncludeFailsWhenAppInfoIsAmbiguous(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/appInfos" {
+			t.Fatalf("unexpected request path %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"data":[
+					{"type":"appInfos","id":"info-live","attributes":{"state":"READY_FOR_DISTRIBUTION"}},
+					{"type":"appInfos","id":"info-rejected","attributes":{"state":"REJECTED"}}
+				]
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "info", "view", "--app", "app-1", "--include", "primaryCategory", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected run error, got nil")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		`multiple app infos found for app "app-1"`,
+		`asc apps info list --app "app-1"`,
+		"READY_FOR_DISTRIBUTION",
+		"REJECTED",
+	} {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, runErr)
+		}
+	}
+}

--- a/internal/cli/cmdtest/categories_app_info_resolution_test.go
+++ b/internal/cli/cmdtest/categories_app_info_resolution_test.go
@@ -1,0 +1,66 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCategoriesSetFailsWhenAppInfoIsAmbiguous(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/appInfos" {
+			t.Fatalf("unexpected request path %s", req.URL.Path)
+		}
+		return jsonResponse(http.StatusOK, `{
+			"data":[
+				{"type":"appInfos","id":"info-live","attributes":{"state":"READY_FOR_DISTRIBUTION"}},
+				{"type":"appInfos","id":"info-rejected","attributes":{"state":"REJECTED"}}
+			]
+		}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"categories", "set", "--app", "app-1", "--primary", "GAMES", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected run error, got nil")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		`multiple app infos found for app "app-1"`,
+		`asc apps info list --app "app-1"`,
+		"READY_FOR_DISTRIBUTION",
+		"REJECTED",
+	} {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, runErr)
+		}
+	}
+}

--- a/internal/cli/cmdtest/localizations_update_test.go
+++ b/internal/cli/cmdtest/localizations_update_test.go
@@ -30,10 +30,10 @@ func setupLocUpdateAuth(t *testing.T) {
 	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
 }
 
-func locUpdateJSONResponse(status int, body string) (*http.Response, error) {
+func locUpdateJSONResponse(body string) (*http.Response, error) {
 	return &http.Response{
-		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
-		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK)),
+		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}, nil
@@ -127,17 +127,17 @@ func TestLocalizationsUpdateAppInfoSubtitle(t *testing.T) {
 		switch {
 		// Resolve app info ID
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appInfos":
-			return locUpdateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{}}]}`)
+			return locUpdateJSONResponse(`{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{}}]}`)
 
 		// List existing localizations
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
-			return locUpdateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"MyApp","subtitle":"Old"}}],"links":{}}`)
+			return locUpdateJSONResponse(`{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"MyApp","subtitle":"Old"}}],"links":{}}`)
 
 		// Update localization
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/loc-en":
 			body, _ := io.ReadAll(req.Body)
 			patchBody = string(body)
-			return locUpdateJSONResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"MyApp","subtitle":"New Subtitle"}}}`)
+			return locUpdateJSONResponse(`{"data":{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"MyApp","subtitle":"New Subtitle"}}}`)
 
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
@@ -171,5 +171,61 @@ func TestLocalizationsUpdateAppInfoSubtitle(t *testing.T) {
 	var result map[string]any
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("failed to parse JSON output: %v (stdout=%q)", err, stdout)
+	}
+}
+
+func TestLocalizationsUpdateAppInfoFailsWhenAppInfoIsAmbiguous(t *testing.T) {
+	setupLocUpdateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = locUpdateRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appInfos":
+			return locUpdateJSONResponse(`{"data":[
+				{"type":"appInfos","id":"appinfo-live","attributes":{"state":"READY_FOR_SALE"}},
+				{"type":"appInfos","id":"appinfo-rejected","attributes":{"state":"REJECTED"}}
+			]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"localizations", "update",
+			"--type", "app-info",
+			"--app", "app-1",
+			"--locale", "en-US",
+			"--subtitle", "New Subtitle",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected run error, got nil")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		`multiple app infos found for app "app-1"`,
+		`asc apps info list --app "app-1"`,
+		"READY_FOR_SALE",
+		"REJECTED",
+	} {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, runErr)
+		}
 	}
 }

--- a/internal/cli/shared/app_resolution.go
+++ b/internal/cli/shared/app_resolution.go
@@ -52,12 +52,39 @@ func ResolveAppInfoID(ctx context.Context, client *asc.Client, appID, appInfoID 
 		return "", fmt.Errorf("no app info found for app %q", appID)
 	}
 	if len(resp.Data) > 1 {
-		selected := SelectBestAppInfoID(resp)
+		selected, reason := autoSelectEditableAppInfoID(resp)
 		if selected == "" {
-			return "", fmt.Errorf("multiple app infos found for app %q; run `asc apps info list --app %q` to inspect candidates, then pass the explicit app info ID", appID, appID)
+			candidates := asc.FormatAppInfoCandidates(asc.AppInfoCandidates(resp.Data))
+			return "", fmt.Errorf("multiple app infos found for app %q (%s); run `asc apps info list --app %q` to inspect candidates, then pass the explicit app info ID", appID, candidates, appID)
 		}
-		fmt.Fprintf(os.Stderr, "Multiple app infos found for app %s, auto-selected %s (editable).\n", appID, selected)
+		fmt.Fprintf(os.Stderr, "Multiple app infos found for app %s, auto-selected %s (%s).\n", appID, selected, reason)
 		return selected, nil
 	}
 	return resp.Data[0].ID, nil
+}
+
+func autoSelectEditableAppInfoID(appInfos *asc.AppInfosResponse) (string, string) {
+	if appInfos == nil {
+		return "", ""
+	}
+
+	const targetState = "PREPARE_FOR_SUBMISSION"
+
+	matches := make([]string, 0, 1)
+	for _, info := range appInfos.Data {
+		state := strings.ToUpper(appInfoAttrString(info.Attributes, "state"))
+		appStoreState := strings.ToUpper(appInfoAttrString(info.Attributes, "appStoreState"))
+		if state != targetState && appStoreState != targetState {
+			continue
+		}
+		if trimmedID := strings.TrimSpace(info.ID); trimmedID != "" {
+			matches = append(matches, trimmedID)
+		}
+	}
+
+	if len(matches) != 1 {
+		return "", ""
+	}
+
+	return matches[0], targetState
 }

--- a/internal/cli/shared/app_resolution_test.go
+++ b/internal/cli/shared/app_resolution_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -39,6 +40,36 @@ func appResolutionJSONResponse(body string) (*http.Response, error) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}, nil
+}
+
+func captureAppResolutionStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stderr = writePipe
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("writePipe.Close() error: %v", err)
+	}
+
+	output, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error: %v", err)
+	}
+	if err := readPipe.Close(); err != nil {
+		t.Fatalf("readPipe.Close() error: %v", err)
+	}
+
+	return string(output)
 }
 
 func TestResolveAppStoreVersionIDAndState_PrefersAppVersionState(t *testing.T) {
@@ -122,46 +153,72 @@ func TestResolveAppInfoID_AutoSelectsEditableFromMultiple(t *testing.T) {
 		]}`)
 	})
 
-	id, err := ResolveAppInfoID(context.Background(), client, "app-1", "")
+	var (
+		id  string
+		err error
+	)
+	stderr := captureAppResolutionStderr(t, func() {
+		id, err = ResolveAppInfoID(context.Background(), client, "app-1", "")
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if id != "info-editable" {
 		t.Fatalf("expected info-editable, got %q", id)
 	}
-}
-
-func TestResolveAppInfoID_AutoSelectsNonLiveWhenNoPrepare(t *testing.T) {
-	client := newAppResolutionTestClient(t, func(req *http.Request) (*http.Response, error) {
-		return appResolutionJSONResponse(`{"data":[
-			{"type":"appInfos","id":"info-live","attributes":{"state":"READY_FOR_SALE"}},
-			{"type":"appInfos","id":"info-review","attributes":{"state":"IN_REVIEW"}}
-		]}`)
-	})
-
-	id, err := ResolveAppInfoID(context.Background(), client, "app-1", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if id != "info-review" {
-		t.Fatalf("expected info-review, got %q", id)
+	if !strings.Contains(stderr, "auto-selected info-editable (PREPARE_FOR_SUBMISSION)") {
+		t.Fatalf("expected PREPARE_FOR_SUBMISSION selection message, got %q", stderr)
 	}
 }
 
-func TestResolveAppInfoID_FallsBackToFirstWhenAllLive(t *testing.T) {
-	client := newAppResolutionTestClient(t, func(req *http.Request) (*http.Response, error) {
-		return appResolutionJSONResponse(`{"data":[
-			{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_SALE"}},
-			{"type":"appInfos","id":"info-2","attributes":{"state":"READY_FOR_DISTRIBUTION"}}
-		]}`)
-	})
-
-	id, err := ResolveAppInfoID(context.Background(), client, "app-1", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestResolveAppInfoID_ReturnsErrorWhenMultipleRemainAmbiguous(t *testing.T) {
+	testCases := []struct {
+		name           string
+		responseBody   string
+		wantSubstrings []string
+	}{
+		{
+			name: "non-live without prepare for submission",
+			responseBody: `{"data":[
+				{"type":"appInfos","id":"info-live","attributes":{"state":"READY_FOR_SALE"}},
+				{"type":"appInfos","id":"info-review","attributes":{"state":"IN_REVIEW"}}
+			]}`,
+			wantSubstrings: []string{`multiple app infos found for app "app-1"`, "READY_FOR_SALE", "IN_REVIEW"},
+		},
+		{
+			name: "all live candidates",
+			responseBody: `{"data":[
+				{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_SALE"}},
+				{"type":"appInfos","id":"info-2","attributes":{"state":"READY_FOR_DISTRIBUTION"}}
+			]}`,
+			wantSubstrings: []string{`multiple app infos found for app "app-1"`, "READY_FOR_SALE", "READY_FOR_DISTRIBUTION"},
+		},
+		{
+			name: "multiple prepare for submission candidates",
+			responseBody: `{"data":[
+				{"type":"appInfos","id":"info-ios","attributes":{"state":"PREPARE_FOR_SUBMISSION"}},
+				{"type":"appInfos","id":"info-macos","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}
+			]}`,
+			wantSubstrings: []string{`multiple app infos found for app "app-1"`, "info-ios", "info-macos", "PREPARE_FOR_SUBMISSION"},
+		},
 	}
-	if id != "info-1" {
-		t.Fatalf("expected info-1 (first), got %q", id)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newAppResolutionTestClient(t, func(req *http.Request) (*http.Response, error) {
+				return appResolutionJSONResponse(tc.responseBody)
+			})
+
+			_, err := ResolveAppInfoID(context.Background(), client, "app-1", "")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			for _, want := range tc.wantSubstrings {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("expected error to contain %q, got %v", want, err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ResolveAppInfoID` now auto-selects the most editable app info instead of erroring when an app has multiple (e.g. READY_FOR_SALE + PREPARE_FOR_SUBMISSION)
- Uses the existing `SelectBestAppInfoID` helper which prefers PREPARE_FOR_SUBMISSION, then any non-live state, then falls back to the first
- Logs the auto-selected ID to stderr for transparency

## Problem

When an app has two app infos (common during updates), every command that resolves app info fails:

```
multiple app infos found for app "123"; run `asc apps info list` ...
```

This forces users to manually look up and pass `--app-info` on every invocation of `categories set`, `metadata push`, `localizations update`, etc.

## Solution

Reuse the existing `SelectBestAppInfoID()` (already used by `validate readiness` and `migrate import`) inside `ResolveAppInfoID()`. The selection priority is:

1. `PREPARE_FOR_SUBMISSION` (the editable one)
2. Any non-live state (IN_REVIEW, WAITING_FOR_REVIEW, etc.)
3. First app info (fallback when all are live)

## Test plan

- [x] 6 new unit tests covering: explicit override, single app info, auto-select editable, auto-select non-live, fallback to first when all live, no app infos error
- [x] Full shared package test suite passes (285 tests)