### PR TITLE
Fix subscription setup availability bootstrap

### DIFF
--- a/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
@@ -327,6 +327,103 @@ func TestSubscriptionsPricesAdd_InitialPriceForwardsAttributes(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsPricesAdd_ExistingPriceForwardsTerritoryOverridePayload(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/relationships/prices"):
+			body := `{"data":[{"type":"subscriptionPrices","id":"existing-price-1"}],"links":{}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode post payload: %v", err)
+			}
+
+			data, ok := payload["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected data object, got %#v", payload["data"])
+			}
+			if got := data["type"]; got != "subscriptionPrices" {
+				t.Fatalf("expected type subscriptionPrices, got %#v", got)
+			}
+
+			attrs, ok := data["attributes"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected attributes object, got %#v", data["attributes"])
+			}
+			if attrs["startDate"] != "2026-05-01" {
+				t.Fatalf("expected startDate 2026-05-01, got %#v", attrs["startDate"])
+			}
+			if attrs["preserveCurrentPrice"] != true {
+				t.Fatalf("expected preserveCurrentPrice true, got %#v", attrs["preserveCurrentPrice"])
+			}
+
+			relationships, ok := data["relationships"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected relationships object, got %#v", data["relationships"])
+			}
+			subscription := relationships["subscription"].(map[string]any)["data"].(map[string]any)
+			if subscription["id"] != "8000000003" {
+				t.Fatalf("expected subscription id 8000000003, got %#v", subscription["id"])
+			}
+			pricePoint := relationships["subscriptionPricePoint"].(map[string]any)["data"].(map[string]any)
+			if pricePoint["id"] != "PP_ID" {
+				t.Fatalf("expected price point PP_ID, got %#v", pricePoint["id"])
+			}
+			territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
+			if territory["id"] != "NOR" {
+				t.Fatalf("expected territory NOR, got %#v", territory["id"])
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body: io.NopCloser(strings.NewReader(
+					`{"data":{"type":"subscriptionPrices","id":"sub-price-1","attributes":{"startDate":"2026-05-01","preserved":true}}}`,
+				)),
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "set",
+			"--subscription-id", "8000000003",
+			"--price-point", "PP_ID",
+			"--territory", "Norway",
+			"--start-date", "2026-05-01",
+			"--preserved",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-price-1"`) {
+		t.Fatalf("expected subscription price response in stdout, got %q", stdout)
+	}
+}
+
 func TestSubscriptionsPricesAdd_TierRequiresTerritory(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
@@ -370,15 +370,36 @@ func TestSubscriptionsPricesAdd_ExistingPriceForwardsTerritoryOverridePayload(t 
 			if !ok {
 				t.Fatalf("expected relationships object, got %#v", data["relationships"])
 			}
-			subscription := relationships["subscription"].(map[string]any)["data"].(map[string]any)
+			subscriptionRelationship, ok := relationships["subscription"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected subscription relationship object, got %#v", relationships["subscription"])
+			}
+			subscription, ok := subscriptionRelationship["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected subscription relationship data object, got %#v", subscriptionRelationship["data"])
+			}
 			if subscription["id"] != "8000000003" {
 				t.Fatalf("expected subscription id 8000000003, got %#v", subscription["id"])
 			}
-			pricePoint := relationships["subscriptionPricePoint"].(map[string]any)["data"].(map[string]any)
+			pricePointRelationship, ok := relationships["subscriptionPricePoint"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected subscriptionPricePoint relationship object, got %#v", relationships["subscriptionPricePoint"])
+			}
+			pricePoint, ok := pricePointRelationship["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected subscriptionPricePoint relationship data object, got %#v", pricePointRelationship["data"])
+			}
 			if pricePoint["id"] != "PP_ID" {
 				t.Fatalf("expected price point PP_ID, got %#v", pricePoint["id"])
 			}
-			territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
+			territoryRelationship, ok := relationships["territory"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected territory relationship object, got %#v", relationships["territory"])
+			}
+			territory, ok := territoryRelationship["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected territory relationship data object, got %#v", territoryRelationship["data"])
+			}
 			if territory["id"] != "NOR" {
 				t.Fatalf("expected territory NOR, got %#v", territory["id"])
 			}

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -179,7 +179,7 @@ func TestSubscriptionsSetupValidationErrors(t *testing.T) {
 				"--product-id", "com.example.pro.monthly",
 				"--available-in-new-territories",
 			},
