### PR TITLE
Add web subscription remove from sale

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -21,6 +21,9 @@ asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP12
 # Bootstrap app availability where the public API falls short
 asc web apps availability create --app "123456789" --territory "USA,GBR" --available-in-new-territories false
 
+# Remove an approved auto-renewable subscription from sale
+asc web subscriptions availability remove-from-sale --subscription-id "SUB_ID" --confirm
+
 # Declare that an app is not a regulated medical device
 asc web apps medical-device set --app "123456789" --declared false
 
@@ -125,6 +128,35 @@ Available commands:
 * `asc web review list` - list review submissions for an app
 * `asc web review show` - inspect one submission and related messages/screenshots
 * `asc web review subscriptions` - inspect and mutate next-version subscription review selection
+
+### `asc web subscriptions`
+
+Subscription sale availability workflows over Apple web-session `/iris` endpoints.
+
+Available commands:
+
+* `asc web subscriptions availability remove-from-sale` - remove an approved auto-renewable subscription from sale
+
+<Warning>
+  Removing an approved auto-renewable subscription from sale requires an Account Holder web session. App Store Connect rejects Admin and App Manager users for this action.
+</Warning>
+
+Example:
+
+```bash  theme={null}
+asc web subscriptions availability remove-from-sale \
+  --subscription-id "SUB_ID" \
+  --confirm
+```
+
+If you know the internal plan availability ID, pass it directly:
+
+```bash  theme={null}
+asc web subscriptions availability remove-from-sale \
+  --subscription-id "SUB_ID" \
+  --plan-availability-id "PLAN_AVAILABILITY_ID" \
+  --confirm
+```
 
 ### `asc web analytics`
 

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -1,0 +1,191 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	webcmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/web"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleRunWithAppSelector(t *testing.T) {
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return webSubscriptionsAvailabilityResponse(t, req)
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"--profile", "test-web",
+			"web", "subscriptions", "availability", "remove-from-sale",
+			"--output", "json",
+			"--app", "app-1",
+			"--subscription-id", "availability",
+			"--confirm",
+		}, "1.0.0")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		SubscriptionID            string   `json:"subscriptionId"`
+		PlanAvailabilityID        string   `json:"planAvailabilityId"`
+		RemovedFromSale           bool     `json:"removedFromSale"`
+		AvailableInNewTerritories bool     `json:"availableInNewTerritories"`
+		AvailableTerritories      []string `json:"availableTerritories"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if payload.SubscriptionID != "sub-1" || payload.PlanAvailabilityID != "plan-1" || !payload.RemovedFromSale {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.AvailableInNewTerritories || len(payload.AvailableTerritories) != 0 {
+		t.Fatalf("expected subscription to be removed from sale, got %+v", payload)
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "missing subscription id",
+			args: []string{
+				"web", "subscriptions", "availability", "remove-from-sale",
+				"--confirm",
+			},
+			wantErr: "--subscription-id is required",
+		},
+		{
+			name: "missing confirm",
+			args: []string{
+				"web", "subscriptions", "availability", "remove-from-sale",
+				"--subscription-id", "sub-1",
+			},
+			wantErr: "--confirm is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, stderr := captureOutput(t, func() {
+				code := cmd.Run(test.args, "1.0.0")
+				if code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request) (*http.Response, error) {
+	t.Helper()
+
+	switch {
+	case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/app-1/subscriptionGroups":
+		if req.URL.Query().Get("include") != "subscriptions" {
+			t.Fatalf("expected subscriptions include, got %q", req.URL.RawQuery)
+		}
+		return webSubscriptionsJSONResponse(`{
+			"data": [{
+				"id": "group-1",
+				"type": "subscriptionGroups",
+				"attributes": {"referenceName": "Premium"},
+				"relationships": {
+					"subscriptions": {
+						"data": [{"type": "subscriptions", "id": "sub-1"}]
+					}
+				}
+			}],
+			"included": [{
+				"id": "sub-1",
+				"type": "subscriptions",
+				"attributes": {
+					"productId": "availability",
+					"name": "Monthly",
+					"state": "APPROVED"
+				}
+			}]
+		}`), nil
+	case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/subscriptions/sub-1/planAvailabilities":
+		return webSubscriptionsJSONResponse(`{
+			"data": [{
+				"id": "plan-1",
+				"type": "subscriptionPlanAvailabilities",
+				"attributes": {
+					"availableInNewTerritories": false,
+					"planType": "UPFRONT"
+				},
+				"relationships": {
+					"availableTerritories": {"data": []}
+				}
+			}]
+		}`), nil
+	case req.Method == http.MethodPatch && req.URL.Path == "/iris/v1/subscriptionPlanAvailabilities/plan-1":
+		rawBody, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var payload struct {
+			Data struct {
+				Attributes struct {
+					AvailableInNewTerritories bool `json:"availableInNewTerritories"`
+				} `json:"attributes"`
+				Relationships struct {
+					AvailableTerritories struct {
+						Data []any `json:"data"`
+					} `json:"availableTerritories"`
+				} `json:"relationships"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(rawBody, &payload); err != nil {
+			t.Fatalf("decode request body: %v\nbody=%s", err, string(rawBody))
+		}
+		if payload.Data.Attributes.AvailableInNewTerritories {
+			t.Fatal("expected availableInNewTerritories=false")
+		}
+		if len(payload.Data.Relationships.AvailableTerritories.Data) != 0 {
+			t.Fatalf("expected availableTerritories.data to be empty, got %#v", payload.Data.Relationships.AvailableTerritories.Data)
+		}
+		return webSubscriptionsJSONResponse(`{
+			"data": {
+				"id": "plan-1",
+				"type": "subscriptionPlanAvailabilities",
+				"attributes": {
+					"availableInNewTerritories": false,
+					"planType": "UPFRONT"
+				}
+			}
+		}`), nil
+	default:
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}
+}
+
+func webSubscriptionsJSONResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -105,6 +105,54 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunRejectsUnownedPlanAvailabi
 	}
 }
 
