### PR TITLE
Publish releases to rorkai homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           export SHA256=$(shasum -a 256 release/asc_${VERSION}_macOS_arm64 | cut -d ' ' -f 1)
 
           # Clone the tap repo
-          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/rudrankriyam/homebrew-tap.git homebrew-tap
+          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/rorkai/homebrew-tap.git homebrew-tap
           cd homebrew-tap
 
           # Update the formula


### PR DESCRIPTION
## Summary
- update the release workflow to push formula updates to `rorkai/homebrew-tap`
- align release automation with the new public tap repo location

## Testing
- not run (workflow/config change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Homebrew distribution infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->