### PR TITLE
apps wall: add Dtd Playlist-Daily Mood Music

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -168,6 +168,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/45/67/fd/4567fd8b-feb1-c665-e8e0-4b05a3016150/DrippedIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Dtd Playlist-Daily Mood Music",
+    "link": "https://apps.apple.com/us/app/dtd-playlist-daily-mood-music/id1631654360?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c3/12/31/c31231ef-8a43-d6dd-84e2-23728b669d59/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "EduSwipe: AI Flashcards & SRS",
     "link": "https://apps.apple.com/us/app/eduswipe-ai-flashcards-srs/id6744727106?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/60/71/236071d7-7827-efd9-4c8f-03db0cee6aa9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Dtd Playlist-Daily Mood Music` to the Wall of Apps

## Entry

- App ID: 1631654360
- App: Dtd Playlist-Daily Mood Music
- Link: https://apps.apple.com/us/app/dtd-playlist-daily-mood-music/id1631654360?uo=4

## Notes

- Submitted via `asc apps wall submit`
