### PR TITLE
Add Pocket Mole Watch to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -867,6 +867,13 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2f/57/02/2f570236-cd2e-4d0b-a797-1130d5b68c19/AppIcon-0-1x_U007emarketing-0-11-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Pocket Mole Watch",
+    "link": "https://apps.apple.com/us/app/pocket-mole-watch/id6766255492?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/89/bd/10/89bd10b6-2a9a-4292-2eaf-16948b018a7a/AppIcon-0-0-1x_U007emarketing-0-11-85-220.png/512x512bb.jpg",
+    "creator": "doublewater777",
+    "platform": ["watchOS"]
+  },
+  {
     "app": "Plushify",
     "link": "https://apps.apple.com/us/app/plushify/id6758206706?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5d/49/25/5d4925ae-e8d1-6d72-5f7c-28f78c126f0f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- Add Pocket Mole Watch to docs/wall-of-apps.json.

## Validation

- [x] JSON parsed successfully and duplicate link check passed with local Ruby script
- [ ] make check-wall-of-apps (not run: Go is not installed in this local shell)

## Wall of Apps (only if this PR adds/updates a Wall app)

- [x] I made the equivalent single-file update manually because local asc 0.37.0 does not expose apps wall submit
- [x] This PR only updates docs/wall-of-apps.json
- [ ] I ran make check-wall-of-apps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Pocket Mole Watch," a new watchOS app to the app directory, including App Store link, icon, and creator metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->