### PR TITLE
apps wall: add Checkify: #1 AI Bill Splitter

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -145,6 +145,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/02/3d/6e/023d6ea0-1a98-d132-613c-d01b115d2e0d/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Checkify: #1 AI Bill Splitter",
+    "link": "https://apps.apple.com/us/app/checkify-1-ai-bill-splitter/id6755905554?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fe/da/29/feda29cd-84dc-ad22-66f4-a276004811fc/appicon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Clip Jar",
     "link": "https://apps.apple.com/us/app/clip-jar/id1628120600?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/51/13/d7/5113d707-1dce-2010-2488-db621e84ae42/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Checkify: #1 AI Bill Splitter` to the Wall of Apps

## Entry

- App ID: 6755905554
- App: Checkify: #1 AI Bill Splitter
- Link: https://apps.apple.com/us/app/checkify-1-ai-bill-splitter/id6755905554?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Checkify: #1 AI Bill Splitter app to the available apps listing with its corresponding App Store URL and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->