### PR TITLE
apps wall: add Pal Cal - AI Calorie Counting

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -728,6 +728,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/00/51/2900519e-a076-de61-c91c-7e0313faf41e/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Pal Cal - AI Calorie Counting",
+    "link": "https://apps.apple.com/us/app/pal-cal-ai-calorie-counting/id6758598728?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/02/b1/bf/02b1bf63-175e-cf12-6954-9bd80ecbe56c/ProteinIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Palabros - Diccionario",
     "link": "https://apps.apple.com/us/app/palabros-diccionario/id6758098070?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a9/25/1a/a9251ac1-2d3d-c390-ffa7-29c0dc645d45/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pal Cal - AI Calorie Counting` to the Wall of Apps

## Entry

- App ID: 6758598728
- App: Pal Cal - AI Calorie Counting
- Link: https://apps.apple.com/us/app/pal-cal-ai-calorie-counting/id6758598728?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Pal Cal - AI Calorie Counting," a new AI-powered calorie counting application, to the featured apps collection. The updated directory now includes the application's App Store link and icon, making it readily available for users to discover and access alongside other featured apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->