### PR TITLE
chore: Run 'make format' for the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOBIN := $(shell $(GO) env GOPATH)/bin
 GO_TOOLCHAIN_VERSION := $(shell $(GO) env GOVERSION)
 GOLANGCI_LINT_TIMEOUT ?= 5m
 INSTALL_PREFIX ?= /usr/local/bin
-GOFUMPT_VERSION ?= v0.9.2
+GOFUMPT_VERSION ?= v0.10.0
 GOLANGCI_LINT_VERSION ?= v2.11.4
 
 # Directories

--- a/apps/studio/app_helpers.go
+++ b/apps/studio/app_helpers.go
@@ -124,14 +124,16 @@ func bundledASCCandidates() []string {
 	var candidates []string
 	if executable, err := osExecutableFunc(); err == nil && strings.TrimSpace(executable) != "" {
 		execDir := filepath.Dir(executable)
-		candidates = append(candidates,
+		candidates = append(
+			candidates,
 			filepath.Clean(filepath.Join(execDir, "..", "Resources", "bin", "asc")),
 			filepath.Clean(filepath.Join(execDir, "bin", "asc")),
 		)
 	}
 
 	if workingDir, err := getwdFunc(); err == nil && strings.TrimSpace(workingDir) != "" {
-		candidates = append(candidates,
+		candidates = append(
+			candidates,
 			filepath.Join(workingDir, "bin", "asc"),
 			filepath.Join(workingDir, "apps", "studio", "bin", "asc"),
 		)

--- a/cmd/age_rating_run_test.go
+++ b/cmd/age_rating_run_test.go
@@ -8,7 +8,8 @@ import (
 func TestRun_AgeRatingSetInvalidAllNoneReturnsUsage(t *testing.T) {
 	resetReportFlags(t)
 
-	stdout, stderr, exitCode := runHelpSubprocess(t, t.TempDir(),
+	stdout, stderr, exitCode := runHelpSubprocess(
+		t, t.TempDir(),
 		"age-rating", "edit",
 		"--id", "age-1",
 		"--all-none=maybe",
@@ -27,7 +28,8 @@ func TestRun_AgeRatingSetInvalidAllNoneReturnsUsage(t *testing.T) {
 func TestRun_AgeRatingSetAllNoneFalseReturnsUsage(t *testing.T) {
 	resetReportFlags(t)
 
-	stdout, stderr, exitCode := runHelpSubprocess(t, t.TempDir(),
+	stdout, stderr, exitCode := runHelpSubprocess(
+		t, t.TempDir(),
 		"age-rating", "edit",
 		"--id", "age-1",
 		"--all-none", "false",

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -817,7 +817,8 @@ func isolatedCLITestEnv(configPath string) []string {
 		"ASC_STRICT_AUTH",
 		"ASC_APP_ID",
 	)
-	return append(env,
+	return append(
+		env,
 		"ASC_BYPASS_KEYCHAIN=1",
 		"ASC_CONFIG_PATH="+configPath,
 		"HOME="+filepath.Dir(configPath),

--- a/internal/asc/beta_license_agreements_test.go
+++ b/internal/asc/beta_license_agreements_test.go
@@ -35,7 +35,8 @@ func TestGetBetaLicenseAgreements(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetBetaLicenseAgreements(context.Background(),
+	_, err := client.GetBetaLicenseAgreements(
+		context.Background(),
 		WithBetaLicenseAgreementsAppIDs([]string{"app-1", "app-2"}),
 		WithBetaLicenseAgreementsFields([]string{"agreementText"}),
 		WithBetaLicenseAgreementsAppFields([]string{"name"}),
@@ -84,7 +85,8 @@ func TestGetBetaLicenseAgreement(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetBetaLicenseAgreement(context.Background(), "bla-1",
+	if _, err := client.GetBetaLicenseAgreement(
+		context.Background(), "bla-1",
 		WithBetaLicenseAgreementFields([]string{"agreementText"}),
 		WithBetaLicenseAgreementInclude([]string{"app"}),
 	); err != nil {

--- a/internal/asc/client_app_metadata_test.go
+++ b/internal/asc/client_app_metadata_test.go
@@ -853,7 +853,8 @@ func TestGetAppInfoTerritoryAgeRatings_SendsRequest(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetAppInfoTerritoryAgeRatings(context.Background(), "info-1",
+	_, err := client.GetAppInfoTerritoryAgeRatings(
+		context.Background(), "info-1",
 		WithTerritoryAgeRatingsFields([]string{"appStoreAgeRating", "territory"}),
 		WithTerritoryAgeRatingsTerritoryFields([]string{"currency"}),
 		WithTerritoryAgeRatingsInclude([]string{"territory"}),

--- a/internal/asc/client_core.go
+++ b/internal/asc/client_core.go
@@ -385,7 +385,8 @@ func WithRetry[T any](ctx context.Context, fn func() (T, error), opts RetryOptio
 		}
 
 		if debugEnabled {
-			debugLogger.Info("⟳ Retrying request",
+			debugLogger.Info(
+				"⟳ Retrying request",
 				"attempt", retryCount+1,
 				"max_retries", opts.MaxRetries,
 				"delay", delay.String(),

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -188,7 +188,8 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 	}
 
 	if debugSettings.verboseHTTP {
-		debugLogger.Info("→ HTTP Request",
+		debugLogger.Info(
+			"→ HTTP Request",
 			"method", method,
 			"url", sanitizeURLForLog(req.URL.String()),
 			"content-type", req.Header.Get("Content-Type"),
@@ -201,7 +202,8 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 
 	if err != nil {
 		if debugSettings.verboseHTTP {
-			debugLogger.Info("← HTTP Error",
+			debugLogger.Info(
+				"← HTTP Error",
 				"error", err.Error(),
 				"elapsed", elapsed.String(),
 			)
@@ -211,7 +213,8 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 	defer resp.Body.Close()
 
 	if debugSettings.verboseHTTP {
-		debugLogger.Info("← HTTP Response",
+		debugLogger.Info(
+			"← HTTP Response",
 			"status", resp.StatusCode,
 			"elapsed", elapsed.String(),
 			"content-type", resp.Header.Get("Content-Type"),

--- a/internal/asc/client_http_app_clips_test.go
+++ b/internal/asc/client_http_app_clips_test.go
@@ -146,7 +146,8 @@ func TestGetAppClipDefaultExperienceLocalizations_WithFilters(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetAppClipDefaultExperienceLocalizations(context.Background(), "exp-1",
+	if _, err := client.GetAppClipDefaultExperienceLocalizations(
+		context.Background(), "exp-1",
 		WithAppClipDefaultExperienceLocalizationsLocales([]string{"en-US", "fr-FR"}),
 		WithAppClipDefaultExperienceLocalizationsLimit(20),
 	); err != nil {
@@ -241,7 +242,8 @@ func TestGetAppClipDefaultExperience_WithInclude(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetAppClipDefaultExperience(context.Background(), "exp-1",
+	if _, err := client.GetAppClipDefaultExperience(
+		context.Background(), "exp-1",
 		WithAppClipDefaultExperienceInclude([]string{"releaseWithAppStoreVersion", "appClipAppStoreReviewDetail"}),
 	); err != nil {
 		t.Fatalf("GetAppClipDefaultExperience() error: %v", err)
@@ -414,7 +416,8 @@ func TestGetAppClipAdvancedExperiences_WithFilters(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetAppClipAdvancedExperiences(context.Background(), "clip-1",
+	if _, err := client.GetAppClipAdvancedExperiences(
+		context.Background(), "clip-1",
 		WithAppClipAdvancedExperiencesActions([]string{"OPEN", "VIEW"}),
 		WithAppClipAdvancedExperiencesStatuses([]string{"ACTIVE"}),
 		WithAppClipAdvancedExperiencesPlaceStatuses([]string{"ACTIVE"}),

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -1235,7 +1235,8 @@ func TestGetBuilds_WithPreReleaseVersion(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	builds, err := client.GetBuilds(context.Background(), "123",
+	builds, err := client.GetBuilds(
+		context.Background(), "123",
 		WithBuildsLimit(1),
 		WithBuildsSort("-uploadedDate"),
 		WithBuildsPreReleaseVersion("prv-456"),
@@ -2230,29 +2231,30 @@ func TestUpdateBuild_EmptyBuildIDReturnsError(t *testing.T) {
 
 func TestUpdateBuild_RefetchesCurrentStateAfterPatchError(t *testing.T) {
 	requestCount := 0
-	client := newTestClientWithResponses(t, func(req *http.Request) {
-		requestCount++
-		switch requestCount {
-		case 1:
-			if req.Method != http.MethodPatch {
-				t.Fatalf("expected PATCH, got %s", req.Method)
+	client := newTestClientWithResponses(
+		t, func(req *http.Request) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				if req.Method != http.MethodPatch {
+					t.Fatalf("expected PATCH, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/builds/build-99" {
+					t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			case 2:
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/builds/build-99" {
+					t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			default:
+				t.Fatalf("unexpected request count %d", requestCount)
 			}
-			if req.URL.Path != "/v1/builds/build-99" {
-				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
-			}
-			assertAuthorized(t, req)
-		case 2:
-			if req.Method != http.MethodGet {
-				t.Fatalf("expected GET, got %s", req.Method)
-			}
-			if req.URL.Path != "/v1/builds/build-99" {
-				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
-			}
-			assertAuthorized(t, req)
-		default:
-			t.Fatalf("unexpected request count %d", requestCount)
-		}
-	},
+		},
 		jsonResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Build update conflict","detail":"The request could not be completed."}]}`),
 		jsonResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-99","attributes":{"version":"2.0","uploadedDate":"2026-03-18T00:00:00Z","usesNonExemptEncryption":false}}}`),
 	)
@@ -2275,29 +2277,30 @@ func TestUpdateBuild_RefetchesCurrentStateAfterPatchError(t *testing.T) {
 
 func TestUpdateBuild_ReturnsOriginalErrorWhenCurrentStateDoesNotMatch(t *testing.T) {
 	requestCount := 0
-	client := newTestClientWithResponses(t, func(req *http.Request) {
-		requestCount++
-		switch requestCount {
-		case 1:
-			if req.Method != http.MethodPatch {
-				t.Fatalf("expected PATCH, got %s", req.Method)
+	client := newTestClientWithResponses(
+		t, func(req *http.Request) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				if req.Method != http.MethodPatch {
+					t.Fatalf("expected PATCH, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/builds/build-99" {
+					t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			case 2:
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/builds/build-99" {
+					t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			default:
+				t.Fatalf("unexpected request count %d", requestCount)
 			}
-			if req.URL.Path != "/v1/builds/build-99" {
-				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
-			}
-			assertAuthorized(t, req)
-		case 2:
-			if req.Method != http.MethodGet {
-				t.Fatalf("expected GET, got %s", req.Method)
-			}
-			if req.URL.Path != "/v1/builds/build-99" {
-				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
-			}
-			assertAuthorized(t, req)
-		default:
-			t.Fatalf("unexpected request count %d", requestCount)
-		}
-	},
+		},
 		jsonResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Build update conflict","detail":"The request could not be completed."}]}`),
 		jsonResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-99","attributes":{"version":"2.0","uploadedDate":"2026-03-18T00:00:00Z","usesNonExemptEncryption":true}}}`),
 	)
@@ -2320,29 +2323,30 @@ func TestUpdateBuild_ReturnsOriginalErrorWhenCurrentStateDoesNotMatch(t *testing
 
 func TestUpdateBuild_DoesNotTreatNonConflictErrorAsNoOp(t *testing.T) {
 	requestCount := 0
-	client := newTestClientWithResponses(t, func(req *http.Request) {
-		requestCount++
-		switch requestCount {
-		case 1:
-			if req.Method != http.MethodPatch {
-				t.Fatalf("expected PATCH, got %s", req.Method)
+	client := newTestClientWithResponses(
+		t, func(req *http.Request) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				if req.Method != http.MethodPatch {
+					t.Fatalf("expected PATCH, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/builds/build-99" {
+					t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			case 2:
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/builds/build-99" {
+					t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
+				}
+				assertAuthorized(t, req)
+			default:
+				t.Fatalf("unexpected request count %d", requestCount)
 			}
-			if req.URL.Path != "/v1/builds/build-99" {
-				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
-			}
-			assertAuthorized(t, req)
-		case 2:
-			if req.Method != http.MethodGet {
-				t.Fatalf("expected GET, got %s", req.Method)
-			}
-			if req.URL.Path != "/v1/builds/build-99" {
-				t.Fatalf("expected path /v1/builds/build-99, got %s", req.URL.Path)
-			}
-			assertAuthorized(t, req)
-		default:
-			t.Fatalf("unexpected request count %d", requestCount)
-		}
-	},
+		},
 		jsonResponse(http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden","detail":"not allowed"}]}`),
 		jsonResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-99","attributes":{"version":"2.0","uploadedDate":"2026-03-18T00:00:00Z","usesNonExemptEncryption":false}}}`),
 	)
@@ -4001,7 +4005,8 @@ func TestGetBuildUploads_WithFilters(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetBuildUploads(context.Background(), "app-1",
+	_, err := client.GetBuildUploads(
+		context.Background(), "app-1",
 		WithBuildUploadsCFBundleShortVersionStrings([]string{"1.0.0", "1.0.1"}),
 		WithBuildUploadsCFBundleVersions([]string{"100"}),
 		WithBuildUploadsPlatforms([]string{"ios", "mac_os"}),
@@ -4193,7 +4198,8 @@ func TestGetBetaTesterUsagesMetrics_WithFilters(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	resp, err := client.GetBetaTesterUsagesMetrics(context.Background(), "tester-1",
+	resp, err := client.GetBetaTesterUsagesMetrics(
+		context.Background(), "tester-1",
 		WithBetaTesterUsagesPeriod("P30D"),
 		WithBetaTesterUsagesAppID("app-1"),
 		WithBetaTesterUsagesLimit(20),
@@ -4228,7 +4234,8 @@ func TestGetAppBetaTesterUsagesMetrics_WithPeriodAndLimit(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	resp, err := client.GetAppBetaTesterUsagesMetrics(context.Background(), "app-1",
+	resp, err := client.GetAppBetaTesterUsagesMetrics(
+		context.Background(), "app-1",
 		WithBetaTesterUsagesPeriod("P90D"),
 		WithBetaTesterUsagesLimit(12),
 	)
@@ -9094,7 +9101,8 @@ func TestGetDevices_WithFilters(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetDevices(context.Background(),
+	if _, err := client.GetDevices(
+		context.Background(),
 		WithDevicesFilterUDIDs([]string{"UDID1", "UDID2"}),
 		WithDevicesFilterPlatforms([]string{"ios"}),
 		WithDevicesFilterStatuses([]string{"enabled"}),
@@ -9140,7 +9148,8 @@ func TestGetDevices_WithFiltersAndLimit(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetDevices(context.Background(),
+	if _, err := client.GetDevices(
+		context.Background(),
 		WithDevicesNames([]string{"My iPhone"}),
 		WithDevicesPlatform("IOS"),
 		WithDevicesStatus("ENABLED"),
@@ -9707,7 +9716,8 @@ func TestGetAppEncryptionDeclarationsForApp(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetAppEncryptionDeclarations(context.Background(), "app-1",
+	if _, err := client.GetAppEncryptionDeclarations(
+		context.Background(), "app-1",
 		WithAppEncryptionDeclarationsBuildIDs([]string{"build-1", "build-2"}),
 		WithAppEncryptionDeclarationsFields([]string{"appDescription", "exempt"}),
 		WithAppEncryptionDeclarationsDocumentFields([]string{"fileName", "fileSize"}),
@@ -9744,7 +9754,8 @@ func TestGetAppEncryptionDeclaration(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetAppEncryptionDeclaration(context.Background(), "decl-1",
+	if _, err := client.GetAppEncryptionDeclaration(
+		context.Background(), "decl-1",
 		WithAppEncryptionDeclarationsFields([]string{"appDescription", "exempt"}),
 		WithAppEncryptionDeclarationsDocumentFields([]string{"fileName", "fileSize"}),
 		WithAppEncryptionDeclarationsInclude([]string{"appEncryptionDeclarationDocument"}),
@@ -9856,7 +9867,8 @@ func TestGetAppEncryptionDeclarationsForAppResource(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetAppEncryptionDeclarationsForApp(context.Background(), "app-1",
+	if _, err := client.GetAppEncryptionDeclarationsForApp(
+		context.Background(), "app-1",
 		WithAppEncryptionDeclarationsBuildIDs([]string{"build-1", "build-2"}),
 		WithAppEncryptionDeclarationsFields([]string{"appDescription", "exempt"}),
 		WithAppEncryptionDeclarationsDocumentFields([]string{"fileName", "fileSize"}),
@@ -10255,7 +10267,8 @@ func TestGetAndroidToIosAppMappingDetails(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetAndroidToIosAppMappingDetails(context.Background(), "app-1",
+	_, err := client.GetAndroidToIosAppMappingDetails(
+		context.Background(), "app-1",
 		WithAndroidToIosAppMappingDetailsFields([]string{"packageName"}),
 		WithAndroidToIosAppMappingDetailsLimit(20),
 	)
@@ -10283,7 +10296,8 @@ func TestGetAndroidToIosAppMappingDetail(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetAndroidToIosAppMappingDetail(context.Background(), "map-1",
+	_, err := client.GetAndroidToIosAppMappingDetail(
+		context.Background(), "map-1",
 		WithAndroidToIosAppMappingDetailsFields([]string{"packageName"}),
 		WithAndroidToIosAppMappingDetailsLimit(20),
 	)

--- a/internal/asc/client_http_webhooks_test.go
+++ b/internal/asc/client_http_webhooks_test.go
@@ -33,7 +33,8 @@ func TestGetAppWebhooks_SendsRequest(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetAppWebhooks(context.Background(), "app-1",
+	_, err := client.GetAppWebhooks(
+		context.Background(), "app-1",
 		WithWebhooksLimit(5),
 		WithWebhooksFields([]string{"name", "url"}),
 		WithWebhooksAppFields([]string{"name"}),
@@ -204,7 +205,8 @@ func TestGetWebhookDeliveries_SendsRequest(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetWebhookDeliveries(context.Background(), "wh-1",
+	_, err := client.GetWebhookDeliveries(
+		context.Background(), "wh-1",
 		WithWebhookDeliveriesLimit(3),
 		WithWebhookDeliveriesDeliveryStates([]string{"failed"}),
 	)

--- a/internal/asc/client_pass_type_ids_test.go
+++ b/internal/asc/client_pass_type_ids_test.go
@@ -84,7 +84,8 @@ func TestGetPassTypeIDs_WithFieldsIncludeSort(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetPassTypeIDs(context.Background(),
+	_, err := client.GetPassTypeIDs(
+		context.Background(),
 		WithPassTypeIDsFilterIDs([]string{"p1", "p2"}),
 		WithPassTypeIDsSort("-name"),
 		WithPassTypeIDsFields([]string{"name", "identifier"}),
@@ -151,7 +152,8 @@ func TestGetPassTypeID_WithFieldsIncludeLimit(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetPassTypeID(context.Background(), "p1",
+	_, err := client.GetPassTypeID(
+		context.Background(), "p1",
 		WithPassTypeIDFields([]string{"name", "identifier"}),
 		WithPassTypeIDCertificateFields([]string{"serialNumber"}),
 		WithPassTypeIDInclude([]string{"certificates"}),

--- a/internal/asc/client_publish.go
+++ b/internal/asc/client_publish.go
@@ -45,7 +45,8 @@ func (c *Client) FindOrCreateAppStoreVersion(ctx context.Context, appID, version
 		return nil, fmt.Errorf("app ID, version, and platform are required")
 	}
 
-	versions, err := c.GetAppStoreVersions(ctx, appID,
+	versions, err := c.GetAppStoreVersions(
+		ctx, appID,
 		WithAppStoreVersionsVersionStrings([]string{version}),
 		WithAppStoreVersionsPlatforms([]string{platformValue}),
 		WithAppStoreVersionsLimit(10),

--- a/internal/asc/customer_review_summarizations_test.go
+++ b/internal/asc/customer_review_summarizations_test.go
@@ -37,7 +37,8 @@ func TestGetCustomerReviewSummarizations(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	_, err := client.GetCustomerReviewSummarizations(context.Background(), "app-1",
+	_, err := client.GetCustomerReviewSummarizations(
+		context.Background(), "app-1",
 		WithCustomerReviewSummarizationsPlatforms([]string{"IOS"}),
 		WithCustomerReviewSummarizationsTerritories([]string{"US"}),
 		WithCustomerReviewSummarizationsFields([]string{"locale", "text"}),

--- a/internal/asc/pricing_test.go
+++ b/internal/asc/pricing_test.go
@@ -64,7 +64,8 @@ func TestGetAppPricePoints_WithTerritory(t *testing.T) {
 		}
 	}, jsonResponse(http.StatusOK, string(body)))
 
-	result, err := client.GetAppPricePoints(context.Background(), "app-1",
+	result, err := client.GetAppPricePoints(
+		context.Background(), "app-1",
 		WithPricePointsTerritory("usa"),
 		WithPricePointsLimit(10),
 	)

--- a/internal/asc/sandbox.go
+++ b/internal/asc/sandbox.go
@@ -207,7 +207,8 @@ func (c *Client) GetSandboxTesters(ctx context.Context, opts ...SandboxTestersOp
 func (c *Client) GetSandboxTester(ctx context.Context, testerID string) (*SandboxTesterResponse, error) {
 	next := ""
 	for {
-		resp, err := c.GetSandboxTesters(ctx,
+		resp, err := c.GetSandboxTesters(
+			ctx,
 			WithSandboxTestersLimit(200),
 			WithSandboxTestersNextURL(next),
 		)

--- a/internal/asc/sandbox_test.go
+++ b/internal/asc/sandbox_test.go
@@ -44,7 +44,8 @@ func TestGetSandboxTesters_WithFilters(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	resp, err := client.GetSandboxTesters(context.Background(),
+	resp, err := client.GetSandboxTesters(
+		context.Background(),
 		WithSandboxTestersEmail("tester@example.com"),
 		WithSandboxTestersTerritory("usa"),
 		WithSandboxTestersLimit(10),

--- a/internal/asc/table_render.go
+++ b/internal/asc/table_render.go
@@ -12,7 +12,8 @@ import (
 // Headers preserve their original casing and are center-aligned.
 // Data rows are left-aligned for readability.
 func RenderTable(headers []string, rows [][]string) {
-	table := tablewriter.NewTable(os.Stdout,
+	table := tablewriter.NewTable(
+		os.Stdout,
 		tablewriter.WithConfig(tablewriter.Config{
 			Header: tw.CellConfig{
 				Formatting: tw.CellFormatting{
@@ -34,7 +35,8 @@ func RenderTable(headers []string, rows [][]string) {
 // Headers preserve their original casing. Data rows are left-aligned.
 // Pipe characters in cell values are escaped automatically by the renderer.
 func RenderMarkdown(headers []string, rows [][]string) {
-	table := tablewriter.NewTable(os.Stdout,
+	table := tablewriter.NewTable(
+		os.Stdout,
 		tablewriter.WithRenderer(renderer.NewMarkdown()),
 		tablewriter.WithConfig(tablewriter.Config{
 			Header: tw.CellConfig{

--- a/internal/asc/upload_test.go
+++ b/internal/asc/upload_test.go
@@ -66,7 +66,8 @@ func TestExecuteUploadOperations_UploadsSlices(t *testing.T) {
 		},
 	}
 
-	err := ExecuteUploadOperations(context.Background(), filePath, ops,
+	err := ExecuteUploadOperations(
+		context.Background(), filePath, ops,
 		WithUploadConcurrency(2),
 		WithUploadHTTPClient(server.Client()),
 	)
@@ -233,7 +234,8 @@ func TestExecuteUploadOperations_CancelsDuringDispatch(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- ExecuteUploadOperations(ctx, filePath, ops,
+		done <- ExecuteUploadOperations(
+			ctx, filePath, ops,
 			WithUploadConcurrency(1),
 			WithUploadHTTPClient(client),
 		)

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -99,7 +99,8 @@ func TestIntegrationAuthConfig(t *testing.T) {
 		tempDir := t.TempDir()
 
 		// Login with bypass-keychain --local writes to .asc/config.json in cwd
-		cmd := exec.Command(ascBinary, "auth", "login",
+		cmd := exec.Command(
+			ascBinary, "auth", "login",
 			"--bypass-keychain",
 			"--local",
 			"--name", "TestKey",
@@ -156,7 +157,8 @@ func TestIntegrationAuthConfig(t *testing.T) {
 
 		// Check auth status
 		cmd := exec.Command(ascBinary, "auth", "status")
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"ASC_CONFIG_PATH="+configPath,
 			"ASC_BYPASS_KEYCHAIN=1",
 		)
@@ -199,7 +201,8 @@ func TestIntegrationAuthConfig(t *testing.T) {
 		}
 
 		cmd := exec.Command(ascBinary, "auth", "switch", "--name", "client")
-		cmd.Env = append(filterEnv(os.Environ(), "ASC_CONFIG_PATH", "ASC_BYPASS_KEYCHAIN"),
+		cmd.Env = append(
+			filterEnv(os.Environ(), "ASC_CONFIG_PATH", "ASC_BYPASS_KEYCHAIN"),
 			"ASC_CONFIG_PATH="+configPath,
 			"ASC_BYPASS_KEYCHAIN=1",
 		)
@@ -217,10 +220,12 @@ func TestIntegrationAuthConfig(t *testing.T) {
 		}
 
 		cmd = exec.Command(ascBinary, "--profile", "client", "apps", "list", "--limit", "1")
-		cmd.Env = append(filterEnv(os.Environ(),
-			"ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
-			"ASC_CONFIG_PATH", "ASC_BYPASS_KEYCHAIN",
-		),
+		cmd.Env = append(
+			filterEnv(
+				os.Environ(),
+				"ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+				"ASC_CONFIG_PATH", "ASC_BYPASS_KEYCHAIN",
+			),
 			"ASC_CONFIG_PATH="+configPath,
 			"ASC_BYPASS_KEYCHAIN=1",
 		)
@@ -250,7 +255,8 @@ func TestIntegrationAuthConfig(t *testing.T) {
 
 		// Try to list apps using config credentials
 		cmd := exec.Command(ascBinary, "apps", "list")
-		cmd.Env = filterEnv(os.Environ(),
+		cmd.Env = filterEnv(
+			os.Environ(),
 			"ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
 		)
 		cmd.Env = append(cmd.Env, "ASC_CONFIG_PATH="+configPath)
@@ -287,7 +293,8 @@ func TestIntegrationAuthConfig(t *testing.T) {
 
 		// Try to list builds without --app flag (should use config app_id)
 		cmd := exec.Command(ascBinary, "builds", "list", "--limit", "1")
-		cmd.Env = filterEnv(os.Environ(),
+		cmd.Env = filterEnv(
+			os.Environ(),
 			"ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH", "ASC_APP_ID",
 		)
 		cmd.Env = append(cmd.Env, "ASC_CONFIG_PATH="+configPath)

--- a/internal/cli/analytics/analytics_instances.go
+++ b/internal/cli/analytics/analytics_instances.go
@@ -135,7 +135,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithLinkagesLimit(analyticsMaxLimit))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetAnalyticsReportInstanceSegmentsRelationships(ctx, id, paginateOpts...)
 					},

--- a/internal/cli/analytics/analytics_reports.go
+++ b/internal/cli/analytics/analytics_reports.go
@@ -135,7 +135,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithLinkagesLimit(analyticsMaxLimit))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetAnalyticsReportInstancesRelationships(ctx, id, paginateOpts...)
 					},

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -176,7 +176,8 @@ Examples:
 
 				if *paginate {
 					paginateOpts := append(opts, asc.WithAnalyticsReportRequestsLimit(200))
-					paginated, err := shared.PaginateWithSpinner(requestCtx,
+					paginated, err := shared.PaginateWithSpinner(
+						requestCtx,
 						func(ctx context.Context) (asc.PaginatedResponse, error) {
 							return client.GetAnalyticsReportRequests(ctx, resolvedAppID, paginateOpts...)
 						},

--- a/internal/cli/androidiosmapping/android_ios_mapping.go
+++ b/internal/cli/androidiosmapping/android_ios_mapping.go
@@ -160,7 +160,8 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetAndroidToIosAppMappingDetail(requestCtx, strings.TrimSpace(*id),
+			resp, err := client.GetAndroidToIosAppMappingDetail(
+				requestCtx, strings.TrimSpace(*id),
 				asc.WithAndroidToIosAppMappingDetailsFields(fieldValues),
 			)
 			if err != nil {

--- a/internal/cli/apps/app_registry.go
+++ b/internal/cli/apps/app_registry.go
@@ -160,7 +160,8 @@ func appsRegistryPull(ctx context.Context, opts appsRegistryPullOptions) error {
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
-	response, err := shared.PaginateWithSpinner(requestCtx,
+	response, err := shared.PaginateWithSpinner(
+		requestCtx,
 		func(ctx context.Context) (asc.PaginatedResponse, error) {
 			return client.GetApps(ctx, asc.WithAppsLimit(200), asc.WithAppsSort("name"))
 		},

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -359,7 +359,8 @@ func appsList(ctx context.Context, output string, pretty bool, bundleID string, 
 
 	if paginate {
 		paginateOpts := append(opts, asc.WithAppsLimit(200))
-		apps, err := shared.PaginateWithSpinner(requestCtx,
+		apps, err := shared.PaginateWithSpinner(
+			requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return client.GetApps(ctx, paginateOpts...)
 			},

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -267,7 +267,8 @@ func doctorMigrationSuggestionResolver() authsvc.MigrationSuggestionResolver {
 
 		if needsAppLookup {
 			appIdentifier := strings.TrimSpace(input.AppIdentifier)
-			appsResp, err := client.GetApps(requestCtx,
+			appsResp, err := client.GetApps(
+				requestCtx,
 				asc.WithAppsBundleIDs([]string{appIdentifier}),
 				asc.WithAppsLimit(1),
 			)
@@ -282,7 +283,8 @@ func doctorMigrationSuggestionResolver() authsvc.MigrationSuggestionResolver {
 
 		versionString := strings.TrimSpace(input.MarketingVersion)
 		if needsVersionLookup && versionString != "" {
-			versionsResp, err := client.GetAppStoreVersions(requestCtx, appID,
+			versionsResp, err := client.GetAppStoreVersions(
+				requestCtx, appID,
 				asc.WithAppStoreVersionsVersionStrings([]string{versionString}),
 				asc.WithAppStoreVersionsLimit(1),
 			)
@@ -297,7 +299,8 @@ func doctorMigrationSuggestionResolver() authsvc.MigrationSuggestionResolver {
 				asc.WithBuildsLimit(1),
 			}
 			if versionString != "" {
-				preReleaseResp, err := client.GetPreReleaseVersions(requestCtx, appID,
+				preReleaseResp, err := client.GetPreReleaseVersions(
+					requestCtx, appID,
 					asc.WithPreReleaseVersionsVersion(versionString),
 					asc.WithPreReleaseVersionsLimit(1),
 				)

--- a/internal/cli/builds/build_test_notes.go
+++ b/internal/cli/builds/build_test_notes.go
@@ -130,7 +130,8 @@ Examples:
 				paginateOpts := append(opts, asc.WithBetaBuildLocalizationsLimit(200))
 				requestCtx, cancel := shared.ContextWithTimeout(ctx)
 				defer cancel()
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.ListBetaBuildLocalizations(ctx, paginateOpts...)
 					},

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -523,7 +523,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBuildsLimit(200))
-				builds, err := shared.PaginateWithSpinner(requestCtx,
+				builds, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBuilds(ctx, resolvedAppID, paginateOpts...)
 					},

--- a/internal/cli/builds/builds_individual_testers.go
+++ b/internal/cli/builds/builds_individual_testers.go
@@ -105,7 +105,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBuildIndividualTestersLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBuildIndividualTesters(ctx, buildID, paginateOpts...)
 					},

--- a/internal/cli/builds/builds_related.go
+++ b/internal/cli/builds/builds_related.go
@@ -260,7 +260,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBuildIconsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBuildIcons(ctx, buildID, paginateOpts...)
 					},

--- a/internal/cli/builds/builds_relationships.go
+++ b/internal/cli/builds/builds_relationships.go
@@ -146,7 +146,8 @@ Examples:
 
 				if *paginate {
 					paginateOpts := append(opts, asc.WithLinkagesLimit(200))
-					resp, err := shared.PaginateWithSpinner(requestCtx,
+					resp, err := shared.PaginateWithSpinner(
+						requestCtx,
 						func(ctx context.Context) (asc.PaginatedResponse, error) {
 							return getBuildRelationshipList(ctx, client, relationshipType, buildID, paginateOpts...)
 						},

--- a/internal/cli/builds/builds_uploads.go
+++ b/internal/cli/builds/builds_uploads.go
@@ -117,7 +117,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBuildUploadsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBuildUploads(ctx, resolvedAppID, paginateOpts...)
 					},
@@ -315,7 +316,8 @@ Examples:
 				}
 
 				paginateOpts := append(opts, asc.WithBuildUploadFilesLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBuildUploadFiles(ctx, uploadValue, paginateOpts...)
 					},

--- a/internal/cli/certificates/certificates.go
+++ b/internal/cli/certificates/certificates.go
@@ -102,7 +102,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithCertificatesLimit(200))
-				paginated, err := shared.PaginateWithSpinner(requestCtx,
+				paginated, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetCertificates(ctx, paginateOpts...)
 					},

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -232,7 +232,8 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetAppEncryptionDeclaration(requestCtx, declarationValue,
+			resp, err := client.GetAppEncryptionDeclaration(
+				requestCtx, declarationValue,
 				asc.WithAppEncryptionDeclarationsFields(fieldsValue),
 				asc.WithAppEncryptionDeclarationsDocumentFields(documentFieldsValue),
 				asc.WithAppEncryptionDeclarationsInclude(includeValue),

--- a/internal/cli/iap/setup.go
+++ b/internal/cli/iap/setup.go
@@ -338,7 +338,8 @@ func executeIAPSetup(ctx context.Context, opts iapSetupOptions) (iapSetupResult,
 
 	hasPricing := opts.hasPricing(opts.StartDate)
 	if !hasPricing {
-		result.Steps = append(result.Steps,
+		result.Steps = append(
+			result.Steps,
 			iapSetupStepResult{
 				Name:    iapSetupStepResolvePricePoint,
 				Status:  "skipped",

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -131,7 +131,8 @@ func newMetadataMutationCommand(cfg metadataMutationCommandConfig) *ffcli.Comman
 		Name:       cfg.name,
 		ShortUsage: fmt.Sprintf(`asc metadata %s --app "APP_ID" --version "1.2.3" --dir "./metadata" [--app-info "APP_INFO_ID"] [--dry-run]`, cfg.name),
 		ShortHelp:  fmt.Sprintf("%s metadata changes from canonical files.", cfg.verbTitle),
-		LongHelp: fmt.Sprintf(`%s metadata changes from canonical files.
+		LongHelp: fmt.Sprintf(
+			`%s metadata changes from canonical files.
 
 Examples:
   asc metadata %s --app "APP_ID" --version "1.2.3" --dir "./metadata" --dry-run
@@ -367,7 +368,8 @@ func buildMetadataAppInfoExample(command, appID, version, platform, dir, appInfo
 	if dirValue == "" {
 		dirValue = "./metadata"
 	}
-	parts = append(parts,
+	parts = append(
+		parts,
 		fmt.Sprintf(`--dir %q`, dirValue),
 		fmt.Sprintf(`--app-info %q`, appInfoID),
 	)

--- a/internal/cli/performance/performance_download.go
+++ b/internal/cli/performance/performance_download.go
@@ -140,7 +140,8 @@ Examples:
 			case trimmedBuildID != "":
 				defaultOutput := fmt.Sprintf("perf_power_metrics_%s.json", trimmedBuildID)
 
-				download, err := client.DownloadPerfPowerMetricsForBuild(requestCtx, trimmedBuildID,
+				download, err := client.DownloadPerfPowerMetricsForBuild(
+					requestCtx, trimmedBuildID,
 					asc.WithPerfPowerMetricsPlatforms(platforms),
 					asc.WithPerfPowerMetricsMetricTypes(metricTypes),
 					asc.WithPerfPowerMetricsDeviceTypes(shared.SplitCSV(*deviceType)),
@@ -184,7 +185,8 @@ Examples:
 			default:
 				defaultOutput := fmt.Sprintf("perf_power_metrics_%s.json", appFlag)
 
-				download, err := client.DownloadPerfPowerMetricsForApp(requestCtx, appFlag,
+				download, err := client.DownloadPerfPowerMetricsForApp(
+					requestCtx, appFlag,
 					asc.WithPerfPowerMetricsPlatforms(platforms),
 					asc.WithPerfPowerMetricsMetricTypes(metricTypes),
 					asc.WithPerfPowerMetricsDeviceTypes(shared.SplitCSV(*deviceType)),

--- a/internal/cli/performance/performance_metrics.go
+++ b/internal/cli/performance/performance_metrics.go
@@ -83,7 +83,8 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetPerfPowerMetricsForApp(requestCtx, resolvedAppID,
+			resp, err := client.GetPerfPowerMetricsForApp(
+				requestCtx, resolvedAppID,
 				asc.WithPerfPowerMetricsPlatforms(platforms),
 				asc.WithPerfPowerMetricsMetricTypes(metricTypes),
 				asc.WithPerfPowerMetricsDeviceTypes(shared.SplitCSV(*deviceType)),
@@ -142,7 +143,8 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetPerfPowerMetricsForBuild(requestCtx, trimmedBuildID,
+			resp, err := client.GetPerfPowerMetricsForBuild(
+				requestCtx, trimmedBuildID,
 				asc.WithPerfPowerMetricsPlatforms(platforms),
 				asc.WithPerfPowerMetricsMetricTypes(metricTypes),
 				asc.WithPerfPowerMetricsDeviceTypes(shared.SplitCSV(*deviceType)),

--- a/internal/cli/pricing/tiers.go
+++ b/internal/cli/pricing/tiers.go
@@ -70,7 +70,8 @@ Examples:
 				return fmt.Errorf("pricing tiers: %w", err)
 			}
 
-			return shared.PrintOutputWithRenderers(tiers, *output.Output, *output.Pretty,
+			return shared.PrintOutputWithRenderers(
+				tiers, *output.Output, *output.Pretty,
 				func() error {
 					return printTiersTable(tiers)
 				},

--- a/internal/cli/profiles/profiles.go
+++ b/internal/cli/profiles/profiles.go
@@ -102,7 +102,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithProfilesLimit(200))
-				paginated, err := shared.PaginateWithSpinner(requestCtx,
+				paginated, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetProfiles(ctx, paginateOpts...)
 					},

--- a/internal/cli/publish/local_build.go
+++ b/internal/cli/publish/local_build.go
@@ -329,7 +329,8 @@ func resolvePublishExportOptionsPath(explicit string) (string, error) {
 }
 
 func defaultPublishArchivePath(scheme, platform, version, buildNumber string) string {
-	fileName := fmt.Sprintf("%s-%s-%s-%s.xcarchive",
+	fileName := fmt.Sprintf(
+		"%s-%s-%s-%s.xcarchive",
 		sanitizePublishArtifactToken(scheme),
 		sanitizePublishArtifactToken(platform),
 		sanitizePublishArtifactToken(version),
@@ -339,7 +340,8 @@ func defaultPublishArchivePath(scheme, platform, version, buildNumber string) st
 }
 
 func defaultPublishIPAPath(scheme, platform, version, buildNumber string) string {
-	fileName := fmt.Sprintf("%s-%s-%s-%s.ipa",
+	fileName := fmt.Sprintf(
+		"%s-%s-%s-%s.ipa",
 		sanitizePublishArtifactToken(scheme),
 		sanitizePublishArtifactToken(platform),
 		sanitizePublishArtifactToken(version),

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -758,7 +758,8 @@ func plannedAppStorePublishResult(mode asc.PublishMode, version, buildNumber str
 func plannedAppStorePublishSteps(localBuildMode, wait, submit bool) []asc.PublishPlanStep {
 	steps := make([]asc.PublishPlanStep, 0, 5)
 	if localBuildMode {
-		steps = append(steps,
+		steps = append(
+			steps,
 			newPublishPlanStep(publishPlanStepArchiveLocalBuild, "Archive the selected Xcode workspace or project to a local .xcarchive."),
 			newPublishPlanStep(publishPlanStepExportLocalBuild, "Export the archive to a local App Store IPA artifact."),
 		)
@@ -768,7 +769,8 @@ func plannedAppStorePublishSteps(localBuildMode, wait, submit bool) []asc.Publis
 	if wait {
 		steps = append(steps, newPublishPlanStep(publishPlanStepWaitForBuildProcessing, "Wait for App Store Connect build processing to reach a terminal state."))
 	}
-	steps = append(steps,
+	steps = append(
+		steps,
 		newPublishPlanStep(publishPlanStepEnsureVersion, "Find the requested App Store version or create it if missing."),
 		newPublishPlanStep(publishPlanStepAttachBuild, "Attach the resolved build to the App Store version."),
 	)

--- a/internal/cli/reviews/review_attachments.go
+++ b/internal/cli/reviews/review_attachments.go
@@ -84,7 +84,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithAppStoreReviewAttachmentsLimit(200))
-				pages, err := shared.PaginateWithSpinner(requestCtx,
+				pages, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, reviewDetailValue, paginateOpts...)
 					},
@@ -158,7 +159,8 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetAppStoreReviewAttachment(requestCtx, attachmentValue,
+			resp, err := client.GetAppStoreReviewAttachment(
+				requestCtx, attachmentValue,
 				asc.WithAppStoreReviewAttachmentsFields(fieldsValue),
 				asc.WithAppStoreReviewAttachmentReviewDetailFields(detailFieldsValue),
 				asc.WithAppStoreReviewAttachmentsInclude(includeValue),

--- a/internal/cli/reviews/review_items.go
+++ b/internal/cli/reviews/review_items.go
@@ -103,7 +103,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithReviewSubmissionItemsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetReviewSubmissionItems(ctx, strings.TrimSpace(*submissionID), paginateOpts...)
 					},

--- a/internal/cli/reviews/review_submissions.go
+++ b/internal/cli/reviews/review_submissions.go
@@ -92,7 +92,8 @@ Examples:
 			if *global {
 				if *paginate {
 					paginateOpts := append(opts, asc.WithReviewSubmissionsLimit(200))
-					resp, err := shared.PaginateWithSpinner(requestCtx,
+					resp, err := shared.PaginateWithSpinner(
+						requestCtx,
 						func(ctx context.Context) (asc.PaginatedResponse, error) {
 							return client.ListReviewSubmissions(ctx, paginateOpts...)
 						},
@@ -117,7 +118,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithReviewSubmissionsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetReviewSubmissions(ctx, resolvedAppID, paginateOpts...)
 					},
@@ -428,7 +430,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetReviewSubmissionItemsRelationships(ctx, trimmedID, paginateOpts...)
 					},

--- a/internal/cli/reviews/reviews.go
+++ b/internal/cli/reviews/reviews.go
@@ -148,7 +148,8 @@ func executeReviewsList(ctx context.Context, appID, output string, pretty bool, 
 
 	if paginate {
 		paginateOpts := append(opts, asc.WithLimit(200))
-		reviews, err := shared.PaginateWithSpinner(requestCtx,
+		reviews, err := shared.PaginateWithSpinner(
+			requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return client.GetReviews(ctx, appID, paginateOpts...)
 			},

--- a/internal/cli/reviews/reviews_summarizations.go
+++ b/internal/cli/reviews/reviews_summarizations.go
@@ -85,7 +85,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithCustomerReviewSummarizationsLimit(200))
-				summaries, err := shared.PaginateWithSpinner(requestCtx,
+				summaries, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetCustomerReviewSummarizations(ctx, resolvedAppID, paginateOpts...)
 					},

--- a/internal/cli/sandbox/sandbox_helpers.go
+++ b/internal/cli/sandbox/sandbox_helpers.go
@@ -82,7 +82,8 @@ func sandboxRenewalRateValues() []string {
 func findSandboxTesterByEmail(ctx context.Context, client *asc.Client, email string) (*asc.SandboxTesterResponse, error) {
 	next := ""
 	for {
-		resp, err := client.GetSandboxTesters(ctx,
+		resp, err := client.GetSandboxTesters(
+			ctx,
 			asc.WithSandboxTestersEmail(email),
 			asc.WithSandboxTestersLimit(200),
 			asc.WithSandboxTestersNextURL(next),

--- a/internal/cli/shared/build_wait.go
+++ b/internal/cli/shared/build_wait.go
@@ -177,7 +177,8 @@ func isTemporaryNetError(err net.Error) bool {
 }
 
 func findBuildByNumber(ctx context.Context, client *asc.Client, appID, version, buildNumber, platform, uploadID string) (*asc.BuildResponse, error) {
-	preReleaseResp, err := client.GetPreReleaseVersions(ctx, appID,
+	preReleaseResp, err := client.GetPreReleaseVersions(
+		ctx, appID,
 		asc.WithPreReleaseVersionsVersion(version),
 		asc.WithPreReleaseVersionsPlatform(platform),
 		asc.WithPreReleaseVersionsLimit(10),

--- a/internal/cli/shared/command_builders.go
+++ b/internal/cli/shared/command_builders.go
@@ -172,7 +172,8 @@ func BuildPaginatedListCommand(config PaginatedListCommandConfig) *ffcli.Command
 				firstPageLimit = limitMax
 			}
 
-			resp, err := PaginateWithSpinner(requestCtx,
+			resp, err := PaginateWithSpinner(
+				requestCtx,
 				func(ctx context.Context) (asc.PaginatedResponse, error) {
 					return config.FetchPage(ctx, client, resolvedParentID, firstPageLimit, *next)
 				},

--- a/internal/cli/shared/test_notes.go
+++ b/internal/cli/shared/test_notes.go
@@ -16,7 +16,8 @@ func UpsertBetaBuildLocalization(ctx context.Context, client *asc.Client, buildI
 		return nil, fmt.Errorf("locale and notes are required")
 	}
 
-	resp, err := client.GetBetaBuildLocalizations(ctx, buildID,
+	resp, err := client.GetBetaBuildLocalizations(
+		ctx, buildID,
 		asc.WithBetaBuildLocalizationsLimit(200),
 	)
 	if err != nil {

--- a/internal/cli/shared/tier_resolver.go
+++ b/internal/cli/shared/tier_resolver.go
@@ -94,7 +94,8 @@ func ResolveTiers(ctx context.Context, client *asc.Client, appID, territory stri
 
 // ResolveSubscriptionTiers resolves subscription price point tiers for a subscription and territory.
 func ResolveSubscriptionTiers(ctx context.Context, client *asc.Client, subscriptionID, territory string, refresh bool) ([]TierEntry, error) {
-	return resolveScopedTiers(ctx, client, "subscription", subscriptionID, territory, tierCacheScopeSubscription, refresh,
+	return resolveScopedTiers(
+		ctx, client, "subscription", subscriptionID, territory, tierCacheScopeSubscription, refresh,
 		func(ctx context.Context, client *asc.Client, resourceID, territory, nextURL string) (tierPage, error) {
 			opts := []asc.SubscriptionPricePointsOption{
 				asc.WithSubscriptionPricePointsLimit(200),
@@ -118,7 +119,8 @@ func ResolveSubscriptionTiers(ctx context.Context, client *asc.Client, subscript
 
 // ResolveIAPTiers resolves in-app purchase price point tiers for an IAP and territory.
 func ResolveIAPTiers(ctx context.Context, client *asc.Client, iapID, territory string, refresh bool) ([]TierEntry, error) {
-	return resolveScopedTiers(ctx, client, "in-app purchase", iapID, territory, tierCacheScopeIAP, refresh,
+	return resolveScopedTiers(
+		ctx, client, "in-app purchase", iapID, territory, tierCacheScopeIAP, refresh,
 		func(ctx context.Context, client *asc.Client, resourceID, territory, nextURL string) (tierPage, error) {
 			opts := []asc.IAPPricePointsOption{
 				asc.WithIAPPricePointsLimit(200),

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -191,7 +191,8 @@ func findCertificates(ctx context.Context, client *asc.Client, profileType, cert
 		next  string
 	)
 	for {
-		resp, err := client.GetCertificates(ctx,
+		resp, err := client.GetCertificates(
+			ctx,
 			asc.WithCertificatesFilterType(certType),
 			asc.WithCertificatesNextURL(next),
 		)
@@ -214,7 +215,8 @@ func findCertificates(ctx context.Context, client *asc.Client, profileType, cert
 func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResourceID, bundleIdentifier, profileType string, certIDs, deviceIDs []string, createMissing bool) (*asc.ProfileResponse, bool, error) {
 	next := ""
 	for {
-		profiles, err := client.GetProfiles(ctx,
+		profiles, err := client.GetProfiles(
+			ctx,
 			asc.WithProfilesFilterType(profileType),
 			asc.WithProfilesNextURL(next),
 		)

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -536,7 +536,8 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 		buildIDs = append(buildIDs, build.ID)
 	}
 
-	betaDetails, err := client.GetBuildBetaDetails(ctx,
+	betaDetails, err := client.GetBuildBetaDetails(
+		ctx,
 		asc.WithBuildBetaDetailsBuildIDs(buildIDs),
 		asc.WithBuildBetaDetailsLimit(200),
 	)
@@ -554,7 +555,8 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 		}
 	}
 
-	reviewSubmissions, err := client.GetBetaAppReviewSubmissions(ctx,
+	reviewSubmissions, err := client.GetBetaAppReviewSubmissions(
+		ctx,
 		asc.WithBetaAppReviewSubmissionsBuildIDs(buildIDs),
 		asc.WithBetaAppReviewSubmissionsLimit(200),
 	)
@@ -993,7 +995,8 @@ func renderDashboard(resp *dashboardResponse, markdown bool) {
 		if resp.Builds.Latest == nil {
 			rows = append(rows, []string{"latest", "[-] none"})
 		} else {
-			rows = append(rows,
+			rows = append(
+				rows,
 				[]string{"latest.id", resp.Builds.Latest.ID},
 				[]string{"latest.version", shared.OrNA(resp.Builds.Latest.Version)},
 				[]string{"latest.buildNumber", shared.OrNA(resp.Builds.Latest.BuildNumber)},

--- a/internal/cli/submit/submit.go
+++ b/internal/cli/submit/submit.go
@@ -1726,19 +1726,22 @@ func printSubmissionErrorHints(err error, ctx submissionErrorHintContext) {
 	signals := collectSubmissionErrorSignals(err)
 	var hints []string
 	if signals.ageRating && strings.TrimSpace(ctx.AppID) != "" {
-		hints = append(hints,
+		hints = append(
+			hints,
 			fmt.Sprintf("Review current age rating: asc age-rating view --app %s", ctx.AppID),
 			"Review age-rating update flags: asc age-rating edit --help",
 		)
 	}
 	if signals.contentRights && strings.TrimSpace(ctx.AppID) != "" {
-		hints = append(hints,
+		hints = append(
+			hints,
 			fmt.Sprintf("If your app does not use third-party content: asc apps update --id %s --content-rights DOES_NOT_USE_THIRD_PARTY_CONTENT", ctx.AppID),
 			fmt.Sprintf("If your app uses third-party content: asc apps update --id %s --content-rights USES_THIRD_PARTY_CONTENT", ctx.AppID),
 		)
 	}
 	if signals.usesNonExempt {
-		hints = append(hints,
+		hints = append(
+			hints,
 			"Set Uses Non-Exempt Encryption for the attached build in App Store Connect, then retry submission.",
 		)
 	}
@@ -1746,19 +1749,22 @@ func printSubmissionErrorHints(err error, ctx submissionErrorHintContext) {
 		hints = append(hints, fmt.Sprintf("Complete App Privacy at: https://appstoreconnect.apple.com/apps/%s/appPrivacy", ctx.AppID))
 	}
 	if signals.primaryCategory {
-		hints = append(hints,
+		hints = append(
+			hints,
 			"List available categories: asc categories list",
 			"Review category update flags: asc app-setup categories set --help",
 		)
 	}
 	if activeID := strings.TrimSpace(signals.activeSubmissionID); activeID != "" {
-		hints = appendUniqueHints(hints,
+		hints = appendUniqueHints(
+			hints,
 			fmt.Sprintf("Check the active submission: asc submit status --id %s", activeID),
 			fmt.Sprintf("Inspect the active submission payload: asc review submissions-get --id %s", activeID),
 		)
 	}
 	if strings.TrimSpace(signals.existingSubmissionID) != "" && strings.TrimSpace(signals.activeSubmissionID) == "" {
-		hints = appendUniqueHints(hints,
+		hints = appendUniqueHints(
+			hints,
 			fmt.Sprintf("Inspect the existing submission: asc submit status --id %s", signals.existingSubmissionID),
 			fmt.Sprintf("Inspect the existing submission payload: asc review submissions-get --id %s", signals.existingSubmissionID),
 		)

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -463,7 +463,8 @@ func findPricePoint(ctx context.Context, client *asc.Client, subID, territory, t
 	priceFilter := shared.PriceFilter{Price: targetPrice}
 
 	firstCtx, firstCancel := shared.ContextWithTimeout(ctx)
-	firstPage, err := client.GetSubscriptionPricePoints(firstCtx, subID,
+	firstPage, err := client.GetSubscriptionPricePoints(
+		firstCtx, subID,
 		asc.WithSubscriptionPricePointsTerritory(territory),
 		asc.WithSubscriptionPricePointsLimit(200),
 	)
@@ -481,11 +482,13 @@ func findPricePoint(ctx context.Context, client *asc.Client, subID, territory, t
 	}
 
 	// Paginate through remaining pages
-	err = asc.PaginateEach(ctx, firstPage,
+	err = asc.PaginateEach(
+		ctx, firstPage,
 		func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
 			pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
 			defer pageCancel()
-			return client.GetSubscriptionPricePoints(pageCtx, subID,
+			return client.GetSubscriptionPricePoints(
+				pageCtx, subID,
 				asc.WithSubscriptionPricePointsNextURL(nextURL),
 			)
 		},
@@ -520,7 +523,8 @@ func fetchEqualizations(ctx context.Context, client *asc.Client, pricePointID, b
 	// relationships with the territory reference, avoiding reliance on
 	// opaque price point ID structure.
 	firstCtx, firstCancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionPricePointEqualizations(firstCtx, pricePointID,
+	resp, err := client.GetSubscriptionPricePointEqualizations(
+		firstCtx, pricePointID,
 		asc.WithSubscriptionPricePointsInclude([]string{"territory"}),
 		asc.WithSubscriptionPricePointsFields([]string{"customerPrice", "territory"}),
 		asc.WithSubscriptionPricePointsLimit(200),
@@ -533,7 +537,8 @@ func fetchEqualizations(ctx context.Context, client *asc.Client, pricePointID, b
 	allPages, err := asc.PaginateAll(ctx, resp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
 		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
 		defer pageCancel()
-		return client.GetSubscriptionPricePointEqualizations(pageCtx, pricePointID,
+		return client.GetSubscriptionPricePointEqualizations(
+			pageCtx, pricePointID,
 			asc.WithSubscriptionPricePointsNextURL(nextURL),
 		)
 	})

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -425,7 +425,8 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 	}
 
 	if !opts.hasPricing(opts.StartDate) {
-		result.Steps = append(result.Steps,
+		result.Steps = append(
+			result.Steps,
 			subscriptionsSetupStepResult{
 				Name:    subscriptionsSetupStepResolvePricePoint,
 				Status:  "skipped",

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -139,7 +139,8 @@ Examples:
 
 				if *paginate {
 					paginateOpts := append(opts, asc.WithBetaGroupsLimit(200))
-					groups, err := shared.PaginateWithSpinner(requestCtx,
+					groups, err := shared.PaginateWithSpinner(
+						requestCtx,
 						func(ctx context.Context) (asc.PaginatedResponse, error) {
 							return client.ListBetaGroups(ctx, paginateOpts...)
 						},
@@ -169,7 +170,8 @@ Examples:
 
 				if *paginate {
 					paginateOpts := append(opts, asc.WithBetaGroupsLimit(200))
-					resp, err := shared.PaginateWithSpinner(requestCtx,
+					resp, err := shared.PaginateWithSpinner(
+						requestCtx,
 						func(ctx context.Context) (asc.PaginatedResponse, error) {
 							return client.GetBetaGroups(ctx, resolvedAppID, paginateOpts...)
 						},
@@ -221,7 +223,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBetaGroupsLimit(200))
-				groups, err := shared.PaginateWithSpinner(requestCtx,
+				groups, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBetaGroups(ctx, resolvedAppID, paginateOpts...)
 					},

--- a/internal/cli/testflight/beta_groups_relationships.go
+++ b/internal/cli/testflight/beta_groups_relationships.go
@@ -119,7 +119,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return getBetaGroupRelationshipList(ctx, client, relationshipType, groupValue, paginateOpts...)
 					},

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -143,7 +143,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBetaTestersLimit(200))
-				testers, err := shared.PaginateWithSpinner(requestCtx,
+				testers, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBetaTesters(ctx, resolvedAppID, paginateOpts...)
 					},

--- a/internal/cli/testflight/beta_testers_related.go
+++ b/internal/cli/testflight/beta_testers_related.go
@@ -97,7 +97,8 @@ Examples:
 					return flag.ErrHelp
 				}
 				paginateOpts := append(opts, asc.WithBetaTesterAppsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBetaTesterApps(ctx, testerValue, paginateOpts...)
 					},
@@ -205,7 +206,8 @@ Examples:
 					return flag.ErrHelp
 				}
 				paginateOpts := append(opts, asc.WithBetaTesterBetaGroupsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBetaTesterBetaGroups(ctx, testerValue, paginateOpts...)
 					},
@@ -313,7 +315,8 @@ Examples:
 					return flag.ErrHelp
 				}
 				paginateOpts := append(opts, asc.WithBetaTesterBuildsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBetaTesterBuilds(ctx, testerValue, paginateOpts...)
 					},

--- a/internal/cli/testflight/beta_testers_relationships.go
+++ b/internal/cli/testflight/beta_testers_relationships.go
@@ -120,7 +120,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return getBetaTesterRelationshipList(ctx, client, relationshipType, testerValue, paginateOpts...)
 					},

--- a/internal/cli/testflight/command_wrappers.go
+++ b/internal/cli/testflight/command_wrappers.go
@@ -534,7 +534,8 @@ Examples:
   asc testflight review submissions view --id "SUBMISSION_ID"`
 	setUsageFuncRecursively(cmd, testflightVisibleUsageFunc)
 
-	cmd.Subcommands = append(cmd.Subcommands,
+	cmd.Subcommands = append(
+		cmd.Subcommands,
 		deprecatedAliasCommand(
 			TestFlightReviewGetCommand(),
 			"asc testflight review view [flags]",
@@ -550,7 +551,8 @@ Examples:
 	)
 
 	if appCmd := findSubcommand(cmd, "app"); appCmd != nil {
-		appCmd.Subcommands = append(appCmd.Subcommands,
+		appCmd.Subcommands = append(
+			appCmd.Subcommands,
 			deprecatedAliasCommand(
 				TestFlightReviewAppGetCommand(),
 				"asc testflight review app view --id \"DETAIL_ID\"",
@@ -561,7 +563,8 @@ Examples:
 	}
 
 	if submissionsCmd := findSubcommand(cmd, "submissions"); submissionsCmd != nil {
-		submissionsCmd.Subcommands = append(submissionsCmd.Subcommands,
+		submissionsCmd.Subcommands = append(
+			submissionsCmd.Subcommands,
 			deprecatedAliasCommand(
 				TestFlightReviewSubmissionsGetCommand(),
 				"asc testflight review submissions view --id \"SUBMISSION_ID\"",

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -400,7 +400,8 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithBetaAppReviewSubmissionsLimit(200))
-				resp, err := shared.PaginateWithSpinner(requestCtx,
+				resp, err := shared.PaginateWithSpinner(
+					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetBetaAppReviewSubmissions(ctx, paginateOpts...)
 					},

--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -232,7 +232,8 @@ func WebAppsCreateCommand() *ffcli.Command {
 		Name:       "create",
 		ShortUsage: "asc web apps create [flags]",
 		ShortHelp:  "[experimental] Create app via unofficial Apple web API.",
-		LongHelp: fmt.Sprintf(`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		LongHelp: fmt.Sprintf(
+			`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
 
 Create an app through Apple's internal web API using a web-session login.
 This is the canonical app-creation path for web-session based flows and is

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -679,7 +679,8 @@ func WebAuthLoginCommand() *ffcli.Command {
 		Name:       "login",
 		ShortUsage: "asc web auth login --apple-id EMAIL [--two-factor-code-command CMD]",
 		ShortHelp:  "[experimental] Authenticate unofficial Apple web session.",
-		LongHelp: fmt.Sprintf(`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		LongHelp: fmt.Sprintf(
+			`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
 
 Authenticate using Apple web-session behavior for detached "asc web" workflows.
 

--- a/internal/cli/xcode/build_upload_lookup.go
+++ b/internal/cli/xcode/build_upload_lookup.go
@@ -29,7 +29,8 @@ func findRecentBuildUploadID(ctx context.Context, client *asc.Client, appID, ver
 	if !exportStartedAt.IsZero() && !exportCompletedAt.IsZero() && exportCompletedAt.Before(exportStartedAt) {
 		exportCompletedAt = exportStartedAt
 	}
-	resp, err := client.GetBuildUploads(ctx, appID,
+	resp, err := client.GetBuildUploads(
+		ctx, appID,
 		asc.WithBuildUploadsCFBundleShortVersionStrings([]string{version}),
 		asc.WithBuildUploadsCFBundleVersions([]string{buildNumber}),
 		asc.WithBuildUploadsPlatforms([]string{platform}),

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -412,7 +412,8 @@ func exportResultRows(result xcodeExportCommandResult) [][]string {
 	} else {
 		rows = append(rows, []string{"ipa_path", "(direct upload — no local artifact)"})
 	}
-	rows = append(rows,
+	rows = append(
+		rows,
 		[]string{"bundle_id", result.BundleID},
 		[]string{"version", result.Version},
 		[]string{"build_number", result.BuildNumber},

--- a/internal/cli/xcodecloud/xcode_cloud_action_resources_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_action_resources_helpers.go
@@ -197,7 +197,8 @@ Examples:
 	ListRunUsage:    "Build run ID to resolve a single issue action from",
 	ListErrorPrefix: "xcode-cloud issues list",
 	ListFetchPage: func(ctx context.Context, client *asc.Client, actionID string, limit int, next string) (asc.PaginatedResponse, error) {
-		return client.GetCiBuildActionIssues(ctx, actionID,
+		return client.GetCiBuildActionIssues(
+			ctx, actionID,
 			asc.WithCiIssuesLimit(limit),
 			asc.WithCiIssuesNextURL(next),
 		)
@@ -241,7 +242,8 @@ Examples:
 	ListRunUsage:    "Build run ID to resolve a single test-result action from",
 	ListErrorPrefix: "xcode-cloud test-results list",
 	ListFetchPage: func(ctx context.Context, client *asc.Client, actionID string, limit int, next string) (asc.PaginatedResponse, error) {
-		return client.GetCiBuildActionTestResults(ctx, actionID,
+		return client.GetCiBuildActionTestResults(
+			ctx, actionID,
 			asc.WithCiTestResultsLimit(limit),
 			asc.WithCiTestResultsNextURL(next),
 		)
@@ -322,7 +324,8 @@ func runXcodeCloudActionResourceList(
 	}
 
 	if paginate {
-		resp, err := shared.PaginateWithSpinner(requestCtx,
+		resp, err := shared.PaginateWithSpinner(
+			requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return fetchPage(ctx, client, resolvedActionID, 200, nextURL)
 			},

--- a/internal/cli/xcodecloud/xcode_cloud_extras.go
+++ b/internal/cli/xcodecloud/xcode_cloud_extras.go
@@ -304,7 +304,8 @@ func xcodeCloudProductsList(ctx context.Context, appID string, limit int, next s
 
 	if paginate {
 		paginateOpts := append(opts, asc.WithCiProductsLimit(200))
-		paginatedResp, err := shared.PaginateWithSpinner(requestCtx,
+		paginatedResp, err := shared.PaginateWithSpinner(
+			requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return client.GetCiProducts(ctx, paginateOpts...)
 			},

--- a/internal/cli/xcodecloud/xcode_cloud_list_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_list_helpers.go
@@ -40,7 +40,8 @@ func runXcodeCloudPaginatedList(
 	defer cancel()
 
 	if paginate {
-		resp, err := shared.PaginateWithSpinner(requestCtx,
+		resp, err := shared.PaginateWithSpinner(
+			requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return fetchPage(ctx, client, 200, nextURL)
 			},

--- a/internal/cli/xcodecloud/xcode_cloud_workflows.go
+++ b/internal/cli/xcodecloud/xcode_cloud_workflows.go
@@ -302,7 +302,8 @@ func xcodeCloudWorkflowsList(ctx context.Context, appID string, limit int, next 
 
 	if paginate {
 		paginateOpts := append(opts, asc.WithCiWorkflowsLimit(200))
-		resp, err := shared.PaginateWithSpinner(requestCtx,
+		resp, err := shared.PaginateWithSpinner(
+			requestCtx,
 			func(ctx context.Context) (asc.PaginatedResponse, error) {
 				return client.GetCiWorkflows(ctx, productID, paginateOpts...)
 			},

--- a/internal/validation/legal_test.go
+++ b/internal/validation/legal_test.go
@@ -5,7 +5,8 @@ import (
 )
 
 func TestLegalChecks_CopyrightEmpty(t *testing.T) {
-	checks := legalChecks("", false, false,
+	checks := legalChecks(
+		"", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -15,7 +16,8 @@ func TestLegalChecks_CopyrightEmpty(t *testing.T) {
 }
 
 func TestLegalChecks_CopyrightWhitespaceOnly(t *testing.T) {
-	checks := legalChecks("   ", false, false,
+	checks := legalChecks(
+		"   ", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -25,7 +27,8 @@ func TestLegalChecks_CopyrightWhitespaceOnly(t *testing.T) {
 }
 
 func TestLegalChecks_CopyrightPresent(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -35,7 +38,8 @@ func TestLegalChecks_CopyrightPresent(t *testing.T) {
 }
 
 func TestLegalChecks_InvalidSupportURL(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "not-a-url"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -45,7 +49,8 @@ func TestLegalChecks_InvalidSupportURL(t *testing.T) {
 }
 
 func TestLegalChecks_ValidSupportURL(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com/support?q=1"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -55,7 +60,8 @@ func TestLegalChecks_ValidSupportURL(t *testing.T) {
 }
 
 func TestLegalChecks_EmptySupportURL_NoFormatCheck(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: ""}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -65,7 +71,8 @@ func TestLegalChecks_EmptySupportURL_NoFormatCheck(t *testing.T) {
 }
 
 func TestLegalChecks_InvalidMarketingURL(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com", MarketingURL: "ftp://bad"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -75,7 +82,8 @@ func TestLegalChecks_InvalidMarketingURL(t *testing.T) {
 }
 
 func TestLegalChecks_InvalidPrivacyPolicyURL(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "not-a-url"}},
 	)
@@ -85,7 +93,8 @@ func TestLegalChecks_InvalidPrivacyPolicyURL(t *testing.T) {
 }
 
 func TestLegalChecks_InvalidPrivacyChoicesURL(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy", PrivacyChoicesURL: "bad-url"}},
 	)
@@ -95,7 +104,8 @@ func TestLegalChecks_InvalidPrivacyChoicesURL(t *testing.T) {
 }
 
 func TestLegalChecks_URLSchemeNoHost(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -105,7 +115,8 @@ func TestLegalChecks_URLSchemeNoHost(t *testing.T) {
 }
 
 func TestLegalChecks_HTTPURLAccepted(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "http://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -115,7 +126,8 @@ func TestLegalChecks_HTTPURLAccepted(t *testing.T) {
 }
 
 func TestLegalChecks_RawSpaceInURLRejected(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com/hello world"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -125,7 +137,8 @@ func TestLegalChecks_RawSpaceInURLRejected(t *testing.T) {
 }
 
 func TestLegalChecks_EmptyHostnameRejected(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://user@:80"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
 	)
@@ -135,7 +148,8 @@ func TestLegalChecks_EmptyHostnameRejected(t *testing.T) {
 }
 
 func TestLegalChecks_PrivacyPolicyRequired_WithSubscriptions(t *testing.T) {
-	checks := legalChecks("2026 My Company", true, false,
+	checks := legalChecks(
+		"2026 My Company", true, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US"}},
 	)
@@ -152,7 +166,8 @@ func TestLegalChecks_PrivacyPolicyRequired_WithSubscriptions(t *testing.T) {
 }
 
 func TestLegalChecks_PrivacyPolicyRequired_WithIAPs(t *testing.T) {
-	checks := legalChecks("2026 My Company", true, false,
+	checks := legalChecks(
+		"2026 My Company", true, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US"}},
 	)
@@ -169,7 +184,8 @@ func TestLegalChecks_PrivacyPolicyRequired_WithIAPs(t *testing.T) {
 }
 
 func TestLegalChecks_PrivacyPolicyNotRequired_NoSubscriptionsNoIAPs(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
 		[]AppInfoLocalization{{Locale: "en-US"}},
 	)
@@ -179,7 +195,8 @@ func TestLegalChecks_PrivacyPolicyNotRequired_NoSubscriptionsNoIAPs(t *testing.T
 }
 
 func TestLegalChecks_MultipleLocales_InvalidURLs(t *testing.T) {
-	checks := legalChecks("2026 Co", false, false,
+	checks := legalChecks(
+		"2026 Co", false, false,
 		[]VersionLocalization{
 			{Locale: "en-US", SupportURL: "bad"},
 			{Locale: "fr-FR", SupportURL: "also-bad"},
@@ -305,7 +322,8 @@ func TestValidate_TermsOfUseLinkNotRequiredWithoutSubscriptions(t *testing.T) {
 }
 
 func TestLegalChecks_AllValid_NoChecks(t *testing.T) {
-	checks := legalChecks("2026 My Company", false, false,
+	checks := legalChecks(
+		"2026 My Company", false, false,
 		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com", MarketingURL: "https://example.com/marketing"}},
 		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy", PrivacyChoicesURL: "https://example.com/choices"}},
 	)

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -196,7 +196,8 @@ func logWebAuthHTTP(stage string, req *http.Request, resp *http.Response, body [
 		"stage", strings.TrimSpace(stage),
 	}
 	if req != nil {
-		fields = append(fields,
+		fields = append(
+			fields,
 			"method", req.Method,
 			"url", sanitizeWebAuthURLForLog(req.URL.String()),
 		)

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1097,7 +1097,8 @@ func helperCommandContext(t *testing.T, logPath string) func(context.Context, st
 		commandArgs := []string{"-test.run=TestXcodeHelperProcess", "--", name}
 		commandArgs = append(commandArgs, args...)
 		cmd := exec.CommandContext(ctx, os.Args[0], commandArgs...)
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"GO_WANT_XCODE_HELPER_PROCESS=1",
 			"ASC_XCODE_HELPER_LOG="+logPath,
 		)


### PR DESCRIPTION
## Summary

I was making a change for #1469 and found that the repo currently wasn't formatter clean. I'm submitting this as a separate PR to keep the commits clean and easier to review.

Outside of the scope of this PR, but it would probably be good to add a CI check that makes sure that `make format` doesn't leave the repo dirty.

## Validation

- [x] `make format`
- [x] `make check-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

If this PR only updates `docs/wall-of-apps.json`, use `make check-wall-of-apps` instead of the full checklist above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reformatted call/argument layout across the codebase for consistent code style and readability.

* **Documentation**
  * Help text for web authentication and web apps commands updated to include an additional warning in displayed guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->