### PR TITLE
apps wall: add Shua - arXiv Paper Reader

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -902,6 +902,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/53/33/66/53336647-1330-96ad-575f-1bdb47d653d1/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Shua - arXiv Paper Reader",
+    "link": "https://apps.apple.com/us/app/shua-arxiv-paper-reader/id6759848629?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/66/fc/74/66fc74ce-6a9d-7344-618d-5b0e5af2110b/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Silk: Relationship Tracker",
     "link": "https://apps.apple.com/us/app/silk-relationship-tracker/id6748890004?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f4/31/09/f4310949-7d27-ee90-c6df-c235c860d590/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Shua - arXiv Paper Reader` to the Wall of Apps

## Entry

- App ID: 6759848629
- App: Shua - arXiv Paper Reader
- Link: https://apps.apple.com/us/app/shua-arxiv-paper-reader/id6759848629?uo=4

## Notes

- Submitted via `asc apps wall submit`
