### PR TITLE
apps wall: add Hands Time - Minimalist Widget

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -348,6 +348,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/1c/5a/13/1c5a13a5-02e5-30c8-a359-e49972d11582/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Hands Time - Minimalist Widget",
+    "link": "https://apps.apple.com/us/app/hands-time-minimalist-widget/id6462440720?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ea/cd/e9/eacde9d6-4e33-e631-55fc-05aa961523a5/AppIcon-0-0-1x_U007ephone-0-0-0-1-0-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "HRM Battery",
     "link": "https://apps.apple.com/app/id6758920011",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7b/43/73/7b4373fc-26e2-030b-7162-2f0ab0a7681d/AppIcon-0-0-1x_U007ewatch-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Hands Time - Minimalist Widget` to the Wall of Apps

## Entry

- App ID: 6462440720
- App: Hands Time - Minimalist Widget
- Link: https://apps.apple.com/us/app/hands-time-minimalist-widget/id6462440720?uo=4

## Notes

- Submitted via `asc apps wall submit`
