### PR TITLE
apps wall: add Splitie – Split & Settle Bills

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -972,6 +972,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/90/bc/20/90bc2003-d998-ba7a-ce45-66d846d7685f/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Splitie – Split & Settle Bills",
+    "link": "https://apps.apple.com/us/app/splitie-split-settle-bills/id6758516466?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/06/18/ba/0618ba46-ef94-b8d0-9f30-0617c08f284f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SquishPic: Image Compressor",
     "link": "https://apps.apple.com/us/app/squishpic-image-compressor/id6757522104?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/65/d1/ae/65d1ae1f-5f97-acb6-5458-79560afb84ab/AppIcon-0-0-85-220-0-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Splitie – Split & Settle Bills` to the Wall of Apps

## Entry

- App ID: 6758516466
- App: Splitie – Split & Settle Bills
- Link: https://apps.apple.com/us/app/splitie-split-settle-bills/id6758516466?uo=4

## Notes

- Submitted via `asc apps wall submit`
