### PR TITLE
apps wall: add Crunch: Compress & Convert

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -154,6 +154,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4d/84/49/4d84498d-802a-03b0-262f-bc80aa2c0f1a/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Crunch: Compress & Convert",
+    "link": "https://apps.apple.com/us/app/crunch-compress-convert/id6748700457?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/9e/88/85/9e888594-e92b-f739-c358-7fd083cae2f6/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Cubby",
     "link": "https://apps.apple.com/app/id6751732388",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2b/cf/8b/2bcf8b94-8050-926d-bce1-b95266a061d0/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Crunch: Compress & Convert` to the Wall of Apps

## Entry

- App ID: 6748700457
- App: Crunch: Compress & Convert
- Link: https://apps.apple.com/us/app/crunch-compress-convert/id6748700457?uo=4

## Notes

- Submitted via `asc apps wall submit`
