### PR TITLE
apps wall: add Galactic Cards - Infinite Game

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -393,6 +393,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/52/0e/ed/520eed9c-d3f0-5d0e-3e68-5b6e698e5efc/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Galactic Cards - Infinite Game",
+    "link": "https://apps.apple.com/us/app/galactic-cards-infinite-game/id6739960236?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/46/3f/3f/463f3fcb-8914-8362-2287-7091b949a573/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Gecko Med",
     "link": "https://apps.apple.com/us/app/gecko-med/id6737719743?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/63/4c/14/634c143e-7e6b-4afb-9748-0816af5d4544/apple-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Galactic Cards - Infinite Game` to the Wall of Apps

## Entry

- App ID: 6739960236
- App: Galactic Cards - Infinite Game
- Link: https://apps.apple.com/us/app/galactic-cards-infinite-game/id6739960236?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Galactic Cards - Infinite Game to the app directory with its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->