### PR TITLE
[codex] docs: clarify localization locale forms

### DIFF
--- a/commands/localizations.mdx
+++ b/commands/localizations.mdx
@@ -198,13 +198,45 @@ asc localizations upload --version "VERSION_ID" --path "./localizations" --dry-r
 
 ***
 
+### `asc localizations supported-locales`
+
+List the shared App Store localization catalog for a version and show which
+locales are already configured.
+
+<ParamField path="--version" type="string" required>
+  App Store version ID to inspect against the shared CLI locale catalog
+</ParamField>
+
+Use this command when you need the canonical locale codes accepted by ASC for a
+version workflow, such as `ar-SA`, `de-DE`, `zh-Hans`, and `zh-Hant`.
+
+**Examples:**
+
+```bash  theme={null}
+asc localizations supported-locales --version "VERSION_ID"
+asc localizations supported-locales --version "VERSION_ID" --output json --pretty
+```
+
+***
+
 ### `asc localizations create`
 
 Create a new version localization.
 
+<ParamField path="--version" type="string" required>
+  App Store version ID to create the localization under
+</ParamField>
+
+<ParamField path="--locale" type="string" required>
+  Canonical App Store Connect locale code to create
+</ParamField>
+
 Use canonical App Store Connect locale identifiers for `--locale`. Common
 accepted forms include `en-US`, `es-MX`, `de-DE`, `ja`, `ar-SA`, `zh-Hans`, and
 `zh-Hant`.
+
+Run `asc localizations supported-locales --version "VERSION_ID"` to inspect the
+shared CLI locale catalog for that version before creating a new locale.
 
 Common failures:
 
@@ -226,9 +258,36 @@ asc localizations create --version "VERSION_ID" --locale "zh-Hans" --description
 
 Update localization metadata.
 
+<ParamField path="--version" type="string">
+  App Store version ID for version localizations
+</ParamField>
+
+<ParamField path="--app" type="string">
+  App Store Connect app ID (or `ASC_APP_ID`) for app-info localizations
+</ParamField>
+
+<ParamField path="--app-info" type="string">
+  App Info ID (optional override for app-info localizations)
+</ParamField>
+
+<ParamField path="--type" type="string" default="version">
+  Localization type: `version` (default) or `app-info`
+</ParamField>
+
+<ParamField path="--locale" type="string" required>
+  Exact App Store Connect locale value to update
+</ParamField>
+
 Use the exact App Store Connect locale already present on the app or version
 when you pass `--locale`. If update fails with a locale mismatch, run
 `asc localizations list` and reuse the `locale` value returned by ASC.
+
+For version workflows, run `asc localizations supported-locales --version
+"VERSION_ID"` to inspect the shared CLI catalog, and `asc localizations list
+--version "VERSION_ID"` to see locales already configured on the version.
+
+For app-info workflows, use `asc localizations list --app "APP_ID" --type
+app-info` to inspect the configured locale values before updating.
 
 Common accepted forms include `en-US`, `de-DE`, `ja`, `ar-SA`, `zh-Hans`, and
 `zh-Hant`.
@@ -289,6 +348,9 @@ The .strings file format is a simple key-value format:
 ```
 
 ## Supported Locales
+
+For the authoritative CLI catalog on a specific version, run
+`asc localizations supported-locales --version "VERSION_ID"`.
 
 Use canonical App Store Connect locale identifiers when possible. For example,
 prefer `ar-SA` over `ar`, and `zh-Hans` / `zh-Hant` over regional variants like

--- a/guides/metadata-management.mdx
+++ b/guides/metadata-management.mdx
@@ -337,13 +337,16 @@ asc localizations list --version "$VERSION_ID" --output table
 
 Common App Store locales:
 
+Use `asc localizations supported-locales --version "VERSION_ID"` to inspect the
+shared CLI locale catalog and see which version locales are already configured.
+
 * `en-US` - English (US)
 * `en-GB` - English (UK)
 * `es-ES` - Spanish (Spain)
 * `es-MX` - Spanish (Mexico)
 * `fr-FR` - French
 * `de-DE` - German
-* `it-IT` - Italian
+* `it` - Italian
 * `ja` - Japanese
 * `ko` - Korean
 * `pt-BR` - Portuguese (Brazil)
@@ -371,7 +374,7 @@ Common App Store locales:
 
   <Step title="Create version localization">
     ```bash  theme={null}
-    asc localizations update \
+    asc localizations create \
       --version "VERSION_ID" \
       --locale "ja" \
       --description "日本語の説明" \
