### PR TITLE
apps wall: add RateTier

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -812,6 +812,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/99/f4/3b/99f43be3-8cd4-448c-26db-bbe190492794/AppIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "RateTier",
+    "link": "https://apps.apple.com/us/app/ratetier/id6759999815?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/eb/49/d8/eb49d8c5-20bb-c2f7-068f-d24a970abb2f/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "rawcast — Terminal Weather",
     "link": "https://apps.apple.com/us/app/rawcast-terminal-weather/id6760224045?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7b/a4/47/7ba447d5-d934-754b-3f42-2b03670f82b7/AppIcon-0-0-1x_U007epad-0-5-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `RateTier` to the Wall of Apps

## Entry

- App ID: 6759999815
- App: RateTier
- Link: https://apps.apple.com/us/app/ratetier/id6759999815?uo=4

## Notes

- Submitted via `asc apps wall submit`
