### PR TITLE
apps wall: add Space - Life Planner

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -516,6 +516,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/87/cf/44/87cf44ee-79ee-1a91-3edc-d195ad86582b/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Space - Life Planner",
+    "link": "https://apps.apple.com/us/app/space-life-planner/id6502294348?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/68/88/12/688812e9-4f3d-ce80-5822-5c55e715b809/default-0-0-1x_U007ephone-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SpeedReader",
     "link": "https://apps.apple.com/app/id6757832936",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/90/bc/20/90bc2003-d998-ba7a-ce45-66d846d7685f/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Space - Life Planner` to the Wall of Apps

## Entry

- App ID: 6502294348
- App: Space - Life Planner
- Link: https://apps.apple.com/us/app/space-life-planner/id6502294348?uo=4

## Notes

- Submitted via `asc apps wall submit`
