### PR TITLE
Add --reuse-existing to analytics request

### DIFF
--- a/guides/analytics-reports.mdx
+++ b/guides/analytics-reports.mdx
@@ -76,12 +76,13 @@ Request custom analytics reports for detailed app metrics.
 
 <Steps>
   <Step title="Request analytics report">
-    Ensure ongoing analytics access exists without creating duplicate requests:
+    Request ongoing analytics access and reuse an existing active request when possible:
 
     ```bash  theme={null}
-    asc analytics requests ensure \
+    asc analytics request \
       --app "YOUR_APP_ID" \
-      --access-type ONGOING
+      --access-type ONGOING \
+      --reuse-existing
     ```
 
     Or create a request directly:
@@ -226,9 +227,9 @@ if [ $(date +%u) -eq 1 ]; then
     --output "$REPORT_DIR/weekly-sales.txt"
 fi
 
-# 3. Ensure analytics access exists
-echo "Ensuring analytics request..."
-REQUEST=$(asc analytics requests ensure --app "$ASC_APP_ID" --access-type ONGOING --output json)
+# 3. Request analytics access, reusing an active request when possible
+echo "Requesting analytics access..."
+REQUEST=$(asc analytics request --app "$ASC_APP_ID" --access-type ONGOING --reuse-existing --output json)
 REQUEST_ID=$(echo "$REQUEST" | jq -r '.requestId')
 
 # 4. Download available analytics instances

--- a/guides/analytics-reports.mdx
+++ b/guides/analytics-reports.mdx
@@ -76,7 +76,15 @@ Request custom analytics reports for detailed app metrics.
 
 <Steps>
   <Step title="Request analytics report">
