### PR TITLE
apps wall: add Boba Tycoon - Idle Tea Shop

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -70,6 +70,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a4/c8/2a/a4c82a25-fae8-4c04-6d02-91a15b72bb4f/BloomIconFinal-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Boba Tycoon - Idle Tea Shop",
+    "link": "https://apps.apple.com/us/app/boba-tycoon-idle-tea-shop/id6758029554?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ad/d4/c3/add4c3bf-d7b2-9445-3245-40d4e97403f9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Bobbin",
     "link": "https://apps.apple.com/us/app/threads-growth-bobbin/id6756035789",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/fe/a3/9d/fea39d77-422f-d815-5af9-c0ee518f5b97/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Boba Tycoon - Idle Tea Shop` to the Wall of Apps

## Entry

- App ID: 6758029554
- App: Boba Tycoon - Idle Tea Shop
- Link: https://apps.apple.com/us/app/boba-tycoon-idle-tea-shop/id6758029554?uo=4

## Notes

- Submitted via `asc apps wall submit`
