### PR TITLE
shots: bump pinned Koubou to v0.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ For full command families, flags, and discovery patterns, see:
 
 ## Acknowledgements
 
-Local screenshot framing uses Koubou (pinned to `0.18.0`) for deterministic device-frame rendering.
+Local screenshot framing uses Koubou (pinned to `0.18.1`) for deterministic device-frame rendering.
 GitHub: https://github.com/bitomule/koubou
 
 Simulator UI automation for screenshot capture and interactions uses AXe CLI.

--- a/internal/cli/shots/shots_frame.go
+++ b/internal/cli/shots/shots_frame.go
@@ -49,7 +49,7 @@ func ShotsFrameCommand() *ffcli.Command {
 		ShortHelp:  "[experimental] Compose a screenshot into an Apple device frame.",
 		LongHelp: `Compose screenshots using Koubou's YAML-based rendering flow (experimental).
 
-Requires Koubou v0.18.0 (pip install koubou==0.18.0).
+Requires Koubou v0.18.1 (pip install koubou==0.18.1).
 
 Use either --input (auto-generated Koubou config) or --config (explicit Koubou YAML).
 

--- a/internal/screenshots/frame.go
+++ b/internal/screenshots/frame.go
@@ -31,7 +31,7 @@ const (
 	FrameDeviceIPhone17    FrameDevice = "iphone-17"
 	FrameDeviceMac         FrameDevice = "mac"
 
-	pinnedKoubouVersion = "0.18.0"
+	pinnedKoubouVersion = "0.18.1"
 )
 
 const (
@@ -81,7 +81,7 @@ type frameDeviceKoubouSpec struct {
 }
 
 // Keeps the existing asc device slugs while delegating rendering to pinned
-// Koubou v0.18.0 frame names.
+// Koubou v0.18.1 frame names.
 var frameDeviceKoubouSpecs = map[FrameDevice]frameDeviceKoubouSpec{
 	FrameDeviceIPhoneAir: {
 		FrameName:   "iPhone Air - Light Gold - Portrait",

--- a/internal/screenshots/frame_bench_test.go
+++ b/internal/screenshots/frame_bench_test.go
@@ -15,7 +15,7 @@ func prepareKoubouVersionBenchmark(b *testing.B) {
 	script := `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 echo "unsupported args" >&2

--- a/internal/screenshots/frame_test.go
+++ b/internal/screenshots/frame_test.go
@@ -341,7 +341,7 @@ func installFrameTestMockKou(t *testing.T, fixturePath, outputPath string) {
 	kouPath := filepath.Join(binDir, "kou")
 	script := `#!/bin/sh
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -577,7 +577,7 @@ func TestRunKoubouGenerate_ParsesJSONFromStdoutWhenStderrHasWarnings(t *testing.
 	writeExecutable(t, filepath.Join(binDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -612,7 +612,7 @@ func TestRunKoubouGenerate_RunsSetupFramesBeforeGenerate(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -654,7 +654,7 @@ func TestRunKoubouGenerate_SetupFramesFailureIncludesHint(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -691,7 +691,7 @@ func TestRunKoubouGenerate_RechecksSetupFramesWhenKouBinaryChanges(t *testing.T)
 	writeExecutable(t, filepath.Join(firstBinDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -711,7 +711,7 @@ exit 1
 	writeExecutable(t, filepath.Join(secondBinDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -762,7 +762,7 @@ func TestRunKoubouGenerate_SkipsSetupFramesForCanvasOnlyConfig(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "kou"), `#!/bin/sh
 set -eu
 if [ "$1" = "--version" ]; then
-  echo "kou 0.18.0"
+  echo "kou 0.18.1"
   exit 0
 fi
 if [ "$1" = "setup-frames" ]; then
@@ -828,7 +828,7 @@ exit 1
 	if !strings.Contains(err.Error(), "unsupported Koubou version 0.12.0") {
 		t.Fatalf("expected unsupported version error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "0.18.0") {
+	if !strings.Contains(err.Error(), "0.18.1") {
 		t.Fatalf("expected pinned version in error, got %v", err)
 	}
 }
@@ -840,7 +840,7 @@ func TestRunKoubouGenerate_NotFoundIncludesPinnedInstallHint(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected not found error")
 	}
-	if !strings.Contains(err.Error(), "pip install koubou==0.18.0") {
+	if !strings.Contains(err.Error(), "pip install koubou==0.18.1") {
 		t.Fatalf("expected pinned install command in error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- bump the pinned Koubou version from `0.18.0` to `0.18.1` for screenshot framing
- align the `screenshots frame` help text, README acknowledgement, and test fixtures with the new pinned install command
- pull in Koubou 0.18.1's upstream iPhone Air native frame auto-fit fix without changing ASC's framing flow

## Test plan
- [x] `make format`
- [x] `make generate-command-docs`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/screenshots`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/shots`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`