### PR TITLE
apps wall: add Expense Tracker: ExpenseKit

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -224,6 +224,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/60/71/236071d7-7827-efd9-4c8f-03db0cee6aa9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Expense Tracker: ExpenseKit",
+    "link": "https://apps.apple.com/us/app/expense-tracker-expensekit/id6756433597?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a5/14/d8/a514d826-9475-8c8e-b4f5-6fe7b4fa660c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "FaceScreen - Desktop Camera",
     "link": "https://apps.apple.com/us/app/facescreen-desktop-camera/id6702028512?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/71/89/797189ca-6bde-e2e0-9e24-99bd6593b928/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Expense Tracker: ExpenseKit` to the Wall of Apps

## Entry

- App ID: 6756433597
- App: Expense Tracker: ExpenseKit
- Link: https://apps.apple.com/us/app/expense-tracker-expensekit/id6756433597?uo=4

## Notes

- Submitted via `asc apps wall submit`
