### PR TITLE
apps wall: add PicSeek: AI Photo Manager

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -562,6 +562,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e7/cb/5c/e7cb5c08-a96f-f0f3-3642-416e1bba991e/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "PicSeek: AI Photo Manager",
+    "link": "https://apps.apple.com/us/app/picseek-ai-photo-manager/id6755383937?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f3/90/bc/f390bc5a-185e-095a-7ea2-c4a105bd89f7/AppIcon-1x_U007emarketing-0-8-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Pievra: Jules AI Coding Agent",
     "link": "https://apps.apple.com/us/app/pievra-jules-ai-coding-agent/id6758630855?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/32/40/cf/3240cf5f-61e5-d99e-b395-a24fae6bb6bd/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `PicSeek: AI Photo Manager` to the Wall of Apps

## Entry

- App ID: 6755383937
- App: PicSeek: AI Photo Manager
- Link: https://apps.apple.com/us/app/picseek-ai-photo-manager/id6755383937?uo=4

## Notes

- Submitted via `asc apps wall submit`
