### PR TITLE
[codex] make asc validate include remediation by default

### DIFF
--- a/internal/asc/output_validate.go
+++ b/internal/asc/output_validate.go
@@ -11,15 +11,11 @@ func init() {
 	registerDirect(func(v *validation.Report, render func([]string, [][]string)) error {
 		h, r := validationSummaryRows(v)
 		render(h, r)
+		if len(v.Remediation.Steps) > 0 {
+			rh, rr := validationRemediationRows(v)
+			render(rh, rr)
+		}
 		oh, or := validationCheckRows(v)
-		render(oh, or)
-		return nil
-	})
-
-	registerDirect(func(v *validation.RemediationReport, render func([]string, [][]string)) error {
-		h, r := remediationSummaryRows(v)
-		render(h, r)
-		oh, or := remediationStepRows(v)
 		render(oh, or)
 		return nil
 	})
@@ -52,7 +48,7 @@ func init() {
 }
 
 func validationSummaryRows(report *validation.Report) ([]string, [][]string) {
-	headers := []string{"App ID", "Version ID", "Version", "Platform", "Errors", "Warnings", "Infos", "Blocking", "Strict"}
+	headers := []string{"App ID", "Version ID", "Version", "Platform", "Errors", "Warnings", "Infos", "Blocking", "Actionable", "Strict"}
 	rows := [][]string{{
 		report.AppID,
 		report.VersionID,
@@ -62,6 +58,7 @@ func validationSummaryRows(report *validation.Report) ([]string, [][]string) {
 		fmt.Sprintf("%d", report.Summary.Warnings),
 		fmt.Sprintf("%d", report.Summary.Infos),
 		fmt.Sprintf("%d", report.Summary.Blocking),
+		fmt.Sprintf("%d", report.Remediation.TotalActionable),
 		formatBool(report.Strict),
 	}}
 	return headers, rows
@@ -88,36 +85,14 @@ func validationCheckRows(report *validation.Report) ([]string, [][]string) {
 	return headers, rows
 }
 
-func remediationSummaryRows(report *validation.RemediationReport) ([]string, [][]string) {
-	headers := []string{"App ID", "Version ID", "Version", "Platform", "Mode", "Actionable", "Errors", "Warnings", "Infos", "Blocking", "Strict"}
-	if report == nil {
-		return headers, [][]string{{"", "", "", "", "", "0", "0", "0", "0", "0", "false"}}
-	}
-
-	rows := [][]string{{
-		report.AppID,
-		report.VersionID,
-		report.VersionString,
-		report.Platform,
-		string(report.Mode),
-		fmt.Sprintf("%d", report.TotalActionable),
-		fmt.Sprintf("%d", report.Summary.Errors),
-		fmt.Sprintf("%d", report.Summary.Warnings),
-		fmt.Sprintf("%d", report.Summary.Infos),
-		fmt.Sprintf("%d", report.Summary.Blocking),
-		formatBool(report.Strict),
-	}}
-	return headers, rows
-}
-
-func remediationStepRows(report *validation.RemediationReport) ([]string, [][]string) {
+func validationRemediationRows(report *validation.Report) ([]string, [][]string) {
 	headers := []string{"Order", "Severity", "Blocking", "Check ID", "Locale", "Field", "Resource", "Message", "Remediation"}
-	if report == nil || len(report.Steps) == 0 {
-		return headers, [][]string{{"0", "info", "false", "validation.ok", "", "", "", "No remediation steps required", ""}}
+	if report == nil || len(report.Remediation.Steps) == 0 {
+		return headers, nil
 	}
 
-	rows := make([][]string, 0, len(report.Steps))
-	for _, step := range report.Steps {
+	rows := make([][]string, 0, len(report.Remediation.Steps))
+	for _, step := range report.Remediation.Steps {
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", step.Order),
 			string(step.Severity),

--- a/internal/cli/cmdtest/validate_blackbox_test.go
+++ b/internal/cli/cmdtest/validate_blackbox_test.go
@@ -24,20 +24,23 @@ func buildASCBlackBoxBinary(t *testing.T) string {
 	return binaryPath
 }
 
-func TestValidateRemediationFlagsRejectInvalidBooleanValues(t *testing.T) {
+func TestValidateRemovedRemediationFlagsReturnUsageExitCode(t *testing.T) {
 	binaryPath := buildASCBlackBoxBinary(t)
 
 	tests := []struct {
-		name string
-		args []string
+		name    string
+		args    []string
+		wantErr string
 	}{
 		{
-			name: "next invalid value",
-			args: []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--next=maybe"},
+			name:    "next removed",
+			args:    []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--next"},
+			wantErr: "flag provided but not defined",
 		},
 		{
-			name: "fix-plan invalid value",
-			args: []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--fix-plan=maybe"},
+			name:    "fix-plan removed",
+			args:    []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--fix-plan"},
+			wantErr: "flag provided but not defined",
 		},
 	}
 
@@ -61,8 +64,8 @@ func TestValidateRemediationFlagsRejectInvalidBooleanValues(t *testing.T) {
 			if stdout.String() != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout.String())
 			}
-			if !strings.Contains(stderr.String(), "invalid boolean value") {
-				t.Fatalf("expected invalid boolean value error, got %q", stderr.String())
+			if !strings.Contains(stderr.String(), test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
 			}
 		})
 	}
@@ -77,9 +80,9 @@ func TestValidateSubcommandsRejectParentValidateFlagsExitCode(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "next before subcommand",
-			args:    []string{"validate", "--next", "testflight", "--app", "app-1", "--build", "build-1"},
-			wantErr: "--next is only valid for asc validate",
+			name:    "version-id before subcommand",
+			args:    []string{"validate", "--version-id", "ver-1", "testflight", "--app", "app-1", "--build", "build-1"},
+			wantErr: "--version-id is only valid for asc validate",
 		},
 		{
 			name:    "strict before subcommand",

--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -368,7 +368,7 @@ func TestValidateVersionAndVersionIDMutuallyExclusive(t *testing.T) {
 	}
 }
 
-func TestValidateNextOutputsHighestPriorityRemediation(t *testing.T) {
+func TestValidateOutputsOrderedRemediationByDefault(t *testing.T) {
 	fixture := validValidateFixture()
 	fixture.version = strings.Replace(fixture.version, `"versionString":"1.0"`, `"versionString":"1.2.3"`, 1)
 	fixture.versions = strings.Replace(fixture.versions, `"versionString":"1.0"`, `"versionString":"1.2.3"`, 1)
@@ -386,7 +386,7 @@ func TestValidateNextOutputsHighestPriorityRemediation(t *testing.T) {
 
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1", "--next"}); err != nil {
+		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())
@@ -399,84 +399,29 @@ func TestValidateNextOutputsHighestPriorityRemediation(t *testing.T) {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
 
-	var report validation.RemediationReport
+	var report validation.Report
 	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
-	if report.Mode != validation.RemediationModeNext {
-		t.Fatalf("expected next remediation mode, got %q", report.Mode)
+	if report.Remediation.TotalActionable < 4 {
+		t.Fatalf("expected multiple actionable steps, got %+v", report.Remediation)
 	}
-	if report.TotalActionable < 3 {
-		t.Fatalf("expected multiple actionable steps, got %d", report.TotalActionable)
+	if len(report.Remediation.Steps) < 4 {
+		t.Fatalf("expected ordered remediation steps, got %+v", report.Remediation.Steps)
 	}
-	if len(report.Steps) != 1 {
-		t.Fatalf("expected a single remediation step, got %d", len(report.Steps))
+	if report.Remediation.Steps[0].CheckID != "metadata.required.description" {
+		t.Fatalf("expected description remediation first, got %+v", report.Remediation.Steps[0])
 	}
-	if report.Steps[0].CheckID != "metadata.required.description" {
-		t.Fatalf("expected description remediation first, got %+v", report.Steps[0])
+	if report.Remediation.Steps[1].CheckID != "categories.primary_missing" {
+		t.Fatalf("expected category remediation second, got %+v", report.Remediation.Steps[1])
 	}
-	if report.Steps[0].Order != 1 {
-		t.Fatalf("expected first remediation order to be 1, got %d", report.Steps[0].Order)
-	}
-	if !report.Steps[0].Blocking {
-		t.Fatalf("expected first remediation to be blocking, got %+v", report.Steps[0])
-	}
-}
-
-func TestValidateFixPlanOutputsOrderedRemediationSteps(t *testing.T) {
-	fixture := validValidateFixture()
-	fixture.version = strings.Replace(fixture.version, `"versionString":"1.0"`, `"versionString":"1.2.3"`, 1)
-	fixture.versions = strings.Replace(fixture.versions, `"versionString":"1.0"`, `"versionString":"1.2.3"`, 1)
-	fixture.versionLocs = `{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US","description":"","keywords":"keyword","whatsNew":"","promotionalText":"Promo","supportUrl":"https://support.example.com","marketingUrl":"https://marketing.example.com"}}]}`
-	fixture.primaryCategory = ""
-	fixture.build = ""
-
-	client := newValidateTestClient(t, fixture)
-	restore := validate.SetClientFactory(func() (*asc.Client, error) {
-		return client, nil
-	})
-	defer restore()
-
-	root := RootCommand("1.2.3")
-
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1", "--fix-plan"}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = root.Run(context.Background())
-	})
-
-	if runErr == nil {
-		t.Fatal("expected blocking remediation output to return an error")
-	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
-
-	var report validation.RemediationReport
-	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
-		t.Fatalf("failed to parse JSON output: %v", err)
-	}
-	if report.Mode != validation.RemediationModeFixPlan {
-		t.Fatalf("expected fix-plan remediation mode, got %q", report.Mode)
-	}
-	if len(report.Steps) < 4 {
-		t.Fatalf("expected multiple remediation steps, got %+v", report.Steps)
-	}
-	if report.Steps[0].CheckID != "metadata.required.description" {
-		t.Fatalf("expected description remediation first, got %+v", report.Steps[0])
-	}
-	if report.Steps[1].CheckID != "categories.primary_missing" {
-		t.Fatalf("expected category remediation second, got %+v", report.Steps[1])
-	}
-	if report.Steps[2].CheckID != "build.required.missing" {
-		t.Fatalf("expected build remediation third, got %+v", report.Steps[2])
+	if report.Remediation.Steps[2].CheckID != "build.required.missing" {
+		t.Fatalf("expected build remediation third, got %+v", report.Remediation.Steps[2])
 	}
 
 	var whatsNewStep validation.RemediationStep
 	foundWhatsNew := false
-	for _, step := range report.Steps {
+	for _, step := range report.Remediation.Steps {
 		if step.CheckID == "metadata.required.whats_new" {
 			whatsNewStep = step
 			foundWhatsNew = true
@@ -484,17 +429,17 @@ func TestValidateFixPlanOutputsOrderedRemediationSteps(t *testing.T) {
 		}
 	}
 	if !foundWhatsNew {
-		t.Fatalf("expected what's new remediation in plan, got %+v", report.Steps)
+		t.Fatalf("expected what's new remediation in plan, got %+v", report.Remediation.Steps)
 	}
 	if whatsNewStep.Blocking {
 		t.Fatalf("expected what's new remediation to be non-blocking by default, got %+v", whatsNewStep)
 	}
-	if whatsNewStep.Order <= report.Steps[2].Order {
-		t.Fatalf("expected warning remediation after blocking errors, got %+v", report.Steps)
+	if whatsNewStep.Order <= report.Remediation.Steps[2].Order {
+		t.Fatalf("expected warning remediation after blocking errors, got %+v", report.Remediation.Steps)
 	}
 }
 
-func TestValidateFixPlanOutputsTable(t *testing.T) {
+func TestValidateTableOutputsRemediationByDefault(t *testing.T) {
 	fixture := validValidateFixture()
 	fixture.version = strings.Replace(fixture.version, `"versionString":"1.0"`, `"versionString":"1.2.3"`, 1)
 	fixture.versions = strings.Replace(fixture.versions, `"versionString":"1.0"`, `"versionString":"1.2.3"`, 1)
@@ -512,7 +457,7 @@ func TestValidateFixPlanOutputsTable(t *testing.T) {
 
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1", "--fix-plan", "--output", "table"}); err != nil {
+		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1", "--output", "table"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())
@@ -525,33 +470,13 @@ func TestValidateFixPlanOutputsTable(t *testing.T) {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
 	if !strings.Contains(stdout, "Actionable") {
-		t.Fatalf("expected remediation summary table, got %q", stdout)
+		t.Fatalf("expected remediation count in summary table, got %q", stdout)
 	}
 	if !strings.Contains(stdout, "Order") {
-		t.Fatalf("expected remediation step table, got %q", stdout)
+		t.Fatalf("expected remediation plan table, got %q", stdout)
 	}
 	if !strings.Contains(stdout, "metadata.required.description") {
 		t.Fatalf("expected description remediation row, got %q", stdout)
-	}
-}
-
-func TestValidateNextAndFixPlanMutuallyExclusive(t *testing.T) {
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-
-	var runErr error
-	_, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1", "--next", "--fix-plan"}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = root.Run(context.Background())
-	})
-
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("expected ErrHelp, got %v", runErr)
-	}
-	if !strings.Contains(stderr, "mutually exclusive") {
-		t.Fatalf("expected mutually exclusive error, got %q", stderr)
 	}
 }
 
@@ -562,9 +487,9 @@ func TestValidateSubcommandsRejectParentValidateFlags(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "top-level remediation flag before subcommand",
-			args:    []string{"validate", "--next", "testflight", "--app", "app-1", "--build", "build-1"},
-			wantErr: "--next is only valid for asc validate",
+			name:    "top-level version selector before subcommand",
+			args:    []string{"validate", "--version-id", "ver-1", "testflight", "--app", "app-1", "--build", "build-1"},
+			wantErr: "--version-id is only valid for asc validate",
 		},
 		{
 			name:    "shared flag before subcommand",

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -20,8 +20,6 @@ type validateOptions struct {
 	VersionID string
 	Platform  string
 	Strict    bool
-	Next      bool
-	FixPlan   bool
 	Output    string
 	Pretty    bool
 }
@@ -40,8 +38,6 @@ func ValidateCommand() *ffcli.Command {
 	versionID := fs.String("version-id", "", "App Store version ID")
 	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	strict := fs.Bool("strict", false, "Treat warnings as errors (exit non-zero)")
-	next := fs.Bool("next", false, "Show only the highest-priority remediation step for the top-level validate report")
-	fixPlan := fs.Bool("fix-plan", false, "Show an ordered remediation plan for the top-level validate report instead of the full report")
 	output := shared.BindOutputFlags(fs)
 
 	testFlight := wrapValidateSubcommand(ValidateTestFlightCommand(), fs)
@@ -57,7 +53,7 @@ func ValidateCommand() *ffcli.Command {
 This is the canonical command for App Store submission readiness.
 Use it instead of ` + "`asc submit preflight`" + `.
 
-Remediation modes apply only to this top-level validate report, not to ` + "`validate`" + ` subcommands.
+The default validate response includes an ordered remediation plan, so the first step is the next thing to fix.
 
 Checks:
   - Metadata length limits
@@ -77,8 +73,6 @@ Examples:
   asc validate --app "APP_ID" --version "1.0.0" --platform IOS
   asc validate --app "APP_ID" --version-id "VERSION_ID" --platform IOS --output table
   asc validate --app "APP_ID" --version-id "VERSION_ID" --strict
-  asc validate --app "APP_ID" --version-id "VERSION_ID" --next
-  asc validate --app "APP_ID" --version-id "VERSION_ID" --fix-plan --output markdown
 
 TestFlight:
   asc validate testflight --app "APP_ID" --build "BUILD_ID"
@@ -109,9 +103,6 @@ Subscriptions:
 			if trimmedVersion != "" && trimmedVersionID != "" {
 				return shared.UsageError("--version and --version-id are mutually exclusive")
 			}
-			if *next && *fixPlan {
-				return shared.UsageError("--next and --fix-plan are mutually exclusive")
-			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
@@ -134,8 +125,6 @@ Subscriptions:
 				VersionID: trimmedVersionID,
 				Platform:  normalizedPlatform,
 				Strict:    *strict,
-				Next:      *next,
-				FixPlan:   *fixPlan,
 				Output:    *output.Output,
 				Pretty:    *output.Pretty,
 			})
@@ -169,7 +158,7 @@ func validateParentFlagUsageMessage(parentFlags *flag.FlagSet) string {
 		switch f.Name {
 		case "app", "output", "pretty", "strict":
 			moveAfterSubcommand = append(moveAfterSubcommand, "--"+f.Name)
-		case "version", "version-id", "platform", "next", "fix-plan":
+		case "version", "version-id", "platform":
 			topLevelOnly = append(topLevelOnly, "--"+f.Name)
 		}
 	})
@@ -221,19 +210,8 @@ func runValidate(ctx context.Context, opts validateOptions) error {
 		return fmt.Errorf("validate: %w", err)
 	}
 
-	if opts.Next || opts.FixPlan {
-		mode := validation.RemediationModeFixPlan
-		if opts.Next {
-			mode = validation.RemediationModeNext
-		}
-		remediationReport := validation.BuildRemediationReport(report, mode)
-		if err := shared.PrintOutput(&remediationReport, opts.Output, opts.Pretty); err != nil {
-			return err
-		}
-	} else {
-		if err := shared.PrintOutput(&report, opts.Output, opts.Pretty); err != nil {
-			return err
-		}
+	if err := shared.PrintOutput(&report, opts.Output, opts.Pretty); err != nil {
+		return err
 	}
 
 	if report.Summary.Blocking > 0 {

--- a/internal/validation/remediation.go
+++ b/internal/validation/remediation.go
@@ -2,14 +2,6 @@ package validation
 
 import "sort"
 
-// RemediationMode identifies the remediation-oriented validate output shape.
-type RemediationMode string
-
-const (
-	RemediationModeNext    RemediationMode = "next"
-	RemediationModeFixPlan RemediationMode = "fix-plan"
-)
-
 // RemediationStep represents one actionable item derived from a validation check.
 type RemediationStep struct {
 	Order        int      `json:"order"`
@@ -24,36 +16,11 @@ type RemediationStep struct {
 	ResourceID   string   `json:"resourceId,omitempty"`
 }
 
-// RemediationReport is the top-level output for validate remediation modes.
-type RemediationReport struct {
-	AppID           string            `json:"appId"`
-	VersionID       string            `json:"versionId"`
-	VersionString   string            `json:"versionString,omitempty"`
-	Platform        string            `json:"platform,omitempty"`
-	Summary         Summary           `json:"summary"`
-	Strict          bool              `json:"strict,omitempty"`
-	Mode            RemediationMode   `json:"mode"`
-	TotalActionable int               `json:"totalActionable"`
-	Steps           []RemediationStep `json:"steps"`
-}
-
-// BuildRemediationReport derives a remediation-oriented view from a validation report.
-func BuildRemediationReport(report Report, mode RemediationMode) RemediationReport {
-	allSteps := RemediationSteps(report.Checks, report.Strict)
-	steps := allSteps
-	if mode == RemediationModeNext && len(steps) > 1 {
-		steps = steps[:1]
-	}
-
-	return RemediationReport{
-		AppID:           report.AppID,
-		VersionID:       report.VersionID,
-		VersionString:   report.VersionString,
-		Platform:        report.Platform,
-		Summary:         report.Summary,
-		Strict:          report.Strict,
-		Mode:            mode,
-		TotalActionable: len(allSteps),
+// BuildRemediation derives an ordered remediation plan from validation checks.
+func BuildRemediation(checks []CheckResult, strict bool) Remediation {
+	steps := RemediationSteps(checks, strict)
+	return Remediation{
+		TotalActionable: len(steps),
 		Steps:           steps,
 	}
 }

--- a/internal/validation/remediation_test.go
+++ b/internal/validation/remediation_test.go
@@ -45,42 +45,32 @@ func TestRemediationStepsOrdersBlockingErrorsBeforeWarningsAndInfos(t *testing.T
 	}
 }
 
-func TestBuildRemediationReportNextLimitsToSingleStep(t *testing.T) {
-	report := Report{
-		AppID:     "app-1",
-		VersionID: "ver-1",
-		Summary: Summary{
-			Errors:   1,
-			Warnings: 1,
-			Blocking: 1,
+func TestBuildRemediationIncludesOrderedPlan(t *testing.T) {
+	remediation := BuildRemediation([]CheckResult{
+		{
+			ID:          "metadata.required.description",
+			Severity:    SeverityError,
+			Message:     "description is required",
+			Remediation: "Provide a description",
 		},
-		Checks: []CheckResult{
-			{
-				ID:          "metadata.required.description",
-				Severity:    SeverityError,
-				Message:     "description is required",
-				Remediation: "Provide a description",
-			},
-			{
-				ID:          "metadata.required.whats_new",
-				Severity:    SeverityWarning,
-				Message:     "what's new is empty",
-				Remediation: "Provide release notes",
-			},
+		{
+			ID:          "metadata.required.whats_new",
+			Severity:    SeverityWarning,
+			Message:     "what's new is empty",
+			Remediation: "Provide release notes",
 		},
-	}
+	}, false)
 
-	next := BuildRemediationReport(report, RemediationModeNext)
-	if next.Mode != RemediationModeNext {
-		t.Fatalf("expected next mode, got %q", next.Mode)
+	if remediation.TotalActionable != 2 {
+		t.Fatalf("expected total actionable 2, got %d", remediation.TotalActionable)
 	}
-	if next.TotalActionable != 2 {
-		t.Fatalf("expected total actionable 2, got %d", next.TotalActionable)
+	if len(remediation.Steps) != 2 {
+		t.Fatalf("expected two ordered remediation steps, got %d", len(remediation.Steps))
 	}
-	if len(next.Steps) != 1 {
-		t.Fatalf("expected one selected step, got %d", len(next.Steps))
+	if remediation.Steps[0].CheckID != "metadata.required.description" {
+		t.Fatalf("expected first step to be description remediation, got %+v", remediation.Steps[0])
 	}
-	if next.Steps[0].CheckID != "metadata.required.description" {
-		t.Fatalf("expected first step to be description remediation, got %+v", next.Steps[0])
+	if remediation.Steps[1].CheckID != "metadata.required.whats_new" {
+		t.Fatalf("expected second step to be what's new remediation, got %+v", remediation.Steps[1])
 	}
 }

--- a/internal/validation/report.go
+++ b/internal/validation/report.go
@@ -45,6 +45,7 @@ func Validate(input Input, strict bool) Report {
 		VersionString: input.VersionString,
 		Platform:      input.Platform,
 		Summary:       summary,
+		Remediation:   BuildRemediation(checks, strict),
 		Checks:        checks,
 		Strict:        strict,
 	}

--- a/internal/validation/types.go
+++ b/internal/validation/types.go
@@ -29,6 +29,12 @@ type Summary struct {
 	Blocking int `json:"blocking"`
 }
 
+// Remediation summarizes actionable validation steps in priority order.
+type Remediation struct {
+	TotalActionable int               `json:"totalActionable"`
+	Steps           []RemediationStep `json:"steps"`
+}
+
 // Report is the top-level validation output.
 type Report struct {
 	AppID         string        `json:"appId"`
@@ -36,6 +42,7 @@ type Report struct {
 	VersionString string        `json:"versionString,omitempty"`
 	Platform      string        `json:"platform,omitempty"`
 	Summary       Summary       `json:"summary"`
+	Remediation   Remediation   `json:"remediation"`
 	Checks        []CheckResult `json:"checks"`
 	Strict        bool          `json:"strict,omitempty"`
 }


### PR DESCRIPTION
## Summary
- make `asc validate` include an ordered remediation plan in the default report
- keep `asc validate` as one canonical readiness command instead of splitting remediation into alternate modes
- render remediation across JSON, table, and markdown while preserving blocking exit behavior
- reject misplaced top-level `validate` flags before subcommands instead of silently ignoring them

## Problem
`asc validate` already knew what was wrong, but it did not make the next action obvious. The issue originally proposed `--next` and `--fix-plan`, but that would have required callers to pick a separate view before the CLI answered the core workflow question: "am I ready, and if not, what should I fix first?"

## Direction Change
The implementation intentionally changed direction from the issue wording.

Instead of introducing separate remediation modes, this PR makes remediation part of the main `asc validate` response. That keeps the command aligned with the rest of the CLI: one canonical validation command, one source of truth, one output that answers both readiness and next steps.

## First-Principles Design
- `asc validate` is the canonical pre-submission readiness command, so a single invocation should answer readiness and remediation together.
- Remediation should be derived from the same check set as the report so there is one source of truth, not parallel output paths.
- The default output should stay audit-friendly: summary first, ordered remediation next, detailed checks after that.
- The CLI should fail clearly on ambiguous flag placement rather than accept flags that get ignored.

## What Changed
- `validation.Report` now includes a `remediation` section with ordered actionable steps.
- Remediation steps are ranked by blocking severity, with stable ordering preserved within each severity bucket.
- `asc validate` table and markdown output now show summary, remediation, and then raw checks.
- JSON output remains the same shape plus one additive `remediation` object.
- The separate `--next` and `--fix-plan` flags were removed in favor of the default report carrying its own remediation.
- `asc validate` now rejects parent flags placed before `testflight`, `iap`, or `subscriptions` when those flags would otherwise be ignored.

## Why This Shape Fits The CLI
- Users should not need to learn alternate modes to get the next fix. The first remediation step is the next fix.
- Keeping one report avoids duplicate docs, duplicated tests, and divergent behavior between "report" and "plan" paths.
- The detailed checks still remain available, so the command stays useful for CI, review, and debugging instead of becoming an opaque recommendation engine.

## Alternatives Considered
- Keep `--next` and `--fix-plan` as separate flags.
This makes the feature explicit, but it fragments the main workflow and adds extra surface area for a command that should stay canonical.
- Replace the detailed check list with remediation only.
This would simplify the output, but it would remove the evidence users need to understand why a step is recommended and would make machine and human auditing worse.

## Compatibility And Blast Radius
- No new stable top-level flags were added.
- Default `asc validate` exit behavior for blocking issues is unchanged.
- JSON output is additive through the new `remediation` field.
- Table and markdown output become richer by default because remediation is now included.
- Removed experimental remediation flags now return usage error `2` instead of continuing on an obsolete path.
- The stricter subcommand flag parsing is an intentional safety improvement and only affects previously ambiguous invocations.

## Expected Usage
- `asc validate --app "APP_ID" --version-id "VERSION_ID"`
- `asc validate --app "APP_ID" --version "1.0.0" --platform IOS`
- `asc validate --app "APP_ID" --version-id "VERSION_ID" --strict`

A successful JSON response now carries `summary`, `remediation`, and `checks` together, so callers can both act on the next step and inspect the full evidence set from one invocation.

## Validation
- `go run . validate --help`
- `make generate-command-docs`
- `make format`
- `make check-command-docs`
- `make lint`
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 make test`

Closes #1364.
