### PR TITLE
apps wall: add Super Shot: EXIF Photo Frame

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -730,6 +730,11 @@
     "link": "https://apps.apple.com/us/app/sunbreak-nightly-app-blocker/id6752121964"
   },
   {
+    "app": "Super Shot: EXIF Photo Frame",
+    "link": "https://apps.apple.com/us/app/super-shot-exif-photo-frame/id6760384143?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/49/01/f9/4901f9f9-8d90-7283-bbec-6e506aec4391/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SwiftBiu",
     "link": "https://apps.apple.com/app/swiftbiu/id6754772331",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/90/3b/2e/903b2ef1-7097-f00c-3557-db67e054e174/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Super Shot: EXIF Photo Frame` to the Wall of Apps

## Entry

- App ID: 6760384143
- App: Super Shot: EXIF Photo Frame
- Link: https://apps.apple.com/us/app/super-shot-exif-photo-frame/id6760384143?uo=4

## Notes

- Submitted via `asc apps wall submit`
