### PR TITLE
apps wall: add Musicer: Simple music player

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -422,6 +422,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/19/ce/4c/19ce4c8e-a1b5-2c3e-e44f-66011b347558/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Musicer: Simple music player",
+    "link": "https://apps.apple.com/us/app/musicer-simple-music-player/id6745227444?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a0/aa/b2/a0aab285-9678-bfb9-a1dc-eff837ccef12/AppIcon-0-0-85-220-0-5-0-2x-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "Neurona: Binaural Beats",
     "link": "https://apps.apple.com/us/app/neurona-binaural-beats/id6757725304?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/1c/77/66/1c776632-25a0-9af7-38ac-2d6c31d42826/icon_composed-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Musicer: Simple music player` to the Wall of Apps

## Entry

- App ID: 6745227444
- App: Musicer: Simple music player
- Link: https://apps.apple.com/us/app/musicer-simple-music-player/id6745227444?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
