### PR TITLE
apps wall: add Iconize Folder

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -312,6 +312,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7b/43/73/7b4373fc-26e2-030b-7162-2f0ab0a7681d/AppIcon-0-0-1x_U007ewatch-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Iconize Folder",
+    "link": "https://apps.apple.com/us/app/iconize-folder/id6478772538?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/57/e3/94/57e39489-2c7c-c1cc-56bc-13f85096d9cc/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
+  },
+  {
     "app": "Impulses: Stop Impulse Buying",
     "link": "https://apps.apple.com/us/app/impulses-stop-impulse-buying/id6754372500?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8a/05/57/8a055708-4850-8120-8070-91424269b2f7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Iconize Folder` to the Wall of Apps

## Entry

- App ID: 6478772538
- App: Iconize Folder
- Link: https://apps.apple.com/us/app/iconize-folder/id6478772538?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
