### PR TITLE
apps wall: add FocusCursor: Highlight &Markup

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -253,6 +253,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/09/e1/ad/09e1adab-b9fd-1707-57fc-387a7e19a7d0/AppIcon-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "FocusCursor: Highlight &Markup",
+    "link": "https://apps.apple.com/us/app/focuscursor-highlight-markup/id6743495172?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/38/68/9e/38689e2a-598d-b3cd-58ac-ae551225d7b7/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
+  },
+  {
     "app": "Foundation Lab",
     "link": "https://testflight.apple.com/join/JWR9FpP3"
   },


### PR DESCRIPTION
## Summary

- add `FocusCursor: Highlight &Markup` to the Wall of Apps

## Entry

- App ID: 6743495172
- App: FocusCursor: Highlight &Markup
- Link: https://apps.apple.com/us/app/focuscursor-highlight-markup/id6743495172?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
