### PR TITLE
apps wall: add Pal Chat - AI Chat Client

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -728,6 +728,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/00/51/2900519e-a076-de61-c91c-7e0313faf41e/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Pal Chat - AI Chat Client",
+    "link": "https://apps.apple.com/us/app/pal-chat-ai-chat-client/id6447545085?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0f/43/12/0f431290-6bfc-8f62-5c1c-b9955f947bbc/GlassIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Palabros - Diccionario",
     "link": "https://apps.apple.com/us/app/palabros-diccionario/id6758098070?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a9/25/1a/a9251ac1-2d3d-c390-ffa7-29c0dc645d45/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pal Chat - AI Chat Client` to the Wall of Apps

## Entry

- App ID: 6447545085
- App: Pal Chat - AI Chat Client
- Link: https://apps.apple.com/us/app/pal-chat-ai-chat-client/id6447545085?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Pal Chat - AI Chat Client" to the public app directory, including its App Store link and icon.
  * No existing app entries were removed or modified; this is an additive documentation update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->