### PR TITLE
apps wall: add Akari Glow: Light Up Puzzles

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -30,6 +30,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a1/85/81/a185815f-0e82-98b4-ac37-aed44c57d719/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Akari Glow: Light Up Puzzles",
+    "link": "https://apps.apple.com/us/app/akari-glow-light-up-puzzles/id6759948370?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6a/d6/06/6ad6063e-a7c4-ef18-dd4e-afecc0c3ba14/AppIcon_Akari-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Appboard: Find Apps · Rankings",
     "link": "https://apps.apple.com/us/app/appboard-find-apps-rankings/id1667492380?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b8/86/4e/b8864eea-7c79-4b57-dc58-4a208fc28863/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Akari Glow: Light Up Puzzles` to the Wall of Apps

## Entry

- App ID: 6759948370
- App: Akari Glow: Light Up Puzzles
- Link: https://apps.apple.com/us/app/akari-glow-light-up-puzzles/id6759948370?uo=4

## Notes

- Submitted via `asc apps wall submit`
