### PR TITLE
[codex] Improve auth status help discoverability

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -48,7 +48,14 @@ Credential resolution order:
   2) Environment variables (fallback for missing fields)
 
 Use --strict-auth or ASC_STRICT_AUTH=true (also: 1, yes, y, on) to fail when sources are mixed.
-Set ASC_BYPASS_KEYCHAIN to 1/true/yes/on to bypass keychain.`,
+Set ASC_BYPASS_KEYCHAIN to 1/true/yes/on to bypass keychain.
+
+Use "asc auth status" to see which credentials/profile are currently active.
+
+Examples:
+  asc auth status
+  asc auth status --verbose
+  asc auth switch --profile work`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -632,7 +639,7 @@ func AuthStatusCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "status",
 		ShortUsage: "asc auth status",
-		ShortHelp:  "Show current authentication status.",
+		ShortHelp:  "Show active profile and authentication status.",
 		LongHelp: `Show current authentication status.
 
 Displays information about stored API keys and which one is currently active.


### PR DESCRIPTION
## Summary

- make `asc auth status` read more clearly as the active identity/profile check by updating its short help
- add a direct hint in `asc auth --help` pointing users to `asc auth status` for the currently active credentials/profile
- add a small auth help example block so the status/switch mental model is visible on first scan

## Why this approach

Issue #1367 suggested adding an `auth whoami` alias or new identity-focused command. We chose not to grow the command surface for a synonym because the capability already exists in `asc auth status`. The lighter-weight fix is to improve discoverability in help text so users can find the existing command faster.

## Impact

- no new commands or flags
- no compatibility risk from aliasing or command lifecycle overhead
- clearer first-run auth discovery for users scanning `asc auth --help`

## Validation

- `go run . auth --help`
- `go run . auth status --help`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Context

- rationale also documented on closed issue #1367