### PR TITLE
apps wall: add Margin: AI Article Reader

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -633,6 +633,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/12/8e/fb/128efb33-a5ee-d321-2720-924431d772dd/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Margin: AI Article Reader",
+    "link": "https://apps.apple.com/us/app/margin-ai-article-reader/id6748705626?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/1a/dd/73/1add730b-0e85-d8fd-09eb-722cb492877d/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Masseter: Jaw Clench Tracker",
     "link": "https://apps.apple.com/us/app/masseter-jaw-clench-tracker/id6758920098?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/9d/34/53/9d345362-2b78-96c5-5294-33d2e084bb90/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Margin: AI Article Reader` to the Wall of Apps

## Entry

- App ID: 6748705626
- App: Margin: AI Article Reader
- Link: https://apps.apple.com/us/app/margin-ai-article-reader/id6748705626?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Margin: AI Article Reader" to the app directory with its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->