### PR TITLE
apps wall: add Subbie - Money Calendar

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -701,6 +701,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/1e/b8/78/1eb878a7-0955-eb1a-f55a-09b630362b71/sw-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Subbie - Money Calendar",
+    "link": "https://apps.apple.com/us/app/subbie-money-calendar/id6759132543?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c5/07/a8/c507a8be-d488-516e-c971-8005a7751fd1/AppIcon-0-0-1x_U007epad-0-1-0-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SubList: Subscription List",
     "link": "https://apps.apple.com/us/app/sublist-subscription-list/id6757860829?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/45/7e/dd/457edd6b-d9f7-89a7-99b2-72a72cab212f/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Subbie - Money Calendar` to the Wall of Apps

## Entry

- App ID: 6759132543
- App: Subbie - Money Calendar
- Link: https://apps.apple.com/us/app/subbie-money-calendar/id6759132543?uo=4

## Notes

- Submitted via `asc apps wall submit`
