### PR TITLE
apps wall: add WordFlux: Word Puzzles

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -615,6 +615,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3c/c6/c1/3cc6c19c-acec-fb4d-ee88-63a1bfc422c4/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "WordFlux: Word Puzzles",
+    "link": "https://apps.apple.com/us/app/wordflux-word-puzzles/id6757514622?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/eb/e9/b7/ebe9b79a-9dd1-d0a7-3bd9-ecb2a4517c83/AppIcon-0-0-1x_U007ephone-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Wozi Vocabulary Builder",
     "link": "https://apps.apple.com/app/id1536585848",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cd/33/e3/cd33e3a5-2c7d-34e8-5c22-07bca8f44d7d/WoziAppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `WordFlux: Word Puzzles` to the Wall of Apps

## Entry

- App ID: 6757514622
- App: WordFlux: Word Puzzles
- Link: https://apps.apple.com/us/app/wordflux-word-puzzles/id6757514622?uo=4

## Notes

- Submitted via `asc apps wall submit`