-			wantErr: "--territories is required when availability flags are provided",
+			wantErr: "--territories is required when availability flags are provided unless --price-territory can be used to derive availability",
 		},
 	}
 
@@ -422,8 +422,8 @@ func TestSubscriptionsSetupPricingAutoEnablesPriceTerritoryAvailability(t *testi
 			if payload.Data.Relationships.Subscription.Data.ID != "sub-1" {
 				t.Fatalf("expected availability to target sub-1, got %q", payload.Data.Relationships.Subscription.Data.ID)
 			}
-			if payload.Data.Attributes.AvailableInNewTerritories {
-				t.Fatalf("expected availableInNewTerritories false")
+			if !payload.Data.Attributes.AvailableInNewTerritories {
+				t.Fatalf("expected availableInNewTerritories true")
 			}
 			if len(payload.Data.Relationships.AvailableTerritories.Data) != 1 {
 				t.Fatalf("expected one auto-enabled territory, got %+v", payload.Data.Relationships.AvailableTerritories.Data)
@@ -431,7 +431,7 @@ func TestSubscriptionsSetupPricingAutoEnablesPriceTerritoryAvailability(t *testi
 			if got := payload.Data.Relationships.AvailableTerritories.Data[0].ID; got != "NOR" {
 				t.Fatalf("expected auto-enabled territory NOR, got %q", got)
 			}
-			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":false}}}`), nil
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`), nil
 		default:
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -452,6 +452,7 @@ func TestSubscriptionsSetupPricingAutoEnablesPriceTerritoryAvailability(t *testi
 			"--subscription-period", "ONE_MONTH",
 			"--price", "19",
 			"--price-territory", "Norway",
+			"--available-in-new-territories",
 			"--no-verify",
 			"--output", "json",
 		}); err != nil {
@@ -473,6 +474,19 @@ func TestSubscriptionsSetupPricingAutoEnablesPriceTerritoryAvailability(t *testi
 	}
 	if result.Status != "ok" || result.AvailabilityID != "avail-1" || result.ResolvedPricePointID != "pp-nok-19" {
 		t.Fatalf("unexpected pricing auto-availability result: %+v", result)
+	}
+	foundAutoAvailabilityMessage := false
+	for _, step := range result.Steps {
+		if step.Name != "set_availability" {
+			continue
+		}
+		if !strings.Contains(step.Message, `auto-enabled pricing territory "NOR"`) {
+			t.Fatalf("expected auto-availability step message, got %q", step.Message)
+		}
+		foundAutoAvailabilityMessage = true
+	}
+	if !foundAutoAvailabilityMessage {
+		t.Fatalf("expected set_availability step with auto-enabled pricing territory message, got %+v", result.Steps)
 	}
 	if result.Verification.Status != "skipped" {
 		t.Fatalf("expected skipped verification with --no-verify, got %+v", result.Verification)

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -366,6 +366,119 @@ func TestSubscriptionsSetupExistingGroupNoVerifySuccess(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsSetupPricingAutoEnablesPriceTerritoryAvailability(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("HOME", t.TempDir())
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionGroups" {
+				t.Fatalf("unexpected group create request: %s %s", req.Method, req.URL.Path)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Pro"}}}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptions" {
+				t.Fatalf("unexpected subscription create request: %s %s", req.Method, req.URL.Path)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA"}}}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/pricePoints" {
+				t.Fatalf("unexpected price-point lookup request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("filter[territory]"); got != "NOR" {
+				t.Fatalf("expected filter[territory]=NOR, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-nok-19","attributes":{"customerPrice":"19.00","proceeds":"14.00","proceedsYear2":"14.00"}}],"links":{"next":""}}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptions/sub-1" {
+				t.Fatalf("unexpected initial price request: %s %s", req.Method, req.URL.Path)
+			}
+			var payload asc.SubscriptionUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode initial price payload: %v", err)
+			}
+			if len(payload.Included) != 1 {
+				t.Fatalf("expected one included price resource, got %d", len(payload.Included))
+			}
+			if payload.Included[0].Relationships.Territory == nil || payload.Included[0].Relationships.Territory.Data.ID != "NOR" {
+				t.Fatalf("expected pricing territory NOR, got %+v", payload.Included[0].Relationships.Territory)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA"}}}`), nil
+		case 5:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionAvailabilities" {
+				t.Fatalf("unexpected availability request: %s %s", req.Method, req.URL.Path)
+			}
+			var payload asc.SubscriptionAvailabilityCreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode availability payload: %v", err)
+			}
+			if payload.Data.Relationships.Subscription.Data.ID != "sub-1" {
+				t.Fatalf("expected availability to target sub-1, got %q", payload.Data.Relationships.Subscription.Data.ID)
+			}
+			if payload.Data.Attributes.AvailableInNewTerritories {
+				t.Fatalf("expected availableInNewTerritories false")
+			}
+			if len(payload.Data.Relationships.AvailableTerritories.Data) != 1 {
+				t.Fatalf("expected one auto-enabled territory, got %+v", payload.Data.Relationships.AvailableTerritories.Data)
+			}
+			if got := payload.Data.Relationships.AvailableTerritories.Data[0].ID; got != "NOR" {
+				t.Fatalf("expected auto-enabled territory NOR, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var result subscriptionsSetupOutput
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "setup",
+			"--app", "app-1",
+			"--group-reference-name", "Pro",
+			"--reference-name", "Pro Monthly",
+			"--product-id", "com.example.pro.monthly",
+			"--subscription-period", "ONE_MONTH",
+			"--price", "19",
+			"--price-territory", "Norway",
+			"--no-verify",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 5 {
+		t.Fatalf("expected create, price, and auto-availability requests, got %d", requestCount)
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse setup result: %v\nstdout=%q", err, stdout)
+	}
+	if result.Status != "ok" || result.AvailabilityID != "avail-1" || result.ResolvedPricePointID != "pp-nok-19" {
+		t.Fatalf("unexpected pricing auto-availability result: %+v", result)
+	}
+	if result.Verification.Status != "skipped" {
+		t.Fatalf("expected skipped verification with --no-verify, got %+v", result.Verification)
+	}
+}
+
 func TestSubscriptionsSetupCreateLocalizationPricingAndAvailabilitySuccess(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -297,6 +297,8 @@ Examples:
 }
 
 func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptions) (subscriptionsSetupResult, error) {
+	availabilityTerritories := subscriptionsSetupAvailabilityTerritories(opts)
+
 	result := subscriptionsSetupResult{
 		Status:             "ok",
 		AppID:              opts.AppID,
@@ -480,7 +482,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		})
 	}
 
