### PR TITLE
[codex] Retry equalize territory updates after rate limiting

### DIFF
--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -688,6 +688,9 @@ func TestSubscriptionsPricingEqualize_FailedInitialPriceStopsBeforePostingRemain
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			body := `{"data":[],"included":[],"links":{"next":""}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/8000000001":
 			patchCount++
 			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","title":"unprocessable","detail":"failed initial price"}]}`), nil
@@ -776,6 +779,18 @@ func TestSubscriptionsPricingEqualize_ReturnsReportedErrorWhenAnyTerritoryFails(
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			body := `{
+				"data":[
+					{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + basePricePointID + `"}}}}
+				],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99","proceeds":"0.70","proceedsYear2":"0.84"}},
+					{"type":"territories","id":"USA","attributes":{"currency":"USD"}}
+				],
+				"links":{"next":""}
+			}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
@@ -965,6 +980,21 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableFailuresButKeepsNonRetryab
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"},{"type":"territories","id":"MEX"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			body := `{
+				"data":[
+					{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + basePricePointID + `"}}}},
+					{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + canPricePointID + `"}}}}
+				],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99","proceeds":"0.70","proceedsYear2":"0.84"}},
+					{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29","proceeds":"0.90","proceedsYear2":"1.05"}},
+					{"type":"territories","id":"USA","attributes":{"currency":"USD"}},
+					{"type":"territories","id":"CAN","attributes":{"currency":"CAD"}}
+				],
+				"links":{"next":""}
+			}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
@@ -1038,6 +1068,226 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableFailuresButKeepsNonRetryab
 	}
 	if len(result.Failures) != 1 || result.Failures[0].Territory != "MEX" {
 		t.Fatalf("expected only the non-retryable MEX failure to remain, got %+v", result.Failures)
+	}
+}
+
+func TestSubscriptionsPricingEqualize_ReconcilesConflictAfterRetryableFailure(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	basePricePointID := testSubscriptionPricePointID("USA")
+	canPricePointID := testSubscriptionPricePointID("CAN")
+
+	canAttempts := 0
+	verifyReads := 0
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/territories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/pricePoints":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			verifyReads++
+			body := `{
+				"data":[
+					{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + basePricePointID + `"}}}},
+					{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + canPricePointID + `"}}}}
+				],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99","proceeds":"0.70","proceedsYear2":"0.84"}},
+					{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29","proceeds":"0.90","proceedsYear2":"1.05"}},
+					{"type":"territories","id":"USA","attributes":{"currency":"USD"}},
+					{"type":"territories","id":"CAN","attributes":{"currency":"CAD"}}
+				],
+				"links":{"next":""}
+			}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			switch {
+			case strings.Contains(string(body), `"id":"USA"`):
+				return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-usa"}}`), nil
+			case strings.Contains(string(body), `"id":"CAN"`):
+				canAttempts++
+				if canAttempts == 1 {
+					return jsonHTTPResponse(http.StatusTooManyRequests, `{"errors":[{"status":"429","code":"RATE_LIMIT_EXCEEDED","title":"Too Many Requests","detail":"retry later"}]}`), nil
+				}
+				return jsonHTTPResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR","title":"Conflict","detail":"duplicate"}]}`), nil
+			default:
+				t.Fatalf("unexpected subscription price body: %s", string(body))
+				return nil, nil
+			}
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "equalize",
+			"--subscription-id", "8000000001",
+			"--base-price", "0.99",
+			"--confirm",
+			"--workers", "2",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if canAttempts != 2 {
+		t.Fatalf("expected CAN create to be retried once before reconciliation, got %d attempts", canAttempts)
+	}
+	if verifyReads != 1 {
+		t.Fatalf("expected one verification read, got %d", verifyReads)
+	}
+
+	var result struct {
+		Total     int `json:"total"`
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+		Failures  []struct {
+			Territory string `json:"territory"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON result: %v", err)
+	}
+	if result.Total != 2 || result.Succeeded != 2 || result.Failed != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(result.Failures) != 0 {
+		t.Fatalf("expected reconciliation to clear failures, got %+v", result.Failures)
+	}
+}
+
+func TestSubscriptionsPricingEqualize_ReconcilesInitialPriceFailureBeforeStopping(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	basePricePointID := testSubscriptionPricePointID("USA")
+	canPricePointID := testSubscriptionPricePointID("CAN")
+
+	verifyReads := 0
+	canPosts := 0
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/territories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/pricePoints":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			verifyReads++
+			body := `{
+				"data":[
+					{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + basePricePointID + `"}}}}
+				],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99","proceeds":"0.70","proceedsYear2":"0.84"}},
+					{"type":"territories","id":"USA","attributes":{"currency":"USD"}}
+				],
+				"links":{"next":""}
+			}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusTooManyRequests, `{"errors":[{"status":"429","code":"RATE_LIMIT_EXCEEDED","title":"Too Many Requests","detail":"retry later"}]}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			canPosts++
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			if !strings.Contains(string(body), `"id":"CAN"`) {
+				t.Fatalf("expected CAN territory in request body, got %s", string(body))
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-can"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "equalize",
+			"--subscription-id", "8000000001",
+			"--base-price", "0.99",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if verifyReads != 1 {
+		t.Fatalf("expected one verification read after initial price failure, got %d", verifyReads)
+	}
+	if canPosts != 1 {
+		t.Fatalf("expected follow-up CAN POST after initial reconciliation, got %d", canPosts)
+	}
+
+	var result struct {
+		Total     int `json:"total"`
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+		Failures  []struct {
+			Territory string `json:"territory"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON result: %v", err)
+	}
+	if result.Total != 2 || result.Succeeded != 2 || result.Failed != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(result.Failures) != 0 {
+		t.Fatalf("expected no failures after reconciling initial price state, got %+v", result.Failures)
 	}
 }
 

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -166,25 +167,35 @@ Examples:
 				_, err := client.SetSubscriptionInitialPrice(initialCtx, subID, baseTarget.PricePointID, baseTarget.Territory, asc.SubscriptionPriceCreateAttributes{})
 				initialCancel()
 				if err != nil {
-					failures = append(failures, equalizeAttemptFailure{
+					initialFailures := []equalizeAttemptFailure{{
 						Target: baseTarget,
 						Err:    err,
-					})
-					result := &equalizeResult{
-						SubscriptionID: subID,
-						BaseTerritory:  territory,
-						BasePrice:      price,
-						DryRun:         false,
-						Total:          len(allTerritories),
-						Succeeded:      succeeded,
-						Failed:         len(failures),
-						Failures:       renderEqualizeFailures(failures),
+					}}
+					reconciled, remaining, verifyErr := reconcileEqualizeFailures(ctx, client, subID, initialFailures)
+					if verifyErr != nil {
+						fmt.Fprintf(os.Stderr, "Warning: could not verify failed initial price update: %v\n", verifyErr)
 					}
-					fmt.Fprintf(os.Stderr, "Done: %d succeeded, %d failed\n", result.Succeeded, result.Failed)
-					if err := printEqualizeResult(result, *output.Output, *output.Pretty); err != nil {
-						return err
+					if len(remaining) == 0 {
+						succeeded += reconciled
+						remainingTerritories = allTerritories[1:]
+					} else {
+						failures = append(failures, remaining...)
+						result := &equalizeResult{
+							SubscriptionID: subID,
+							BaseTerritory:  territory,
+							BasePrice:      price,
+							DryRun:         false,
+							Total:          len(allTerritories),
+							Succeeded:      succeeded,
+							Failed:         len(failures),
+							Failures:       renderEqualizeFailures(failures),
+						}
+						fmt.Fprintf(os.Stderr, "Done: %d succeeded, %d failed\n", result.Succeeded, result.Failed)
+						if err := printEqualizeResult(result, *output.Output, *output.Pretty); err != nil {
+							return err
+						}
+						return shared.NewReportedError(fmt.Errorf("equalize: failed to set initial price in %s", baseTarget.Territory))
 					}
-					return shared.NewReportedError(fmt.Errorf("equalize: failed to set initial price in %s", baseTarget.Territory))
 				} else {
 					succeeded++
 					remainingTerritories = allTerritories[1:]
@@ -255,6 +266,13 @@ func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string,
 	retryable, finalFailures := partitionEqualizeFailures(failures)
 
 	for pass := 1; len(retryable) > 0 && pass <= maxEqualizeRecoveryPasses; pass++ {
+		if delay := maxEqualizeRetryAfter(retryable); delay > 0 {
+			fmt.Fprintf(os.Stderr, "Waiting %s before retrying %d retryable territory update(s)...\n", delay.Round(time.Second), len(retryable))
+			if err := sleepWithContext(ctx, delay); err != nil {
+				finalFailures = append(finalFailures, retryable...)
+				return succeeded, finalFailures
+			}
+		}
 		fmt.Fprintf(os.Stderr, "Retrying %d retryable territory update(s) with %d worker...\n", len(retryable), equalizeRecoveryWorkers)
 		retrySucceeded, retryFailures := runEqualizePricePass(ctx, client, subID, equalizeTargetsFromFailures(retryable), equalizeRecoveryWorkers)
 		succeeded += retrySucceeded
@@ -267,7 +285,13 @@ func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string,
 		finalFailures = append(finalFailures, retryable...)
 	}
 
-	return succeeded, finalFailures
+	reconciled, remaining, err := reconcileEqualizeFailures(ctx, client, subID, finalFailures)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not verify %d failed territory update(s): %v\n", len(finalFailures), err)
+		return succeeded, finalFailures
+	}
+	succeeded += reconciled
+	return succeeded, remaining
 }
 
 func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string, targets []equalization, workers int) (int, []equalizeAttemptFailure) {
@@ -368,6 +392,69 @@ func renderEqualizeFailures(failures []equalizeAttemptFailure) []equalizeFailure
 		})
 	}
 	return rendered
+}
+
+func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID string, failures []equalizeAttemptFailure) (int, []equalizeAttemptFailure, error) {
+	if len(failures) == 0 {
+		return 0, nil, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Verifying %d territory update(s) against current prices...\n", len(failures))
+
+	verifyCtx, verifyCancel := shared.ContextWithTimeout(ctx)
+	defer verifyCancel()
+
+	resolved, err := fetchResolvedSubscriptionPrices(verifyCtx, client, subID, 200, "", time.Now())
+	if err != nil {
+		return 0, failures, err
+	}
+
+	currentByTerritory := make(map[string]string, len(resolved.Prices))
+	for _, row := range resolved.Prices {
+		territoryID := strings.ToUpper(strings.TrimSpace(row.Territory))
+		if territoryID == "" {
+			continue
+		}
+		currentByTerritory[territoryID] = strings.TrimSpace(row.PricePointID)
+	}
+
+	reconciled := 0
+	remaining := make([]equalizeAttemptFailure, 0, len(failures))
+	for _, failure := range failures {
+		if currentByTerritory[strings.ToUpper(strings.TrimSpace(failure.Target.Territory))] == strings.TrimSpace(failure.Target.PricePointID) {
+			reconciled++
+			continue
+		}
+		remaining = append(remaining, failure)
+	}
+
+	return reconciled, remaining, nil
+}
+
+func maxEqualizeRetryAfter(failures []equalizeAttemptFailure) time.Duration {
+	var maxDelay time.Duration
+	for _, failure := range failures {
+		if delay := asc.GetRetryAfter(failure.Err); delay > maxDelay {
+			maxDelay = delay
+		}
+	}
+	return maxDelay
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func findPricePoint(ctx context.Context, client *asc.Client, subID, territory, targetPrice string) (string, error) {


### PR DESCRIPTION
## Summary
- retry retryable `subscriptions pricing equalize` territory failures with a serial recovery pass
- keep non-retryable territory failures visible in the final report
- add CLI tests covering retryable recovery and mixed retryable/non-retryable outcomes

## Root Cause
The ASC client already retries individual subscription price mutations, but the command treated any retry-exhausted territory failure from the concurrent fanout as terminal. Large equalize runs could therefore exit with partial coverage even when a slower retry would succeed.

## Impact
Default equalize runs now automatically recover retryable territory updates instead of requiring a manual rerun with `--workers 1`.

## Validation
- `go test ./internal/cli/cmdtest -run ^'^TestSubscriptionsPricingEqualize'`
- `make format`
- `make check-command-docs`
- `go build -o /tmp/asc-issue-1346 .`
- `/tmp/asc-issue-1346 subscriptions pricing equalize --help` (exit 0)
- `/tmp/asc-issue-1346 subscriptions pricing equalize --subscription-id 8000000001 --base-price 0.99` (exit 2, confirm required)
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

Fixes #1346
