### PR TITLE
apps wall: add AI Chat Assistant - Chappie

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -20,6 +20,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4e/44/bd/4e44bde8-ee38-ba9a-c1f1-ff8485e5e5ff/aetherIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "AI Chat Assistant - Chappie",
+    "link": "https://apps.apple.com/us/app/ai-chat-assistant-chappie/id6756681102?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/60/12/19/60121940-0202-b42d-6c0d-074edb4fff49/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Airtist",
     "link": "https://apps.apple.com/app/id6745053878",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a1/85/81/a185815f-0e82-98b4-ac37-aed44c57d719/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `AI Chat Assistant - Chappie` to the Wall of Apps

## Entry

- App ID: 6756681102
- App: AI Chat Assistant - Chappie
- Link: https://apps.apple.com/us/app/ai-chat-assistant-chappie/id6756681102?uo=4

## Notes

- Submitted via `asc apps wall submit`
