### PR TITLE
apps wall: add Pop - Find by Color

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -436,6 +436,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5d/49/25/5d4925ae-e8d1-6d72-5f7c-28f78c126f0f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Pop - Find by Color",
+    "link": "https://apps.apple.com/us/app/pop-find-by-color/id6758629086?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ee/8a/b3/ee8ab36e-f44e-a3d8-baf5-bf9036af5532/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Popcorn Stack: Track Watchlist",
     "link": "https://apps.apple.com/app/id6759187614",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/1b/9c/62/1b9c62c3-b960-84cd-77a1-f1f4a734a572/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pop - Find by Color` to the Wall of Apps

## Entry

- App ID: 6758629086
- App: Pop - Find by Color
- Link: https://apps.apple.com/us/app/pop-find-by-color/id6758629086?uo=4

## Notes

- Submitted via `asc apps wall submit`
