### PR TITLE
Migrate repo links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
 
         This form is for reproducible bugs. If you need install help, auth setup help,
         workflow advice, or want to ask "how do I...?", please use GitHub Discussions:
-        https://github.com/rudrankriyam/App-Store-Connect-CLI/discussions
+        https://github.com/rorkai/App-Store-Connect-CLI/discussions
 
         Please include enough detail for someone else to reproduce the issue.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,16 +1,16 @@
 blank_issues_enabled: false
 contact_links:
   - name: Start here / troubleshooting
-    url: https://github.com/rudrankriyam/App-Store-Connect-CLI#quick-start
+    url: https://github.com/rorkai/App-Store-Connect-CLI#quick-start
     about: Install asc, authenticate, validate auth, and troubleshoot common Homebrew or output issues
   - name: Questions and workflow help
-    url: https://github.com/rudrankriyam/App-Store-Connect-CLI/discussions
+    url: https://github.com/rorkai/App-Store-Connect-CLI/discussions
     about: Ask "how do I...?" questions, get install help, and share workflows
   - name: Support policy
-    url: https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/main/SUPPORT.md
+    url: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/SUPPORT.md
     about: See when to use Discussions vs Issues and what to include in a bug report
   - name: asc skills
-    url: https://github.com/rudrankriyam/app-store-connect-cli-skills
+    url: https://github.com/rorkai/app-store-connect-cli-skills
     about: Agent skills to automate asc workflows
   - name: Documentation
     url: https://asccli.sh

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
 
         If this is a question, install issue, auth setup problem, or workflow support request,
         please use GitHub Discussions instead:
-        https://github.com/rudrankriyam/App-Store-Connect-CLI/discussions
+        https://github.com/rorkai/App-Store-Connect-CLI/discussions
 
   - type: textarea
     id: problem

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
   integration:
     runs-on: macos-latest
     # Only run if secrets are available (skips forks)
-    if: github.repository == 'rudrankriyam/App-Store-Connect-CLI'
+    if: github.repository == 'rorkai/App-Store-Connect-CLI'
     timeout-minutes: 15
     steps:
       - name: Checkout code

--- a/.github/workflows/refresh-installs-badge.yml
+++ b/.github/workflows/refresh-installs-badge.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   update:
-    if: github.repository == 'rudrankriyam/App-Store-Connect-CLI'
+    if: github.repository == 'rorkai/App-Store-Connect-CLI'
     runs-on: ubuntu-latest
     steps:
       # release.* checks out the tag by default; we must commit on main.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
               class Asc < Formula
                 desc "A fast, AI-agent friendly CLI for App Store Connect"
-                homepage 'https://github.com/rudrankriyam/App-Store-Connect-CLI'
+                homepage 'https://github.com/rorkai/App-Store-Connect-CLI'
                 version '{version}'
                 license 'MIT'
 
@@ -145,10 +145,10 @@ jobs:
 
                 on_macos do
                   if Hardware::CPU.arm?
-                    url 'https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/download/{version}/asc_{version}_macOS_arm64'
+                    url 'https://github.com/rorkai/App-Store-Connect-CLI/releases/download/{version}/asc_{version}_macOS_arm64'
                     sha256 '{sha256_arm64}'
                   else
-                    url 'https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/download/{version}/asc_{version}_macOS_amd64'
+                    url 'https://github.com/rorkai/App-Store-Connect-CLI/releases/download/{version}/asc_{version}_macOS_amd64'
                     sha256 '{sha256_amd64}'
                   end
                 end

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Unofficial, fast, lightweight, agent-assisted, reviewer-owned CLI for the App St
 
 ## asc skills
 
