### PR TITLE
[codex] Fix Windows auth key permission checks

### DIFF
--- a/internal/auth/doctor.go
+++ b/internal/auth/doctor.go
@@ -131,7 +131,7 @@ func inspectStorage(options DoctorOptions) DoctorSection {
 		Message: fmt.Sprintf("Config file exists at %s", configPath),
 	})
 
-	if info.Mode().Perm()&0o077 != 0 {
+	if filePermissionsTooPermissive(info.Mode()) {
 		check := DoctorCheck{
 			Status:         DoctorWarn,
 			Message:        fmt.Sprintf("Config file permissions are too permissive (%#o)", info.Mode().Perm()),
@@ -331,7 +331,7 @@ func inspectPrivateKeyPath(path string, options DoctorOptions) DoctorCheck {
 		Message: fmt.Sprintf("%s - permissions %#o", path, info.Mode().Perm()),
 	}
 
-	if info.Mode().Perm()&0o077 != 0 {
+	if filePermissionsTooPermissive(info.Mode()) {
 		check.Status = DoctorWarn
 		check.Message = fmt.Sprintf("%s - permissions %#o (expected 0600)", path, info.Mode().Perm())
 		check.Recommendation = fmt.Sprintf("Run: chmod 600 %q", path)

--- a/internal/auth/file_permissions.go
+++ b/internal/auth/file_permissions.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"io/fs"
+	"runtime"
+)
+
+func filePermissionsTooPermissive(mode fs.FileMode) bool {
+	return filePermissionsTooPermissiveForOS(mode, runtime.GOOS)
+}
+
+func filePermissionsTooPermissiveForOS(mode fs.FileMode, goos string) bool {
+	return goos != "windows" && mode.Perm()&0o077 != 0
+}

--- a/internal/auth/file_permissions_test.go
+++ b/internal/auth/file_permissions_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilePermissionsTooPermissiveForOS(t *testing.T) {
+	tests := []struct {
+		name string
+		mode os.FileMode
+		goos string
+		want bool
+	}{
+		{name: "unix secure", mode: 0o600, goos: "darwin", want: false},
+		{name: "unix insecure", mode: 0o644, goos: "darwin", want: true},
+		{name: "windows secure", mode: 0o600, goos: "windows", want: false},
+		{name: "windows insecure", mode: 0o644, goos: "windows", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filePermissionsTooPermissiveForOS(tt.mode, tt.goos); got != tt.want {
+				t.Fatalf("filePermissionsTooPermissiveForOS(%#o, %q) = %v, want %v", tt.mode.Perm(), tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateKeyFileForOSWindowsSkipsUnixPermissionCheck(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+
+	writeECDSAPEM(t, keyPath, 0o644, true)
+
+	if err := validateKeyFileForOS(keyPath, "windows"); err != nil {
+		t.Fatalf("expected Windows validation to ignore Unix permission bits, got %v", err)
+	}
+}

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -187,6 +188,10 @@ var legacyKeyringOpener = func() (keyring.Keyring, error) {
 
 // ValidateKeyFile validates that the private key file exists and is valid
 func ValidateKeyFile(path string) error {
+	return validateKeyFileForOS(path, runtime.GOOS)
+}
+
+func validateKeyFileForOS(path, goos string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("failed to open key file: %w", err)
@@ -200,7 +205,7 @@ func ValidateKeyFile(path string) error {
 	if info.IsDir() {
 		return fmt.Errorf("private key path is a directory")
 	}
-	if info.Mode().Perm()&0o077 != 0 {
+	if filePermissionsTooPermissiveForOS(info.Mode(), goos) {
 		return fmt.Errorf("private key file is too permissive; run: chmod 600 %q", path)
 	}
 


### PR DESCRIPTION
## Summary
- skip Unix-style private-key permission enforcement on Windows during auth validation
- reuse the same OS-aware permission helper in `auth doctor`
- add regression tests for Windows behavior while preserving Unix enforcement

## Why
Issue #1307 reported `asc auth login` on Windows always failing with `private key file is too permissive`. The root cause was unconditional use of Unix permission bits (`mode.Perm()&0o077`) even on Windows, where Go only uses the owner-writable bit for `Chmod` and NTFS ACLs are not represented by these permission bits.

The reporter's workaround was correct for the login path. This PR packages that fix behind a shared helper and applies it to `auth doctor` too so Windows users do not get false `chmod 600` guidance.

## Impact
- Windows users can authenticate with valid private key files instead of hitting a false permission error.
- Unix-like platforms still enforce the existing 0600-style check.
- `asc auth doctor` no longer emits false-positive permission warnings on Windows.

## Validation
- `go test ./internal/auth -count=1`
- `go test ./internal/cli/auth -run 'TestAuthLoginCommand' -count=1`
- `go test ./internal/cli/cmdtest -run 'TestAuth(LoginValidationFailurePreventsStore|LoginSkipValidationBypassesJWT)$' -count=1`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `GOOS=windows GOARCH=amd64 go build -o /tmp/asc-issue-1307.exe .`

Refs #1307