### PR TITLE
fix: clarify invalid web auth credentials

### DIFF
--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -359,3 +359,49 @@ func TestResolveSessionPrintsExpiredNoticeBeforePrompt(t *testing.T) {
 		t.Fatalf("expected expired notice output, got %q", got)
 	}
 }
+
+func TestWebAuthLoginReportsInvalidCredentialMessage(t *testing.T) {
+	origTryResume := tryResumeSessionFn
+	origTryResumeLast := tryResumeLastFn
+	origWebLogin := webLoginFn
+	t.Cleanup(func() {
+		tryResumeSessionFn = origTryResume
+		tryResumeLastFn = origTryResumeLast
+		webLoginFn = origWebLogin
+	})
+
+	t.Setenv(webPasswordEnv, "secret")
+
+	tryResumeSessionFn = func(ctx context.Context, username string) (*webcore.AuthSession, bool, error) {
+		if username != "user@example.com" {
+			t.Fatalf("expected username user@example.com, got %q", username)
+		}
+		return nil, false, nil
+	}
+	tryResumeLastFn = func(ctx context.Context) (*webcore.AuthSession, bool, error) {
+		t.Fatal("did not expect last-session cache lookup when apple-id is provided")
+		return nil, false, nil
+	}
+	webLoginFn = func(ctx context.Context, creds webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if creds.Username != "user@example.com" {
+			t.Fatalf("expected login username user@example.com, got %q", creds.Username)
+		}
+		if creds.Password != "secret" {
+			t.Fatalf("expected password from env to be used, got %q", creds.Password)
+		}
+		return nil, errors.New("srp login failed: signin complete failed: incorrect Apple Account email or password")
+	}
+
+	cmd := WebAuthLoginCommand()
+	if err := cmd.FlagSet.Parse([]string{"--apple-id", "user@example.com"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected login error")
+	}
+	if got, want := err.Error(), "web auth login failed: srp login failed: signin complete failed: incorrect Apple Account email or password"; got != want {
+		t.Fatalf("expected error %q, got %q", want, got)
+	}
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -49,7 +49,10 @@ const (
 	minimumWebMinRequestInterval = 200 * time.Millisecond
 )
 
-var errTwoFactorRequired = errors.New("two-factor authentication required")
+var (
+	errTwoFactorRequired              = errors.New("two-factor authentication required")
+	errInvalidAppleAccountCredentials = errors.New("incorrect Apple Account email or password")
+)
 
 var webTLSRootBundlePaths = []string{
 	"/etc/ssl/cert.pem",
@@ -892,6 +895,9 @@ func signinComplete(ctx context.Context, client *http.Client, username, m1, m2 s
 			SCNT:             strings.TrimSpace(resp.Header.Get("scnt")),
 		}
 	}
+	if isInvalidAppleAccountCredentialsSigninComplete(resp.StatusCode, respBody) {
+		return errInvalidAppleAccountCredentials
+	}
 	return fmt.Errorf("signin complete failed with status %d", resp.StatusCode)
 }
 
@@ -1161,6 +1167,19 @@ func extractServiceErrorCodes(respBody []byte) []string {
 		}
 	}
 	return codes
+}
+
+// Apple currently returns -20101 when signin/complete rejects SRP credentials.
+func isInvalidAppleAccountCredentialsSigninComplete(status int, respBody []byte) bool {
+	if status != http.StatusUnauthorized {
+		return false
+	}
+	for _, code := range extractServiceErrorCodes(respBody) {
+		if code == "-20101" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) waitForRateLimit(ctx context.Context) error {

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -11,6 +11,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
+	"io"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -21,6 +23,12 @@ import (
 	"testing"
 	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestLogWebAuthHTTPRedactsSensitiveQueryValues(t *testing.T) {
 	origLogger := webDebugLogger
@@ -108,6 +116,73 @@ func TestLogWebAuthHTTPNoopWhenDebugDisabled(t *testing.T) {
 
 	if logs.Len() != 0 {
 		t.Fatalf("expected no debug output when disabled, got %q", logs.String())
+	}
+}
+
+func TestSigninCompleteReturnsInvalidCredentialsErrorForRejectedCredentials(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST request, got %s", req.Method)
+			}
+			if got, want := req.URL.String(), authServiceURL+"/signin/complete?isRememberMeEnabled=false"; got != want {
+				t.Fatalf("expected request URL %q, got %q", want, got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"serviceErrors":[{"code":"-20101"}]}`)),
+			}, nil
+		}),
+	}
+
+	err := signinComplete(
+		context.Background(),
+		client,
+		"user@example.com",
+		"m1-proof",
+		"m2-proof",
+		json.RawMessage(`{"v":1}`),
+		"service-key",
+		"hashcash-token",
+	)
+	if !errors.Is(err, errInvalidAppleAccountCredentials) {
+		t.Fatalf("expected invalid-credentials error, got %v", err)
+	}
+	if got, want := err.Error(), errInvalidAppleAccountCredentials.Error(); got != want {
+		t.Fatalf("expected error %q, got %q", want, got)
+	}
+}
+
+func TestSigninCompleteKeepsGenericUnauthorizedErrorsForOtherCodes(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"serviceErrors":[{"code":"-99999"}]}`)),
+			}, nil
+		}),
+	}
+
+	err := signinComplete(
+		context.Background(),
+		client,
+		"user@example.com",
+		"m1-proof",
+		"m2-proof",
+		json.RawMessage(`{"v":1}`),
+		"service-key",
+		"hashcash-token",
+	)
+	if err == nil {
+		t.Fatal("expected unauthorized error")
+	}
+	if errors.Is(err, errInvalidAppleAccountCredentials) {
+		t.Fatalf("expected generic unauthorized error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "signin complete failed with status 401") {
+		t.Fatalf("expected generic status error, got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- translate Apple signin `-20101` credential rejects into a clear `incorrect Apple Account email or password` error for `asc web auth login`
- keep other unauthorized `signin/complete` responses on the generic status path so we do not misclassify unrelated 401s
- add focused tests for the low-level signin classification and the surfaced login error message

## Test plan
- [x] `go test ./internal/web ./internal/cli/web -run 'TestSigninComplete|TestWebAuthLoginReportsInvalidCredentialMessage'`
- [x] `go test ./internal/web ./internal/cli/web`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go build -o /tmp/asc .`