### PR TITLE
[codex] Explain stale removed review submissions in review status

### DIFF
--- a/internal/cli/cmdtest/review_status_doctor_test.go
+++ b/internal/cli/cmdtest/review_status_doctor_test.go
@@ -405,6 +405,154 @@ func TestReviewStatusExplainsCompleteSubmissionWithOnlyRemovedItems(t *testing.T
 	}
 }
 
+func TestReviewStatusIgnoresUnrelatedActiveSubmissionItems(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	itemRequests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/123456789/appStoreVersions":
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"appStoreVersions",
+						"id":"ver-1",
+						"attributes":{
+							"platform":"IOS",
+							"versionString":"1.2.3",
+							"appVersionState":"DEVELOPER_REJECTED",
+							"createdDate":"2026-03-15T00:00:00Z"
+						}
+					}
+				],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/appStoreVersions/ver-1/appStoreReviewDetail":
+			return statusJSONResponse(`{
+				"data":{
+					"type":"appStoreReviewDetails",
+					"id":"detail-1",
+					"attributes":{"contactEmail":"dev@example.com"}
+				}
+			}`), nil
+		case "/v1/apps/123456789/reviewSubmissions":
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"reviewSubmissions",
+						"id":"review-sub-1",
+						"attributes":{"state":"COMPLETE","platform":"IOS","submittedDate":"2026-03-15T01:00:00Z"},
+						"relationships":{
+							"appStoreVersionForReview":{
+								"data":{"type":"appStoreVersions","id":"ver-1"}
+							}
+						}
+					}
+				],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/reviewSubmissions/review-sub-1/items":
+			itemRequests++
+			if req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("expected items limit 200, got %q", req.URL.Query().Get("limit"))
+			}
+			if req.URL.Query().Get("fields[reviewSubmissionItems]") != "state,appStoreVersion" {
+				t.Fatalf("expected item fields state,appStoreVersion, got %q", req.URL.Query().Get("fields[reviewSubmissionItems]"))
+			}
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"reviewSubmissionItems",
+						"id":"item-version-removed",
+						"attributes":{"state":"REMOVED"},
+						"relationships":{
+							"appStoreVersion":{
+								"data":{"type":"appStoreVersions","id":"ver-1"}
+							},
+							"reviewSubmission":{
+								"data":{"type":"reviewSubmissions","id":"review-sub-1"}
+							}
+						}
+					},
+					{
+						"type":"reviewSubmissionItems",
+						"id":"item-background-active",
+						"attributes":{"state":"APPROVED"},
+						"relationships":{
+							"backgroundAssetVersion":{
+								"data":{"type":"backgroundAssetVersions","id":"bg-1"}
+							},
+							"reviewSubmission":{
+								"data":{"type":"reviewSubmissions","id":"review-sub-1"}
+							}
+						}
+					}
+				],
+				"links":{"next":""}
+			}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"review", "status", "--app", "123456789"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if itemRequests != 1 {
+		t.Fatalf("expected 1 review submission item request, got %d", itemRequests)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	if payload["reviewState"] != "COMPLETE" {
+		t.Fatalf("expected reviewState COMPLETE, got %v", payload["reviewState"])
+	}
+	if payload["nextAction"] != "Create a fresh review submission for the current version." {
+		t.Fatalf("expected stale submission next action, got %v", payload["nextAction"])
+	}
+
+	blockers, ok := payload["blockers"].([]any)
+	if !ok {
+		t.Fatalf("expected blockers array, got %T", payload["blockers"])
+	}
+	if len(blockers) == 0 {
+		t.Fatal("expected stale submission blocker")
+	}
+
+	found := false
+	for _, blocker := range blockers {
+		if strings.Contains(blocker.(string), "no longer contains active review items") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected stale submission blocker in %v", blockers)
+	}
+}
+
 func TestReviewStatusFiltersSubmissionsToSelectedVersion(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/reviews/review_overview.go
+++ b/internal/cli/reviews/review_overview.go
@@ -270,8 +270,8 @@ func buildReviewSnapshot(ctx context.Context, client *asc.Client, appID, version
 		selectedVersionID = strings.TrimSpace(versionContext.ID)
 	}
 	snapshot.LatestSubmission = selectRelevantReviewSubmission(reviewSubmissions, selectedVersionID)
-	if shouldInspectReviewSubmissionItems(snapshot.LatestSubmission) {
-		submissionItems, err := summarizeReviewSubmissionItems(ctx, client, snapshot.LatestSubmission.ID)
+	if selectedVersionID != "" && shouldInspectReviewSubmissionItems(snapshot.LatestSubmission) {
+		submissionItems, err := summarizeReviewSubmissionItems(ctx, client, snapshot.LatestSubmission.ID, selectedVersionID)
 		if err != nil {
 			return snapshot, fmt.Errorf("fetch review submission items for %q: %w", snapshot.LatestSubmission.ID, err)
 		}
@@ -382,21 +382,27 @@ func shouldInspectReviewSubmissionItems(submission *reviewSubmissionContext) boo
 	return strings.EqualFold(strings.TrimSpace(submission.State), string(asc.ReviewSubmissionStateComplete))
 }
 
-func summarizeReviewSubmissionItems(ctx context.Context, client *asc.Client, submissionID string) (reviewSubmissionItemsContext, error) {
+func summarizeReviewSubmissionItems(ctx context.Context, client *asc.Client, submissionID, versionID string) (reviewSubmissionItemsContext, error) {
 	var summary reviewSubmissionItemsContext
 
 	submissionID = strings.TrimSpace(submissionID)
+	versionID = strings.TrimSpace(versionID)
 	if submissionID == "" || client == nil {
 		return summary, nil
 	}
 
-	resp, err := client.GetReviewSubmissionItems(ctx, submissionID, asc.WithReviewSubmissionItemsLimit(200))
+	resp, err := client.GetReviewSubmissionItems(
+		ctx,
+		submissionID,
+		asc.WithReviewSubmissionItemsLimit(200),
+		asc.WithReviewSubmissionItemsFields([]string{"state", "appStoreVersion"}),
+	)
 	if err != nil {
 		return summary, err
 	}
 
 	for {
-		accumulateReviewSubmissionItems(&summary, resp.Data)
+		accumulateReviewSubmissionItems(&summary, resp.Data, versionID)
 
 		nextURL := strings.TrimSpace(resp.Links.Next)
 		if nextURL == "" {
@@ -410,12 +416,15 @@ func summarizeReviewSubmissionItems(ctx context.Context, client *asc.Client, sub
 	}
 }
 
-func accumulateReviewSubmissionItems(summary *reviewSubmissionItemsContext, items []asc.ReviewSubmissionItemResource) {
+func accumulateReviewSubmissionItems(summary *reviewSubmissionItemsContext, items []asc.ReviewSubmissionItemResource, versionID string) {
 	if summary == nil {
 		return
 	}
 
 	for _, item := range items {
+		if !reviewSubmissionItemTargetsVersion(item, versionID) {
+			continue
+		}
 		summary.TotalCount++
 		if strings.EqualFold(strings.TrimSpace(item.Attributes.State), "REMOVED") {
 			summary.RemovedCount++
@@ -423,6 +432,16 @@ func accumulateReviewSubmissionItems(summary *reviewSubmissionItemsContext, item
 		}
 		summary.ActiveCount++
 	}
+}
+
+func reviewSubmissionItemTargetsVersion(item asc.ReviewSubmissionItemResource, versionID string) bool {
+	if strings.TrimSpace(versionID) == "" {
+		return true
+	}
+	if item.Relationships == nil || item.Relationships.AppStoreVersion == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(item.Relationships.AppStoreVersion.Data.ID), strings.TrimSpace(versionID))
 }
 
 func reviewSnapshotHasOnlyRemovedItems(snapshot reviewSnapshot) bool {

--- a/internal/cli/reviews/review_overview_test.go
+++ b/internal/cli/reviews/review_overview_test.go
@@ -183,6 +183,57 @@ func TestBuildReviewDoctorResultAddsRemovedItemsOnlyBlocker(t *testing.T) {
 	}
 }
 
+func TestAccumulateReviewSubmissionItemsIgnoresUnrelatedSubmissionItems(t *testing.T) {
+	summary := reviewSubmissionItemsContext{}
+	items := []asc.ReviewSubmissionItemResource{
+		{
+			ID: "item-removed-version",
+			Attributes: asc.ReviewSubmissionItemAttributes{
+				State: "REMOVED",
+			},
+			Relationships: &asc.ReviewSubmissionItemRelationships{
+				AppStoreVersion: &asc.Relationship{
+					Data: asc.ResourceData{ID: "ver-1", Type: asc.ResourceTypeAppStoreVersions},
+				},
+			},
+		},
+		{
+			ID: "item-active-background",
+			Attributes: asc.ReviewSubmissionItemAttributes{
+				State: "APPROVED",
+			},
+			Relationships: &asc.ReviewSubmissionItemRelationships{
+				BackgroundAssetVersion: &asc.Relationship{
+					Data: asc.ResourceData{ID: "bg-1", Type: asc.ResourceTypeBackgroundAssetVersions},
+				},
+			},
+		},
+		{
+			ID: "item-other-version",
+			Attributes: asc.ReviewSubmissionItemAttributes{
+				State: "APPROVED",
+			},
+			Relationships: &asc.ReviewSubmissionItemRelationships{
+				AppStoreVersion: &asc.Relationship{
+					Data: asc.ResourceData{ID: "ver-2", Type: asc.ResourceTypeAppStoreVersions},
+				},
+			},
+		},
+	}
+
+	accumulateReviewSubmissionItems(&summary, items, "ver-1")
+
+	if summary.TotalCount != 1 {
+		t.Fatalf("expected only selected version item to count, got total=%d", summary.TotalCount)
+	}
+	if summary.RemovedCount != 1 {
+		t.Fatalf("expected removed count 1, got %d", summary.RemovedCount)
+	}
+	if summary.ActiveCount != 0 {
+		t.Fatalf("expected no active selected-version items, got %d", summary.ActiveCount)
+	}
+}
+
 func TestSelectRelevantReviewSubmissionPrefersActiveSubmissionWithoutSubmittedDate(t *testing.T) {
 	submissions := []asc.ReviewSubmissionResource{
 		{


### PR DESCRIPTION
## Summary
- inspect review submission items when `asc review status` or `asc review doctor` encounters the latest `COMPLETE` submission
- surface a dedicated stale-submission diagnosis when all review items were removed, with a fresh-submission next action instead of the generic fallback
- add CLI and package-level regression tests for the removed-items-only path and update existing `COMPLETE` submission fixtures to model active items explicitly

## Why
A completed submission whose only review items were removed looked healthy at the submission level, even though the version was no longer actively submitted. The only reliable signal lived behind a separate `review items-list` call, which made `asc review status` misleading for exactly the scenario reported in the issue.

## Validation
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-1347 review status --app 6759231657 --output json --pretty`
- attempted live stale-state repro on ASC Test app `6759231657`; adding the version to review was blocked by unrelated App Store Connect readiness requirements, so the stale path itself was validated through the new regression tests

Closes #1347