### PR TITLE
workflow: allow duplicate output step names across independent workflows

### DIFF
--- a/commands/workflow.mdx
+++ b/commands/workflow.mdx
@@ -96,6 +96,10 @@ asc workflow validate
 asc workflow validate --file ./.asc/workflow.json
 ```
 
+Independent workflows can reuse output-producing step names like `archive`. If a
+single workflow execution can reach both producers, validation still rejects the
+duplicate name.
+
 ### workflow run
 
 Run a workflow by name and pass runtime parameters as `KEY:VALUE` arguments:
@@ -105,7 +109,7 @@ asc workflow run beta
 asc workflow run beta BUILD_ID:123456789 GROUP_ID:abcdef
 asc workflow run release VERSION:2.1.0
 asc workflow run --dry-run beta
-asc workflow run --resume beta-20260312T120000Z-deadbeef release
+asc workflow run release --resume beta-20260312T120000Z-deadbeef
 ```
 
 ## Features
@@ -121,6 +125,10 @@ Steps can reference another workflow with a `workflow` key and pass scoped varia
 ### Persistent outputs
 
 If a step emits JSON and declares `outputs`, later steps can reference values like `${steps.resolve_build.BUILD_ID}`.
+
+Independent workflows can reuse output-producing step names. For example,
+`testflight_beta.archive` and `appstore_release.archive` are both valid as long
+as no single workflow run can reach both producers.
 
 ### Repo-local run state
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -117,5 +117,6 @@ Notes:
 - Add `"ASC_BYPASS_KEYCHAIN": "1"` to the top-level `env` block if you want the
   workflow to resolve credentials from environment variables or config instead
   of the macOS keychain.
