### PR TITLE
[codex] app-clips: support inline invocation localizations

### DIFF
--- a/internal/asc/client_app_clips.go
+++ b/internal/asc/client_app_clips.go
@@ -420,6 +420,14 @@ type BetaAppClipInvocationLocalizationCreateAttributes struct {
 	Locale string `json:"locale"`
 }
 
+// BetaAppClipInvocationLocalizationInlineCreate describes an inline localization create payload.
+type BetaAppClipInvocationLocalizationInlineCreate struct {
+	Type          ResourceType                                      `json:"type"`
+	ID            string                                            `json:"id,omitempty"`
+	Attributes    BetaAppClipInvocationLocalizationCreateAttributes `json:"attributes"`
+	Relationships *BetaAppClipInvocationLocalizationRelationships   `json:"relationships,omitempty"`
+}
+
 // BetaAppClipInvocationLocalizationUpdateAttributes describes localization update attributes.
 type BetaAppClipInvocationLocalizationUpdateAttributes struct {
 	Title *string `json:"title,omitempty"`
@@ -445,7 +453,8 @@ type BetaAppClipInvocationCreateData struct {
 
 // BetaAppClipInvocationCreateRequest is the create request payload.
 type BetaAppClipInvocationCreateRequest struct {
-	Data BetaAppClipInvocationCreateData `json:"data"`
+	Data     BetaAppClipInvocationCreateData                 `json:"data"`
+	Included []BetaAppClipInvocationLocalizationInlineCreate `json:"included,omitempty"`
 }
 
 // BetaAppClipInvocationUpdateData is the payload for updating an invocation.
@@ -1848,7 +1857,7 @@ func (c *Client) GetBetaAppClipInvocation(ctx context.Context, invocationID stri
 }
 
 // CreateBetaAppClipInvocation creates a beta App Clip invocation.
-func (c *Client) CreateBetaAppClipInvocation(ctx context.Context, buildBundleID string, attrs BetaAppClipInvocationCreateAttributes, localizationIDs []string) (*BetaAppClipInvocationResponse, error) {
+func (c *Client) CreateBetaAppClipInvocation(ctx context.Context, buildBundleID string, attrs BetaAppClipInvocationCreateAttributes, localizationIDs []string, inlineLocalizations []BetaAppClipInvocationLocalizationCreateAttributes) (*BetaAppClipInvocationResponse, error) {
 	buildBundleID = strings.TrimSpace(buildBundleID)
 	if buildBundleID == "" {
 		return nil, fmt.Errorf("buildBundleID is required")
@@ -1862,22 +1871,49 @@ func (c *Client) CreateBetaAppClipInvocation(ctx context.Context, buildBundleID 
 			},
 		},
 	}
-	if len(localizationIDs) > 0 {
-		list := make([]ResourceData, 0, len(localizationIDs))
-		for _, id := range localizationIDs {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				continue
-			}
-			list = append(list, ResourceData{
-				Type: ResourceTypeBetaAppClipInvocationLocalizations,
-				ID:   id,
-			})
+
+	localizationData := make([]ResourceData, 0, len(localizationIDs)+len(inlineLocalizations))
+	for _, id := range localizationIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
 		}
-		if len(list) > 0 {
-			relationships.BetaAppClipInvocationLocalizations = &RelationshipList{Data: list}
-		}
+		localizationData = append(localizationData, ResourceData{
+			Type: ResourceTypeBetaAppClipInvocationLocalizations,
+			ID:   id,
+		})
 	}
+
+	included := make([]BetaAppClipInvocationLocalizationInlineCreate, 0, len(inlineLocalizations))
+	for idx, localization := range inlineLocalizations {
+		localeValue := strings.TrimSpace(localization.Locale)
+		titleValue := strings.TrimSpace(localization.Title)
+		if localeValue == "" {
+			return nil, fmt.Errorf("inline localization %d: locale is required", idx+1)
+		}
+		if titleValue == "" {
+			return nil, fmt.Errorf("inline localization %d: title is required", idx+1)
+		}
+
+		resourceID := fmt.Sprintf("${localization-%d}", idx+1)
+		localizationData = append(localizationData, ResourceData{
+			Type: ResourceTypeBetaAppClipInvocationLocalizations,
+			ID:   resourceID,
+		})
+		included = append(included, BetaAppClipInvocationLocalizationInlineCreate{
+			Type: ResourceTypeBetaAppClipInvocationLocalizations,
+			ID:   resourceID,
+			Attributes: BetaAppClipInvocationLocalizationCreateAttributes{
+				Locale: localeValue,
+				Title:  titleValue,
+			},
+		})
+	}
+
+	if len(localizationData) == 0 {
+		return nil, fmt.Errorf("at least one localization is required")
+	}
+	relationships.BetaAppClipInvocationLocalizations = &RelationshipList{Data: localizationData}
 
 	payload := BetaAppClipInvocationCreateRequest{
 		Data: BetaAppClipInvocationCreateData{
@@ -1885,6 +1921,9 @@ func (c *Client) CreateBetaAppClipInvocation(ctx context.Context, buildBundleID 
 			Attributes:    attrs,
 			Relationships: relationships,
 		},
+	}
+	if len(included) > 0 {
+		payload.Included = included
 	}
 
 	body, err := BuildRequestBody(payload)

--- a/internal/asc/client_http_app_clips_test.go
+++ b/internal/asc/client_http_app_clips_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -596,15 +597,91 @@ func TestCreateBetaAppClipInvocation(t *testing.T) {
 		if payload.Data.Relationships.BuildBundle.Data.ID != "bundle-1" {
 			t.Fatalf("expected buildBundle id bundle-1, got %s", payload.Data.Relationships.BuildBundle.Data.ID)
 		}
+		if payload.Data.Relationships.BetaAppClipInvocationLocalizations == nil {
+			t.Fatal("expected localization relationships to be present")
+		}
+		if len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data) != 1 {
+			t.Fatalf("expected one localization relationship, got %d", len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data))
+		}
+		if payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0].ID != "loc-1" {
+			t.Fatalf("expected localization id loc-1, got %s", payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0].ID)
+		}
 		if payload.Data.Attributes.URL != "https://example.com/clip" {
 			t.Fatalf("expected url https://example.com/clip, got %s", payload.Data.Attributes.URL)
+		}
+		if len(payload.Included) != 0 {
+			t.Fatalf("expected no included localizations, got %d", len(payload.Included))
 		}
 		assertAuthorized(t, req)
 	}, response)
 
 	attrs := BetaAppClipInvocationCreateAttributes{URL: "https://example.com/clip"}
