### PR TITLE
fix(submit): quieter stale warnings + actionable error hints

### DIFF
--- a/internal/cli/submit/submit.go
+++ b/internal/cli/submit/submit.go
@@ -749,7 +749,7 @@ func printSubmissionErrorHints(err error, appID string) {
 }
 
 func isExpectedNonCancellableReviewSubmissionError(err error) bool {
-	return errors.Is(err, asc.ErrConflict) || isResourceStateInvalid(err)
+	return isResourceStateInvalid(err)
 }
 
 // isResourceStateInvalid returns true if the error message indicates the

--- a/internal/cli/submit/submit_test.go
+++ b/internal/cli/submit/submit_test.go
@@ -640,6 +640,71 @@ func TestCleanupEmptyReviewSubmissionIgnoresExpectedNonCancellableState(t *testi
 	}
 }
 
+func TestCleanupEmptyReviewSubmissionWarnsOnGenericConflict(t *testing.T) {
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/reviewSubmissions/empty-sub-1" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return submitJSONResponse(http.StatusConflict, `{
+			"errors": [{
+				"status": "409",
+				"code": "CONFLICT",
+				"title": "Conflict",
+				"detail": "Another operation is already in progress"
+			}]
+		}`)
+	}))
+
+	stderr := captureSubmitStderr(t, func() {
+		cleanupEmptyReviewSubmission(context.Background(), client, "empty-sub-1")
+	})
+	if !strings.Contains(stderr, "Warning: failed to cancel empty submission empty-sub-1:") {
+		t.Fatalf("expected cleanup warning for generic conflict, got %q", stderr)
+	}
+}
+
+func TestCancelStaleReviewSubmissionsWarnsOnGenericConflict(t *testing.T) {
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
+			return submitJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "reviewSubmissions",
+					"id": "stale-sub-1",
+					"attributes": {
+						"state": "READY_FOR_REVIEW",
+						"platform": "IOS"
+					}
+				}]
+			}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1":
+			return submitJSONResponse(http.StatusConflict, `{
+				"errors": [{
+					"status": "409",
+					"code": "CONFLICT",
+					"title": "Conflict",
+					"detail": "Another operation is already in progress"
+				}]
+			}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+
+	stderr := captureSubmitStderr(t, func() {
+		got := cancelStaleReviewSubmissions(context.Background(), client, "app-1", "IOS")
+		if got != nil {
+			t.Fatalf("expected no canceled submissions, got %#v", got)
+		}
+	})
+	if !strings.Contains(stderr, "Warning: failed to cancel stale submission stale-sub-1:") {
+		t.Fatalf("expected stale submission warning for generic conflict, got %q", stderr)
+	}
+	if strings.Contains(stderr, "Skipped stale submission stale-sub-1") {
+		t.Fatalf("did not expect stale submission skip message, got %q", stderr)
+	}
+}
+
 func TestPrintSubmissionErrorHintsUsesExistingRunnableCommands(t *testing.T) {
 	stderr := captureSubmitStderr(t, func() {
 		printSubmissionErrorHints(errors.New("ageRatingDeclaration contentRightsDeclaration appDataUsage primaryCategory"), "app-1")


### PR DESCRIPTION
## Summary
Two UX improvements to `asc submit create`:
1. Silences noisy "failed to cancel stale submission" warnings
2. Adds actionable fix hints when submission fails

## Problem
**Stale warnings:** Every `submit create` prints 2-3 "Warning: failed to cancel stale submission" lines. These are expected (non-cancellable states) and confuse users.

**No guidance on fix:** When submission fails due to missing age rating, content rights, or app privacy, the error dumps 20+ raw API errors with no suggestion on how to fix them.

## Solution
**Warnings:** Silenced — non-cancellable stale submissions are silently skipped.

**Hints:** After submission failure, inspects error messages and prints actionable commands:
```
Hint: Fix age rating: asc age-rating set --app APP_ID --all-none
Hint: Set category: asc app-setup categories set --app APP_ID --primary SPORTS
Hint: Complete App Privacy at: https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
Hint: Content rights must be set in App Store Connect: https://appstoreconnect.apple.com/apps/APP_ID
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cli/submit/...` passes