### PR TITLE
Add local app registry pull

### DIFF
--- a/internal/cli/apps/app_registry.go
+++ b/internal/cli/apps/app_registry.go
@@ -86,24 +86,25 @@ func AppsRegistryPullCommand() *ffcli.Command {
 	path := fs.String("path", defaultAppRegistryPath, "Registry JSON path")
 	dryRun := fs.Bool("dry-run", false, "Preview the merged registry without writing it")
 	pruneMissing := fs.Bool("prune-missing", false, "Remove local registry entries not returned by App Store Connect")
+	confirm := fs.Bool("confirm", false, "Confirm pruning local registry entries")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "pull",
-		ShortUsage: "asc apps registry pull [--path PATH] [--dry-run] [--prune-missing] [flags]",
+		ShortUsage: "asc apps registry pull [--path PATH] [--dry-run] [--prune-missing --confirm] [flags]",
 		ShortHelp:  "Pull App Store Connect apps into a local registry.",
 		LongHelp: `Pull App Store Connect apps into a local registry.
 
 The command fetches all apps available to the configured API key, updates ASC
 identity fields, and preserves local-only fields by asc_app_id. By default,
 entries not returned by App Store Connect are kept to avoid accidental data
-loss when using a limited API key. Use --prune-missing to remove them.
+loss when using a limited API key. Use --prune-missing --confirm to remove them.
 
 Examples:
   asc apps registry pull
   asc apps registry pull --dry-run --output json
   asc apps registry pull --path "/Users/me/clawd/config/app_registry.json"
-  asc apps registry pull --path ".asc/app-registry.json" --prune-missing`,
+  asc apps registry pull --path ".asc/app-registry.json" --prune-missing --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -115,6 +116,7 @@ Examples:
 				Path:         *path,
 				DryRun:       *dryRun,
 				PruneMissing: *pruneMissing,
+				Confirm:      *confirm,
 				Output:       *output.Output,
 				Pretty:       *output.Pretty,
 			})
@@ -126,6 +128,7 @@ type appsRegistryPullOptions struct {
 	Path         string
 	DryRun       bool
 	PruneMissing bool
+	Confirm      bool
 	Output       string
 	Pretty       bool
 }
