### PR TITLE
apps wall: add KeyClicker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -342,6 +342,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ee/f4/e6/eef4e6d4-c2af-3856-6cdf-80af085b1cb9/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "KeyClicker",
+    "link": "https://apps.apple.com/us/app/keyclicker/id6740425504?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b3/48/0f/b3480f03-46d0-aa8e-d172-0c0e054890e3/AppIcon-0-0-85-220-0-5-0-2x-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "KeyScreen - Display Keystrokes",
     "link": "https://apps.apple.com/us/app/keyscreen-display-keystrokes/id6753302381?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c8/38/fd/c838fddf-a2db-5007-12be-8cb9906926e1/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `KeyClicker` to the Wall of Apps

## Entry

- App ID: 6740425504
- App: KeyClicker
- Link: https://apps.apple.com/us/app/keyclicker/id6740425504?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
