### PR TITLE
apps wall: add Scooter Tools

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -837,6 +837,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/95/ed/7c/95ed7cad-90a7-5d3b-8742-444542d3dc55/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.png"
   },
   {
+    "app": "Scooter Tools",
+    "link": "https://apps.apple.com/us/app/scooter-tools/id6452079114?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/cf/8e/88/cf8e88b7-50bc-e82f-f37b-734549d82fcd/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "SF Catalog",
     "link": "https://apps.apple.com/us/app/sf-catalog/id6759371914?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/69/3d/6b/693d6bb5-f68d-1ce3-0ec3-2382a45ffc3d/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Scooter Tools` to the Wall of Apps

## Entry

- App ID: 6452079114
- App: Scooter Tools
- Link: https://apps.apple.com/us/app/scooter-tools/id6452079114?uo=4

## Notes

- Submitted via `asc apps wall submit`
