### PR TITLE
apps wall: add Music Plus - Player Extensions

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -362,6 +362,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a6/6f/1d/a66f1dd5-40fb-a7e8-f089-53f1790e67d7/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Music Plus - Player Extensions",
+    "link": "https://apps.apple.com/us/app/music-plus-player-extensions/id1626398921?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/19/ce/4c/19ce4c8e-a1b5-2c3e-e44f-66011b347558/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Neurona: Binaural Beats",
     "link": "https://apps.apple.com/us/app/neurona-binaural-beats/id6757725304?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/1c/77/66/1c776632-25a0-9af7-38ac-2d6c31d42826/icon_composed-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Music Plus - Player Extensions` to the Wall of Apps

## Entry

- App ID: 1626398921
- App: Music Plus - Player Extensions
- Link: https://apps.apple.com/us/app/music-plus-player-extensions/id1626398921?uo=4

## Notes

- Submitted via `asc apps wall submit`