-    Create a request for ongoing analytics access:
+    Ensure ongoing analytics access exists without creating duplicate requests:
+
+    ```bash  theme={null}
+    asc analytics requests ensure \
+      --app "YOUR_APP_ID" \
+      --access-type ONGOING
+    ```
+
+    Or create a request directly:
 
     ```bash  theme={null}
     asc analytics request \
@@ -218,18 +226,13 @@ if [ $(date +%u) -eq 1 ]; then
     --output "$REPORT_DIR/weekly-sales.txt"
 fi
 
-# 3. Request analytics if not already requested
-echo "Checking for analytics request..."
-REQUESTS=$(asc analytics requests --app "$ASC_APP_ID" --output json)
-
-if [ "$(echo $REQUESTS | jq '.data | length')" -eq 0 ]; then
-  echo "Creating analytics request..."
-  asc analytics request --app "$ASC_APP_ID" --access-type ONGOING
-fi
+# 3. Ensure analytics access exists
+echo "Ensuring analytics request..."
+REQUEST=$(asc analytics requests ensure --app "$ASC_APP_ID" --access-type ONGOING --output json)
+REQUEST_ID=$(echo "$REQUEST" | jq -r '.requestId')
 
 # 4. Download available analytics instances
-REQUEST_ID=$(echo $REQUESTS | jq -r '.data[0].id')
-if [ -n "$REQUEST_ID" ]; then
+if [ -n "$REQUEST_ID" ] && [ "$REQUEST_ID" != "null" ]; then
   echo "Downloading analytics instances..."
   REPORTS=$(asc analytics view --request-id "$REQUEST_ID" --output json)
   

--- a/internal/asc/analytics_output.go
+++ b/internal/asc/analytics_output.go
@@ -26,6 +26,16 @@ type AnalyticsReportRequestResult struct {
 	CreatedDate string `json:"createdDate,omitempty"`
 }
 
+// AnalyticsReportRequestEnsureResult represents CLI output for idempotent request creation.
+type AnalyticsReportRequestEnsureResult struct {
+	RequestID   string `json:"requestId"`
+	AppID       string `json:"appId"`
+	AccessType  string `json:"accessType"`
+	State       string `json:"state,omitempty"`
+	CreatedDate string `json:"createdDate,omitempty"`
+	Created     bool   `json:"created"`
+}
+
 // AnalyticsReportRequestDeleteResult represents CLI output for deleted requests.
 type AnalyticsReportRequestDeleteResult struct {
 	RequestID string `json:"requestId"`
@@ -100,6 +110,19 @@ func salesReportResultRows(result *SalesReportResult) ([]string, [][]string) {
 func analyticsReportRequestResultRows(result *AnalyticsReportRequestResult) ([]string, [][]string) {
 	headers := []string{"Request ID", "App ID", "Access Type", "State", "Created Date"}
 	rows := [][]string{{result.RequestID, result.AppID, result.AccessType, result.State, result.CreatedDate}}
+	return headers, rows
+}
+
+func analyticsReportRequestEnsureResultRows(result *AnalyticsReportRequestEnsureResult) ([]string, [][]string) {
+	headers := []string{"Request ID", "App ID", "Access Type", "State", "Created Date", "Created"}
+	rows := [][]string{{
+		result.RequestID,
+		result.AppID,
+		result.AccessType,
+		result.State,
+		result.CreatedDate,
+		fmt.Sprintf("%t", result.Created),
+	}}
 	return headers, rows
 }
 

--- a/internal/asc/analytics_output.go
+++ b/internal/asc/analytics_output.go
@@ -26,8 +26,8 @@ type AnalyticsReportRequestResult struct {
 	CreatedDate string `json:"createdDate,omitempty"`
 }
 
-// AnalyticsReportRequestEnsureResult represents CLI output for idempotent request creation.
-type AnalyticsReportRequestEnsureResult struct {
+// AnalyticsReportRequestReuseResult represents CLI output for reused or created requests.
+type AnalyticsReportRequestReuseResult struct {
 	RequestID   string `json:"requestId"`
 	AppID       string `json:"appId"`
 	AccessType  string `json:"accessType"`
@@ -113,7 +113,7 @@ func analyticsReportRequestResultRows(result *AnalyticsReportRequestResult) ([]s
 	return headers, rows
 }
 
-func analyticsReportRequestEnsureResultRows(result *AnalyticsReportRequestEnsureResult) ([]string, [][]string) {
+func analyticsReportRequestReuseResultRows(result *AnalyticsReportRequestReuseResult) ([]string, [][]string) {
 	headers := []string{"Request ID", "App ID", "Access Type", "State", "Created Date", "Created"}
 	rows := [][]string{{
 		result.RequestID,

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -301,7 +301,7 @@ func init() {
 	registerRows(financeReportResultRows)
 	registerRows(financeRegionsRows)
 	registerRows(analyticsReportRequestResultRows)
-	registerRows(analyticsReportRequestEnsureResultRows)
+	registerRows(analyticsReportRequestReuseResultRows)
 	registerRows(analyticsReportRequestDeleteResultRows)
 	registerRowsWithSingleToListAdapter[AnalyticsReportRequestResponse, AnalyticsReportRequestsResponse](analyticsReportRequestsRows)
 	registerRows(analyticsReportDownloadResultRows)

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -301,6 +301,7 @@ func init() {
 	registerRows(financeReportResultRows)
 	registerRows(financeRegionsRows)
 	registerRows(analyticsReportRequestResultRows)
+	registerRows(analyticsReportRequestEnsureResultRows)
 	registerRows(analyticsReportRequestDeleteResultRows)
 	registerRowsWithSingleToListAdapter[AnalyticsReportRequestResponse, AnalyticsReportRequestsResponse](analyticsReportRequestsRows)
 	registerRows(analyticsReportDownloadResultRows)

--- a/internal/cli/analytics/analytics.go
+++ b/internal/cli/analytics/analytics.go
@@ -21,8 +21,8 @@ func AnalyticsCommand() *ffcli.Command {
 Examples:
   asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency DAILY --date "2024-01-20"
   asc analytics request --app "APP_ID" --access-type ONGOING
+  asc analytics request --app "APP_ID" --access-type ONGOING --reuse-existing
   asc analytics requests --app "APP_ID"
-  asc analytics requests ensure --app "APP_ID" --access-type ONGOING
   asc analytics get --request-id "REQUEST_ID"
   asc analytics reports get --report-id "REPORT_ID"
   asc analytics instances links --instance-id "INSTANCE_ID"

--- a/internal/cli/analytics/analytics.go
+++ b/internal/cli/analytics/analytics.go
@@ -22,6 +22,7 @@ Examples:
   asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency DAILY --date "2024-01-20"
   asc analytics request --app "APP_ID" --access-type ONGOING
   asc analytics requests --app "APP_ID"
+  asc analytics requests ensure --app "APP_ID" --access-type ONGOING
   asc analytics get --request-id "REQUEST_ID"
   asc analytics reports get --report-id "REPORT_ID"
   asc analytics instances links --instance-id "INSTANCE_ID"

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -101,6 +101,7 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			AnalyticsRequestsEnsureCommand(),
 			AnalyticsRequestsDeleteCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -186,6 +187,120 @@ Examples:
 
 			return shared.PrintOutput(response, *output.Output, *output.Pretty)
 		},
+	}
+}
+
+// AnalyticsRequestsEnsureCommand creates an analytics report request only when one does not already exist.
+func AnalyticsRequestsEnsureCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ensure", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	accessType := fs.String("access-type", "", "Access type to ensure: ONGOING or ONE_TIME_SNAPSHOT")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "ensure",
+		ShortUsage: "asc analytics requests ensure --app \"APP_ID\" --access-type ONGOING",
+		ShortHelp:  "Ensure an analytics report request exists.",
+		LongHelp: `Ensure an analytics report request exists for an app.
+
+The command first lists existing analytics report requests for the app. If it
+finds an active request with the requested access type, it returns that request
+with created=false. Otherwise, it creates a new request and returns it with
+created=true.
+
+Examples:
+  asc analytics requests ensure --app "123456789" --access-type ONGOING
+  asc analytics requests ensure --app "123456789" --access-type ONGOING --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return flag.ErrHelp
+			}
+
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+			if strings.TrimSpace(*accessType) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --access-type is required")
+				return flag.ErrHelp
+			}
+			normalizedAccessType, err := normalizeAnalyticsAccessType(*accessType)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("analytics requests ensure: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			result, err := ensureAnalyticsReportRequest(requestCtx, client, resolvedAppID, normalizedAccessType)
+			if err != nil {
+				return fmt.Errorf("analytics requests ensure: %w", err)
+			}
+
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func ensureAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID string, accessType asc.AnalyticsAccessType) (*asc.AnalyticsReportRequestEnsureResult, error) {
+	existing, err := client.GetAnalyticsReportRequests(ctx, appID, asc.WithAnalyticsReportRequestsLimit(200))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list requests: %w", err)
+	}
+
+	paginated, err := asc.PaginateAll(ctx, existing, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetAnalyticsReportRequests(ctx, appID, asc.WithAnalyticsReportRequestsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	requests, ok := paginated.(*asc.AnalyticsReportRequestsResponse)
+	if !ok || requests == nil {
+		requests = existing
+	}
+
+	for _, request := range requests.Data {
+		if analyticsReportRequestMatches(request, accessType) {
+			return analyticsReportRequestEnsureResult(appID, request, false), nil
+		}
+	}
+
+	created, err := client.CreateAnalyticsReportRequest(ctx, appID, accessType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return analyticsReportRequestEnsureResult(appID, created.Data, true), nil
+}
+
+func analyticsReportRequestMatches(request asc.AnalyticsReportRequestResource, accessType asc.AnalyticsAccessType) bool {
+	if request.Attributes.AccessType != accessType {
+		return false
+	}
+	if request.Attributes.State == asc.AnalyticsReportRequestStateFailed {
+		return false
+	}
+	return request.Attributes.StoppedDueToInactivity == nil || !*request.Attributes.StoppedDueToInactivity
+}
+
+func analyticsReportRequestEnsureResult(appID string, request asc.AnalyticsReportRequestResource, created bool) *asc.AnalyticsReportRequestEnsureResult {
+	return &asc.AnalyticsReportRequestEnsureResult{
+		RequestID:   request.ID,
+		AppID:       appID,
+		AccessType:  string(request.Attributes.AccessType),
+		State:       string(request.Attributes.State),
+		CreatedDate: request.Attributes.CreatedDate,
+		Created:     created,
 	}
 }
 

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -264,9 +264,12 @@ func ensureAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID
 		return nil, err
 	}
 
+	if paginated == nil {
+		return nil, fmt.Errorf("failed to list requests: empty paginated response")
+	}
 	requests, ok := paginated.(*asc.AnalyticsReportRequestsResponse)
 	if !ok || requests == nil {
-		requests = existing
+		return nil, fmt.Errorf("failed to list requests: unexpected paginated response type %T", paginated)
 	}
 
 	for _, request := range requests.Data {

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -2,8 +2,10 @@ package analytics
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -201,6 +203,36 @@ Examples:
 }
 
 func createOrReuseAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID string, accessType asc.AnalyticsAccessType) (*asc.AnalyticsReportRequestReuseResult, error) {
+	requests, err := listAnalyticsReportRequestsForReuse(ctx, client, appID)
+	if err != nil {
+		return nil, err
+	}
+
+	if request, ok := findReusableAnalyticsReportRequest(requests, accessType); ok {
+		return analyticsReportRequestReuseResult(appID, request, false), nil
+	}
+
+	created, err := client.CreateAnalyticsReportRequest(ctx, appID, accessType)
+	if err != nil {
+		if !isAnalyticsReportRequestCreateConflict(err) {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		requests, listErr := listAnalyticsReportRequestsForReuse(ctx, client, appID)
+		if listErr != nil {
+			return nil, listErr
+		}
+		if request, ok := findReusableAnalyticsReportRequest(requests, accessType); ok {
+			return analyticsReportRequestReuseResult(appID, request, false), nil
+		}
+
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return analyticsReportRequestReuseResult(appID, created.Data, true), nil
+}
+
+func listAnalyticsReportRequestsForReuse(ctx context.Context, client *asc.Client, appID string) (*asc.AnalyticsReportRequestsResponse, error) {
 	existing, err := client.GetAnalyticsReportRequests(ctx, appID, asc.WithAnalyticsReportRequestsLimit(200))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list requests: %w", err)
@@ -221,18 +253,25 @@ func createOrReuseAnalyticsReportRequest(ctx context.Context, client *asc.Client
 		return nil, fmt.Errorf("failed to list requests: unexpected paginated response type %T", paginated)
 	}
 
+	return requests, nil
+}
+
+func findReusableAnalyticsReportRequest(requests *asc.AnalyticsReportRequestsResponse, accessType asc.AnalyticsAccessType) (asc.AnalyticsReportRequestResource, bool) {
+	if requests == nil {
+		return asc.AnalyticsReportRequestResource{}, false
+	}
 	for _, request := range requests.Data {
 		if analyticsReportRequestMatches(request, accessType) {
-			return analyticsReportRequestReuseResult(appID, request, false), nil
+			return request, true
 		}
 	}
 
-	created, err := client.CreateAnalyticsReportRequest(ctx, appID, accessType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
+	return asc.AnalyticsReportRequestResource{}, false
+}
 
-	return analyticsReportRequestReuseResult(appID, created.Data, true), nil
+func isAnalyticsReportRequestCreateConflict(err error) bool {
+	var apiErr *asc.APIError
+	return errors.As(err, &apiErr) && apiErr != nil && apiErr.StatusCode == http.StatusConflict
 }
 
 func analyticsReportRequestMatches(request asc.AnalyticsReportRequestResource, accessType asc.AnalyticsAccessType) bool {

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -19,6 +19,7 @@ func AnalyticsRequestCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	accessType := fs.String("access-type", "", "Access type: ONGOING or ONE_TIME_SNAPSHOT")
+	reuseExisting := fs.Bool("reuse-existing", false, "Return an existing active request with the same access type instead of creating a duplicate")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -29,6 +30,7 @@ func AnalyticsRequestCommand() *ffcli.Command {
 
 Examples:
   asc analytics request --app "123456789" --access-type ONGOING
+  asc analytics request --app "123456789" --access-type ONGOING --reuse-existing
   asc analytics request --app "123456789" --access-type ONE_TIME_SNAPSHOT`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -44,7 +46,7 @@ Examples:
 			}
 			normalizedAccessType, err := normalizeAnalyticsAccessType(*accessType)
 			if err != nil {
-				return fmt.Errorf("analytics request: %w", err)
+				return shared.UsageError(err.Error())
 			}
 
 			client, err := shared.GetASCClient()
@@ -54,6 +56,15 @@ Examples:
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
+
+			if *reuseExisting {
+				result, err := createOrReuseAnalyticsReportRequest(requestCtx, client, resolvedAppID, normalizedAccessType)
+				if err != nil {
+					return fmt.Errorf("analytics request: %w", err)
+				}
+
+				return shared.PrintOutput(result, *output.Output, *output.Pretty)
+			}
 
 			response, err := client.CreateAnalyticsReportRequest(requestCtx, resolvedAppID, normalizedAccessType)
 			if err != nil {
@@ -101,7 +112,6 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
-			AnalyticsRequestsEnsureCommand(),
 			AnalyticsRequestsDeleteCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -190,68 +200,7 @@ Examples:
 	}
 }
 
-// AnalyticsRequestsEnsureCommand creates an analytics report request only when one does not already exist.
-func AnalyticsRequestsEnsureCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("ensure", flag.ExitOnError)
-
-	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	accessType := fs.String("access-type", "", "Access type to ensure: ONGOING or ONE_TIME_SNAPSHOT")
-	output := shared.BindOutputFlags(fs)
-
-	return &ffcli.Command{
-		Name:       "ensure",
-		ShortUsage: "asc analytics requests ensure --app \"APP_ID\" --access-type ONGOING",
-		ShortHelp:  "Ensure an analytics report request exists.",
-		LongHelp: `Ensure an analytics report request exists for an app.
-
-The command first lists existing analytics report requests for the app. If it
-finds an active request with the requested access type, it returns that request
-with created=false. Otherwise, it creates a new request and returns it with
-created=true.
-
-Examples:
-  asc analytics requests ensure --app "123456789" --access-type ONGOING
-  asc analytics requests ensure --app "123456789" --access-type ONGOING --output json`,
-		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
-		Exec: func(ctx context.Context, args []string) error {
-			if len(args) > 0 {
-				return flag.ErrHelp
-			}
-
-			resolvedAppID := shared.ResolveAppID(*appID)
-			if resolvedAppID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
-			}
-			if strings.TrimSpace(*accessType) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --access-type is required")
-				return flag.ErrHelp
-			}
-			normalizedAccessType, err := normalizeAnalyticsAccessType(*accessType)
-			if err != nil {
-				return shared.UsageError(err.Error())
-			}
-
-			client, err := shared.GetASCClient()
-			if err != nil {
-				return fmt.Errorf("analytics requests ensure: %w", err)
-			}
-
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
-			result, err := ensureAnalyticsReportRequest(requestCtx, client, resolvedAppID, normalizedAccessType)
-			if err != nil {
-				return fmt.Errorf("analytics requests ensure: %w", err)
-			}
-
-			return shared.PrintOutput(result, *output.Output, *output.Pretty)
-		},
-	}
-}
-
-func ensureAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID string, accessType asc.AnalyticsAccessType) (*asc.AnalyticsReportRequestEnsureResult, error) {
+func createOrReuseAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID string, accessType asc.AnalyticsAccessType) (*asc.AnalyticsReportRequestReuseResult, error) {
 	existing, err := client.GetAnalyticsReportRequests(ctx, appID, asc.WithAnalyticsReportRequestsLimit(200))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list requests: %w", err)
@@ -274,7 +223,7 @@ func ensureAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID
 
 	for _, request := range requests.Data {
 		if analyticsReportRequestMatches(request, accessType) {
-			return analyticsReportRequestEnsureResult(appID, request, false), nil
+			return analyticsReportRequestReuseResult(appID, request, false), nil
 		}
 	}
 
@@ -283,7 +232,7 @@ func ensureAnalyticsReportRequest(ctx context.Context, client *asc.Client, appID
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	return analyticsReportRequestEnsureResult(appID, created.Data, true), nil
+	return analyticsReportRequestReuseResult(appID, created.Data, true), nil
 }
 
 func analyticsReportRequestMatches(request asc.AnalyticsReportRequestResource, accessType asc.AnalyticsAccessType) bool {
@@ -296,8 +245,8 @@ func analyticsReportRequestMatches(request asc.AnalyticsReportRequestResource, a
 	return request.Attributes.StoppedDueToInactivity == nil || !*request.Attributes.StoppedDueToInactivity
 }
 
-func analyticsReportRequestEnsureResult(appID string, request asc.AnalyticsReportRequestResource, created bool) *asc.AnalyticsReportRequestEnsureResult {
-	return &asc.AnalyticsReportRequestEnsureResult{
+func analyticsReportRequestReuseResult(appID string, request asc.AnalyticsReportRequestResource, created bool) *asc.AnalyticsReportRequestReuseResult {
+	return &asc.AnalyticsReportRequestReuseResult{
 		RequestID:   request.ID,
 		AppID:       appID,
 		AccessType:  string(request.Attributes.AccessType),

--- a/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
+++ b/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
@@ -12,16 +12,17 @@ import (
 	"testing"
 )
 
-func TestAnalyticsRequestsEnsureRejectsInvalidAccessType(t *testing.T) {
+func TestAnalyticsRequestReuseExistingRejectsInvalidAccessType(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"analytics", "requests", "ensure",
+			"analytics", "request",
 			"--app", "app-1",
 			"--access-type", "DAILY",
+			"--reuse-existing",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -42,7 +43,7 @@ func TestAnalyticsRequestsEnsureRejectsInvalidAccessType(t *testing.T) {
 	}
 }
 
-func TestAnalyticsRequestsEnsureUsesExistingRequest(t *testing.T) {
+func TestAnalyticsRequestReuseExistingUsesExistingRequest(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -66,7 +67,7 @@ func TestAnalyticsRequestsEnsureUsesExistingRequest(t *testing.T) {
 			`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}},` +
 			`{"type":"analyticsReportRequests","id":"req-existing","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
 			`],"links":{"next":""}}`
-		return analyticsEnsureJSONResponse(http.StatusOK, body), nil
+		return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 	}))
 
 	root := RootCommand("1.2.3")
@@ -74,9 +75,10 @@ func TestAnalyticsRequestsEnsureUsesExistingRequest(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"analytics", "requests", "ensure",
+			"analytics", "request",
 			"--app", "app-1",
 			"--access-type", "ONGOING",
+			"--reuse-existing",
 			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -101,7 +103,7 @@ func TestAnalyticsRequestsEnsureUsesExistingRequest(t *testing.T) {
 	}
 }
 
-func TestAnalyticsRequestsEnsureUsesExistingRequestFromLaterPage(t *testing.T) {
+func TestAnalyticsRequestReuseExistingUsesExistingRequestFromLaterPage(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -118,7 +120,7 @@ func TestAnalyticsRequestsEnsureUsesExistingRequestFromLaterPage(t *testing.T) {
 			body := `{"data":[` +
 				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}}` +
 				`],"links":{"next":"/v1/apps/app-1/analyticsReportRequests?cursor=2"}}`
-			return analyticsEnsureJSONResponse(http.StatusOK, body), nil
+			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		case 2:
 			if req.Method != http.MethodGet {
 				t.Fatalf("expected second request GET, got %s", req.Method)
@@ -132,7 +134,7 @@ func TestAnalyticsRequestsEnsureUsesExistingRequestFromLaterPage(t *testing.T) {
 			body := `{"data":[` +
 				`{"type":"analyticsReportRequests","id":"req-existing-page-2","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
 				`],"links":{"next":""}}`
-			return analyticsEnsureJSONResponse(http.StatusOK, body), nil
+			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		default:
 			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
 			return nil, nil
@@ -144,9 +146,10 @@ func TestAnalyticsRequestsEnsureUsesExistingRequestFromLaterPage(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"analytics", "requests", "ensure",
+			"analytics", "request",
 			"--app", "app-1",
 			"--access-type", "ONGOING",
+			"--reuse-existing",
 			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -171,7 +174,7 @@ func TestAnalyticsRequestsEnsureUsesExistingRequestFromLaterPage(t *testing.T) {
 	}
 }
 
-func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
+func TestAnalyticsRequestReuseExistingUsesExistingRequestFromFirstPageWithMultiplePages(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -185,7 +188,78 @@ func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
 			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
 				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
 			}
-			return analyticsEnsureJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+			body := `{"data":[` +
+				`{"type":"analyticsReportRequests","id":"req-existing-page-1","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
+				`],"links":{"next":"/v1/apps/app-1/analyticsReportRequests?cursor=2"}}`
+			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected second request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			if req.URL.Query().Get("cursor") != "2" {
+				t.Fatalf("expected cursor=2, got %q", req.URL.Query().Get("cursor"))
+			}
+			body := `{"data":[` +
+				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}}` +
+				`],"links":{"next":""}}`
+			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "request",
+			"--app", "app-1",
+			"--access-type", "ONGOING",
+			"--reuse-existing",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result["requestId"] != "req-existing-page-1" {
+		t.Fatalf("expected existing request id from first page, got %#v", result["requestId"])
+	}
+	if result["created"] != false {
+		t.Fatalf("expected created=false, got %#v", result["created"])
+	}
+}
+
+func TestAnalyticsRequestReuseExistingCreatesMissingRequest(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var requestCount lockedCounter
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch count := requestCount.Inc(); count {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected first request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			return analyticsReuseExistingJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
 		case 2:
 			if req.Method != http.MethodPost {
 				t.Fatalf("expected second request POST, got %s", req.Method)
@@ -202,7 +276,7 @@ func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
 				t.Fatalf("unexpected create payload: %s", body)
 			}
 			response := `{"data":{"type":"analyticsReportRequests","id":"req-created","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-02T00:00:00Z"}}}`
-			return analyticsEnsureJSONResponse(http.StatusCreated, response), nil
+			return analyticsReuseExistingJSONResponse(http.StatusCreated, response), nil
 		default:
 			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
 			return nil, nil
@@ -214,9 +288,10 @@ func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"analytics", "requests", "ensure",
+			"analytics", "request",
 			"--app", "app-1",
 			"--access-type", "ONGOING",
+			"--reuse-existing",
 			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -241,7 +316,7 @@ func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
 	}
 }
 
-func analyticsEnsureJSONResponse(status int, body string) *http.Response {
+func analyticsReuseExistingJSONResponse(status int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(body)),

--- a/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
+++ b/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
@@ -1,12 +1,14 @@
 package cmdtest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"io"
 	"net/http"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,6 +42,60 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidAccessType(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "--access-type must be ONGOING or ONE_TIME_SNAPSHOT") {
 		t.Fatalf("expected invalid access type error, got %q", stderr)
+	}
+}
+
+func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "invalid bool",
+			args: []string{
+				"analytics", "request",
+				"--app", "app-1",
+				"--access-type", "ONGOING",
+				"--reuse-existing=maybe",
+			},
+		},
+		{
+			name: "invalid bool mixed flag order",
+			args: []string{
+				"analytics", "request",
+				"--access-type=ONGOING",
+				"--reuse-existing=maybe",
+				"--app", "app-1",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, test.args...)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected process exit error, got %v", err)
+			}
+			if exitErr.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
+			}
+			if stdout.String() != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), `invalid boolean value "maybe" for -reuse-existing`) {
+				t.Fatalf("expected invalid bool error, got %q", stderr.String())
+			}
+		})
 	}
 }
 
