### PR TITLE
apps wall: add Floating Head, show yourself

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -379,6 +379,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a1/e6/4f/a1e64f9f-de99-5fc1-f7e0-7ecbe7fafedb/AppIcon-0-1x_U007emarketing-0-11-0-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Floating Head, show yourself",
+    "link": "https://apps.apple.com/us/app/floating-head-show-yourself/id1565946661?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a8/1c/5f/a81c5f95-aeea-6b4a-08c2-f1e029af022c/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
+  },
+  {
     "app": "Focus Rail: Pomodoro Timer",
     "link": "https://apps.apple.com/us/app/focus-rail-pomodoro-timer/id6758016543?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7d/f9/0e/7df90e3f-3a37-c70c-7bf9-cb3cc9c0f16d/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Floating Head, show yourself` to the Wall of Apps

## Entry

- App ID: 1565946661
- App: Floating Head, show yourself
- Link: https://apps.apple.com/us/app/floating-head-show-yourself/id1565946661?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new app entry to the app showcase: "Floating Head, show yourself" with corresponding App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->