### PR TITLE
apps wall: add FaceScreen - Desktop Camera

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -148,6 +148,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/60/71/236071d7-7827-efd9-4c8f-03db0cee6aa9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "FaceScreen - Desktop Camera",
+    "link": "https://apps.apple.com/us/app/facescreen-desktop-camera/id6702028512?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/71/89/797189ca-6bde-e2e0-9e24-99bd6593b928/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "Fermento Fermentation Journal",
     "link": "https://apps.apple.com/us/app/fermento-fermentation-journal/id6470132496?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e4/e3/59/e4e3593b-0e71-922d-2313-b31c35cde061/AppIcon-0-0-1x_U007epad-0-1-85-220.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `FaceScreen - Desktop Camera` to the Wall of Apps

## Entry

- App ID: 6702028512
- App: FaceScreen - Desktop Camera
- Link: https://apps.apple.com/us/app/facescreen-desktop-camera/id6702028512?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