+func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsesOwnedPlanAvailabilityID(t *testing.T) {
+	availabilityListCalls := 0
+	patchCalls := 0
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return webSubscriptionsAvailabilityResponse(t, req, &availabilityListCalls, &patchCalls)
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"--profile", "test-web",
+			"web", "subscriptions", "availability", "remove-from-sale",
+			"--output", "json",
+			"--app", "app-1",
+			"--subscription-id", "availability",
+			"--plan-availability-id", "plan-1",
+			"--confirm",
+		}, "1.0.0")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		PlanAvailabilityID string `json:"planAvailabilityId"`
+		RemovedFromSale    bool   `json:"removedFromSale"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if payload.PlanAvailabilityID != "plan-1" || !payload.RemovedFromSale {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if availabilityListCalls != 2 {
+		t.Fatalf("expected ownership and readback availability reads, got %d", availabilityListCalls)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("expected one remove-from-sale patch, got %d", patchCalls)
+	}
+}
+
 func TestWebSubscriptionsAvailabilityRemoveFromSaleRunFailsWhenReadbackStillOnSale(t *testing.T) {
 	availabilityListCalls := 0
 	patchCalls := 0

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -66,6 +66,84 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunWithAppSelector(t *testing
 	}
 }
 
+func TestWebSubscriptionsAvailabilityRemoveFromSaleRunRejectsUnownedPlanAvailabilityID(t *testing.T) {
+	availabilityListCalls := 0
+	patchCalls := 0
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return webSubscriptionsAvailabilityResponse(t, req, &availabilityListCalls, &patchCalls)
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"--profile", "test-web",
+			"web", "subscriptions", "availability", "remove-from-sale",
+			"--app", "app-1",
+			"--subscription-id", "availability",
+			"--plan-availability-id", "plan-other",
+			"--confirm",
+		}, "1.0.0")
+		if code != cmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitError)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `plan availability "plan-other" was not found for subscription "sub-1"`) {
+		t.Fatalf("expected plan ownership error, got %q", stderr)
+	}
+	if availabilityListCalls != 1 {
+		t.Fatalf("expected one availability read before rejection, got %d", availabilityListCalls)
+	}
+	if patchCalls != 0 {
+		t.Fatalf("expected no patch for unowned plan availability, got %d", patchCalls)
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleRunFailsWhenReadbackStillOnSale(t *testing.T) {
+	availabilityListCalls := 0
+	patchCalls := 0
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return webSubscriptionsAvailabilityResponse(t, req, &availabilityListCalls, &patchCalls, false)
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"--profile", "test-web",
+			"web", "subscriptions", "availability", "remove-from-sale",
+			"--output", "json",
+			"--app", "app-1",
+			"--subscription-id", "availability",
+			"--confirm",
+		}, "1.0.0")
+		if code != cmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitError)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `plan availability "plan-1" is still available after patch`) {
+		t.Fatalf("expected readback verification error, got %q", stderr)
+	}
+	if availabilityListCalls != 2 {
+		t.Fatalf("expected pre-patch and post-patch availability reads, got %d", availabilityListCalls)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("expected one remove-from-sale patch before verification failed, got %d", patchCalls)
+	}
+}
+
 func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -115,8 +193,13 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) 
 	}
 }
 
-func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, availabilityListCalls *int, patchCalls *int) (*http.Response, error) {
+func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, availabilityListCalls *int, patchCalls *int, postPatchRemoved ...bool) (*http.Response, error) {
 	t.Helper()
+
+	shouldReturnRemovedAfterPatch := true
+	if len(postPatchRemoved) > 0 {
+		shouldReturnRemovedAfterPatch = postPatchRemoved[0]
+	}
 
 	switch {
 	case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/app-1/subscriptionGroups":
@@ -146,7 +229,7 @@ func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, avail
 		}`), nil
 	case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/subscriptions/sub-1/planAvailabilities":
 		*availabilityListCalls++
