### PR TITLE
apps wall: add Terraforge: Alchemy Craft Game

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1036,6 +1036,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/eb/ba/d4/ebbad4d9-6a72-5d73-9a18-cf2719e6b8f3/telescopo-icon-0-0-85-220-0-6-0-2x-0-0-0.png/512x512bb.png"
   },
   {
+    "app": "Terraforge: Alchemy Craft Game",
+    "link": "https://apps.apple.com/us/app/terraforge-alchemy-craft-game/id6759879809?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f4/f1/65/f4f165e3-9826-8ced-d9be-d33b8a8e154c/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "text to speech · speakeasy",
     "link": "https://apps.apple.com/app/id6758816495",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0a/49/48/0a49486e-92b3-37b5-8bb8-c038aee9a0a4/speakeasy-icon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Terraforge: Alchemy Craft Game` to the Wall of Apps

## Entry

- App ID: 6759879809
- App: Terraforge: Alchemy Craft Game
- Link: https://apps.apple.com/us/app/terraforge-alchemy-craft-game/id6759879809?uo=4

## Notes

- Submitted via `asc apps wall submit`
