### PR TITLE
fix: show bundle IDs in xcode-cloud products table

### DIFF
--- a/internal/cli/cmdtest/xcode_cloud_products_bundle_id_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_products_bundle_id_test.go
@@ -1,0 +1,79 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestXcodeCloudProductsTableIncludesRelatedAppBundleID(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/ciProducts" {
+				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
+			}
+			if req.URL.Query().Get("limit") != "1" {
+				t.Fatalf("expected limit=1, got %q", req.URL.Query().Get("limit"))
+			}
+			body := `{"data":[{"type":"ciProducts","id":"prod-1","attributes":{"name":"FoundationLab","createdDate":"2025-06-25T08:55:49.429Z","productType":"APP"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/ciProducts/prod-1/app" {
+				t.Fatalf("unexpected second request: %s %s", req.Method, req.URL.String())
+			}
+			body := `{"data":{"type":"apps","id":"app-1","attributes":{"name":"FoundationLab","bundleId":"com.rudrankriyam.foundationlab","sku":"FoundationLab123","primaryLocale":"en-US"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "products", "--limit", "1", "--output", "table"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Bundle ID") {
+		t.Fatalf("expected Bundle ID header, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "com.rudrankriyam.foundationlab") {
+		t.Fatalf("expected bundle ID value in output, got %q", stdout)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected exactly 2 requests, got %d", callCount)
+	}
+}

--- a/internal/cli/xcodecloud/xcode_cloud_extras.go
+++ b/internal/cli/xcodecloud/xcode_cloud_extras.go
@@ -304,7 +304,7 @@ func xcodeCloudProductsList(ctx context.Context, appID string, limit int, next s
 
 	if paginate {
 		paginateOpts := append(opts, asc.WithCiProductsLimit(200))
-		resp, err := shared.PaginateWithSpinner(requestCtx,
+		paginatedResp, err := shared.PaginateWithSpinner(requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return client.GetCiProducts(ctx, paginateOpts...)
 			},
@@ -316,6 +316,16 @@ func xcodeCloudProductsList(ctx context.Context, appID string, limit int, next s
 			return fmt.Errorf("xcode-cloud products: %w", err)
 		}
 
+		resp, ok := paginatedResp.(*asc.CiProductsResponse)
+		if !ok {
+			return fmt.Errorf("xcode-cloud products: unexpected response type %T", paginatedResp)
+		}
+		if shouldHydrateCiProductBundleIDs(output) {
+			if err := hydrateCiProductBundleIDs(requestCtx, client, resp); err != nil {
+				return fmt.Errorf("xcode-cloud products: %w", err)
+			}
+		}
+
 		return shared.PrintOutput(resp, output, pretty)
 	}
 
@@ -323,8 +333,48 @@ func xcodeCloudProductsList(ctx context.Context, appID string, limit int, next s
 	if err != nil {
 		return fmt.Errorf("xcode-cloud products: %w", err)
 	}
+	if shouldHydrateCiProductBundleIDs(output) {
+		if err := hydrateCiProductBundleIDs(requestCtx, client, resp); err != nil {
+			return fmt.Errorf("xcode-cloud products: %w", err)
+		}
+	}
 
 	return shared.PrintOutput(resp, output, pretty)
+}
+
+func shouldHydrateCiProductBundleIDs(output string) bool {
+	switch shared.NormalizeOutputFormat(output) {
+	case "table", "markdown", "md":
+		return true
+	default:
+		return false
+	}
+}
+
+func hydrateCiProductBundleIDs(ctx context.Context, client *asc.Client, resp *asc.CiProductsResponse) error {
+	if client == nil || resp == nil {
+		return nil
+	}
+
+	for i := range resp.Data {
+		if strings.TrimSpace(resp.Data[i].Attributes.BundleID) != "" {
+			continue
+		}
+
+		productID := strings.TrimSpace(resp.Data[i].ID)
+		if productID == "" {
+			continue
+		}
+
+		appResp, err := client.GetCiProductApp(ctx, productID)
+		if err != nil {
+			return fmt.Errorf("resolve app for product %q: %w", productID, err)
+		}
+
+		resp.Data[i].Attributes.BundleID = strings.TrimSpace(appResp.Data.Attributes.BundleID)
+	}
+
+	return nil
 }
 
 func xcodeCloudVersionListFlags(fs *flag.FlagSet) (limit *int, next *string, paginate *bool, output *string, pretty *bool) {


### PR DESCRIPTION
## Summary
- hydrate Xcode Cloud product bundle IDs from the related app endpoint before rendering human-readable product lists
- keep machine-readable product output unchanged while fixing the table view that users rely on for app/product matching
- add cmdtest coverage that verifies `asc xcode-cloud products --output table` includes the resolved bundle ID

## Test plan
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] live-check `asc xcode-cloud products --output table --limit 5` against FoundationLab and confirm the bundle ID renders as `com.rudrankriyam.foundationlab`

Fixes #1055.