@@ -419,7 +422,7 @@ echo "All locales created. Update translations in App Store Connect or via CLI."
 
 2. **Use dry-run**: Test uploads with `--dry-run` to catch errors before applying changes
 
-3. **Separate app info from version metadata**: Update persistent metadata (name, subtitle) via `app-setup info set`, version-specific content via `localizations update`
+3. **Separate app info from version metadata**: Update persistent metadata (name, subtitle) via `app-setup info set`; create new version locales with `localizations create`, then edit existing version metadata with `localizations update`
 
 4. **Optimize keywords**: Research popular search terms and use all 100 characters effectively
 
@@ -440,7 +443,7 @@ echo "All locales created. Update translations in App Store Connect or via CLI."
 **Solution**: Create the localization first:
 
 ```bash  theme={null}
-asc localizations update \
+asc localizations create \
   --version "VERSION_ID" \
   --locale "ja" \
   --description "Initial description"

--- a/internal/cli/localizations/create.go
+++ b/internal/cli/localizations/create.go
@@ -36,6 +36,9 @@ func LocalizationsCreateCommand() *ffcli.Command {
 Use canonical App Store Connect locale identifiers when possible. Common accepted
 forms include en-US, es-MX, de-DE, ja, ar-SA, zh-Hans, and zh-Hant.
 
+To inspect the shared CLI locale catalog for a version, run:
+  asc localizations supported-locales --version "VERSION_ID"
+
 Common failures:
   "ar" is usually rejected; use "ar-SA"
   "de" should usually be "de-DE"

--- a/internal/cli/localizations/localizations_test.go
+++ b/internal/cli/localizations/localizations_test.go
@@ -92,6 +92,7 @@ func TestLocalizationsCreateCommand_HelpMentionsCanonicalLocaleForms(t *testing.
 		}
 	}
 	for _, want := range []string{
+		`asc localizations supported-locales --version "VERSION_ID"`,
 		`"ar" is usually rejected; use "ar-SA"`,
 		`"de" should usually be "de-DE"`,
 		`"zh-Hans-CN"`,
@@ -116,10 +117,12 @@ func TestLocalizationsUpdateCommand_HelpMentionsCanonicalLocaleForms(t *testing.
 		}
 	}
 	for _, want := range []string{
+		`asc localizations supported-locales --version "VERSION_ID"`,
+		`asc localizations list --version "VERSION_ID"`,
+		`asc localizations list --app "APP_ID" --type app-info`,
 		`"ar" is usually stored as "ar-SA"`,
 		`"de" is usually stored as "de-DE"`,
 		`"zh-Hans-CN" and "zh-Hant-TW"`,
-		`run asc localizations list and reuse the`,
 	} {
 		if !strings.Contains(cmd.LongHelp, want) {
 			t.Fatalf("expected long help to contain %q, got %q", want, cmd.LongHelp)

--- a/internal/cli/localizations/update.go
+++ b/internal/cli/localizations/update.go
@@ -55,8 +55,12 @@ Common failures:
   "de" is usually stored as "de-DE"
   "zh-Hans-CN" and "zh-Hant-TW" are usually stored as "zh-Hans" and "zh-Hant"
 
-If a locale is rejected or not found, run asc localizations list and reuse the
-exact locale value from the response.
+If a version locale is rejected or not found, run:
+  asc localizations supported-locales --version "VERSION_ID"
+  asc localizations list --version "VERSION_ID"
+
+For app-info localizations, inspect configured locales with:
+  asc localizations list --app "APP_ID" --type app-info
 
 For app-info localizations (name, subtitle, privacy URLs):
   asc localizations update --app "APP_ID" --type app-info --locale "ar-SA" --subtitle "Arabic subtitle"


### PR DESCRIPTION
## Summary
- clarify `asc localizations create` help text to document canonical App Store Connect locale forms
- clarify `asc localizations update` help text to explain exact-locale matching and common failures
- align the authored localization command docs with the CLI guidance

## Why
Users currently see locale-shape validation, but they still have to trial-and-error accepted App Store Connect locale forms such as `ar` vs `ar-SA` and `zh-Hans` vs `zh-Hans-CN`.

This change documents the canonical examples and the most common failure cases without changing runtime behavior.

## Impact
- users get clearer `--help` output for `localizations create` and `localizations update`
- docs now point users toward canonical ASC locale identifiers like `ar-SA`, `de-DE`, `zh-Hans`, and `zh-Hant`
- update guidance now tells users to reuse the exact locale returned by `asc localizations list`

## Validation
- `go run . localizations create --help`
- `go run . localizations update --help`
- `make format`
- `make generate-command-docs`
- `make check-command-docs`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestLocalizations(Create|Update)'`

Closes #1350
