### PR TITLE
[codex] Add web signing unsupported guidance

### DIFF
--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -71,6 +71,49 @@ func TestWebXcodeCloudWorkflowsCreateSubcommandIsRegistered(t *testing.T) {
 	}
 }
 
+func TestWebUnsupportedSigningCommandsExplainAPIKeyBoundary(t *testing.T) {
+	tests := []struct {
+		name             string
+		supportedCommand string
+	}{
+		{name: "certificates", supportedCommand: "asc certificates"},
+		{name: "signing", supportedCommand: "asc signing"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			cmd := findSubcommand(root, "web", tc.name)
+			if cmd == nil {
+				t.Fatalf("expected web %s command", tc.name)
+			}
+
+			usage := cmd.UsageFunc(cmd)
+			for _, want := range []string{"Unsupported web-session signing workflow", tc.supportedCommand, "API-key authentication"} {
+				if !strings.Contains(usage, want) {
+					t.Fatalf("expected %q in usage, got %q", want, usage)
+				}
+			}
+
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{"web", tc.name}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected ErrHelp, got %v", runErr)
+			}
+			if !strings.Contains(stderr, "unsupported") || !strings.Contains(stderr, tc.supportedCommand) {
+				t.Fatalf("expected unsupported guidance in stderr, got %q", stderr)
+			}
+		})
+	}
+}
+
 func TestWebAppsCreateMissingRequiredFlags(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -50,12 +50,36 @@ Examples:
 			WebReviewCommand(),
 			WebAnalyticsCommand(),
 			WebXcodeCloudCommand(),
+			webUnsupportedSigningCommand("certificates", "asc certificates"),
+			webUnsupportedSigningCommand("signing", "asc signing"),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
 			fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n\n", strings.TrimSpace(args[0]))
+			return flag.ErrHelp
+		},
+	}
+}
+
+func webUnsupportedSigningCommand(name, supportedCommand string) *ffcli.Command {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       name,
+		ShortUsage: "asc web " + name,
+		ShortHelp:  "[experimental] [unsupported] Use " + supportedCommand + "; web sessions do not support signing management.",
+		LongHelp: `Unsupported web-session signing workflow.
+
+Certificate and signing management is not supported through ` + "`asc web`" + ` sessions.
+Use ` + "`" + supportedCommand + "`" + ` with App Store Connect API-key authentication instead.
+
+Examples:
+  ` + supportedCommand + ` --help`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			fmt.Fprintf(os.Stderr, "Error: asc web %s is unsupported; use %s with App Store Connect API-key auth instead.\n", name, supportedCommand)
 			return flag.ErrHelp
 		},
 	}


### PR DESCRIPTION
## Summary

- add explicit unsupported `asc web certificates` and `asc web signing` guidance
- point users back to the supported API-key signing commands
- cover help text and usage-error behavior in cmdtest

Fixes #1490.

## Validation

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestExperimentalCommandsHaveStabilityLabel|TestWebUnsupportedSigningCommandsExplainAPIKeyBoundary' -count=1`\n- `go build -o /tmp/asc . && /tmp/asc web certificates` -> exit code 2 with unsupported/API-key guidance\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n\n## Notes\n\nThis does not add private web-session certificate automation. It only makes the unsupported boundary discoverable and actionable.