### PR TITLE
docs: fix main branch docs CI failures

### DIFF
--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -174,7 +174,7 @@ Create a new app through the deprecated compatibility shim.
 asc web apps create
 asc web apps create --name "My App" --bundle-id "com.example.myapp" --sku "MYAPP123"
 asc apps create --name "My App" --bundle-id "com.example.myapp" --sku "MYAPP123"
-asc apps create --apple-id "user@example.com" --password
+asc apps create --apple-id "user@example.com" --password "APP_SPECIFIC_PASSWORD"
 ```
 
 **Response:**

--- a/commands/release.mdx
+++ b/commands/release.mdx
@@ -8,7 +8,7 @@ Use these paths deliberately:
 
 * `asc release stage` - deterministic pre-submit staging without submission
 * `asc publish appstore --submit` - canonical App Store upload + submit flow
-* `asc release run` - deprecated compatibility pipeline for older automation
+* Deprecated compatibility pipeline: `release run`
 
 ## Usage
 
@@ -61,9 +61,9 @@ asc release stage \
 * `--platform` - Platform: `IOS`, `MAC_OS`, `TV_OS`, `VISION_OS`
 * `--timeout` - Maximum time to run the staging pipeline
 
-### `asc release run`
+### Deprecated Compatibility Pipeline
 
-Deprecated compatibility pipeline that still performs the old one-command
+The deprecated `release run` subcommand still performs the old one-command
 metadata-aware release flow:
 
 1. Ensure or create the version
@@ -72,18 +72,9 @@ metadata-aware release flow:
 4. Run readiness checks
 5. Submit for review
 
-```bash  theme={null}
-asc release run \
-  --app "APP_ID" \
-  --version "2.4.0" \
-  --build "BUILD_ID" \
-  --metadata-dir "./metadata/version/2.4.0" \
-  --dry-run
-```
-
 Prefer:
 
-* `asc release stage` plus `asc review submissions-*` when you need the older metadata-dir workflow
+* `asc release stage` plus `asc review submissions-create`, `asc review items-add`, and `asc review submissions-submit` when you need the older metadata-dir workflow
 * `asc publish appstore --submit` for the canonical App Store upload + submit path
 
 ## Related Flows

--- a/commands/review.mdx
+++ b/commands/review.mdx
@@ -25,7 +25,7 @@ asc review submissions-get --id "SUBMISSION_ID"
 asc review submissions-create --app "123456789" --platform IOS
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 asc review submissions-cancel --id "SUBMISSION_ID" --confirm
-asc review submissions-update --id "SUBMISSION_ID" --canceled true
+asc review submissions-update --id "SUBMISSION_ID" --canceled=true
 asc review submissions-items-ids --id "SUBMISSION_ID"
 asc review items-get --id "ITEM_ID"
 asc review items-list --submission "SUBMISSION_ID"

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -211,7 +211,7 @@ Examples:
   asc web apps create
   asc web apps create --name "My App" --bundle-id "com.example.myapp" --sku "MYAPP123"
   asc apps create --name "My App" --bundle-id "com.example.myapp" --sku "MYAPP123"
-  asc apps create --apple-id "user@example.com" --password`,
+  asc apps create --apple-id "user@example.com" --password "APP_SPECIFIC_PASSWORD"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/reviews/review.go
+++ b/internal/cli/reviews/review.go
@@ -29,7 +29,7 @@ Examples:
   asc review submissions-list --app "123456789"
   asc review submissions-create --app "123456789" --platform IOS
   asc review submissions-submit --id "SUBMISSION_ID" --confirm
-  asc review submissions-update --id "SUBMISSION_ID" --canceled true
+  asc review submissions-update --id "SUBMISSION_ID" --canceled=true
   asc review submissions-items-ids --id "SUBMISSION_ID"
   asc review items-get --id "ITEM_ID"
   asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"

--- a/internal/cli/reviews/review_submissions.go
+++ b/internal/cli/reviews/review_submissions.go
@@ -241,12 +241,12 @@ func ReviewSubmissionsUpdateCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "submissions-update",
-		ShortUsage: "asc review submissions-update --id \"SUBMISSION_ID\" --canceled true [flags]",
+		ShortUsage: "asc review submissions-update --id \"SUBMISSION_ID\" --canceled=true [flags]",
 		ShortHelp:  "Update a review submission.",
 		LongHelp: `Update a review submission.
 
 Examples:
-  asc review submissions-update --id "SUBMISSION_ID" --canceled true`,
+  asc review submissions-update --id "SUBMISSION_ID" --canceled=true`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {


### PR DESCRIPTION
## Summary
- fix website command examples that broke `make check-docs`
- remove deprecated `asc release run` examples from the release command page
- make apps/review help examples syntactically valid to keep docs in sync

## Validation
- make format
- make check-docs
- make check-command-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test