### PR TITLE
Add beta review submission to publish testflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,9 @@ asc workflow run --dry-run testflight_beta VERSION:1.2.3
 
 See [docs/WORKFLOWS.md](docs/WORKFLOWS.md) for a copyable `.asc/workflow.json`
 and `ExportOptions.plist` that use `asc builds next-build-number`, `asc xcode archive`,
-`asc xcode export`, and `asc publish testflight --group ... --wait`.
+`asc xcode export`, and `asc publish testflight --group ... --wait`. Add
+`--submit --confirm` when distributing to an external TestFlight group that needs
+beta app review submission.
 
 ```bash
 asc workflow validate

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -18,6 +18,8 @@ This pattern was validated against a real app using:
 - `asc xcode export` to create a deterministic `.ipa`
 - `asc publish testflight --group ... --wait` to upload, wait for processing,
   and add the build to a TestFlight group
+- `--submit --confirm` on `asc publish testflight` when the target is an
+  external group that should trigger beta app review submission
 
 Create `.asc/export-options-app-store.plist`:
 

--- a/internal/asc/output_publish.go
+++ b/internal/asc/output_publish.go
@@ -6,10 +6,14 @@ import (
 )
 
 func testFlightPublishResultRows(result *TestFlightPublishResult) ([]string, [][]string) {
-	headers := []string{"Build ID", "Version", "Build Number", "Processing", "Groups", "Uploaded", "Notified", "Notification Action"}
+	headers := []string{"Build ID", "Version", "Build Number", "Processing", "Groups", "Uploaded", "Notified", "Notification Action", "Beta Review Submitted", "Beta Review Submission ID"}
 	notified := ""
 	if result.Notified != nil {
 		notified = fmt.Sprintf("%t", *result.Notified)
+	}
+	betaReviewSubmitted := ""
+	if result.BetaReviewSubmitted != nil {
+		betaReviewSubmitted = fmt.Sprintf("%t", *result.BetaReviewSubmitted)
 	}
 	rows := [][]string{{
 		result.BuildID,
@@ -20,6 +24,8 @@ func testFlightPublishResultRows(result *TestFlightPublishResult) ([]string, [][
 		fmt.Sprintf("%t", result.Uploaded),
 		notified,
 		string(result.NotificationAction),
+		betaReviewSubmitted,
+		result.BetaReviewSubmissionID,
 	}}
 	return headers, rows
 }

--- a/internal/asc/publish.go
+++ b/internal/asc/publish.go
@@ -42,14 +42,16 @@ type PublishPlanStep struct {
 // TestFlightPublishStageResult duplicates the publish summary inside
 // local-build mode so agents can inspect stage-specific output.
 type TestFlightPublishStageResult struct {
-	BuildID            string                            `json:"buildId"`
-	BuildVersion       string                            `json:"buildVersion,omitempty"`
-	BuildNumber        string                            `json:"buildNumber,omitempty"`
-	GroupIDs           []string                          `json:"groupIds,omitempty"`
-	Uploaded           bool                              `json:"uploaded"`
-	ProcessingState    string                            `json:"processingState,omitempty"`
-	Notified           *bool                             `json:"notified,omitempty"`
-	NotificationAction BuildBetaGroupsNotificationAction `json:"notificationAction,omitempty"`
+	BuildID                string                            `json:"buildId"`
+	BuildVersion           string                            `json:"buildVersion,omitempty"`
+	BuildNumber            string                            `json:"buildNumber,omitempty"`
+	GroupIDs               []string                          `json:"groupIds,omitempty"`
+	Uploaded               bool                              `json:"uploaded"`
+	ProcessingState        string                            `json:"processingState,omitempty"`
+	Notified               *bool                             `json:"notified,omitempty"`
+	NotificationAction     BuildBetaGroupsNotificationAction `json:"notificationAction,omitempty"`
+	BetaReviewSubmitted    *bool                             `json:"betaReviewSubmitted,omitempty"`
+	BetaReviewSubmissionID string                            `json:"betaReviewSubmissionId,omitempty"`
 }
 
 // AppStorePublishStageResult duplicates the publish summary inside local-build
@@ -67,18 +69,20 @@ type AppStorePublishStageResult struct {
 
 // Result types for the publish workflow.
 type TestFlightPublishResult struct {
-	Mode               PublishMode                       `json:"mode,omitempty"`
-	BuildID            string                            `json:"buildId"`
-	BuildVersion       string                            `json:"buildVersion,omitempty"`
-	BuildNumber        string                            `json:"buildNumber,omitempty"`
-	GroupIDs           []string                          `json:"groupIds,omitempty"`
-	Uploaded           bool                              `json:"uploaded"`
-	ProcessingState    string                            `json:"processingState,omitempty"`
-	Notified           *bool                             `json:"notified,omitempty"`
-	NotificationAction BuildBetaGroupsNotificationAction `json:"notificationAction,omitempty"`
-	Archive            *PublishArchiveStageResult        `json:"archive,omitempty"`
-	Export             *PublishExportStageResult         `json:"export,omitempty"`
-	Publish            *TestFlightPublishStageResult     `json:"publish,omitempty"`
+	Mode                   PublishMode                       `json:"mode,omitempty"`
+	BuildID                string                            `json:"buildId"`
+	BuildVersion           string                            `json:"buildVersion,omitempty"`
+	BuildNumber            string                            `json:"buildNumber,omitempty"`
+	GroupIDs               []string                          `json:"groupIds,omitempty"`
+	Uploaded               bool                              `json:"uploaded"`
+	ProcessingState        string                            `json:"processingState,omitempty"`
+	Notified               *bool                             `json:"notified,omitempty"`
+	NotificationAction     BuildBetaGroupsNotificationAction `json:"notificationAction,omitempty"`
+	BetaReviewSubmitted    *bool                             `json:"betaReviewSubmitted,omitempty"`
+	BetaReviewSubmissionID string                            `json:"betaReviewSubmissionId,omitempty"`
+	Archive                *PublishArchiveStageResult        `json:"archive,omitempty"`
+	Export                 *PublishExportStageResult         `json:"export,omitempty"`
+	Publish                *TestFlightPublishStageResult     `json:"publish,omitempty"`
 }
 
 // AppStorePublishResult captures the App Store publish workflow output.

--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -87,7 +86,7 @@ Examples:
 				return fmt.Errorf("builds add-groups: failed to add groups: %w", err)
 			}
 
-			submissionMessage, err := submitBuildBetaReviewIfNeeded(requestCtx, client, buildID, resolvedGroups, addResult.AddedGroupIDs, *submit)
+			submissionResult, err := shared.SubmitBuildBetaReviewIfNeeded(requestCtx, client, buildID, resolvedGroups, addResult.AddedGroupIDs, *submit, "builds add-groups")
 			if err != nil {
 				return err
 			}
@@ -106,8 +105,8 @@ Examples:
 			} else {
 				fmt.Fprintf(os.Stderr, "Successfully added %d group(s) to build %s\n", len(addResult.AddedGroupIDs), buildID)
 			}
-			if submissionMessage != "" {
-				fmt.Fprintln(os.Stderr, submissionMessage)
+			if submissionResult.Message != "" {
+				fmt.Fprintln(os.Stderr, submissionResult.Message)
 			}
 
 			if len(addResult.AddedGroupIDs) == 0 {
@@ -165,56 +164,6 @@ func resolveBuildBetaGroupIDsFromList(inputGroups []string, groups *asc.BetaGrou
 		resolvedIDs = append(resolvedIDs, group.ID)
 	}
 	return resolvedIDs, nil
-}
-
-func submitBuildBetaReviewIfNeeded(ctx context.Context, client *asc.Client, buildID string, groups []resolvedBuildBetaGroup, addedGroupIDs []string, submit bool) (string, error) {
-	if !submit {
-		return "", nil
-	}
-
-	if !hasAddedExternalBuildBetaGroup(groups, addedGroupIDs) {
-		return fmt.Sprintf("Skipped beta app review submission for build %s because no external groups were added", buildID), nil
-	}
-
-	existingSubmission, err := client.GetBuildBetaAppReviewSubmission(ctx, buildID)
-	if err == nil {
-		submissionID := strings.TrimSpace(existingSubmission.Data.ID)
-		if submissionID == "" {
-			return fmt.Sprintf("Build %s already has a beta app review submission", buildID), nil
-		}
-		return fmt.Sprintf("Build %s already has beta app review submission %s", buildID, submissionID), nil
-	}
-	if !asc.IsNotFound(err) {
-		return "", fmt.Errorf("builds add-groups: failed to inspect beta app review submission: %w", err)
-	}
-
-	submission, err := client.CreateBetaAppReviewSubmission(ctx, buildID)
-	if err != nil {
-		return "", fmt.Errorf("builds add-groups: beta groups were added to build %q, but beta app review submission failed: %w", buildID, err)
-	}
-
-	submissionID := strings.TrimSpace(submission.Data.ID)
-	if submissionID == "" {
-		return fmt.Sprintf("Submitted build %s for beta app review", buildID), nil
-	}
-	return fmt.Sprintf("Submitted build %s for beta app review (%s)", buildID, submissionID), nil
-}
-
-func hasAddedExternalBuildBetaGroup(groups []resolvedBuildBetaGroup, addedGroupIDs []string) bool {
-	if len(groups) == 0 || len(addedGroupIDs) == 0 {
-		return false
-	}
-
-	for _, group := range groups {
-		if group.IsInternalGroup {
-			continue
-		}
-		if slices.Contains(addedGroupIDs, group.ID) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // BuildsUpdateCommand returns the builds update subcommand.

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -13,10 +13,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
 	authcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/auth"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -3727,9 +3729,10 @@ func TestPublishValidationErrors(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+		name     string
+		args     []string
+		wantErr  string
+		wantExit int
 	}{
 		{
 			name:    "publish testflight missing app",
@@ -3762,9 +3765,21 @@ func TestPublishValidationErrors(t *testing.T) {
 			wantErr: "Error: --confirm is required with --submit",
 		},
 		{
+			name:     "publish testflight submit invalid value",
+			args:     []string{"publish", "testflight", "--app", "APP_123", "--build", "BUILD_123", "--group", "GROUP_ID", "--submit=maybe"},
+			wantErr:  `invalid boolean value "maybe" for -submit`,
+			wantExit: rootcmd.ExitUsage,
+		},
+		{
 			name:    "publish testflight confirm requires submit",
 			args:    []string{"publish", "testflight", "--app", "APP_123", "--build", "BUILD_123", "--group", "GROUP_ID", "--confirm"},
 			wantErr: "Error: --confirm requires --submit",
+		},
+		{
+			name:     "publish testflight confirm invalid value",
+			args:     []string{"publish", "testflight", "--app", "APP_123", "--build", "BUILD_123", "--group", "GROUP_ID", "--confirm=maybe"},
+			wantErr:  `invalid boolean value "maybe" for -confirm`,
+			wantExit: rootcmd.ExitUsage,
 		},
 		{
 			name:    "publish appstore missing app",
@@ -3873,8 +3888,40 @@ func TestPublishValidationErrors(t *testing.T) {
 		},
 	}
 
+	parentT := t
+	var binaryPath string
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.wantExit != 0 {
+				if binaryPath == "" {
+					binaryPath = buildASCBlackBoxBinary(parentT)
+				}
+				command := exec.Command(binaryPath, test.args...)
+
+				var stdout strings.Builder
+				var stderr strings.Builder
+				command.Stdout = &stdout
+				command.Stderr = &stderr
+
+				err := command.Run()
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) {
+					t.Fatalf("expected process exit error, got %v", err)
+				}
+				if exitErr.ExitCode() != test.wantExit {
+					t.Fatalf("expected exit code %d, got %d", test.wantExit, exitErr.ExitCode())
+				}
+
+				if stdout.String() != "" {
+					t.Fatalf("expected empty stdout, got %q", stdout.String())
+				}
+				if !strings.Contains(stderr.String(), test.wantErr) {
+					t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
+				}
+				return
+			}
+
 			root := RootCommand("1.2.3")
 			root.FlagSet.SetOutput(io.Discard)
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3757,6 +3757,16 @@ func TestPublishValidationErrors(t *testing.T) {
 			wantErr: "Error: --test-notes is required with --locale",
 		},
 		{
+			name:    "publish testflight submit missing confirm",
+			args:    []string{"publish", "testflight", "--app", "APP_123", "--build", "BUILD_123", "--group", "GROUP_ID", "--submit"},
+			wantErr: "Error: --confirm is required with --submit",
+		},
+		{
+			name:    "publish testflight confirm requires submit",
+			args:    []string{"publish", "testflight", "--app", "APP_123", "--build", "BUILD_123", "--group", "GROUP_ID", "--confirm"},
+			wantErr: "Error: --confirm requires --submit",
+		},
+		{
 			name:    "publish appstore missing app",
 			args:    []string{"publish", "appstore", "--ipa", "app.ipa", "--version", "1.0.0"},
 			wantErr: "Error: --app is required",

--- a/internal/cli/cmdtest/publish_testflight_submit_test.go
+++ b/internal/cli/cmdtest/publish_testflight_submit_test.go
@@ -118,6 +118,91 @@ func TestPublishTestflightSubmitCreatesBetaReviewSubmissionForExternalGroups(t *
 	}
 }
 
+func TestPublishTestflightSubmitWaitsForProcessingBeforeAddingGroups(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"PROCESSING"}}}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"VALID"}}}`), nil
+		case 4:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 5:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`), nil
+		case 6:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppReviewSubmissions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"betaAppReviewSubmissions","id":"submission-1"}}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"publish", "testflight",
+			"--app", "123",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--poll-interval", "1ms",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 6 {
+		t.Fatalf("expected group lookup, build lookup, processing wait, group add, submission lookup, and submission create; got %d requests", requestCount)
+	}
+	result := decodePublishTestFlightSubmitOutput(t, stdout)
+	if result.BetaReviewSubmitted == nil || !*result.BetaReviewSubmitted {
+		t.Fatalf("expected betaReviewSubmitted=true, got %#v", result.BetaReviewSubmitted)
+	}
+	if !strings.Contains(stdout, `"processingState":"VALID"`) {
+		t.Fatalf("expected processed build state in output, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Submitted build build-1 for beta app review (submission-1)") {
+		t.Fatalf("expected beta review submission message, got %q", stderr)
+	}
+}
+
 func TestPublishTestflightSubmitSkipsBetaReviewSubmissionForInternalGroups(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/publish_testflight_submit_test.go
+++ b/internal/cli/cmdtest/publish_testflight_submit_test.go
@@ -1,0 +1,355 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type publishTestFlightSubmitOutput struct {
+	BuildID                string   `json:"buildId"`
+	GroupIDs               []string `json:"groupIds"`
+	BetaReviewSubmitted    *bool    `json:"betaReviewSubmitted,omitempty"`
+	BetaReviewSubmissionID string   `json:"betaReviewSubmissionId,omitempty"`
+}
+
+func TestPublishTestflightSubmitCreatesBetaReviewSubmissionForExternalGroups(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"VALID"}}}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read group assignment payload: %v", err)
+			}
+			if !strings.Contains(string(payload), `"id":"group-external"`) {
+				t.Fatalf("expected group assignment payload to include group-external, got %s", string(payload))
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`), nil
+		case 5:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppReviewSubmissions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read beta review submission payload: %v", err)
+			}
+			bodyText := string(payload)
+			if !strings.Contains(bodyText, `"type":"betaAppReviewSubmissions"`) || !strings.Contains(bodyText, `"id":"build-1"`) {
+				t.Fatalf("expected beta review submission payload for build-1, got %s", bodyText)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"betaAppReviewSubmissions","id":"submission-1"}}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"publish", "testflight",
+			"--app", "123",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 5 {
+		t.Fatalf("expected group lookup, build lookup, group add, submission lookup, and submission create; got %d requests", requestCount)
+	}
+	result := decodePublishTestFlightSubmitOutput(t, stdout)
+	if result.BuildID != "build-1" {
+		t.Fatalf("expected build-1 output, got %q", result.BuildID)
+	}
+	if !slices.Contains(result.GroupIDs, "group-external") {
+		t.Fatalf("expected group-external in output, got %#v", result.GroupIDs)
+	}
+	if result.BetaReviewSubmitted == nil || !*result.BetaReviewSubmitted {
+		t.Fatalf("expected betaReviewSubmitted=true, got %#v", result.BetaReviewSubmitted)
+	}
+	if result.BetaReviewSubmissionID != "submission-1" {
+		t.Fatalf("expected submission-1 output, got %q", result.BetaReviewSubmissionID)
+	}
+	if !strings.Contains(stderr, "Submitted build build-1 for beta app review (submission-1)") {
+		t.Fatalf("expected beta review submission message, got %q", stderr)
+	}
+}
+
+func TestPublishTestflightSubmitSkipsBetaReviewSubmissionForInternalGroups(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-internal","attributes":{"name":"Friends and Family","isInternalGroup":true}}]}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"VALID"}}}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"publish", "testflight",
+			"--app", "123",
+			"--build", "build-1",
+			"--group", "group-internal",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 3 {
+		t.Fatalf("expected group lookup, build lookup, and group add; got %d requests", requestCount)
+	}
+	result := decodePublishTestFlightSubmitOutput(t, stdout)
+	if result.BetaReviewSubmitted == nil || *result.BetaReviewSubmitted {
+		t.Fatalf("expected betaReviewSubmitted=false, got %#v", result.BetaReviewSubmitted)
+	}
+	if result.BetaReviewSubmissionID != "" {
+		t.Fatalf("expected empty beta review submission ID, got %q", result.BetaReviewSubmissionID)
+	}
+	if !strings.Contains(stderr, "Skipped beta app review submission for build build-1 because no external groups were added") {
+		t.Fatalf("expected beta review skip message, got %q", stderr)
+	}
+}
+
+func TestPublishTestflightSubmitTreatsExistingSubmissionAsAlreadyDone(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"VALID"}}}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"betaAppReviewSubmissions","id":"submission-existing"}}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"publish", "testflight",
+			"--app", "123",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 4 {
+		t.Fatalf("expected group lookup, build lookup, group add, and submission lookup; got %d requests", requestCount)
+	}
+	result := decodePublishTestFlightSubmitOutput(t, stdout)
+	if result.BetaReviewSubmitted == nil || !*result.BetaReviewSubmitted {
+		t.Fatalf("expected betaReviewSubmitted=true, got %#v", result.BetaReviewSubmitted)
+	}
+	if result.BetaReviewSubmissionID != "submission-existing" {
+		t.Fatalf("expected existing submission ID, got %q", result.BetaReviewSubmissionID)
+	}
+	if !strings.Contains(stderr, "Build build-1 already has beta app review submission submission-existing") {
+		t.Fatalf("expected existing submission message, got %q", stderr)
+	}
+}
+
+func TestPublishTestflightSubmitPreservesPartialSuccessWhenSubmissionFails(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-external","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"VALID"}}}`), nil
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/builds/build-1/relationships/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNoContent, ``), nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/betaAppReviewSubmission" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`), nil
+		case 5:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppReviewSubmissions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable","detail":"beta review temporarily unavailable"}]}`), nil
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"publish", "testflight",
+			"--app", "123",
+			"--build", "build-1",
+			"--group", "group-external",
+			"--submit",
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(runErr.Error(), `publish testflight: beta groups were added to build "build-1", but beta app review submission failed`) {
+		t.Fatalf("expected partial-success submission error, got %v", runErr)
+	}
+	if strings.Contains(runErr.Error(), "failed to add groups") {
+		t.Fatalf("did not expect misleading add-groups wrapper, got %v", runErr)
+	}
+	if !strings.Contains(runErr.Error(), "Service unavailable: beta review temporarily unavailable") {
+		t.Fatalf("expected underlying submission error, got %v", runErr)
+	}
+}
+
+func decodePublishTestFlightSubmitOutput(t *testing.T, stdout string) publishTestFlightSubmitOutput {
+	t.Helper()
+
+	var result publishTestFlightSubmitOutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to decode publish testflight output %q: %v", stdout, err)
+	}
+	return result
+}

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -100,6 +100,7 @@ asc submit cancel --version-id "VERSION_ID" --confirm
 ```bash
 asc testflight groups list --app "APP_ID"
 asc publish testflight --app "APP_ID" --ipa "./App.ipa" --group "GROUP_ID" --wait
+asc publish testflight --app "APP_ID" --ipa "./App.ipa" --group "EXTERNAL_GROUP_ID" --wait --submit --confirm
 ```
 
 Lower-level alternative:

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -86,7 +86,7 @@ func PublishTestFlightCommand() *ffcli.Command {
 
 Steps:
 1. Build locally with Xcode or upload an IPA (unless --build/--build-number is provided)
-2. Wait for processing (if --wait)
+2. Wait for processing when needed (--wait, --test-notes, or --submit)
 3. Add build to specified beta groups
 4. Optionally notify testers
 5. Optionally submit for beta app review with --submit --confirm
@@ -305,7 +305,7 @@ Examples:
 				resolvedBuildNumberValue = strings.TrimSpace(buildResp.Data.Attributes.Version)
 			}
 
