### PR TITLE
docs: clarify README localizations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ asc review doctor --app "123456789"
 ### Metadata and localization
 
 ```bash
-asc localizations list --app "123456789"
+asc localizations list --app "123456789" --type app-info
 asc metadata apply --app "123456789" --version "1.2.3" --dir "./metadata" --dry-run
 asc metadata keywords audit --app "123456789" --version "1.2.3" --blocked-terms-file "./blocked-terms.txt"
 asc apps info view --app "123456789" --output json --pretty


### PR DESCRIPTION
Follow-up to #1456.

## Summary
- update the README metadata/localization example to use `--type app-info` explicitly
- keep the generic localization example aligned with the current CLI behavior

Closes #1455.

## Test plan
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make check-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the localization listing command example to demonstrate correct usage with the `--type app-info` flag for proper app information filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->