-Agent Skills for automating `asc` workflows including builds, TestFlight, metadata sync, submissions, and signing. https://github.com/rudrankriyam/app-store-connect-cli-skills
+Agent Skills for automating `asc` workflows including builds, TestFlight, metadata sync, submissions, and signing. https://github.com/rorkai/app-store-connect-cli-skills
 
 ## Core Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Requirements:
 
 Clone and build:
 ```bash
-git clone https://github.com/rudrankriyam/App-Store-Connect-CLI.git
+git clone https://github.com/rorkai/App-Store-Connect-CLI.git
 cd App-Store-Connect-CLI
 make build
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # App Store Connect CLI
 
 <p align="center">
-  <a href="https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/latest"><img src="https://img.shields.io/github/v/release/rudrankriyam/App-Store-Connect-CLI?style=for-the-badge&color=blue" alt="Latest Release"></a>
-  <a href="https://github.com/rudrankriyam/App-Store-Connect-CLI/stargazers"><img src="https://img.shields.io/github/stars/rudrankriyam/App-Store-Connect-CLI?style=for-the-badge" alt="GitHub Stars"></a>
+  <a href="https://github.com/rorkai/App-Store-Connect-CLI/releases/latest"><img src="https://img.shields.io/github/v/release/rorkai/App-Store-Connect-CLI?style=for-the-badge&color=blue" alt="Latest Release"></a>
+  <a href="https://github.com/rorkai/App-Store-Connect-CLI/stargazers"><img src="https://img.shields.io/github/stars/rorkai/App-Store-Connect-CLI?style=for-the-badge" alt="GitHub Stars"></a>
   <img src="https://img.shields.io/badge/Go-1.26+-00ADD8?style=for-the-badge&logo=go" alt="Go Version">
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License">
   <img src="https://img.shields.io/badge/Homebrew-compatible-blue?style=for-the-badge" alt="Homebrew">
-  <a href="https://github.com/rudrankriyam/App-Store-Connect-CLI/releases" title="GitHub release assets (all-time) + Homebrew installs (365d), see docs/badges/README.md"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frudrankriyam%2FApp-Store-Connect-CLI%2Fmain%2Fdocs%2Fbadges%2Finstalls-total.json&amp;style=for-the-badge&amp;color=brightgreen" alt="Estimated total downloads"></a>
+  <a href="https://github.com/rorkai/App-Store-Connect-CLI/releases" title="GitHub release assets (all-time) + Homebrew installs (365d), see docs/badges/README.md"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frorkai%2FApp-Store-Connect-CLI%2Fmain%2Fdocs%2Fbadges%2Finstalls-total.json&amp;style=for-the-badge&amp;color=brightgreen" alt="Estimated total downloads"></a>
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@ Automate iOS, macOS, tvOS, and visionOS release workflows from your terminal, ID
 ## asc skills
 
 Agent Skills for automating `asc` workflows including builds, TestFlight, metadata sync, submissions, and signing:
-https://github.com/rudrankriyam/app-store-connect-cli-skills
+https://github.com/rorkai/app-store-connect-cli-skills
 
 ## Sponsors
 
@@ -71,7 +71,7 @@ curl -fsSL https://asccli.sh/install | bash
 ```
 
 Windows users can download the signed release binaries directly from the
