### PR TITLE
apps wall: add Clean Links: URL Privacy

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -150,6 +150,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fe/da/29/feda29cd-84dc-ad22-66f4-a276004811fc/appicon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Clean Links: URL Privacy",
+    "link": "https://apps.apple.com/us/app/clean-links-url-privacy/id6747395062?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/06/bd/0d/06bd0de6-4342-ed6d-357d-6178b1ebce6c/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Clip Jar",
     "link": "https://apps.apple.com/us/app/clip-jar/id1628120600?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/51/13/d7/5113d707-1dce-2010-2488-db621e84ae42/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Clean Links: URL Privacy` to the Wall of Apps

## Entry

- App ID: 6747395062
- App: Clean Links: URL Privacy
- Link: https://apps.apple.com/us/app/clean-links-url-privacy/id6747395062?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new app entry for "Clean Links: URL Privacy" to the registry, including its store link and icon. This is a single-record addition; no existing entries or fields were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->