@@ -133,9 +136,16 @@ type appsRegistryPullOptions struct {
 func appsRegistryPull(ctx context.Context, opts appsRegistryPullOptions) error {
 	path := strings.TrimSpace(opts.Path)
 	if path == "" {
-		fmt.Fprintln(os.Stderr, "Error: --path is required")
-		return flag.ErrHelp
+		return shared.UsageError("--path is required")
 	}
+	if opts.PruneMissing && !opts.DryRun && !opts.Confirm {
+		return shared.UsageError("--confirm is required with --prune-missing unless --dry-run is set")
+	}
+	output, err := shared.ValidateOutputFormat(opts.Output, opts.Pretty)
+	if err != nil {
+		return shared.UsageError(err.Error())
+	}
+	opts.Output = output
 
 	existing, err := readAppRegistry(path)
 	if err != nil {

--- a/internal/cli/apps/app_registry.go
+++ b/internal/cli/apps/app_registry.go
@@ -1,0 +1,498 @@
+package apps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const defaultAppRegistryPath = ".asc/app-registry.json"
+
+type appRegistryFile struct {
+	Apps []appRegistryEntry `json:"apps"`
+}
+
+type appRegistryEntry struct {
+	Key           string   `json:"key"`
+	Name          string   `json:"name"`
+	ASCAppID      string   `json:"asc_app_id"`
+	BundleID      string   `json:"bundle_id"`
+	Platform      *string  `json:"platform"`
+	PrimaryLocale string   `json:"primary_locale"`
+	RepoPath      *string  `json:"repo_path"`
+	GA4PropertyID *string  `json:"ga4_property_id"`
+	Aliases       []string `json:"aliases"`
+}
+
+type appRegistrySyncResult struct {
+	Path      string           `json:"path"`
+	DryRun    bool             `json:"dryRun"`
+	Total     int              `json:"total"`
+	Created   int              `json:"created"`
+	Updated   int              `json:"updated"`
+	Unchanged int              `json:"unchanged"`
+	Preserved int              `json:"preserved"`
+	Pruned    int              `json:"pruned"`
+	Registry  *appRegistryFile `json:"registry,omitempty"`
+}
+
+// AppsRegistryCommand returns the local app registry subtree.
+func AppsRegistryCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps registry", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "registry",
+		ShortUsage: "asc apps registry <subcommand> [flags]",
+		ShortHelp:  "Manage a local app registry for agent workflows.",
+		LongHelp: `Manage a local app registry for agent workflows.
+
+The registry mirrors App Store Connect app identity fields and preserves
+local-only automation fields such as repo paths, analytics IDs, aliases, and
+platform hints.
+
+Examples:
+  asc apps registry sync
+  asc apps registry sync --path ".asc/app-registry.json"
+  asc apps registry sync --path "/Users/me/clawd/config/app_registry.json" --dry-run
+  asc apps registry sync --prune-missing`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AppsRegistrySyncCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// AppsRegistrySyncCommand returns the app registry sync subcommand.
+func AppsRegistrySyncCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps registry sync", flag.ExitOnError)
+
+	path := fs.String("path", defaultAppRegistryPath, "Registry JSON path")
+	dryRun := fs.Bool("dry-run", false, "Preview the merged registry without writing it")
+	pruneMissing := fs.Bool("prune-missing", false, "Remove local registry entries not returned by App Store Connect")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "sync",
+		ShortUsage: "asc apps registry sync [--path PATH] [--dry-run] [--prune-missing] [flags]",
+		ShortHelp:  "Sync a local app registry from App Store Connect.",
+		LongHelp: `Sync a local app registry from App Store Connect.
+
+The command fetches all apps available to the configured API key, updates ASC
+identity fields, and preserves local-only fields by asc_app_id. By default,
+entries not returned by App Store Connect are kept to avoid accidental data
+loss when using a limited API key. Use --prune-missing to remove them.
+
+Examples:
+  asc apps registry sync
+  asc apps registry sync --dry-run --output json
+  asc apps registry sync --path "/Users/me/clawd/config/app_registry.json"
+  asc apps registry sync --path ".asc/app-registry.json" --prune-missing`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				fmt.Fprintln(os.Stderr, "Error: apps registry sync does not accept positional arguments")
+				return flag.ErrHelp
+			}
+			return appsRegistrySync(ctx, appsRegistrySyncOptions{
+				Path:         *path,
+				DryRun:       *dryRun,
+				PruneMissing: *pruneMissing,
+				Output:       *output.Output,
+				Pretty:       *output.Pretty,
+			})
+		},
+	}
+}
+
+type appsRegistrySyncOptions struct {
+	Path         string
+	DryRun       bool
+	PruneMissing bool
+	Output       string
+	Pretty       bool
+}
+
+func appsRegistrySync(ctx context.Context, opts appsRegistrySyncOptions) error {
+	path := strings.TrimSpace(opts.Path)
+	if path == "" {
+		fmt.Fprintln(os.Stderr, "Error: --path is required")
+		return flag.ErrHelp
+	}
+
+	existing, err := readAppRegistry(path)
+	if err != nil {
+		return fmt.Errorf("apps registry sync: %w", err)
+	}
+
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("apps registry sync: %w", err)
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+
+	response, err := shared.PaginateWithSpinner(requestCtx,
+		func(ctx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetApps(ctx, asc.WithAppsLimit(200), asc.WithAppsSort("name"))
+		},
+		func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetApps(ctx, asc.WithAppsNextURL(nextURL))
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("apps registry sync: failed to fetch apps: %w", err)
+	}
+
+	appsResponse, ok := response.(*asc.AppsResponse)
+	if !ok {
+		return fmt.Errorf("apps registry sync: unexpected apps response type %T", response)
+	}
+
+	result, registry := mergeAppRegistry(existing, appsResponse.Data, opts.PruneMissing)
+	result.Path = path
+	result.DryRun = opts.DryRun
+	if opts.DryRun {
+		result.Registry = &registry
+	}
+
+	if !opts.DryRun {
+		if err := writeAppRegistry(path, registry); err != nil {
+			return fmt.Errorf("apps registry sync: failed to write registry: %w", err)
+		}
+	}
+
+	return printAppRegistrySyncResult(&result, opts.Output, opts.Pretty)
+}
+
+func readAppRegistry(path string) (appRegistryFile, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return appRegistryFile{}, nil
+	}
+	if err != nil {
+		return appRegistryFile{}, err
+	}
+
+	var registry appRegistryFile
+	if err := json.Unmarshal(data, &registry); err != nil {
+		return appRegistryFile{}, fmt.Errorf("invalid registry JSON %q: %w", path, err)
+	}
+	normalizeRegistryEntries(registry.Apps)
+	return registry, nil
+}
+
+func writeAppRegistry(path string, registry appRegistryFile) error {
+	data, err := json.MarshalIndent(registry, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	hadExisting := false
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink %q", path)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("registry path %q is a directory", path)
+		}
+		hadExisting = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(path), ".app-registry-*.json")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Chmod(0o600); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		if !hadExisting {
+			return err
+		}
+
+		backupFile, backupErr := os.CreateTemp(filepath.Dir(path), ".app-registry-backup-*.json")
+		if backupErr != nil {
+			return err
+		}
+		backupPath := backupFile.Name()
+		if closeErr := backupFile.Close(); closeErr != nil {
+			return closeErr
+		}
+		if removeErr := os.Remove(backupPath); removeErr != nil {
+			return removeErr
+		}
+
+		if moveErr := os.Rename(path, backupPath); moveErr != nil {
+			return moveErr
+		}
+		if moveErr := os.Rename(tempPath, path); moveErr != nil {
+			_ = os.Rename(backupPath, path)
+			return moveErr
+		}
+		_ = os.Remove(backupPath)
+	}
+	success = true
+	return nil
+}
+
+func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.AppAttributes], pruneMissing bool) (appRegistrySyncResult, appRegistryFile) {
+	normalizeRegistryEntries(existing.Apps)
+
+	existingByID := make(map[string]appRegistryEntry, len(existing.Apps))
+	for _, app := range existing.Apps {
+		if strings.TrimSpace(app.ASCAppID) == "" {
+			continue
+		}
+		existingByID[app.ASCAppID] = app
+	}
+
+	sort.Slice(resources, func(i, j int) bool {
+		left := resources[i]
+		right := resources[j]
+		leftName := strings.ToLower(strings.TrimSpace(left.Attributes.Name))
+		rightName := strings.ToLower(strings.TrimSpace(right.Attributes.Name))
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		return left.ID < right.ID
+	})
+
+	usedKeys := make(map[string]struct{}, len(existing.Apps)+len(resources))
+	for _, app := range existing.Apps {
+		if key := strings.TrimSpace(app.Key); key != "" {
+			usedKeys[key] = struct{}{}
+		}
+	}
+
+	seenASCIDs := make(map[string]struct{}, len(resources))
+	merged := make([]appRegistryEntry, 0, len(existing.Apps)+len(resources))
+	result := appRegistrySyncResult{}
+
+	for _, resource := range resources {
+		appID := strings.TrimSpace(resource.ID)
+		if appID == "" {
+			continue
+		}
+		seenASCIDs[appID] = struct{}{}
+
+		existingApp, found := existingByID[appID]
+		before := existingApp
+		if !found {
+			existingApp = appRegistryEntry{
+				Key:           uniqueAppRegistryKey(slugifyAppRegistryKey(resource.Attributes.Name, appID), usedKeys),
+				ASCAppID:      appID,
+				Platform:      nil,
+				RepoPath:      nil,
+				GA4PropertyID: nil,
+				Aliases:       []string{},
+			}
+			result.Created++
+		} else if strings.TrimSpace(existingApp.Key) == "" {
+			existingApp.Key = uniqueAppRegistryKey(slugifyAppRegistryKey(resource.Attributes.Name, appID), usedKeys)
+		}
+
+		mergedApp := existingApp
+		mergedApp.Name = strings.TrimSpace(resource.Attributes.Name)
+		mergedApp.ASCAppID = appID
+		mergedApp.BundleID = strings.TrimSpace(resource.Attributes.BundleID)
+		mergedApp.PrimaryLocale = strings.TrimSpace(resource.Attributes.PrimaryLocale)
+		normalizeRegistryEntry(&mergedApp)
+
+		if found {
+			if reflect.DeepEqual(before, mergedApp) {
+				result.Unchanged++
+			} else {
+				result.Updated++
+			}
+		}
+		merged = append(merged, mergedApp)
+		usedKeys[mergedApp.Key] = struct{}{}
+	}
+
+	for _, app := range existing.Apps {
+		if _, seen := seenASCIDs[app.ASCAppID]; seen {
+			continue
+		}
+		if pruneMissing {
+			result.Pruned++
+			continue
+		}
+		merged = append(merged, app)
+		result.Preserved++
+	}
+
+	sortAppRegistryEntries(merged)
+	result.Total = len(merged)
+	return result, appRegistryFile{Apps: merged}
+}
+
+func normalizeRegistryEntries(entries []appRegistryEntry) {
+	for i := range entries {
+		normalizeRegistryEntry(&entries[i])
+	}
+}
+
+func normalizeRegistryEntry(entry *appRegistryEntry) {
+	entry.Key = strings.TrimSpace(entry.Key)
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.ASCAppID = strings.TrimSpace(entry.ASCAppID)
+	entry.BundleID = strings.TrimSpace(entry.BundleID)
+	entry.PrimaryLocale = strings.TrimSpace(entry.PrimaryLocale)
+	entry.Platform = trimOptionalString(entry.Platform)
+	entry.RepoPath = trimOptionalString(entry.RepoPath)
+	entry.GA4PropertyID = trimOptionalString(entry.GA4PropertyID)
+	if entry.Aliases == nil {
+		entry.Aliases = []string{}
+	}
+	for j := range entry.Aliases {
+		entry.Aliases[j] = strings.TrimSpace(entry.Aliases[j])
+	}
+}
+
+func trimOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func sortAppRegistryEntries(entries []appRegistryEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		left := entries[i]
+		right := entries[j]
+		leftName := strings.ToLower(strings.TrimSpace(left.Name))
+		rightName := strings.ToLower(strings.TrimSpace(right.Name))
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		if left.ASCAppID != right.ASCAppID {
+			return left.ASCAppID < right.ASCAppID
+		}
+		return left.Key < right.Key
+	})
+}
+
+func slugifyAppRegistryKey(name string, appID string) string {
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			builder.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && builder.Len() > 0 {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+
+	key := strings.Trim(builder.String(), "-")
+	if key == "" {
+		key = "app-" + strings.TrimSpace(appID)
+	}
+	return key
+}
+
+func uniqueAppRegistryKey(base string, used map[string]struct{}) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "app"
+	}
+	if _, exists := used[base]; !exists {
+		used[base] = struct{}{}
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := base + "-" + strconv.Itoa(i)
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+}
+
+func printAppRegistrySyncResult(result *appRegistrySyncResult, format string, pretty bool) error {
+	return shared.PrintOutputWithRenderers(
+		result,
+		format,
+		pretty,
+		func() error { return renderAppRegistrySyncResult(result, false) },
+		func() error { return renderAppRegistrySyncResult(result, true) },
+	)
+}
+
+func renderAppRegistrySyncResult(result *appRegistrySyncResult, markdown bool) error {
+	if result == nil {
+		return fmt.Errorf("registry sync result is nil")
+	}
+
+	headers := []string{"Path", "Dry Run", "Total", "Created", "Updated", "Unchanged", "Preserved", "Pruned"}
+	rows := [][]string{{
+		result.Path,
+		strconv.FormatBool(result.DryRun),
+		strconv.Itoa(result.Total),
+		strconv.Itoa(result.Created),
+		strconv.Itoa(result.Updated),
+		strconv.Itoa(result.Unchanged),
+		strconv.Itoa(result.Preserved),
+		strconv.Itoa(result.Pruned),
+	}}
+
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return nil
+	}
+	asc.RenderTable(headers, rows)
+	return nil
+}

