### PR TITLE
apps wall: add Slop Or Not - AI Fake Detector

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1037,6 +1037,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/98/db/d6/98dbd62d-1923-b384-c9fe-7233fcf3e8e7/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Slop Or Not - AI Fake Detector",
+    "link": "https://apps.apple.com/us/app/slop-or-not-ai-fake-detector/id6744578596?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fb/f9/05/fbf9052f-756b-1660-e575-62e7a85d73b7/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Smart Music Stations: Wavyy",
     "link": "https://apps.apple.com/us/app/smart-music-stations-wavyy/id6458877273?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5a/c6/8d/5ac68df8-3d3f-4bf4-984c-06554678468d/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Slop Or Not - AI Fake Detector` to the Wall of Apps

## Entry

- App ID: 6744578596
- App: Slop Or Not - AI Fake Detector
- Link: https://apps.apple.com/us/app/slop-or-not-ai-fake-detector/id6744578596?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new application to the directory: 'Slop Or Not - AI Fake Detector' with its corresponding App Store link and thumbnail icon for user access and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->