### PR TITLE
apps wall: add SiteCalc: Trades Calculator

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -922,6 +922,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/9c/1d/75/9c1d7502-e0d7-0db1-bb9e-e9f9edd2c6da/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "SiteCalc: Trades Calculator",
+    "link": "https://apps.apple.com/us/app/sitecalc-trades-calculator/id6761667513?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/98/db/d6/98dbd62d-1923-b384-c9fe-7233fcf3e8e7/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Smart Music Stations: Wavyy",
     "link": "https://apps.apple.com/us/app/smart-music-stations-wavyy/id6458877273?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5a/c6/8d/5ac68df8-3d3f-4bf4-984c-06554678468d/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `SiteCalc: Trades Calculator` to the Wall of Apps

## Entry

- App ID: 6761667513
- App: SiteCalc: Trades Calculator
- Link: https://apps.apple.com/us/app/sitecalc-trades-calculator/id6761667513?uo=4

## Notes

- Submitted via `asc apps wall submit`
