### PR TITLE
refactor(testflight): canonicalize build-id selectors

### DIFF
--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -861,27 +861,27 @@ func TestBetaManagementValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "beta-testers add-builds missing id",
-			args:    []string{"testflight", "beta-testers", "add-builds", "--build", "BUILD_ID"},
+			args:    []string{"testflight", "beta-testers", "add-builds", "--build-id", "BUILD_ID"},
 			wantErr: "--id is required",
 		},
 		{
 			name:    "beta-testers add-builds missing build",
 			args:    []string{"testflight", "beta-testers", "add-builds", "--id", "TESTER_ID"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "beta-testers remove-builds missing id",
-			args:    []string{"testflight", "beta-testers", "remove-builds", "--build", "BUILD_ID", "--confirm"},
+			args:    []string{"testflight", "beta-testers", "remove-builds", "--build-id", "BUILD_ID", "--confirm"},
 			wantErr: "--id is required",
 		},
 		{
 			name:    "beta-testers remove-builds missing build",
 			args:    []string{"testflight", "beta-testers", "remove-builds", "--id", "TESTER_ID", "--confirm"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "beta-testers remove-builds missing confirm",
-			args:    []string{"testflight", "beta-testers", "remove-builds", "--id", "TESTER_ID", "--build", "BUILD_ID"},
+			args:    []string{"testflight", "beta-testers", "remove-builds", "--id", "TESTER_ID", "--build-id", "BUILD_ID"},
 			wantErr: "Error: --confirm is required",
 		},
 		{
@@ -2117,11 +2117,11 @@ func TestTestFlightReviewValidationErrors(t *testing.T) {
 		{
 			name:    "review submit missing build",
 			args:    []string{"testflight", "review", "submit", "--confirm"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "review submit missing confirm",
-			args:    []string{"testflight", "review", "submit", "--build", "BUILD_ID"},
+			args:    []string{"testflight", "review", "submit", "--build-id", "BUILD_ID"},
 			wantErr: "--confirm is required",
 		},
 	}
@@ -3025,7 +3025,7 @@ func TestTestFlightBetaDetailsValidationErrors(t *testing.T) {
 		{
 			name:    "beta-details get missing build",
 			args:    []string{"testflight", "beta-details", "get"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "beta-details update missing id",
@@ -3180,8 +3180,8 @@ func TestTestFlightSyncValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "testflight sync pull build filter without include",
-			args:    []string{"testflight", "sync", "pull", "--app", "APP_ID", "--output", "./testflight.yaml", "--build", "BUILD_ID"},
-			wantErr: "--build requires --include-builds",
+			args:    []string{"testflight", "sync", "pull", "--app", "APP_ID", "--output", "./testflight.yaml", "--build-id", "BUILD_ID"},
+			wantErr: "--build-id requires --include-builds",
 		},
 		{
 			name:    "testflight sync pull tester filter without include",
@@ -3262,7 +3262,7 @@ func TestBetaTestersListAcceptsBuildFilter(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
-	if err := root.Parse([]string{"testflight", "beta-testers", "list", "--app", "X", "--build", "Y"}); err != nil {
+	if err := root.Parse([]string{"testflight", "beta-testers", "list", "--app", "X", "--build-id", "Y"}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 }

--- a/internal/cli/cmdtest/testflight_beta_crash_logs_notifications_test.go
+++ b/internal/cli/cmdtest/testflight_beta_crash_logs_notifications_test.go
@@ -101,7 +101,7 @@ func TestTestFlightBetaNotificationsCreateOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "beta-notifications", "create", "--build", "build-1"}); err != nil {
+		if err := root.Parse([]string{"testflight", "beta-notifications", "create", "--build-id", "build-1"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -145,7 +145,7 @@ func TestTestFlightBetaNotificationsCreateExplainsAutoNotifyAlreadyEnabled(t *te
 
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "beta-notifications", "create", "--build", "build-1"}); err != nil {
+		if err := root.Parse([]string{"testflight", "beta-notifications", "create", "--build-id", "build-1"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())

--- a/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
+++ b/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
@@ -46,7 +46,7 @@ func TestTestFlightBetaDetailsGetOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "beta-details", "get", "--build", "build-1", "--limit", "1"}); err != nil {
+		if err := root.Parse([]string{"testflight", "beta-details", "get", "--build-id", "build-1", "--limit", "1"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/cmdtest/testflight_beta_testers_updates_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_updates_test.go
@@ -43,7 +43,7 @@ func TestTestFlightBetaTestersAddBuildsOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "beta-testers", "add-builds", "--id", "tester-1", "--build", "build-1,build-2"}); err != nil {
+		if err := root.Parse([]string{"testflight", "beta-testers", "add-builds", "--id", "tester-1", "--build-id", "build-1,build-2"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -99,7 +99,7 @@ func TestTestFlightBetaTestersRemoveBuildsOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "beta-testers", "remove-builds", "--id", "tester-2", "--build", "build-3,build-4", "--confirm"}); err != nil {
+		if err := root.Parse([]string{"testflight", "beta-testers", "remove-builds", "--id", "tester-2", "--build-id", "build-3,build-4", "--confirm"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/cmdtest/testflight_build_id_migration_test.go
+++ b/internal/cli/cmdtest/testflight_build_id_migration_test.go
@@ -1,0 +1,190 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testFlightLegacyBuildWarning = "Warning: `--build` is deprecated. Use `--build-id`."
+
+func runTestFlightBuildIDCommand(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	return stdout, stderr, runErr
+}
+
+func TestTestFlightBuildIDAliasConflictErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "review submit conflicting build values",
+			args: []string{"testflight", "review", "submit", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY", "--confirm"},
+		},
+		{
+			name: "beta testers add-builds conflicting build values",
+			args: []string{"testflight", "beta-testers", "add-builds", "--id", "TESTER_ID", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY"},
+		},
+		{
+			name: "sync pull conflicting build values",
+			args: []string{"testflight", "sync", "pull", "--app", "APP_ID", "--output", "./testflight.yaml", "--include-builds", "--build-id", "BUILD_CANON", "--build", "BUILD_LEGACY"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr, runErr := runTestFlightBuildIDCommand(t, test.args)
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected ErrHelp, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "Error: --build conflicts with --build-id; use only --build-id") {
+				t.Fatalf("expected conflicting build selector error, got %q", stderr)
+			}
+			if strings.Contains(stderr, testFlightLegacyBuildWarning) {
+				t.Fatalf("expected conflict to fail before deprecation warning, got %q", stderr)
+			}
+		})
+	}
+}
+
+func TestTestFlightReviewSubmissionsListBuildAliasWarnsAndMatchesCanonical(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppReviewSubmissions" {
+			t.Fatalf("expected path /v1/betaAppReviewSubmissions, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if query.Get("filter[build]") != "build-1" {
+			t.Fatalf("expected build filter build-1, got %q", query.Get("filter[build]"))
+		}
+		body := `{"data":[{"type":"betaAppReviewSubmissions","id":"submission-1","attributes":{"betaReviewState":"WAITING_FOR_REVIEW","submittedDate":"2024-01-01T00:00:00Z"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	canonicalStdout, canonicalStderr, canonicalErr := runTestFlightBuildIDCommand(t, []string{
+		"testflight", "review", "submissions", "list", "--build-id", "build-1", "--output", "json",
+	})
+	if canonicalErr != nil {
+		t.Fatalf("canonical run error: %v", canonicalErr)
+	}
+	if canonicalStderr != "" {
+		t.Fatalf("expected empty canonical stderr, got %q", canonicalStderr)
+	}
+
+	aliasStdout, aliasStderr, aliasErr := runTestFlightBuildIDCommand(t, []string{
+		"testflight", "review", "submissions", "list", "--build", "build-1", "--output", "json",
+	})
+	if aliasErr != nil {
+		t.Fatalf("alias run error: %v", aliasErr)
+	}
+	if canonicalStdout != aliasStdout {
+		t.Fatalf("expected identical stdout, canonical=%q alias=%q", canonicalStdout, aliasStdout)
+	}
+	if !strings.Contains(aliasStderr, testFlightLegacyBuildWarning) {
+		t.Fatalf("expected legacy build warning, got %q", aliasStderr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two requests, got %d", requestCount)
+	}
+}
+
+func TestTestFlightBetaTestersAddBuildsAliasWarnsAndMatchesCanonical(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaTesters/tester-1/relationships/builds" {
+			t.Fatalf("expected beta tester builds relationship path, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		bodyText := string(body)
+		if !strings.Contains(bodyText, `"id":"build-1"`) || !strings.Contains(bodyText, `"id":"build-2"`) {
+			t.Fatalf("expected both build IDs in body, got %q", bodyText)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	canonicalStdout, canonicalStderr, canonicalErr := runTestFlightBuildIDCommand(t, []string{
+		"testflight", "beta-testers", "add-builds", "--id", "tester-1", "--build-id", "build-1,build-2", "--output", "json",
+	})
+	if canonicalErr != nil {
+		t.Fatalf("canonical run error: %v", canonicalErr)
+	}
+	if strings.Contains(canonicalStderr, testFlightLegacyBuildWarning) {
+		t.Fatalf("did not expect canonical warning, got %q", canonicalStderr)
+	}
+
+	aliasStdout, aliasStderr, aliasErr := runTestFlightBuildIDCommand(t, []string{
+		"testflight", "beta-testers", "add-builds", "--id", "tester-1", "--build", "build-1,build-2", "--output", "json",
+	})
+	if aliasErr != nil {
+		t.Fatalf("alias run error: %v", aliasErr)
+	}
+	if canonicalStdout != aliasStdout {
+		t.Fatalf("expected identical stdout, canonical=%q alias=%q", canonicalStdout, aliasStdout)
+	}
+	if !strings.Contains(aliasStderr, testFlightLegacyBuildWarning) {
+		t.Fatalf("expected legacy build warning, got %q", aliasStderr)
+	}
+	if !strings.Contains(aliasStderr, "Successfully added tester tester-1 to 2 build(s)") {
+		t.Fatalf("expected success message in stderr, got %q", aliasStderr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two requests, got %d", requestCount)
+	}
+}

--- a/internal/cli/cmdtest/testflight_canonical_surface_test.go
+++ b/internal/cli/cmdtest/testflight_canonical_surface_test.go
@@ -187,7 +187,7 @@ func TestDeprecatedHelpShowsCanonicalPathsOnly(t *testing.T) {
 		{
 			name:        "beta notifications alias help",
 			args:        []string{"testflight", "beta-notifications"},
-			wantUsage:   "asc testflight notifications send --build \"BUILD_ID\"",
+			wantUsage:   "asc testflight notifications send --build-id \"BUILD_ID\"",
 			wantWarning: "",
 			wantNotShown: []string{
 				"asc testflight beta-notifications <subcommand> [flags]",
@@ -546,7 +546,7 @@ func TestCanonicalTestFlightValidationPaths(t *testing.T) {
 		{
 			name:    "distribution view missing build",
 			args:    []string{"testflight", "distribution", "view"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "agreements view missing selector",
@@ -556,7 +556,7 @@ func TestCanonicalTestFlightValidationPaths(t *testing.T) {
 		{
 			name:    "notifications send missing build",
 			args:    []string{"testflight", "notifications", "send"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "metrics app-testers missing app",
@@ -922,7 +922,7 @@ func TestTestFlightDistributionViewOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "distribution", "view", "--build", "build-1"}); err != nil {
+		if err := root.Parse([]string{"testflight", "distribution", "view", "--build-id", "build-1"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -1245,7 +1245,7 @@ func TestDeprecatedTestFlightRootsAcceptCanonicalChildCommands(t *testing.T) {
 		{
 			name:    "beta details root accepts view",
 			args:    []string{"testflight", "beta-details", "view"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "beta details nested build accepts view",
@@ -1265,7 +1265,7 @@ func TestDeprecatedTestFlightRootsAcceptCanonicalChildCommands(t *testing.T) {
 		{
 			name:    "beta notifications root accepts send",
 			args:    []string{"testflight", "beta-notifications", "send"},
-			wantErr: "--build is required",
+			wantErr: "--build-id is required",
 		},
 		{
 			name:    "sync root accepts export",

--- a/internal/cli/cmdtest/testflight_review_commands_test.go
+++ b/internal/cli/cmdtest/testflight_review_commands_test.go
@@ -147,7 +147,7 @@ func TestTestFlightReviewSubmitOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "review", "submit", "--build", "build-1", "--confirm"}); err != nil {
+		if err := root.Parse([]string{"testflight", "review", "submit", "--build-id", "build-1", "--confirm"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/cmdtest/testflight_review_next_validation_test.go
+++ b/internal/cli/cmdtest/testflight_review_next_validation_test.go
@@ -314,7 +314,7 @@ func TestTestFlightReviewSubmissionsListRejectsInvalidNextURL(t *testing.T) {
 
 			var runErr error
 			stdout, stderr := captureOutput(t, func() {
-				if err := root.Parse([]string{"testflight", "review", "submissions", "list", "--build", "build-1", "--next", test.next}); err != nil {
+				if err := root.Parse([]string{"testflight", "review", "submissions", "list", "--build-id", "build-1", "--next", test.next}); err != nil {
 					t.Fatalf("parse error: %v", err)
 				}
 				runErr = root.Run(context.Background())
@@ -384,7 +384,7 @@ func TestTestFlightReviewSubmissionsListPaginateFromNext(t *testing.T) {
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"testflight", "review", "submissions", "list",
-			"--build", "build-1",
+			"--build-id", "build-1",
 			"--paginate",
 			"--next", firstURL,
 		}); err != nil {

--- a/internal/cli/cmdtest/testflight_review_submissions_list_test.go
+++ b/internal/cli/cmdtest/testflight_review_submissions_list_test.go
@@ -28,8 +28,8 @@ func TestTestFlightReviewSubmissionsListMissingBuild(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --build is required") {
-		t.Fatalf("expected error %q, got %q", "Error: --build is required", stderr)
+	if !strings.Contains(stderr, "Error: --build-id is required") {
+		t.Fatalf("expected error %q, got %q", "Error: --build-id is required", stderr)
 	}
 }
 
@@ -69,7 +69,7 @@ func TestTestFlightReviewSubmissionsListOutputTable(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "review", "submissions", "list", "--build", "build-1", "--limit", "2", "--output", "table"}); err != nil {
+		if err := root.Parse([]string{"testflight", "review", "submissions", "list", "--build-id", "build-1", "--limit", "2", "--output", "table"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/testflight/beta_notifications.go
+++ b/internal/cli/testflight/beta_notifications.go
@@ -22,7 +22,7 @@ func BetaNotificationsCommand() *ffcli.Command {
 		LongHelp: `Send TestFlight beta build notifications.
 
 Examples:
-  asc testflight beta-notifications create --build "BUILD_ID"`,
+  asc testflight beta-notifications create --build-id "BUILD_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -38,23 +38,26 @@ Examples:
 func BetaNotificationsCreateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("create", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "create",
-		ShortUsage: "asc testflight beta-notifications create --build \"BUILD_ID\"",
+		ShortUsage: "asc testflight beta-notifications create --build-id \"BUILD_ID\"",
 		ShortHelp:  "Send a beta notification for a build.",
 		LongHelp: `Send a beta notification for a build.
 
 Examples:
-  asc testflight beta-notifications create --build "BUILD_ID"`,
+  asc testflight beta-notifications create --build-id "BUILD_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -33,8 +33,8 @@ Examples:
   asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com"
   asc testflight beta-testers add-groups --id "TESTER_ID" --group "GROUP_ID"
   asc testflight beta-testers remove-groups --id "TESTER_ID" --group "GROUP_ID"
-  asc testflight beta-testers add-builds --id "TESTER_ID" --build "BUILD_ID"
-  asc testflight beta-testers remove-builds --id "TESTER_ID" --build "BUILD_ID" --confirm
+  asc testflight beta-testers add-builds --id "TESTER_ID" --build-id "BUILD_ID"
+  asc testflight beta-testers remove-builds --id "TESTER_ID" --build-id "BUILD_ID" --confirm
   asc testflight beta-testers remove-apps --id "TESTER_ID" --app "APP_ID" --confirm
   asc testflight beta-testers invite --app "APP_ID" --email "tester@example.com"
   asc testflight beta-testers invite --app "APP_ID" --email "tester@example.com" --group "Beta"`,
@@ -70,7 +70,7 @@ func BetaTestersListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	buildID := fs.String("build", "", "Build ID to filter")
+	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID to filter")
 	group := fs.String("group", "", "Beta group name or ID to filter")
 	email := fs.String("email", "", "Filter by tester email")
 	output := shared.BindOutputFlags(fs)
@@ -86,13 +86,16 @@ func BetaTestersListCommand() *ffcli.Command {
 
 Examples:
   asc testflight beta-testers list --app "APP_ID"
-  asc testflight beta-testers list --app "APP_ID" --build "BUILD_ID"
+  asc testflight beta-testers list --app "APP_ID" --build-id "BUILD_ID"
   asc testflight beta-testers list --app "APP_ID" --group "Beta"
   asc testflight beta-testers list --app "APP_ID" --limit 25
   asc testflight beta-testers list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("beta-testers list: --limit must be between 1 and 200")
 			}
@@ -453,30 +456,33 @@ func BetaTestersAddBuildsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add-builds", flag.ExitOnError)
 
 	id := fs.String("id", "", "Beta tester ID")
-	builds := fs.String("build", "", "Comma-separated build IDs")
+	buildIDs, legacyBuildIDs := bindBuildIDFlag(fs, "Comma-separated build IDs")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "add-builds",
-		ShortUsage: "asc testflight beta-testers add-builds --id TESTER_ID --build BUILD_ID[,BUILD_ID...]",
+		ShortUsage: "asc testflight beta-testers add-builds --id TESTER_ID --build-id BUILD_ID[,BUILD_ID...]",
 		ShortHelp:  "Add builds to a beta tester.",
 		LongHelp: `Add builds to a beta tester.
 
 Examples:
-  asc testflight beta-testers add-builds --id "TESTER_ID" --build "BUILD_ID"
-  asc testflight beta-testers add-builds --id "TESTER_ID" --build "BUILD_ID1,BUILD_ID2"`,
+  asc testflight beta-testers add-builds --id "TESTER_ID" --build-id "BUILD_ID"
+  asc testflight beta-testers add-builds --id "TESTER_ID" --build-id "BUILD_ID1,BUILD_ID2"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildIDs, legacyBuildIDs); err != nil {
+				return err
+			}
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return flag.ErrHelp
 			}
 
-			buildIDs := shared.SplitCSV(*builds)
-			if len(buildIDs) == 0 {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+			parsedBuildIDs := shared.SplitCSV(*buildIDs)
+			if len(parsedBuildIDs) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 
@@ -488,13 +494,13 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			if err := client.AddBuildsToBetaTester(requestCtx, testerID, buildIDs); err != nil {
+			if err := client.AddBuildsToBetaTester(requestCtx, testerID, parsedBuildIDs); err != nil {
 				return fmt.Errorf("beta-testers add-builds: failed to add builds: %w", err)
 			}
 
 			result := &asc.BetaTesterBuildsUpdateResult{
 				TesterID: testerID,
-				BuildIDs: buildIDs,
+				BuildIDs: parsedBuildIDs,
 				Action:   "added",
 			}
 
@@ -502,7 +508,7 @@ Examples:
 				return err
 			}
 
-			fmt.Fprintf(os.Stderr, "Successfully added tester %s to %d build(s)\n", testerID, len(buildIDs))
+			fmt.Fprintf(os.Stderr, "Successfully added tester %s to %d build(s)\n", testerID, len(parsedBuildIDs))
 			return nil
 		},
 	}
@@ -513,31 +519,34 @@ func BetaTestersRemoveBuildsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-builds", flag.ExitOnError)
 
 	id := fs.String("id", "", "Beta tester ID")
-	builds := fs.String("build", "", "Comma-separated build IDs")
+	buildIDs, legacyBuildIDs := bindBuildIDFlag(fs, "Comma-separated build IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "remove-builds",
-		ShortUsage: "asc testflight beta-testers remove-builds --id TESTER_ID --build BUILD_ID[,BUILD_ID...] --confirm",
+		ShortUsage: "asc testflight beta-testers remove-builds --id TESTER_ID --build-id BUILD_ID[,BUILD_ID...] --confirm",
 		ShortHelp:  "Remove builds from a beta tester.",
 		LongHelp: `Remove builds from a beta tester.
 
 Examples:
-  asc testflight beta-testers remove-builds --id "TESTER_ID" --build "BUILD_ID" --confirm
-  asc testflight beta-testers remove-builds --id "TESTER_ID" --build "BUILD_ID1,BUILD_ID2" --confirm`,
+  asc testflight beta-testers remove-builds --id "TESTER_ID" --build-id "BUILD_ID" --confirm
+  asc testflight beta-testers remove-builds --id "TESTER_ID" --build-id "BUILD_ID1,BUILD_ID2" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildIDs, legacyBuildIDs); err != nil {
+				return err
+			}
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return flag.ErrHelp
 			}
 
-			buildIDs := shared.SplitCSV(*builds)
-			if len(buildIDs) == 0 {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+			parsedBuildIDs := shared.SplitCSV(*buildIDs)
+			if len(parsedBuildIDs) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 			if !*confirm {
@@ -553,13 +562,13 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			if err := client.RemoveBuildsFromBetaTester(requestCtx, testerID, buildIDs); err != nil {
+			if err := client.RemoveBuildsFromBetaTester(requestCtx, testerID, parsedBuildIDs); err != nil {
 				return fmt.Errorf("beta-testers remove-builds: failed to remove builds: %w", err)
 			}
 
 			result := &asc.BetaTesterBuildsUpdateResult{
 				TesterID: testerID,
-				BuildIDs: buildIDs,
+				BuildIDs: parsedBuildIDs,
 				Action:   "removed",
 			}
 
@@ -567,7 +576,7 @@ Examples:
 				return err
 			}
 
-			fmt.Fprintf(os.Stderr, "Successfully removed tester %s from %d build(s)\n", testerID, len(buildIDs))
+			fmt.Fprintf(os.Stderr, "Successfully removed tester %s from %d build(s)\n", testerID, len(parsedBuildIDs))
 			return nil
 		},
 	}

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -63,7 +63,7 @@ func BetaTestersExportCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	outputPath := fs.String("output", "", "Output CSV file path (required)")
 	group := fs.String("group", "", "Beta group name or ID to filter (optional)")
-	buildID := fs.String("build", "", "Build ID to filter (optional)")
+	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID to filter (optional)")
 	email := fs.String("email", "", "Filter by tester email (optional)")
 	includeGroups := fs.Bool("include-groups", false, "Include a groups column (requires additional API calls)")
 	format := shared.BindOutputFlagsWith(fs, "format", "json", "Summary output format: json (default), table, markdown")
@@ -81,12 +81,15 @@ CSV format:
 Examples:
   asc testflight beta-testers export --app "APP_ID" --output "./testflight-testers.csv"
   asc testflight beta-testers export --app "APP_ID" --group "Beta" --output "./testers.csv"
-  asc testflight beta-testers export --app "APP_ID" --build "BUILD_ID" --output "./testers.csv"
+  asc testflight beta-testers export --app "APP_ID" --build-id "BUILD_ID" --output "./testers.csv"
   asc testflight beta-testers export --app "APP_ID" --email "tester@example.com" --output "./testers.csv"
   asc testflight beta-testers export --app "APP_ID" --output "./testers.csv" --include-groups`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")

--- a/internal/cli/testflight/build_id_flag_aliases.go
+++ b/internal/cli/testflight/build_id_flag_aliases.go
@@ -1,0 +1,70 @@
+package testflight
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type trackedStringFlag struct {
+	value string
+	set   bool
+}
+
+func (f *trackedStringFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	return f.value
+}
+
+func (f *trackedStringFlag) Set(value string) error {
+	f.value = value
+	f.set = true
+	return nil
+}
+
+func (f *trackedStringFlag) Used() bool {
+	return f != nil && f.set
+}
+
+func (f *trackedStringFlag) Value() string {
+	if f == nil {
+		return ""
+	}
+	return strings.TrimSpace(f.value)
+}
+
+func bindHiddenStringFlag(fs *flag.FlagSet, name, usage string) *trackedStringFlag {
+	value := &trackedStringFlag{}
+	fs.Var(value, name, usage)
+	shared.HideFlagFromHelp(fs.Lookup(name))
+	return value
+}
+
+func bindBuildIDFlag(fs *flag.FlagSet, usage string) (*string, *trackedStringFlag) {
+	return fs.String("build-id", "", usage), bindHiddenStringFlag(fs, "build", "DEPRECATED: use --build-id")
+}
+
+const legacyBuildIDWarning = "Warning: `--build` is deprecated. Use `--build-id`."
+
+func applyLegacyBuildIDAlias(buildID *string, legacyBuildID *trackedStringFlag) error {
+	if buildID == nil || legacyBuildID == nil || !legacyBuildID.Used() {
+		return nil
+	}
+
+	legacyValue := legacyBuildID.Value()
+	canonicalValue := strings.TrimSpace(*buildID)
+	if canonicalValue != "" && legacyValue != "" && canonicalValue != legacyValue {
+		return shared.UsageError("--build conflicts with --build-id; use only --build-id")
+	}
+	if canonicalValue == "" {
+		*buildID = legacyValue
+	}
+
+	fmt.Fprintln(os.Stderr, legacyBuildIDWarning)
+	return nil
+}

--- a/internal/cli/testflight/command_wrappers.go
+++ b/internal/cli/testflight/command_wrappers.go
@@ -590,9 +590,9 @@ func TestFlightReviewSurfaceCommand() *ffcli.Command {
 Examples:
   asc testflight review view --app "APP_ID"
   asc testflight review edit --id "DETAIL_ID" --contact-email "dev@example.com"
-  asc testflight review submit --build "BUILD_ID" --confirm
+  asc testflight review submit --build-id "BUILD_ID" --confirm
   asc testflight review app view --id "DETAIL_ID"
-  asc testflight review submissions list --build "BUILD_ID"
+  asc testflight review submissions list --build-id "BUILD_ID"
   asc testflight review submissions view --id "SUBMISSION_ID"`
 	setUsageFuncRecursively(cmd, testflightVisibleUsageFunc)
 
@@ -665,7 +665,7 @@ func TestFlightDistributionCommand() *ffcli.Command {
 	cmd.LongHelp = `Manage TestFlight distribution settings.
 
 Examples:
-  asc testflight distribution view --build "BUILD_ID"
+  asc testflight distribution view --build-id "BUILD_ID"
   asc testflight distribution edit --id "DETAIL_ID" --auto-notify
   asc testflight distribution build view --id "DETAIL_ID"`
 	setUsageFuncRecursively(cmd, testflightVisibleUsageFunc)
@@ -915,16 +915,16 @@ func DeprecatedBetaNotificationsAliasCommand() *ffcli.Command {
 				"create":             "send",
 			},
 		),
-		"asc testflight notifications send --build \"BUILD_ID\"",
+		"asc testflight notifications send --build-id \"BUILD_ID\"",
 		"Compatibility alias: use `asc testflight notifications send`.",
-		"Compatibility alias: use `asc testflight notifications send --build BUILD_ID`.",
+		"Compatibility alias: use `asc testflight notifications send --build-id BUILD_ID`.",
 	)
 	setUsageFuncRecursively(cmd, shared.DeprecatedUsageFunc)
 	markDeprecatedSubcommands(cmd)
 	if sendCmd := shared.DeprecatedAliasLeafCommand(
 		findSubcommand(cmd, "create"),
 		"send",
-		"asc testflight notifications send --build \"BUILD_ID\"",
+		"asc testflight notifications send --build-id \"BUILD_ID\"",
 		"asc testflight notifications send",
 		"Warning: `asc testflight beta-notifications send` is deprecated. Use `asc testflight notifications send`.",
 	); sendCmd != nil {

--- a/internal/cli/testflight/testflight.go
+++ b/internal/cli/testflight/testflight.go
@@ -24,11 +24,11 @@ Examples:
   asc testflight crashes view --submission-id "SUBMISSION_ID"
   asc testflight crashes log --submission-id "SUBMISSION_ID"
   asc testflight review view --app "APP_ID"
-  asc testflight distribution view --build "BUILD_ID"
+  asc testflight distribution view --build-id "BUILD_ID"
   asc testflight metrics group-testers --group "GROUP_ID"
   asc testflight metrics app-testers --app "APP_ID"
   asc testflight agreements view --app "APP_ID"
-  asc testflight notifications send --build "BUILD_ID"
+  asc testflight notifications send --build-id "BUILD_ID"
   asc testflight config export --app "APP_ID" --output "./testflight.yaml"
   asc testflight app-localizations list --app "APP_ID"
   asc testflight pre-release list --app "APP_ID"`,

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -27,9 +27,9 @@ func TestFlightReviewCommand() *ffcli.Command {
 Examples:
   asc testflight review get --app "APP_ID"
   asc testflight review update --id "DETAIL_ID" --contact-email "dev@example.com"
-  asc testflight review submit --build "BUILD_ID" --confirm
+  asc testflight review submit --build-id "BUILD_ID" --confirm
   asc testflight review app get --id "DETAIL_ID"
-  asc testflight review submissions list --build "BUILD_ID"
+  asc testflight review submissions list --build-id "BUILD_ID"
   asc testflight review submissions get --id "SUBMISSION_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -209,23 +209,26 @@ Examples:
 func TestFlightReviewSubmitCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("submit", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID")
 	confirm := fs.Bool("confirm", false, "Confirm submission")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "submit",
-		ShortUsage: "asc testflight review submit --build BUILD_ID --confirm",
+		ShortUsage: "asc testflight review submit --build-id BUILD_ID --confirm",
 		ShortHelp:  "Submit a build for beta app review.",
 		LongHelp: `Submit a build for beta app review.
 
 Examples:
-  asc testflight review submit --build "BUILD_ID" --confirm`,
+  asc testflight review submit --build-id "BUILD_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
 			if strings.TrimSpace(*buildID) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 			if !*confirm {
@@ -329,7 +332,7 @@ func TestFlightReviewSubmissionsCommand() *ffcli.Command {
 Examples:
   asc testflight review submissions get --id "SUBMISSION_ID"
   asc testflight review submissions build --id "SUBMISSION_ID"
-  asc testflight review submissions list --build "BUILD_ID"`,
+  asc testflight review submissions list --build-id "BUILD_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -347,7 +350,7 @@ Examples:
 func TestFlightReviewSubmissionsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("submissions list", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID to filter")
+	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID to filter")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -355,19 +358,22 @@ func TestFlightReviewSubmissionsListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc testflight review submissions list --build \"BUILD_ID\" [flags]",
+		ShortUsage: "asc testflight review submissions list --build-id \"BUILD_ID\" [flags]",
 		ShortHelp:  "List beta app review submissions.",
 		LongHelp: `List beta app review submissions.
 
 Examples:
-  asc testflight review submissions list --build "BUILD_ID"
-  asc testflight review submissions list --build "BUILD_ID" --paginate`,
+  asc testflight review submissions list --build-id "BUILD_ID"
+  asc testflight review submissions list --build-id "BUILD_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
 			buildValue := strings.TrimSpace(*buildID)
 			if buildValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
@@ -514,7 +520,7 @@ func TestFlightBetaDetailsCommand() *ffcli.Command {
 		LongHelp: `Manage TestFlight build beta details.
 
 Examples:
-  asc testflight beta-details get --build "BUILD_ID"
+  asc testflight beta-details get --build-id "BUILD_ID"
   asc testflight beta-details update --id "DETAIL_ID" --auto-notify`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -533,7 +539,7 @@ Examples:
 func TestFlightBetaDetailsGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("get", flag.ExitOnError)
 
-	buildID := fs.String("build", "", "Build ID")
+	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID")
 	output := shared.BindOutputFlags(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -545,10 +551,13 @@ func TestFlightBetaDetailsGetCommand() *ffcli.Command {
 		LongHelp: `Fetch build beta details for a build.
 
 Examples:
-  asc testflight beta-details get --build "BUILD_ID"`,
+  asc testflight beta-details get --build-id "BUILD_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildID, legacyBuildID); err != nil {
+				return err
+			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("testflight beta-details get: --limit must be between 1 and 200")
 			}
@@ -558,7 +567,7 @@ Examples:
 
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" && strings.TrimSpace(*next) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --build is required")
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
 				return flag.ErrHelp
 			}
 

--- a/internal/cli/testflight/testflight_sync.go
+++ b/internal/cli/testflight/testflight_sync.go
@@ -124,7 +124,7 @@ func TestFlightSyncPullCommand() *ffcli.Command {
 	includeBuilds := fs.Bool("include-builds", false, "Include builds and group assignments")
 	includeTesters := fs.Bool("include-testers", false, "Include testers and group memberships")
 	groupFilter := fs.String("group", "", "Filter to a specific beta group (name or ID)")
-	buildFilter := fs.String("build", "", "Filter to build ID(s), comma-separated")
+	buildFilter, legacyBuildFilter := bindBuildIDFlag(fs, "Filter to build ID(s), comma-separated")
 	testerFilter := fs.String("tester", "", "Filter to tester ID(s) or emails, comma-separated")
 	pretty := shared.BindPrettyJSONFlag(fs)
 
@@ -141,6 +141,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := applyLegacyBuildIDAlias(buildFilter, legacyBuildFilter); err != nil {
+				return err
+			}
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
@@ -156,7 +159,7 @@ Examples:
 			buildFilters := shared.SplitCSV(*buildFilter)
 			testerFilters := shared.SplitCSV(*testerFilter)
 			if len(buildFilters) > 0 && !*includeBuilds {
-				fmt.Fprintf(os.Stderr, "Error: --build requires --include-builds\n\n")
+				fmt.Fprintf(os.Stderr, "Error: --build-id requires --include-builds\n\n")
 				return flag.ErrHelp
 			}
 			if len(testerFilters) > 0 && !*includeTesters {


### PR DESCRIPTION
## Summary
- switch TestFlight build-targeting commands to `--build-id` for both single-build and comma-separated multi-build flows
- keep `--build` as a hidden deprecated alias with warning and conflict handling so existing automation keeps working during migration
- update help text and cmdtests, including dedicated migration coverage for canonical, legacy, and conflicting selector cases

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestTestFlight(BuildIDAliasConflictErrors|ReviewSubmissionsListBuildAliasWarnsAndMatchesCanonical|BetaTestersAddBuildsAliasWarnsAndMatchesCanonical|HelpShowsCanonicalSubcommands|ReviewSubmissionsListMissingBuild|ReviewSubmissionsListOutputTable|SyncValidationErrors|ReviewValidationErrors|BetaDetailsValidationErrors)|TestBetaManagementValidationErrors|TestBetaTestersListAcceptsBuildFilter|TestDeprecatedHelpShowsCanonicalPathsOnly'`
- [x] `make format`
- [x] `make generate-command-docs`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `git fetch origin main && git rebase origin/main`
- [x] `make check-command-docs && make lint && ASC_BYPASS_KEYCHAIN=1 make test`