### PR TITLE
apps wall: add Long Distance: Couple & BFF

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -398,6 +398,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/bf/cf/5d/bfcf5d5a-2cd1-b41a-f65d-a751085736c5/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Long Distance: Couple & BFF",
+    "link": "https://apps.apple.com/us/app/long-distance-couple-bff/id6757593531?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d0/e1/3e/d0e13e2d-b2e9-70dd-538f-c8aa66ae7f54/AppIcon-0-1x_U007ephone-0-1-sRGB-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Loverzz: Couples App & Widgets",
     "link": "https://apps.apple.com/us/app/loverzz-couples-app-widgets/id6744887601?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/34/14/b8/3414b8a0-0647-c6b2-550a-e2ca1eb28e77/AppIcon-0-1x_U007ephone-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Long Distance: Couple & BFF` to the Wall of Apps

## Entry

- App ID: 6757593531
- App: Long Distance: Couple & BFF
- Link: https://apps.apple.com/us/app/long-distance-couple-bff/id6757593531?uo=4

## Notes

- Submitted via `asc apps wall submit`
