### PR TITLE
apps wall: add Safe Period Tracker - Soso

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -697,6 +697,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/63/a9/01/63a90152-943b-ba07-d666-402df1f9694e/AppIcon-0-0-1x_U007epad-0-1-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Safe Period Tracker - Soso",
+    "link": "https://apps.apple.com/us/app/safe-period-tracker-soso/id6757295825?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e1/e5/26/e1e526f7-2399-d1b2-a7c0-9603fd42acbf/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SajdaTV",
     "link": "https://apps.apple.com/us/app/sajdatv/id6759179587",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/86/a6/a286a647-d984-7f1d-6f2b-7d4fda64c3e2/App_Icon-marketing.lsr/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Safe Period Tracker - Soso` to the Wall of Apps

## Entry

- App ID: 6757295825
- App: Safe Period Tracker - Soso
- Link: https://apps.apple.com/us/app/safe-period-tracker-soso/id6757295825?uo=4

## Notes

- Submitted via `asc apps wall submit`