@@ -313,6 +369,80 @@ func TestAnalyticsRequestReuseExistingCreatesMissingRequest(t *testing.T) {
 	}
 	if result["created"] != true {
 		t.Fatalf("expected created=true, got %#v", result["created"])
+	}
+}
+
+func TestAnalyticsRequestReuseExistingRefetchesAfterCreateConflict(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var requestCount lockedCounter
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch count := requestCount.Inc(); count {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected first request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			return analyticsReuseExistingJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected second request POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/analyticsReportRequests" {
+				t.Fatalf("expected create path, got %s", req.URL.Path)
+			}
+			body := `{"errors":[{"status":"409","code":"ENTITY_ERROR","title":"Conflict","detail":"duplicate request"}]}`
+			return analyticsReuseExistingJSONResponse(http.StatusConflict, body), nil
+		case 3:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected third request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			body := `{"data":[` +
+				`{"type":"analyticsReportRequests","id":"req-created-by-race","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-03T00:00:00Z"}}` +
+				`],"links":{"next":""}}`
+			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "request",
+			"--app", "app-1",
+			"--access-type", "ONGOING",
+			"--reuse-existing",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result["requestId"] != "req-created-by-race" {
+		t.Fatalf("expected raced request id, got %#v", result["requestId"])
+	}
+	if result["created"] != false {
+		t.Fatalf("expected created=false, got %#v", result["created"])
 	}
 }
 

