### PR TITLE
apps wall: add Reminders at a Glance

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -692,6 +692,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2e/57/88/2e5788c4-8164-e931-a976-fba05975baac/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Reminders at a Glance",
+    "link": "https://apps.apple.com/us/app/reminders-at-a-glance/id6760935916?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/03/19/51/031951c7-0539-a87b-5569-b5b60a6581be/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Repetti",
     "link": "https://apps.apple.com/us/app/repetti-the-chores-list-app/id6758055413",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e8/77/5c/e8775cab-2c64-3b11-e132-c636f3993a44/Icon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Reminders at a Glance` to the Wall of Apps

## Entry

- App ID: 6760935916
- App: Reminders at a Glance
- Link: https://apps.apple.com/us/app/reminders-at-a-glance/id6760935916?uo=4

## Notes

- Submitted via `asc apps wall submit`
