### PR TITLE
apps wall: add Grove ◦ Fiber Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -318,6 +318,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e8/a4/81/e8a4813c-4d02-65b3-442a-3703431813d7/AppIcon-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Grove ◦ Fiber Tracker",
+    "link": "https://apps.apple.com/us/app/grove-fiber-tracker/id6760088502?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/99/ac/ff/99acff42-6f6f-4bbf-70e3-19000f97430d/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "GrowPal: Health & Fitness",
     "link": "https://apps.apple.com/us/app/growpal-health-fitness/id1560604814?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0c/be/8b/0cbe8bfa-a36d-7ebb-6580-959481f43294/Grow-0-0-1x_U007ephone-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Grove ◦ Fiber Tracker` to the Wall of Apps

## Entry

- App ID: 6760088502
- App: Grove ◦ Fiber Tracker
- Link: https://apps.apple.com/us/app/grove-fiber-tracker/id6760088502?uo=4

## Notes

- Submitted via `asc apps wall submit`
