### PR TITLE
apps wall: add Step Counter: Steps App

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -782,6 +782,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/90/bc/20/90bc2003-d998-ba7a-ce45-66d846d7685f/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Step Counter: Steps App",
+    "link": "https://apps.apple.com/us/app/step-counter-steps-app/id6753876664?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6e/08/ae/6e08ae21-ae96-34fb-44fc-62d0b99a802c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Steps: Workout & Pedometer",
     "link": "https://apps.apple.com/us/app/steps-workout-pedometer/id6746096378",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/db/43/04/db430406-c791-e82a-1b4a-4283cca28b78/StepsIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Step Counter: Steps App` to the Wall of Apps

## Entry

- App ID: 6753876664
- App: Step Counter: Steps App
- Link: https://apps.apple.com/us/app/step-counter-steps-app/id6753876664?uo=4

## Notes

- Submitted via `asc apps wall submit`
