### PR TITLE
fix(auth): preserve config fallback credentials on default switches

### DIFF
--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -1478,10 +1478,6 @@ func saveDefaultName(name string) error {
 		cfg = &config.Config{}
 	}
 	trimmedName := strings.TrimSpace(name)
-	previousDefault := strings.TrimSpace(cfg.DefaultKeyName)
-	if previousDefault == "" {
-		previousDefault = "default"
-	}
 	cfg.DefaultKeyName = trimmedName
 	if trimmedName != "" {
 		for _, cred := range cfg.Keys {
@@ -1492,11 +1488,6 @@ func saveDefaultName(name string) error {
 				return config.Save(cfg)
 			}
 		}
-	}
-	if trimmedName != previousDefault {
-		cfg.KeyID = ""
-		cfg.IssuerID = ""
-		cfg.PrivateKeyPath = ""
 	}
 	return config.Save(cfg)
 }

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -329,7 +329,7 @@ func TestSaveDefaultNameAlignsLegacyFields(t *testing.T) {
 	}
 }
 
-func TestSaveDefaultNameClearsLegacyFieldsOnMismatch(t *testing.T) {
+func TestSaveDefaultNamePreservesLegacyFieldsOnMismatch(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)
@@ -364,8 +364,14 @@ func TestSaveDefaultNameClearsLegacyFieldsOnMismatch(t *testing.T) {
 	if updated.DefaultKeyName != "other" {
 		t.Fatalf("expected DefaultKeyName to be other, got %q", updated.DefaultKeyName)
 	}
-	if updated.KeyID != "" || updated.IssuerID != "" || updated.PrivateKeyPath != "" {
-		t.Fatal("expected legacy credentials to be cleared when no matching profile")
+	if updated.KeyID != "KEY1" {
+		t.Fatalf("expected legacy KeyID KEY1 to be preserved, got %q", updated.KeyID)
+	}
+	if updated.IssuerID != "ISSUER1" {
+		t.Fatalf("expected legacy IssuerID ISSUER1 to be preserved, got %q", updated.IssuerID)
+	}
+	if updated.PrivateKeyPath != "/tmp/personal.p8" {
+		t.Fatalf("expected legacy PrivateKeyPath /tmp/personal.p8 to be preserved, got %q", updated.PrivateKeyPath)
 	}
 }
 

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -494,6 +494,55 @@ func TestAuthSwitchCommand(t *testing.T) {
 			t.Fatalf("DefaultKeyName = %q, want demo", cfg.DefaultKeyName)
 		}
 	})
+
+	t.Run("preserves legacy fallback fields for summary-only profile", func(t *testing.T) {
+		cfgPath := filepath.Join(t.TempDir(), "config.json")
+		t.Setenv("ASC_CONFIG_PATH", cfgPath)
+
+		if err := config.SaveAt(cfgPath, &config.Config{
+			DefaultKeyName: "personal",
+			KeyID:          "KEY1",
+			IssuerID:       "ISSUER1",
+			PrivateKeyPath: "/tmp/personal.p8",
+		}); err != nil {
+			t.Fatalf("SaveAt() error: %v", err)
+		}
+
+		restoreSummary := SetListCredentialSummaries(func() ([]authsvc.Credential, error) {
+			return []authsvc.Credential{{
+				Name:      "other",
+				KeyID:     "KEY2",
+				IsDefault: false,
+				Source:    "keychain",
+			}}, nil
+		})
+		t.Cleanup(restoreSummary)
+
+		cmd := AuthSwitchCommand()
+		if err := cmd.FlagSet.Parse([]string{"--name", "other"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		if err := cmd.Exec(context.Background(), []string{}); err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+
+		cfg, err := config.LoadAt(cfgPath)
+		if err != nil {
+			t.Fatalf("LoadAt() error: %v", err)
+		}
+		if cfg.DefaultKeyName != "other" {
+			t.Fatalf("DefaultKeyName = %q, want other", cfg.DefaultKeyName)
+		}
+		if cfg.KeyID != "KEY1" {
+			t.Fatalf("KeyID = %q, want KEY1", cfg.KeyID)
+		}
+		if cfg.IssuerID != "ISSUER1" {
+			t.Fatalf("IssuerID = %q, want ISSUER1", cfg.IssuerID)
+		}
+		if cfg.PrivateKeyPath != "/tmp/personal.p8" {
+			t.Fatalf("PrivateKeyPath = %q, want /tmp/personal.p8", cfg.PrivateKeyPath)
+		}
+	})
 }
 
 func TestAuthLogoutCommand(t *testing.T) {


### PR DESCRIPTION
## Summary
- reproduce the config rewrite with a regression that shows `saveDefaultName()` blanking top-level fallback credentials when the default profile changes
- stop `saveDefaultName()` from clearing `key_id`, `issuer_id`, and `private_key_path` when only `default_key_name` changes
- add command-level coverage for `asc auth switch --name ...` so switching to a summary-only keychain profile keeps `ASC_BYPASS_KEYCHAIN=1` fallback auth intact

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/auth -run TestSaveDefaultNamePreservesLegacyFieldsOnMismatch -count=1`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/auth -run 'TestAuthSwitchCommand/(success|preserves legacy fallback fields for summary-only profile)' -count=1`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/auth ./internal/cli/auth ./internal/cli/cmdtest -count=1`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`