### PR TITLE
apps wall: add EchoKeep: Smarter RSS Reader

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -274,6 +274,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c3/12/31/c31231ef-8a43-d6dd-84e2-23728b669d59/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "EchoKeep: Smarter RSS Reader",
+    "link": "https://apps.apple.com/us/app/echokeep-smarter-rss-reader/id6752524967?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/4a/dc/234adc2b-ac03-64c7-b503-05112d5ad183/EchoKeep-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "EduSwipe: AI Flashcards & SRS",
     "link": "https://apps.apple.com/us/app/eduswipe-ai-flashcards-srs/id6744727106?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/60/71/236071d7-7827-efd9-4c8f-03db0cee6aa9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `EchoKeep: Smarter RSS Reader` to the Wall of Apps

## Entry

- App ID: 6752524967
- App: EchoKeep: Smarter RSS Reader
- Link: https://apps.apple.com/us/app/echokeep-smarter-rss-reader/id6752524967?uo=4

## Notes

- Submitted via `asc apps wall submit`
