### PR TITLE
apps wall: add wrkout - gym plan, log & track

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -895,6 +895,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d8/48/f4/d848f4b9-7de8-3d14-57d0-bf534e142069/AppIcon-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "wrkout - gym plan, log & track",
+    "link": "https://apps.apple.com/us/app/wrkout-gym-plan-log-track/id6759204353?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/01/0e/ce/010ece8d-5bcf-70fc-ef4a-7ed6c8aaa6ef/Logo-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "XO: Have I Ever",
     "link": "https://apps.apple.com/us/app/xo-have-i-ever/id6757594745",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d7/4d/4c/d74d4c07-c147-fa7e-86fe-cff01727629b/XO-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `wrkout - gym plan, log & track` to the Wall of Apps

## Entry

- App ID: 6759204353
- App: wrkout - gym plan, log & track
- Link: https://apps.apple.com/us/app/wrkout-gym-plan-log-track/id6759204353?uo=4

## Notes

- Submitted via `asc apps wall submit`
