### PR TITLE
Add Focus Rail to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -344,6 +344,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/38/68/9e/38689e2a-598d-b3cd-58ac-ae551225d7b7/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
+    "app": "Focus Rail: Pomodoro Timer",
+    "link": "https://apps.apple.com/us/app/focus-rail-pomodoro-timer/id6758016543?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7d/f9/0e/7df90e3f-3a37-c70c-7bf9-cb3cc9c0f16d/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Forerunner: Running & Wellness",
     "link": "https://apps.apple.com/us/app/forerunner-running-wellness/id6745802851?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/06/bb/79/06bb796e-81a0-8812-5c4a-6148ee92e8bf/AppIcon-0-0-1x_U007epad-0-0-0-1-0-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary\n- add Focus Rail: Pomodoro Timer to the community wall of apps\n- include the public App Store URL and icon resolved from App Store Connect\n\n## Notes\n- app id: 6758016543\n- bundle id: nota.godzilla.focusrail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Focus Rail: Pomodoro Timer" to the app gallery, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->