### PR TITLE
fix(xcode): warn on beta toolchains for App Store exports

### DIFF
--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	runtimeGOOS      = runtime.GOOS
-	lookPathFn       = exec.LookPath
-	commandContextFn = exec.CommandContext
+	runtimeGOOS          = runtime.GOOS
+	lookPathFn           = exec.LookPath
+	commandContextFn     = exec.CommandContext
+	activeDeveloperDirFn = activeDeveloperDir
 )
 
 const xcodebuildErrorTailLimit = 64 * 1024
@@ -116,6 +117,7 @@ func Export(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 	if err := prepareIPAPath(opts.IPAPath, opts.Overwrite); err != nil {
 		return nil, err
 	}
+	maybeWarnAboutBetaXcodeForAppStoreExport(ctx, opts.ExportOptions, opts.LogWriter)
 
 	tempExportDir, err := os.MkdirTemp(filepath.Dir(opts.IPAPath), ".asc-xcode-export-*")
 	if err != nil {
@@ -287,6 +289,69 @@ func ensureXcodeAvailable(ctx context.Context) error {
 		return fmt.Errorf("xcodebuild not usable: %w", err)
 	}
 	return nil
+}
+
+func maybeWarnAboutBetaXcodeForAppStoreExport(ctx context.Context, exportOptionsPath string, logWriter io.Writer) {
+	if logWriter == nil || !isAppStoreExport(exportOptionsPath) {
+		return
+	}
+	developerDir, err := activeDeveloperDirFn(ctx)
+	if err != nil || !isBetaXcodePath(developerDir) {
+		return
+	}
+	fmt.Fprintf(
+		logWriter,
+		"Warning: active Xcode developer directory %q appears to be a beta build. App Store Connect may accept uploads from beta Xcode, but App Store review can later reject builds for unsupported SDK/Xcode. Prefer a stable Xcode via DEVELOPER_DIR or xcode-select for App Store submission exports.\n",
+		developerDir,
+	)
+}
+
+func isAppStoreExport(exportOptionsPath string) bool {
+	data, err := os.ReadFile(strings.TrimSpace(exportOptionsPath))
+	if err != nil {
+		return false
+	}
+	var payload map[string]any
+	if _, err := plist.Unmarshal(data, &payload); err != nil {
+		return false
+	}
+
+	method, _ := payload["method"].(string)
+	switch strings.ToLower(strings.TrimSpace(method)) {
+	case "app-store", "app-store-connect":
+		return true
+	}
+
+	destination, _ := payload["destination"].(string)
+	return strings.EqualFold(strings.TrimSpace(destination), "upload")
+}
+
+func activeDeveloperDir(ctx context.Context) (string, error) {
+	if developerDir := strings.TrimSpace(os.Getenv("DEVELOPER_DIR")); developerDir != "" {
+		return filepath.Clean(developerDir), nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, "xcode-select", "-p")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(strings.TrimSpace(string(output))), nil
+}
+
+func isBetaXcodePath(pathValue string) bool {
+	if strings.TrimSpace(pathValue) == "" {
+		return false
+	}
+	for _, segment := range strings.Split(filepath.Clean(pathValue), string(os.PathSeparator)) {
+		normalized := strings.ToLower(strings.TrimSpace(segment))
+		if strings.Contains(normalized, "xcode") && strings.Contains(normalized, "beta") {
+			return true
+		}
+	}
+	return false
 }
 
 func buildArchiveCommand(opts ArchiveOptions) []string {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -318,6 +318,122 @@ func TestExportWritesIPAAtExactPathAndReturnsMetadata(t *testing.T) {
 	}
 }
 
+func TestExportWarnsForBetaXcodeAppStoreExport(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+	if err := os.MkdirAll(archivePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	exportOptionsPath := filepath.Join(tempDir, "ExportOptions.plist")
+	writeExportOptionsPlist(t, exportOptionsPath, map[string]any{
+		"destination":  "upload",
+		"method":       "app-store-connect",
+		"signingStyle": "automatic",
+	})
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Setenv("DEVELOPER_DIR", "/Applications/Xcode-beta.app/Contents/Developer")
+	t.Cleanup(restore)
+
+	var stderr bytes.Buffer
+	_, err := Export(context.Background(), ExportOptions{
+		ArchivePath:   archivePath,
+		ExportOptions: exportOptionsPath,
+		IPAPath:       filepath.Join(tempDir, "Demo.ipa"),
+		LogWriter:     &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), `Warning: active Xcode developer directory "/Applications/Xcode-beta.app/Contents/Developer" appears to be a beta build`) {
+		t.Fatalf("expected beta Xcode warning, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "App Store review can later reject builds for unsupported SDK/Xcode") {
+		t.Fatalf("expected warning to explain App Store review risk, got %q", stderr.String())
+	}
+}
+
+func TestExportDoesNotWarnForStableXcodeAppStoreExport(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+	if err := os.MkdirAll(archivePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	exportOptionsPath := filepath.Join(tempDir, "ExportOptions.plist")
+	writeExportOptionsPlist(t, exportOptionsPath, map[string]any{
+		"destination":  "upload",
+		"method":       "app-store-connect",
+		"signingStyle": "automatic",
+	})
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Setenv("DEVELOPER_DIR", "/Applications/Xcode-26.3.0.app/Contents/Developer")
+	t.Cleanup(restore)
+
+	var stderr bytes.Buffer
+	_, err := Export(context.Background(), ExportOptions{
+		ArchivePath:   archivePath,
+		ExportOptions: exportOptionsPath,
+		IPAPath:       filepath.Join(tempDir, "Demo.ipa"),
+		LogWriter:     &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if strings.Contains(stderr.String(), "beta build") {
+		t.Fatalf("did not expect beta Xcode warning, got %q", stderr.String())
+	}
+}
+
+func TestExportDoesNotWarnForBetaXcodeDevelopmentExport(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+	if err := os.MkdirAll(archivePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	exportOptionsPath := filepath.Join(tempDir, "ExportOptions.plist")
+	writeExportOptionsPlist(t, exportOptionsPath, map[string]any{
+		"method":       "development",
+		"signingStyle": "automatic",
+	})
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Setenv("DEVELOPER_DIR", "/Applications/Xcode-beta.app/Contents/Developer")
+	t.Cleanup(restore)
+
+	var stderr bytes.Buffer
+	_, err := Export(context.Background(), ExportOptions{
+		ArchivePath:   archivePath,
+		ExportOptions: exportOptionsPath,
+		IPAPath:       filepath.Join(tempDir, "Demo.ipa"),
+		LogWriter:     &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if strings.Contains(stderr.String(), "beta build") {
+		t.Fatalf("did not expect beta Xcode warning, got %q", stderr.String())
+	}
+}
+
 func TestExportRejectsExistingIPAWithoutOverwrite(t *testing.T) {
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
@@ -394,10 +510,12 @@ func overrideTestEnvironment(t *testing.T) func() {
 	originalGOOS := runtimeGOOS
 	originalLookPath := lookPathFn
 	originalCommandContext := commandContextFn
+	originalActiveDeveloperDir := activeDeveloperDirFn
 	return func() {
 		runtimeGOOS = originalGOOS
 		lookPathFn = originalLookPath
 		commandContextFn = originalCommandContext
+		activeDeveloperDirFn = originalActiveDeveloperDir
 	}
 }
 
@@ -543,6 +661,18 @@ func writeArchiveInfoPlist(archivePath string) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(archivePath, "Info.plist"), data, 0o644)
+}
+
+func writeExportOptionsPlist(t *testing.T, path string, payload map[string]any) {
+	t.Helper()
+
+	data, err := plist.Marshal(payload, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("plist.Marshal() error: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
 }
 
 func writeTestIPA(path string) error {


### PR DESCRIPTION
## Summary
- warn during `asc xcode export` when App Store export options are used with an active beta Xcode developer directory
- keep the behavior non-fatal and avoid changing output payloads or exit codes so existing scripts continue to work
- add regression coverage for beta App Store exports, stable App Store exports, and non-App-Store exports

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/xcode`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestXcode'`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`