### PR TITLE
apps wall: add Riverside Podcast Video Studio

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -737,6 +737,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/19/33/17/193317c5-5112-6151-9fd9-5b98ac41b52d/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Riverside Podcast Video Studio",
+    "link": "https://apps.apple.com/us/app/riverside-podcast-video-studio/id1554443872?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/50/64/bd/5064bd5c-0e6c-4b46-dd11-c3c7848c845a/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Ryform Golf",
     "link": "https://apps.apple.com/us/app/id6746525972",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/63/a9/01/63a90152-943b-ba07-d666-402df1f9694e/AppIcon-0-0-1x_U007epad-0-1-85-220.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Riverside Podcast Video Studio` to the Wall of Apps

## Entry

- App ID: 1554443872
- App: Riverside Podcast Video Studio
- Link: https://apps.apple.com/us/app/riverside-podcast-video-studio/id1554443872?uo=4

## Notes

- Submitted via `asc apps wall submit`
