### PR TITLE
apps wall: add Moda: Driving Permit Hours Log

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -598,6 +598,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/71/af/7f/71af7f55-1c60-1638-6161-8491e23edd0e/AppIcon-0-0-1x_U007ephone-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Moda: Driving Permit Hours Log",
+    "link": "https://apps.apple.com/us/app/moda-driving-permit-hours-log/id6760154154?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/86/48/0d/86480d5e-7118-7a35-6a74-7cba92a9099d/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "mojo - GLP-1 Weight Tracker",
     "link": "https://apps.apple.com/app/id6751704399",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ee/00/84/ee008451-9632-a851-0da8-6a69caab37a5/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Moda: Driving Permit Hours Log` to the Wall of Apps

## Entry

- App ID: 6760154154
- App: Moda: Driving Permit Hours Log
- Link: https://apps.apple.com/us/app/moda-driving-permit-hours-log/id6760154154?uo=4

## Notes

- Submitted via `asc apps wall submit`
