### PR TITLE
[DOCKER SEEDING] Add Helix Dockerfile and run-tests-eval script

### DIFF
--- a/.helix/Dockerfile.helix
+++ b/.helix/Dockerfile.helix
@@ -1,0 +1,26 @@
+FROM golang:1.26-bookworm
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN go mod download
+
+RUN chmod +x .helix/run-tests-eval.sh
+
+# Run tests as a non-root user so permission-sensitive tests (e.g. legacy session cache cleanup)
+# behave like developer/CI environments instead of root-only Linux semantics.
+RUN useradd -m -u 1000 helix \
+	&& mkdir -p /tmp/gocache \
+	&& chown -R helix:helix /app /tmp/gocache
+
+USER helix
+
+ENV ASC_BYPASS_KEYCHAIN=1
+ENV GOCACHE=/tmp/gocache
+
+CMD ["./.helix/run-tests-eval.sh"]

--- a/.helix/metadata.json
+++ b/.helix/metadata.json
@@ -1,0 +1,22 @@
+[
+  {
+    "instance_id": "handshake",
+    "task_title": "handshake",
+    "problem_statement": "",
+    "hints": "",
+    "repo": "handshake",
+    "repo_path_or_url": "handshake",
+    "FAIL_TO_PASS": "",
+    "PASS_TO_PASS": "",
+    "language": "handshake",
+    "docker_file": "handshake",
+    "run_script": "handshake",
+    "task_type": "handshake",
+    "task_category": "handshake",
+    "repo_category": "handshake",
+    "version": "handshake",
+    "container_mem": "handshake",
+    "container_memswap": "handshake",
+    "container_network_needed": "handshake"
+  }
+]

--- a/.helix/run-tests-eval.sh
+++ b/.helix/run-tests-eval.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Run the Go test suite. No Docker invocations — CI builds the image and runs this script inside it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+export ASC_BYPASS_KEYCHAIN=1
+
+# Root-level tests read `.github/workflows/release.yml`; some sparse checkouts omit it.
+run_all() {
+	local -a skip=()
+	if [[ ! -f .github/workflows/release.yml ]]; then
+		skip=(-skip '^TestReleaseWorkflow')
+	fi
+	go test -v ./... "${skip[@]}"
+}
+
+# Comma-separated paths → unique package directories (go test runs per package).
+run_targeted() {
+	local csv="$1"
+	local -a files=()
+	local IFS=','
+
+	read -ra files <<< "$csv"
+
+	if [[ ${#files[@]} -eq 0 ]]; then
+		run_all
+		return
+	fi
+
+	declare -A pkgs=()
+	local f dir
+	for f in "${files[@]}"; do
+		f="${f#"${f%%[![:space:]]*}"}"
+		f="${f%"${f##*[![:space:]]}"}"
+		[[ -z "$f" ]] && continue
+		if [[ ! -e "$f" ]]; then
+			echo "Error: test path does not exist: $f" >&2
+			exit 1
+		fi
+		dir="$(dirname "$f")"
+		pkgs["./$dir"]=1
+	done
+
+	if [[ ${#pkgs[@]} -eq 0 ]]; then
+		run_all
+		return
+	fi
+
+	go test -v "${!pkgs[@]}"
+}
+
+if [[ $# -eq 0 ]]; then
+	run_all
+else
+	run_targeted "$1"
+fi


### PR DESCRIPTION
Adds `.helix/` for Helix validation: Dockerfile.helix (Go 1.26, git, ca-certificates, non-root test user), run-tests-eval.sh, and metadata.json placeholder.

All validation checks passed locally (docker build + run-tests-eval.sh full suite and targeted runs).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added Docker configuration for test environment setup.
  * Introduced test runner script for automated testing.
  * Added metadata configuration file for task definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->