### PR TITLE
apps wall: add Do? - Sex Tracker & Map Log

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -215,7 +215,7 @@
   },
   {
     "app": "Do? - Sex Tracker & Map Log",
-    "link": "https://apps.apple.com/us/app/do-sex-tracker-map-log/id6757778324?uo=4",
+    "link": "https://apps.apple.com/app/id6757778324",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/74/16/00/7416000d-28a9-7c8f-6537-9b6d8b92cc18/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {


### PR DESCRIPTION
## Summary

- add `Do? - Sex Tracker & Map Log` to the Wall of Apps

## Entry

- App ID: 6757778324
- App: Do? - Sex Tracker & Map Log
- Link: https://apps.apple.com/us/app/do-sex-tracker-map-log/id6757778324?uo=4

## Notes

- Submitted via `asc apps wall submit`
