### PR TITLE
apps wall: add MiniHue: Color Mini Sudoku 6x6

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -598,6 +598,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/09/0a/21/090a21e8-5b19-ec94-c5d0-6c2d0f5175bd/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "MiniHue: Color Mini Sudoku 6x6",
+    "link": "https://apps.apple.com/us/app/minihue-color-mini-sudoku-6x6/id6761858520?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/28/3c/03/283c0325-ab33-bf68-b7f8-d51ce7e9ec48/AppIcon_MiniHue-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Minimal Diary -  Life timeline",
     "link": "https://apps.apple.com/us/app/minimal-diary-life-timeline/id1568936702?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3d/26/b2/3d26b23e-3e10-76d2-ce22-6ac9d2094499/md-glass-icon-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `MiniHue: Color Mini Sudoku 6x6` to the Wall of Apps

## Entry

- App ID: 6761858520
- App: MiniHue: Color Mini Sudoku 6x6
- Link: https://apps.apple.com/us/app/minihue-color-mini-sudoku-6x6/id6761858520?uo=4

## Notes

- Submitted via `asc apps wall submit`
