### PR TITLE
apps wall: add AdMate App

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -10,6 +10,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5c/ce/67/5cce6782-729c-07af-1e0b-7322b8ffd914/SixtysixStreaksIcon-0-0-1x_U007emarketing-0-9-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "AdMate App",
+    "link": "https://apps.apple.com/us/app/admate-app/id6705137320?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/fb/86/59/fb865967-771a-6e3f-d5b6-325f5c60287f/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "aether: Remote Deck ControlPad",
     "link": "https://apps.apple.com/us/app/aether-remote-deck-controlpad/id6761128470?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4e/44/bd/4e44bde8-ee38-ba9a-c1f1-ff8485e5e5ff/aetherIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `AdMate App` to the Wall of Apps

## Entry

- App ID: 6705137320
- App: AdMate App
- Link: https://apps.apple.com/us/app/admate-app/id6705137320?uo=4

## Notes

- Submitted via `asc apps wall submit`
