### PR TITLE
apps wall: add Tintz: Color Picker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -951,6 +951,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/d5/00/51/d500514a-c728-8598-f562-105dcc8005b9/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Tintz: Color Picker",
+    "link": "https://apps.apple.com/us/app/tintz-color-picker/id6748126014?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/53/33/80/5333806a-5c46-8d24-6f30-fc455847922e/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "TMS - Bible Memory",
     "link": "https://apps.apple.com/us/app/tms-bible-memory/id6463799590?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/9a/7a/a3/9a7aa376-7dd9-8939-d6ba-90012b0cf417/tmsAppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Tintz: Color Picker` to the Wall of Apps

## Entry

- App ID: 6748126014
- App: Tintz: Color Picker
- Link: https://apps.apple.com/us/app/tintz-color-picker/id6748126014?uo=4

## Notes

- Submitted via `asc apps wall submit`
