### PR TITLE
apps wall: add Beauty Fonts - Font Keyboard

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -24,6 +24,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/de/bd/7c/debd7c60-6be9-a231-d7c0-aa54a776dc3c/astrologica-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Beauty Fonts - Font Keyboard",
+    "link": "https://apps.apple.com/us/app/beauty-fonts-font-keyboard/id1438854446?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ce/85/c5/ce85c50d-e009-34b8-96f1-924e6881a364/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Bibliostats",
     "link": "https://apps.apple.com/app/id6759411516",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/06/d8/48/06d84871-63f1-8c85-ceb5-e6a140b2831c/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Beauty Fonts - Font Keyboard` to the Wall of Apps

## Entry

- App ID: 1438854446
- App: Beauty Fonts - Font Keyboard
- Link: https://apps.apple.com/us/app/beauty-fonts-font-keyboard/id1438854446?uo=4

## Notes

- Submitted via `asc apps wall submit`
