### PR TITLE
[codex] Create intro offers for all territories

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -434,6 +434,23 @@ asc subscriptions offers introductory create \
   --offer-mode FREE_TRIAL \
   --number-of-periods 1
 
+# Create the same free trial in every currently available subscription territory
+asc subscriptions offers introductory create \
+  --subscription-id "SUB_ID" \
+  --all-territories \
+  --offer-duration ONE_MONTH \
+  --offer-mode FREE_TRIAL \
+  --number-of-periods 1
+
+# Preview all-territory introductory offer creation without mutating ASC
+asc subscriptions offers introductory create \
+  --subscription-id "SUB_ID" \
+  --territory ALL \
+  --dry-run \
+  --offer-duration ONE_MONTH \
+  --offer-mode FREE_TRIAL \
+  --number-of-periods 1
+
 # Import introductory offers from CSV
 asc subscriptions offers introductory import \
   --subscription-id "SUB_ID" \
@@ -460,6 +477,7 @@ asc subscriptions offers introductory delete \
 * Header alias: `price_point` -> `price_point_id`
 * Territory values may be 3-letter ASC IDs, 2-letter country codes, or English territory names
 * Row values override command-level defaults, so a territory-only CSV can inherit a shared offer shape from flags
+* Use `create --all-territories` or `create --territory ALL` when every current subscription availability territory should receive the same free-trial shape
 
 **Offer Types:**
 

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -3,8 +3,12 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -57,5 +61,307 @@ func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) 
 	}
 	if err := root.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesDryRunSummarizesAvailability(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	seen := make([]string, 0, 3)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		seen = append(seen, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories" && req.URL.Query().Get("cursor") == "":
+			body := `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptionAvailabilities/avail-1/availableTerritories?cursor=2"}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories" && req.URL.Query().Get("cursor") == "2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"GBR"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/introductoryOffers":
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"eyJpIjoiVVMifQ"}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var summary struct {
+		SubscriptionID string `json:"subscriptionId"`
+		AllTerritories bool   `json:"allTerritories"`
+		DryRun         bool   `json:"dryRun"`
+		Total          int    `json:"total"`
+		Created        int    `json:"created"`
+		Skipped        int    `json:"skipped"`
+		Failed         int    `json:"failed"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--all-territories",
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.SubscriptionID != "8000000001" || !summary.AllTerritories || !summary.DryRun {
+		t.Fatalf("unexpected summary identity: %+v", summary)
+	}
+	if summary.Total != 3 || summary.Created != 2 || summary.Skipped != 1 || summary.Failed != 0 {
+		t.Fatalf("unexpected summary counts: %+v", summary)
+	}
+	for _, request := range seen {
+		if strings.HasPrefix(request, http.MethodPost+" ") {
+			t.Fatalf("dry-run should not POST, saw requests: %v", seen)
+		}
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesCreatesPerAvailabilityTerritory(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	postedTerritories := make([]string, 0, 2)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"CAN"},{"type":"territories","id":"USA"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/introductoryOffers":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			var payload struct {
+				Data struct {
+					Attributes struct {
+						Duration        string `json:"duration"`
+						OfferMode       string `json:"offerMode"`
+						NumberOfPeriods int    `json:"numberOfPeriods"`
+					} `json:"attributes"`
+					Relationships struct {
+						Territory struct {
+							Data struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"territory"`
+					} `json:"relationships"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if payload.Data.Attributes.Duration != "ONE_MONTH" || payload.Data.Attributes.OfferMode != "FREE_TRIAL" || payload.Data.Attributes.NumberOfPeriods != 1 {
+				t.Fatalf("unexpected attributes: %+v", payload.Data.Attributes)
+			}
+			postedTerritories = append(postedTerritories, payload.Data.Relationships.Territory.Data.ID)
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"intro-new"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var summary struct {
+		Total   int `json:"total"`
+		Created int `json:"created"`
+		Skipped int `json:"skipped"`
+		Failed  int `json:"failed"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--territory", "ALL",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Total != 2 || summary.Created != 2 || summary.Skipped != 0 || summary.Failed != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if got := strings.Join(postedTerritories, ","); got != "CAN,USA" {
+		t.Fatalf("expected POSTs for CAN,USA in availability order, got %s", got)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesPartialFailureReturnsReportedError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"CAN"},{"type":"territories","id":"USA"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/introductoryOffers":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			var payload struct {
+				Data struct {
+					Relationships struct {
+						Territory struct {
+							Data struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"territory"`
+					} `json:"relationships"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if payload.Data.Relationships.Territory.Data.ID == "CAN" {
+				return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","detail":"duplicate territory"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"intro-new"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--all-territories",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var summary struct {
+		Created  int `json:"created"`
+		Failed   int `json:"failed"`
+		Failures []struct {
+			Territory string `json:"territory"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Created != 1 || summary.Failed != 1 || len(summary.Failures) != 1 || summary.Failures[0].Territory != "CAN" {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesRejectsConcreteTerritoryAndPricePoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "all territories and concrete territory",
+			args: []string{
+				"subscriptions", "offers", "introductory", "create",
+				"--subscription-id", "8000000001",
+				"--offer-duration", "ONE_MONTH",
+				"--offer-mode", "FREE_TRIAL",
+				"--number-of-periods", "1",
+				"--all-territories",
+				"--territory", "USA",
+			},
+			wantErr: "Error: --territory and --all-territories are mutually exclusive",
+		},
+		{
+			name: "all territories and price point",
+			args: []string{
+				"subscriptions", "offers", "introductory", "create",
+				"--subscription-id", "8000000001",
+				"--offer-duration", "ONE_MONTH",
+				"--offer-mode", "FREE_TRIAL",
+				"--number-of-periods", "1",
+				"--all-territories",
+				"--price-point", "price-1",
+			},
+			wantErr: "Error: --price-point cannot be used with --all-territories or --territory ALL",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected flag.ErrHelp, got %v", err)
+				}
+			})
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
 	}
 }

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -2,6 +2,8 @@ package subscriptions
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -181,7 +183,10 @@ func SubscriptionsIntroductoryOffersCreateCommand() *ffcli.Command {
 	startDate := fs.String("start-date", "", "Start date (YYYY-MM-DD)")
 	endDate := fs.String("end-date", "", "End date (YYYY-MM-DD)")
 	territory := fs.String("territory", "", "Territory input for price override (accepts alpha-2, alpha-3, or exact English country name)")
+	allTerritories := fs.Bool("all-territories", false, "Create introductory offers for all current subscription availability territories")
 	pricePoint := fs.String("price-point", "", "Subscription price point ID")
+	dryRun := fs.Bool("dry-run", false, "Resolve territories and print summary without creating offers")
+	continueOnError := fs.Bool("continue-on-error", true, "Continue creating offers after a territory fails")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -191,7 +196,9 @@ func SubscriptionsIntroductoryOffersCreateCommand() *ffcli.Command {
 		LongHelp: `Create an introductory offer.
 
 Examples:
-  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1`,
+  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --territory ALL --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -237,10 +244,23 @@ Examples:
 			}
 
 			territoryID := strings.TrimSpace(*territory)
+			useAllTerritories := *allTerritories || strings.EqualFold(territoryID, "ALL")
+			if *allTerritories && territoryID != "" && !strings.EqualFold(territoryID, "ALL") {
+				fmt.Fprintln(os.Stderr, "Error: --territory and --all-territories are mutually exclusive")
+				return flag.ErrHelp
+			}
+			if useAllTerritories && strings.TrimSpace(*pricePoint) != "" {
+				fmt.Fprintln(os.Stderr, "Error: --price-point cannot be used with --all-territories or --territory ALL")
+				return flag.ErrHelp
+			}
 			if territoryID != "" {
-				territoryID, err = ascterritory.Normalize(territoryID)
-				if err != nil {
-					return shared.UsageError(err.Error())
+				if useAllTerritories {
+					territoryID = ""
+				} else {
+					territoryID, err = ascterritory.Normalize(territoryID)
+					if err != nil {
+						return shared.UsageError(err.Error())
+					}
 				}
 			}
 
@@ -254,9 +274,6 @@ Examples:
 				return err
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
 			attrs := asc.SubscriptionIntroductoryOfferCreateAttributes{
 				Duration:        duration,
 				OfferMode:       mode,
@@ -268,6 +285,22 @@ Examples:
 			if normalizedEndDate != "" {
 				attrs.EndDate = normalizedEndDate
 			}
+
+			if useAllTerritories {
+				return createSubscriptionIntroductoryOffersForAllTerritories(
+					ctx,
+					client,
+					id,
+					attrs,
+					*dryRun,
+					*continueOnError,
+					*output.Output,
+					*output.Pretty,
+				)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
 
 			resp, err := client.CreateSubscriptionIntroductoryOffer(
 				requestCtx,
@@ -283,6 +316,301 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+type subscriptionIntroductoryOfferCreateBulkSummary struct {
+	SubscriptionID  string                                                  `json:"subscriptionId"`
+	AvailabilityID  string                                                  `json:"availabilityId,omitempty"`
+	AllTerritories  bool                                                    `json:"allTerritories"`
+	DryRun          bool                                                    `json:"dryRun"`
+	ContinueOnError bool                                                    `json:"continueOnError"`
+	Total           int                                                     `json:"total"`
+	Created         int                                                     `json:"created"`
+	Skipped         int                                                     `json:"skipped"`
+	Failed          int                                                     `json:"failed"`
+	Skips           []subscriptionIntroductoryOfferCreateBulkSummarySkip    `json:"skips,omitempty"`
+	Failures        []subscriptionIntroductoryOfferCreateBulkSummaryFailure `json:"failures,omitempty"`
+}
+
+type subscriptionIntroductoryOfferCreateBulkSummarySkip struct {
+	Territory string `json:"territory"`
+	Reason    string `json:"reason"`
+}
+
+type subscriptionIntroductoryOfferCreateBulkSummaryFailure struct {
+	Territory string `json:"territory"`
+	Error     string `json:"error"`
+}
+
+func createSubscriptionIntroductoryOffersForAllTerritories(
+	ctx context.Context,
+	client *asc.Client,
+	subscriptionID string,
+	attrs asc.SubscriptionIntroductoryOfferCreateAttributes,
+	dryRun bool,
+	continueOnError bool,
+	output string,
+	pretty bool,
+) error {
+	availabilityID, territories, err := fetchIntroductoryOfferAvailabilityTerritories(ctx, client, subscriptionID)
+	if err != nil {
+		return fmt.Errorf("subscriptions introductory-offers create: %w", err)
+	}
+
+	existing, err := fetchIntroductoryOfferTerritories(ctx, client, subscriptionID)
+	if err != nil {
+		return fmt.Errorf("subscriptions introductory-offers create: %w", err)
+	}
+
+	summary := &subscriptionIntroductoryOfferCreateBulkSummary{
+		SubscriptionID:  subscriptionID,
+		AvailabilityID:  availabilityID,
+		AllTerritories:  true,
+		DryRun:          dryRun,
+		ContinueOnError: continueOnError,
+		Total:           len(territories),
+	}
+
+	for _, territoryID := range territories {
+		if _, ok := existing[territoryID]; ok {
+			appendSubscriptionIntroductoryOfferCreateBulkSkip(summary, territoryID, "introductory offer already exists for territory")
+			continue
+		}
+
+		if dryRun {
+			summary.Created++
+			continue
+		}
+
+		createCtx, createCancel := shared.ContextWithTimeout(ctx)
+		_, err := client.CreateSubscriptionIntroductoryOffer(createCtx, subscriptionID, attrs, territoryID, "")
+		createCancel()
+		if err != nil {
+			appendSubscriptionIntroductoryOfferCreateBulkFailure(summary, territoryID, err)
+			if !continueOnError {
+				break
+			}
+			continue
+		}
+
+		summary.Created++
+	}
+
+	if err := shared.PrintOutputWithRenderers(
+		summary,
+		output,
+		pretty,
+		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, false) },
+		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, true) },
+	); err != nil {
+		return err
+	}
+	if summary.Failed > 0 {
+		return shared.NewReportedError(fmt.Errorf("subscriptions introductory-offers create: %d territor%s failed", summary.Failed, pluralizeIntroductoryOfferCreateTerritories(summary.Failed)))
+	}
+	return nil
+}
+
+func fetchIntroductoryOfferAvailabilityTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (string, []string, error) {
+	availabilityCtx, availabilityCancel := shared.ContextWithTimeout(ctx)
+	availability, err := client.GetSubscriptionAvailabilityForSubscription(availabilityCtx, subscriptionID)
+	availabilityCancel()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to fetch subscription availability: %w", err)
+	}
+
+	availabilityID := strings.TrimSpace(availability.Data.ID)
+	if availabilityID == "" {
+		return "", nil, fmt.Errorf("subscription availability readback returned empty id")
+	}
+
+	territoriesCtx, territoriesCancel := shared.ContextWithTimeout(ctx)
+	firstPage, err := client.GetSubscriptionAvailabilityAvailableTerritories(territoriesCtx, availabilityID, asc.WithSubscriptionAvailabilityTerritoriesLimit(200))
+	territoriesCancel()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to fetch subscription availability territories: %w", err)
+	}
+
+	allPages, err := asc.PaginateAll(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
+		defer pageCancel()
+		return client.GetSubscriptionAvailabilityAvailableTerritories(pageCtx, availabilityID, asc.WithSubscriptionAvailabilityTerritoriesNextURL(nextURL))
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("paginate subscription availability territories: %w", err)
+	}
+
+	typed, ok := allPages.(*asc.TerritoriesResponse)
+	if !ok {
+		return "", nil, fmt.Errorf("unexpected subscription availability territories response type %T", allPages)
+	}
+
+	territories := make([]string, 0, len(typed.Data))
+	seen := make(map[string]struct{}, len(typed.Data))
+	for _, territory := range typed.Data {
+		id := strings.ToUpper(strings.TrimSpace(territory.ID))
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		territories = append(territories, id)
+	}
+	return availabilityID, territories, nil
+}
+
+func fetchIntroductoryOfferTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (map[string]struct{}, error) {
+	offersCtx, offersCancel := shared.ContextWithTimeout(ctx)
+	firstPage, err := client.GetSubscriptionIntroductoryOffers(offersCtx, subscriptionID, asc.WithSubscriptionIntroductoryOffersLimit(200))
+	offersCancel()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch existing introductory offers: %w", err)
+	}
+
+	allPages, err := asc.PaginateAll(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
+		defer pageCancel()
+		return client.GetSubscriptionIntroductoryOffers(pageCtx, subscriptionID, asc.WithSubscriptionIntroductoryOffersNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate existing introductory offers: %w", err)
+	}
+
+	typed, ok := allPages.(*asc.SubscriptionIntroductoryOffersResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected introductory offers response type %T", allPages)
+	}
+
+	existing := make(map[string]struct{}, len(typed.Data))
+	for _, offer := range typed.Data {
+		territoryID := introductoryOfferTerritoryID(offer)
+		if territoryID == "" {
+			continue
+		}
+		existing[territoryID] = struct{}{}
+	}
+	return existing, nil
+}
+
+func introductoryOfferTerritoryID(offer asc.Resource[asc.SubscriptionIntroductoryOfferAttributes]) string {
+	if len(offer.Relationships) != 0 {
+		var relationships struct {
+			Territory *struct {
+				Data struct {
+					ID string `json:"id"`
+				} `json:"data"`
+			} `json:"territory"`
+		}
+		if err := json.Unmarshal(offer.Relationships, &relationships); err == nil && relationships.Territory != nil {
+			if territoryID := strings.ToUpper(strings.TrimSpace(relationships.Territory.Data.ID)); territoryID != "" {
+				return territoryID
+			}
+		}
+	}
+	return introductoryOfferTerritoryIDFromEncodedID(offer.ID)
+}
+
+func introductoryOfferTerritoryIDFromEncodedID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(id)
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(id)
+		if err != nil {
+			return ""
+		}
+	}
+
+	// ASC currently omits territory relationships from introductory offer lists,
+	// but the opaque offer ID contains the App Store territory code under "i".
+	var payload struct {
+		Territory string `json:"i"`
+	}
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return ""
+	}
+
+	territoryID, err := ascterritory.Normalize(payload.Territory)
+	if err != nil {
+		return strings.ToUpper(strings.TrimSpace(payload.Territory))
+	}
+	return territoryID
+}
+
+func appendSubscriptionIntroductoryOfferCreateBulkSkip(summary *subscriptionIntroductoryOfferCreateBulkSummary, territoryID, reason string) {
+	if summary == nil {
+		return
+	}
+	summary.Skipped++
+	summary.Skips = append(summary.Skips, subscriptionIntroductoryOfferCreateBulkSummarySkip{
+		Territory: territoryID,
+		Reason:    reason,
+	})
+}
+
+func appendSubscriptionIntroductoryOfferCreateBulkFailure(summary *subscriptionIntroductoryOfferCreateBulkSummary, territoryID string, err error) {
+	if summary == nil || err == nil {
+		return
+	}
+	summary.Failed++
+	summary.Failures = append(summary.Failures, subscriptionIntroductoryOfferCreateBulkSummaryFailure{
+		Territory: territoryID,
+		Error:     err.Error(),
+	})
+}
+
+func renderSubscriptionIntroductoryOfferCreateBulkSummary(summary *subscriptionIntroductoryOfferCreateBulkSummary, markdown bool) error {
+	if summary == nil {
+		return fmt.Errorf("summary is nil")
+	}
+
+	render := asc.RenderTable
+	if markdown {
+		render = asc.RenderMarkdown
+	}
+
+	render(
+		[]string{"Subscription ID", "Availability ID", "Dry Run", "Total", "Created", "Skipped", "Failed"},
+		[][]string{{
+			summary.SubscriptionID,
+			summary.AvailabilityID,
+			fmt.Sprintf("%t", summary.DryRun),
+			fmt.Sprintf("%d", summary.Total),
+			fmt.Sprintf("%d", summary.Created),
+			fmt.Sprintf("%d", summary.Skipped),
+			fmt.Sprintf("%d", summary.Failed),
+		}},
+	)
+
+	if len(summary.Skips) > 0 {
+		rows := make([][]string, 0, len(summary.Skips))
+		for _, skip := range summary.Skips {
+			rows = append(rows, []string{skip.Territory, skip.Reason})
+		}
+		render([]string{"Skipped Territory", "Reason"}, rows)
+	}
+
+	if len(summary.Failures) > 0 {
+		rows := make([][]string, 0, len(summary.Failures))
+		for _, failure := range summary.Failures {
+			rows = append(rows, []string{failure.Territory, failure.Error})
+		}
+		render([]string{"Failed Territory", "Error"}, rows)
+	}
+
+	return nil
+}
+
+func pluralizeIntroductoryOfferCreateTerritories(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
 }
 
 // SubscriptionsIntroductoryOffersUpdateCommand returns the introductory offers update subcommand.


