### PR TITLE
apps wall: add Daily – Hours & Time Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -123,6 +123,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5d/65/7f/5d657f01-3cf3-2d0b-c343-45112c16a295/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Daily – Hours & Time Tracker",
+    "link": "https://apps.apple.com/us/app/daily-hours-time-tracker/id686910553?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f0/02/8d/f0028d3e-b002-ff2a-2c0a-0d60041bc9ff/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Dandelion",
     "link": "https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e1/e4/e3/e1e4e3af-42bc-bbb0-cd4d-3876d720de3e/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Daily – Hours & Time Tracker` to the Wall of Apps

## Entry

- App ID: 686910553
- App: Daily – Hours & Time Tracker
- Link: https://apps.apple.com/us/app/daily-hours-time-tracker/id686910553?uo=4

## Notes

- Submitted via `asc apps wall submit`
