### PR TITLE
apps wall: add 6 Nations - Rugby Scores Live

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1,5 +1,10 @@
 [
   {
+    "app": "6 Nations - Rugby Scores Live",
+    "link": "https://apps.apple.com/us/app/6-nations-rugby-scores-live/id414001342?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/34/09/f3/3409f3bc-b011-ef18-f9cf-1e885da8f97f/6nations-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "66-Day Streak: Habit Builder",
     "link": "https://apps.apple.com/us/app/66-day-streak-habit-builder/id6759220059",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5c/ce/67/5cce6782-729c-07af-1e0b-7322b8ffd914/SixtysixStreaksIcon-0-0-1x_U007emarketing-0-9-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `6 Nations - Rugby Scores Live` to the Wall of Apps

## Entry

- App ID: 414001342
- App: 6 Nations - Rugby Scores Live
- Link: https://apps.apple.com/us/app/6-nations-rugby-scores-live/id414001342?uo=4

## Notes

- Submitted via `asc apps wall submit`
