### PR TITLE
apps wall: add TMS - Bible Memory

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -931,6 +931,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d5/00/51/d500514a-c728-8598-f562-105dcc8005b9/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "TMS - Bible Memory",
+    "link": "https://apps.apple.com/us/app/tms-bible-memory/id6463799590?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/9a/7a/a3/9a7aa376-7dd9-8939-d6ba-90012b0cf417/tmsAppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "ToMe: Save to Self",
     "link": "https://apps.apple.com/app/id6755589008",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ea/39/63/ea3963e1-524c-7402-fe36-f930ddedcc36/ToMe_Liquid-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `TMS - Bible Memory` to the Wall of Apps

## Entry

- App ID: 6463799590
- App: TMS - Bible Memory
- Link: https://apps.apple.com/us/app/tms-bible-memory/id6463799590?uo=4

## Notes

- Submitted via `asc apps wall submit`
