### PR TITLE
apps wall: add Forerunner: Running & Wellness

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -319,6 +319,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/38/68/9e/38689e2a-598d-b3cd-58ac-ae551225d7b7/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
+    "app": "Forerunner: Running & Wellness",
+    "link": "https://apps.apple.com/us/app/forerunner-running-wellness/id6745802851?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/06/bb/79/06bb796e-81a0-8812-5c4a-6148ee92e8bf/AppIcon-0-0-1x_U007epad-0-0-0-1-0-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Foundation Lab",
     "link": "https://testflight.apple.com/join/JWR9FpP3"
   },


### PR DESCRIPTION
## Summary

- add `Forerunner: Running & Wellness` to the Wall of Apps

## Entry

- App ID: 6745802851
- App: Forerunner: Running & Wellness
- Link: https://apps.apple.com/us/app/forerunner-running-wellness/id6745802851?uo=4

## Notes

- Submitted via `asc apps wall submit`
