### PR TITLE
feat: add `builds update` command for encryption compliance

### DIFF
--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -300,6 +300,49 @@ func (c *Client) GetBuildAppEncryptionDeclaration(ctx context.Context, buildID s
 	return &response, nil
 }
 
+// BuildUpdateAttributes describes mutable attributes on a build resource.
+type BuildUpdateAttributes struct {
+	UsesNonExemptEncryption *bool `json:"usesNonExemptEncryption,omitempty"`
+	Expired                 *bool `json:"expired,omitempty"`
+}
+
+// UpdateBuild patches a build resource with the given attributes.
+func (c *Client) UpdateBuild(ctx context.Context, buildID string, attrs BuildUpdateAttributes) (*BuildResponse, error) {
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("buildID is required")
+	}
+
+	payload := struct {
+		Data struct {
+			Type       ResourceType         `json:"type"`
+			ID         string               `json:"id"`
+			Attributes BuildUpdateAttributes `json:"attributes"`
+		} `json:"data"`
+	}{}
+	payload.Data.Type = ResourceTypeBuilds
+	payload.Data.ID = buildID
+	payload.Data.Attributes = attrs
+
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/v1/builds/%s", buildID)
+	data, err := c.do(ctx, "PATCH", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 // ExpireBuild expires a build for TestFlight testing.
 func (c *Client) ExpireBuild(ctx context.Context, buildID string) (*BuildResponse, error) {
 	payload := struct {

--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -136,6 +136,69 @@ func resolveBuildBetaGroupIDsFromList(inputGroups []string, groups *asc.BetaGrou
 	return resolvedIDs, nil
 }
 
+// BuildsUpdateCommand returns the builds update subcommand.
+func BuildsUpdateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("builds update", flag.ExitOnError)
+
+	buildID := fs.String("build", "", "Build ID (required)")
+	usesNonExemptEncryption := fs.String("uses-non-exempt-encryption", "", "Set encryption compliance: true or false")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "update",
+		ShortUsage: "asc builds update --build BUILD_ID [flags]",
+		ShortHelp:  "Update build attributes.",
+		LongHelp: `Update build attributes such as encryption compliance.
+
+Examples:
+  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false
+  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=true`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedBuildID := strings.TrimSpace(*buildID)
+			if trimmedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				return flag.ErrHelp
+			}
+
+			trimmedEncryption := strings.TrimSpace(strings.ToLower(*usesNonExemptEncryption))
+			if trimmedEncryption == "" {
+				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required (e.g. --uses-non-exempt-encryption)")
+				return flag.ErrHelp
+			}
+
+			attrs := asc.BuildUpdateAttributes{}
+			switch trimmedEncryption {
+			case "true":
+				v := true
+				attrs.UsesNonExemptEncryption = &v
+			case "false":
+				v := false
+				attrs.UsesNonExemptEncryption = &v
+			default:
+				return shared.UsageError("--uses-non-exempt-encryption must be 'true' or 'false'")
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("builds update: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.UpdateBuild(requestCtx, trimmedBuildID, attrs)
+			if err != nil {
+				return fmt.Errorf("builds update: %w", err)
+			}
+
+			fmt.Fprintf(os.Stderr, "Updated build %s\n", trimmedBuildID)
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+		},
+	}
+}
+
 // BuildsRemoveGroupsCommand returns the builds remove-groups subcommand.
 func BuildsRemoveGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-groups", flag.ExitOnError)

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -395,6 +395,7 @@ Examples:
   asc builds uploads list --app "123456789"
   asc builds test-notes list --build "BUILD_ID"
   asc builds individual-testers list --build "BUILD_ID"
+  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false
   asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
   asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID"
   asc builds app get --build "BUILD_ID"
@@ -419,6 +420,7 @@ Examples:
 			BuildsUploadsCommand(),
 			BuildsTestNotesCommand(),
 			BuildsAppEncryptionDeclarationCommand(),
+			BuildsUpdateCommand(),
 			BuildsAddGroupsCommand(),
 			BuildsRemoveGroupsCommand(),
 			BuildsIndividualTestersCommand(),

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -109,3 +109,40 @@ func TestNormalizeBuildProcessingStateFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildsUpdateCommand_Shape(t *testing.T) {
+	cmd := BuildsUpdateCommand()
+	if cmd.Name != "update" {
+		t.Fatalf("unexpected command name: %q", cmd.Name)
+	}
+
+	buildFlag := cmd.FlagSet.Lookup("build")
+	if buildFlag == nil {
+		t.Fatal("expected --build flag to be defined")
+	}
+
+	encFlag := cmd.FlagSet.Lookup("uses-non-exempt-encryption")
+	if encFlag == nil {
+		t.Fatal("expected --uses-non-exempt-encryption flag to be defined")
+	}
+}
+
+func TestBuildsUpdateCommand_HelpContainsExamples(t *testing.T) {
+	cmd := BuildsUpdateCommand()
+	if !strings.Contains(cmd.LongHelp, "--uses-non-exempt-encryption=false") {
+		t.Fatalf("expected long help to include encryption example, got %q", cmd.LongHelp)
+	}
+}
+
+func TestBuildUpdateAttributes_JSON(t *testing.T) {
+	v := false
+	attrs := asc.BuildUpdateAttributes{
+		UsesNonExemptEncryption: &v,
+	}
+	if attrs.UsesNonExemptEncryption == nil {
+		t.Fatal("expected UsesNonExemptEncryption to be set")
+	}
+	if *attrs.UsesNonExemptEncryption != false {
+		t.Fatal("expected UsesNonExemptEncryption to be false")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `asc builds update --build BUILD_ID --uses-non-exempt-encryption=false` to set the `usesNonExemptEncryption` attribute on builds via `PATCH /v1/builds/{id}`
- Without this, builds uploaded via `xcodebuild` require a manual API call or App Store Connect UI visit to clear the encryption flag before submission — a common blocker in CI/CD pipelines

## Changes
- **`internal/asc/client_builds.go`** — `BuildUpdateAttributes` struct + `UpdateBuild()` client method
- **`internal/cli/builds/builds.go`** — `BuildsUpdateCommand()` CLI command with validation
- **`internal/cli/builds/builds_commands.go`** — Registered in subcommand list + help examples
- **`internal/cli/builds/builds_commands_test.go`** — 3 tests (command shape, help content, attribute struct)

## Usage
```bash
# Set encryption compliance to false (most common case)
asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false

# Set encryption compliance to true
asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=true
```

## Test plan
- [x] `go build ./...` passes
- [x] 2289 tests pass across `internal/cli/builds` and `internal/asc` packages
- [x] `asc builds update --help` renders correctly
- [ ] Manual test: set `usesNonExemptEncryption=false` on a real build