### PR TITLE
Add beta review submission option to builds add-groups

### DIFF
--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -20,11 +21,13 @@ func BuildsAddGroupsCommand() *ffcli.Command {
 	buildID := fs.String("build", "", "Build ID")
 	groups := fs.String("group", "", "Comma-separated beta group IDs or names")
 	skipInternal := fs.Bool("skip-internal", false, "Skip internal beta groups instead of adding them")
+	submit := fs.Bool("submit", false, "Submit build for beta app review after adding external groups")
+	confirm := fs.Bool("confirm", false, "Confirm beta app review submission (required with --submit)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "add-groups",
-		ShortUsage: "asc builds add-groups --build BUILD_ID --group GROUP_ID[,GROUP_ID...]",
+		ShortUsage: "asc builds add-groups --build BUILD_ID --group GROUP_ID[,GROUP_ID...] [--submit --confirm]",
 		ShortHelp:  "Add beta groups to a build for TestFlight distribution.",
 		LongHelp: `Add beta groups to a build for TestFlight distribution.
 
@@ -32,7 +35,8 @@ Examples:
   asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
   asc builds add-groups --build "BUILD_ID" --group "External Testers"
   asc builds add-groups --build "BUILD_ID" --group "GROUP1,GROUP2"
-  asc builds add-groups --build "BUILD_ID" --group "INTERNAL_ID,EXTERNAL_ID" --skip-internal`,
+  asc builds add-groups --build "BUILD_ID" --group "INTERNAL_ID,EXTERNAL_ID" --skip-internal
+  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID" --submit --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -45,6 +49,14 @@ Examples:
 			groupInputs := shared.SplitCSV(*groups)
 			if len(groupInputs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
+				return flag.ErrHelp
+			}
+			if *submit && !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --submit")
+				return flag.ErrHelp
+			}
+			if *confirm && !*submit {
+				fmt.Fprintln(os.Stderr, "Error: --confirm requires --submit")
 				return flag.ErrHelp
 			}
 
@@ -68,6 +80,11 @@ Examples:
 				return fmt.Errorf("builds add-groups: failed to add groups: %w", err)
 			}
 