-	if !opts.hasAvailability() {
+	if len(availabilityTerritories) == 0 {
 		result.Steps = append(result.Steps, subscriptionsSetupStepResult{
 			Name:    subscriptionsSetupStepSetAvailability,
 			Status:  "skipped",
@@ -488,7 +490,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		})
 	} else {
 		availabilityCtx, availabilityCancel := shared.ContextWithTimeout(ctx)
-		availabilityResp, err := client.CreateSubscriptionAvailability(availabilityCtx, result.SubscriptionID, opts.Territories, asc.SubscriptionAvailabilityAttributes{
+		availabilityResp, err := client.CreateSubscriptionAvailability(availabilityCtx, result.SubscriptionID, availabilityTerritories, asc.SubscriptionAvailabilityAttributes{
 			AvailableInNewTerritories: opts.AvailableInNewTerritories,
 		})
 		availabilityCancel()
@@ -505,9 +507,10 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		}
 		result.AvailabilityID = strings.TrimSpace(availabilityResp.Data.ID)
 		result.Steps = append(result.Steps, subscriptionsSetupStepResult{
-			Name:   subscriptionsSetupStepSetAvailability,
-			Status: "completed",
-			ID:     result.AvailabilityID,
+			Name:    subscriptionsSetupStepSetAvailability,
+			Status:  "completed",
+			ID:      result.AvailabilityID,
+			Message: subscriptionsSetupAvailabilityMessage(opts, availabilityTerritories),
 		})
 	}
 
@@ -521,7 +524,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		return result, nil
 	}
 
-	verification, verifyStep, err := verifySubscriptionsSetupState(ctx, client, result, opts)
+	verification, verifyStep, err := verifySubscriptionsSetupState(ctx, client, result, opts, availabilityTerritories)
 	if err != nil {
 		result.Status = "error"
 		result.Error = err.Error()
@@ -536,7 +539,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 	return result, nil
 }
 
-func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, result subscriptionsSetupResult, opts subscriptionsSetupOptions) (*subscriptionsSetupVerification, subscriptionsSetupStepResult, error) {
+func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, result subscriptionsSetupResult, opts subscriptionsSetupOptions, availabilityTerritories []string) (*subscriptionsSetupVerification, subscriptionsSetupStepResult, error) {
 	verification := &subscriptionsSetupVerification{Status: "verified"}
 
 	groupCtx, groupCancel := shared.ContextWithTimeout(ctx)
@@ -638,7 +641,7 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		verification.PriceVerified = &value
 	}
 
