### PR TITLE
apps wall: add Pico-8 Emulator: Picpic

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -371,6 +371,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cb/8f/0b/cb8f0b7e-ba14-a1cf-49ef-09c64d9ce87e/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Pico-8 Emulator: Picpic",
+    "link": "https://apps.apple.com/us/app/pico-8-emulator-picpic/id6759208792?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e7/cb/5c/e7cb5c08-a96f-f0f3-3642-416e1bba991e/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Planit: Gamified Daily Planner",
     "link": "https://apps.apple.com/us/app/planit-gamified-daily-planner/id6759006335",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/94/b1/94/94b194db-586e-18bf-bc6f-b7a7acaed8bb/testiconPlanit-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pico-8 Emulator: Picpic` to the Wall of Apps

## Entry

- App ID: 6759208792
- App: Pico-8 Emulator: Picpic
- Link: https://apps.apple.com/us/app/pico-8-emulator-picpic/id6759208792?uo=4

## Notes

- Submitted via `asc apps wall submit`
