### PR TITLE
refactor(builds): standardize mutating build selectors

### DIFF
--- a/docs/BUILD_SELECTOR_REFACTOR.md
+++ b/docs/BUILD_SELECTOR_REFACTOR.md
@@ -50,8 +50,8 @@ Progress checklist:
 - [x] Keep legacy selector spellings as deprecated aliases that warn and forward
   to the canonical flags
 - [x] Update focused tests and command docs for the PR 1 slice
-- [ ] Decide whether `builds wait` should later reuse more of the shared
-  selector engine instead of only sharing vocabulary
+- [x] Defer deeper `builds wait` selector-engine sharing for now; current
+  shared vocabulary cleanup is sufficient without adding more internal coupling
 - [x] Extend `--build-id` vocabulary to the remaining read-oriented explicit
   build commands in `builds`
 
@@ -215,7 +215,7 @@ Design note:
 
 ### PR 4: Redesign `builds test-notes`
 
-Status: in progress on the combined PR 4/5 branch
+Status: complete
 
 Scope:
 
@@ -226,13 +226,23 @@ Scope:
 
 ### PR 5: Legacy Removal + Remaining Read Commands
 
-Status: folded into the combined PR 4/5 branch
+Status: complete
 
 Scope:
 
 - remove live `beta-build-localizations` behavior and leave removed-command guidance
 - remove live `builds test-notes get` behavior and leave removed-command guidance
 - standardize remaining read-oriented build commands on `--build-id`
+
+### PR 6: Mutating Command Selector Vocabulary
+
+Status: complete
+
+Scope:
+
+- standardize visible explicit selector naming to `--build-id` for mutating build commands
+- keep hidden deprecated `--build` aliases with warnings during the transition
+- do not add inferred selectors like `--app --latest` to destructive or mutating commands in this slice
 
 ## Command Target Shape
 
@@ -260,6 +270,5 @@ asc builds test-notes delete --app "123" --latest --locale "en-US" --confirm
 
 - `builds latest` remains in the repo after PR 3 as a hidden deprecated shim
   that warns toward `builds info --latest` and `builds next-build-number`.
-- Mutating commands like `expire`, `update`, `add-groups`, `remove-groups`, and
-  `individual-testers` should be reviewed separately before inheriting inferred
-  build selection.
+- PR 6 standardizes explicit `--build-id` for mutating commands. Inferred
+  selection for mutating/destructive commands remains intentionally deferred.

