### PR TITLE
apps wall: add Haven: Setup Codes

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -403,6 +403,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ea/cd/e9/eacde9d6-4e33-e631-55fc-05aa961523a5/AppIcon-0-0-1x_U007ephone-0-0-0-1-0-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Haven: Setup Codes",
+    "link": "https://apps.apple.com/us/app/haven-setup-codes/id6760440926?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/72/e6/1f/72e61fe0-7f0e-bb59-732d-c89ed669ed59/Haven-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "HoverCalc",
     "link": "https://apps.apple.com/us/app/hovercalc/id6759318126?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4d/d5/0f/4dd50f26-4b76-e382-9774-5894156f11df/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Haven: Setup Codes` to the Wall of Apps

## Entry

- App ID: 6760440926
- App: Haven: Setup Codes
- Link: https://apps.apple.com/us/app/haven-setup-codes/id6760440926?uo=4

## Notes

- Submitted via `asc apps wall submit`