-		if *availabilityListCalls == 1 {
+		if *availabilityListCalls == 1 || !shouldReturnRemovedAfterPatch {
 			return webSubscriptionsJSONResponse(`{
 				"data": [{
 					"id": "plan-1",

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -14,10 +14,12 @@ import (
 )
 
 func TestWebSubscriptionsAvailabilityRemoveFromSaleRunWithAppSelector(t *testing.T) {
+	availabilityListCalls := 0
+	patchCalls := 0
 	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
 		return &webcore.AuthSession{
 			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				return webSubscriptionsAvailabilityResponse(t, req)
+				return webSubscriptionsAvailabilityResponse(t, req, &availabilityListCalls, &patchCalls)
 			})},
 		}, "cache", nil
 	})
@@ -56,6 +58,12 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunWithAppSelector(t *testing
 	if payload.AvailableInNewTerritories || len(payload.AvailableTerritories) != 0 {
 		t.Fatalf("expected subscription to be removed from sale, got %+v", payload)
 	}
+	if availabilityListCalls != 2 {
+		t.Fatalf("expected pre-patch and post-patch availability reads, got %d", availabilityListCalls)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("expected one remove-from-sale patch, got %d", patchCalls)
+	}
 }
 
 func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) {
@@ -80,6 +88,16 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) 
 			},
 			wantErr: "--confirm is required",
 		},
+		{
+			name: "invalid output",
+			args: []string{
+				"web", "subscriptions", "availability", "remove-from-sale",
+				"--subscription-id", "sub-1",
+				"--confirm",
+				"--output", "yaml",
+			},
+			wantErr: "unsupported format: yaml",
+		},
 	}
 
 	for _, test := range tests {
@@ -97,7 +115,7 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) 
 	}
 }
 
-func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request) (*http.Response, error) {
+func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, availabilityListCalls *int, patchCalls *int) (*http.Response, error) {
 	t.Helper()
 
 	switch {
@@ -127,6 +145,22 @@ func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request) (*htt
 			}]
 		}`), nil
 	case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/subscriptions/sub-1/planAvailabilities":
+		*availabilityListCalls++
+		if *availabilityListCalls == 1 {
+			return webSubscriptionsJSONResponse(`{
+				"data": [{
+					"id": "plan-1",
+					"type": "subscriptionPlanAvailabilities",
+					"attributes": {
+						"availableInNewTerritories": true,
+						"planType": "UPFRONT"
+					},
+					"relationships": {
+						"availableTerritories": {"data": [{"type": "territories", "id": "USA"}]}
+					}
+				}]
+			}`), nil
+		}
 		return webSubscriptionsJSONResponse(`{
 			"data": [{
 				"id": "plan-1",
@@ -141,6 +175,7 @@ func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request) (*htt
 			}]
 		}`), nil
 	case req.Method == http.MethodPatch && req.URL.Path == "/iris/v1/subscriptionPlanAvailabilities/plan-1":
+		*patchCalls++
 		rawBody, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Fatalf("read request body: %v", err)

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -39,6 +39,7 @@ Examples:
   asc web review list --app "123456789" --apple-id "user@example.com"
   asc web review show --app "123456789" --apple-id "user@example.com"
   asc web review subscriptions list --app "123456789" --apple-id "user@example.com"
+  asc web subscriptions availability remove-from-sale --subscription-id "SUB_ID" --confirm
   asc web analytics overview --app "123456789" --start 2025-12-24 --end 2026-03-23`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -48,6 +49,7 @@ Examples:
 			WebAppsCommand(),
 			WebPrivacyCommand(),
 			WebReviewCommand(),
+			WebSubscriptionsCommand(),
 			WebAnalyticsCommand(),
 			WebXcodeCloudCommand(),
 		},

--- a/internal/cli/web/web_subscriptions.go
+++ b/internal/cli/web/web_subscriptions.go
@@ -146,14 +146,21 @@ Examples:
 				trimmedSubscriptionID = strings.TrimSpace(selected.ID)
 			}
 
-			if trimmedPlanAvailabilityID == "" {
-				availabilities, err := withWebSpinnerValue("Loading subscription plan availability", func() ([]webcore.SubscriptionPlanAvailability, error) {
-					return listWebSubscriptionPlanAvailabilitiesFn(requestCtx, client, trimmedSubscriptionID)
-				})
+			availabilities, err := withWebSpinnerValue("Loading subscription plan availability", func() ([]webcore.SubscriptionPlanAvailability, error) {
+				return listWebSubscriptionPlanAvailabilitiesFn(requestCtx, client, trimmedSubscriptionID)
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web subscriptions availability remove-from-sale")
+			}
+
+			var selected webcore.SubscriptionPlanAvailability
+			if trimmedPlanAvailabilityID != "" {
+				selected, err = findSubscriptionPlanAvailability(availabilities, trimmedPlanAvailabilityID)
 				if err != nil {
-					return withWebAuthHint(err, "web subscriptions availability remove-from-sale")
+					return fmt.Errorf("web subscriptions availability remove-from-sale failed: plan availability %q was not found for subscription %q", trimmedPlanAvailabilityID, trimmedSubscriptionID)
 				}
-				selected, err := selectSubscriptionPlanAvailability(availabilities)
+			} else {
+				selected, err = selectSubscriptionPlanAvailability(availabilities)
 				if err != nil {
 					return fmt.Errorf("web subscriptions availability remove-from-sale failed: %w", err)
 				}
@@ -169,14 +176,38 @@ Examples:
 			if removed == nil || strings.TrimSpace(removed.ID) == "" {
 				return fmt.Errorf("web subscriptions availability remove-from-sale failed: plan availability ID missing from response")
 			}
+			if !strings.EqualFold(strings.TrimSpace(removed.ID), trimmedPlanAvailabilityID) {
+				return fmt.Errorf("web subscriptions availability remove-from-sale failed: Apple returned plan availability %q after patching %q", strings.TrimSpace(removed.ID), trimmedPlanAvailabilityID)
+			}
+
+			verifiedAvailabilities, err := withWebSpinnerValue("Verifying subscription removal from sale", func() ([]webcore.SubscriptionPlanAvailability, error) {
+				return listWebSubscriptionPlanAvailabilitiesFn(requestCtx, client, trimmedSubscriptionID)
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web subscriptions availability remove-from-sale")
+			}
+			verified, err := findSubscriptionPlanAvailability(verifiedAvailabilities, trimmedPlanAvailabilityID)
+			if err != nil {
+				return fmt.Errorf("web subscriptions availability remove-from-sale failed: could not verify plan availability %q for subscription %q after patch", trimmedPlanAvailabilityID, trimmedSubscriptionID)
+			}
+			removedFromSale := subscriptionPlanAvailabilityRemovedFromSale(verified)
+			if !removedFromSale {
+				return fmt.Errorf(
+					"web subscriptions availability remove-from-sale failed: plan availability %q is still available after patch (availableInNewTerritories=%t, availableTerritoriesLoaded=%t, availableTerritories=%d)",
+					trimmedPlanAvailabilityID,
+					verified.AvailableInNewTerritories,
+					verified.AvailableTerritoriesLoaded,
+					len(verified.AvailableTerritories),
+				)
+			}
 
 			result := webSubscriptionRemoveFromSaleResult{
 				SubscriptionID:            trimmedSubscriptionID,
-				PlanAvailabilityID:        strings.TrimSpace(removed.ID),
-				PlanType:                  strings.TrimSpace(removed.PlanType),
-				RemovedFromSale:           true,
-				AvailableInNewTerritories: removed.AvailableInNewTerritories,
-				AvailableTerritories:      removed.AvailableTerritories,
+				PlanAvailabilityID:        strings.TrimSpace(verified.ID),
+				PlanType:                  strings.TrimSpace(verified.PlanType),
+				RemovedFromSale:           removedFromSale,
+				AvailableInNewTerritories: verified.AvailableInNewTerritories,
+				AvailableTerritories:      verified.AvailableTerritories,
 				RequiresAccountHolderRole: true,
 			}
 			return shared.PrintOutputWithRenderers(
@@ -207,6 +238,20 @@ func selectSubscriptionPlanAvailability(availabilities []webcore.SubscriptionPla
 		return upfrontMatches[0], nil
 	}
 	return webcore.SubscriptionPlanAvailability{}, fmt.Errorf("multiple subscription plan availabilities matched; pass --plan-availability-id")
+}
+
+func findSubscriptionPlanAvailability(availabilities []webcore.SubscriptionPlanAvailability, planAvailabilityID string) (webcore.SubscriptionPlanAvailability, error) {
+	planAvailabilityID = strings.TrimSpace(planAvailabilityID)
+	for _, availability := range availabilities {
+		if strings.EqualFold(strings.TrimSpace(availability.ID), planAvailabilityID) {
+			return availability, nil
+		}
+	}
+	return webcore.SubscriptionPlanAvailability{}, fmt.Errorf("plan availability not found")
+}
+
+func subscriptionPlanAvailabilityRemovedFromSale(availability webcore.SubscriptionPlanAvailability) bool {
+	return !availability.AvailableInNewTerritories && availability.AvailableTerritoriesLoaded && len(availability.AvailableTerritories) == 0
 }
 
 func withWebAccountHolderHint(err error, operation string) error {

--- a/internal/cli/web/web_subscriptions.go
+++ b/internal/cli/web/web_subscriptions.go
@@ -1,0 +1,251 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+var (
+	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
+		return client.ListSubscriptionPlanAvailabilities(ctx, subscriptionID)
+	}
+	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
+		return client.RemoveSubscriptionPlanAvailabilityFromSale(ctx, planAvailabilityID)
+	}
+)
+
+type webSubscriptionRemoveFromSaleResult struct {
+	SubscriptionID            string   `json:"subscriptionId"`
+	PlanAvailabilityID        string   `json:"planAvailabilityId"`
+	PlanType                  string   `json:"planType,omitempty"`
+	RemovedFromSale           bool     `json:"removedFromSale"`
+	AvailableInNewTerritories bool     `json:"availableInNewTerritories"`
+	AvailableTerritories      []string `json:"availableTerritories"`
+	RequiresAccountHolderRole bool     `json:"requiresAccountHolderRole"`
+}
+
+// WebSubscriptionsCommand returns the web subscriptions command group.
+func WebSubscriptionsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "subscriptions",
+		ShortUsage: "asc web subscriptions <subcommand> [flags]",
+		ShortHelp:  "[experimental] Manage subscriptions via web sessions.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Manage subscription workflows that App Store Connect exposes only through web-session endpoints.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebSubscriptionsAvailabilityCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebSubscriptionsAvailabilityCommand returns the web subscription availability command group.
+func WebSubscriptionsAvailabilityCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions availability", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "availability",
+		ShortUsage: "asc web subscriptions availability <subcommand> [flags]",
+		ShortHelp:  "[experimental] Manage subscription sale availability via web sessions.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Manage subscription sale availability through Apple's internal web API.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebSubscriptionsAvailabilityRemoveFromSaleCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebSubscriptionsAvailabilityRemoveFromSaleCommand removes an approved subscription from sale.
+func WebSubscriptionsAvailabilityRemoveFromSaleCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions availability remove-from-sale", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App ID; enables product ID or exact name lookup")
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	planAvailabilityID := fs.String("plan-availability-id", "", "Subscription plan availability ID")
+	confirm := fs.Bool("confirm", false, "Confirm removing the subscription from sale")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "remove-from-sale",
+		ShortUsage: "asc web subscriptions availability remove-from-sale --subscription-id SUB_ID --confirm [flags]",
+		ShortHelp:  "[experimental] Remove an auto-renewable subscription from sale.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Remove an approved auto-renewable subscription from sale using the same internal web API flow
+as App Store Connect. Apple allows this action only for Account Holder users.
+
+Examples:
+  asc web subscriptions availability remove-from-sale --subscription-id "SUB_ID" --confirm
+  asc web subscriptions availability remove-from-sale --app "APP_ID" --subscription-id "com.example.monthly" --confirm
+  asc web subscriptions availability remove-from-sale --subscription-id "SUB_ID" --plan-availability-id "PLAN_AVAILABILITY_ID" --confirm
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web subscriptions availability remove-from-sale does not accept positional arguments")
+			}
+
+			trimmedSubscriptionID := strings.TrimSpace(*subscriptionID)
+			trimmedAppID := strings.TrimSpace(shared.ResolveAppID(*appID))
+			trimmedPlanAvailabilityID := strings.TrimSpace(*planAvailabilityID)
+			switch {
+			case trimmedSubscriptionID == "":
+				return shared.UsageError("--subscription-id is required")
+			case !*confirm:
+				return shared.UsageError("--confirm is required")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			if trimmedAppID != "" {
+				subscriptions, err := loadReviewSubscriptionsWithLabel(requestCtx, client, trimmedAppID, "Loading subscriptions")
+				if err != nil {
+					return withWebAuthHint(err, "web subscriptions availability remove-from-sale")
+				}
+				selected, err := findReviewSubscription(subscriptions, trimmedSubscriptionID)
+				if err != nil {
+					return fmt.Errorf("subscription lookup for app %q failed: %w", trimmedAppID, err)
+				}
+				trimmedSubscriptionID = strings.TrimSpace(selected.ID)
+			}
+
+			if trimmedPlanAvailabilityID == "" {
+				availabilities, err := withWebSpinnerValue("Loading subscription plan availability", func() ([]webcore.SubscriptionPlanAvailability, error) {
+					return listWebSubscriptionPlanAvailabilitiesFn(requestCtx, client, trimmedSubscriptionID)
+				})
+				if err != nil {
+					return withWebAuthHint(err, "web subscriptions availability remove-from-sale")
+				}
+				selected, err := selectSubscriptionPlanAvailability(availabilities)
+				if err != nil {
+					return fmt.Errorf("web subscriptions availability remove-from-sale failed: %w", err)
+				}
+				trimmedPlanAvailabilityID = strings.TrimSpace(selected.ID)
+			}
+
+			removed, err := withWebSpinnerValue("Removing subscription from sale", func() (*webcore.SubscriptionPlanAvailability, error) {
+				return removeWebSubscriptionPlanAvailabilityFromSaleFn(requestCtx, client, trimmedPlanAvailabilityID)
+			})
+			if err != nil {
+				return withWebAccountHolderHint(err, "web subscriptions availability remove-from-sale")
+			}
+			if removed == nil || strings.TrimSpace(removed.ID) == "" {
+				return fmt.Errorf("web subscriptions availability remove-from-sale failed: plan availability ID missing from response")
+			}
+
+			result := webSubscriptionRemoveFromSaleResult{
+				SubscriptionID:            trimmedSubscriptionID,
+				PlanAvailabilityID:        strings.TrimSpace(removed.ID),
+				PlanType:                  strings.TrimSpace(removed.PlanType),
+				RemovedFromSale:           true,
+				AvailableInNewTerritories: removed.AvailableInNewTerritories,
+				AvailableTerritories:      removed.AvailableTerritories,
+				RequiresAccountHolderRole: true,
+			}
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderWebSubscriptionRemoveFromSaleTable(result) },
+				func() error { return renderWebSubscriptionRemoveFromSaleMarkdown(result) },
+			)
+		},
+	}
+}
+
+func selectSubscriptionPlanAvailability(availabilities []webcore.SubscriptionPlanAvailability) (webcore.SubscriptionPlanAvailability, error) {
+	if len(availabilities) == 0 {
+		return webcore.SubscriptionPlanAvailability{}, fmt.Errorf("no subscription plan availability was found; pass --plan-availability-id if App Store Connect returned one elsewhere")
+	}
+	if len(availabilities) == 1 {
+		return availabilities[0], nil
+	}
+	upfrontMatches := make([]webcore.SubscriptionPlanAvailability, 0, 1)
+	for _, availability := range availabilities {
+		if strings.EqualFold(strings.TrimSpace(availability.PlanType), "UPFRONT") {
+			upfrontMatches = append(upfrontMatches, availability)
+		}
+	}
+	if len(upfrontMatches) == 1 {
+		return upfrontMatches[0], nil
+	}
+	return webcore.SubscriptionPlanAvailability{}, fmt.Errorf("multiple subscription plan availabilities matched; pass --plan-availability-id")
+}
+
+func withWebAccountHolderHint(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *webcore.APIError
+	if errors.As(err, &apiErr) && apiErr.Status == http.StatusForbidden {
+		return fmt.Errorf("%s failed: removing an approved auto-renewable subscription from sale requires the App Store Connect Account Holder role: %w", operation, err)
+	}
+	return withWebAuthHint(err, operation)
+}
+
+func renderWebSubscriptionRemoveFromSaleTable(result webSubscriptionRemoveFromSaleResult) error {
+	asc.RenderTable(
+		[]string{"Subscription ID", "Plan Availability ID", "Plan Type", "Removed From Sale", "Available In New Territories", "Available Territories"},
+		[][]string{{
+			result.SubscriptionID,
+			result.PlanAvailabilityID,
+			result.PlanType,
+			fmt.Sprintf("%t", result.RemovedFromSale),
+			fmt.Sprintf("%t", result.AvailableInNewTerritories),
+			strings.Join(result.AvailableTerritories, ","),
+		}},
+	)
+	return nil
+}
+
+func renderWebSubscriptionRemoveFromSaleMarkdown(result webSubscriptionRemoveFromSaleResult) error {
+	fmt.Println("| Subscription ID | Plan Availability ID | Plan Type | Removed From Sale | Available In New Territories | Available Territories |")
+	fmt.Println("|---|---|---|---|---|---|")
+	fmt.Printf(
+		"| %s | %s | %s | %t | %t | %s |\n",
+		result.SubscriptionID,
+		result.PlanAvailabilityID,
+		result.PlanType,
+		result.RemovedFromSale,
+		result.AvailableInNewTerritories,
+		strings.Join(result.AvailableTerritories, ","),
+	)
+	return nil
+}

--- a/internal/cli/web/web_subscriptions_test.go
+++ b/internal/cli/web/web_subscriptions_test.go
@@ -14,11 +14,11 @@ import (
 
 func stubWebSubscriptionsSession(t *testing.T) {
 	t.Helper()
-	origResolveSession := resolveSessionFn
-	t.Cleanup(func() { resolveSessionFn = origResolveSession })
-	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+
+	t.Setenv("ASC_APP_ID", "")
+	t.Cleanup(SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
 		return &webcore.AuthSession{Client: &http.Client{}}, "cache", nil
-	}
+	}))
 }
 
 func resetWebSubscriptionAvailabilityStubs(t *testing.T) {

--- a/internal/cli/web/web_subscriptions_test.go
+++ b/internal/cli/web/web_subscriptions_test.go
@@ -1,0 +1,190 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"net/http"
+	"strings"
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func stubWebSubscriptionsSession(t *testing.T) {
+	t.Helper()
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() { resolveSessionFn = origResolveSession })
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{Client: &http.Client{}}, "cache", nil
+	}
+}
+
+func resetWebSubscriptionAvailabilityStubs(t *testing.T) {
+	t.Helper()
+	origList := listWebSubscriptionPlanAvailabilitiesFn
+	origRemove := removeWebSubscriptionPlanAvailabilityFromSaleFn
+	t.Cleanup(func() {
+		listWebSubscriptionPlanAvailabilitiesFn = origList
+		removeWebSubscriptionPlanAvailabilityFromSaleFn = origRemove
+	})
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleCommand(t *testing.T) {
+	labels := stubWebProgressLabels(t)
+	stubWebSubscriptionsSession(t)
+	resetWebSubscriptionAvailabilityStubs(t)
+
+	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
+		if subscriptionID != "sub-1" {
+			t.Fatalf("expected subscription sub-1, got %q", subscriptionID)
+		}
+		return []webcore.SubscriptionPlanAvailability{
+			{ID: "plan-ignored", PlanType: "OTHER", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}},
+			{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}},
+		}, nil
+	}
+	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
+		if planAvailabilityID != "plan-1" {
+			t.Fatalf("expected plan-1, got %q", planAvailabilityID)
+		}
+		return &webcore.SubscriptionPlanAvailability{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: false}, nil
+	}
+
+	cmd := WebSubscriptionsAvailabilityRemoveFromSaleCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--subscription-id", "sub-1",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	var payload webSubscriptionRemoveFromSaleResult
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("decode stdout: %v\nstdout=%s", err, stdout)
+	}
+	if payload.SubscriptionID != "sub-1" || payload.PlanAvailabilityID != "plan-1" || !payload.RemovedFromSale {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if payload.AvailableInNewTerritories {
+		t.Fatalf("expected availableInNewTerritories=false: %#v", payload)
+	}
+	wantLabels := []string{"Loading subscription plan availability", "Removing subscription from sale"}
+	for i, want := range wantLabels {
+		if len(*labels) <= i || (*labels)[i] != want {
+			t.Fatalf("expected labels %v, got %v", wantLabels, *labels)
+		}
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandUsesDirectPlanAvailabilityID(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+	stubWebSubscriptionsSession(t)
+	resetWebSubscriptionAvailabilityStubs(t)
+
+	listCalled := false
+	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
+		listCalled = true
+		return nil, nil
+	}
+	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
+		if planAvailabilityID != "plan-direct" {
+			t.Fatalf("expected plan-direct, got %q", planAvailabilityID)
+		}
+		return &webcore.SubscriptionPlanAvailability{ID: "plan-direct", AvailableInNewTerritories: false}, nil
+	}
+
+	cmd := WebSubscriptionsAvailabilityRemoveFromSaleCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--subscription-id", "sub-1",
+		"--plan-availability-id", "plan-direct",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+	if listCalled {
+		t.Fatal("expected direct plan availability id to skip availability listing")
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandRequiresFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing subscription id", args: []string{"--confirm"}, wantErr: "--subscription-id is required"},
+		{name: "missing confirm", args: []string{"--subscription-id", "sub-1"}, wantErr: "--confirm is required"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := WebSubscriptionsAvailabilityRemoveFromSaleCommand()
+			if err := cmd.FlagSet.Parse(tt.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			_, stderr := captureOutput(t, func() {
+				err := cmd.Exec(context.Background(), nil)
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected flag.ErrHelp, got %v", err)
+				}
+			})
+			if !strings.Contains(stderr, tt.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", tt.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandAccountHolderError(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+	stubWebSubscriptionsSession(t)
+	resetWebSubscriptionAvailabilityStubs(t)
+
+	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
+		return []webcore.SubscriptionPlanAvailability{{ID: "plan-1", PlanType: "UPFRONT"}}, nil
+	}
+	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
+		return nil, &webcore.APIError{Status: http.StatusForbidden}
+	}
+
+	cmd := WebSubscriptionsAvailabilityRemoveFromSaleCommand()
+	if err := cmd.FlagSet.Parse([]string{"--subscription-id", "sub-1", "--confirm"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected Account Holder error")
+	}
+	if !strings.Contains(err.Error(), "requires the App Store Connect Account Holder role") {
+		t.Fatalf("expected Account Holder guidance, got %v", err)
+	}
+	if strings.Contains(err.Error(), "unauthorized or expired") {
+		t.Fatalf("expected specific Account Holder guidance, got %v", err)
+	}
+}
+
+func TestSelectSubscriptionPlanAvailabilityAmbiguous(t *testing.T) {
+	_, err := selectSubscriptionPlanAvailability([]webcore.SubscriptionPlanAvailability{
+		{ID: "plan-1", PlanType: "ONE"},
+		{ID: "plan-2", PlanType: "TWO"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple subscription plan availabilities matched") {
+		t.Fatalf("expected ambiguous plan availability error, got %v", err)
+	}
+}

--- a/internal/cli/web/web_subscriptions_test.go
+++ b/internal/cli/web/web_subscriptions_test.go
@@ -36,13 +36,20 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleCommand(t *testing.T) {
 	stubWebSubscriptionsSession(t)
 	resetWebSubscriptionAvailabilityStubs(t)
 
+	listCalls := 0
 	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
 		if subscriptionID != "sub-1" {
 			t.Fatalf("expected subscription sub-1, got %q", subscriptionID)
 		}
+		listCalls++
+		if listCalls > 1 {
+			return []webcore.SubscriptionPlanAvailability{
+				{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: false, AvailableTerritoriesLoaded: true},
+			}, nil
+		}
 		return []webcore.SubscriptionPlanAvailability{
-			{ID: "plan-ignored", PlanType: "OTHER", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}},
-			{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}},
+			{ID: "plan-ignored", PlanType: "OTHER", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}, AvailableTerritoriesLoaded: true},
+			{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}, AvailableTerritoriesLoaded: true},
 		}, nil
 	}
 	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
@@ -77,7 +84,7 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleCommand(t *testing.T) {
 	if payload.AvailableInNewTerritories {
 		t.Fatalf("expected availableInNewTerritories=false: %#v", payload)
 	}
-	wantLabels := []string{"Loading subscription plan availability", "Removing subscription from sale"}
+	wantLabels := []string{"Loading subscription plan availability", "Removing subscription from sale", "Verifying subscription removal from sale"}
 	for i, want := range wantLabels {
 		if len(*labels) <= i || (*labels)[i] != want {
 			t.Fatalf("expected labels %v, got %v", wantLabels, *labels)
@@ -90,10 +97,12 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandUsesDirectPlanAvailabi
 	stubWebSubscriptionsSession(t)
 	resetWebSubscriptionAvailabilityStubs(t)
 
-	listCalled := false
+	listCalls := 0
 	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
-		listCalled = true
-		return nil, nil
+		listCalls++
+		return []webcore.SubscriptionPlanAvailability{
+			{ID: "plan-direct", PlanType: "UPFRONT", AvailableInNewTerritories: listCalls == 1, AvailableTerritoriesLoaded: true},
+		}, nil
 	}
 	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
 		if planAvailabilityID != "plan-direct" {
@@ -116,8 +125,68 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandUsesDirectPlanAvailabi
 			t.Fatalf("exec error: %v", err)
 		}
 	})
-	if listCalled {
-		t.Fatal("expected direct plan availability id to skip availability listing")
+	if listCalls != 2 {
+		t.Fatalf("expected direct plan availability id to verify before and after patch, got %d list calls", listCalls)
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandRejectsMismatchedDirectPlanAvailabilityID(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+	stubWebSubscriptionsSession(t)
+	resetWebSubscriptionAvailabilityStubs(t)
+
+	removeCalled := false
+	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
+		return []webcore.SubscriptionPlanAvailability{{ID: "plan-other", PlanType: "UPFRONT", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}, AvailableTerritoriesLoaded: true}}, nil
+	}
+	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
+		removeCalled = true
+		return nil, nil
+	}
+
+	cmd := WebSubscriptionsAvailabilityRemoveFromSaleCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--subscription-id", "sub-1",
+		"--plan-availability-id", "plan-direct",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), `plan availability "plan-direct" was not found for subscription "sub-1"`) {
+		t.Fatalf("expected mismatched plan availability error, got %v", err)
+	}
+	if removeCalled {
+		t.Fatal("expected mismatched direct plan availability id to stop before removal")
+	}
+}
+
+func TestWebSubscriptionsAvailabilityRemoveFromSaleCommandFailsWhenReadbackStillOnSale(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+	stubWebSubscriptionsSession(t)
+	resetWebSubscriptionAvailabilityStubs(t)
+
+	listCalls := 0
+	listWebSubscriptionPlanAvailabilitiesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string) ([]webcore.SubscriptionPlanAvailability, error) {
+		listCalls++
+		return []webcore.SubscriptionPlanAvailability{
+			{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: true, AvailableTerritories: []string{"USA"}, AvailableTerritoriesLoaded: true},
+		}, nil
+	}
+	removeWebSubscriptionPlanAvailabilityFromSaleFn = func(ctx context.Context, client *webcore.Client, planAvailabilityID string) (*webcore.SubscriptionPlanAvailability, error) {
+		return &webcore.SubscriptionPlanAvailability{ID: "plan-1", PlanType: "UPFRONT", AvailableInNewTerritories: false}, nil
+	}
+
+	cmd := WebSubscriptionsAvailabilityRemoveFromSaleCommand()
+	if err := cmd.FlagSet.Parse([]string{"--subscription-id", "sub-1", "--confirm"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "is still available after patch") {
+		t.Fatalf("expected verification error, got %v", err)
+	}
+	if listCalls != 2 {
+		t.Fatalf("expected preflight and readback list calls, got %d", listCalls)
 	}
 }
 

--- a/internal/web/subscription_plan_availability.go
+++ b/internal/web/subscription_plan_availability.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SubscriptionPlanAvailability models the internal web API subscription plan availability resource.
+type SubscriptionPlanAvailability struct {
+	ID                        string   `json:"id"`
+	Type                      string   `json:"type,omitempty"`
+	AvailableInNewTerritories bool     `json:"availableInNewTerritories"`
+	PlanType                  string   `json:"planType,omitempty"`
+	AvailableTerritories      []string `json:"availableTerritories,omitempty"`
+}
+
+func decodeSubscriptionPlanAvailabilityResource(resource jsonAPIResource) SubscriptionPlanAvailability {
+	availability := SubscriptionPlanAvailability{
+		ID:                        strings.TrimSpace(resource.ID),
+		Type:                      strings.TrimSpace(resource.Type),
+		AvailableInNewTerritories: boolAttr(resource.Attributes, "availableInNewTerritories"),
+		PlanType:                  stringAttr(resource.Attributes, "planType"),
+	}
+
+	refs := relationshipRefs(resource, "availableTerritories")
+	if len(refs) == 0 {
+		return availability
+	}
+
+	territories := make([]string, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		territoryID := strings.ToUpper(strings.TrimSpace(ref.ID))
+		if territoryID == "" {
+			continue
+		}
+		if _, ok := seen[territoryID]; ok {
+			continue
+		}
+		seen[territoryID] = struct{}{}
+		territories = append(territories, territoryID)
+	}
+	availability.AvailableTerritories = territories
+	return availability
+}
+
+// ListSubscriptionPlanAvailabilities retrieves sale availability plans for a subscription.
+func (c *Client) ListSubscriptionPlanAvailabilities(ctx context.Context, subscriptionID string) ([]SubscriptionPlanAvailability, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	if subscriptionID == "" {
+		return nil, fmt.Errorf("subscription id is required")
+	}
+
+	query := url.Values{}
+	query.Set("include", "availableTerritories")
+	query.Set("limit[availableTerritories]", "200")
+	path := queryPath("/subscriptions/"+url.PathEscape(subscriptionID)+"/planAvailabilities", query)
+
+	responseBody, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload jsonAPIListPayload
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription plan availabilities response: %w", err)
+	}
+
+	availabilities := make([]SubscriptionPlanAvailability, 0, len(payload.Data))
+	for _, resource := range payload.Data {
+		availabilities = append(availabilities, decodeSubscriptionPlanAvailabilityResource(resource))
+	}
+	return availabilities, nil
+}
+
+// RemoveSubscriptionPlanAvailabilityFromSale clears all available territories for a subscription plan availability.
+func (c *Client) RemoveSubscriptionPlanAvailabilityFromSale(ctx context.Context, planAvailabilityID string) (*SubscriptionPlanAvailability, error) {
+	planAvailabilityID = strings.TrimSpace(planAvailabilityID)
+	if planAvailabilityID == "" {
+		return nil, fmt.Errorf("subscription plan availability id is required")
+	}
+
+	requestBody := map[string]any{
+		"data": map[string]any{
+			"type": "subscriptionPlanAvailabilities",
+			"id":   planAvailabilityID,
+			"attributes": map[string]bool{
+				"availableInNewTerritories": false,
+			},
+			"relationships": map[string]any{
+				"availableTerritories": map[string]any{
+					"data": []any{},
+				},
+			},
+		},
+	}
+
+	path := "/subscriptionPlanAvailabilities/" + url.PathEscape(planAvailabilityID)
+	responseBody, err := c.doRequest(ctx, http.MethodPatch, path, requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload struct {
+		Data jsonAPIResource `json:"data"`
+	}
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription plan availability response: %w", err)
+	}
+
+	availability := decodeSubscriptionPlanAvailabilityResource(payload.Data)
+	return &availability, nil
+}

--- a/internal/web/subscription_plan_availability.go
+++ b/internal/web/subscription_plan_availability.go
@@ -11,11 +11,12 @@ import (
 
 // SubscriptionPlanAvailability models the internal web API subscription plan availability resource.
 type SubscriptionPlanAvailability struct {
-	ID                        string   `json:"id"`
-	Type                      string   `json:"type,omitempty"`
-	AvailableInNewTerritories bool     `json:"availableInNewTerritories"`
-	PlanType                  string   `json:"planType,omitempty"`
-	AvailableTerritories      []string `json:"availableTerritories,omitempty"`
+	ID                         string   `json:"id"`
+	Type                       string   `json:"type,omitempty"`
+	AvailableInNewTerritories  bool     `json:"availableInNewTerritories"`
+	PlanType                   string   `json:"planType,omitempty"`
+	AvailableTerritories       []string `json:"availableTerritories,omitempty"`
+	AvailableTerritoriesLoaded bool     `json:"-"`
 }
 
 func decodeSubscriptionPlanAvailabilityResource(resource jsonAPIResource) SubscriptionPlanAvailability {
@@ -26,7 +27,13 @@ func decodeSubscriptionPlanAvailabilityResource(resource jsonAPIResource) Subscr
 		PlanType:                  stringAttr(resource.Attributes, "planType"),
 	}
 
-	refs := relationshipRefs(resource, "availableTerritories")
+	relationship, ok := resource.Relationships["availableTerritories"]
+	if ok {
+		trimmedData := strings.TrimSpace(string(relationship.Data))
+		availability.AvailableTerritoriesLoaded = trimmedData != "" && trimmedData != "null"
+	}
+
+	refs := parseRelationshipRefs(relationship.Data)
 	if len(refs) == 0 {
 		return availability
 	}

--- a/internal/web/subscription_plan_availability_test.go
+++ b/internal/web/subscription_plan_availability_test.go
@@ -53,6 +53,9 @@ func TestListSubscriptionPlanAvailabilitiesBuildsExpectedRequest(t *testing.T) {
 	if len(got[0].AvailableTerritories) != 1 || got[0].AvailableTerritories[0] != "USA" {
 		t.Fatalf("unexpected decoded territories: %#v", got[0].AvailableTerritories)
 	}
+	if !got[0].AvailableTerritoriesLoaded {
+		t.Fatalf("expected available territories relationship to be loaded: %#v", got[0])
+	}
 }
 
 func TestRemoveSubscriptionPlanAvailabilityFromSaleBuildsExpectedRequest(t *testing.T) {

--- a/internal/web/subscription_plan_availability_test.go
+++ b/internal/web/subscription_plan_availability_test.go
@@ -1,0 +1,126 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListSubscriptionPlanAvailabilitiesBuildsExpectedRequest(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [{
+				"id": "plan-1",
+				"type": "subscriptionPlanAvailabilities",
+				"attributes": {"availableInNewTerritories": true, "planType": "UPFRONT"},
+				"relationships": {
+					"availableTerritories": {
+						"data": [{"type": "territories", "id": "USA"}]
+					}
+				}
+			}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	got, err := client.ListSubscriptionPlanAvailabilities(context.Background(), "sub-1")
+	if err != nil {
+		t.Fatalf("ListSubscriptionPlanAvailabilities() error = %v", err)
+	}
+
+	if gotPath != "/iris/v1/subscriptions/sub-1/planAvailabilities" {
+		t.Fatalf("expected plan availabilities path, got %q", gotPath)
+	}
+	if !strings.Contains(gotQuery, "include=availableTerritories") || !strings.Contains(gotQuery, "limit%5BavailableTerritories%5D=200") {
+		t.Fatalf("unexpected query: %q", gotQuery)
+	}
+	if len(got) != 1 || got[0].ID != "plan-1" || got[0].PlanType != "UPFRONT" || !got[0].AvailableInNewTerritories {
+		t.Fatalf("unexpected decoded plan availability: %#v", got)
+	}
+	if len(got[0].AvailableTerritories) != 1 || got[0].AvailableTerritories[0] != "USA" {
+		t.Fatalf("unexpected decoded territories: %#v", got[0].AvailableTerritories)
+	}
+}
+
+func TestRemoveSubscriptionPlanAvailabilityFromSaleBuildsExpectedRequest(t *testing.T) {
+	var payload struct {
+		Data struct {
+			Type       string `json:"type"`
+			ID         string `json:"id"`
+			Attributes struct {
+				AvailableInNewTerritories bool `json:"availableInNewTerritories"`
+			} `json:"attributes"`
+			Relationships struct {
+				AvailableTerritories struct {
+					Data []any `json:"data"`
+				} `json:"availableTerritories"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/iris/v1/subscriptionPlanAvailabilities/plan-1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"id": "plan-1",
+				"type": "subscriptionPlanAvailabilities",
+				"attributes": {"availableInNewTerritories": false, "planType": "UPFRONT"}
+			}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	got, err := client.RemoveSubscriptionPlanAvailabilityFromSale(context.Background(), "plan-1")
+	if err != nil {
+		t.Fatalf("RemoveSubscriptionPlanAvailabilityFromSale() error = %v", err)
+	}
+
+	if payload.Data.Type != "subscriptionPlanAvailabilities" || payload.Data.ID != "plan-1" {
+		t.Fatalf("unexpected payload identity: %#v", payload.Data)
+	}
+	if payload.Data.Attributes.AvailableInNewTerritories {
+		t.Fatal("expected availableInNewTerritories=false")
+	}
+	if len(payload.Data.Relationships.AvailableTerritories.Data) != 0 {
+		t.Fatalf("expected availableTerritories.data to be empty, got %#v", payload.Data.Relationships.AvailableTerritories.Data)
+	}
+	if got.ID != "plan-1" || got.AvailableInNewTerritories {
+		t.Fatalf("unexpected response: %#v", got)
+	}
+}
+
+func TestSubscriptionPlanAvailabilityRequiresIDs(t *testing.T) {
+	client := &Client{}
+	if _, err := client.ListSubscriptionPlanAvailabilities(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "subscription id is required") {
+		t.Fatalf("expected subscription id error, got %v", err)
+	}
+	if _, err := client.RemoveSubscriptionPlanAvailabilityFromSale(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "subscription plan availability id is required") {
+		t.Fatalf("expected plan availability id error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an experimental web-session command for removing an approved auto-renewable subscription from sale:

```bash
asc web subscriptions availability remove-from-sale \
  --app "APP_ID" \
  --subscription-id "PRODUCT_ID_OR_SUBSCRIPTION_ID" \
  --confirm
```

The command follows the App Store Connect web flow we observed for this action by patching the subscription plan availability, setting `availableInNewTerritories=false`, and clearing `availableTerritories`.

## Why

The public App Store Connect API does not expose a documented first-class operation for removing an approved auto-renewable subscription from sale. App Store Connect performs this through the internal web `/iris` plan availability endpoint, and this repo already has an experimental `asc web` command family for reviewer-owned web-session workflows where the public API falls short.

This keeps the feature in the web-session namespace instead of presenting it as a stable public API command.

## Behavior

- Adds `asc web subscriptions availability remove-from-sale`.
- Requires `--confirm` because this is a destructive sale-availability mutation.
- Accepts `--subscription-id` as a subscription ID, product ID, or exact current name.
- Accepts `--app` to resolve product ID/name through existing web subscription listing.
- Accepts `--plan-availability-id` for direct mutation when the internal availability ID is already known.
- Returns structured JSON/table/markdown output with the selected plan availability and removal state.
- Converts Apple `403` responses into an explicit Account Holder role error, matching App Store Connect behavior for approved subscriptions.

## Validation

Local gates:

```bash
make format
make check-command-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
go build -o /tmp/asc-subscription-remove-from-sale .
```

Black-box CLI checks:

```bash
/tmp/asc-subscription-remove-from-sale web subscriptions availability remove-from-sale --help
/tmp/asc-subscription-remove-from-sale web subscriptions availability remove-from-sale --subscription-id SUB_ID
```

Live App Store Connect smoke test against a user-approved subscription:

```bash
/tmp/asc-subscription-remove-from-sale web review subscriptions list \
  --apple-id "REDACTED" \
  --app "REDACTED_APP_ID" \
  --output json \
  --pretty

/tmp/asc-subscription-remove-from-sale web subscriptions availability remove-from-sale \
  --apple-id "REDACTED" \
  --app "REDACTED_APP_ID" \
  --subscription-id "REDACTED_PRODUCT_ID" \
  --confirm \
  --output json \
  --pretty
```

Result:

```json
{
  "subscriptionId": "REDACTED_SUBSCRIPTION_ID",
  "planAvailabilityId": "REDACTED_PLAN_AVAILABILITY_ID",
  "planType": "UPFRONT",
  "removedFromSale": true,
  "availableInNewTerritories": false,
  "availableTerritories": null,
  "requiresAccountHolderRole": true
}
```

## Notes

This is intentionally marked experimental and documented under `asc web` because it depends on private, undocumented Apple web-session endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "asc web subscriptions availability remove-from-sale" command available under the web command to remove a subscription plan from sale; requires Account Holder session and explicit confirmation.

* **Documentation**
  * Added docs with usage examples, Account Holder session warning, and guidance for supplying a plan-availability-id.

* **Tests**
  * Added comprehensive tests covering removal flows, ID validation, verification/read-back, authorization guidance, progress messaging, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->