### PR TITLE
apps wall: add ThaiQuest

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1081,6 +1081,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0a/49/48/0a49486e-92b3-37b5-8bb8-c038aee9a0a4/speakeasy-icon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "ThaiQuest",
+    "link": "https://apps.apple.com/us/app/thaiquest/id6759592901?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/49/51/6b/49516bdb-9a33-055e-3296-38f930c5d311/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Thought Ease: End Overthinking",
     "link": "https://apps.apple.com/app/id6759291269",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/38/89/82/3889821a-7a9e-d068-89ca-937b482923ed/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `ThaiQuest` to the Wall of Apps

## Entry

- App ID: 6759592901
- App: ThaiQuest
- Link: https://apps.apple.com/us/app/thaiquest/id6759592901?uo=4

## Notes

- Submitted via `asc apps wall submit`
