### PR TITLE
apps wall: add Telescopo: Markdown & Diagrams

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -936,6 +936,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/26/a3/f7/26a3f7f9-3cb6-dc8e-fcbd-0fc93630dd4c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Telescopo: Markdown & Diagrams",
+    "link": "https://apps.apple.com/us/app/telescopo-markdown-diagrams/id6747908871?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/eb/ba/d4/ebbad4d9-6a72-5d73-9a18-cf2719e6b8f3/telescopo-icon-0-0-85-220-0-6-0-2x-0-0-0.png/512x512bb.png"
+  },
+  {
     "app": "text to speech · speakeasy",
     "link": "https://apps.apple.com/app/id6758816495",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0a/49/48/0a49486e-92b3-37b5-8bb8-c038aee9a0a4/speakeasy-icon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Telescopo: Markdown & Diagrams` to the Wall of Apps

## Entry

- App ID: 6747908871
- App: Telescopo: Markdown & Diagrams
- Link: https://apps.apple.com/us/app/telescopo-markdown-diagrams/id6747908871?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`
