### PR TITLE
apps wall: add Truessay: Academic AI Writer

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -725,6 +725,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/1d/b0/ea/1db0eaa8-4504-cbe3-b472-5eab73d634c9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Truessay: Academic AI Writer",
+    "link": "https://apps.apple.com/us/app/truessay-academic-ai-writer/id6757461906?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ea/b1/01/eab10103-3a5d-9de7-5094-0e6233c9c034/AppIcon-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "TV Show Tracker",
     "link": "https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/b8/67/43b86702-f67b-c314-f65b-cd60980205b0/Icon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Truessay: Academic AI Writer` to the Wall of Apps

## Entry

- App ID: 6757461906
- App: Truessay: Academic AI Writer
- Link: https://apps.apple.com/us/app/truessay-academic-ai-writer/id6757461906?uo=4

## Notes

- Submitted via `asc apps wall submit`
