### PR TITLE
fix: suppress 409 Conflict warnings on stale submission cancel

### DIFF
--- a/internal/cli/cmdtest/submit_create_test.go
+++ b/internal/cli/cmdtest/submit_create_test.go
@@ -516,12 +516,12 @@ func TestSubmitCreateSilentlySkipsConflictOnStaleSubmissionCancel(t *testing.T) 
 		}
 	})
 
-	// 409 Conflict on stale cancel should be silently suppressed — no warning
+	// 409 Conflict should produce a clear info message, not the scary "Warning: failed to cancel" dump
 	if strings.Contains(stderr, "Warning: failed to cancel stale submission") {
 		t.Fatalf("expected no warning for 409 conflict on stale cancel, got: %q", stderr)
 	}
-	if strings.Contains(stderr, "stale-1") {
-		t.Fatalf("expected no mention of stale-1 in stderr, got: %q", stderr)
+	if !strings.Contains(stderr, "Skipped stale submission stale-1: already transitioned to a non-cancellable state") {
+		t.Fatalf("expected info message about skipped stale submission, got: %q", stderr)
 	}
 	if stdout == "" {
 		t.Fatal("expected JSON output on stdout")

--- a/internal/cli/submit/submit.go
+++ b/internal/cli/submit/submit.go
@@ -690,9 +690,9 @@ func cancelStaleReviewSubmissions(ctx context.Context, client *asc.Client, appID
 		}
 
 		if _, cancelErr := client.CancelReviewSubmission(ctx, sub.ID); cancelErr != nil {
-			// Silently skip submissions that transitioned to a non-cancellable
-			// state between the list query and the cancel attempt (409 Conflict).
-			if !errors.Is(cancelErr, asc.ErrConflict) {
+			if errors.Is(cancelErr, asc.ErrConflict) {
+				fmt.Fprintf(os.Stderr, "Skipped stale submission %s: already transitioned to a non-cancellable state\n", sub.ID)
+			} else {
 				fmt.Fprintf(os.Stderr, "Warning: failed to cancel stale submission %s: %v\n", sub.ID, cancelErr)
 			}
 			continue


### PR DESCRIPTION
## Summary

- When `submit create` cancels stale READY_FOR_REVIEW submissions before creating a new one, a race condition can cause the cancel to hit a 409 Conflict (submission already transitioned to a non-cancellable state between list and cancel)
- Previously this printed alarming `Warning: failed to cancel stale submission` messages to stderr even though the situation is harmless
- Now silently skips 409 Conflict errors while still warning on genuine failures (502, 500, etc.)

## Test plan

- [x] New test `TestSubmitCreateSilentlySkipsConflictOnStaleSubmissionCancel` — verifies 409 on cancel produces no warning
- [x] Existing `TestSubmitCreateWarnsWhenStaleSubmissionCancelFails` — still warns on 502
- [x] Full test suite passes (`ASC_BYPASS_KEYCHAIN=1 make test`)