### PR TITLE
apps wall: add SweatCount - Workout Calendar

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -986,6 +986,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/49/01/f9/4901f9f9-8d90-7283-bbec-6e506aec4391/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "SweatCount - Workout Calendar",
+    "link": "https://apps.apple.com/us/app/sweatcount-workout-calendar/id6755407742?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/9c/4a/88/9c4a88f0-7ce8-6c72-8eb4-6462b67625e5/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SwiftBiu",
     "link": "https://apps.apple.com/app/swiftbiu/id6754772331",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/90/3b/2e/903b2ef1-7097-f00c-3557-db67e054e174/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `SweatCount - Workout Calendar` to the Wall of Apps

## Entry

- App ID: 6755407742
- App: SweatCount - Workout Calendar
- Link: https://apps.apple.com/us/app/sweatcount-workout-calendar/id6755407742?uo=4

## Notes

- Submitted via `asc apps wall submit`