-			if *wait || testNotesValue != "" {
+			if *wait || testNotesValue != "" || (*submit && !isPublishBuildProcessed(buildResp)) {
 				buildResp, err = waitForPublishBuildProcessingFn(requestCtx, client, buildResp.Data.ID, *pollInterval)
 				if err != nil {
 					return fmt.Errorf("publish testflight: %w", err)
@@ -787,6 +787,13 @@ func canPlanAppStorePublishWithoutASC(appID string, localBuildMode bool, buildNu
 		return true
 	}
 	return strings.TrimSpace(buildNumber) != ""
+}
+
+func isPublishBuildProcessed(buildResp *asc.BuildResponse) bool {
+	if buildResp == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(buildResp.Data.Attributes.ProcessingState), asc.BuildProcessingStateValid)
 }
 
 func newPublishPlanStep(name, message string) asc.PublishPlanStep {

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -68,6 +68,8 @@ func PublishTestFlightCommand() *ffcli.Command {
 	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	groupIDs := fs.String("group", "", "Beta group ID(s) or name(s), comma-separated")
 	notify := fs.Bool("notify", false, "Notify testers after adding to groups")
+	submit := fs.Bool("submit", false, "Submit build for beta app review after adding external groups")
+	confirm := fs.Bool("confirm", false, "Confirm beta app review submission (required with --submit)")
 	wait := fs.Bool("wait", false, "Wait for build processing to complete")
 	pollInterval := fs.Duration("poll-interval", shared.PublishDefaultPollInterval, "Polling interval for --wait and build discovery")
 	timeout := fs.Duration("timeout", 0, "Override upload + processing timeout (e.g., 30m)")
@@ -87,12 +89,14 @@ Steps:
 2. Wait for processing (if --wait)
 3. Add build to specified beta groups
 4. Optionally notify testers
+5. Optionally submit for beta app review with --submit --confirm
 
 Examples:
   asc publish testflight --app "123" --ipa app.ipa --group "GROUP_ID"
   asc publish testflight --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --group "GROUP_ID"
   asc publish testflight --app "123" --ipa app.ipa --group "External Testers"
   asc publish testflight --app "123" --ipa app.ipa --group "G1,G2" --wait --notify
+  asc publish testflight --app "123" --ipa app.ipa --group "External Testers" --submit --confirm
   asc publish testflight --app "123" --ipa app.ipa --group "GROUP_ID" --test-notes "Test instructions" --locale "en-US" --wait
   asc publish testflight --app "123" --build "BUILD_ID" --group "GROUP_ID" --wait
   asc publish testflight --app "123" --build-number "42" --group "GROUP_ID" --wait`,
@@ -149,6 +153,14 @@ Examples:
 			parsedGroupIDs := shared.SplitCSV(*groupIDs)
 			if len(parsedGroupIDs) == 0 {
 				fmt.Fprintf(os.Stderr, "Error: --group is required\n\n")
+				return flag.ErrHelp
+			}
+			if *submit && !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --submit")
+				return flag.ErrHelp
+			}
+			if *confirm && !*submit {
+				fmt.Fprintln(os.Stderr, "Error: --confirm requires --submit")
 				return flag.ErrHelp
 			}
 
@@ -316,10 +328,23 @@ Examples:
 				return wrapPublishTestFlightAddGroupsError(err)
 			}
 
+			submissionResult, err := shared.SubmitBuildBetaReviewIfNeeded(requestCtx, client, buildResp.Data.ID, resolvedGroups, addResult.AddedGroupIDs, *submit, "publish testflight")
+			if err != nil {
+				return err
+			}
+			if submissionResult.Message != "" {
+				fmt.Fprintln(os.Stderr, submissionResult.Message)
+			}
+
 			var notified *bool
 			if *notify {
 				value := addResult.NotificationAction == asc.BuildBetaGroupsNotificationActionManual
 				notified = &value
+			}
+			var betaReviewSubmitted *bool
+			if *submit {
+				value := submissionResult.Submitted
+				betaReviewSubmitted = &value
 			}
 
 			for _, group := range addResult.SkippedInternalAllBuildsGroups {
@@ -332,28 +357,32 @@ Examples:
 			}
 
 			result := &asc.TestFlightPublishResult{
-				Mode:               mode,
-				BuildID:            buildResp.Data.ID,
-				BuildVersion:       resolvedVersionValue,
-				BuildNumber:        resolvedBuildNumberValue,
-				GroupIDs:           resolvedPublishBetaGroupIDs(resolvedGroups),
-				Uploaded:           uploaded,
-				ProcessingState:    buildResp.Data.Attributes.ProcessingState,
-				Notified:           notified,
-				NotificationAction: addResult.NotificationAction,
+				Mode:                   mode,
+				BuildID:                buildResp.Data.ID,
+				BuildVersion:           resolvedVersionValue,
+				BuildNumber:            resolvedBuildNumberValue,
+				GroupIDs:               resolvedPublishBetaGroupIDs(resolvedGroups),
+				Uploaded:               uploaded,
+				ProcessingState:        buildResp.Data.Attributes.ProcessingState,
+				Notified:               notified,
+				NotificationAction:     addResult.NotificationAction,
+				BetaReviewSubmitted:    betaReviewSubmitted,
+				BetaReviewSubmissionID: submissionResult.SubmissionID,
 			}
 			if localBuildResult != nil {
 				result.Archive = localBuildResult.Archive
 				result.Export = localBuildResult.Export
 				result.Publish = &asc.TestFlightPublishStageResult{
-					BuildID:            result.BuildID,
-					BuildVersion:       result.BuildVersion,
-					BuildNumber:        result.BuildNumber,
-					GroupIDs:           append([]string(nil), result.GroupIDs...),
-					Uploaded:           result.Uploaded,
-					ProcessingState:    result.ProcessingState,
-					Notified:           result.Notified,
-					NotificationAction: result.NotificationAction,
+					BuildID:                result.BuildID,
+					BuildVersion:           result.BuildVersion,
+					BuildNumber:            result.BuildNumber,
+					GroupIDs:               append([]string(nil), result.GroupIDs...),
+					Uploaded:               result.Uploaded,
+					ProcessingState:        result.ProcessingState,
+					Notified:               result.Notified,
+					NotificationAction:     result.NotificationAction,
+					BetaReviewSubmitted:    result.BetaReviewSubmitted,
+					BetaReviewSubmissionID: result.BetaReviewSubmissionID,
 				}
 			}
 

--- a/internal/cli/shared/beta_review_submission.go
+++ b/internal/cli/shared/beta_review_submission.go
@@ -1,0 +1,84 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type buildBetaReviewSubmissionClient interface {
+	GetBuildBetaAppReviewSubmission(ctx context.Context, buildID string) (*asc.BetaAppReviewSubmissionResponse, error)
+	CreateBetaAppReviewSubmission(ctx context.Context, buildID string) (*asc.BetaAppReviewSubmissionResponse, error)
+}
+
+// BuildBetaReviewSubmissionResult reports the beta app review submission outcome.
+type BuildBetaReviewSubmissionResult struct {
+	Submitted    bool
+	SubmissionID string
+	Message      string
+}
+
+// SubmitBuildBetaReviewIfNeeded submits a build for beta app review when requested
+// and when the build was added to at least one external beta group.
+func SubmitBuildBetaReviewIfNeeded(ctx context.Context, client buildBetaReviewSubmissionClient, buildID string, groups []ResolvedBetaGroup, addedGroupIDs []string, submit bool, operationName string) (*BuildBetaReviewSubmissionResult, error) {
+	result := &BuildBetaReviewSubmissionResult{}
+	if !submit {
+		return result, nil
+	}
+
+	if !hasAddedExternalBuildBetaGroup(groups, addedGroupIDs) {
+		result.Message = fmt.Sprintf("Skipped beta app review submission for build %s because no external groups were added", buildID)
+		return result, nil
+	}
+
+	existingSubmission, err := client.GetBuildBetaAppReviewSubmission(ctx, buildID)
+	if err == nil {
+		submissionID := strings.TrimSpace(existingSubmission.Data.ID)
+		result.Submitted = true
+		result.SubmissionID = submissionID
+		if submissionID == "" {
+			result.Message = fmt.Sprintf("Build %s already has a beta app review submission", buildID)
+			return result, nil
+		}
+		result.Message = fmt.Sprintf("Build %s already has beta app review submission %s", buildID, submissionID)
+		return result, nil
+	}
+	if !asc.IsNotFound(err) {
+		return nil, fmt.Errorf("%s: failed to inspect beta app review submission: %w", operationName, err)
+	}
+
+	submission, err := client.CreateBetaAppReviewSubmission(ctx, buildID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: beta groups were added to build %q, but beta app review submission failed: %w", operationName, buildID, err)
+	}
+
+	submissionID := strings.TrimSpace(submission.Data.ID)
+	result.Submitted = true
+	result.SubmissionID = submissionID
+	if submissionID == "" {
+		result.Message = fmt.Sprintf("Submitted build %s for beta app review", buildID)
+		return result, nil
+	}
+	result.Message = fmt.Sprintf("Submitted build %s for beta app review (%s)", buildID, submissionID)
+	return result, nil
+}
+
+func hasAddedExternalBuildBetaGroup(groups []ResolvedBetaGroup, addedGroupIDs []string) bool {
+	if len(groups) == 0 || len(addedGroupIDs) == 0 {
+		return false
+	}
+
+	for _, group := range groups {
+		if group.IsInternalGroup {
+			continue
+		}
+		if slices.Contains(addedGroupIDs, group.ID) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
IIUC - I saw #1175 and thought it made sense to have the same logic applied for `asc publish testflight`. I was surprised when initially I published to TestFlight and it stayed in the "Ready to Submit" state even though I'd elected to add an external TestFlight group.

One open question:
- What should the behavior be without passing the `--wait` flag be? Should it error out if `--wait` is omitted on a fresh upload? Or should the `--wait` behavior be implicit part of `--submit`? For now, I'm going with the latter, but doing that as a separate commit for discussion and potential alteration.

## Summary
- add `--submit --confirm` args to `asc publish testflight` so external TestFlight distribution can create the beta app review submission in the same high-level command
- move beta review submission handling into a shared helper reused by `builds add-groups` and `publish testflight`
- report beta review submission status in TestFlight publish output and document the external-group workflow

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestPublish(TestflightSubmit|ValidationErrors)'`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestBuilds(AddGroupsSubmit|GroupValidationErrors)'`
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make check-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `go build -o /tmp/asc .`
- [x] `/tmp/asc publish testflight --app APP_123 --build BUILD_123 --group GROUP_ID --submit` returns exit code `2` with `Error: --confirm is required with --submit`
- [x] `/tmp/asc publish testflight --app APP_123 --build BUILD_123 --group GROUP_ID --submit=maybe --confirm` returns exit code `2`
- [x] `/tmp/asc publish testflight --app APP_123 --build BUILD_123 --group GROUP_ID --submit --confirm=maybe` returns exit code `2`

## End-to-End Integration Test

```
> asc publish testflight ... --wait --submit --confirm
```

Log output from my script:
```
{"archive_path":".asc/artifacts/Puzz-1.5.0-68.xcarchive","ipa_path":".asc/artifacts/Puzz-1.5.0-68.ipa","bundle_id":"kids.puzz.app","version":"1.5.0","build_number":"69"}

Uploading to TestFlight (group: Beta)...
Uploading Puzz-1.5.0-68.ipa (57075395 bytes) to App Store Connect...
Upload committed in App Store Connect.
Waiting for build 69 (1.5.0) to appear in App Store Connect...
Submitted build bf637aee-3210-42e6-b84c-49ce8c98413e for beta app review (bf637aee-3210-42e6-b84c-49ce8c98413e)
{"mode":"ipa_upload","buildId":"bf637aee-3210-42e6-b84c-49ce8c98413e","buildVersion":"1.5.0","buildNumber":"69","groupIds":["b178ae06-72bb-4492-9289-6752240e2a19"],"uploaded":true,"processingState":"VALID","betaReviewSubmitted":true,"betaReviewSubmissionId":"bf637aee-3210-42e6-b84c-49ce8c98413e"}

Done! Beta build 1.5.0 (68) distributed.
```

and from the ASC command line:
<img width="1195" height="259" alt="image" src="https://github.com/user-attachments/assets/dac364f4-14fa-49f7-856e-dff8bd571678" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --submit and --confirm to publish testflight to allow automatic beta app review submission for external groups; command now reports beta review submitted and submission ID.

* **Documentation**
  * Updated workflow docs and README examples to show usage when publishing to external TestFlight groups (include --submit --confirm).

* **Tests**
  * Added flag-validation and integration tests covering the submit/confirm flow and various submission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->