### PR TITLE
Update README.md to include a full example snippet on how to upload screenshots for a single locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ Uploading screenshots for a single locale:
 
 ```bash
 asc apps list
-asc versions list --app [123456789]
-asc localizations list --version [12345678-1234-1234-1234-1234567890123456] --output json --locale en_US | jsonpp
-asc screenshots upload --version-localization [version_localization_id] --path ./screenshots/en-US --device-type "IPHONE_65" --replace
+asc versions list --app "APP_ID"
+asc localizations list --version "VERSION_ID" --output json --locale "en-US" | jsonpp
+asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/en-US" --device-type "IPHONE_65" --replace
 ```
 
 ### Signing and bundle IDs

--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ asc screenshots list --version-localization "LOC_ID"
 asc video-previews list --app "123456789"
 ```
 
+Uploading screenshots for a single locale:
+
+```bash
+asc apps list
+asc versions list --app [123456789]
+asc localizations list --version [12345678-1234-1234-1234-1234567890123456] --output json --locale en_US | jsonpp
+asc screenshots upload --version-localization [version_localization_id] --path ./screenshots/en-US --device-type "IPHONE_65" --replace
+```
+
 ### Signing and bundle IDs
 
 ```bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a README subsection "Uploading screenshots for a single locale" with step‑by‑step guidance and example commands to list apps and versions, retrieve a specific locale's version localization ID, and upload screenshots for that localization while specifying device type and replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->