### PR TITLE
apps wall: add Blimber – Student Planner

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -70,6 +70,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/71/18/13/71181314-64e0-ab1a-4e44-9f6134f12f01/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Blimber – Student Planner",
+    "link": "https://apps.apple.com/us/app/blimber-student-planner/id6751923150?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/1b/d4/ca/1bd4ca07-3310-f9e9-b2a6-06e0a7c7a955/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Bloom",
     "link": "https://apps.apple.com/app/id6739955926",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8e/9b/52/8e9b5222-940f-0058-1528-aec270296b39/Blueberry-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Blimber – Student Planner` to the Wall of Apps

## Entry

- App ID: 6751923150
- App: Blimber – Student Planner
- Link: https://apps.apple.com/us/app/blimber-student-planner/id6751923150?uo=4

## Notes

- Submitted via `asc apps wall submit`
