### PR TITLE
apps wall: add BratVPN

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -115,6 +115,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f9/73/48/f9734812-afa3-83b4-4862-a9331863f84b/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "BratVPN",
+    "link": "https://apps.apple.com/us/app/bratvpn/id6759875957?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/91/b8/2991b84b-72ec-130e-071e-18f6fd175a44/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "BuddyTask: AI To Do List",
     "link": "https://apps.apple.com/us/app/buddytask-ai-to-do-list/id6758902036?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/80/f5/84/80f584d0-6956-72b2-1294-8a5157c450b9/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `BratVPN` to the Wall of Apps

## Entry

- App ID: 6759875957
- App: BratVPN
- Link: https://apps.apple.com/us/app/bratvpn/id6759875957?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BratVPN as a new available app in the directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->