-	if _, err := client.CreateBetaAppClipInvocation(context.Background(), "bundle-1", attrs, nil); err != nil {
+	if _, err := client.CreateBetaAppClipInvocation(context.Background(), "bundle-1", attrs, []string{"loc-1"}, nil); err != nil {
 		t.Fatalf("CreateBetaAppClipInvocation() error: %v", err)
+	}
+}
+
+func TestCreateBetaAppClipInvocationWithInlineLocalization(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"betaAppClipInvocations","id":"inv-1","attributes":{"url":"https://example.com/clip"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaAppClipInvocations" {
+			t.Fatalf("expected path /v1/betaAppClipInvocations, got %s", req.URL.Path)
+		}
+		var payload BetaAppClipInvocationCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Data.Relationships.BetaAppClipInvocationLocalizations == nil {
+			t.Fatal("expected localization relationships to be present")
+		}
+		if len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data) != 1 {
+			t.Fatalf("expected one localization relationship, got %d", len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data))
+		}
+		relationship := payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0]
+		if relationship.ID != "${localization-1}" {
+			t.Fatalf("expected inline localization id ${localization-1}, got %s", relationship.ID)
+		}
+		if len(payload.Included) != 1 {
+			t.Fatalf("expected one included localization, got %d", len(payload.Included))
+		}
+		included := payload.Included[0]
+		if included.ID != relationship.ID {
+			t.Fatalf("expected included id %s, got %s", relationship.ID, included.ID)
+		}
+		if included.Attributes.Locale != "en-US" {
+			t.Fatalf("expected locale en-US, got %s", included.Attributes.Locale)
+		}
+		if included.Attributes.Title != "Try it" {
+			t.Fatalf("expected title Try it, got %s", included.Attributes.Title)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	attrs := BetaAppClipInvocationCreateAttributes{URL: "https://example.com/clip"}
+	inline := []BetaAppClipInvocationLocalizationCreateAttributes{{
+		Locale: "en-US",
+		Title:  "Try it",
+	}}
+	if _, err := client.CreateBetaAppClipInvocation(context.Background(), "bundle-1", attrs, nil, inline); err != nil {
+		t.Fatalf("CreateBetaAppClipInvocation() error: %v", err)
+	}
+}
+
+func TestCreateBetaAppClipInvocationRequiresLocalization(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		t.Fatalf("did not expect request, got %s %s", req.Method, req.URL.Path)
+	}, jsonResponse(http.StatusCreated, `{"data":{"type":"betaAppClipInvocations","id":"inv-1"}}`))
+
+	attrs := BetaAppClipInvocationCreateAttributes{URL: "https://example.com/clip"}
+	_, err := client.CreateBetaAppClipInvocation(context.Background(), "bundle-1", attrs, nil, nil)
+	if err == nil {
+		t.Fatal("expected localization validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one localization is required") {
+		t.Fatalf("expected localization validation error, got %v", err)
 	}
 }
 

