### PR TITLE
screenshots: pin Koubou to 0.17.1 and preserve stable frame slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ For full command families, flags, and discovery patterns, see:
 
 ## Acknowledgements
 
-Local screenshot framing uses Koubou (pinned to `0.14.0`) for deterministic device-frame rendering.
+Local screenshot framing uses Koubou (pinned to `0.17.1`) for deterministic device-frame rendering.
 GitHub: https://github.com/bitomule/koubou
 
 Simulator UI automation for screenshot capture and interactions uses AXe CLI.

--- a/internal/cli/cmdtest/shots_frame_test.go
+++ b/internal/cli/cmdtest/shots_frame_test.go
@@ -99,7 +99,12 @@ func TestShotsFrame_DefaultDeviceIsIPhoneAir(t *testing.T) {
 	writeFramePNG(t, rawPath, makeRawImage(100, 220))
 	kouFixturePath := filepath.Join(t.TempDir(), "kou-fixture.png")
 	writeFramePNG(t, kouFixturePath, makeRawImage(1320, 2868))
-	installMockKou(t, kouFixturePath, filepath.Join(t.TempDir(), "kou-out", "framed.png"))
+	installValidatingMockKou(
+		t,
+		kouFixturePath,
+		filepath.Join(t.TempDir(), "kou-out", "framed.png"),
+		"iPhone 16 Pro - White Titanium - Portrait",
+	)
 
 	outputDir := filepath.Join(t.TempDir(), "framed")
 	root := RootCommand("1.2.3")
@@ -626,7 +631,7 @@ func installMockKou(t *testing.T, fixturePath, outputPath string) {
 	kouPath := filepath.Join(binDir, "kou")
 	script := `#!/bin/sh
 if [ "$1" = "--version" ]; then
-  echo "kou 0.14.0"
+  echo "kou 0.17.1"
   exit 0
 fi
 if [ "$1" = "generate" ]; then
@@ -642,6 +647,39 @@ exit 1
 		t.Fatalf("write kou mock script: %v", err)
 	}
 
+	t.Setenv("MOCK_KOU_FIXTURE", fixturePath)
+	t.Setenv("MOCK_KOU_OUTPUT", outputPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func installValidatingMockKou(t *testing.T, fixturePath, outputPath, expectedDevice string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	kouPath := filepath.Join(binDir, "kou")
+	script := `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "kou 0.17.1"
+  exit 0
+fi
+if [ "$1" = "generate" ]; then
+  if ! grep -F "$MOCK_KOU_EXPECTED_DEVICE" "$2" >/dev/null 2>&1; then
+    echo "Unexpected error: unsupported device frame" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$MOCK_KOU_OUTPUT")"
+  cp "$MOCK_KOU_FIXTURE" "$MOCK_KOU_OUTPUT"
+  printf '[{"name":"framed","path":"%s","success":true}]' "$MOCK_KOU_OUTPUT"
+  exit 0
+fi
+echo "unsupported args" >&2
+exit 1
+`
+	if err := os.WriteFile(kouPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write kou mock script: %v", err)
+	}
+
+	t.Setenv("MOCK_KOU_EXPECTED_DEVICE", expectedDevice)
 	t.Setenv("MOCK_KOU_FIXTURE", fixturePath)
 	t.Setenv("MOCK_KOU_OUTPUT", outputPath)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/cli/shots/shots_frame.go
+++ b/internal/cli/shots/shots_frame.go
@@ -47,7 +47,7 @@ func ShotsFrameCommand() *ffcli.Command {
 		ShortHelp:  "[experimental] Compose a screenshot into an Apple device frame.",
 		LongHelp: `Compose screenshots using Koubou's YAML-based rendering flow (experimental).
 
-Requires Koubou v0.14.0 (pip install koubou==0.14.0).
+Requires Koubou v0.17.1 (pip install koubou==0.17.1).
 
 Use either --input (auto-generated Koubou config) or --config (explicit Koubou YAML).
 

--- a/internal/screenshots/frame.go
+++ b/internal/screenshots/frame.go
@@ -31,7 +31,7 @@ const (
 	FrameDeviceIPhone17    FrameDevice = "iphone-17"
 	FrameDeviceMac         FrameDevice = "mac"
 
-	pinnedKoubouVersion = "0.14.0"
+	pinnedKoubouVersion = "0.17.1"
 )
 
 const (
@@ -73,35 +73,42 @@ var supportedFrameDevices = []FrameDevice{
 
 type frameDeviceKoubouSpec struct {
 	FrameName   string
+	Aliases     []string
 	OutputSize  string // Koubou named size (e.g. "iPhone6_9" or "AppDesktop_2880")
 	DisplayType string
 	Canvas      bool // true = plain canvas, no device bezel; screenshot scaled to fill
 }
 
-// Keeps the existing asc device slugs while delegating rendering to Koubou frame names.
+// Keeps the existing asc device slugs while delegating rendering to pinned
+// Koubou v0.17.1 frame names.
 var frameDeviceKoubouSpecs = map[FrameDevice]frameDeviceKoubouSpec{
 	FrameDeviceIPhoneAir: {
-		FrameName:   "iPhone Air - Light Gold - Portrait",
+		FrameName:   "iPhone 16 Pro - White Titanium - Portrait",
+		Aliases:     []string{"iPhone Air - Light Gold - Portrait"},
 		OutputSize:  "iPhone6_9",
 		DisplayType: "APP_IPHONE_69",
 	},
 	FrameDeviceIPhone17PM: {
-		FrameName:   "iPhone 17 Pro Max - Silver - Portrait",
+		FrameName:   "iPhone 16 Pro Max - White Titanium - Portrait",
+		Aliases:     []string{"iPhone 17 Pro Max - Silver - Portrait"},
 		OutputSize:  "iPhone6_9",
 		DisplayType: "APP_IPHONE_69",
 	},
 	FrameDeviceIPhone17Pro: {
-		FrameName:   "iPhone 17 Pro - Silver - Portrait",
+		FrameName:   "iPhone 15 Pro - White Titanium - Portrait",
+		Aliases:     []string{"iPhone 17 Pro - Silver - Portrait"},
 		OutputSize:  "iPhone6_7",
 		DisplayType: "APP_IPHONE_67",
 	},
 	FrameDeviceIPhone17: {
-		FrameName:   "iPhone 17 - Teal - Portrait",
+		FrameName:   "iPhone 14 Pro Portrait",
+		Aliases:     []string{"iPhone 17 - Teal - Portrait"},
 		OutputSize:  "iPhone6_7",
 		DisplayType: "APP_IPHONE_67",
 	},
 	FrameDeviceIPhone16e: {
-		FrameName:   "iPhone 16e - White - Portrait",
+		FrameName:   "iPhone 16 - White - Portrait",
+		Aliases:     []string{"iPhone 16e - White - Portrait"},
 		OutputSize:  "iPhone6_1",
 		DisplayType: "APP_IPHONE_61",
 	},
@@ -558,11 +565,23 @@ func resolveFrameDeviceForConfig(frameRef, fallback string) string {
 		return fallback
 	}
 	for device, spec := range frameDeviceKoubouSpecs {
-		if strings.EqualFold(strings.TrimSpace(spec.FrameName), trimmedFrameRef) {
+		if frameSpecMatchesFrameRef(spec, trimmedFrameRef) {
 			return string(device)
 		}
 	}
 	return trimmedFrameRef
+}
+
+func frameSpecMatchesFrameRef(spec frameDeviceKoubouSpec, frameRef string) bool {
+	if strings.EqualFold(strings.TrimSpace(spec.FrameName), frameRef) {
+		return true
+	}
+	for _, alias := range spec.Aliases {
+		if strings.EqualFold(strings.TrimSpace(alias), frameRef) {
+			return true
+		}
+	}
+	return false
 }
 
 // ResolveFrameDeviceFromConfig resolves the config device to a supported CLI slug.

--- a/internal/screenshots/frame_bench_test.go
+++ b/internal/screenshots/frame_bench_test.go
@@ -15,7 +15,7 @@ func prepareKoubouVersionBenchmark(b *testing.B) {
 	script := `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.14.0"
+  echo "kou 0.17.1"
   exit 0
 fi
 echo "unsupported args" >&2

--- a/internal/screenshots/frame_test.go
+++ b/internal/screenshots/frame_test.go
@@ -45,6 +45,27 @@ func TestFrameDeviceOptions_DefaultMarked(t *testing.T) {
 	}
 }
 
+func TestFrameDeviceKoubouSpecs_UsePinnedKoubouFrames(t *testing.T) {
+	want := map[FrameDevice]string{
+		FrameDeviceIPhoneAir:   "iPhone 16 Pro - White Titanium - Portrait",
+		FrameDeviceIPhone17PM:  "iPhone 16 Pro Max - White Titanium - Portrait",
+		FrameDeviceIPhone17Pro: "iPhone 15 Pro - White Titanium - Portrait",
+		FrameDeviceIPhone17:    "iPhone 14 Pro Portrait",
+		FrameDeviceIPhone16e:   "iPhone 16 - White - Portrait",
+		FrameDeviceMac:         "Mac",
+	}
+
+	for device, wantFrame := range want {
+		spec, ok := frameDeviceKoubouSpecs[device]
+		if !ok {
+			t.Fatalf("missing Koubou spec for %q", device)
+		}
+		if spec.FrameName != wantFrame {
+			t.Fatalf("%q FrameName = %q, want %q", device, spec.FrameName, wantFrame)
+		}
+	}
+}
+
 func TestParseFrameDevice_NormalizesInput(t *testing.T) {
 	tests := []struct {
 		name string
@@ -267,7 +288,7 @@ func installFrameTestMockKou(t *testing.T, fixturePath, outputPath string) {
 	kouPath := filepath.Join(binDir, "kou")
 	script := `#!/bin/sh
 if [ "$1" = "--version" ]; then
-  echo "kou 0.14.0"
+  echo "kou 0.17.1"
   exit 0
 fi
 if [ "$1" = "generate" ]; then
@@ -500,7 +521,7 @@ func TestRunKoubouGenerate_ParsesJSONFromStdoutWhenStderrHasWarnings(t *testing.
 	writeExecutable(t, filepath.Join(binDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.14.0"
+  echo "kou 0.17.1"
   exit 0
 fi
 if [ "$1" != "generate" ]; then
@@ -548,7 +569,7 @@ exit 1
 	if !strings.Contains(err.Error(), "unsupported Koubou version 0.12.0") {
 		t.Fatalf("expected unsupported version error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "0.14.0") {
+	if !strings.Contains(err.Error(), "0.17.1") {
 		t.Fatalf("expected pinned version in error, got %v", err)
 	}
 }
@@ -560,7 +581,7 @@ func TestRunKoubouGenerate_NotFoundIncludesPinnedInstallHint(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected not found error")
 	}
-	if !strings.Contains(err.Error(), "pip install koubou==0.14.0") {
+	if !strings.Contains(err.Error(), "pip install koubou==0.17.1") {
 		t.Fatalf("expected pinned install command in error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- pin screenshot framing to Koubou `0.17.1`
- keep the existing `asc` frame device slugs stable while translating them to real Koubou frame names shipped by `0.17.1`
- add regression coverage so `iphone-air` framing fails if the generated Koubou config drifts back to unsupported frame names
- update screenshot framing docs and install hints to the new pinned Koubou version

Fixes #1174.

## Validation

- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

## Notes

- Upstream Koubou `0.17.1` is the latest release, but it still does not ship `iPhone Air`, `iPhone 17*`, or `iPhone 16e` frame names.
- This PR keeps the CLI slugs stable and maps them to frame assets that actually exist in the pinned upstream package.
- Black-box smoke test passed with the real `kou 0.17.1` binary:
  - `/tmp/asc-1174 screenshots frame --input docs/images/banner.png --device iphone-air --output json --output-dir /tmp/asc-1174-framed`
