### PR TITLE
apps wall: add Zen Flip Clock - Minimal Timer

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -906,6 +906,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d7/4d/4c/d74d4c07-c147-fa7e-86fe-cff01727629b/XO-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Zen Flip Clock - Minimal Timer",
+    "link": "https://apps.apple.com/us/app/zen-flip-clock-minimal-timer/id1265404088?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4b/f4/13/4bf4138d-b804-9563-f684-92a9a2845b16/zfc-glass-icon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "ZenShelf",
     "link": "https://apps.apple.com/app/id6670147622",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/61/5a/dc/615adc54-4abd-f5f0-34a8-0ee239868470/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Zen Flip Clock - Minimal Timer` to the Wall of Apps

## Entry

- App ID: 1265404088
- App: Zen Flip Clock - Minimal Timer
- Link: https://apps.apple.com/us/app/zen-flip-clock-minimal-timer/id1265404088?uo=4

## Notes

- Submitted via `asc apps wall submit`