+			submissionMessage, err := submitBuildBetaReviewIfNeeded(requestCtx, client, trimmedBuildID, resolvedGroups, addResult.AddedGroupIDs, *submit)
+			if err != nil {
+				return err
+			}
+
 			for _, group := range addResult.SkippedInternalGroups {
 				fmt.Fprintf(
 					os.Stderr,
@@ -79,6 +96,14 @@ Examples:
 
 			if len(addResult.AddedGroupIDs) == 0 {
 				fmt.Fprintf(os.Stderr, "No groups to add for build %s after applying filters\n", trimmedBuildID)
+			} else {
+				fmt.Fprintf(os.Stderr, "Successfully added %d group(s) to build %s\n", len(addResult.AddedGroupIDs), trimmedBuildID)
+			}
+			if submissionMessage != "" {
+				fmt.Fprintln(os.Stderr, submissionMessage)
+			}
+
+			if len(addResult.AddedGroupIDs) == 0 {
 				result := &asc.BuildBetaGroupsUpdateResult{
 					BuildID:  trimmedBuildID,
 					GroupIDs: []string{},
@@ -87,7 +112,6 @@ Examples:
 				return shared.PrintOutput(result, *output.Output, *output.Pretty)
 			}
 
-			fmt.Fprintf(os.Stderr, "Successfully added %d group(s) to build %s\n", len(addResult.AddedGroupIDs), trimmedBuildID)
 			result := &asc.BuildBetaGroupsUpdateResult{
 				BuildID:  trimmedBuildID,
 				GroupIDs: addResult.AddedGroupIDs,
@@ -134,6 +158,56 @@ func resolveBuildBetaGroupIDsFromList(inputGroups []string, groups *asc.BetaGrou
 		resolvedIDs = append(resolvedIDs, group.ID)
 	}
 	return resolvedIDs, nil
+}
+
+func submitBuildBetaReviewIfNeeded(ctx context.Context, client *asc.Client, buildID string, groups []resolvedBuildBetaGroup, addedGroupIDs []string, submit bool) (string, error) {
+	if !submit {
+		return "", nil
+	}
+
+	if !hasAddedExternalBuildBetaGroup(groups, addedGroupIDs) {
+		return fmt.Sprintf("Skipped beta app review submission for build %s because no external groups were added", buildID), nil
+	}
+
+	existingSubmission, err := client.GetBuildBetaAppReviewSubmission(ctx, buildID)
+	if err == nil {
+		submissionID := strings.TrimSpace(existingSubmission.Data.ID)
+		if submissionID == "" {
+			return fmt.Sprintf("Build %s already has a beta app review submission", buildID), nil
+		}
+		return fmt.Sprintf("Build %s already has beta app review submission %s", buildID, submissionID), nil
+	}
+	if !asc.IsNotFound(err) {
+		return "", fmt.Errorf("builds add-groups: failed to inspect beta app review submission: %w", err)
+	}
+
+	submission, err := client.CreateBetaAppReviewSubmission(ctx, buildID)
+	if err != nil {
+		return "", fmt.Errorf("builds add-groups: beta groups were added to build %q, but beta app review submission failed: %w", buildID, err)
+	}
+
+	submissionID := strings.TrimSpace(submission.Data.ID)
+	if submissionID == "" {
+		return fmt.Sprintf("Submitted build %s for beta app review", buildID), nil
+	}
+	return fmt.Sprintf("Submitted build %s for beta app review (%s)", buildID, submissionID), nil
+}
+
+func hasAddedExternalBuildBetaGroup(groups []resolvedBuildBetaGroup, addedGroupIDs []string) bool {
+	if len(groups) == 0 || len(addedGroupIDs) == 0 {
+		return false
+	}
+
+	for _, group := range groups {
+		if group.IsInternalGroup {
+			continue
+		}
+		if slices.Contains(addedGroupIDs, group.ID) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // BuildsUpdateCommand returns the builds update subcommand.

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -398,6 +398,7 @@ Examples:
   asc builds individual-testers list --build "BUILD_ID"
   asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false
   asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
+  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID" --submit --confirm
   asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID"
   asc builds app get --build "BUILD_ID"
   asc builds pre-release-version get --build "BUILD_ID"

--- a/internal/cli/cmdtest/builds_add_groups_submit_test.go
+++ b/internal/cli/cmdtest/builds_add_groups_submit_test.go
@@ -1,0 +1,323 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildsAddGroupsSubmitCreatesBetaReviewSubmissionForExternalGroups(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/app" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read request body: %v", err)
+			}
+			if !strings.Contains(string(payload), `"id":"group-external"`) {
+				t.Fatalf("expected beta group add payload to include group-external, got %s", string(payload))
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`), nil
+		case 5:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppReviewSubmissions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read request body: %v", err)
+			}
+			bodyText := string(payload)
+			if !strings.Contains(bodyText, `"type":"betaAppReviewSubmissions"`) || !strings.Contains(bodyText, `"id":"build-1"`) {
+				t.Fatalf("expected beta review submission payload for build-1, got %s", bodyText)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"betaAppReviewSubmissions","id":"submission-1"}}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "add-groups",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 5 {
+		t.Fatalf("expected app lookup, group lookup, add request, submission lookup, and submission create; got %d requests", requestCount)
+	}
+	if !strings.Contains(stdout, `"groupIds":["group-external"]`) {
+		t.Fatalf("expected external group in output, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Successfully added 1 group(s) to build build-1") {
+		t.Fatalf("expected add-groups success message, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Submitted build build-1 for beta app review (submission-1)") {
+		t.Fatalf("expected beta review submission message, got %q", stderr)
+	}
+}
+
+func TestBuildsAddGroupsSubmitSkipsBetaReviewSubmissionForInternalGroups(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/app" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-internal","attributes":{"name":"Friends & Family","isInternalGroup":true}}]}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read request body: %v", err)
+			}
+			if !strings.Contains(string(payload), `"id":"group-internal"`) {
+				t.Fatalf("expected beta group add payload to include group-internal, got %s", string(payload))
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "add-groups",
+			"--build", "build-1",
+			"--group", "group-internal",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 3 {
+		t.Fatalf("expected app lookup, group lookup, and add request; got %d requests", requestCount)
+	}
+	if !strings.Contains(stdout, `"groupIds":["group-internal"]`) {
+		t.Fatalf("expected internal group in output, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Successfully added 1 group(s) to build build-1") {
+		t.Fatalf("expected add-groups success message, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Skipped beta app review submission for build build-1 because no external groups were added") {
+		t.Fatalf("expected beta review skip message, got %q", stderr)
+	}
+}
+
+func TestBuildsAddGroupsSubmitTreatsExistingSubmissionAsAlreadyDone(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/app" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"betaAppReviewSubmissions","id":"submission-existing"}}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "add-groups",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 4 {
+		t.Fatalf("expected app lookup, group lookup, add request, and submission lookup; got %d requests", requestCount)
+	}
+	if !strings.Contains(stdout, `"groupIds":["group-external"]`) {
+		t.Fatalf("expected external group in output, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Build build-1 already has beta app review submission submission-existing") {
+		t.Fatalf("expected existing submission message, got %q", stderr)
+	}
+}
+
+func TestBuildsAddGroupsSubmitPreservesPartialSuccessWhenSubmissionFails(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/app" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`), nil
+		case 5:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppReviewSubmissions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable","detail":"beta review temporarily unavailable"}]}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "add-groups",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(runErr.Error(), `builds add-groups: beta groups were added to build "build-1", but beta app review submission failed`) {
+		t.Fatalf("expected partial-success error, got %v", runErr)
+	}
+	if strings.Contains(runErr.Error(), "failed to add groups") {
+		t.Fatalf("did not expect misleading add-groups wrapper, got %v", runErr)
+	}
+	if !strings.Contains(runErr.Error(), "Service unavailable: beta review temporarily unavailable") {
+		t.Fatalf("expected underlying submission error, got %v", runErr)
+	}
+}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -439,6 +439,16 @@ func TestBuildsGroupValidationErrors(t *testing.T) {
 			wantErr: "Error: --group is required",
 		},
 		{
+			name:    "builds add-groups submit missing confirm",
+			args:    []string{"builds", "add-groups", "--build", "BUILD_123", "--group", "GROUP_123", "--submit"},
+			wantErr: "Error: --confirm is required with --submit",
+		},
+		{
+			name:    "builds add-groups confirm requires submit",
+			args:    []string{"builds", "add-groups", "--build", "BUILD_123", "--group", "GROUP_123", "--confirm"},
+			wantErr: "Error: --confirm requires --submit",
+		},
+		{
 			name:    "builds remove-groups missing build",
 			args:    []string{"builds", "remove-groups"},
 			wantErr: "Error: --build is required",

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -98,6 +98,7 @@ asc submit create --app "APP_ID" --version "1.0.0" --build "BUILD_ID" --confirm
 asc testflight groups list --app "APP_ID"
 asc testflight groups list --app "APP_ID" --internal
 asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
+asc builds add-groups --build "BUILD_ID" --group "GROUP_ID" --submit --confirm
 ```
 
 ### Migrate Metadata (Fastlane)


### PR DESCRIPTION
Closes #1175

## Summary
- add `--submit --confirm` to `asc builds add-groups` so external TestFlight distribution can optionally create the beta app review submission in the same command
- skip review submission when no external groups were added and treat an existing build review submission as already complete instead of failing
- cover validation, successful submission, internal-only no-op, existing submission, and partial-success failure handling in cmdtests

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestBuilds(AddGroupsSubmit|GroupValidationErrors)'`
- [x] `go build -o /tmp/asc-submit .`
- [x] `/tmp/asc-submit builds add-groups --build BUILD_123 --group GROUP_123 --submit` returns exit code `2` with `Error: --confirm is required with --submit`
- [x] `make format`
- [x] `make generate-command-docs`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`