### PR TITLE
[codex] Stabilize web auth interrupt CI test

### DIFF
--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -632,11 +632,11 @@ func TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError(t *testing.T) {
 		t.Fatalf("process did not exit promptly after interrupt\noutput:\n%s", output.String())
 	}
 
-	_ = ptmx.Close()
-
 	select {
 	case <-readDone:
 	case <-time.After(2 * time.Second):
+		// Let the child close the PTY so the reader can drain the final
+		// interrupt-specific stderr before we tear the PTY down ourselves.
 		t.Fatalf("PTY reader did not exit after process completion\noutput:\n%s", output.String())
 	}
 


### PR DESCRIPTION
## Summary
- stabilize the `web auth login` PTY interrupt exit-code test on CI
- let the PTY reader drain the final interrupt-specific stderr before tearing the PTY down

## Root cause
The merged change did not break runtime behavior. The failure on `main` was a flaky test in `cmd/exit_codes_test.go`:

- CI failed in `Main Branch (with integration tests)` run `24552665468`
- the failing test was `TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError`
- the captured stderr only contained the password prompt because the test closed the PTY immediately after `Wait()`, which could race the reader goroutine and drop the trailing `password prompt interrupted` text on GitHub's macOS runner

## Why this approach
I kept the CLI behavior unchanged and fixed the race in the test harness instead.

Alternative considered:
- changing `web auth login` interrupt handling itself
- trade-off: much riskier for user-facing behavior, while the evidence pointed to PTY teardown timing in the black-box test rather than a real runtime regression

## Validation
- `go test ./cmd -run 'TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError|TestWebAuthLoginPromptInterruptSkipsSkillsAutoCheck' -count=20`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for web authentication login prompt interrupt handling by enhancing PTY resource cleanup and ensuring proper capture of interrupt-specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->