### PR TITLE
apps wall: add Appboard: Find Apps · Rankings

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -14,6 +14,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a1/85/81/a185815f-0e82-98b4-ac37-aed44c57d719/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Appboard: Find Apps · Rankings",
+    "link": "https://apps.apple.com/us/app/appboard-find-apps-rankings/id1667492380?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b8/86/4e/b8864eea-7c79-4b57-dc58-4a208fc28863/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Aseta - Net Worth Tracker",
     "link": "https://apps.apple.com/us/app/aseta-net-worth-tracker/id6759186841?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/32/51/2d/32512d40-1347-5bcc-5a37-845b35c537ea/AppIconAseta-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Appboard: Find Apps · Rankings` to the Wall of Apps

## Entry

- App ID: 1667492380
- App: Appboard: Find Apps · Rankings
- Link: https://apps.apple.com/us/app/appboard-find-apps-rankings/id1667492380?uo=4

## Notes

- Submitted via `asc apps wall submit`
