### PR TITLE
apps wall: add Klick #1 AI Camera Assistant

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -498,6 +498,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c8/38/fd/c838fddf-a2db-5007-12be-8cb9906926e1/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"
   },
   {
+    "app": "Klick #1 AI Camera Assistant",
+    "link": "https://apps.apple.com/us/app/klick-1-ai-camera-assistant/id6749798728?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/47/23/d9/4723d958-44ab-af95-67a7-5431d6ff981a/AppIcon-0-0-1x_U007ephone-0-1-85-220.jpeg/512x512bb.jpg"
+  },
+  {
     "app": "Klick: keyboard sounds",
     "link": "https://apps.apple.com/us/app/klick-keyboard-sounds/id6758880736?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d1/c0/46/d1c046e6-f966-f063-e294-0a1969396b60/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Klick #1 AI Camera Assistant` to the Wall of Apps

## Entry

- App ID: 6749798728
- App: Klick #1 AI Camera Assistant
- Link: https://apps.apple.com/us/app/klick-1-ai-camera-assistant/id6749798728?uo=4

## Notes

- Submitted via `asc apps wall submit`
