### PR TITLE
apps wall: add Shluffy - A Baby Sleep Coach

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -912,6 +912,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/53/33/66/53336647-1330-96ad-575f-1bdb47d653d1/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Shluffy - A Baby Sleep Coach",
+    "link": "https://apps.apple.com/us/app/shluffy-a-baby-sleep-coach/id6758364198?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/27/e1/3a/27e13a84-a7d7-b9f5-1ee3-51a56210385e/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Shua - arXiv Paper Reader",
     "link": "https://apps.apple.com/us/app/shua-arxiv-paper-reader/id6759848629?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/66/fc/74/66fc74ce-6a9d-7344-618d-5b0e5af2110b/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Shluffy - A Baby Sleep Coach` to the Wall of Apps

## Entry

- App ID: 6758364198
- App: Shluffy - A Baby Sleep Coach
- Link: https://apps.apple.com/us/app/shluffy-a-baby-sleep-coach/id6758364198?uo=4

## Notes

- Submitted via `asc apps wall submit`