--- a/internal/cli/appclips/invocations.go
+++ b/internal/cli/appclips/invocations.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+var appClipsClientFactory = shared.GetASCClient
+
 // AppClipInvocationsCommand returns the invocations command group.
 func AppClipInvocationsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("invocations", flag.ExitOnError)
@@ -77,7 +79,7 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := appClipsClientFactory()
 			if err != nil {
 				return fmt.Errorf("app-clips invocations list: %w", err)
 			}
@@ -151,7 +153,7 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := appClipsClientFactory()
 			if err != nil {
 				return fmt.Errorf("app-clips invocations get: %w", err)
 			}
@@ -175,17 +177,22 @@ func AppClipInvocationsCreateCommand() *ffcli.Command {
 
 	buildBundleID := fs.String("build-bundle-id", "", "Build bundle ID")
 	url := fs.String("url", "", "Invocation URL")
-	localizationIDs := fs.String("localization-id", "", "Localization ID(s), comma-separated")
+	localizationIDs := fs.String("localization-id", "", "Existing localization ID(s), comma-separated")
+	locale := fs.String("locale", "", "Inline localization locale (use with --title)")
+	title := fs.String("title", "", "Inline localization title (use with --locale)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "create",
-		ShortUsage: "asc app-clips invocations create --build-bundle-id \"BUILD_BUNDLE_ID\" --url \"https://example.com/clip\" [flags]",
+		ShortUsage: "asc app-clips invocations create --build-bundle-id \"BUILD_BUNDLE_ID\" --url \"https://example.com/clip\" (--localization-id \"LOC_ID\" | --locale \"en-US\" --title \"Try it\") [flags]",
 		ShortHelp:  "Create a beta App Clip invocation.",
 		LongHelp: `Create a beta App Clip invocation.
 
+Provide either pre-existing localization IDs with ` + "`--localization-id`" + ` or an inline localization with ` + "`--locale`" + ` and ` + "`--title`" + `.
+
 Examples:
-  asc app-clips invocations create --build-bundle-id "BUILD_BUNDLE_ID" --url "https://example.com/clip"`,
+  asc app-clips invocations create --build-bundle-id "BUILD_BUNDLE_ID" --url "https://example.com/clip" --locale "en-US" --title "Try it"
+  asc app-clips invocations create --build-bundle-id "BUILD_BUNDLE_ID" --url "https://example.com/clip" --localization-id "LOC_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -201,7 +208,31 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			client, err := shared.GetASCClient()
+			localizationValues := shared.SplitCSV(*localizationIDs)
+			localeValue := strings.TrimSpace(*locale)
+			titleValue := strings.TrimSpace(*title)
+			if titleValue != "" && localeValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --locale is required when --title is set")
+				return flag.ErrHelp
+			}
+			if localeValue != "" && titleValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --title is required when --locale is set")
+				return flag.ErrHelp
+			}
+
+			inlineLocalizations := make([]asc.BetaAppClipInvocationLocalizationCreateAttributes, 0, 1)
+			if localeValue != "" && titleValue != "" {
+				inlineLocalizations = append(inlineLocalizations, asc.BetaAppClipInvocationLocalizationCreateAttributes{
+					Locale: localeValue,
+					Title:  titleValue,
+				})
+			}
+			if len(localizationValues) == 0 && len(inlineLocalizations) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: provide --localization-id or both --locale and --title")
+				return flag.ErrHelp
+			}
+
+			client, err := appClipsClientFactory()
 			if err != nil {
 				return fmt.Errorf("app-clips invocations create: %w", err)
 			}
