### PR TITLE
apps wall: add Harvest - One-Tap Summary

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -463,6 +463,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ea/cd/e9/eacde9d6-4e33-e631-55fc-05aa961523a5/AppIcon-0-0-1x_U007ephone-0-0-0-1-0-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Harvest - One-Tap Summary",
+    "link": "https://apps.apple.com/us/app/harvest-one-tap-summary/id6738302076?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0c/16/4e/0c164e6e-0b93-c0b3-314e-4b6b9742f282/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Haven: Setup Codes",
     "link": "https://apps.apple.com/us/app/haven-setup-codes/id6760440926?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/72/e6/1f/72e61fe0-7f0e-bb59-732d-c89ed669ed59/Haven-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Harvest - One-Tap Summary` to the Wall of Apps

## Entry

- App ID: 6738302076
- App: Harvest - One-Tap Summary
- Link: https://apps.apple.com/us/app/harvest-one-tap-summary/id6738302076?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "Harvest - One-Tap Summary" app to the app directory so it now appears in the apps listing with its link and icon, making it discoverable from the wall-of-apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->