### PR TITLE
fix(pricing): paginate territory availabilities

### DIFF
--- a/internal/cli/cmdtest/pricing_availability_territory_availabilities_test.go
+++ b/internal/cli/cmdtest/pricing_availability_territory_availabilities_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"strings"
@@ -184,14 +186,14 @@ func TestPricingAvailabilityTerritoryAvailabilitiesRejectsInvalidLimit(t *testin
 	if runErr == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(runErr.Error(), "pricing availability territory-availabilities: --limit must be between 1 and 200") {
-		t.Fatalf("expected invalid limit error, got %v", runErr)
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, "Error: pricing availability territory-availabilities: --limit must be between 1 and 200") {
+		t.Fatalf("expected invalid limit usage error, got %q", stderr)
 	}
 }
 
@@ -213,13 +215,13 @@ func TestPricingAvailabilityTerritoryAvailabilitiesRejectsInvalidNextURL(t *test
 	if runErr == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(runErr.Error(), "pricing availability territory-availabilities: --next must be an App Store Connect URL") {
-		t.Fatalf("expected invalid next url error, got %v", runErr)
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, "Error: pricing availability territory-availabilities: --next must be an App Store Connect URL") {
+		t.Fatalf("expected invalid next url usage error, got %q", stderr)
 	}
 }

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -2,6 +2,7 @@ package pricing
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -579,7 +580,7 @@ Examples:
 
 // PricingAvailabilityTerritoryAvailabilitiesCommand returns the availability territory-availabilities subcommand.
 func PricingAvailabilityTerritoryAvailabilitiesCommand() *ffcli.Command {
-	return shared.BuildPaginatedListCommand(shared.PaginatedListCommandConfig{
+	cmd := shared.BuildPaginatedListCommand(shared.PaginatedListCommandConfig{
 		FlagSetName: "pricing availability territory-availabilities",
 		Name:        "territory-availabilities",
 		ShortUsage:  "asc pricing availability territory-availabilities --availability AVAILABILITY_ID [--limit N] [--next URL] [--paginate]",
@@ -606,6 +607,26 @@ Examples:
 			return client.GetTerritoryAvailabilities(ctx, availabilityID, opts...)
 		},
 	})
+
+	originalExec := cmd.Exec
+	cmd.Exec = func(ctx context.Context, args []string) error {
+		err := originalExec(ctx, args)
+		if err == nil || errors.Is(err, flag.ErrHelp) {
+			return err
+		}
+		if isPricingAvailabilityTerritoryAvailabilitiesUsageError(err) {
+			return shared.UsageError(err.Error())
+		}
+		return err
+	}
+
+	return cmd
+}
+
+func isPricingAvailabilityTerritoryAvailabilitiesUsageError(err error) bool {
+	message := err.Error()
+	return strings.HasPrefix(message, "pricing availability territory-availabilities: --limit must be between 1 and ") ||
+		strings.HasPrefix(message, "pricing availability territory-availabilities: --next ")
 }
 
 // PricingAvailabilitySetCommand returns the availability set subcommand.


### PR DESCRIPTION
Fixes #1085.

## Summary
- add `--limit`, `--next`, and `--paginate` support to `asc pricing availability territory-availabilities` by routing it through the shared paginated list command path
- keep the existing command placement under `pricing availability` while exposing the same pagination semantics used by other list commands in the CLI
- add cmdtests for paginated aggregation, explicit `--limit`, direct `--next` continuation, and invalid `--limit` / `--next` validation

## Reproduction
Using `ASC_BYPASS_KEYCHAIN=1` on fresh `origin/main` against the throwaway app availability `6759231657`:

```bash
ASC_BYPASS_KEYCHAIN=1 asc pricing availability territory-availabilities --availability 6759231657 --output json | jq '.data | length'
# 50
```

The same availability returned a `links.next`, proving the CLI stopped after the first page.
Direct API comparison with the same credentials-backed token showed the full dataset:

```bash
TOKEN=$(ASC_BYPASS_KEYCHAIN=1 asc auth token --confirm)
curl -sS -H "Authorization: Bearer $TOKEN" \
  "https://api.appstoreconnect.apple.com/v2/appAvailabilities/6759231657/territoryAvailabilities?limit=200" \
  | jq '.data | length'
# 175
```

## Why this approach
- the client already supported `limit` and `nextURL` for `GetTerritoryAvailabilities`, so the bug was in the CLI surface rather than the API layer
- using the shared paginated-list builder keeps validation and pagination behavior aligned with other commands instead of introducing one-off pagination code just for pricing availability

## Alternatives considered
- auto-paginate by default: rejected to avoid changing existing single-page behavior for scripts that currently rely on the first page only
- add a bespoke pagination implementation just for this command: rejected because the repo already has a shared list-command abstraction for `--limit`, `--next`, and `--paginate`

## OpenAPI / API validation
The offline snapshot already exposes the paginated endpoint used here:
- `GET /v2/appAvailabilities/{id}/territoryAvailabilities`

No new endpoint or unsupported query parameter was introduced; the fix only exposes existing pagination support in the CLI.

## Test plan
- [x] `go test ./internal/cli/cmdtest -run 'TestPricingAvailabilityTerritoryAvailabilities'`
- [x] `go test ./internal/cli/pricing`
- [x] `go test ./internal/cli/cmdtest -run 'PricingAvailability|PricingTiers|PricingSchedule'`
- [x] `make format`
- [x] `make generate-command-docs`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go build -o /tmp/asc .`
- [x] `/tmp/asc pricing availability territory-availabilities --help` exits `0`
- [x] `ASC_BYPASS_KEYCHAIN=1 /tmp/asc pricing availability territory-availabilities --availability 6759231657 --paginate --output json` returns `175` records and no `links.next`
- [x] `ASC_BYPASS_KEYCHAIN=1 /tmp/asc pricing availability territory-availabilities --availability 6759231657 --limit 175 --output json` returns `175` records and no `links.next`