### PR TITLE
apps wall: add Impulses: Stop Impulse Buying

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -237,6 +237,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7b/43/73/7b4373fc-26e2-030b-7162-2f0ab0a7681d/AppIcon-0-0-1x_U007ewatch-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Impulses: Stop Impulse Buying",
+    "link": "https://apps.apple.com/us/app/impulses-stop-impulse-buying/id6754372500?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8a/05/57/8a055708-4850-8120-8070-91424269b2f7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Inkput",
     "link": "https://apps.apple.com/app/id6758570182",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/83/e2/68/83e26872-d3d5-ab92-7164-673371673443/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Impulses: Stop Impulse Buying` to the Wall of Apps

## Entry

- App ID: 6754372500
- App: Impulses: Stop Impulse Buying
- Link: https://apps.apple.com/us/app/impulses-stop-impulse-buying/id6754372500?uo=4

## Notes

- Submitted via `asc apps wall submit`
