### PR TITLE
apps wall: add Auto Metric -  Expense Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -34,6 +34,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/75/4b/bd/754bbd84-d6f5-3393-1de4-b0b04c6be328/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
+    "app": "Auto Metric -  Expense Tracker",
+    "link": "https://apps.apple.com/us/app/auto-metric-expense-tracker/id6757914584?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/51/07/86/51078666-e31e-5e8c-14f8-833eb7091863/AppIcon-1x_U007emarketing-0-11-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Beauty Fonts - Font Keyboard",
     "link": "https://apps.apple.com/us/app/beauty-fonts-font-keyboard/id1438854446?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ce/85/c5/ce85c50d-e009-34b8-96f1-924e6881a364/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Auto Metric -  Expense Tracker` to the Wall of Apps

## Entry

- App ID: 6757914584
- App: Auto Metric -  Expense Tracker
- Link: https://apps.apple.com/us/app/auto-metric-expense-tracker/id6757914584?uo=4

## Notes

- Submitted via `asc apps wall submit`
