### PR TITLE
Prepare ASC Studio 0.0.1 release

### DIFF
--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -25,6 +25,26 @@ jobs:
           VERSION="${VERSION#v}"
           printf 'VERSION=%s\n' "$VERSION" >> "$GITHUB_ENV"
 
+      - name: Validate Studio release secrets
+        env:
+          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
+          APPLE_DEVELOPER_ID_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_PASSWORD }}
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+        run: |
+          missing=0
+          for name in APPLE_DEVELOPER_ID_CERT APPLE_DEVELOPER_ID_PASSWORD APPLE_DEVELOPER_ID ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_B64; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Required secret ${name} is not set"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Set up Node
         uses: actions/setup-node@v5
         with:
@@ -38,8 +58,42 @@ jobs:
           go-version: '1.26.x'
           cache: true
 
+      - name: Import Apple certificate
+        uses: apple-actions/import-codesign-certs@v6
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
+          p12-password: ${{ secrets.APPLE_DEVELOPER_ID_PASSWORD }}
+
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+
+      - name: Prepare App Store Connect auth
+        env:
+          ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+        run: |
+          python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          Path("/tmp/AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"]))
+          PY
+
+      - name: Sync Studio product version
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("apps/studio/wails.json")
+          data = json.loads(path.read_text())
+          info = data.setdefault("info", {})
+          info["productVersion"] = os.environ["VERSION"]
+          path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+          PY
 
       - name: Install Studio frontend dependencies
         working-directory: apps/studio/frontend
@@ -55,9 +109,11 @@ jobs:
 
       - name: Build bundled asc helper
         run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           mkdir -p apps/studio/bin
-          GOOS=darwin GOARCH=arm64 go build -o apps/studio/bin/asc-arm64 .
-          GOOS=darwin GOARCH=amd64 go build -o apps/studio/bin/asc-amd64 .
+          GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o apps/studio/bin/asc-arm64 .
+          GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o apps/studio/bin/asc-amd64 .
           lipo -create -output apps/studio/bin/asc apps/studio/bin/asc-arm64 apps/studio/bin/asc-amd64
           chmod +x apps/studio/bin/asc
 
@@ -73,6 +129,71 @@ jobs:
         run: |
           mkdir -p release
           cp -R apps/studio/build/bin/ASC\ Studio.app release/
+
+      - name: Sign ASC Studio app
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+        run: |
+          codesign --force --sign "${APPLE_DEVELOPER_ID}" --timestamp --options=runtime "release/ASC Studio.app/Contents/Resources/bin/asc"
+          codesign --force --deep --sign "${APPLE_DEVELOPER_ID}" --timestamp --options=runtime "release/ASC Studio.app"
+          codesign --verify --deep --strict --verbose=2 "release/ASC Studio.app"
+
+      - name: Verify notarization auth
+        env:
+          ASC_BYPASS_KEYCHAIN: "1"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+        run: |
+          apps/studio/bin/asc auth status --validate --output json
+
+      - name: Create notarization archive
+        run: |
+          cd release
+          ditto -c -k --sequesterRsrc --keepParent "ASC Studio.app" "ASC-Studio-${VERSION}-notarization.zip"
+
+      - name: Notarize Studio release
+        env:
+          ASC_BYPASS_KEYCHAIN: "1"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+        run: |
+          set +e
+          apps/studio/bin/asc notarization submit \
+            --file "release/ASC-Studio-${VERSION}-notarization.zip" \
+            --wait \
+            --timeout 1h \
+            --output json >/tmp/studio-notarization.json 2>/tmp/studio-notarization.stderr
+          status=$?
+          set -e
+
+          cat /tmp/studio-notarization.stderr >&2 || true
+          cat /tmp/studio-notarization.json
+
+          submission_id=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          try:
+              payload = json.loads(Path("/tmp/studio-notarization.json").read_text())
+          except Exception:
+              print("")
+          else:
+              print(payload.get("data", {}).get("id", ""))
+          PY
+          )
+          if [ "$status" -ne 0 ]; then
+            if [ -n "$submission_id" ]; then
+              apps/studio/bin/asc notarization log --id "$submission_id" --output json || true
+            fi
+            exit "$status"
+          fi
+
+      - name: Staple ASC Studio app
+        run: |
+          xcrun stapler staple "release/ASC Studio.app"
+          xcrun stapler validate "release/ASC Studio.app"
 
       - name: Archive Studio release
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,4 @@ worktrees/
 
 # ASC Studio generated artifacts
 /apps/studio/build/bin/
-/apps/studio/build/darwin/Info.dev.plist
 /apps/studio/frontend/package.json.md5

