### PR TITLE
apps wall: add aether: Remote Deck ControlPad

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -10,6 +10,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5c/ce/67/5cce6782-729c-07af-1e0b-7322b8ffd914/SixtysixStreaksIcon-0-0-1x_U007emarketing-0-9-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "aether: Remote Deck ControlPad",
+    "link": "https://apps.apple.com/us/app/aether-remote-deck-controlpad/id6761128470?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4e/44/bd/4e44bde8-ee38-ba9a-c1f1-ff8485e5e5ff/aetherIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Airtist",
     "link": "https://apps.apple.com/app/id6745053878",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a1/85/81/a185815f-0e82-98b4-ac37-aed44c57d719/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `aether: Remote Deck ControlPad` to the Wall of Apps

## Entry

- App ID: 6761128470
- App: aether: Remote Deck ControlPad
- Link: https://apps.apple.com/us/app/aether-remote-deck-controlpad/id6761128470?uo=4

## Notes

- Submitted via `asc apps wall submit`
