### PR TITLE
apps wall: add Lifterly

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -448,6 +448,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6d/fa/a9/6dfaa937-68e3-31e5-a090-9341aa41d70f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Lifterly",
+    "link": "https://apps.apple.com/us/app/lifterly/id6753913630?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/78/df/1e/78df1e26-9a13-20e6-3b37-df45306a684e/app-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "LilyFM",
     "link": "https://apps.apple.com/app/id6745472149",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a6/aa/4e/a6aa4ed4-1750-12c4-c206-8b1031c9c95c/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Lifterly` to the Wall of Apps

## Entry

- App ID: 6753913630
- App: Lifterly
- Link: https://apps.apple.com/us/app/lifterly/id6753913630?uo=4

## Notes

- Submitted via `asc apps wall submit`