### PR DESCRIPTION
## Summary
- add `--all-territories` and `--territory ALL` bulk mode to `subscriptions offers introductory create`
- resolve subscription availability territories, skip existing intro offers, support dry-run and partial-failure summaries
- document the new introductory-offer workflow

Closes #1466

## Issue Audit
Issue #1466 is still open and correctly labeled `enhancement`, `p2`, and `medium`. Recent commits on latest `main` did not add global introductory-offer creation, so the gap still existed before this branch.

## Why
Introductory offer creation previously required either a single territory or a prebuilt CSV. The common same-free-trial-in-every-available-territory flow needed a first-class command path.

## Implementation Notes
- uses the subscription availability relationship and paginated available-territories endpoint
- keeps existing single-territory behavior backward-compatible
- rejects `--price-point` for all-territories because price points are territory-specific; CSV remains the safer path for paid per-territory offers
- falls back to decoding the current ASC intro-offer ID shape for skip detection because live list responses omit territory relationships

## Validation
- `go run . --help`
- `go run . subscriptions offers introductory create --help`
- `go run . schema --method POST --pretty subscriptionIntroductoryOffers`
- `go run . schema --method GET --pretty subscriptionAvailability`
- `go run . schema --method GET --pretty availableTerritories`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestSubscriptionsIntroductoryOffersCreate(AllTerritories|Normalizes)' -v`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestSubscriptionsIntroductoryOffers(Create|Import)'`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `/tmp/asc ... --all-territories --territory USA` -> exit 2
- `/tmp/asc ... --all-territories --price-point price-1` -> exit 2

## Live Smoke
Using throwaway app `ASC Test 20260216074703` (`6759231657`):
- existing subscription `6759789022`: dry-run resolved 175 territories and made no mutations
- created temporary subscription `6764161986` in existing group `21952974` with JPN availability
- `--all-territories --dry-run`: total 1, created 1, skipped 0, failed 0
- `--all-territories`: total 1, created 1, skipped 0, failed 0
- `--territory ALL --dry-run` after creation: total 1, created 0, skipped 1, failed 0
- cleaned up introductory offer `eyJzIjoiNjc2NDE2MTk4NiIsImQiOjE3NzcyNzMyMDAsImkiOiJKUCIsInQiOiIiLCJwIjoiMCJ9`
- cleaned up temporary subscription `6764161986`

## Alternatives Considered
- CSV-only: already supported, but does not solve the requested default global flow.
- Paid global offers with one `--price-point`: rejected because price points are territory-specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk creation of introductory offers across all subscription territories via the new `--all-territories` flag.
  * Preview functionality with `--dry-run` flag for non-mutating operations.
  * `--continue-on-error` flag to gracefully handle partial failures during bulk operations.

* **Documentation**
  * Added examples for creating free-trial offers across all territories and previewing operations before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->