### PR TITLE
apps wall: add Gradient Match Game: Descent

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -212,6 +212,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/11/49/d6/1149d644-0ac6-6277-9847-c9ac124510a8/AppIcon-0-1x_U007ephone-0-1-85-220-0.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Gradient Match Game: Descent",
+    "link": "https://apps.apple.com/us/app/gradient-match-game-descent/id1479784361?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e8/a4/81/e8a4813c-4d02-65b3-442a-3703431813d7/AppIcon-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "GrowPal: Health & Fitness",
     "link": "https://apps.apple.com/us/app/growpal-health-fitness/id1560604814?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0c/be/8b/0cbe8bfa-a36d-7ebb-6580-959481f43294/Grow-0-0-1x_U007ephone-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Gradient Match Game: Descent` to the Wall of Apps

## Entry

- App ID: 1479784361
- App: Gradient Match Game: Descent
- Link: https://apps.apple.com/us/app/gradient-match-game-descent/id1479784361?uo=4

## Notes

- Manual equivalent of `asc apps wall submit`
- `asc apps wall submit --app "1479784361" --dry-run` currently errors for the upstream owner account because it requires a fork under the authenticated GitHub login.
