### PR TITLE
feat: add auth issuer-id command

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -56,6 +56,7 @@ Set ASC_BYPASS_KEYCHAIN to 1/true/yes/on to bypass keychain.`,
 			AuthLogoutCommand(),
 			AuthDoctorCommand(),
 			AuthStatusCommand(),
+			AuthIssuerIDCommand(),
 			AuthTokenCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -888,6 +889,62 @@ func authStatusEnvironmentNote(profile string, bypassKeychain, envProvided, envC
 func boolPointer(value bool) *bool {
 	result := value
 	return &result
+}
+
+// AuthIssuerIDCommand prints the active App Store Connect issuer ID.
+func AuthIssuerIDCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("auth issuer-id", flag.ExitOnError)
+
+	name := fs.String("name", "", "Profile name (uses default profile if omitted)")
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "text", "Output format: text (raw issuer ID), json", "text", "json")
+
+	return &ffcli.Command{
+		Name:       "issuer-id",
+		ShortUsage: "asc auth issuer-id [flags]",
+		ShortHelp:  "Print the active App Store Connect issuer ID.",
+		LongHelp: `Print the active App Store Connect issuer ID.
+
+This reads the issuer ID from the currently resolved authentication credentials
+without making a network request.
+
+Examples:
+  asc auth issuer-id
+  asc auth issuer-id --name "MyKey"
+  asc auth issuer-id --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			trimmedName := strings.TrimSpace(*name)
+			if trimmedName == "" && *name != "" {
+				return shared.UsageError("--name cannot be blank")
+			}
+			normalizedOutput, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "text", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			cred, err := shared.ResolveAuthCredentials(trimmedName)
+			if err != nil {
+				return fmt.Errorf("auth issuer-id: %w", err)
+			}
+
+			if normalizedOutput == "json" {
+				return shared.PrintOutput(struct {
+					IssuerID string `json:"issuerId"`
+					Profile  string `json:"profile,omitempty"`
+				}{
+					IssuerID: cred.IssuerID,
+					Profile:  cred.Profile,
+				}, "json", *output.Pretty)
+			}
+
+			fmt.Print(cred.IssuerID)
+			return nil
+		},
+	}
 }
 
 // AuthTokenCommand prints a signed JWT for direct API calls.

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -1067,6 +1067,172 @@ func TestAuthTokenCommand(t *testing.T) {
 	})
 }
 
