### PR TITLE
apps wall: add Minimal Diary -  Life timeline

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -448,6 +448,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/09/0a/21/090a21e8-5b19-ec94-c5d0-6c2d0f5175bd/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Minimal Diary -  Life timeline",
+    "link": "https://apps.apple.com/us/app/minimal-diary-life-timeline/id1568936702?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3d/26/b2/3d26b23e-3e10-76d2-ce22-6ac9d2094499/md-glass-icon-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "minute cryptic • wordplay",
     "link": "https://apps.apple.com/app/id6748607228",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/95/51/28/955128eb-6041-160a-464c-41795f7d0f12/wordplay-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Minimal Diary -  Life timeline` to the Wall of Apps

## Entry

- App ID: 1568936702
- App: Minimal Diary -  Life timeline
- Link: https://apps.apple.com/us/app/minimal-diary-life-timeline/id1568936702?uo=4

## Notes

- Submitted via `asc apps wall submit`
