### PR TITLE
[codex] Report partial metadata keyword failures per locale

### DIFF
--- a/internal/cli/cmdtest/metadata_keywords_test.go
+++ b/internal/cli/cmdtest/metadata_keywords_test.go
@@ -2282,6 +2282,107 @@ func TestMetadataKeywordsSyncStopsWhenImportPreviewHasIssues(t *testing.T) {
 	}
 }
 
+func TestMetadataKeywordsApplyEarlyPlanningErrorDoesNotPrintOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	versionDir := filepath.Join(dir, "version", "1.2.3")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "en-US.json"), []byte(`{"keywords":"habit tracker,mood journal"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial test failure")
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "keywords", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected planning error")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(runErr.Error(), "metadata keywords apply:") || !strings.Contains(runErr.Error(), "dial test failure") {
+		t.Fatalf("expected wrapped planning error, got %v", runErr)
+	}
+}
+
+func TestMetadataKeywordsSyncEarlyPlanningErrorDoesNotPrintOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(t.TempDir(), "keywords.txt")
+	if err := os.WriteFile(inputPath, []byte("habit tracker,mood journal"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial test failure")
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "keywords", "sync",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+			"--input", inputPath,
+			"--format", "text",
+			"--locale", "en-US",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected planning error")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(runErr.Error(), "metadata keywords sync:") || !strings.Contains(runErr.Error(), "dial test failure") {
+		t.Fatalf("expected wrapped planning error, got %v", runErr)
+	}
+}
+
 func TestMetadataKeywordsSyncMissingAppDoesNotWriteImportOutput(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	dir := t.TempDir()

--- a/internal/cli/metadata/keywords.go
+++ b/internal/cli/metadata/keywords.go
@@ -210,6 +210,13 @@ type metadataKeywordsApplySummary struct {
 	Results   []MetadataKeywordsMutationResult
 }
 
+func shouldPrintMetadataKeywordsPlanResult(result MetadataKeywordsPlanResult, err error) bool {
+	if err == nil {
+		return true
+	}
+	return result.Total > 0 || result.Succeeded > 0 || result.Failed > 0 || len(result.Results) > 0 || result.FailureArtifactPath != ""
+}
+
 // MetadataKeywordSideDataRecord captures non-publishable research fields from imports.
 type MetadataKeywordSideDataRecord struct {
 	Locale   string         `json:"locale,omitempty"`
@@ -550,6 +557,9 @@ Examples:
 			if err != nil && errors.Is(err, flag.ErrHelp) {
 				return err
 			}
+			if !shouldPrintMetadataKeywordsPlanResult(result, err) {
+				return fmt.Errorf("metadata keywords apply: %w", err)
+			}
 			if printErr := shared.PrintOutputWithRenderers(
 				result,
 				*output.Output,
@@ -657,6 +667,9 @@ Examples:
 			})
 			if err != nil && errors.Is(err, flag.ErrHelp) {
 				return err
+			}
+			if !shouldPrintMetadataKeywordsPlanResult(planResult, err) {
+				return fmt.Errorf("metadata keywords sync: %w", err)
 			}
 
 			result := MetadataKeywordsSyncResult{


### PR DESCRIPTION
## Summary

This PR fixes the keyword metadata partial-apply gap behind issue #1351.

`asc metadata keywords apply` and `asc metadata keywords sync --confirm` could mutate earlier locales successfully, fail on a later locale, and then exit without a structured record of what succeeded and what failed.

## What Changed

- execute keyword mutation attempts across all planned locales instead of stopping after the first runtime failure
- return per-locale mutation results with succeeded/failed status in JSON output when any keyword apply fails
- write a failure artifact under `.asc/reports/...` so the user has a durable record of partial apply state
- surface the same behavior through both `metadata keywords apply` and `metadata keywords sync`
- add command tests covering partial-failure behavior for both commands

## Why

The root cause was that the keyword workflow reused a fail-fast version-localization apply path. Once one locale failed, the command returned immediately even though earlier locale mutations had already been committed remotely.

That left users to inspect App Store Connect manually to understand the real post-run state.

## Impact

Users now get a clear, machine-readable summary of partial keyword mutations and a saved artifact they can use to recover or continue safely. This improves trust in multi-locale metadata automation without claiming API-level atomicity that App Store Connect does not provide.

Closes #1351.

## Validation

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