-- Output-producing step names should stay unique within the workflow file when
-  you define multiple workflows that use `outputs`.
+- Output-producing step names only need to stay unique within workflows that
+  can execute together in the same run graph. Independent workflows can reuse
+  names like `archive` or `publish`.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -62,15 +62,15 @@ Create `.asc/workflow.json`:
           "run": "if [ -z \"$VERSION\" ]; then echo \"VERSION is required\" >&2; exit 1; fi"
         },
         {
-          "name": "beta_resolve_next_build",
+          "name": "resolve_next_build",
           "run": "asc builds latest --app \"$APP_ID\" --version \"$VERSION\" --platform IOS --next --initial-build-number 1 --output json",
           "outputs": {
             "BUILD_NUMBER": "$.nextBuildNumber"
           }
         },
         {
-          "name": "beta_archive",
-          "run": "asc xcode archive --project \"$PROJECT_PATH\" --scheme \"$SCHEME\" --configuration \"$CONFIGURATION\" --archive-path \".asc/artifacts/App-$VERSION-${steps.beta_resolve_next_build.BUILD_NUMBER}.xcarchive\" --clean --overwrite --xcodebuild-flag=-destination --xcodebuild-flag=generic/platform=iOS --xcodebuild-flag=-allowProvisioningUpdates --xcodebuild-flag=MARKETING_VERSION=$VERSION --xcodebuild-flag=CURRENT_PROJECT_VERSION=${steps.beta_resolve_next_build.BUILD_NUMBER} --output json",
+          "name": "archive",
+          "run": "asc xcode archive --project \"$PROJECT_PATH\" --scheme \"$SCHEME\" --configuration \"$CONFIGURATION\" --archive-path \".asc/artifacts/App-$VERSION-${steps.resolve_next_build.BUILD_NUMBER}.xcarchive\" --clean --overwrite --xcodebuild-flag=-destination --xcodebuild-flag=generic/platform=iOS --xcodebuild-flag=-allowProvisioningUpdates --xcodebuild-flag=MARKETING_VERSION=$VERSION --xcodebuild-flag=CURRENT_PROJECT_VERSION=${steps.resolve_next_build.BUILD_NUMBER} --output json",
           "outputs": {
             "ARCHIVE_PATH": "$.archive_path",
             "VERSION": "$.version",
@@ -78,8 +78,8 @@ Create `.asc/workflow.json`:
           }
         },
         {
-          "name": "beta_export",
-          "run": "asc xcode export --archive-path ${steps.beta_archive.ARCHIVE_PATH} --export-options \"$EXPORT_OPTIONS\" --ipa-path \".asc/artifacts/App-$VERSION-${steps.beta_archive.BUILD_NUMBER}.ipa\" --overwrite --xcodebuild-flag=-allowProvisioningUpdates --output json",
+          "name": "export",
+          "run": "asc xcode export --archive-path ${steps.archive.ARCHIVE_PATH} --export-options \"$EXPORT_OPTIONS\" --ipa-path \".asc/artifacts/App-$VERSION-${steps.archive.BUILD_NUMBER}.ipa\" --overwrite --xcodebuild-flag=-allowProvisioningUpdates --output json",
           "outputs": {
             "IPA_PATH": "$.ipa_path",
             "VERSION": "$.version",
@@ -87,8 +87,8 @@ Create `.asc/workflow.json`:
           }
         },
         {
-          "name": "beta_publish",
-          "run": "asc publish testflight --app \"$APP_ID\" --ipa ${steps.beta_export.IPA_PATH} --group \"$TESTFLIGHT_GROUP\" --wait --poll-interval 10s --output json",
+          "name": "publish",
+          "run": "asc publish testflight --app \"$APP_ID\" --ipa ${steps.export.IPA_PATH} --group \"$TESTFLIGHT_GROUP\" --wait --poll-interval 10s --output json",
           "outputs": {
             "BUILD_ID": "$.buildId",
             "BUILD_NUMBER": "$.buildNumber"
@@ -120,3 +120,38 @@ Notes:
 - Output-producing step names only need to stay unique within workflows that
   can execute together in the same run graph. Independent workflows can reuse
   names like `archive` or `publish`.
+
+Example:
+
+```json
+{
+  "workflows": {
+    "testflight_beta": {
+      "steps": [
+        {
+          "name": "archive",
+          "run": "printf '{\"buildId\":\"beta\"}'",
+          "outputs": {
+            "BUILD_ID": "$.buildId"
+          }
+        }
+      ]
+    },
+    "appstore_release": {
+      "steps": [
+        {
+          "name": "archive",
+          "run": "printf '{\"buildId\":\"release\"}'",
+          "outputs": {
+            "BUILD_ID": "$.buildId"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+This is valid because those workflows are independent. If a third workflow can
+call both of them in the same run, the duplicate `archive` producers still need
+to be renamed.

--- a/internal/cli/cmdtest/workflow_test.go
+++ b/internal/cli/cmdtest/workflow_test.go
@@ -1642,3 +1642,53 @@ func TestWorkflowValidate_Pretty(t *testing.T) {
 		t.Fatalf("expected valid=true, got %v", result["valid"])
 	}
 }
+
+func TestWorkflowValidate_AllowsDuplicateOutputProducerNamesAcrossIndependentWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflowJSON(t, dir, `{
+		"workflows": {
+			"testflight_beta": {
+				"steps": [
+					{
+						"name": "archive",
+						"run": "printf '{\"buildId\":\"beta\"}'",
+						"outputs": {
+							"BUILD_ID": "$.buildId"
+						}
+					}
+				]
+			},
+			"appstore_release": {
+				"steps": [
+					{
+						"name": "archive",
+						"run": "printf '{\"buildId\":\"release\"}'",
+						"outputs": {
+							"BUILD_ID": "$.buildId"
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"workflow", "validate", "--file", path}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", stdout, err)
+	}
+	if result["valid"] != true {
+		t.Fatalf("expected valid=true, got %v", result["valid"])
+	}
+}

--- a/internal/cli/cmdtest/workflow_test.go
+++ b/internal/cli/cmdtest/workflow_test.go
@@ -49,6 +49,9 @@ func TestWorkflow_ShowsHelp(t *testing.T) {
 	if !strings.Contains(stderr, "${steps.resolve_build.BUILD_ID}") {
 		t.Fatalf("expected help to document step output references, got %q", stderr)
 	}
+	if !strings.Contains(stderr, "Output-producing step names only need to stay unique across workflows that can execute together in the same run graph.") {
+		t.Fatalf("expected help to explain output-producing step name scoping, got %q", stderr)
+	}
 	if !strings.Contains(stderr, `"BUILD_ID": "$.data.id"`) {
 		t.Fatalf("expected help example to extract build IDs from $.data.id, got %q", stderr)
 	}
@@ -1690,5 +1693,82 @@ func TestWorkflowValidate_AllowsDuplicateOutputProducerNamesAcrossIndependentWor
 	}
 	if result["valid"] != true {
 		t.Fatalf("expected valid=true, got %v", result["valid"])
+	}
+}
+
+func TestWorkflowValidate_RejectsDuplicateOutputProducerNamesInSameRunGraph(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflowJSON(t, dir, `{
+		"workflows": {
+			"ship": {
+				"steps": [
+					{"workflow": "testflight_beta"},
+					{"workflow": "appstore_release"}
+				]
+			},
+			"testflight_beta": {
+				"steps": [
+					{
+						"name": "archive",
+						"run": "printf '{\"buildId\":\"beta\"}'",
+						"outputs": {
+							"BUILD_ID": "$.buildId"
+						}
+					}
+				]
+			},
+			"appstore_release": {
+				"steps": [
+					{
+						"name": "archive",
+						"run": "printf '{\"buildId\":\"release\"}'",
+						"outputs": {
+							"BUILD_ID": "$.buildId"
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"workflow", "validate", "--file", path}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected validation failure")
+		}
+		if _, ok := errors.AsType[ReportedError](err); !ok {
+			t.Fatalf("expected ReportedError, got %T: %v", err, err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", stdout, err)
+	}
+	if result["valid"] != false {
+		t.Fatalf("expected valid=false, got %v", result["valid"])
+	}
+	errs, ok := result["errors"].([]any)
+	if !ok || len(errs) == 0 {
+		t.Fatalf("expected validation errors, got %T: %v", result["errors"], result["errors"])
+	}
+	foundDuplicate := false
+	for _, entry := range errs {
+		errMap, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("expected error entry object, got %T: %v", entry, entry)
+		}
+		if errMap["code"] == "duplicate_output_producer_name" {
+			foundDuplicate = true
+		}
+	}
+	if !foundDuplicate {
+		t.Fatalf("expected duplicate_output_producer_name error, got %v", errs)
 	}
 }

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -47,6 +47,7 @@ Tips:
   Use asc workflow validate before running a new workflow file.
   Preview the plan with asc workflow run --dry-run <name>.
   Run-step outputs can be referenced later as ${steps.resolve_build.BUILD_ID}.
+  Output-producing step names only need to stay unique across workflows that can execute together in the same run graph.
   For asc commands that declare outputs, usually pass --output json.
   A proven local Xcode -> TestFlight shape is: asc builds next-build-number --app $APP_ID -> asc xcode archive -> asc xcode export -> asc publish testflight --group ... --wait.
 

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -73,7 +73,7 @@ func Validate(def *Definition) []*ValidationError {
 		}
 	}
 
-	outputProducerWorkflows := map[string]string{}
+	outputProducerConflicts := collectOutputProducerConflicts(def)
 
 	for _, name := range names {
 		wf := def.Workflows[name]
@@ -147,15 +147,13 @@ func Validate(def *Definition) []*ValidationError {
 						Message:  fmt.Sprintf("workflow %q step %d must use a reference-safe 'name' when declaring outputs", name, idx),
 					})
 				} else {
-					if prevWorkflow, exists := outputProducerWorkflows[trimmedName]; exists {
+					if prevWorkflow, exists := outputProducerConflicts[name][idx]; exists {
 						errs = append(errs, &ValidationError{
 							Code:     ErrDuplicateOutputProducerName,
 							Workflow: name,
 							Step:     idx,
 							Message:  fmt.Sprintf("workflow %q step %d reuses output-producing step name %q already declared in workflow %q", name, idx, trimmedName, prevWorkflow),
 						})
-					} else {
-						outputProducerWorkflows[trimmedName] = name
 					}
 				}
 
@@ -198,6 +196,73 @@ func Validate(def *Definition) []*ValidationError {
 	}
 
 	return errs
+}
+
+func collectOutputProducerConflicts(def *Definition) map[string]map[int]string {
+	conflicts := map[string]map[int]string{}
+	reachabilityCache := map[string]map[string]struct{}{}
+
+	for _, root := range slices.Sorted(maps.Keys(def.Workflows)) {
+		reachable := workflowsReachableFrom(def, root, reachabilityCache, map[string]bool{})
+		seen := map[string]string{}
+
+		reachableNames := slices.Sorted(maps.Keys(reachable))
+		for _, workflowName := range reachableNames {
+			wf := def.Workflows[workflowName]
+			for i, step := range wf.Steps {
+				if len(step.Outputs) == 0 {
+					continue
+				}
+
+				trimmedName := strings.TrimSpace(step.Name)
+				if trimmedName == "" || !validWorkflowName.MatchString(trimmedName) {
+					continue
+				}
+
+				if prevWorkflow, exists := seen[trimmedName]; exists {
+					if conflicts[workflowName] == nil {
+						conflicts[workflowName] = map[int]string{}
+					}
+					if _, recorded := conflicts[workflowName][i+1]; !recorded {
+						conflicts[workflowName][i+1] = prevWorkflow
+					}
+					continue
+				}
+
+				seen[trimmedName] = workflowName
+			}
+		}
+	}
+
+	return conflicts
+}
+
+func workflowsReachableFrom(def *Definition, root string, cache map[string]map[string]struct{}, visiting map[string]bool) map[string]struct{} {
+	if reachable, ok := cache[root]; ok {
+		return reachable
+	}
+	if visiting[root] {
+		return map[string]struct{}{root: {}}
+	}
+
+	visiting[root] = true
+	reachable := map[string]struct{}{root: {}}
+
+	if wf, ok := def.Workflows[root]; ok {
+		for _, step := range wf.Steps {
+			ref := strings.TrimSpace(step.Workflow)
+			if ref == "" {
+				continue
+			}
+			for name := range workflowsReachableFrom(def, ref, cache, visiting) {
+				reachable[name] = struct{}{}
+			}
+		}
+	}
+
+	delete(visiting, root)
+	cache[root] = reachable
+	return reachable
 }
 
 // detectCycles performs DFS across all workflows to find circular references.

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -261,7 +261,9 @@ func workflowsReachableFrom(def *Definition, root string, cache map[string]map[s
 	}
 
 	delete(visiting, root)
-	cache[root] = reachable
+	if len(visiting) == 0 {
+		cache[root] = reachable
+	}
 	return reachable
 }
 

--- a/internal/workflow/validate_test.go
+++ b/internal/workflow/validate_test.go
@@ -302,22 +302,60 @@ func TestValidate_StepOutputsRejectWorkflowStep(t *testing.T) {
 	assertValidationCode(t, errs, ErrStepOutputsOnWorkflow)
 }
 
-func TestValidate_StepOutputsRequireUniqueProducerNames(t *testing.T) {
+func TestValidate_StepOutputsAllowDuplicateProducerNamesAcrossIndependentWorkflows(t *testing.T) {
 	def := &Definition{
 		Workflows: map[string]Workflow{
-			"main": {
+			"beta": {
 				Steps: []Step{
 					{
-						Name:    "upload",
+						Name:    "archive",
 						Run:     `printf '{"buildId":"one"}'`,
 						Outputs: map[string]string{"BUILD_ID": "$.buildId"},
 					},
 				},
 			},
-			"helper": {
+			"release": {
 				Steps: []Step{
 					{
-						Name:    "upload",
+						Name:    "archive",
+						Run:     `printf '{"buildId":"two"}'`,
+						Outputs: map[string]string{"BUILD_ID": "$.buildId"},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(def)
+	for _, err := range errs {
+		if err.Code == ErrDuplicateOutputProducerName {
+			t.Fatalf("expected duplicate output producer names to be allowed across independent workflows, got %v", errs)
+		}
+	}
+}
+
+func TestValidate_StepOutputsRejectDuplicateProducerNamesInSameExecutionGraph(t *testing.T) {
+	def := &Definition{
+		Workflows: map[string]Workflow{
+			"ship": {
+				Steps: []Step{
+					{Workflow: "beta"},
+					{Workflow: "release"},
+				},
+			},
+			"beta": {
+				Steps: []Step{
+					{
+						Name:    "archive",
+						Run:     `printf '{"buildId":"one"}'`,
+						Outputs: map[string]string{"BUILD_ID": "$.buildId"},
+					},
+				},
+			},
+			"release": {
+				Steps: []Step{
+					{
+						Name:    "archive",
 						Run:     `printf '{"buildId":"two"}'`,
 						Outputs: map[string]string{"BUILD_ID": "$.buildId"},
 					},

--- a/internal/workflow/validate_test.go
+++ b/internal/workflow/validate_test.go
@@ -368,6 +368,46 @@ func TestValidate_StepOutputsRejectDuplicateProducerNamesInSameExecutionGraph(t 
 	assertValidationCode(t, errs, ErrDuplicateOutputProducerName)
 }
 
+func TestValidate_StepOutputsRejectDuplicateProducerNamesAcrossCycle(t *testing.T) {
+	def := &Definition{
+		Workflows: map[string]Workflow{
+			"a": {
+				Steps: []Step{
+					{Workflow: "b"},
+					{Workflow: "x"},
+				},
+			},
+			"b": {
+				Steps: []Step{
+					{Workflow: "a"},
+				},
+			},
+			"x": {
+				Steps: []Step{
+					{
+						Name:    "common",
+						Run:     `printf '{"id":"x"}'`,
+						Outputs: map[string]string{"ID": "$.id"},
+					},
+				},
+			},
+			"d": {
+				Steps: []Step{
+					{Workflow: "b"},
+					{
+						Name:    "common",
+						Run:     `printf '{"id":"d"}'`,
+						Outputs: map[string]string{"ID": "$.id"},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(def)
+	assertValidationCode(t, errs, ErrDuplicateOutputProducerName)
+}
+
 func TestValidate_StepOutputsRejectInvalidOutputExpr(t *testing.T) {
 	def := &Definition{
 		Workflows: map[string]Workflow{


### PR DESCRIPTION
## Summary
- allow duplicate output-producing step names when workflows are independent and cannot execute in the same run graph
- keep rejecting duplicate output-producing step names when a single workflow execution can reach both producers
- add validation coverage, CLI coverage, and update workflow docs to reflect the narrower uniqueness rule

## Why this approach
The issue is valid for independent top-level workflows, but fully isolating `steps.*` per workflow at runtime would risk changing existing nested-workflow semantics. This keeps the current runtime model and removes only the unnecessary file-wide validation restriction.

## Alternatives considered
- Scope all step outputs per workflow invocation at runtime. Cleaner on paper, but higher compatibility risk because nested workflows currently share a flat output map.
- Remove duplicate-name validation entirely. Simpler, but unsafe because same-run collisions would still overwrite each other.

## Validation
- `go test ./internal/workflow -run 'TestValidate_StepOutputs(AllowDuplicateProducerNamesAcrossIndependentWorkflows|RejectDuplicateProducerNamesInSameExecutionGraph)'`
- `go test ./internal/cli/cmdtest -run TestWorkflowValidate_AllowsDuplicateOutputProducerNamesAcrossIndependentWorkflows`
- `go test ./internal/workflow`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `/tmp/asc workflow validate --file <independent-workflows.json>` -> exit `0`, `{\"valid\":true}`
- `/tmp/asc workflow validate --file <conflicting-workflows.json>` -> exit `1`, duplicate output producer validation error

Closes #1460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that output-producing step names must be unique only among workflows that can run together; added examples and corrected usage ordering in workflow docs and help text.

* **Bug Fixes**
  * Validation now considers run-graph reachability so duplicate producer names are allowed for independent workflows but reported when they can execute together.

* **Tests**
  * Added/updated tests covering allowed duplicates and conflict detection in connected workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->