--- a/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
+++ b/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
@@ -49,8 +49,9 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
 	binaryPath := buildASCBlackBoxBinary(t)
 
 	tests := []struct {
-		name string
-		args []string
+		name    string
+		args    []string
+		wantErr string
 	}{
 		{
 			name: "invalid bool",
@@ -60,6 +61,7 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
 				"--access-type", "ONGOING",
 				"--reuse-existing=maybe",
 			},
+			wantErr: `invalid boolean value "maybe" for -reuse-existing`,
 		},
 		{
 			name: "invalid bool mixed flag order",
@@ -69,6 +71,17 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
 				"--reuse-existing=maybe",
 				"--app", "app-1",
 			},
+			wantErr: `invalid boolean value "maybe" for -reuse-existing`,
+		},
+		{
+			name: "invalid bool before subcommand",
+			args: []string{
+				"--reuse-existing=maybe",
+				"analytics", "request",
+				"--app", "app-1",
+				"--access-type", "ONGOING",
+			},
+			wantErr: "flag provided but not defined: -reuse-existing",
 		},
 	}
 
@@ -92,7 +105,7 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
 			if stdout.String() != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout.String())
 			}
-			if !strings.Contains(stderr.String(), `invalid boolean value "maybe" for -reuse-existing`) {
+			if !strings.Contains(stderr.String(), test.wantErr) {
 				t.Fatalf("expected invalid bool error, got %q", stderr.String())
 			}
 		})
