### PR TITLE
apps wall: add CUStats Go - AI Usage Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -108,6 +108,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2b/cf/8b/2bcf8b94-8050-926d-bce1-b95266a061d0/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "CUStats Go",
+    "link": "https://apps.apple.com/us/app/custats-go/id6757679404?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5d/65/7f/5d657f01-3cf3-2d0b-c343-45112c16a295/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Dandelion",
     "link": "https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e1/e4/e3/e1e4e3af-42bc-bbb0-cd4d-3876d720de3e/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `CUStats Go` to the Wall of Apps

## Entry

- App ID: 6757679404
- App: CUStats Go - AI Usage Tracker
- Link: https://apps.apple.com/us/app/custats-go/id6757679404?uo=4

## Notes

- Submitted via `asc apps wall submit`