--- a/apps/studio/build/darwin/Info.dev.plist
+++ b/apps/studio/build/darwin/Info.dev.plist
@@ -1,0 +1,68 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleName</key>
+        <string>{{.Info.ProductName}}</string>
+        <key>CFBundleExecutable</key>
+        <string>{{.OutputFilename}}</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.rudrankriyam.ascstudio</string>
+        <key>CFBundleVersion</key>
+        <string>{{.Info.ProductVersion}}</string>
+        <key>CFBundleGetInfoString</key>
+        <string>{{.Info.Comments}}</string>
+        <key>CFBundleShortVersionString</key>
+        <string>{{.Info.ProductVersion}}</string>
+        <key>CFBundleIconFile</key>
+        <string>iconfile</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.13.0</string>
+        <key>NSHighResolutionCapable</key>
+        <string>true</string>
+        <key>NSHumanReadableCopyright</key>
+        <string>{{.Info.Copyright}}</string>
+        {{if .Info.FileAssociations}}
+        <key>CFBundleDocumentTypes</key>
+        <array>
+          {{range .Info.FileAssociations}}
+          <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+              <string>{{.Ext}}</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>{{.Name}}</string>
+            <key>CFBundleTypeRole</key>
+            <string>{{.Role}}</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>{{.IconName}}</string>
+          </dict>
+          {{end}}
+        </array>
+        {{end}}
+        {{if .Info.Protocols}}
+        <key>CFBundleURLTypes</key>
+        <array>
+          {{range .Info.Protocols}}
+            <dict>
+                <key>CFBundleURLName</key>
+                <string>com.rudrankriyam.{{.Scheme}}</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>{{.Scheme}}</string>
+                </array>
+                <key>CFBundleTypeRole</key>
+                <string>{{.Role}}</string>
+            </dict>
+          {{end}}
+        </array>
+        {{end}}
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSAllowsLocalNetworking</key>
+            <true/>
+        </dict>
+    </dict>
+</plist>

--- a/apps/studio/build/darwin/Info.plist
+++ b/apps/studio/build/darwin/Info.plist
@@ -1,0 +1,68 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleName</key>
+        <string>{{.Info.ProductName}}</string>
+        <key>CFBundleExecutable</key>
+        <string>{{.OutputFilename}}</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.rudrankriyam.ascstudio</string>
+        <key>CFBundleVersion</key>
+        <string>{{.Info.ProductVersion}}</string>
+        <key>CFBundleGetInfoString</key>
+        <string>{{.Info.Comments}}</string>
+        <key>CFBundleShortVersionString</key>
+        <string>{{.Info.ProductVersion}}</string>
+        <key>CFBundleIconFile</key>
+        <string>iconfile</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.13.0</string>
+        <key>NSHighResolutionCapable</key>
+        <string>true</string>
+        <key>NSHumanReadableCopyright</key>
+        <string>{{.Info.Copyright}}</string>
+        {{if .Info.FileAssociations}}
+        <key>CFBundleDocumentTypes</key>
+        <array>
+          {{range .Info.FileAssociations}}
+          <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+              <string>{{.Ext}}</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>{{.Name}}</string>
+            <key>CFBundleTypeRole</key>
+            <string>{{.Role}}</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>{{.IconName}}</string>
+          </dict>
+          {{end}}
+        </array>
+        {{end}}
+        {{if .Info.Protocols}}
+        <key>CFBundleURLTypes</key>
+        <array>
+          {{range .Info.Protocols}}
+            <dict>
+                <key>CFBundleURLName</key>
+                <string>com.rudrankriyam.{{.Scheme}}</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>{{.Scheme}}</string>
+                </array>
+                <key>CFBundleTypeRole</key>
+                <string>{{.Role}}</string>
+            </dict>
+          {{end}}
+        </array>
+        {{end}}
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSAllowsLocalNetworking</key>
+            <true/>
+        </dict>
+    </dict>
+</plist>

--- a/apps/studio/wails.json
+++ b/apps/studio/wails.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
   "name": "ASC Studio",
+  "info": {
+    "companyName": "Rudrank Riyam",
+    "productName": "ASC Studio",
+    "productVersion": "0.0.1",
+    "copyright": "© 2026 Rudrank Riyam",
+    "comments": "ASC Studio for App Store Connect"
+  },
   "outputfilename": "ASC Studio",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",


### PR DESCRIPTION
## Summary
- set ASC Studio bundle metadata for 0.0.1 with the new bundle identifier
- version the darwin plist templates for both dev and release builds
- add Developer ID signing and asc-powered notarization to the Studio release workflow

## Verification
- wails build -clean -platform darwin/universal
- go test ./apps/studio/...
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-studio.yml")'