### PR TITLE
apps wall: add Scap: Screenshot & Markup Edit

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -596,6 +596,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/86/a6/a286a647-d984-7f1d-6f2b-7d4fda64c3e2/App_Icon-marketing.lsr/512x512bb.jpg"
   },
   {
+    "app": "Scap: Screenshot & Markup Edit",
+    "link": "https://apps.apple.com/us/app/scap-screenshot-markup-edit/id6758053530?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/95/ed/7c/95ed7cad-90a7-5d3b-8742-444542d3dc55/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "Sharing Me: Shared Journal",
     "link": "https://apps.apple.com/us/app/sharing-me-shared-journal/id6756325680?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/53/33/66/53336647-1330-96ad-575f-1bdb47d653d1/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Scap: Screenshot & Markup Edit` to the Wall of Apps

## Entry

- App ID: 6758053530
- App: Scap: Screenshot & Markup Edit
- Link: https://apps.apple.com/us/app/scap-screenshot-markup-edit/id6758053530?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
