### PR TITLE
apps wall: add Fasting Works: IF & Meal Log

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -339,6 +339,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/71/89/797189ca-6bde-e2e0-9e24-99bd6593b928/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"
   },
   {
+    "app": "Fasting Works: IF & Meal Log",
+    "link": "https://apps.apple.com/us/app/fasting-works-if-meal-log/id6757606218?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/56/72/22/567222b9-40dd-cca2-1a58-01a46cfaa2d9/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Fermento Fermentation Journal",
     "link": "https://apps.apple.com/us/app/fermento-fermentation-journal/id6470132496?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e4/e3/59/e4e3593b-0e71-922d-2313-b31c35cde061/AppIcon-0-0-1x_U007epad-0-1-85-220.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Fasting Works: IF & Meal Log` to the Wall of Apps

## Entry

- App ID: 6757606218
- App: Fasting Works: IF & Meal Log
- Link: https://apps.apple.com/us/app/fasting-works-if-meal-log/id6757606218?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Fasting Works: IF & Meal Log" app to the directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->