### PR TITLE
apps wall: add Pocket Mole Watch

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -872,6 +872,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5d/49/25/5d4925ae-e8d1-6d72-5f7c-28f78c126f0f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Pocket Mole Watch",
+    "link": "https://apps.apple.com/us/app/pocket-mole-watch/id6766255492?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/89/bd/10/89bd10b6-2a9a-4292-2eaf-16948b018a7a/AppIcon-0-0-1x_U007emarketing-0-11-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Pop - Find by Color",
     "link": "https://apps.apple.com/us/app/pop-find-by-color/id6758629086?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ee/8a/b3/ee8ab36e-f44e-a3d8-baf5-bf9036af5532/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pocket Mole Watch` to the Wall of Apps

## Entry

- App ID: 6766255492
- App: Pocket Mole Watch
- Link: https://apps.apple.com/us/app/pocket-mole-watch/id6766255492?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Plushify entry data.

* **Documentation**
  * Added Pocket Mole Watch to the apps collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->