### PR TITLE
apps wall: add Idle Coffee Empire Clicker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -338,6 +338,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/57/e3/94/57e39489-2c7c-c1cc-56bc-13f85096d9cc/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
+    "app": "Idle Coffee Empire Clicker",
+    "link": "https://apps.apple.com/us/app/idle-coffee-empire-clicker/id6761031587?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4f/c9/94/4fc994dc-39e7-a593-8dd9-b5feff9e579a/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Impulses: Stop Impulse Buying",
     "link": "https://apps.apple.com/us/app/impulses-stop-impulse-buying/id6754372500?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8a/05/57/8a055708-4850-8120-8070-91424269b2f7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Idle Coffee Empire Clicker` to the Wall of Apps

## Entry

- App ID: 6761031587
- App: Idle Coffee Empire Clicker
- Link: https://apps.apple.com/us/app/idle-coffee-empire-clicker/id6761031587?uo=4

## Notes

- Submitted via `asc apps wall submit`
