### PR TITLE
apps wall: add Menuist: Right-Click & MenuBar

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -377,6 +377,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2f/ca/21/2fca210d-91ad-8736-575b-d729d3002f17/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Menuist: Right-Click & MenuBar",
+    "link": "https://apps.apple.com/us/app/menuist-right-click-menubar/id6737160756?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7e/f5/ee/7ef5eea0-ae74-a4a1-475a-4df5b8bab935/AppIcon-0-0-85-220-0-5-0-2x-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "Meshing",
     "link": "https://apps.apple.com/app/id6567933550",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/77/7b/8f/777b8f6c-b8e6-0fef-50fb-9e6a59166d06/Meshing_Icon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Menuist: Right-Click & MenuBar` to the Wall of Apps

## Entry

- App ID: 6737160756
- App: Menuist: Right-Click & MenuBar
- Link: https://apps.apple.com/us/app/menuist-right-click-menubar/id6737160756?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
