### PR TITLE
apps wall: add Kilowatt – Electric Car Timer

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -553,6 +553,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c8/38/fd/c838fddf-a2db-5007-12be-8cb9906926e1/AppIcon-0-0-85-220-0-5-0-2x-P3-0-0-0.png/512x512bb.png"
   },
   {
+    "app": "Kilowatt – Electric Car Timer",
+    "link": "https://apps.apple.com/us/app/kilowatt-electric-car-timer/id1502312657?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cd/ac/b6/cdacb60b-c1c2-79f1-a7cf-7b3e6674b963/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Klick #1 AI Camera Assistant",
     "link": "https://apps.apple.com/us/app/klick-1-ai-camera-assistant/id6749798728?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/47/23/d9/4723d958-44ab-af95-67a7-5431d6ff981a/AppIcon-0-0-1x_U007ephone-0-1-85-220.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Kilowatt – Electric Car Timer` to the Wall of Apps

## Entry

- App ID: 1502312657
- App: Kilowatt – Electric Car Timer
- Link: https://apps.apple.com/us/app/kilowatt-electric-car-timer/id1502312657?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Kilowatt – Electric Car Timer to the app directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->