@@ -210,7 +241,7 @@ Examples:
 			defer cancel()
 
 			attrs := asc.BetaAppClipInvocationCreateAttributes{URL: urlValue}
-			resp, err := client.CreateBetaAppClipInvocation(requestCtx, buildBundleValue, attrs, shared.SplitCSV(*localizationIDs))
+			resp, err := client.CreateBetaAppClipInvocation(requestCtx, buildBundleValue, attrs, localizationValues, inlineLocalizations)
 			if err != nil {
 				return fmt.Errorf("app-clips invocations create: failed to create: %w", err)
 			}
@@ -257,7 +288,7 @@ Examples:
 			urlValue := strings.TrimSpace(*url)
 			attrs := &asc.BetaAppClipInvocationUpdateAttributes{URL: &urlValue}
 
-			client, err := shared.GetASCClient()
+			client, err := appClipsClientFactory()
 			if err != nil {
 				return fmt.Errorf("app-clips invocations update: %w", err)
 			}
@@ -304,7 +335,7 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := appClipsClientFactory()
 			if err != nil {
 				return fmt.Errorf("app-clips invocations delete: %w", err)
 			}

--- a/internal/cli/appclips/test_hooks.go
+++ b/internal/cli/appclips/test_hooks.go
@@ -1,0 +1,20 @@
+package appclips
+
+import (
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// SetClientFactory replaces the ASC client factory for tests.
+// It returns a restore function to reset the previous handler.
+func SetClientFactory(fn func() (*asc.Client, error)) func() {
+	previous := appClipsClientFactory
+	if fn == nil {
+		appClipsClientFactory = shared.GetASCClient
+	} else {
+		appClipsClientFactory = fn
+	}
+	return func() {
+		appClipsClientFactory = previous
+	}
+}

--- a/internal/cli/cmdtest/appclips_invocations_create_test.go
+++ b/internal/cli/cmdtest/appclips_invocations_create_test.go
@@ -1,0 +1,198 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	appclipscli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/appclips"
+)
+
+func TestAppClipsInvocationsCreateSupportsInlineLocalization(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/betaAppClipInvocations" {
+			t.Fatalf("expected path /v1/betaAppClipInvocations, got %s", r.URL.Path)
+		}
+
+		var payload asc.BetaAppClipInvocationCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.BuildBundle == nil {
+			t.Fatal("expected build bundle relationship")
+		}
+		if payload.Data.Relationships.BuildBundle.Data.ID != "bundle-1" {
+			t.Fatalf("expected build bundle id bundle-1, got %s", payload.Data.Relationships.BuildBundle.Data.ID)
+		}
+		if payload.Data.Relationships.BetaAppClipInvocationLocalizations == nil {
+			t.Fatal("expected localization relationships")
+		}
+		if len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data) != 1 {
+			t.Fatalf("expected one localization relationship, got %d", len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data))
+		}
+		if payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0].ID != "${localization-1}" {
+			t.Fatalf("expected placeholder localization id, got %s", payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0].ID)
+		}
+		if len(payload.Included) != 1 {
+			t.Fatalf("expected one included localization, got %d", len(payload.Included))
+		}
+		if payload.Included[0].Attributes.Locale != "en-US" {
+			t.Fatalf("expected locale en-US, got %s", payload.Included[0].Attributes.Locale)
+		}
+		if payload.Included[0].Attributes.Title != "Try it" {
+			t.Fatalf("expected title Try it, got %s", payload.Included[0].Attributes.Title)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"type":"betaAppClipInvocations","id":"inv-1","attributes":{"url":"https://example.com/clip"}},"links":{}}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	keyPath := t.TempDir() + "/key.p8"
+	writeECDSAPEM(t, keyPath)
+
+	transport := appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	restore := appclipscli.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"app-clips", "invocations", "create",
+			"--build-bundle-id", "bundle-1",
+			"--url", "https://example.com/clip",
+			"--locale", "en-US",
+			"--title", "Try it",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response asc.BetaAppClipInvocationResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nstdout=%q", err, stdout)
+	}
+	if response.Data.ID != "inv-1" {
+		t.Fatalf("expected invocation id inv-1, got %s", response.Data.ID)
+	}
+}
+
+func TestAppClipsInvocationsCreateSupportsExistingLocalizationIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/betaAppClipInvocations" {
+			t.Fatalf("expected path /v1/betaAppClipInvocations, got %s", r.URL.Path)
+		}
+
+		var payload asc.BetaAppClipInvocationCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.BetaAppClipInvocationLocalizations == nil {
+			t.Fatal("expected localization relationships")
+		}
+		if len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data) != 1 {
+			t.Fatalf("expected one localization relationship, got %d", len(payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data))
+		}
+		if payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0].ID != "loc-1" {
+			t.Fatalf("expected localization id loc-1, got %s", payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data[0].ID)
+		}
+		if len(payload.Included) != 0 {
+			t.Fatalf("expected no included localizations, got %d", len(payload.Included))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"type":"betaAppClipInvocations","id":"inv-1","attributes":{"url":"https://example.com/clip"}},"links":{}}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	keyPath := t.TempDir() + "/key.p8"
+	writeECDSAPEM(t, keyPath)
+
+	transport := appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	restore := appclipscli.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"app-clips", "invocations", "create",
+			"--build-bundle-id", "bundle-1",
+			"--url", "https://example.com/clip",
+			"--localization-id", "loc-1",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response asc.BetaAppClipInvocationResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nstdout=%q", err, stdout)
+	}
+	if response.Data.ID != "inv-1" {
+		t.Fatalf("expected invocation id inv-1, got %s", response.Data.ID)
+	}
+}
+
+type appClipsRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn appClipsRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -4606,6 +4606,21 @@ func TestAppClipsValidationErrors(t *testing.T) {
 			wantErr: "Error: --build-bundle-id is required",
 		},
 		{
+			name:    "invocations create missing localization source",
+			args:    []string{"app-clips", "invocations", "create", "--build-bundle-id", "BUNDLE_ID", "--url", "https://example.com/clip"},
+			wantErr: "Error: provide --localization-id or both --locale and --title",
+		},
+		{
+			name:    "invocations create missing locale for inline localization",
+			args:    []string{"app-clips", "invocations", "create", "--build-bundle-id", "BUNDLE_ID", "--url", "https://example.com/clip", "--title", "Try it"},
+			wantErr: "Error: --locale is required when --title is set",
+		},
+		{
+			name:    "invocations create missing title for inline localization",
+			args:    []string{"app-clips", "invocations", "create", "--build-bundle-id", "BUNDLE_ID", "--url", "https://example.com/clip", "--locale", "en-US"},
+			wantErr: "Error: --title is required when --locale is set",
+		},
+		{
 			name:    "domain status cache missing build bundle",
 			args:    []string{"app-clips", "domain-status", "cache"},
 			wantErr: "Error: --build-bundle-id is required",


### PR DESCRIPTION
## Summary
- add `--locale` and `--title` to `asc app-clips invocations create` so the command can send inline `included[]` localizations
- keep `--localization-id` working for pre-existing localizations and validate locally that at least one localization source is provided
- cover the client payload, CLI validation, and both create paths with focused tests

## Why
Fixes the chicken-and-egg flow in #1434: the App Store Connect API requires `betaAppClipInvocationLocalizations` on create, but the CLI could only reference existing localization IDs.

## Approach
This PR chooses explicit inline-localization flags instead of auto-creating a default localization because:
- it matches the issue’s preferred UX directly
- it keeps locale/title explicit and reviewable
- it avoids hidden defaults in a mutating command

Alternatives considered:
- auto-create a default localization when none is provided: simpler CLI surface, but it would require guessing locale/title semantics
- leave validation to the API: smaller change, but it preserves the current broken UX and poor error loop

## Validation
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- built binary check: `/tmp/asc app-clips invocations create --build-bundle-id bundle-1 --url https://example.com/clip` exits `2` with `Error: provide --localization-id or both --locale and --title`

## Live ASC verification
- Verified read-only discovery with `ASC_BYPASS_KEYCHAIN=1 /tmp/asc builds list --app 6759231657 --limit 5 --output json` and confirmed the preferred disposable app currently has zero builds, so there was no safe throwaway build bundle to mutate.
- Confirmed read-only build-bundle and invocation listing on another app, but intentionally did not create/delete an invocation on a non-throwaway app.

Closes #1434