### PR TITLE
apps wall: add OffScreen: Screen Time Control

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -417,6 +417,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d7/83/48/d783480d-74fa-4033-44ce-f4154c3ab7de/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "OffScreen: Screen Time Control",
+    "link": "https://apps.apple.com/us/app/offscreen-screen-time-control/id1474340105?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/00/51/2900519e-a076-de61-c91c-7e0313faf41e/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Palabros - Diccionario",
     "link": "https://apps.apple.com/us/app/palabros-diccionario/id6758098070?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a9/25/1a/a9251ac1-2d3d-c390-ffa7-29c0dc645d45/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `OffScreen: Screen Time Control` to the Wall of Apps

## Entry

- App ID: 1474340105
- App: OffScreen: Screen Time Control
- Link: https://apps.apple.com/us/app/offscreen-screen-time-control/id1474340105?uo=4

## Notes

- Submitted via `asc apps wall submit`
