### PR TITLE
apps wall: add Printer Tools App

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -732,6 +732,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7a/04/14/7a04148e-e548-f6bf-8c0e-c26b9157a7cb/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Printer Tools App",
+    "link": "https://apps.apple.com/us/app/printer-tools-app/id6745528803?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0c/4b/03/0c4b03c9-821c-d641-4c9a-27eb39885edc/AppIcon-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "PrivaNota: Private AI Notes",
     "link": "https://apps.apple.com/us/app/privanota-private-ai-notes/id6752555660",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7f/e6/22/7fe622bc-1260-bcfd-a8e2-c179ba33e727/PrivaNota-0.6-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Printer Tools App` to the Wall of Apps

## Entry

- App ID: 6745528803
- App: Printer Tools App
- Link: https://apps.apple.com/us/app/printer-tools-app/id6745528803?uo=4

## Notes

- Submitted via `asc apps wall submit`
