### PR TITLE
apps wall: add SnapSong - AI Music from Photo

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -752,6 +752,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/83/d3/34/83d334a4-f19b-047a-8d62-75f1866d1c37/snapop-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "SnapSong - AI Music from Photo",
+    "link": "https://apps.apple.com/us/app/snapsong-ai-music-from-photo/id6758351507?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/58/de/7b/58de7b85-a047-2d07-b570-acd38f6e873b/SnapSong-Icon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SnapVinyl",
     "link": "https://apps.apple.com/app/id6741057688",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c3/87/7c/c3877c8c-bac8-537d-453e-98ba2e171fe1/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `SnapSong - AI Music from Photo` to the Wall of Apps

## Entry

- App ID: 6758351507
- App: SnapSong - AI Music from Photo
- Link: https://apps.apple.com/us/app/snapsong-ai-music-from-photo/id6758351507?uo=4

## Notes

- Submitted via `asc apps wall submit`
