### PR TITLE
apps wall: add KeyScreen - Display Keystrokes

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -242,6 +242,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ee/f4/e6/eef4e6d4-c2af-3856-6cdf-80af085b1cb9/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "KeyScreen - Display Keystrokes",
+    "link": "https://apps.apple.com/us/app/keyscreen-display-keystrokes/id6753302381?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c8/38/fd/c838fddf-a2db-5007-12be-8cb9906926e1/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "Klick: keyboard sounds",
     "link": "https://apps.apple.com/us/app/klick-keyboard-sounds/id6758880736?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d1/c0/46/d1c046e6-f966-f063-e294-0a1969396b60/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `KeyScreen - Display Keystrokes` to the Wall of Apps

## Entry

- App ID: 6753302381
- App: KeyScreen - Display Keystrokes
- Link: https://apps.apple.com/us/app/keyscreen-display-keystrokes/id6753302381?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
