### PR TITLE
web: strengthen disclaimer and raise default rate limit to 1s

### DIFF
--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-const webWarningText = "EXPERIMENTAL / UNOFFICIAL / DISCOURAGED: This command family uses Apple web-session /iris behavior (not the public App Store Connect API), sends intentionally low-rate requests, requires user-owned Apple Account sessions, and redacts signed URLs/tokens by default. It may break anytime and should not be used for production-critical automation."
+const webWarningText = "EXPERIMENTAL / UNOFFICIAL / DISCOURAGED: This command family uses private, undocumented Apple web-session endpoints (not the public App Store Connect API). These endpoints are not sanctioned by Apple for third-party use. Using them may violate Apple's Developer Program License Agreement and may result in account restrictions, lockouts, or termination. You use these commands entirely at your own risk. The authors of this tool accept no responsibility for any action Apple takes against your account. As a precaution, these commands enforce an intentionally low request rate (default 1 request/second) to avoid appearing as bot traffic, require user-owned Apple Account sessions, and redact signed URLs/tokens by default. They may break without notice and should not be used for production-critical automation."
 
 // WebCommand returns the detached experimental web command group.
 func WebCommand() *ffcli.Command {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -48,7 +48,7 @@ const (
 
 	// Guardrails for unofficial web/iris calls.
 	webMinRequestIntervalEnv     = "ASC_WEB_MIN_REQUEST_INTERVAL"
-	defaultWebMinRequestInterval = 350 * time.Millisecond
+	defaultWebMinRequestInterval = 1 * time.Second
 	minimumWebMinRequestInterval = 200 * time.Millisecond
 )
 


### PR DESCRIPTION
## Summary

- **Strengthen `webWarningText`** to explicitly warn that using private/undocumented Apple web-session endpoints may violate Apple's Developer Program License Agreement and may result in account restrictions, lockouts, or termination. Users accept all risk; the authors accept no responsibility for Apple account action.
- **Raise `defaultWebMinRequestInterval`** from 350ms to 1s (~60 req/min max) to further reduce the chance of tripping Apple's undocumented rate thresholds on private web-session endpoints.

### Context

Apple's enforcement around private endpoint usage is opaque but real:
- [Fastlane Spaceship 2FA loop causing 12h account lockouts](https://github.com/fastlane/fastlane/issues/20707)
- [2024 App Store Transparency Report](https://www.apple.com/legal/more-resources/docs/2024-App-Store-Transparency-Report.pdf): 146,747 accounts terminated, 2.8% reinstatement rate

The previous warning text only mentioned technical breakage ("may break anytime"). It did not mention account risk, Apple's DPLA, or disclaim liability — leaving users unaware of the most severe consequence.

## Test plan

- [x] `make format` — clean
- [x] `make check-command-docs` — up to date
- [x] `make lint` — clean
- [x] `ASC_BYPASS_KEYCHAIN=1 make test` — all pass
- [x] Existing `TestResolveWebMinRequestInterval` uses the constant name, not hardcoded 350ms, so it picks up the new 1s default automatically