### PR TITLE
apps wall: add Master Indicator

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -638,6 +638,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/9d/34/53/9d345362-2b78-96c5-5294-33d2e084bb90/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Master Indicator",
+    "link": "https://apps.apple.com/us/app/master-indicator/id6758697856?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/25/2c/78/252c787f-d9e8-738e-51fb-61c64ee95c32/AppIcon-1x_U007emarketing-0-10-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "MD Clock - Flip Clock",
     "link": "https://apps.apple.com/us/app/md-clock-flip-clock/id1536358464?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4c/07/b7/4c07b7c5-0612-7f65-0b65-91594843e0fb/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Master Indicator` to the Wall of Apps

## Entry

- App ID: 6758697856
- App: Master Indicator
- Link: https://apps.apple.com/us/app/master-indicator/id6758697856?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Master Indicator has been added to the apps catalog, expanding the directory of available applications for users to discover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->