### PR TITLE
apps wall: add Dateminder - Event Reminders

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -214,6 +214,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cf/14/8f/cf148fbc-2902-8a67-35a7-350b1ec57971/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Dateminder - Event Reminders",
+    "link": "https://apps.apple.com/us/app/dateminder-event-reminders/id6480020164?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/23/3c/a2233c68-f1ef-e5a4-4574-9ec5fa2a1d4c/AppIcon-0-1x_U007ephone-0-1-sRGB-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "DayBar",
     "link": "https://apps.apple.com/us/app/daybar/id6739052447?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/79/16/d5/7916d56d-bf7f-37a0-cb0c-bb50f04ed4f3/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Dateminder - Event Reminders` to the Wall of Apps

## Entry

- App ID: 6480020164
- App: Dateminder - Event Reminders
- Link: https://apps.apple.com/us/app/dateminder-event-reminders/id6480020164?uo=4

## Notes

- Submitted via `asc apps wall submit`
