### PR TITLE
apps wall: add Geni Kids

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -323,6 +323,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/37/b6/e1/37b6e1c0-87da-9cb0-1d76-6d2a88b86b0a/Geeps-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Geni Kids",
+    "link": "https://apps.apple.com/us/app/geni-kids/id6761134405?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/72/a9/92/72a99255-2c75-ee9c-6bdf-215957eff996/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Glint: Morse Code Translator",
     "link": "https://apps.apple.com/us/app/glint-morse-code-translator/id6758366218?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/69/e1/b3/69e1b3be-109a-084a-62a3-8df22c8076c2/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Geni Kids` to the Wall of Apps

## Entry

- App ID: 6761134405
- App: Geni Kids
- Link: https://apps.apple.com/us/app/geni-kids/id6761134405?uo=4

## Notes

- Submitted via `asc apps wall submit`