@@ -327,9 +340,25 @@ func TestAnalyticsRequestReuseExistingCreatesMissingRequest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read request body: %v", err)
 			}
-			body := string(bodyBytes)
-			if !strings.Contains(body, `"accessType":"ONGOING"`) || !strings.Contains(body, `"id":"app-1"`) {
-				t.Fatalf("unexpected create payload: %s", body)
+			var payload struct {
+				Data struct {
+					Attributes struct {
+						AccessType string `json:"accessType"`
+					} `json:"attributes"`
+					Relationships struct {
+						App struct {
+							Data struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"app"`
+					} `json:"relationships"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+				t.Fatalf("failed to parse create payload: %v", err)
+			}
+			if payload.Data.Attributes.AccessType != "ONGOING" || payload.Data.Relationships.App.Data.ID != "app-1" {
+				t.Fatalf("unexpected create payload: %#v", payload)
 			}
 			response := `{"data":{"type":"analyticsReportRequests","id":"req-created","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-02T00:00:00Z"}}}`
 			return analyticsReuseExistingJSONResponse(http.StatusCreated, response), nil

--- a/internal/cli/cmdtest/analytics_requests_ensure_test.go
+++ b/internal/cli/cmdtest/analytics_requests_ensure_test.go
@@ -1,0 +1,180 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAnalyticsRequestsEnsureRejectsInvalidAccessType(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "requests", "ensure",
+			"--app", "app-1",
+			"--access-type", "DAILY",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--access-type must be ONGOING or ONE_TIME_SNAPSHOT") {
+		t.Fatalf("expected invalid access type error, got %q", stderr)
+	}
+}
+
+func TestAnalyticsRequestsEnsureUsesExistingRequest(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var requestCount lockedCounter
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		count := requestCount.Inc()
+		if count != 1 {
+			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
+		}
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+			t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "200" {
+			t.Fatalf("expected limit=200, got %q", req.URL.Query().Get("limit"))
+		}
+
+		body := `{"data":[` +
+			`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}},` +
+			`{"type":"analyticsReportRequests","id":"req-existing","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
+			`],"links":{"next":""}}`
+		return analyticsEnsureJSONResponse(http.StatusOK, body), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "requests", "ensure",
+			"--app", "app-1",
+			"--access-type", "ONGOING",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result["requestId"] != "req-existing" {
+		t.Fatalf("expected existing request id, got %#v", result["requestId"])
+	}
+	if result["created"] != false {
+		t.Fatalf("expected created=false, got %#v", result["created"])
+	}
+}
+
+func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var requestCount lockedCounter
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch count := requestCount.Inc(); count {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected first request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			return analyticsEnsureJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected second request POST, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/analyticsReportRequests" {
+				t.Fatalf("expected create path, got %s", req.URL.Path)
+			}
+			bodyBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("failed to read request body: %v", err)
+			}
+			body := string(bodyBytes)
+			if !strings.Contains(body, `"accessType":"ONGOING"`) || !strings.Contains(body, `"id":"app-1"`) {
+				t.Fatalf("unexpected create payload: %s", body)
+			}
+			response := `{"data":{"type":"analyticsReportRequests","id":"req-created","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-02T00:00:00Z"}}}`
+			return analyticsEnsureJSONResponse(http.StatusCreated, response), nil
+		default:
+			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "requests", "ensure",
+			"--app", "app-1",
+			"--access-type", "ONGOING",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result["requestId"] != "req-created" {
+		t.Fatalf("expected created request id, got %#v", result["requestId"])
+	}
+	if result["created"] != true {
+		t.Fatalf("expected created=true, got %#v", result["created"])
+	}
+}
+
+func analyticsEnsureJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}

--- a/internal/cli/cmdtest/analytics_requests_ensure_test.go
+++ b/internal/cli/cmdtest/analytics_requests_ensure_test.go
@@ -101,6 +101,76 @@ func TestAnalyticsRequestsEnsureUsesExistingRequest(t *testing.T) {
 	}
 }
 
+func TestAnalyticsRequestsEnsureUsesExistingRequestFromLaterPage(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var requestCount lockedCounter
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch count := requestCount.Inc(); count {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected first request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			body := `{"data":[` +
+				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}}` +
+				`],"links":{"next":"/v1/apps/app-1/analyticsReportRequests?cursor=2"}}`
+			return analyticsEnsureJSONResponse(http.StatusOK, body), nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected second request GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-1/analyticsReportRequests" {
+				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
+			}
+			if req.URL.Query().Get("cursor") != "2" {
+				t.Fatalf("expected cursor=2, got %q", req.URL.Query().Get("cursor"))
+			}
+			body := `{"data":[` +
+				`{"type":"analyticsReportRequests","id":"req-existing-page-2","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
+				`],"links":{"next":""}}`
+			return analyticsEnsureJSONResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "requests", "ensure",
+			"--app", "app-1",
+			"--access-type", "ONGOING",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result["requestId"] != "req-existing-page-2" {
+		t.Fatalf("expected existing request id from second page, got %#v", result["requestId"])
+	}
+	if result["created"] != false {
+		t.Fatalf("expected created=false, got %#v", result["created"])
+	}
+}
+
 func TestAnalyticsRequestsEnsureCreatesMissingRequest(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/analytics_test.go
+++ b/internal/cli/cmdtest/analytics_test.go
@@ -50,6 +50,16 @@ func TestAnalyticsValidationErrors(t *testing.T) {
 			args:    []string{"analytics", "requests", "delete", "--request-id", "11111111-1111-1111-1111-111111111111"},
 			wantErr: "--confirm is required",
 		},
+		{
+			name:    "requests ensure missing app",
+			args:    []string{"analytics", "requests", "ensure", "--access-type", "ONGOING"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "requests ensure missing access type",
+			args:    []string{"analytics", "requests", "ensure", "--app", "APP_ID"},
+			wantErr: "--access-type is required",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/analytics_test.go
+++ b/internal/cli/cmdtest/analytics_test.go
@@ -51,19 +51,21 @@ func TestAnalyticsValidationErrors(t *testing.T) {
 			wantErr: "--confirm is required",
 		},
 		{
-			name:    "requests ensure missing app",
-			args:    []string{"analytics", "requests", "ensure", "--access-type", "ONGOING"},
+			name:    "request reuse existing missing app",
+			args:    []string{"analytics", "request", "--access-type", "ONGOING", "--reuse-existing"},
 			wantErr: "--app is required",
 		},
 		{
-			name:    "requests ensure missing access type",
-			args:    []string{"analytics", "requests", "ensure", "--app", "APP_ID"},
+			name:    "request reuse existing missing access type",
+			args:    []string{"analytics", "request", "--app", "APP_ID", "--reuse-existing"},
 			wantErr: "--access-type is required",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_APP_ID", "")
+
 			root := RootCommand("1.2.3")
 			root.FlagSet.SetOutput(io.Discard)
 


### PR DESCRIPTION
## Summary
- add `--reuse-existing` to `asc analytics request` so automation can reuse an existing active request with the same access type before creating a duplicate
- keep plain `asc analytics request` as the direct create path, and return `created` in the reuse path output so callers can tell whether a request was reused
- refetch after a create conflict so concurrent reuse calls can recover from the list-then-create race
- update the analytics guide and command tests for validation, pagination, conflict recovery, and reuse/create behavior

## Validation
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- targeted CLI smoke checks for `analytics request --help`, removed `analytics requests ensure`, and invalid `--access-type` exit code 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --reuse-existing flag to analytics request to reuse active requests and indicate whether a request was created.

* **Documentation**
  * Updated analytics reporting guidance and examples to recommend the reuse flow for ongoing analytics and to show safe handling of empty/null request IDs.

* **Tests**
  * Added extensive tests for reuse behavior: validation, pagination, creation, conflict-retry, and flag parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->