+func TestAuthIssuerIDCommand(t *testing.T) {
+	t.Run("no credentials", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+		clearResolvedAuthEnv(t)
+
+		cmd := AuthIssuerIDCommand()
+		if err := cmd.FlagSet.Parse([]string{}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		err := cmd.Exec(context.Background(), []string{})
+		if err == nil || !strings.Contains(err.Error(), "missing authentication") {
+			t.Fatalf("expected missing authentication error, got %v", err)
+		}
+	})
+
+	t.Run("prints raw issuer id to stdout", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+		clearResolvedAuthEnv(t)
+		keyPath := writeTempECDSAKeyFile(t)
+		if err := authsvc.StoreCredentialsConfigAt("demo", "KEY123", "ISS456", keyPath, cfgPath); err != nil {
+			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+		}
+
+		cmd := AuthIssuerIDCommand()
+		if err := cmd.FlagSet.Parse([]string{}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, _ := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+		if stdout != "ISS456" {
+			t.Fatalf("expected raw issuer id, got %q", stdout)
+		}
+	})
+
+	t.Run("json output includes issuer id and profile", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+		clearResolvedAuthEnv(t)
+		keyPath := writeTempECDSAKeyFile(t)
+		if err := authsvc.StoreCredentialsConfigAt("demo", "KEY123", "ISS456", keyPath, cfgPath); err != nil {
+			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+		}
+
+		cmd := AuthIssuerIDCommand()
+		if err := cmd.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, _ := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+
+		var payload struct {
+			IssuerID string `json:"issuerId"`
+			Profile  string `json:"profile"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("failed to unmarshal json: %v; stdout=%q", err, stdout)
+		}
+		if payload.IssuerID != "ISS456" {
+			t.Fatalf("expected issuerId ISS456, got %q", payload.IssuerID)
+		}
+		if payload.Profile != "demo" {
+			t.Fatalf("expected profile demo, got %q", payload.Profile)
+		}
+	})
+
+	t.Run("selects named profile", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+		clearResolvedAuthEnv(t)
+		keyPath := writeTempECDSAKeyFile(t)
+		if err := authsvc.StoreCredentialsConfigAt("first", "KEY_A", "ISS_A", keyPath, cfgPath); err != nil {
+			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+		}
+		if err := authsvc.StoreCredentialsConfigAt("second", "KEY_B", "ISS_B", keyPath, cfgPath); err != nil {
+			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+		}
+
+		cmd := AuthIssuerIDCommand()
+		if err := cmd.FlagSet.Parse([]string{"--name", "second", "--output", "json"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, _ := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+
+		var payload struct {
+			IssuerID string `json:"issuerId"`
+			Profile  string `json:"profile"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("failed to unmarshal json: %v", err)
+		}
+		if payload.IssuerID != "ISS_B" {
+			t.Fatalf("expected ISS_B, got %q", payload.IssuerID)
+		}
+		if payload.Profile != "second" {
+			t.Fatalf("expected profile second, got %q", payload.Profile)
+		}
+	})
+
+	t.Run("falls back to env credentials", func(t *testing.T) {
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+		clearResolvedAuthEnv(t)
+		t.Setenv("ASC_KEY_ID", "ENVKEY")
+		t.Setenv("ASC_ISSUER_ID", "ENVISS")
+		t.Setenv("ASC_PRIVATE_KEY_PATH", writeTempECDSAKeyFile(t))
+		t.Setenv("ASC_PRIVATE_KEY", "")
+		t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+		cmd := AuthIssuerIDCommand()
+		if err := cmd.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, _ := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+
+		var payload struct {
+			IssuerID string `json:"issuerId"`
+			Profile  string `json:"profile"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("failed to unmarshal json: %v", err)
+		}
+		if payload.IssuerID != "ENVISS" {
+			t.Fatalf("expected ENVISS, got %q", payload.IssuerID)
+		}
+		if payload.Profile != "" {
+			t.Fatalf("expected empty profile for env credentials, got %q", payload.Profile)
+		}
+	})
+
+	t.Run("unexpected args rejected", func(t *testing.T) {
+		cmd := AuthIssuerIDCommand()
+		if err := cmd.FlagSet.Parse([]string{}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{"extra"})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "unexpected argument") {
+			t.Fatalf("expected unexpected argument error, got %q", stderr)
+		}
+	})
+}
+
 func writeTempECDSAKeyFile(t *testing.T) string {
 	t.Helper()
 

--- a/internal/cli/cmdtest/auth_issuer_id_test.go
+++ b/internal/cli/cmdtest/auth_issuer_id_test.go
@@ -1,0 +1,127 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+func TestAuthIssuerIDOutputJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+
+	cfg := &config.Config{
+		DefaultKeyName: "default",
+		Keys: []config.Credential{
+			{
+				Name:           "default",
+				KeyID:          "KEY123",
+				IssuerID:       "ISS456",
+				PrivateKeyPath: keyPath,
+			},
+		},
+	}
+	if err := config.SaveAt(configPath, cfg); err != nil {
+		t.Fatalf("SaveAt() error: %v", err)
+	}
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = cmd.Run([]string{"auth", "issuer-id", "--output", "json"}, "1.0.0")
+	})
+	if code != cmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, cmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		IssuerID string `json:"issuerId"`
+		Profile  string `json:"profile"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to unmarshal auth issuer-id json: %v; stdout=%q", err, stdout)
+	}
+	if payload.IssuerID != "ISS456" {
+		t.Fatalf("expected issuerId ISS456, got %q", payload.IssuerID)
+	}
+	if payload.Profile != "default" {
+		t.Fatalf("expected profile default, got %q", payload.Profile)
+	}
+}
+
+func TestAuthIssuerIDTextOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+
+	cfg := &config.Config{
+		DefaultKeyName: "default",
+		Keys: []config.Credential{
+			{
+				Name:           "default",
+				KeyID:          "KEY123",
+				IssuerID:       "ISS456",
+				PrivateKeyPath: keyPath,
+			},
+		},
+	}
+	if err := config.SaveAt(configPath, cfg); err != nil {
+		t.Fatalf("SaveAt() error: %v", err)
+	}
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = cmd.Run([]string{"auth", "issuer-id"}, "1.0.0")
+	})
+	if code != cmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, cmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if stdout != "ISS456" {
+		t.Fatalf("expected raw issuer id, got %q", stdout)
+	}
+}
+
+func TestAuthIssuerIDOutputInvalidReturnsExitUsage(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	_, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"auth", "issuer-id", "--output", "yaml"}, "1.0.0")
+		if code != cmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+		}
+	})
+	if !strings.Contains(stderr, "unsupported format: yaml") {
+		t.Fatalf("expected stderr to contain unsupported format error, got %q", stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- add `asc auth issuer-id` to print the active resolved issuer ID without opening App Store Connect or making a network request
- support shell-friendly text output plus JSON output and named profile selection for automation
- add unit and command tests covering missing auth, named profiles, env fallback, invalid output, and unexpected arguments

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/auth -run 'AuthIssuerID|AuthToken' -count=1`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run AuthIssuerID -count=1`
- [x] `go build -o /tmp/asc .`
- [x] `ASC_BYPASS_KEYCHAIN=1 /tmp/asc auth issuer-id --output json`
- [x] `make generate-command-docs`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`