### PR TITLE
[codex] fix migrate import fastlane screenshot handling

### DIFF
--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -669,6 +669,50 @@ func TestMigrateImportSkipScreenshotsRejectsInvalidBooleanExitCode(t *testing.T)
 	}
 }
 
+func TestMigrateImportDryRunSkipScreenshotsAllowsMissingFastlaneScreenshotsDir(t *testing.T) {
+	root := t.TempDir()
+	fastlaneDir := filepath.Join(root, "fastlane")
+	metadataDir := filepath.Join(fastlaneDir, "metadata", "en-US")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	writeFile(t, filepath.Join(metadataDir, "description.txt"), "English description")
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", fastlaneDir,
+			"--dry-run",
+			"--skip-screenshots",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := rootCmd.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result migrate.MigrateImportResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.MetadataFiles) != 1 {
+		t.Fatalf("expected metadata plan to survive missing screenshots dir, got %+v", result.MetadataFiles)
+	}
+	if len(result.ScreenshotPlan) != 0 {
+		t.Fatalf("expected no screenshot plan, got %+v", result.ScreenshotPlan)
+	}
+}
+
 func migrateJSONResponse(status int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: status,

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -10,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -580,6 +582,90 @@ func TestMigrateImportRejectsInvalidScreenshot(t *testing.T) {
 	}
 	if !strings.Contains(runErr.Error(), badPath) {
 		t.Fatalf("expected error to mention %q, got %v", badPath, runErr)
+	}
+}
+
+func TestMigrateImportDryRunSkipScreenshotsFlag(t *testing.T) {
+	root := t.TempDir()
+	metadataDir := filepath.Join(root, "metadata", "en-US")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	writeFile(t, filepath.Join(metadataDir, "description.txt"), "English description")
+
+	screenshotsDir := filepath.Join(root, "screenshots", "en-US")
+	if err := os.MkdirAll(screenshotsDir, 0o755); err != nil {
+		t.Fatalf("mkdir screenshots: %v", err)
+	}
+	writePNGForMigrate(t, filepath.Join(screenshotsDir, "iphone_65_screen.png"), 1242, 2688)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--dry-run",
+			"--skip-screenshots",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := rootCmd.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result migrate.MigrateImportResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.ScreenshotPlan) != 0 {
+		t.Fatalf("expected no screenshot plan, got %+v", result.ScreenshotPlan)
+	}
+	if len(result.Skipped) == 0 {
+		t.Fatalf("expected screenshots dir to be reported as skipped")
+	}
+}
+
+func TestMigrateImportSkipScreenshotsRejectsInvalidBooleanExitCode(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+	cmd := exec.Command(binaryPath, "migrate", "import", "--app", "APP_ID", "--version-id", "VERSION_ID", "--skip-screenshots=maybe")
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected process exit error, got %v", err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
+	}
+	if stdout.String() != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid boolean value") {
+		t.Fatalf("expected invalid boolean error, got %q", stderr.String())
 	}
 }
 

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -54,6 +54,7 @@ func MigrateImportCommand() *ffcli.Command {
 	versionID := fs.String("version-id", "", "App Store version ID (required unless Deliverfile app_version + platform)")
 	fastlaneDir := fs.String("fastlane-dir", "", "Path to fastlane directory (optional)")
 	dryRun := fs.Bool("dry-run", false, "Preview changes without uploading")
+	skipScreenshots := fs.Bool("skip-screenshots", false, "Skip screenshot discovery and upload")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -93,7 +94,8 @@ or conventional metadata/ and screenshots/ directories:
 
 Examples:
   asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane
-  asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane --dry-run`,
+  asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane --dry-run
+  asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane --skip-screenshots`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -123,6 +125,13 @@ Examples:
 				skipped = append(skipped, SkippedItem{
 					Path:   screenshotsDir,
 					Reason: "skip_screenshots in Deliverfile",
+				})
+				screenshotsDir = ""
+			}
+			if *skipScreenshots && screenshotsDir != "" {
+				skipped = append(skipped, SkippedItem{
+					Path:   screenshotsDir,
+					Reason: "skipped by --skip-screenshots",
 				})
 				screenshotsDir = ""
 			}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -105,8 +105,9 @@ Examples:
 			}
 
 			inputs, skipped, err := resolveImportInputs(importInputOptions{
-				WorkDir:     workDir,
-				FastlaneDir: strings.TrimSpace(*fastlaneDir),
+				WorkDir:         workDir,
+				FastlaneDir:     strings.TrimSpace(*fastlaneDir),
+				SkipScreenshots: *skipScreenshots,
 			})
 			if err != nil {
 				return fmt.Errorf("migrate import: %w", err)

--- a/internal/cli/migrate/path_resolution.go
+++ b/internal/cli/migrate/path_resolution.go
@@ -16,10 +16,11 @@ const (
 )
 
 type importInputOptions struct {
-	WorkDir        string
-	FastlaneDir    string
-	MetadataDir    string
-	ScreenshotsDir string
+	WorkDir         string
+	FastlaneDir     string
+	MetadataDir     string
+	ScreenshotsDir  string
+	SkipScreenshots bool
 }
 
 type importInputs struct {
@@ -67,15 +68,18 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 
 	metadataDir, metadataSource := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.MetadataDir, config.MetadataPath, "metadata")
 	screenshotsDir, screenshotsSource := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots")
+	skipScreenshots := opts.SkipScreenshots || config.SkipScreenshots
 
 	skipped := []SkippedItem{}
 	metadataDir, skipped, err = validateResolvedDir(metadataDir, metadataSource, "metadata", skipped)
 	if err != nil {
 		return importInputs{}, nil, err
 	}
-	screenshotsDir, skipped, err = validateResolvedDir(screenshotsDir, screenshotsSource, "screenshots", skipped)
-	if err != nil {
-		return importInputs{}, nil, err
+	if !skipScreenshots {
+		screenshotsDir, skipped, err = validateResolvedDir(screenshotsDir, screenshotsSource, "screenshots", skipped)
+		if err != nil {
+			return importInputs{}, nil, err
+		}
 	}
 
 	inputs.MetadataDir = metadataDir

--- a/internal/cli/migrate/path_resolution_test.go
+++ b/internal/cli/migrate/path_resolution_test.go
@@ -140,3 +140,29 @@ func TestResolveImportInputs_SkipsMissingDefaultDirectories(t *testing.T) {
 		t.Fatalf("expected 2 skipped entries, got %d", len(skipped))
 	}
 }
+
+func TestResolveImportInputs_AllowsMissingFastlaneScreenshotsWhenSkipped(t *testing.T) {
+	root := t.TempDir()
+	fastlaneDir := filepath.Join(root, "fastlane")
+	if err := os.MkdirAll(filepath.Join(fastlaneDir, "metadata"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+
+	inputs, skipped, err := resolveImportInputs(importInputOptions{
+		WorkDir:         root,
+		FastlaneDir:     fastlaneDir,
+		SkipScreenshots: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("expected no skipped entries during path resolution, got %+v", skipped)
+	}
+	if inputs.MetadataDir != filepath.Join(fastlaneDir, "metadata") {
+		t.Fatalf("expected metadata dir %q, got %q", filepath.Join(fastlaneDir, "metadata"), inputs.MetadataDir)
+	}
+	if inputs.ScreenshotsDir != filepath.Join(fastlaneDir, "screenshots") {
+		t.Fatalf("expected screenshots dir %q, got %q", filepath.Join(fastlaneDir, "screenshots"), inputs.ScreenshotsDir)
+	}
+}

--- a/internal/cli/migrate/screenshots.go
+++ b/internal/cli/migrate/screenshots.go
@@ -49,10 +49,11 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 			return nil, nil, fmt.Errorf("invalid locale directory %q: %w", localeName, err)
 		}
 		localeDir := filepath.Join(screenshotsDir, entry.Name())
-		files, err := collectScreenshotFiles(localeDir)
+		files, localeSkipped, err := collectScreenshotFiles(localeDir)
 		if err != nil {
 			return nil, nil, err
 		}
+		skipped = append(skipped, localeSkipped...)
 		for _, filePath := range files {
 			dimensions, err := asc.ReadImageDimensions(filePath)
 			if err != nil {
@@ -87,8 +88,9 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 	return result, skipped, nil
 }
 
-func collectScreenshotFiles(localeDir string) ([]string, error) {
+func collectScreenshotFiles(localeDir string) ([]string, []SkippedItem, error) {
 	var files []string
+	var skipped []SkippedItem
 	err := filepath.WalkDir(localeDir, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -106,17 +108,28 @@ func collectScreenshotFiles(localeDir string) ([]string, error) {
 		if !info.Mode().IsRegular() {
 			return nil
 		}
+		if shouldSkipScreenshotFile(path) {
+			skipped = append(skipped, SkippedItem{
+				Path:   path,
+				Reason: "unsupported screenshot file",
+			})
+			return nil
+		}
 		files = append(files, path)
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no screenshots found in %q", localeDir)
+		skipped = append(skipped, SkippedItem{
+			Path:   localeDir,
+			Reason: "no supported screenshots found",
+		})
+		return nil, skipped, nil
 	}
 	sort.Strings(files)
-	return files, nil
+	return files, skipped, nil
 }
 
 func inferScreenshotDisplayType(path string) (string, error) {
@@ -157,42 +170,45 @@ func readImageDimensions(path string) (int, int, error) {
 func inferDisplayTypeFromFilename(path string) string {
 	name := strings.ToLower(filepath.Base(path))
 	replacements := map[string]string{
-		"iphone 6.9":      "APP_IPHONE_69",
-		"iphone6.9":       "APP_IPHONE_69",
-		"iphone 6.7":      "APP_IPHONE_67",
-		"iphone6.7":       "APP_IPHONE_67",
-		"iphone 6.5":      "APP_IPHONE_65",
-		"iphone6.5":       "APP_IPHONE_65",
-		"iphone 6.1":      "APP_IPHONE_61",
-		"iphone6.1":       "APP_IPHONE_61",
-		"iphone 5.8":      "APP_IPHONE_58",
-		"iphone5.8":       "APP_IPHONE_58",
-		"iphone 5.5":      "APP_IPHONE_55",
-		"iphone5.5":       "APP_IPHONE_55",
-		"iphone 4.7":      "APP_IPHONE_47",
-		"iphone4.7":       "APP_IPHONE_47",
-		"iphone 4.0":      "APP_IPHONE_40",
-		"iphone4.0":       "APP_IPHONE_40",
-		"iphone 3.5":      "APP_IPHONE_35",
-		"iphone3.5":       "APP_IPHONE_35",
-		"ipad 12.9":       "APP_IPAD_PRO_129",
-		"ipad12.9":        "APP_IPAD_PRO_129",
-		"ipad 11":         "APP_IPAD_PRO_3GEN_11",
-		"ipad11":          "APP_IPAD_PRO_3GEN_11",
-		"ipad 10.5":       "APP_IPAD_105",
-		"ipad10.5":        "APP_IPAD_105",
-		"ipad 9.7":        "APP_IPAD_97",
-		"ipad9.7":         "APP_IPAD_97",
-		"apple tv":        "APP_APPLE_TV",
-		"appletv":         "APP_APPLE_TV",
-		"vision pro":      "APP_APPLE_VISION_PRO",
-		"desktop":         "APP_DESKTOP",
-		"mac":             "APP_DESKTOP",
-		"watch ultra":     "APP_WATCH_ULTRA",
-		"watch series 10": "APP_WATCH_SERIES_10",
-		"watch series 7":  "APP_WATCH_SERIES_7",
-		"watch series 4":  "APP_WATCH_SERIES_4",
-		"watch series 3":  "APP_WATCH_SERIES_3",
+		"ipad pro 13":      "APP_IPAD_PRO_129",
+		"ipad pro 13-inch": "APP_IPAD_PRO_129",
+		"ipad pro 13 inch": "APP_IPAD_PRO_129",
+		"iphone 6.9":       "APP_IPHONE_69",
+		"iphone6.9":        "APP_IPHONE_69",
+		"iphone 6.7":       "APP_IPHONE_67",
+		"iphone6.7":        "APP_IPHONE_67",
+		"iphone 6.5":       "APP_IPHONE_65",
+		"iphone6.5":        "APP_IPHONE_65",
+		"iphone 6.1":       "APP_IPHONE_61",
+		"iphone6.1":        "APP_IPHONE_61",
+		"iphone 5.8":       "APP_IPHONE_58",
+		"iphone5.8":        "APP_IPHONE_58",
+		"iphone 5.5":       "APP_IPHONE_55",
+		"iphone5.5":        "APP_IPHONE_55",
+		"iphone 4.7":       "APP_IPHONE_47",
+		"iphone4.7":        "APP_IPHONE_47",
+		"iphone 4.0":       "APP_IPHONE_40",
+		"iphone4.0":        "APP_IPHONE_40",
+		"iphone 3.5":       "APP_IPHONE_35",
+		"iphone3.5":        "APP_IPHONE_35",
+		"ipad 12.9":        "APP_IPAD_PRO_129",
+		"ipad12.9":         "APP_IPAD_PRO_129",
+		"ipad 11":          "APP_IPAD_PRO_3GEN_11",
+		"ipad11":           "APP_IPAD_PRO_3GEN_11",
+		"ipad 10.5":        "APP_IPAD_105",
+		"ipad10.5":         "APP_IPAD_105",
+		"ipad 9.7":         "APP_IPAD_97",
+		"ipad9.7":          "APP_IPAD_97",
+		"apple tv":         "APP_APPLE_TV",
+		"appletv":          "APP_APPLE_TV",
+		"vision pro":       "APP_APPLE_VISION_PRO",
+		"desktop":          "APP_DESKTOP",
+		"mac":              "APP_DESKTOP",
+		"watch ultra":      "APP_WATCH_ULTRA",
+		"watch series 10":  "APP_WATCH_SERIES_10",
+		"watch series 7":   "APP_WATCH_SERIES_7",
+		"watch series 4":   "APP_WATCH_SERIES_4",
+		"watch series 3":   "APP_WATCH_SERIES_3",
 	}
 	for key, value := range replacements {
 		if strings.Contains(name, key) {
@@ -240,6 +256,8 @@ func inferDisplayTypeFromDimensions(width, height int) string {
 		return "APP_IPHONE_35"
 	case maxDim == 2732 && minDim == 2048:
 		return "APP_IPAD_PRO_129"
+	case maxDim == 2752 && minDim == 2064:
+		return "APP_IPAD_PRO_129"
 	case maxDim == 2420 && minDim == 1668:
 		return "APP_IPAD_PRO_3GEN_11"
 	case maxDim == 2388 && minDim == 1668:
@@ -256,5 +274,19 @@ func inferDisplayTypeFromDimensions(width, height int) string {
 		return "APP_APPLE_TV"
 	default:
 		return ""
+	}
+}
+
+func shouldSkipScreenshotFile(path string) bool {
+	name := filepath.Base(path)
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".png", ".jpg", ".jpeg":
+		return false
+	default:
+		return true
 	}
 }

--- a/internal/cli/migrate/screenshots_test.go
+++ b/internal/cli/migrate/screenshots_test.go
@@ -168,6 +168,76 @@ func TestDiscoverScreenshotPlan_NormalizesLocale(t *testing.T) {
 	}
 }
 
+func TestDiscoverScreenshotPlan_SkipsHiddenAndNonImageFiles(t *testing.T) {
+	root := t.TempDir()
+	localeDir := filepath.Join(root, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("mkdir locale dir: %v", err)
+	}
+	writePNG(t, filepath.Join(localeDir, "iPhone 17 Pro Max-1-main-screen.png"), 1320, 2868)
+	if err := os.WriteFile(filepath.Join(localeDir, ".DS_Store"), []byte("not an image"), 0o644); err != nil {
+		t.Fatalf("write hidden file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localeDir, "notes.txt"), []byte("not an image"), 0o644); err != nil {
+		t.Fatalf("write notes file: %v", err)
+	}
+
+	plans, skipped, err := discoverScreenshotPlan(root)
+	if err != nil {
+		t.Fatalf("discoverScreenshotPlan() error: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(plans))
+	}
+	if len(plans[0].Files) != 1 {
+		t.Fatalf("expected 1 image file, got %d", len(plans[0].Files))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped files, got %+v", skipped)
+	}
+}
+
+func TestDiscoverScreenshotPlan_IgnoresEmptyLocaleDirectories(t *testing.T) {
+	root := t.TempDir()
+	emptyLocaleDir := filepath.Join(root, "ja")
+	if err := os.MkdirAll(emptyLocaleDir, 0o755); err != nil {
+		t.Fatalf("mkdir empty locale dir: %v", err)
+	}
+	localeDir := filepath.Join(root, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("mkdir locale dir: %v", err)
+	}
+	writePNG(t, filepath.Join(localeDir, "iphone_65_screen.png"), 1242, 2688)
+
+	plans, skipped, err := discoverScreenshotPlan(root)
+	if err != nil {
+		t.Fatalf("discoverScreenshotPlan() error: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(plans))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped locale, got %+v", skipped)
+	}
+	if skipped[0].Path != emptyLocaleDir {
+		t.Fatalf("expected skipped path %q, got %q", emptyLocaleDir, skipped[0].Path)
+	}
+}
+
+func TestInferScreenshotDisplayType_FastlaneIPadPro13Filename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "iPad Pro 13-inch (M5)-1-main-screen.png")
+	writePNG(t, path, 2064, 2752)
+
+	displayType, err := inferScreenshotDisplayType(path)
+	if err != nil {
+		t.Fatalf("inferScreenshotDisplayType() error: %v", err)
+	}
+	if displayType != "APP_IPAD_PRO_129" {
+		t.Fatalf("expected APP_IPAD_PRO_129, got %q", displayType)
+	}
+}
+
 func writePNG(t *testing.T, path string, width, height int) {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, width, height))


### PR DESCRIPTION
## Summary

Fixes #1419 by making `asc migrate import` more tolerant of real fastlane screenshot output.

This change:
- adds `--skip-screenshots` for metadata-only imports
- skips hidden and unsupported non-image files like `.DS_Store` instead of aborting
- treats empty locale screenshot directories as "nothing to upload" instead of an error
- recognizes fastlane-style modern iPad Pro 13-inch screenshot names and dimensions

## Root Cause

`migrate import` assumed every regular file under a screenshot locale was a valid image and only understood a narrow set of display-type hints. That broke on common fastlane `snapshot` output, which uses `SIMULATOR_DEVICE_NAME-name.png` filenames and often lives in directories that may also contain macOS metadata files.

I also verified upstream fastlane behavior in a temporary clone:
- `snapshot/lib/assets/SnapshotHelper.swift` writes screenshots as `"\(simulator)-\(name).png"`
- the simulator portion comes from `SIMULATOR_DEVICE_NAME`

## Why This Approach

I kept the fix inside `migrate import` instead of introducing a parallel workflow so existing migration users get the behavior they expect with minimal command-shape churn.

Alternatives considered:
- only adding `--skip-screenshots`: this unblocks metadata imports, but still leaves default fastlane screenshot folders brittle
- only broadening device-name inference: this still leaves `.DS_Store` and empty locale folders as hard failures

## Examples

```bash
asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane --skip-screenshots
```

```bash
asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane
```

With this patch, the second command now tolerates:
- `fastlane/screenshots/en-US/.DS_Store`
- empty locale folders like `fastlane/screenshots/ja/`
- files named like `iPad Pro 13-inch (M5)-1-main-screen.png`

## Validation

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go test ./internal/cli/migrate ./internal/cli/cmdtest -run 'TestDiscoverScreenshotPlan_SkipsHiddenAndNonImageFiles|TestDiscoverScreenshotPlan_IgnoresEmptyLocaleDirectories|TestInferScreenshotDisplayType_FastlaneIPadPro13Filename|TestMigrateImportDryRunSkipScreenshotsFlag|TestMigrateImportSkipScreenshotsRejectsInvalidBooleanExitCode'`

## Risks / Notes

- corrupt files that still use supported image extensions continue to fail, which is intentional
- the new fastlane mapping is targeted at the concrete modern iPad Pro case reported in #1419 rather than trying to infer every future simulator name pattern up front
