### PR TITLE
apps wall: add PrivaNota: Private AI Notes

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -436,6 +436,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7a/04/14/7a04148e-e548-f6bf-8c0e-c26b9157a7cb/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "PrivaNota: Private AI Notes",
+    "link": "https://apps.apple.com/us/app/privanota-private-ai-notes/id6752555660",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7f/e6/22/7fe622bc-1260-bcfd-a8e2-c179ba33e727/PrivaNota-0.6-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Progressio: Habit Tracker",
     "link": "https://apps.apple.com/app/progressio-habit-tracker/id6740454461",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0a/a6/3a/0aa63a87-186d-e560-42fe-377337abdd7a/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `PrivaNota: Private AI Notes` to the Wall of Apps

## Entry

- App: PrivaNota: Private AI Notes
- Link: https://apps.apple.com/us/app/privanota-private-ai-notes/id6752555660

## Notes

- Submitted via `asc apps wall submit`