-[GitHub releases page](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/latest).
+[GitHub releases page](https://github.com/rorkai/App-Store-Connect-CLI/releases/latest).
 
 For source builds and contributor setup, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -167,8 +167,8 @@ depending on a command in CI or scripts:
 
 ## Support
 
-- Use [GitHub Discussions](https://github.com/rudrankriyam/App-Store-Connect-CLI/discussions) for install help, authentication setup, workflow advice, and "how do I...?" questions
-- Use [GitHub Issues](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues) for reproducible bugs and concrete feature requests
+- Use [GitHub Discussions](https://github.com/rorkai/App-Store-Connect-CLI/discussions) for install help, authentication setup, workflow advice, and "how do I...?" questions
+- Use [GitHub Issues](https://github.com/rorkai/App-Store-Connect-CLI/issues) for reproducible bugs and concrete feature requests
 - See [SUPPORT.md](SUPPORT.md) for the support policy and bug-report checklist
 - Before filing an auth or API bug, retry with `ASC_BYPASS_KEYCHAIN=1`; if it is safe to do so, include redacted output from `ASC_DEBUG=api asc ...` or `asc --api-debug ...`
 
@@ -342,7 +342,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rudrankriyam/App-Store-Connect-CLI&type=Date)](https://star-history.com/#rudrankriyam/App-Store-Connect-CLI&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=rorkai/App-Store-Connect-CLI&type=Date)](https://star-history.com/#rorkai/App-Store-Connect-CLI&Date)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 Please do not open a public GitHub issue for security vulnerabilities.
 
 Instead, report security issues privately using GitHub Security Advisories:
-https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new
+https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new
 
 If you can't use GitHub Security Advisories, contact the maintainer via:
 https://github.com/rudrankriyam
@@ -22,4 +22,3 @@ Security updates are provided for:
 
 - The latest stable release
 - The `main` branch
-

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,8 +3,8 @@
 ## Start Here
 
 - Quick start and troubleshooting: [README.md](README.md)
-- Questions and workflow help: [GitHub Discussions](https://github.com/rudrankriyam/App-Store-Connect-CLI/discussions)
-- Bugs and feature requests: [GitHub Issues](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues)
+- Questions and workflow help: [GitHub Discussions](https://github.com/rorkai/App-Store-Connect-CLI/discussions)
+- Bugs and feature requests: [GitHub Issues](https://github.com/rorkai/App-Store-Connect-CLI/issues)
 
 ## Use Discussions For
 

--- a/cicd/github-actions.mdx
+++ b/cicd/github-actions.mdx
@@ -503,7 +503,7 @@ jobs:
   <Accordion title="Version not found">
     The setup-asc action failed to find the specified version:
 
-    * Check [releases](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases) for available versions
+    * Check [releases](https://github.com/rorkai/App-Store-Connect-CLI/releases) for available versions
     * Use `latest` for the most recent release
     * Ensure version format is correct (e.g., `1.0.0`, not `v1.0.0`)
   </Accordion>

--- a/commands/screenshots.mdx
+++ b/commands/screenshots.mdx
@@ -10,7 +10,7 @@ The `screenshots` command provides both local automation for capturing and frami
 
 ## Local Workflow (Experimental)
 
-The local screenshot automation features are experimental. If you encounter issues, please [file feedback](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose).
+The local screenshot automation features are experimental. If you encounter issues, please [file feedback](https://github.com/rorkai/App-Store-Connect-CLI/issues/new/choose).
 
 ### Capture Screenshots
 

--- a/concepts/error-handling.mdx
+++ b/concepts/error-handling.mdx
@@ -345,4 +345,4 @@ unset ASC_DEBUG
 
 * [Authentication](/authentication) - Set up API credentials
 * [Workflows](/concepts/workflows) - Error handling in multi-step workflows
-* [Exit Codes Reference](https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/main/cmd/exit_codes.go) - Source code
+* [Exit Codes Reference](https://github.com/rorkai/App-Store-Connect-CLI/blob/main/cmd/exit_codes.go) - Source code

--- a/docs.json
+++ b/docs.json
@@ -174,7 +174,7 @@
       "anchors": [
         {
           "anchor": "GitHub",
-          "href": "https://github.com/rudrankriyam/App-Store-Connect-CLI",
+          "href": "https://github.com/rorkai/App-Store-Connect-CLI",
           "icon": "github"
         }
       ]
@@ -190,7 +190,7 @@
     "primary": {
       "type": "button",
       "label": "GitHub",
-      "href": "https://github.com/rudrankriyam/App-Store-Connect-CLI"
+      "href": "https://github.com/rorkai/App-Store-Connect-CLI"
     }
   },
   "contextual": {
@@ -207,7 +207,7 @@
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/rudrankriyam/App-Store-Connect-CLI",
+      "github": "https://github.com/rorkai/App-Store-Connect-CLI",
       "x": "https://x.com/rudrankriyam"
     }
   },

--- a/guides/analytics-reports.mdx
+++ b/guides/analytics-reports.mdx
@@ -265,7 +265,7 @@ jobs:
       
       - name: Install asc CLI
         run: |
-          curl -fsSL https://raw.githubusercontent.com/rudrankriyam/App-Store-Connect-CLI/main/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/rorkai/App-Store-Connect-CLI/main/install.sh | bash
       
       - name: Configure credentials
         env:

--- a/guides/automation.mdx
+++ b/guides/automation.mdx
@@ -401,7 +401,7 @@ jobs:
       
       - name: Install asc CLI
         run: |
-          curl -fsSL https://raw.githubusercontent.com/rudrankriyam/App-Store-Connect-CLI/main/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/rorkai/App-Store-Connect-CLI/main/install.sh | bash
       
       - name: Configure credentials
         env:
@@ -434,7 +434,7 @@ release:production:
   tags:
     - linux
   script:
-    - curl -fsSL https://raw.githubusercontent.com/rudrankriyam/App-Store-Connect-CLI/main/install.sh | bash
+    - curl -fsSL https://raw.githubusercontent.com/rorkai/App-Store-Connect-CLI/main/install.sh | bash
     - asc workflow run release VERSION:$VERSION
   variables:
     VERSION: "1.0.0"

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -278,7 +278,7 @@ jobs:
       
       - name: Install asc CLI
         run: |
-          curl -fsSL https://raw.githubusercontent.com/rudrankriyam/App-Store-Connect-CLI/main/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/rorkai/App-Store-Connect-CLI/main/install.sh | bash
       
       - name: Configure ASC credentials
         env:
@@ -332,7 +332,7 @@ fetch_signing:
   tags:
     - macos
   script:
-    - curl -fsSL https://raw.githubusercontent.com/rudrankriyam/App-Store-Connect-CLI/main/install.sh | bash
+    - curl -fsSL https://raw.githubusercontent.com/rorkai/App-Store-Connect-CLI/main/install.sh | bash
     - |
       asc signing fetch \
         --bundle-id com.example.myapp \

--- a/guides/screenshots.mdx
+++ b/guides/screenshots.mdx
@@ -155,7 +155,7 @@ asc screenshots delete --id "SCREENSHOT_ID" --confirm
 
 <Note>
   Local screenshot commands are experimental. Please report issues at:
-  [https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose)
+  [https://github.com/rorkai/App-Store-Connect-CLI/issues/new/choose](https://github.com/rorkai/App-Store-Connect-CLI/issues/new/choose)
 </Note>
 
 ### Complete Local Workflow

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="rudrankriyam/App-Store-Connect-CLI"
+REPO="rorkai/App-Store-Connect-CLI"
 BIN_NAME="asc"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
 if [ -n "${HOME:-}" ]; then

--- a/installation.mdx
+++ b/installation.mdx
@@ -56,7 +56,7 @@ For automated setups or environments without Homebrew:
   </Step>
 
   <Step title="Download the latest release">
-    Fetches the appropriate binary from [GitHub Releases](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/latest)
+    Fetches the appropriate binary from [GitHub Releases](https://github.com/rorkai/App-Store-Connect-CLI/releases/latest)
   </Step>
 
   <Step title="Verify checksums">
@@ -102,7 +102,7 @@ For maximum control, download binaries directly from GitHub:
 
 <Steps>
   <Step title="Visit releases page">
-    Go to [github.com/rudrankriyam/App-Store-Connect-CLI/releases/latest](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/latest)
+    Go to [github.com/rorkai/App-Store-Connect-CLI/releases/latest](https://github.com/rorkai/App-Store-Connect-CLI/releases/latest)
   </Step>
 
   <Step title="Download your platform binary">
@@ -134,7 +134,7 @@ For contributors or custom builds:
 <Steps>
   <Step title="Clone the repository">
     ```bash  theme={null}
-    git clone https://github.com/rudrankriyam/App-Store-Connect-CLI.git
+    git clone https://github.com/rorkai/App-Store-Connect-CLI.git
     cd App-Store-Connect-CLI
     ```
   </Step>
@@ -157,7 +157,7 @@ For contributors or custom builds:
 </Steps>
 
 <Note>
-  See [CONTRIBUTING.md](https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/main/CONTRIBUTING.md) for development setup, testing, and PR guidelines.
+  See [CONTRIBUTING.md](https://github.com/rorkai/App-Store-Connect-CLI/blob/main/CONTRIBUTING.md) for development setup, testing, and PR guidelines.
 </Note>
 
 ### Development tools
@@ -218,7 +218,7 @@ Reload your shell to activate completions.
   </Tab>
 
   <Tab title="Manual">
-    Download the latest binary from [releases](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/latest) and replace your existing binary.
+    Download the latest binary from [releases](https://github.com/rorkai/App-Store-Connect-CLI/releases/latest) and replace your existing binary.
   </Tab>
 
   <Tab title="Source">

--- a/internal/cli/apps/community_wall.go
+++ b/internal/cli/apps/community_wall.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	communityWallSourceEnv     = "ASC_WALL_SOURCE"
-	communityWallRemoteURL     = "https://raw.githubusercontent.com/rudrankriyam/App-Store-Connect-CLI/main/docs/wall-of-apps.json"
+	communityWallRemoteURL     = "https://raw.githubusercontent.com/rorkai/App-Store-Connect-CLI/main/docs/wall-of-apps.json"
 	communityWallSourcePath    = "docs/wall-of-apps.json"
 	defaultCommunityWallSort   = "name"
 	defaultCommunityWallOutput = "table"

--- a/internal/cli/apps/community_wall_submit.go
+++ b/internal/cli/apps/community_wall_submit.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	communityWallUpstreamOwner        = "rudrankriyam"
+	communityWallUpstreamOwner        = "rorkai"
 	communityWallUpstreamRepo         = "App-Store-Connect-CLI"
 	communityWallUpstreamBranch       = "main"
 	communityWallGitHubMaxBodyBytes   = 8192

--- a/internal/cli/apps/community_wall_submit_test.go
+++ b/internal/cli/apps/community_wall_submit_test.go
@@ -143,13 +143,13 @@ func TestSubmitCommunityWallEntryDryRunReturnsPlan(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/tester/App-Store-Connect-CLI":
 			http.NotFound(w, r)
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/rudrankriyam/App-Store-Connect-CLI/git/ref/heads/main":
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/git/ref/heads/main":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"object": map[string]any{
 					"sha": "base-sha-123",
 				},
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/rudrankriyam/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
 			if got := r.URL.Query().Get("ref"); got != "base-sha-123" {
 				t.Fatalf("expected ref=base-sha-123, got %q", got)
 			}
@@ -238,14 +238,14 @@ func TestSubmitCommunityWallEntryRejectsDuplicateAppID(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/tester/App-Store-Connect-CLI":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"full_name":"tester/App-Store-Connect-CLI","fork":true,"parent":{"full_name":"rudrankriyam/App-Store-Connect-CLI"}}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/rudrankriyam/App-Store-Connect-CLI/git/ref/heads/main":
+			_, _ = w.Write([]byte(`{"full_name":"tester/App-Store-Connect-CLI","fork":true,"parent":{"full_name":"rorkai/App-Store-Connect-CLI"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/git/ref/heads/main":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"object": map[string]any{
 					"sha": "base-sha-123",
 				},
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/rudrankriyam/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
 			if got := r.URL.Query().Get("ref"); got != "base-sha-123" {
 				t.Fatalf("expected ref=base-sha-123, got %q", got)
 			}
@@ -309,14 +309,14 @@ func TestSubmitCommunityWallEntryRejectsMalformedExistingSource(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/tester/App-Store-Connect-CLI":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"full_name":"tester/App-Store-Connect-CLI","fork":true,"parent":{"full_name":"rudrankriyam/App-Store-Connect-CLI"}}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/rudrankriyam/App-Store-Connect-CLI/git/ref/heads/main":
+			_, _ = w.Write([]byte(`{"full_name":"tester/App-Store-Connect-CLI","fork":true,"parent":{"full_name":"rorkai/App-Store-Connect-CLI"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/git/ref/heads/main":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"object": map[string]any{
 					"sha": "base-sha-123",
 				},
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/rudrankriyam/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
 			if got := r.URL.Query().Get("ref"); got != "base-sha-123" {
 				t.Fatalf("expected ref=base-sha-123, got %q", got)
 			}
@@ -405,7 +405,7 @@ func TestSubmitCommunityWallEntryRejectsExistingNonForkRepo(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected non-fork repo error")
 	}
-	if !strings.Contains(err.Error(), "is not a fork of rudrankriyam/App-Store-Connect-CLI") {
+	if !strings.Contains(err.Error(), "is not a fork of rorkai/App-Store-Connect-CLI") {
 		t.Fatalf("expected non-fork repo error, got %v", err)
 	}
 }

--- a/internal/cli/cmdtest/snitch_test.go
+++ b/internal/cli/cmdtest/snitch_test.go
@@ -64,7 +64,7 @@ func TestSnitchDryRunWithValidLabels(t *testing.T) {
 		callCount++
 		switch callCount {
 		case 1:
-			if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rudrankriyam/App-Store-Connect-CLI/labels" {
+			if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rorkai/App-Store-Connect-CLI/labels" {
 				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
 			}
 			if req.Header.Get("Authorization") != "Bearer test-token" {
@@ -126,7 +126,7 @@ func TestSnitchDryRunContinuesWhenLabelValidationLookupFails(t *testing.T) {
 		callCount++
 		switch callCount {
 		case 1:
-			if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rudrankriyam/App-Store-Connect-CLI/labels" {
+			if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rorkai/App-Store-Connect-CLI/labels" {
 				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
 			}
 			return &http.Response{
@@ -188,7 +188,7 @@ func TestSnitchDryRunContinuesAfterLabelValidationTimeout(t *testing.T) {
 		callCount++
 		switch callCount {
 		case 1:
-			if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rudrankriyam/App-Store-Connect-CLI/labels" {
+			if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rorkai/App-Store-Connect-CLI/labels" {
 				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
 			}
 			<-req.Context().Done()
@@ -242,7 +242,7 @@ func TestSnitchInvalidLabelReturnsUsage(t *testing.T) {
 	})
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rudrankriyam/App-Store-Connect-CLI/labels" {
+		if req.Method != http.MethodGet || req.URL.Host != "api.github.com" || req.URL.Path != "/repos/rorkai/App-Store-Connect-CLI/labels" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 		body := `[{"name":"enhancement"},{"name":"p3"},{"name":"easy"},{"name":"asc-snitch"}]`

--- a/internal/cli/screenshots/screenshots.go
+++ b/internal/cli/screenshots/screenshots.go
@@ -23,7 +23,7 @@ func ScreenshotsCommand() *ffcli.Command {
 
 Local screenshot automation commands are experimental.
 If you face issues, please file feedback at:
-https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose
+https://github.com/rorkai/App-Store-Connect-CLI/issues/new/choose
 
 Local workflow (experimental):
   asc screenshots run --plan .asc/screenshots.json

--- a/internal/cli/snitch/snitch.go
+++ b/internal/cli/snitch/snitch.go
@@ -26,7 +26,7 @@ import (
 const (
 	githubTokenEnvVar    = "GITHUB_TOKEN"
 	githubTokenGHEnvVar  = "GH_TOKEN"
-	defaultOwner         = "rudrankriyam"
+	defaultOwner         = "rorkai"
 	defaultRepo          = "App-Store-Connect-CLI"
 	maxSearchResults     = 5
 	maxResponseBodyBytes = 8192

--- a/internal/cli/snitch/snitch_test.go
+++ b/internal/cli/snitch/snitch_test.go
@@ -178,7 +178,7 @@ func TestSearchIssues(t *testing.T) {
 		}
 
 		q := r.URL.Query().Get("q")
-		if !strings.Contains(q, "repo:rudrankriyam/App-Store-Connect-CLI") {
+		if !strings.Contains(q, "repo:rorkai/App-Store-Connect-CLI") {
 			t.Errorf("query missing repo filter: %s", q)
 		}
 		if !strings.Contains(q, "is:open") {
@@ -202,7 +202,7 @@ func TestSearchIssues(t *testing.T) {
 				{
 					"number":   42,
 					"title":    "crashes --app doesn't support bundle ID",
-					"html_url": "https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/42",
+					"html_url": "https://github.com/rorkai/App-Store-Connect-CLI/issues/42",
 					"state":    "open",
 				},
 			},
@@ -244,7 +244,7 @@ func TestSnitchCommandPreviewWithoutConfirmDoesNotCreateIssue(t *testing.T) {
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Fatalf("json.NewEncoder().Encode() error: %v", err)
 			}
-		case "/repos/rudrankriyam/App-Store-Connect-CLI/issues":
+		case "/repos/rorkai/App-Store-Connect-CLI/issues":
 			createCalls++
 			t.Fatal("createIssue should not be called without --confirm")
 		default:
@@ -295,19 +295,19 @@ func TestSnitchCommandConfirmCreatesIssue(t *testing.T) {
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Fatalf("json.NewEncoder().Encode() error: %v", err)
 			}
-		case "/repos/rudrankriyam/App-Store-Connect-CLI/issues":
+		case "/repos/rorkai/App-Store-Connect-CLI/issues":
 			createCalls++
 			resp := map[string]any{
 				"number":   77,
 				"title":    "confirmed issue",
-				"html_url": "https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/77",
+				"html_url": "https://github.com/rorkai/App-Store-Connect-CLI/issues/77",
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Fatalf("json.NewEncoder().Encode() error: %v", err)
 			}
-		case "/repos/rudrankriyam/App-Store-Connect-CLI/issues/77/labels":
+		case "/repos/rorkai/App-Store-Connect-CLI/issues/77/labels":
 			labelCalls++
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(map[string]any{"labels": []string{"asc-snitch", "bug"}}); err != nil {
@@ -361,7 +361,7 @@ func TestSnitchCommandConfirmCreatesIssueWhenLabelsCannotBeApplied(t *testing.T)
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Fatalf("json.NewEncoder().Encode() error: %v", err)
 			}
-		case "/repos/rudrankriyam/App-Store-Connect-CLI/issues":
+		case "/repos/rorkai/App-Store-Connect-CLI/issues":
 			createCalls++
 
 			var payload map[string]any
@@ -379,14 +379,14 @@ func TestSnitchCommandConfirmCreatesIssueWhenLabelsCannotBeApplied(t *testing.T)
 			resp := map[string]any{
 				"number":   77,
 				"title":    "confirmed issue",
-				"html_url": "https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/77",
+				"html_url": "https://github.com/rorkai/App-Store-Connect-CLI/issues/77",
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Fatalf("json.NewEncoder().Encode() error: %v", err)
 			}
-		case "/repos/rudrankriyam/App-Store-Connect-CLI/issues/77/labels":
+		case "/repos/rorkai/App-Store-Connect-CLI/issues/77/labels":
 			labelCalls++
 			w.WriteHeader(http.StatusForbidden)
 			if _, err := w.Write([]byte(`{"message":"Resource not accessible by integration"}`)); err != nil {
@@ -447,7 +447,7 @@ func TestCreateIssue(t *testing.T) {
 		resp := map[string]any{
 			"number":   99,
 			"title":    receivedPayload["title"],
-			"html_url": "https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/99",
+			"html_url": "https://github.com/rorkai/App-Store-Connect-CLI/issues/99",
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -489,7 +489,7 @@ func TestAddIssueLabels(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/repos/rudrankriyam/App-Store-Connect-CLI/issues/99/labels" {
+		if r.URL.Path != "/repos/rorkai/App-Store-Connect-CLI/issues/99/labels" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 
@@ -532,7 +532,7 @@ func TestListRepoLabelsPaginatesAndDedupes(t *testing.T) {
 	githubHTTPClient = func() *http.Client {
 		return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			pageCalls++
-			if r.URL.Path != "/repos/rudrankriyam/App-Store-Connect-CLI/labels" {
+			if r.URL.Path != "/repos/rorkai/App-Store-Connect-CLI/labels" {
 				t.Fatalf("unexpected path: %s", r.URL.Path)
 			}
 

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -119,7 +119,7 @@ Try it:
   asc workflow run release --resume beta-20260312T120000Z-deadbeef
 
 More docs:
-  https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/main/docs/WORKFLOWS.md
+  https://github.com/rorkai/App-Store-Connect-CLI/blob/main/docs/WORKFLOWS.md
 
 Examples:
   asc workflow list

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -440,5 +440,5 @@ See [Environment Variables Reference](/configuration/environment-variables) for 
 ## Get help
 
 * **Built-in docs**: `asc --help` or `asc <command> --help`
-* **GitHub Issues**: [Report bugs or request features](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues)
-* **Discussions**: [Ask questions and share workflows](https://github.com/rudrankriyam/App-Store-Connect-CLI/discussions)
+* **GitHub Issues**: [Report bugs or request features](https://github.com/rorkai/App-Store-Connect-CLI/issues)
+* **Discussions**: [Ask questions and share workflows](https://github.com/rorkai/App-Store-Connect-CLI/discussions)

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -6,7 +6,7 @@
 
 The App Store Connect CLI follows semantic versioning. All releases are available on GitHub:
 
-[https://github.com/rudrankriyam/App-Store-Connect-CLI/releases](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases)
+[https://github.com/rorkai/App-Store-Connect-CLI/releases](https://github.com/rorkai/App-Store-Connect-CLI/releases)
 
 ## Latest Releases
 
@@ -294,8 +294,8 @@ No unreleased changes yet.
 
 For a complete release history, see:
 
-* **GitHub Releases**: [https://github.com/rudrankriyam/App-Store-Connect-CLI/releases](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases)
-* **Git Tags**: [https://github.com/rudrankriyam/App-Store-Connect-CLI/tags](https://github.com/rudrankriyam/App-Store-Connect-CLI/tags)
+* **GitHub Releases**: [https://github.com/rorkai/App-Store-Connect-CLI/releases](https://github.com/rorkai/App-Store-Connect-CLI/releases)
+* **Git Tags**: [https://github.com/rorkai/App-Store-Connect-CLI/tags](https://github.com/rorkai/App-Store-Connect-CLI/tags)
 
 ## Viewing Releases
 
@@ -304,7 +304,7 @@ For a complete release history, see:
 View all releases with detailed release notes:
 
 ```bash  theme={null}
-open https://github.com/rudrankriyam/App-Store-Connect-CLI/releases
+open https://github.com/rorkai/App-Store-Connect-CLI/releases
 ```
 
 ### Via Git
@@ -392,7 +392,7 @@ brew install asc
 Latest development version. May include unreleased features and fixes.
 
 ```bash  theme={null}
-git clone https://github.com/rudrankriyam/App-Store-Connect-CLI.git
+git clone https://github.com/rorkai/App-Store-Connect-CLI.git
 cd App-Store-Connect-CLI
 make build
 ```
@@ -488,8 +488,8 @@ refactor(cli): standardize pagination loops
 
 Found a bug or regression? Report it:
 
-* **GitHub Issues**: [https://github.com/rudrankriyam/App-Store-Connect-CLI/issues](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues)
-* **Security Issues**: [https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new](https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new) (private reporting)
+* **GitHub Issues**: [https://github.com/rorkai/App-Store-Connect-CLI/issues](https://github.com/rorkai/App-Store-Connect-CLI/issues)
+* **Security Issues**: [https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new](https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new) (private reporting)
 
 Include:
 
@@ -505,7 +505,7 @@ Include:
 
 Watch the repository for release notifications:
 
-1. Go to [https://github.com/rudrankriyam/App-Store-Connect-CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI)
+1. Go to [https://github.com/rorkai/App-Store-Connect-CLI](https://github.com/rorkai/App-Store-Connect-CLI)
 2. Click "Watch" → "Custom" → "Releases"
 
 ### RSS Feed
@@ -513,14 +513,14 @@ Watch the repository for release notifications:
 Subscribe to releases via RSS:
 
 ```
-https://github.com/rudrankriyam/App-Store-Connect-CLI/releases.atom
+https://github.com/rorkai/App-Store-Connect-CLI/releases.atom
 ```
 
 ### Star History
 
 View project growth:
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rudrankriyam/App-Store-Connect-CLI\&type=Date)](https://star-history.com/#rudrankriyam/App-Store-Connect-CLI\&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=rorkai/App-Store-Connect-CLI\&type=Date)](https://star-history.com/#rorkai/App-Store-Connect-CLI\&Date)
 
 ## Contributing
 

--- a/resources/contributing.mdx
+++ b/resources/contributing.mdx
@@ -17,7 +17,7 @@ Thanks for your interest in contributing to the App Store Connect CLI! This guid
 Clone the repository and build the CLI:
 
 ```bash  theme={null}
-git clone https://github.com/rudrankriyam/App-Store-Connect-CLI.git
+git clone https://github.com/rorkai/App-Store-Connect-CLI.git
 cd App-Store-Connect-CLI
 make build
 ```
@@ -286,7 +286,7 @@ Do not delete stable commands directly. Deprecate first with:
 **Do NOT open public GitHub issues** for security vulnerabilities.
 
 Report privately using GitHub Security Advisories:
-[https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new](https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new)
+[https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new](https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new)
 
 If you can't use GitHub Security Advisories, contact the maintainer:
 [https://github.com/rudrankriyam](https://github.com/rudrankriyam)
@@ -360,7 +360,7 @@ Platform values are free-form labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `vision
 
 If you need help:
 
-1. **Check existing issues**: [https://github.com/rudrankriyam/App-Store-Connect-CLI/issues](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues)
+1. **Check existing issues**: [https://github.com/rorkai/App-Store-Connect-CLI/issues](https://github.com/rorkai/App-Store-Connect-CLI/issues)
 2. **Read documentation**: Command reference, API notes, testing guide
 3. **Ask in discussions**: Open a GitHub discussion
 4. **Open an issue**: If you've found a bug or have a feature request
@@ -371,7 +371,7 @@ By contributing, you agree that your contributions will be licensed under the MI
 
 ## Code of Conduct
 
-Please review and follow the [Code of Conduct](https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/main/CODE_OF_CONDUCT.md).
+Please review and follow the [Code of Conduct](https://github.com/rorkai/App-Store-Connect-CLI/blob/main/CODE_OF_CONDUCT.md).
 
 ## Thank You!
 

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -141,7 +141,7 @@
   * **Bitrise**: Use the [setup-asc step](https://github.com/rudrankriyam/steps-setup-asc)
   * **CircleCI**: Use the [asc orb](https://github.com/rudrankriyam/asc-orb)
 
-  See the [CI/CD guide](https://github.com/rudrankriyam/App-Store-Connect-CLI/blob/main/docs/CI_CD.md) for detailed examples.
+  See the [CI/CD guide](https://github.com/rorkai/App-Store-Connect-CLI/blob/main/docs/CI_CD.md) for detailed examples.
 </Accordion>
 
 <Accordion title="How do I upload builds to TestFlight?">
@@ -388,7 +388,7 @@
   Do NOT open public GitHub issues for security vulnerabilities.
 
   Report privately using GitHub Security Advisories:
-  [https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new](https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new)
+  [https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new](https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new)
 
   Include:
 
@@ -406,7 +406,7 @@
   * App submissions
   * Signing and provisioning
 
-  Learn more: [https://github.com/rudrankriyam/app-store-connect-cli-skills](https://github.com/rudrankriyam/app-store-connect-cli-skills)
+  Learn more: [https://github.com/rorkai/app-store-connect-cli-skills](https://github.com/rorkai/app-store-connect-cli-skills)
 </Accordion>
 
 <Accordion title="Can I use this on Linux?">
@@ -444,7 +444,7 @@
   asc version
   ```
 
-  View releases: [https://github.com/rudrankriyam/App-Store-Connect-CLI/releases](https://github.com/rudrankriyam/App-Store-Connect-CLI/releases)
+  View releases: [https://github.com/rorkai/App-Store-Connect-CLI/releases](https://github.com/rorkai/App-Store-Connect-CLI/releases)
 </Accordion>
 
 <Accordion title="Why does output format change between terminal and scripts?">
@@ -470,5 +470,5 @@
   4. **Troubleshooting**: See [Troubleshooting Guide](/resources/troubleshooting)
   5. **API Notes**: Check [API Notes](/resources/api-notes) for quirks
 
-  For issues: [https://github.com/rudrankriyam/App-Store-Connect-CLI/issues](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues)
+  For issues: [https://github.com/rorkai/App-Store-Connect-CLI/issues](https://github.com/rorkai/App-Store-Connect-CLI/issues)
 </Accordion>

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -304,13 +304,13 @@ asc <command> <subcommand> --help
 
 If you've found a bug:
 
-1. Check existing issues: [https://github.com/rudrankriyam/App-Store-Connect-CLI/issues](https://github.com/rudrankriyam/App-Store-Connect-CLI/issues)
+1. Check existing issues: [https://github.com/rorkai/App-Store-Connect-CLI/issues](https://github.com/rorkai/App-Store-Connect-CLI/issues)
 2. Include:
    * CLI version (`asc version`)
    * Platform (macOS/Linux, architecture)
    * Command run (sanitize sensitive data)
    * Full error output with `ASC_DEBUG=api`
-3. For security issues, use private reporting: [https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new](https://github.com/rudrankriyam/App-Store-Connect-CLI/security/advisories/new)
+3. For security issues, use private reporting: [https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new](https://github.com/rorkai/App-Store-Connect-CLI/security/advisories/new)
 
 ## Performance Optimization
 

--- a/scripts/download_stats_total.py
+++ b/scripts/download_stats_total.py
@@ -21,7 +21,7 @@ import sys
 import urllib.request
 from pathlib import Path
 
-REPO = "rudrankriyam/App-Store-Connect-CLI"
+REPO = "rorkai/App-Store-Connect-CLI"
 FORMULA = "asc"
 WRITEUP = "https://til.bhupesh.me/shell/get-download-stats-github-brew"
 


### PR DESCRIPTION
## Summary
- migrate GitHub repo links from `rudrankriyam` to `rorkai`
- update install, docs, support, workflow, and badge references
- update runtime/test defaults that depend on the upstream repo slug

## Testing
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/snitch ./internal/cli/apps ./internal/cli/cmdtest -run 'Snitch|CommunityWall'`