-	if opts.hasAvailability() {
+	if len(availabilityTerritories) > 0 {
 		availabilityCtx, availabilityCancel := shared.ContextWithTimeout(ctx)
 		availabilityResp, err := client.GetSubscriptionAvailabilityForSubscription(availabilityCtx, result.SubscriptionID)
 		availabilityCancel()
@@ -672,7 +675,7 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 			actualTerritories = append(actualTerritories, id)
 			actualSet[id] = struct{}{}
 		}
-		for _, expected := range opts.Territories {
+		for _, expected := range availabilityTerritories {
 			if _, ok := actualSet[expected]; !ok {
 				verification.Status = "failed"
 				return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: fmt.Sprintf("missing availability territory %q", expected)}, fmt.Errorf("missing availability territory %q", expected)
@@ -684,6 +687,26 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 	}
 
 	return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "completed"}, nil
+}
+
+func subscriptionsSetupAvailabilityTerritories(opts subscriptionsSetupOptions) []string {
+	if len(opts.Territories) > 0 {
+		return opts.Territories
+	}
+	if opts.hasPricing(opts.StartDate) && opts.PriceTerritory != "" {
+		return []string{opts.PriceTerritory}
+	}
+	return nil
+}
+
+func subscriptionsSetupAvailabilityMessage(opts subscriptionsSetupOptions, territories []string) string {
+	if len(opts.Territories) > 0 {
+		return ""
+	}
+	if len(territories) == 1 && opts.PriceTerritory != "" {
+		return fmt.Sprintf("auto-enabled pricing territory %q", territories[0])
+	}
+	return ""
 }
 
 func resolveExpectedSubscriptionSetupPricePoint(ctx context.Context, client *asc.Client, subID string, opts subscriptionsSetupOptions) (string, error) {

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -280,8 +280,8 @@ Examples:
 				opts.StartDate = normalizedStartDate
 			}
 
-			if opts.hasAvailability() && len(opts.Territories) == 0 {
-				return shared.UsageError("--territories is required when availability flags are provided")
+			if opts.hasAvailability() && len(subscriptionsSetupAvailabilityTerritories(opts)) == 0 {
+				return shared.UsageError("--territories is required when availability flags are provided unless --price-territory can be used to derive availability")
 			}
 
 			result, runErr := executeSubscriptionsSetup(ctx, opts)


### PR DESCRIPTION
## Summary
- auto-create subscription availability for the pricing territory during `asc subscriptions setup` when pricing is configured but no explicit availability territories are passed
- add a regression test for the original setup repro: `--price 19 --price-territory Norway` now creates a `subscriptionAvailabilities` record for `NOR`
- add a command-level regression test proving per-territory `asc subscriptions pricing prices set` posts the required `subscription`, `territory`, and `subscriptionPricePoint` relationships with `preserveCurrentPrice`

## Verification
- `go test ./internal/cli/cmdtest -run 'TestSubscriptions(Setup|PricesAdd)'`
- `go test ./internal/asc -run 'Test(SetSubscriptionInitialPrice|CreateSubscriptionPrice|CreateSubscriptionAvailability)'`

## Notes
- this keeps the setup fix minimal by auto-enabling the pricing territory when no explicit `--territories` were provided
- the per-territory subscription price override flow already serializes the correct payload; the new regression test locks that behavior in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Territory-specific subscription pricing: create prices that forward start date and preserve existing prices, with territory overrides.
  * Enhanced subscription setup: derives availability from a price territory when provided and auto-enables the corresponding territory.

* **Tests**
  * Added CLI tests covering the existing-price flow, territory override payloads, and the price-territory availability setup and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->