### PR TITLE
apps wall: add Dot. Extend Your Digital World

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -274,6 +274,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c6/e9/77/c6e977ac-bc3b-5f1c-fbdb-e7f46ae3e467/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Dot. Extend Your Digital World",
+    "link": "https://apps.apple.com/us/app/dot-extend-your-digital-world/id6739468133?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3b/74/fe/3b74fe4f-e2d1-eb5c-2c3f-2255d003c618/icon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "DoubleMemory",
     "link": "https://apps.apple.com/app/id6737529034",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/65/58/32/6558325e-7e32-4385-90a8-454c6b80e373/DoubleMemory-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Dot. Extend Your Digital World` to the Wall of Apps

## Entry

- App ID: 6739468133
- App: Dot. Extend Your Digital World
- Link: https://apps.apple.com/us/app/dot-extend-your-digital-world/id6739468133?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new app entry to the app directory: "Dot. Extend Your Digital World," including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->