### PR TITLE
apps wall: add DeskTally

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -219,6 +219,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/55/90/80/55908099-0de3-f577-f029-7e76d29e3481/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "DeskTally",
+    "link": "https://apps.apple.com/us/app/desktally/id6760261861?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ca/bd/6c/cabd6c0c-3283-a46e-e1ed-51e2fc253af6/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "DevHub",
     "link": "https://apps.apple.com/us/app/devhub/id6476452351?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c9/fa/8b/c9fa8b9f-1ec9-3612-2cb6-a0dbb610468d/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `DeskTally` to the Wall of Apps

## Entry

- App ID: 6760261861
- App: DeskTally
- Link: https://apps.apple.com/us/app/desktally/id6760261861?uo=4

## Notes

- Submitted via `asc apps wall submit`