--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -18,7 +18,8 @@ import (
 func BuildsAddGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add-groups", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID := fs.String("build-id", "", "Build ID")
+	legacyBuildID := bindHiddenStringFlag(fs, "build")
 	groups := fs.String("group", "", "Comma-separated beta group IDs or names")
 	skipInternal := fs.Bool("skip-internal", false, "Skip internal beta groups instead of adding them")
 	submit := fs.Bool("submit", false, "Submit build for beta app review after adding external groups")
@@ -27,22 +28,26 @@ func BuildsAddGroupsCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "add-groups",
-		ShortUsage: "asc builds add-groups --build BUILD_ID --group GROUP_ID[,GROUP_ID...] [--submit --confirm]",
+		ShortUsage: "asc builds add-groups --build-id BUILD_ID --group GROUP_ID[,GROUP_ID...] [--submit --confirm]",
 		ShortHelp:  "Add beta groups to a build for TestFlight distribution.",
 		LongHelp: `Add beta groups to a build for TestFlight distribution.
 
 Examples:
-  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
-  asc builds add-groups --build "BUILD_ID" --group "External Testers"
-  asc builds add-groups --build "BUILD_ID" --group "GROUP1,GROUP2"
-  asc builds add-groups --build "BUILD_ID" --group "INTERNAL_ID,EXTERNAL_ID" --skip-internal
-  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID" --submit --confirm`,
+  asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID"
+  asc builds add-groups --build-id "BUILD_ID" --group "External Testers"
+  asc builds add-groups --build-id "BUILD_ID" --group "GROUP1,GROUP2"
+  asc builds add-groups --build-id "BUILD_ID" --group "INTERNAL_ID,EXTERNAL_ID" --skip-internal
+  asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
+
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 
@@ -214,25 +219,30 @@ func hasAddedExternalBuildBetaGroup(groups []resolvedBuildBetaGroup, addedGroupI
 func BuildsUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("builds update", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID (required)")
+	buildID := fs.String("build-id", "", "Build ID (required)")
+	legacyBuildID := bindHiddenStringFlag(fs, "build")
 	usesNonExemptEncryption := fs.String("uses-non-exempt-encryption", "", "Set encryption compliance: true or false")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "update",
-		ShortUsage: "asc builds update --build BUILD_ID --uses-non-exempt-encryption [true|false] [flags]",
+		ShortUsage: "asc builds update --build-id BUILD_ID --uses-non-exempt-encryption [true|false] [flags]",
 		ShortHelp:  "Update build attributes.",
 		LongHelp: `Update build attributes such as encryption compliance.
 
 Examples:
-  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false
-  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=true`,
+  asc builds update --build-id "BUILD_ID" --uses-non-exempt-encryption=false
+  asc builds update --build-id "BUILD_ID" --uses-non-exempt-encryption=true`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
+
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 
@@ -277,26 +287,31 @@ Examples:
 func BuildsRemoveGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-groups", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID := fs.String("build-id", "", "Build ID")
+	legacyBuildID := bindHiddenStringFlag(fs, "build")
 	groups := fs.String("group", "", "Comma-separated beta group IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "remove-groups",
-		ShortUsage: "asc builds remove-groups --build BUILD_ID --group GROUP_ID[,GROUP_ID...] --confirm",
+		ShortUsage: "asc builds remove-groups --build-id BUILD_ID --group GROUP_ID[,GROUP_ID...] --confirm",
 		ShortHelp:  "Remove beta groups from a build.",
 		LongHelp: `Remove beta groups from a build.
 
 Examples:
-  asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID" --confirm
-  asc builds remove-groups --build "BUILD_ID" --group "GROUP1,GROUP2" --confirm`,
+  asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm
+  asc builds remove-groups --build-id "BUILD_ID" --group "GROUP1,GROUP2" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
+
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -409,17 +409,17 @@ Examples:
   asc builds info --app "123456789" --latest --version "1.2.3" --platform IOS
   asc builds info --app "123456789" --build-number "42"
   asc builds next-build-number --app "123456789" --version "1.2.3" --platform IOS
-  asc builds expire --build "BUILD_ID"
+  asc builds expire --build-id "BUILD_ID"
   asc builds expire-all --app "123456789" --older-than 90d --dry-run
   asc builds upload --app "123456789" --ipa "app.ipa"
   asc builds upload --app "123456789" --pkg "app.pkg" --version "1.0.0" --build-number "1"
   asc builds uploads list --app "123456789"
   asc builds test-notes list --build-id "BUILD_ID"
   asc builds individual-testers list --build-id "BUILD_ID"
-  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false
-  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"
-  asc builds add-groups --build "BUILD_ID" --group "GROUP_ID" --submit --confirm
-  asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID"
+  asc builds update --build-id "BUILD_ID" --uses-non-exempt-encryption=false
+  asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID"
+  asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm
+  asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID"
   asc builds app view --build-id "BUILD_ID"
   asc builds pre-release-version view --build-id "BUILD_ID"
   asc builds icons list --build-id "BUILD_ID"
@@ -837,25 +837,30 @@ Examples:
 func BuildsExpireCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("builds expire", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID := fs.String("build-id", "", "Build ID")
+	legacyBuildID := bindHiddenStringFlag(fs, "build")
 	confirm := fs.Bool("confirm", false, "Confirm expiration")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "expire",
-		ShortUsage: "asc builds expire --build BUILD_ID --confirm [flags]",
+		ShortUsage: "asc builds expire --build-id BUILD_ID --confirm [flags]",
 		ShortHelp:  "Expire a build for TestFlight.",
 		LongHelp: `Expire a build for TestFlight.
 
 This action is irreversible for the specified build.
 
 Examples:
-  asc builds expire --build "BUILD_ID" --confirm`,
+  asc builds expire --build-id "BUILD_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
+
 			if strings.TrimSpace(*buildID) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 			if !*confirm {

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -117,9 +117,14 @@ func TestBuildsUpdateCommand_Shape(t *testing.T) {
 		t.Fatalf("unexpected command name: %q", cmd.Name)
 	}
 
+	buildIDFlag := cmd.FlagSet.Lookup("build-id")
+	if buildIDFlag == nil {
+		t.Fatal("expected --build-id flag to be defined")
+	}
+
 	buildFlag := cmd.FlagSet.Lookup("build")
 	if buildFlag == nil {
-		t.Fatal("expected --build flag to be defined")
+		t.Fatal("expected hidden legacy --build flag to be defined")
 	}
 
 	encFlag := cmd.FlagSet.Lookup("uses-non-exempt-encryption")
@@ -137,7 +142,7 @@ func TestBuildsUpdateCommand_HelpContainsExamples(t *testing.T) {
 
 func TestBuildsUpdateCommand_ShortUsageShowsRequiredFlag(t *testing.T) {
 	cmd := BuildsUpdateCommand()
-	want := "asc builds update --build BUILD_ID --uses-non-exempt-encryption [true|false] [flags]"
+	want := "asc builds update --build-id BUILD_ID --uses-non-exempt-encryption [true|false] [flags]"
 	if cmd.ShortUsage != want {
 		t.Fatalf("expected ShortUsage %q, got %q", want, cmd.ShortUsage)
 	}

--- a/internal/cli/builds/builds_individual_testers.go
+++ b/internal/cli/builds/builds_individual_testers.go
@@ -25,8 +25,8 @@ func BuildsIndividualTestersCommand() *ffcli.Command {
 
 Examples:
   asc builds individual-testers list --build-id "BUILD_ID"
-  asc builds individual-testers add --build "BUILD_ID" --tester "TESTER_ID"
-  asc builds individual-testers remove --build "BUILD_ID" --tester "TESTER_ID"`,
+  asc builds individual-testers add --build-id "BUILD_ID" --tester "TESTER_ID"
+  asc builds individual-testers remove --build-id "BUILD_ID" --tester "TESTER_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -128,25 +128,30 @@ Examples:
 func BuildsIndividualTestersAddCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("individual-testers add", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID := fs.String("build-id", "", "Build ID")
+	legacyBuildID := bindHiddenStringFlag(fs, "build")
 	testers := fs.String("tester", "", "Comma-separated tester IDs")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "add",
-		ShortUsage: "asc builds individual-testers add --build \"BUILD_ID\" --tester \"TESTER_ID[,TESTER_ID...]\"",
+		ShortUsage: "asc builds individual-testers add --build-id \"BUILD_ID\" --tester \"TESTER_ID[,TESTER_ID...]\"",
 		ShortHelp:  "Add individual testers to a build.",
 		LongHelp: `Add individual testers to a build.
 
 Examples:
-  asc builds individual-testers add --build "BUILD_ID" --tester "TESTER_ID"
-  asc builds individual-testers add --build "BUILD_ID" --tester "TESTER_ID1,TESTER_ID2"`,
+  asc builds individual-testers add --build-id "BUILD_ID" --tester "TESTER_ID"
+  asc builds individual-testers add --build-id "BUILD_ID" --tester "TESTER_ID1,TESTER_ID2"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
+
 			buildValue := strings.TrimSpace(*buildID)
 			if buildValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 
@@ -183,26 +188,31 @@ Examples:
 func BuildsIndividualTestersRemoveCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("individual-testers remove", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID := fs.String("build-id", "", "Build ID")
+	legacyBuildID := bindHiddenStringFlag(fs, "build")
 	testers := fs.String("tester", "", "Comma-separated tester IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "remove",
-		ShortUsage: "asc builds individual-testers remove --build \"BUILD_ID\" --tester \"TESTER_ID[,TESTER_ID...]\" --confirm",
+		ShortUsage: "asc builds individual-testers remove --build-id \"BUILD_ID\" --tester \"TESTER_ID[,TESTER_ID...]\" --confirm",
 		ShortHelp:  "Remove individual testers from a build.",
 		LongHelp: `Remove individual testers from a build.
 
 Examples:
-  asc builds individual-testers remove --build "BUILD_ID" --tester "TESTER_ID" --confirm
-  asc builds individual-testers remove --build "BUILD_ID" --tester "TESTER_ID1,TESTER_ID2" --confirm`,
+  asc builds individual-testers remove --build-id "BUILD_ID" --tester "TESTER_ID" --confirm
+  asc builds individual-testers remove --build-id "BUILD_ID" --tester "TESTER_ID1,TESTER_ID2" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
+
 			buildValue := strings.TrimSpace(*buildID)
 			if buildValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 

--- a/internal/cli/cmdtest/builds_add_groups_internal_test.go
+++ b/internal/cli/cmdtest/builds_add_groups_internal_test.go
@@ -69,7 +69,7 @@ func TestBuildsAddGroupsInternalGroupAddsGroup(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"builds", "add-groups", "--build", "build-1", "--group", "group-internal"}); err != nil {
+		if err := root.Parse([]string{"builds", "add-groups", "--build-id", "build-1", "--group", "group-internal"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -150,7 +150,7 @@ func TestBuildsAddGroupsAddsMixedInternalAndExternalGroups(t *testing.T) {
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-internal,group-external",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -230,7 +230,7 @@ func TestBuildsAddGroupsSkipInternalAddsOnlyExternalGroups(t *testing.T) {
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-internal,group-external",
 			"--skip-internal",
 		}); err != nil {
@@ -294,7 +294,7 @@ func TestBuildsAddGroupsSkipInternalWithOnlyInternalGroupsIsNoOp(t *testing.T) {
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-internal",
 			"--skip-internal",
 		}); err != nil {

--- a/internal/cli/cmdtest/builds_add_groups_submit_test.go
+++ b/internal/cli/cmdtest/builds_add_groups_submit_test.go
@@ -74,7 +74,7 @@ func TestBuildsAddGroupsSubmitCreatesBetaReviewSubmissionForExternalGroups(t *te
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-external",
 			"--submit",
 			"--confirm",
@@ -147,7 +147,7 @@ func TestBuildsAddGroupsSubmitSkipsBetaReviewSubmissionForInternalGroups(t *test
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-internal",
 			"--submit",
 			"--confirm",
@@ -218,7 +218,7 @@ func TestBuildsAddGroupsSubmitTreatsExistingSubmissionAsAlreadyDone(t *testing.T
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-external",
 			"--submit",
 			"--confirm",
@@ -292,7 +292,7 @@ func TestBuildsAddGroupsSubmitPreservesPartialSuccessWhenSubmissionFails(t *test
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"builds", "add-groups",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--group", "group-external",
 			"--submit",
 			"--confirm",

--- a/internal/cli/cmdtest/builds_parity_test.go
+++ b/internal/cli/cmdtest/builds_parity_test.go
@@ -86,23 +86,23 @@ func TestBuildsParityValidationErrors(t *testing.T) {
 			wantErr: "--build-id is required",
 		},
 		{
-			name:    "builds individual-testers add missing build",
+			name:    "builds individual-testers add missing build id",
 			args:    []string{"builds", "individual-testers", "add", "--tester", "TESTER_ID"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "builds individual-testers add missing tester",
-			args:    []string{"builds", "individual-testers", "add", "--build", "BUILD_ID"},
+			args:    []string{"builds", "individual-testers", "add", "--build-id", "BUILD_ID"},
 			wantErr: "--tester is required",
 		},
 		{
-			name:    "builds individual-testers remove missing build",
+			name:    "builds individual-testers remove missing build id",
 			args:    []string{"builds", "individual-testers", "remove", "--tester", "TESTER_ID"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "builds individual-testers remove missing tester",
-			args:    []string{"builds", "individual-testers", "remove", "--build", "BUILD_ID"},
+			args:    []string{"builds", "individual-testers", "remove", "--build-id", "BUILD_ID"},
 			wantErr: "--tester is required",
 		},
 		{

--- a/internal/cli/cmdtest/builds_selector_migration_test.go
+++ b/internal/cli/cmdtest/builds_selector_migration_test.go
@@ -64,6 +64,48 @@ func TestBuildsSelectorAliasesWarnAndMatchCanonicalValidationPaths(t *testing.T)
 			warning:       buildsLegacyBuildWarning,
 			wantErr:       "Error: --build-id cannot be combined with --app, --latest, --build-number, --version, --platform, --processing-state, --exclude-expired, or --not-expired",
 		},
+		{
+			name:          "expire build alias",
+			canonicalArgs: []string{"builds", "expire", "--build-id", "BUILD_123"},
+			aliasArgs:     []string{"builds", "expire", "--build", "BUILD_123"},
+			warning:       buildsLegacyBuildWarning,
+			wantErr:       "Error: --confirm is required to expire build",
+		},
+		{
+			name:          "update build alias",
+			canonicalArgs: []string{"builds", "update", "--build-id", "BUILD_123"},
+			aliasArgs:     []string{"builds", "update", "--build", "BUILD_123"},
+			warning:       buildsLegacyBuildWarning,
+			wantErr:       "Error: at least one update flag is required (e.g. --uses-non-exempt-encryption)",
+		},
+		{
+			name:          "add-groups build alias",
+			canonicalArgs: []string{"builds", "add-groups", "--build-id", "BUILD_123"},
+			aliasArgs:     []string{"builds", "add-groups", "--build", "BUILD_123"},
+			warning:       buildsLegacyBuildWarning,
+			wantErr:       "Error: --group is required",
+		},
+		{
+			name:          "remove-groups build alias",
+			canonicalArgs: []string{"builds", "remove-groups", "--build-id", "BUILD_123"},
+			aliasArgs:     []string{"builds", "remove-groups", "--build", "BUILD_123"},
+			warning:       buildsLegacyBuildWarning,
+			wantErr:       "Error: --group is required",
+		},
+		{
+			name:          "individual-testers add build alias",
+			canonicalArgs: []string{"builds", "individual-testers", "add", "--build-id", "BUILD_123"},
+			aliasArgs:     []string{"builds", "individual-testers", "add", "--build", "BUILD_123"},
+			warning:       buildsLegacyBuildWarning,
+			wantErr:       "Error: --tester is required",
+		},
+		{
+			name:          "individual-testers remove build alias",
+			canonicalArgs: []string{"builds", "individual-testers", "remove", "--build-id", "BUILD_123", "--tester", "tester-1"},
+			aliasArgs:     []string{"builds", "individual-testers", "remove", "--build", "BUILD_123", "--tester", "tester-1"},
+			warning:       buildsLegacyBuildWarning,
+			wantErr:       "Error: --confirm is required",
+		},
 	}
 
 	for _, test := range tests {
@@ -318,6 +360,30 @@ func TestBuildsSelectorAliasesRejectConflictingBuildValues(t *testing.T) {
 		{
 			name: "dsyms conflicting build values",
 			args: []string{"builds", "dsyms", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY"},
+		},
+		{
+			name: "expire conflicting build values",
+			args: []string{"builds", "expire", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--confirm"},
+		},
+		{
+			name: "update conflicting build values",
+			args: []string{"builds", "update", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--uses-non-exempt-encryption", "true"},
+		},
+		{
+			name: "add-groups conflicting build values",
+			args: []string{"builds", "add-groups", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--group", "GROUP_123"},
+		},
+		{
+			name: "remove-groups conflicting build values",
+			args: []string{"builds", "remove-groups", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--group", "GROUP_123", "--confirm"},
+		},
+		{
+			name: "individual-testers add conflicting build values",
+			args: []string{"builds", "individual-testers", "add", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--tester", "tester-1"},
+		},
+		{
+			name: "individual-testers remove conflicting build values",
+			args: []string{"builds", "individual-testers", "remove", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--tester", "tester-1", "--confirm"},
 		},
 	}
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -367,7 +367,7 @@ func TestBuildsExpireRequiresBuildID(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "--build is required") {
+	if !strings.Contains(stderr, "--build-id is required") {
 		t.Fatalf("expected missing build error, got %q", stderr)
 	}
 }
@@ -503,38 +503,38 @@ func TestBuildsGroupValidationErrors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "builds add-groups missing build",
+			name:    "builds add-groups missing build id",
 			args:    []string{"builds", "add-groups"},
-			wantErr: "Error: --build is required",
+			wantErr: "Error: --build-id is required",
 		},
 		{
 			name:    "builds add-groups missing group",
-			args:    []string{"builds", "add-groups", "--build", "BUILD_123"},
+			args:    []string{"builds", "add-groups", "--build-id", "BUILD_123"},
 			wantErr: "Error: --group is required",
 		},
 		{
 			name:    "builds add-groups submit missing confirm",
-			args:    []string{"builds", "add-groups", "--build", "BUILD_123", "--group", "GROUP_123", "--submit"},
+			args:    []string{"builds", "add-groups", "--build-id", "BUILD_123", "--group", "GROUP_123", "--submit"},
 			wantErr: "Error: --confirm is required with --submit",
 		},
 		{
 			name:    "builds add-groups confirm requires submit",
-			args:    []string{"builds", "add-groups", "--build", "BUILD_123", "--group", "GROUP_123", "--confirm"},
+			args:    []string{"builds", "add-groups", "--build-id", "BUILD_123", "--group", "GROUP_123", "--confirm"},
 			wantErr: "Error: --confirm requires --submit",
 		},
 		{
-			name:    "builds remove-groups missing build",
+			name:    "builds remove-groups missing build id",
 			args:    []string{"builds", "remove-groups"},
-			wantErr: "Error: --build is required",
+			wantErr: "Error: --build-id is required",
 		},
 		{
 			name:    "builds remove-groups missing group",
-			args:    []string{"builds", "remove-groups", "--build", "BUILD_123"},
+			args:    []string{"builds", "remove-groups", "--build-id", "BUILD_123"},
 			wantErr: "Error: --group is required",
 		},
 		{
 			name:    "builds remove-groups missing confirm",
-			args:    []string{"builds", "remove-groups", "--build", "BUILD_123", "--group", "GROUP_123"},
+			args:    []string{"builds", "remove-groups", "--build-id", "BUILD_123", "--group", "GROUP_123"},
 			wantErr: "Error: --confirm is required",
 		},
 	}
@@ -636,13 +636,13 @@ func TestBuildsExpireValidationErrors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "builds expire missing build",
+			name:    "builds expire missing build id",
 			args:    []string{"builds", "expire"},
-			wantErr: "Error: --build is required",
+			wantErr: "Error: --build-id is required",
 		},
 		{
 			name:    "builds expire missing confirm",
-			args:    []string{"builds", "expire", "--build", "BUILD_ID"},
+			args:    []string{"builds", "expire", "--build-id", "BUILD_ID"},
 			wantErr: "Error: --confirm is required to expire build",
 		},
 	}
@@ -680,7 +680,7 @@ func TestBuildsIndividualTestersValidationErrors(t *testing.T) {
 	}{
 		{
 			name:    "builds individual-testers remove missing confirm",
-			args:    []string{"builds", "individual-testers", "remove", "--build", "BUILD_ID", "--tester", "TESTER_ID"},
+			args:    []string{"builds", "individual-testers", "remove", "--build-id", "BUILD_ID", "--tester", "TESTER_ID"},
 			wantErr: "Error: --confirm is required",
 		},
 	}

--- a/internal/cli/cmdtest/encryption_exempt_declare_test.go
+++ b/internal/cli/cmdtest/encryption_exempt_declare_test.go
@@ -45,7 +45,7 @@ func TestEncryptionDeclarationsExemptDeclare_ShowsLocalWorkflowGuidance(t *testi
 	if !strings.Contains(stderr, `asc submit preflight --app "APP_ID" --version "1.0"`) {
 		t.Fatalf("expected submit preflight guidance, got %q", stderr)
 	}
-	if !strings.Contains(stderr, `asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false`) {
+	if !strings.Contains(stderr, `asc builds update --build-id "BUILD_ID" --uses-non-exempt-encryption=false`) {
 		t.Fatalf("expected build update guidance, got %q", stderr)
 	}
 }

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -390,7 +390,7 @@ For uploaded builds in App Store Connect, verify encryption state with:
   asc submit preflight --app "APP_ID" --version "1.0"
 
 If a build still reports non-exempt encryption incorrectly, update the build:
-  asc builds update --build "BUILD_ID" --uses-non-exempt-encryption=false
+  asc builds update --build-id "BUILD_ID" --uses-non-exempt-encryption=false
 
 For details, see:
   https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption`)

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -76,7 +76,7 @@ Example workflow file (.asc/workflow.json):
         },
         {
           "name": "add_build_to_group",
-          "run": "asc builds add-groups --build ${steps.resolve_build.BUILD_ID} --group $GROUP_ID"
+          "run": "asc builds add-groups --build-id ${steps.resolve_build.BUILD_ID} --group $GROUP_ID"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- standardize the visible explicit selector to `--build-id` for `builds expire`, `builds update`, `builds add-groups`, `builds remove-groups`, and `builds individual-testers add/remove`
- keep hidden deprecated `--build` aliases with warnings so existing scripts still transition cleanly
- update help/examples, workflow/encryption guidance, and selector-migration tests; record that deeper `builds wait` resolver sharing is intentionally deferred for now

## Test plan
- [x] `go build -o /tmp/asc .`
- [x] `/tmp/asc builds --help`
- [x] `/tmp/asc builds expire --help`
- [x] `/tmp/asc builds update --help`
- [x] `/tmp/asc builds add-groups --help`
- [x] `/tmp/asc builds remove-groups --help`
- [x] `/tmp/asc builds individual-testers add --help`
- [x] `/tmp/asc builds individual-testers remove --help`
- [x] `make generate-command-docs`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`