### PR TITLE
apps wall: add QuickPhrase - Quick Text Input

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -581,6 +581,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d6/55/7f/d6557fd2-7a41-2057-7ca4-0b67c1c0638c/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "QuickPhrase - Quick Text Input",
+    "link": "https://apps.apple.com/us/app/quickphrase-quick-text-input/id6756532440?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e5/28/3e/e5283eca-f679-a08e-a84f-8284e09f044d/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Quietude",
     "link": "https://apps.apple.com/app/id6758955377",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/57/73/ae/5773ae23-b9f6-362c-893f-c2d85e59e916/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `QuickPhrase - Quick Text Input` to the Wall of Apps

## Entry

- App ID: 6756532440
- App: QuickPhrase - Quick Text Input
- Link: https://apps.apple.com/us/app/quickphrase-quick-text-input/id6756532440?uo=4

## Notes

- Submitted via `asc apps wall submit`