--- a/internal/cli/apps/app_registry.go
+++ b/internal/cli/apps/app_registry.go
@@ -37,7 +37,7 @@ type appRegistryEntry struct {
 	Aliases       []string `json:"aliases"`
 }
 
-type appRegistrySyncResult struct {
+type appRegistryPullResult struct {
 	Path      string           `json:"path"`
 	DryRun    bool             `json:"dryRun"`
 	Total     int              `json:"total"`
@@ -56,22 +56,22 @@ func AppsRegistryCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "registry",
 		ShortUsage: "asc apps registry <subcommand> [flags]",
-		ShortHelp:  "Manage a local app registry for agent workflows.",
-		LongHelp: `Manage a local app registry for agent workflows.
+		ShortHelp:  "Manage a local app registry for automation.",
+		LongHelp: `Manage a local app registry for automation.
 
 The registry mirrors App Store Connect app identity fields and preserves
 local-only automation fields such as repo paths, analytics IDs, aliases, and
 platform hints.
 
 Examples:
-  asc apps registry sync
-  asc apps registry sync --path ".asc/app-registry.json"
-  asc apps registry sync --path "/Users/me/clawd/config/app_registry.json" --dry-run
-  asc apps registry sync --prune-missing`,
+  asc apps registry pull
+  asc apps registry pull --path ".asc/app-registry.json"
+  asc apps registry pull --path "/Users/me/clawd/config/app_registry.json" --dry-run
+  asc apps registry pull --prune-missing`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
-			AppsRegistrySyncCommand(),
+			AppsRegistryPullCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
@@ -79,9 +79,9 @@ Examples:
 	}
 }
 
-// AppsRegistrySyncCommand returns the app registry sync subcommand.
-func AppsRegistrySyncCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("apps registry sync", flag.ExitOnError)
+// AppsRegistryPullCommand returns the app registry pull subcommand.
+func AppsRegistryPullCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps registry pull", flag.ExitOnError)
 
 	path := fs.String("path", defaultAppRegistryPath, "Registry JSON path")
 	dryRun := fs.Bool("dry-run", false, "Preview the merged registry without writing it")
@@ -89,10 +89,10 @@ func AppsRegistrySyncCommand() *ffcli.Command {
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "sync",
-		ShortUsage: "asc apps registry sync [--path PATH] [--dry-run] [--prune-missing] [flags]",
-		ShortHelp:  "Sync a local app registry from App Store Connect.",
-		LongHelp: `Sync a local app registry from App Store Connect.
+		Name:       "pull",
+		ShortUsage: "asc apps registry pull [--path PATH] [--dry-run] [--prune-missing] [flags]",
+		ShortHelp:  "Pull App Store Connect apps into a local registry.",
+		LongHelp: `Pull App Store Connect apps into a local registry.
 
 The command fetches all apps available to the configured API key, updates ASC
 identity fields, and preserves local-only fields by asc_app_id. By default,
@@ -100,18 +100,18 @@ entries not returned by App Store Connect are kept to avoid accidental data
 loss when using a limited API key. Use --prune-missing to remove them.
 
 Examples:
-  asc apps registry sync
-  asc apps registry sync --dry-run --output json
-  asc apps registry sync --path "/Users/me/clawd/config/app_registry.json"
-  asc apps registry sync --path ".asc/app-registry.json" --prune-missing`,
+  asc apps registry pull
+  asc apps registry pull --dry-run --output json
+  asc apps registry pull --path "/Users/me/clawd/config/app_registry.json"
+  asc apps registry pull --path ".asc/app-registry.json" --prune-missing`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
-				fmt.Fprintln(os.Stderr, "Error: apps registry sync does not accept positional arguments")
+				fmt.Fprintln(os.Stderr, "Error: apps registry pull does not accept positional arguments")
 				return flag.ErrHelp
 			}
