### PR TITLE
apps wall: add FlightCatcherPro – Plane Spot

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -334,6 +334,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/20/33/96/203396ba-0542-cf69-356b-355b9948201b/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "FlightCatcherPro – Plane Spot",
+    "link": "https://apps.apple.com/us/app/flightcatcherpro-plane-spot/id6749510087?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/79/4f/bc/794fbcf4-100d-d1ff-8458-5324666f4552/AppIcon-0-0-1x_U007emarketing-0-6-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "FlipKit - Flipbook Maker",
     "link": "https://apps.apple.com/us/app/flipkit-flipbook-maker/id1507694594?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a1/e6/4f/a1e64f9f-de99-5fc1-f7e0-7ecbe7fafedb/AppIcon-0-1x_U007emarketing-0-11-0-sRGB-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `FlightCatcherPro – Plane Spot` to the Wall of Apps

## Entry

- App ID: 6749510087
- App: FlightCatcherPro – Plane Spot
- Link: https://apps.apple.com/us/app/flightcatcherpro-plane-spot/id6749510087?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new application entry to the apps showcase collection with its corresponding link and icon information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->