### PR TITLE
apps wall: add Focus Rail: Pomodoro Timer

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -344,6 +344,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a1/e6/4f/a1e64f9f-de99-5fc1-f7e0-7ecbe7fafedb/AppIcon-0-1x_U007emarketing-0-11-0-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Focus Rail: Pomodoro Timer",
+    "link": "https://apps.apple.com/us/app/focus-rail-pomodoro-timer/id6758016543?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7d/f9/0e/7df90e3f-3a37-c70c-7bf9-cb3cc9c0f16d/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "FocusAir: Deep Focus Timer",
     "link": "https://apps.apple.com/us/app/focusair-deep-focus-timer/id6756526902?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/09/e1/ad/09e1adab-b9fd-1707-57fc-387a7e19a7d0/AppIcon-0-1x_U007ephone-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Focus Rail: Pomodoro Timer` to the Wall of Apps

## Entry

- App ID: 6758016543
- App: Focus Rail: Pomodoro Timer
- Link: https://apps.apple.com/us/app/focus-rail-pomodoro-timer/id6758016543?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Focus Rail: Pomodoro Timer to the directory of available applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->