-			return appsRegistrySync(ctx, appsRegistrySyncOptions{
+			return appsRegistryPull(ctx, appsRegistryPullOptions{
 				Path:         *path,
 				DryRun:       *dryRun,
 				PruneMissing: *pruneMissing,
@@ -122,7 +122,7 @@ Examples:
 	}
 }
 
-type appsRegistrySyncOptions struct {
+type appsRegistryPullOptions struct {
 	Path         string
 	DryRun       bool
 	PruneMissing bool
@@ -130,7 +130,7 @@ type appsRegistrySyncOptions struct {
 	Pretty       bool
 }
 
-func appsRegistrySync(ctx context.Context, opts appsRegistrySyncOptions) error {
+func appsRegistryPull(ctx context.Context, opts appsRegistryPullOptions) error {
 	path := strings.TrimSpace(opts.Path)
 	if path == "" {
 		fmt.Fprintln(os.Stderr, "Error: --path is required")
@@ -139,12 +139,12 @@ func appsRegistrySync(ctx context.Context, opts appsRegistrySyncOptions) error {
 
 	existing, err := readAppRegistry(path)
 	if err != nil {
-		return fmt.Errorf("apps registry sync: %w", err)
+		return fmt.Errorf("apps registry pull: %w", err)
 	}
 
 	client, err := shared.GetASCClient()
 	if err != nil {
-		return fmt.Errorf("apps registry sync: %w", err)
+		return fmt.Errorf("apps registry pull: %w", err)
 	}
 
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -159,17 +159,17 @@ func appsRegistrySync(ctx context.Context, opts appsRegistrySyncOptions) error {
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("apps registry sync: failed to fetch apps: %w", err)
+		return fmt.Errorf("apps registry pull: failed to fetch apps: %w", err)
 	}
 
 	appsResponse, ok := response.(*asc.AppsResponse)
 	if !ok {
-		return fmt.Errorf("apps registry sync: unexpected apps response type %T", response)
+		return fmt.Errorf("apps registry pull: unexpected apps response type %T", response)
 	}
 
 	result, registry, err := mergeAppRegistry(existing, appsResponse.Data, opts.PruneMissing)
 	if err != nil {
-		return fmt.Errorf("apps registry sync: %w", err)
+		return fmt.Errorf("apps registry pull: %w", err)
 	}
 	result.Path = path
 	result.DryRun = opts.DryRun
@@ -179,11 +179,11 @@ func appsRegistrySync(ctx context.Context, opts appsRegistrySyncOptions) error {
 
 	if !opts.DryRun {
 		if err := writeAppRegistry(path, registry); err != nil {
-			return fmt.Errorf("apps registry sync: failed to write registry: %w", err)
+			return fmt.Errorf("apps registry pull: failed to write registry: %w", err)
 		}
 	}
 
-	return printAppRegistrySyncResult(&result, opts.Output, opts.Pretty)
+	return printAppRegistryPullResult(&result, opts.Output, opts.Pretty)
 }
 
 func readAppRegistry(path string) (appRegistryFile, error) {
@@ -283,13 +283,16 @@ func writeAppRegistry(path string, registry appRegistryFile) error {
 	return nil
 }
 
-func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.AppAttributes], pruneMissing bool) (appRegistrySyncResult, appRegistryFile, error) {
+func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.AppAttributes], pruneMissing bool) (appRegistryPullResult, appRegistryFile, error) {
 	normalizeRegistryEntries(existing.Apps)
+	if err := validateUniqueRegistryKeys(existing.Apps); err != nil {
+		return appRegistryPullResult{}, appRegistryFile{}, err
+	}
 	if err := validateUniqueRegistryASCAppIDs(existing.Apps); err != nil {
-		return appRegistrySyncResult{}, appRegistryFile{}, err
+		return appRegistryPullResult{}, appRegistryFile{}, err
 	}
 	if err := validateUniqueASCResources(resources); err != nil {
-		return appRegistrySyncResult{}, appRegistryFile{}, err
+		return appRegistryPullResult{}, appRegistryFile{}, err
 	}
 
 	existingByID := make(map[string]appRegistryEntry, len(existing.Apps))
@@ -320,7 +323,7 @@ func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.App
 
 	seenASCIDs := make(map[string]struct{}, len(resources))
 	merged := make([]appRegistryEntry, 0, len(existing.Apps)+len(resources))
-	result := appRegistrySyncResult{}
+	result := appRegistryPullResult{}
 
 	for _, resource := range resources {
 		appID := strings.TrimSpace(resource.ID)
@@ -378,6 +381,21 @@ func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.App
 	sortAppRegistryEntries(merged)
 	result.Total = len(merged)
 	return result, appRegistryFile{Apps: merged}, nil
+}
+
+func validateUniqueRegistryKeys(apps []appRegistryEntry) error {
+	seen := make(map[string]struct{}, len(apps))
+	for _, app := range apps {
+		key := strings.TrimSpace(app.Key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("registry contains duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
 }
 
 func validateUniqueRegistryASCAppIDs(apps []appRegistryEntry) error {
@@ -501,19 +519,19 @@ func uniqueAppRegistryKey(base string, used map[string]struct{}) string {
 	}
 }
 
-func printAppRegistrySyncResult(result *appRegistrySyncResult, format string, pretty bool) error {
+func printAppRegistryPullResult(result *appRegistryPullResult, format string, pretty bool) error {
 	return shared.PrintOutputWithRenderers(
 		result,
 		format,
 		pretty,
-		func() error { return renderAppRegistrySyncResult(result, false) },
-		func() error { return renderAppRegistrySyncResult(result, true) },
+		func() error { return renderAppRegistryPullResult(result, false) },
+		func() error { return renderAppRegistryPullResult(result, true) },
 	)
 }
 
-func renderAppRegistrySyncResult(result *appRegistrySyncResult, markdown bool) error {
+func renderAppRegistryPullResult(result *appRegistryPullResult, markdown bool) error {
 	if result == nil {
-		return fmt.Errorf("registry sync result is nil")
+		return fmt.Errorf("registry pull result is nil")
 	}
 
 	headers := []string{"Path", "Dry Run", "Total", "Created", "Updated", "Unchanged", "Preserved", "Pruned"}

--- a/internal/cli/apps/app_registry.go
+++ b/internal/cli/apps/app_registry.go
@@ -167,7 +167,10 @@ func appsRegistrySync(ctx context.Context, opts appsRegistrySyncOptions) error {
 		return fmt.Errorf("apps registry sync: unexpected apps response type %T", response)
 	}
 
-	result, registry := mergeAppRegistry(existing, appsResponse.Data, opts.PruneMissing)
+	result, registry, err := mergeAppRegistry(existing, appsResponse.Data, opts.PruneMissing)
+	if err != nil {
+		return fmt.Errorf("apps registry sync: %w", err)
+	}
 	result.Path = path
 	result.DryRun = opts.DryRun
 	if opts.DryRun {
@@ -280,8 +283,14 @@ func writeAppRegistry(path string, registry appRegistryFile) error {
 	return nil
 }
 
-func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.AppAttributes], pruneMissing bool) (appRegistrySyncResult, appRegistryFile) {
+func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.AppAttributes], pruneMissing bool) (appRegistrySyncResult, appRegistryFile, error) {
 	normalizeRegistryEntries(existing.Apps)
+	if err := validateUniqueRegistryASCAppIDs(existing.Apps); err != nil {
+		return appRegistrySyncResult{}, appRegistryFile{}, err
+	}
+	if err := validateUniqueASCResources(resources); err != nil {
+		return appRegistrySyncResult{}, appRegistryFile{}, err
+	}
 
 	existingByID := make(map[string]appRegistryEntry, len(existing.Apps))
 	for _, app := range existing.Apps {
@@ -368,7 +377,37 @@ func mergeAppRegistry(existing appRegistryFile, resources []asc.Resource[asc.App
 
 	sortAppRegistryEntries(merged)
 	result.Total = len(merged)
-	return result, appRegistryFile{Apps: merged}
+	return result, appRegistryFile{Apps: merged}, nil
+}
+
+func validateUniqueRegistryASCAppIDs(apps []appRegistryEntry) error {
+	seen := make(map[string]struct{}, len(apps))
+	for _, app := range apps {
+		appID := strings.TrimSpace(app.ASCAppID)
+		if appID == "" {
+			continue
+		}
+		if _, ok := seen[appID]; ok {
+			return fmt.Errorf("registry contains duplicate asc_app_id %q", appID)
+		}
+		seen[appID] = struct{}{}
+	}
+	return nil
+}
+
+func validateUniqueASCResources(resources []asc.Resource[asc.AppAttributes]) error {
+	seen := make(map[string]struct{}, len(resources))
+	for _, resource := range resources {
+		appID := strings.TrimSpace(resource.ID)
+		if appID == "" {
+			continue
+		}
+		if _, ok := seen[appID]; ok {
+			return fmt.Errorf("App Store Connect returned duplicate app id %q", appID)
+		}
+		seen[appID] = struct{}{}
+	}
+	return nil
 }
 
 func normalizeRegistryEntries(entries []appRegistryEntry) {

--- a/internal/cli/apps/app_registry.go
+++ b/internal/cli/apps/app_registry.go
@@ -403,7 +403,7 @@ func validateUniqueASCResources(resources []asc.Resource[asc.AppAttributes]) err
 			continue
 		}
 		if _, ok := seen[appID]; ok {
-			return fmt.Errorf("App Store Connect returned duplicate app id %q", appID)
+			return fmt.Errorf("app store connect returned duplicate app id %q", appID)
 		}
 		seen[appID] = struct{}{}
 	}

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -48,6 +48,7 @@ Examples:
   asc apps public view --app "1234567890"
   asc apps public search --term "focus" --country us
   asc apps public storefronts list
+  asc apps registry sync --path ".asc/app-registry.json"
   asc apps view --id "APP_ID"
   asc apps info view --app "APP_ID"
   asc apps info edit --app "APP_ID" --locale "en-US" --whats-new "Bug fixes"
@@ -68,6 +69,7 @@ Examples:
 			RemovedAppsCreateCommand(),
 			AppsWallCommand(),
 			AppsPublicCommand(),
+			AppsRegistryCommand(),
 			AppsGetCommand(),
 			AppsInfoCommand(),
 			AppsCIProductCommand(),

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -48,7 +48,7 @@ Examples:
   asc apps public view --app "1234567890"
   asc apps public search --term "focus" --country us
   asc apps public storefronts list
-  asc apps registry sync --path ".asc/app-registry.json"
+  asc apps registry pull --path ".asc/app-registry.json"
   asc apps view --id "APP_ID"
   asc apps info view --app "APP_ID"
   asc apps info edit --app "APP_ID" --locale "en-US" --whats-new "Bug fixes"

--- a/internal/cli/cmdtest/apps_registry_pull_test.go
+++ b/internal/cli/cmdtest/apps_registry_pull_test.go
@@ -276,6 +276,115 @@ func TestAppsRegistryPullPrunesMissingWhenRequested(t *testing.T) {
 	}
 }
 
+func TestAppsRegistryPullPrunesMissingWhenConfirmed(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	if err := os.WriteFile(registryPath, []byte(`{"apps":[{"key":"gone","name":"Gone","asc_app_id":"gone-1","bundle_id":"gone.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]}]}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "pull",
+			"--path", registryPath,
+			"--prune-missing",
+			"--confirm",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Total    int             `json:"total"`
+		Pruned   int             `json:"pruned"`
+		Registry json.RawMessage `json:"registry"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result.Total != 0 || result.Pruned != 1 || result.Registry != nil {
+		t.Fatalf("unexpected prune result: %+v", result)
+	}
+
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	var registry struct {
+		Apps []map[string]any `json:"apps"`
+	}
+	if err := json.Unmarshal(data, &registry); err != nil {
+		t.Fatalf("failed to parse registry %q: %v", string(data), err)
+	}
+	if len(registry.Apps) != 0 {
+		t.Fatalf("expected registry to be pruned, got %#v", registry.Apps)
+	}
+}
+
+func TestAppsRegistryPullPruneMissingRequiresConfirmBeforeNetwork(t *testing.T) {
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	initialRegistry := `{"apps":[{"key":"gone","name":"Gone","asc_app_id":"gone-1","bundle_id":"gone.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]}]}`
+	if err := os.WriteFile(registryPath, []byte(initialRegistry), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	callCount := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "pull",
+			"--path", registryPath,
+			"--prune-missing",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected help error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm is required with --prune-missing unless --dry-run is set") {
+		t.Fatalf("expected confirm error, got %q", stderr)
+	}
+	if callCount != 0 {
+		t.Fatalf("expected no network calls before confirm error, got %d", callCount)
+	}
+	if got, err := os.ReadFile(registryPath); err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	} else if string(got) != initialRegistry {
+		t.Fatalf("expected registry to remain unchanged, got %q", string(got))
+	}
+}
+
 func TestAppsRegistryPullRejectsInvalidRegistryJSON(t *testing.T) {
 	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
 	if err := os.WriteFile(registryPath, []byte(`{"apps":[`), 0o600); err != nil {
@@ -482,6 +591,53 @@ func TestAppsRegistryPullParserPermutations(t *testing.T) {
 	}
 }
 
+func TestAppsRegistryPullInvalidOutputDoesNotWriteRegistry(t *testing.T) {
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	initialRegistry := `{"apps":[]}`
+	if err := os.WriteFile(registryPath, []byte(initialRegistry), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	callCount := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		return appsRegistryJSONResponse(`{"data":[{"type":"apps","id":"app-1","attributes":{"name":"New App","bundleId":"com.example.new","sku":"NEW","primaryLocale":"en-US"}}],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "pull",
+			"--path", registryPath,
+			"--output", "pull",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected help error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unsupported format: pull") {
+		t.Fatalf("expected unsupported output error, got %q", stderr)
+	}
+	if callCount != 0 {
+		t.Fatalf("expected no network calls before output validation error, got %d", callCount)
+	}
+	if got, err := os.ReadFile(registryPath); err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	} else if string(got) != initialRegistry {
+		t.Fatalf("expected registry to remain unchanged, got %q", string(got))
+	}
+}
+
 func TestAppsRegistryPullInvalidFlagValues(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -538,7 +694,7 @@ func TestAppsRegistryPullInvalidFlagValues(t *testing.T) {
 	}
 }
 
-func TestAppsRegistryPullInvalidBoolExitCode(t *testing.T) {
+func TestAppsRegistryPullInvalidFlagExitCode(t *testing.T) {
 	binaryPath := buildASCBlackBoxBinary(t)
 
 	tests := []struct {
@@ -546,6 +702,14 @@ func TestAppsRegistryPullInvalidBoolExitCode(t *testing.T) {
 		args    []string
 		wantErr string
 	}{
+		{
+			name: "empty path",
+			args: []string{
+				"apps", "registry", "pull",
+				"--path", "",
+			},
+			wantErr: "--path is required",
+		},
 		{
 			name: "invalid dry run",
 			args: []string{
@@ -563,6 +727,15 @@ func TestAppsRegistryPullInvalidBoolExitCode(t *testing.T) {
 				"--prune-missing=maybe",
 			},
 			wantErr: `invalid boolean value "maybe" for -prune-missing`,
+		},
+		{
+			name: "invalid confirm",
+			args: []string{
+				"apps", "registry", "pull",
+				"--path", filepath.Join(t.TempDir(), "registry.json"),
+				"--confirm=maybe",
+			},
+			wantErr: `invalid boolean value "maybe" for -confirm`,
 		},
 		{
 			name: "invalid dry run mixed flag order",

--- a/internal/cli/cmdtest/apps_registry_pull_test.go
+++ b/internal/cli/cmdtest/apps_registry_pull_test.go
@@ -1,6 +1,7 @@
 package cmdtest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,12 +9,13 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestAppsRegistrySyncDryRunMergesAndPreservesLocalFields(t *testing.T) {
+func TestAppsRegistryPullDryRunMergesAndPreservesLocalFields(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -75,7 +77,7 @@ func TestAppsRegistrySyncDryRunMergesAndPreservesLocalFields(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", registryPath,
 			"--dry-run",
 			"--output", "json",
@@ -131,7 +133,7 @@ func TestAppsRegistrySyncDryRunMergesAndPreservesLocalFields(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncWritesRegistryFile(t *testing.T) {
+func TestAppsRegistryPullWritesRegistryFile(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -146,7 +148,7 @@ func TestAppsRegistrySyncWritesRegistryFile(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", registryPath,
 			"--output", "json",
 		}); err != nil {
@@ -190,7 +192,7 @@ func TestAppsRegistrySyncWritesRegistryFile(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncWriteFailsWhenPathIsDirectory(t *testing.T) {
+func TestAppsRegistryPullWriteFailsWhenPathIsDirectory(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -205,7 +207,7 @@ func TestAppsRegistrySyncWriteFailsWhenPathIsDirectory(t *testing.T) {
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", registryPath,
 			"--output", "json",
 		}); err != nil {
@@ -225,7 +227,7 @@ func TestAppsRegistrySyncWriteFailsWhenPathIsDirectory(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncPrunesMissingWhenRequested(t *testing.T) {
+func TestAppsRegistryPullPrunesMissingWhenRequested(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -243,7 +245,7 @@ func TestAppsRegistrySyncPrunesMissingWhenRequested(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", registryPath,
 			"--prune-missing",
 			"--dry-run",
@@ -274,7 +276,7 @@ func TestAppsRegistrySyncPrunesMissingWhenRequested(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncRejectsInvalidRegistryJSON(t *testing.T) {
+func TestAppsRegistryPullRejectsInvalidRegistryJSON(t *testing.T) {
 	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
 	if err := os.WriteFile(registryPath, []byte(`{"apps":[`), 0o600); err != nil {
 		t.Fatalf("WriteFile() error: %v", err)
@@ -286,7 +288,7 @@ func TestAppsRegistrySyncRejectsInvalidRegistryJSON(t *testing.T) {
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", registryPath,
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -311,7 +313,7 @@ func TestAppsRegistrySyncRejectsInvalidRegistryJSON(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncRejectsDuplicateExistingASCAppIDs(t *testing.T) {
+func TestAppsRegistryPullRejectsDuplicateExistingASCAppIDs(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -334,7 +336,7 @@ func TestAppsRegistrySyncRejectsDuplicateExistingASCAppIDs(t *testing.T) {
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", registryPath,
 			"--dry-run",
 		}); err != nil {
@@ -351,7 +353,47 @@ func TestAppsRegistrySyncRejectsDuplicateExistingASCAppIDs(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncRejectsDuplicateASCResponseIDs(t *testing.T) {
+func TestAppsRegistryPullRejectsDuplicateExistingKeys(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	duplicateRegistry := `{"apps":[` +
+		`{"key":"same","name":"First","asc_app_id":"app-1","bundle_id":"one.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]},` +
+		`{"key":"same","name":"Second","asc_app_id":"app-2","bundle_id":"two.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]}` +
+		`]}`
+	if err := os.WriteFile(registryPath, []byte(duplicateRegistry), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "pull",
+			"--path", registryPath,
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), `duplicate key "same"`) {
+		t.Fatalf("expected duplicate key error, got %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected empty output, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestAppsRegistryPullRejectsDuplicateASCResponseIDs(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -369,7 +411,7 @@ func TestAppsRegistrySyncRejectsDuplicateASCResponseIDs(t *testing.T) {
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", filepath.Join(t.TempDir(), "registry.json"),
 			"--dry-run",
 		}); err != nil {
@@ -386,7 +428,7 @@ func TestAppsRegistrySyncRejectsDuplicateASCResponseIDs(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncParserPermutations(t *testing.T) {
+func TestAppsRegistryPullParserPermutations(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -400,15 +442,15 @@ func TestAppsRegistrySyncParserPermutations(t *testing.T) {
 	}{
 		{
 			name: "root flag before subcommand",
-			args: []string{"--debug=false", "apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "json"},
+			args: []string{"--debug=false", "apps", "registry", "pull", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "json"},
 		},
 		{
 			name: "mixed flag order",
-			args: []string{"apps", "registry", "sync", "--output", "json", "--dry-run", "--path", filepath.Join(t.TempDir(), "registry.json")},
+			args: []string{"apps", "registry", "pull", "--output", "json", "--dry-run", "--path", filepath.Join(t.TempDir(), "registry.json")},
 		},
 		{
 			name: "flag value equals subcommand name",
-			args: []string{"apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "sync"), "--dry-run", "--output", "json"},
+			args: []string{"apps", "registry", "pull", "--path", filepath.Join(t.TempDir(), "pull"), "--dry-run", "--output", "json"},
 		},
 	}
 
@@ -440,7 +482,7 @@ func TestAppsRegistrySyncParserPermutations(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncInvalidFlagValues(t *testing.T) {
+func TestAppsRegistryPullInvalidFlagValues(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -455,17 +497,17 @@ func TestAppsRegistrySyncInvalidFlagValues(t *testing.T) {
 	}{
 		{
 			name:    "empty path",
-			args:    []string{"apps", "registry", "sync", "--path", ""},
+			args:    []string{"apps", "registry", "pull", "--path", ""},
 			wantErr: "--path is required",
 		},
 		{
 			name:    "output value equals subcommand",
-			args:    []string{"apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "sync"},
-			wantErr: "unsupported format: sync",
+			args:    []string{"apps", "registry", "pull", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "pull"},
+			wantErr: "unsupported format: pull",
 		},
 		{
 			name:    "pretty with table output",
-			args:    []string{"apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "table", "--pretty"},
+			args:    []string{"apps", "registry", "pull", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "table", "--pretty"},
 			wantErr: "--pretty is only valid with JSON output",
 		},
 	}
@@ -496,7 +538,72 @@ func TestAppsRegistrySyncInvalidFlagValues(t *testing.T) {
 	}
 }
 
-func TestAppsRegistrySyncTableOutput(t *testing.T) {
+func TestAppsRegistryPullInvalidBoolExitCode(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "invalid dry run",
+			args: []string{
+				"apps", "registry", "pull",
+				"--path", filepath.Join(t.TempDir(), "registry.json"),
+				"--dry-run=maybe",
+			},
+			wantErr: `invalid boolean value "maybe" for -dry-run`,
+		},
+		{
+			name: "invalid prune missing",
+			args: []string{
+				"apps", "registry", "pull",
+				"--path", filepath.Join(t.TempDir(), "registry.json"),
+				"--prune-missing=maybe",
+			},
+			wantErr: `invalid boolean value "maybe" for -prune-missing`,
+		},
+		{
+			name: "invalid dry run mixed flag order",
+			args: []string{
+				"apps", "registry", "pull",
+				"--output", "json",
+				"--dry-run=maybe",
+				"--path", filepath.Join(t.TempDir(), "registry.json"),
+			},
+			wantErr: `invalid boolean value "maybe" for -dry-run`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, test.args...)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected process exit error, got %v", err)
+			}
+			if exitErr.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
+			}
+			if stdout.String() != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.wantErr) {
+				t.Fatalf("expected stderr %q, got %q", test.wantErr, stderr.String())
+			}
+		})
+	}
+}
+
+func TestAppsRegistryPullTableOutput(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -509,7 +616,7 @@ func TestAppsRegistrySyncTableOutput(t *testing.T) {
 
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"apps", "registry", "sync",
+			"apps", "registry", "pull",
 			"--path", filepath.Join(t.TempDir(), "registry.json"),
 			"--dry-run",
 			"--output", "table",

--- a/internal/cli/cmdtest/apps_registry_sync_test.go
+++ b/internal/cli/cmdtest/apps_registry_sync_test.go
@@ -190,6 +190,41 @@ func TestAppsRegistrySyncWritesRegistryFile(t *testing.T) {
 	}
 }
 
+func TestAppsRegistrySyncWriteFailsWhenPathIsDirectory(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	registryPath := t.TempDir()
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", registryPath,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), "is a directory") {
+		t.Fatalf("expected directory-path write error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
 func TestAppsRegistrySyncPrunesMissingWhenRequested(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/apps_registry_sync_test.go
+++ b/internal/cli/cmdtest/apps_registry_sync_test.go
@@ -67,7 +67,7 @@ func TestAppsRegistrySyncDryRunMergesAndPreservesLocalFields(t *testing.T) {
 			`{"type":"apps","id":"app-2","attributes":{"name":"New App!","bundleId":"com.example.new","sku":"NEW","primaryLocale":"en-GB"}},` +
 			`{"type":"apps","id":"app-1","attributes":{"name":"Fresh Name","bundleId":"com.example.fresh","sku":"FRESH","primaryLocale":"en-US"}}` +
 			`],"links":{"next":""}}`
-		return appsRegistryJSONResponse(http.StatusOK, body), nil
+		return appsRegistryJSONResponse(body), nil
 	}))
 
 	root := RootCommand("1.2.3")
@@ -138,7 +138,7 @@ func TestAppsRegistrySyncWritesRegistryFile(t *testing.T) {
 	registryPath := filepath.Join(t.TempDir(), "nested", "app-registry.json")
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		body := `{"data":[{"type":"apps","id":"app-1","attributes":{"name":"Write Me","bundleId":"com.example.write","sku":"WRITE","primaryLocale":"en-US"}}],"links":{"next":""}}`
-		return appsRegistryJSONResponse(http.StatusOK, body), nil
+		return appsRegistryJSONResponse(body), nil
 	}))
 
 	root := RootCommand("1.2.3")
@@ -200,7 +200,7 @@ func TestAppsRegistrySyncPrunesMissingWhenRequested(t *testing.T) {
 	}
 
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return appsRegistryJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
 	}))
 
 	root := RootCommand("1.2.3")
@@ -281,7 +281,7 @@ func TestAppsRegistrySyncTableOutput(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return appsRegistryJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
 	}))
 
 	root := RootCommand("1.2.3")
@@ -323,9 +323,9 @@ func registryAppsByID(t *testing.T, apps []map[string]any) map[string]map[string
 	return byID
 }
 
-func appsRegistryJSONResponse(status int, body string) *http.Response {
+func appsRegistryJSONResponse(body string) *http.Response {
 	return &http.Response{
-		StatusCode: status,
+		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 	}

--- a/internal/cli/cmdtest/apps_registry_sync_test.go
+++ b/internal/cli/cmdtest/apps_registry_sync_test.go
@@ -1,0 +1,332 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppsRegistrySyncDryRunMergesAndPreservesLocalFields(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "app_registry.json")
+	initialRegistry := `{
+  "apps": [
+    {
+      "key": "existing-key",
+      "name": "Old Name",
+      "asc_app_id": "app-1",
+      "bundle_id": "old.bundle",
+      "platform": "IOS",
+      "primary_locale": "en-US",
+      "repo_path": "/tmp/existing",
+      "ga4_property_id": "123",
+      "aliases": ["old", "alias"]
+    },
+    {
+      "key": "local-only",
+      "name": "Local Only",
+      "asc_app_id": "local-1",
+      "bundle_id": "local.bundle",
+      "platform": "TV_OS",
+      "primary_locale": "en-US",
+      "repo_path": null,
+      "ga4_property_id": null,
+      "aliases": []
+    }
+  ]
+}`
+	if err := os.WriteFile(registryPath, []byte(initialRegistry), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps" {
+			t.Fatalf("expected apps path, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("limit") != "200" {
+			t.Fatalf("expected limit=200, got %q", req.URL.Query().Get("limit"))
+		}
+		if req.URL.Query().Get("sort") != "name" {
+			t.Fatalf("expected sort=name, got %q", req.URL.Query().Get("sort"))
+		}
+
+		body := `{"data":[` +
+			`{"type":"apps","id":"app-2","attributes":{"name":"New App!","bundleId":"com.example.new","sku":"NEW","primaryLocale":"en-GB"}},` +
+			`{"type":"apps","id":"app-1","attributes":{"name":"Fresh Name","bundleId":"com.example.fresh","sku":"FRESH","primaryLocale":"en-US"}}` +
+			`],"links":{"next":""}}`
+		return appsRegistryJSONResponse(http.StatusOK, body), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", registryPath,
+			"--dry-run",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if got, err := os.ReadFile(registryPath); err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	} else if strings.TrimSpace(string(got)) != strings.TrimSpace(initialRegistry) {
+		t.Fatalf("dry-run changed registry file:\n%s", string(got))
+	}
+
+	var result struct {
+		DryRun    bool `json:"dryRun"`
+		Total     int  `json:"total"`
+		Created   int  `json:"created"`
+		Updated   int  `json:"updated"`
+		Unchanged int  `json:"unchanged"`
+		Preserved int  `json:"preserved"`
+		Pruned    int  `json:"pruned"`
+		Registry  struct {
+			Apps []map[string]any `json:"apps"`
+		} `json:"registry"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if !result.DryRun || result.Total != 3 || result.Created != 1 || result.Updated != 1 || result.Unchanged != 0 || result.Preserved != 1 || result.Pruned != 0 {
+		t.Fatalf("unexpected summary: %+v", result)
+	}
+
+	byID := registryAppsByID(t, result.Registry.Apps)
+	existing := byID["app-1"]
+	if existing["key"] != "existing-key" || existing["platform"] != "IOS" || existing["repo_path"] != "/tmp/existing" || existing["ga4_property_id"] != "123" {
+		t.Fatalf("local fields were not preserved: %#v", existing)
+	}
+	if existing["name"] != "Fresh Name" || existing["bundle_id"] != "com.example.fresh" {
+		t.Fatalf("ASC fields were not updated: %#v", existing)
+	}
+	if byID["app-2"]["key"] != "new-app" {
+		t.Fatalf("expected generated key new-app, got %#v", byID["app-2"]["key"])
+	}
+	if _, ok := byID["local-1"]; !ok {
+		t.Fatalf("expected local-only app to be preserved, got %#v", byID)
+	}
+}
+
+func TestAppsRegistrySyncWritesRegistryFile(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	registryPath := filepath.Join(t.TempDir(), "nested", "app-registry.json")
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"data":[{"type":"apps","id":"app-1","attributes":{"name":"Write Me","bundleId":"com.example.write","sku":"WRITE","primaryLocale":"en-US"}}],"links":{"next":""}}`
+		return appsRegistryJSONResponse(http.StatusOK, body), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", registryPath,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if _, ok := result["registry"]; ok {
+		t.Fatalf("expected registry payload to be omitted for non-dry-run output: %#v", result["registry"])
+	}
+
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	var registry struct {
+		Apps []map[string]any `json:"apps"`
+	}
+	if err := json.Unmarshal(data, &registry); err != nil {
+		t.Fatalf("failed to parse written registry %q: %v", string(data), err)
+	}
+	if len(registry.Apps) != 1 {
+		t.Fatalf("expected one app, got %#v", registry.Apps)
+	}
+	app := registry.Apps[0]
+	if app["key"] != "write-me" || app["asc_app_id"] != "app-1" || app["bundle_id"] != "com.example.write" {
+		t.Fatalf("unexpected written app: %#v", app)
+	}
+	if app["platform"] != nil || app["repo_path"] != nil || app["ga4_property_id"] != nil {
+		t.Fatalf("expected unknown local fields to be null, got %#v", app)
+	}
+}
+
+func TestAppsRegistrySyncPrunesMissingWhenRequested(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	if err := os.WriteFile(registryPath, []byte(`{"apps":[{"key":"gone","name":"Gone","asc_app_id":"gone-1","bundle_id":"gone.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]}]}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", registryPath,
+			"--prune-missing",
+			"--dry-run",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Total    int `json:"total"`
+		Pruned   int `json:"pruned"`
+		Registry struct {
+			Apps []map[string]any `json:"apps"`
+		} `json:"registry"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+	}
+	if result.Total != 0 || result.Pruned != 1 || len(result.Registry.Apps) != 0 {
+		t.Fatalf("unexpected prune result: %+v", result)
+	}
+}
+
+func TestAppsRegistrySyncRejectsInvalidRegistryJSON(t *testing.T) {
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	if err := os.WriteFile(registryPath, []byte(`{"apps":[`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", registryPath,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected runtime error, got ErrHelp")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(runErr.Error(), "invalid registry JSON") {
+		t.Fatalf("expected invalid JSON error, got %v", runErr)
+	}
+}
+
+func TestAppsRegistrySyncTableOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", filepath.Join(t.TempDir(), "registry.json"),
+			"--dry-run",
+			"--output", "table",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Path") || !strings.Contains(stdout, "Dry Run") {
+		t.Fatalf("expected table output, got %q", stdout)
+	}
+}
+
+func registryAppsByID(t *testing.T, apps []map[string]any) map[string]map[string]any {
+	t.Helper()
+
+	byID := make(map[string]map[string]any, len(apps))
+	for _, app := range apps {
+		id, ok := app["asc_app_id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("app missing asc_app_id: %#v", app)
+		}
+		byID[id] = app
+	}
+	return byID
+}
+
+func appsRegistryJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}

--- a/internal/cli/cmdtest/apps_registry_sync_test.go
+++ b/internal/cli/cmdtest/apps_registry_sync_test.go
@@ -276,6 +276,191 @@ func TestAppsRegistrySyncRejectsInvalidRegistryJSON(t *testing.T) {
 	}
 }
 
+func TestAppsRegistrySyncRejectsDuplicateExistingASCAppIDs(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	registryPath := filepath.Join(t.TempDir(), "app_registry.json")
+	duplicateRegistry := `{"apps":[` +
+		`{"key":"first","name":"First","asc_app_id":"app-1","bundle_id":"one.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]},` +
+		`{"key":"second","name":"Second","asc_app_id":"app-1","bundle_id":"two.bundle","platform":null,"primary_locale":"en-US","repo_path":null,"ga4_property_id":null,"aliases":[]}` +
+		`]}`
+	if err := os.WriteFile(registryPath, []byte(duplicateRegistry), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", registryPath,
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), `duplicate asc_app_id "app-1"`) {
+		t.Fatalf("expected duplicate asc_app_id error, got %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected empty output, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestAppsRegistrySyncRejectsDuplicateASCResponseIDs(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"data":[` +
+			`{"type":"apps","id":"app-1","attributes":{"name":"One","bundleId":"one.bundle","sku":"ONE","primaryLocale":"en-US"}},` +
+			`{"type":"apps","id":"app-1","attributes":{"name":"Two","bundleId":"two.bundle","sku":"TWO","primaryLocale":"en-US"}}` +
+			`],"links":{"next":""}}`
+		return appsRegistryJSONResponse(body), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "registry", "sync",
+			"--path", filepath.Join(t.TempDir(), "registry.json"),
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), `duplicate app id "app-1"`) {
+		t.Fatalf("expected duplicate app id error, got %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected empty output, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestAppsRegistrySyncParserPermutations(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "root flag before subcommand",
+			args: []string{"--debug=false", "apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "json"},
+		},
+		{
+			name: "mixed flag order",
+			args: []string{"apps", "registry", "sync", "--output", "json", "--dry-run", "--path", filepath.Join(t.TempDir(), "registry.json")},
+		},
+		{
+			name: "flag value equals subcommand name",
+			args: []string{"apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "sync"), "--dry-run", "--output", "json"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			var result map[string]any
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("failed to parse JSON output %q: %v", stdout, err)
+			}
+			if result["dryRun"] != true {
+				t.Fatalf("expected dryRun=true, got %#v", result["dryRun"])
+			}
+		})
+	}
+}
+
+func TestAppsRegistrySyncInvalidFlagValues(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return appsRegistryJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+	}))
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "empty path",
+			args:    []string{"apps", "registry", "sync", "--path", ""},
+			wantErr: "--path is required",
+		},
+		{
+			name:    "output value equals subcommand",
+			args:    []string{"apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "sync"},
+			wantErr: "unsupported format: sync",
+		},
+		{
+			name:    "pretty with table output",
+			args:    []string{"apps", "registry", "sync", "--path", filepath.Join(t.TempDir(), "registry.json"), "--dry-run", "--output", "table", "--pretty"},
+			wantErr: "--pretty is only valid with JSON output",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected help error, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
 func TestAppsRegistrySyncTableOutput(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))


### PR DESCRIPTION
## Summary
- add `asc apps registry pull` for OpenClaw-style local app registries
- pull ASC app identity fields into the registry while preserving local repo, GA4, platform, and alias fields
- reject duplicate registry keys/ASC app IDs, support dry-run previews, safe default preservation, and optional `--prune-missing`

## Why pull
`sync` sounded bidirectional, but this command is one-way from App Store Connect into a local registry. `pull` matches the behavior and the existing CLI language used by commands like `metadata pull`.

## Tests
- `go run . apps --help`
- `go run . apps registry --help`
- `go run . apps registry pull --help`
- `go run . apps registry sync --help` (validated old name exits 2 / unknown)
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestAppsRegistryPull' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/apps -count=1`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `apps registry pull` CLI command to synchronize local app registry with App Store Connect data. Features include merging remote apps while preserving local fields, automatic key generation for new entries, duplicate validation, dry-run preview mode, optional pruning of missing apps, and table/markdown output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->