### PR TITLE
apps wall: add Newgrain: Film Photo Community

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -648,6 +648,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/1c/77/66/1c776632-25a0-9af7-38ac-2d6c31d42826/icon_composed-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Newgrain: Film Photo Community",
+    "link": "https://apps.apple.com/us/app/newgrain-film-photo-community/id6444198677?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/de/fa/c2/defac22e-5f4d-1204-4fb7-7bdeb1dfb970/AppIcon-1x_U007ephone-0-1-0-85-220-0.jpeg/512x512bb.jpg"
+  },
+  {
     "app": "NextCatch",
     "link": "https://apps.apple.com/us/app/nextcatch/id6758589575?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5c/6c/21/5c6c21ac-7b19-3556-a639-55a63601163a/AppIcon-0-0-1x_U007emarketing-0-6-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Newgrain: Film Photo Community` to the Wall of Apps

## Entry

- App ID: 6444198677
- App: Newgrain: Film Photo Community
- Link: https://apps.apple.com/us/app/newgrain-film-photo-community/id6444198677?uo=4

## Notes

- Submitted via `asc apps wall submit`
