### PR TITLE
fix(offer-codes): skip --prices requirement and payload for FREE_TRIAL mode

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -64,6 +64,10 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - Device management UI lives in the Apple Developer portal, not App Store Connect.
 - Device reset is limited to once per membership year; disabling does not free slots.
 
+## Subscription Offer Codes
+
+- `POST /v1/subscriptionOfferCodes`: for `FREE_TRIAL` offers the `prices` relationship **must be omitted entirely** — the API returns 409 if it is present (even as an empty list). The OpenAPI snapshot marks `prices` as required in the relationships schema, but that is incorrect for `FREE_TRIAL` mode. The CLI and client enforce this by omitting the relationship and rejecting `--prices` when `--offer-mode FREE_TRIAL` is set.
+
 ## Pass Type IDs
 
 - Live API rejects `include=passTypeId` and `fields[passTypeIds]` on `/v1/passTypeIds/{id}/certificates` despite the OpenAPI spec allowing them.

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -648,44 +648,54 @@ func (c *Client) CreateSubscriptionOfferCode(ctx context.Context, subscriptionID
 	if subscriptionID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
 	}
-	if len(prices) == 0 {
+	// FREE_TRIAL offers must not include a subscriptionPricePoint — the API rejects it.
+	if len(prices) > 0 && attrs.OfferMode == SubscriptionOfferModeFreeTrial {
+		return nil, fmt.Errorf("prices must not be set for FREE_TRIAL offer mode")
+	}
+	if len(prices) == 0 && attrs.OfferMode != SubscriptionOfferModeFreeTrial {
 		return nil, fmt.Errorf("at least one price is required")
 	}
 
-	included := make([]SubscriptionOfferCodePriceInlineCreate, 0, len(prices))
-	priceData := make([]ResourceData, 0, len(prices))
-	for idx, price := range prices {
-		territoryID := strings.ToUpper(strings.TrimSpace(price.TerritoryID))
-		pricePointID := strings.TrimSpace(price.PricePointID)
-		if territoryID == "" {
-			return nil, fmt.Errorf("territory ID is required")
-		}
-		if pricePointID == "" {
-			return nil, fmt.Errorf("price point ID is required")
-		}
-		resourceID := fmt.Sprintf("${local-price-%d}", idx+1)
-		priceData = append(priceData, ResourceData{
-			Type: ResourceTypeSubscriptionOfferCodePrices,
-			ID:   resourceID,
-		})
-		included = append(included, SubscriptionOfferCodePriceInlineCreate{
-			Type: ResourceTypeSubscriptionOfferCodePrices,
-			ID:   resourceID,
-			Relationships: SubscriptionOfferCodePriceRelationships{
-				Territory: Relationship{
-					Data: ResourceData{
-						Type: ResourceTypeTerritories,
-						ID:   territoryID,
+	var included []SubscriptionOfferCodePriceInlineCreate
+	var pricesRel *RelationshipList
+
+	if attrs.OfferMode != SubscriptionOfferModeFreeTrial {
+		priceData := make([]ResourceData, 0, len(prices))
+		included = make([]SubscriptionOfferCodePriceInlineCreate, 0, len(prices))
+		for idx, price := range prices {
+			territoryID := strings.ToUpper(strings.TrimSpace(price.TerritoryID))
+			pricePointID := strings.TrimSpace(price.PricePointID)
+			if territoryID == "" {
+				return nil, fmt.Errorf("territory ID is required")
+			}
+			if pricePointID == "" {
+				return nil, fmt.Errorf("price point ID is required")
+			}
+			resourceID := fmt.Sprintf("${local-price-%d}", idx+1)
+			priceData = append(priceData, ResourceData{
+				Type: ResourceTypeSubscriptionOfferCodePrices,
+				ID:   resourceID,
+			})
+			included = append(included, SubscriptionOfferCodePriceInlineCreate{
+				Type: ResourceTypeSubscriptionOfferCodePrices,
+				ID:   resourceID,
+				Relationships: SubscriptionOfferCodePriceRelationships{
+					Territory: Relationship{
+						Data: ResourceData{
+							Type: ResourceTypeTerritories,
+							ID:   territoryID,
+						},
+					},
+					SubscriptionPricePoint: Relationship{
+						Data: ResourceData{
+							Type: ResourceTypeSubscriptionPricePoints,
+							ID:   pricePointID,
+						},
 					},
 				},
-				SubscriptionPricePoint: Relationship{
-					Data: ResourceData{
-						Type: ResourceTypeSubscriptionPricePoints,
-						ID:   pricePointID,
-					},
-				},
-			},
-		})
+			})
+		}
+		pricesRel = &RelationshipList{Data: priceData}
 	}
 
 	payload := SubscriptionOfferCodeCreateRequest{
@@ -699,7 +709,7 @@ func (c *Client) CreateSubscriptionOfferCode(ctx context.Context, subscriptionID
 						ID:   subscriptionID,
 					},
 				},
-				Prices: RelationshipList{Data: priceData},
+				Prices: pricesRel,
 			},
 		},
 		Included: included,

--- a/internal/asc/subscription_resources.go
+++ b/internal/asc/subscription_resources.go
@@ -250,8 +250,8 @@ type SubscriptionOfferCodeUpdateAttributes struct {
 
 // SubscriptionOfferCodeRelationships describes relationships for offer codes.
 type SubscriptionOfferCodeRelationships struct {
-	Subscription Relationship     `json:"subscription"`
-	Prices       RelationshipList `json:"prices"`
+	Subscription Relationship      `json:"subscription"`
+	Prices       *RelationshipList `json:"prices,omitempty"`
 }
 
 // SubscriptionOfferCodeCreateData is the data portion of an offer code create request.

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -781,7 +781,7 @@ func TestCreateSubscriptionOfferCode(t *testing.T) {
 		OfferEligibility:      SubscriptionOfferEligibilityStackWithIntroOffers,
 		CustomerEligibilities: []SubscriptionCustomerEligibility{SubscriptionCustomerEligibilityNew},
 		Duration:              SubscriptionOfferDurationOneMonth,
-		OfferMode:             SubscriptionOfferModeFreeTrial,
+		OfferMode:             SubscriptionOfferModePayAsYouGo,
 		NumberOfPeriods:       1,
 	}
 	prices := []SubscriptionOfferCodePrice{
@@ -792,6 +792,63 @@ func TestCreateSubscriptionOfferCode(t *testing.T) {
 	}
 	if _, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, prices); err != nil {
 		t.Fatalf("CreateSubscriptionOfferCode() error: %v", err)
+	}
+}
+
+func TestCreateSubscriptionOfferCodeFreeTrial(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionOfferCodes","id":"code-ft-1","attributes":{"name":"One Year Free"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptionOfferCodes" {
+			t.Fatalf("expected path /v1/subscriptionOfferCodes, got %s", req.URL.Path)
+		}
+		var payload SubscriptionOfferCodeCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if payload.Data.Type != ResourceTypeSubscriptionOfferCodes {
+			t.Fatalf("expected type subscriptionOfferCodes, got %q", payload.Data.Type)
+		}
+		if payload.Data.Attributes.OfferMode != SubscriptionOfferModeFreeTrial {
+			t.Fatalf("expected offer mode FREE_TRIAL, got %q", payload.Data.Attributes.OfferMode)
+		}
+		if payload.Data.Relationships.Prices != nil {
+			t.Fatalf("expected no prices relationship for FREE_TRIAL, got %+v", payload.Data.Relationships.Prices)
+		}
+		if len(payload.Included) != 0 {
+			t.Fatalf("expected no included entries for FREE_TRIAL, got %d", len(payload.Included))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	attrs := SubscriptionOfferCodeCreateAttributes{
+		Name:                  "One Year Free",
+		OfferEligibility:      SubscriptionOfferEligibilityStackWithIntroOffers,
+		CustomerEligibilities: []SubscriptionCustomerEligibility{SubscriptionCustomerEligibilityNew},
+		Duration:              SubscriptionOfferDurationOneYear,
+		OfferMode:             SubscriptionOfferModeFreeTrial,
+		NumberOfPeriods:       1,
+	}
+	if _, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, nil); err != nil {
+		t.Fatalf("CreateSubscriptionOfferCode() error: %v", err)
+	}
+}
+
+func TestCreateSubscriptionOfferCodeFreeTrialRejectsPrices(t *testing.T) {
+	attrs := SubscriptionOfferCodeCreateAttributes{
+		OfferMode: SubscriptionOfferModeFreeTrial,
+	}
+	prices := []SubscriptionOfferCodePrice{{TerritoryID: "USA", PricePointID: "price-1"}}
+	client := &Client{} // no HTTP needed — validation fires before any call
+	_, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, prices)
+	if err == nil {
+		t.Fatal("expected error for FREE_TRIAL with prices, got nil")
+	}
+	const want = "prices must not be set for FREE_TRIAL offer mode"
+	if err.Error() != want {
+		t.Fatalf("expected %q, got %q", want, err.Error())
 	}
 }
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1775,13 +1775,18 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "subscriptions offer-codes create missing name",
-			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--prices", "PRICE_ID"},
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "PAY_AS_YOU_GO", "--number-of-periods", "1", "--prices", "PRICE_ID"},
 			wantErr: "--name is required",
 		},
 		{
 			name:    "subscriptions offer-codes create missing prices",
-			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1"},
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "PAY_AS_YOU_GO", "--number-of-periods", "1"},
 			wantErr: "--prices is required",
+		},
+		{
+			name:    "subscriptions offer-codes create free-trial with prices rejected",
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--prices", "USA:PRICE_ID"},
+			wantErr: "--prices must not be set for FREE_TRIAL offers",
 		},
 		{
 			name:    "subscriptions offer-codes update missing active",

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -417,6 +417,16 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			args:    []string{"apps", "public", "view", "--app", "-123"},
 			wantErr: "--app must be a numeric App Store app ID",
 		},
+		{
+			name:    "subscriptions offer-codes create non-free-trial without prices",
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "PAY_AS_YOU_GO", "--number-of-periods", "1"},
+			wantErr: "--prices is required",
+		},
+		{
+			name:    "subscriptions offer-codes create free-trial with prices rejected",
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--prices", "USA:PRICE_ID"},
+			wantErr: "--prices must not be set for FREE_TRIAL offers",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/stable_selector_resolution_test.go
+++ b/internal/cli/cmdtest/stable_selector_resolution_test.go
@@ -631,8 +631,16 @@ func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndOmitsPrices(t *testing
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"sub-offer-ft-2"`) {
-		t.Fatalf("expected offer code id in output, got %q", stdout)
+	var resp struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if resp.Data.ID != "sub-offer-ft-2" {
+		t.Fatalf("expected offer code id sub-offer-ft-2, got %q", resp.Data.ID)
 	}
 }
 
@@ -656,6 +664,40 @@ func TestSubscriptionsOfferCodesCreateFreeTrialWithPricesIsRejected(t *testing.T
 	}
 	if !strings.Contains(stderr, "--prices must not be set for FREE_TRIAL") {
 		t.Fatalf("expected validation message in stderr, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsOfferCodesCreateNonFreeTrialWithoutPricesIsRejected(t *testing.T) {
+	tests := []struct {
+		name      string
+		offerMode string
+	}{
+		{"pay_as_you_go", "PAY_AS_YOU_GO"},
+		{"pay_up_front", "PAY_UP_FRONT"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, stderr, runErr := runRootCommand(t, []string{
+				"subscriptions", "offers", "offer-codes", "create",
+				"--subscription-id", "8000000001",
+				"--name", "SPRING",
+				"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
+				"--customer-eligibilities", "NEW",
+				"--offer-duration", "ONE_MONTH",
+				"--offer-mode", tc.offerMode,
+				"--number-of-periods", "1",
+			})
+			if runErr == nil {
+				t.Fatalf("expected error for %s without prices, got nil", tc.offerMode)
+			}
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp (exit 2), got %v", runErr)
+			}
+			if !strings.Contains(stderr, "--prices is required") {
+				t.Fatalf("expected --prices is required in stderr, got %q", stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/stable_selector_resolution_test.go
+++ b/internal/cli/cmdtest/stable_selector_resolution_test.go
@@ -561,6 +561,104 @@ func TestSubscriptionsOfferCodesCreateFreeTrialStopsBeforeMutationWhenLookupFail
 	}
 }
 
+func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndOmitsPrices(t *testing.T) {
+	setupStableSelectorAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/subscriptionGroups":
+			return selectorJSONResponse(`{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}]}`), nil
+		case "/v1/subscriptionGroups/group-1/subscriptions":
+			if req.URL.Query().Get("filter[productId]") != "com.example.monthly" {
+				t.Fatalf("expected product filter on lookup request, got %q", req.URL.Query().Get("filter[productId]"))
+			}
+			return selectorJSONResponse(`{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}]}`), nil
+		case "/v1/subscriptionOfferCodes":
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST to /v1/subscriptionOfferCodes, got %s", req.Method)
+			}
+			rawBody, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body error: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(rawBody, &payload); err != nil {
+				t.Fatalf("decode request body: %v\nbody=%s", err, string(rawBody))
+			}
+			data, ok := payload["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected payload.data to be an object, got %T", payload["data"])
+			}
+			relationships, ok := data["relationships"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected payload.data.relationships to be an object, got %T", data["relationships"])
+			}
+			if _, ok := relationships["prices"]; ok {
+				t.Fatalf("expected no prices relationship for FREE_TRIAL, but found one: %#v", relationships["prices"])
+			}
+			if _, ok := payload["included"]; ok {
+				t.Fatalf("expected no included entries for FREE_TRIAL, but found some: %#v", payload["included"])
+			}
+			body := `{"data":{"type":"subscriptionOfferCodes","id":"sub-offer-ft-2","attributes":{"name":"SPRING","active":true}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, runErr := runRootCommand(t, []string{
+		"subscriptions", "offers", "offer-codes", "create",
+		"--app", "app-1",
+		"--subscription-id", "com.example.monthly",
+		"--name", "SPRING",
+		"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
+		"--customer-eligibilities", "NEW",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
+	})
+	if runErr != nil {
+		t.Fatalf("expected nil error, got %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-offer-ft-2"`) {
+		t.Fatalf("expected offer code id in output, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsOfferCodesCreateFreeTrialWithPricesIsRejected(t *testing.T) {
+	_, stderr, runErr := runRootCommand(t, []string{
+		"subscriptions", "offers", "offer-codes", "create",
+		"--subscription-id", "8000000001",
+		"--name", "SPRING",
+		"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
+		"--customer-eligibilities", "NEW",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
+		"--prices", "usa:pp-us",
+	})
+	if runErr == nil {
+		t.Fatal("expected error for FREE_TRIAL with prices, got nil")
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp (exit 2), got %v", runErr)
+	}
+	if !strings.Contains(stderr, "--prices must not be set for FREE_TRIAL") {
+		t.Fatalf("expected validation message in stderr, got %q", stderr)
+	}
+}
+
 func TestWinBackOffersLinksResolvesStableSelector(t *testing.T) {
 	setupStableSelectorAuth(t)
 

--- a/internal/cli/cmdtest/stable_selector_resolution_test.go
+++ b/internal/cli/cmdtest/stable_selector_resolution_test.go
@@ -501,9 +501,54 @@ func TestSubscriptionsOfferCodesCreateStopsBeforeMutationWhenLookupFails(t *test
 		"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
 		"--customer-eligibilities", "NEW",
 		"--offer-duration", "ONE_MONTH",
-		"--offer-mode", "FREE_TRIAL",
+		"--offer-mode", "PAY_AS_YOU_GO",
 		"--number-of-periods", "1",
 		"--prices", "usa:pp-us",
+	})
+	if runErr == nil {
+		t.Fatal("expected lookup error")
+	}
+	if !strings.Contains(runErr.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", runErr)
+	}
+	if requests == 0 {
+		t.Fatal("expected lookup requests before failure")
+	}
+}
+
+func TestSubscriptionsOfferCodesCreateFreeTrialStopsBeforeMutationWhenLookupFails(t *testing.T) {
+	setupStableSelectorAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionOfferCodes" {
+			t.Fatalf("unexpected mutation request during failed lookup: %s %s", req.Method, req.URL.String())
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/subscriptionGroups":
+			return selectorJSONResponse(`{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}]}`), nil
+		case "/v1/subscriptionGroups/group-1/subscriptions":
+			return selectorJSONResponse(`{"data":[]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	_, _, runErr := runRootCommand(t, []string{
+		"subscriptions", "offers", "offer-codes", "create",
+		"--app", "app-1",
+		"--subscription-id", "com.example.missing",
+		"--name", "SPRING",
+		"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
+		"--customer-eligibilities", "NEW",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
 	})
 	if runErr == nil {
 		t.Fatal("expected lookup error")

--- a/internal/cli/cmdtest/subscriptions_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/subscriptions_offer_codes_output_test.go
@@ -51,8 +51,8 @@ func TestSubscriptionsOfferCodesCreateNormalizesValuesAndBuildsPayload(t *testin
 		if attrs["duration"] != "ONE_MONTH" {
 			t.Fatalf("expected normalized duration ONE_MONTH, got %#v", attrs["duration"])
 		}
-		if attrs["offerMode"] != "FREE_TRIAL" {
-			t.Fatalf("expected normalized offerMode FREE_TRIAL, got %#v", attrs["offerMode"])
+		if attrs["offerMode"] != "PAY_AS_YOU_GO" {
+			t.Fatalf("expected normalized offerMode PAY_AS_YOU_GO, got %#v", attrs["offerMode"])
 		}
 		if attrs["numberOfPeriods"] != float64(2) {
 			t.Fatalf("expected numberOfPeriods 2, got %#v", attrs["numberOfPeriods"])
@@ -104,7 +104,7 @@ func TestSubscriptionsOfferCodesCreateNormalizesValuesAndBuildsPayload(t *testin
 			"--offer-eligibility", "replace_intro_offers",
 			"--customer-eligibilities", "new,existing",
 			"--offer-duration", "one_month",
-			"--offer-mode", "free_trial",
+			"--offer-mode", "pay_as_you_go",
 			"--number-of-periods", "2",
 			"--prices", "usa:pp-us",
 			"--auto-renew-enabled", "true",
@@ -130,6 +130,142 @@ func TestSubscriptionsOfferCodesCreateNormalizesValuesAndBuildsPayload(t *testin
 	}
 	if out.Data.ID != "sub-offer-1" {
 		t.Fatalf("expected created offer code id sub-offer-1, got %q", out.Data.ID)
+	}
+}
+
+func TestSubscriptionsOfferCodesCreateFreeTrialOmitsPrices(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rawBody, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(rawBody, &payload); err != nil {
+			t.Fatalf("decode request body: %v\nbody=%s", err, string(rawBody))
+		}
+
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected payload.data to be an object, got %T", payload["data"])
+		}
+		attrs, ok := data["attributes"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected payload.data.attributes to be an object, got %T", data["attributes"])
+		}
+		if attrs["offerMode"] != "FREE_TRIAL" {
+			t.Fatalf("expected offerMode FREE_TRIAL, got %#v", attrs["offerMode"])
+		}
+
+		relationships, ok := data["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected payload.data.relationships to be an object, got %T", data["relationships"])
+		}
+		if _, ok := relationships["prices"]; ok {
+			t.Fatalf("expected no prices relationship for FREE_TRIAL, but found one: %#v", relationships["prices"])
+		}
+		if _, ok := payload["included"]; ok {
+			t.Fatalf("expected no included entries for FREE_TRIAL, but found some: %#v", payload["included"])
+		}
+
+		body := `{"data":{"type":"subscriptionOfferCodes","id":"sub-offer-ft-1","attributes":{"name":"One Year Free","active":true}}}`
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "offer-codes", "create",
+			"--subscription-id", "8000000001",
+			"--name", "One Year Free",
+			"--offer-eligibility", "stack_with_intro_offers",
+			"--customer-eligibilities", "new",
+			"--offer-duration", "one_year",
+			"--offer-mode", "free_trial",
+			"--number-of-periods", "1",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var out struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if out.Data.ID != "sub-offer-ft-1" {
+		t.Fatalf("expected created offer code id sub-offer-ft-1, got %q", out.Data.ID)
+	}
+}
+
+func TestSubscriptionsOfferCodesCreateNonFreeTrialRequiresPrices(t *testing.T) {
+	tests := []struct {
+		name      string
+		offerMode string
+	}{
+		{"pay_as_you_go", "pay_as_you_go"},
+		{"pay_up_front", "pay_up_front"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"subscriptions", "offers", "offer-codes", "create",
+					"--subscription-id", "8000000001",
+					"--name", "Spring Promo",
+					"--offer-eligibility", "stack_with_intro_offers",
+					"--customer-eligibilities", "new",
+					"--offer-duration", "one_month",
+					"--offer-mode", test.offerMode,
+					"--number-of-periods", "1",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+			}
+			if !strings.Contains(stderr, "--prices is required") {
+				t.Fatalf("expected --prices is required in stderr, got %q", stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+		})
 	}
 }
 
@@ -169,7 +305,7 @@ func TestSubscriptionsOfferCodesCreateReturnsCreateFailure(t *testing.T) {
 			"--offer-eligibility", "replace_intro_offers",
 			"--customer-eligibilities", "new",
 			"--offer-duration", "one_month",
-			"--offer-mode", "free_trial",
+			"--offer-mode", "pay_as_you_go",
 			"--number-of-periods", "1",
 			"--prices", "usa:pp-us",
 		}); err != nil {

--- a/internal/cli/offercodes/subscription_offer_codes.go
+++ b/internal/cli/offercodes/subscription_offer_codes.go
@@ -135,6 +135,7 @@ func OfferCodesCreateCommand() *ffcli.Command {
 		LongHelp: `Create a subscription offer code.
 
 Examples:
+  asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
   asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "USA:PRICE_POINT_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -203,8 +204,12 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("offer-codes create: %w", err)
 			}
-			if len(priceEntries) == 0 {
+			if len(priceEntries) == 0 && offerModeValue != asc.SubscriptionOfferModeFreeTrial {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
+				return flag.ErrHelp
+			}
+			if len(priceEntries) > 0 && offerModeValue == asc.SubscriptionOfferModeFreeTrial {
+				fmt.Fprintln(os.Stderr, "Error: --prices must not be set for FREE_TRIAL offers")
 				return flag.ErrHelp
 			}
 

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -27,6 +27,7 @@ func SubscriptionsOfferCodesCommand() *ffcli.Command {
 Examples:
   asc subscriptions offer-codes list --subscription-id "SUB_ID"
   asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"
   asc subscriptions offer-codes generate --offer-code-id "OFFER_CODE_ID" --quantity 10 --expiration-date "2026-02-01"
   asc subscriptions offer-codes values --batch-id "ONE_TIME_USE_CODE_ID" --output "./offer-codes.txt"`,
 		FlagSet:   fs,

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -26,7 +26,7 @@ func SubscriptionsOfferCodesCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions offer-codes list --subscription-id "SUB_ID"
-  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US:PRICE_POINT_ID"
+  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
   asc subscriptions offer-codes generate --offer-code-id "OFFER_CODE_ID" --quantity 10 --expiration-date "2026-02-01"
   asc subscriptions offer-codes values --batch-id "ONE_TIME_USE_CODE_ID" --output "./offer-codes.txt"`,
 		FlagSet:   fs,
@@ -197,7 +197,8 @@ func SubscriptionsOfferCodesCreateCommand() *ffcli.Command {
 		LongHelp: `Create an offer code.
 
 Examples:
-  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US:PRICE_POINT_ID"`,
+  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -247,8 +248,12 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp
 			}
-			if len(priceEntries) == 0 {
+			if len(priceEntries) == 0 && mode != asc.SubscriptionOfferModeFreeTrial {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
+				return flag.ErrHelp
+			}
+			if len(priceEntries) > 0 && mode == asc.SubscriptionOfferModeFreeTrial {
+				fmt.Fprintln(os.Stderr, "Error: --prices must not be set for FREE_TRIAL offers")
 				return flag.ErrHelp
 			}
 


### PR DESCRIPTION
## Summary

- `--prices` is no longer required when `--offer-mode FREE_TRIAL` — the ASC API rejects `subscriptionPricePoint` for FREE_TRIAL offers with 409: "For FREE_TRIAL offerMode, subscriptionPricePoint must be null"
- For FREE_TRIAL, the `prices` relationship and `included` entries are omitted from the request body entirely
- `Prices` field in `SubscriptionOfferCodeRelationships` changed to `*RelationshipList` with `omitempty` so it serializes as absent (not `{"data":[]}`) when nil

Fix applied at three layers: CLI validation guard, client-layer validation/payload guard, and struct field pointer+omitempty.

Fixes #1500

## Test plan

- [ ] `TestCreateSubscriptionOfferCodeFreeTrial` — new test verifying FREE_TRIAL sends no `prices` relationship and no `included` entries
- [ ] `TestSubscriptionsOfferCodesCreateFreeTrialOmitsPrices` — new CLI-level test verifying FREE_TRIAL succeeds without `--prices`
- [ ] `TestSubscriptionsOfferCodesCreateNonFreeTrialRequiresPrices` — new CLI-level test verifying PAY_AS_YOU_GO and PAY_UP_FRONT still require `--prices`
- [ ] Existing `TestCreateSubscriptionOfferCode` updated to use `PAY_AS_YOU_GO` (tests the price-sending path)
- [ ] Existing `subscriptions offer-codes create missing prices` validation test updated to use `PAY_AS_YOU_GO`
- [ ] `ASC_BYPASS_KEYCHAIN=1 make test` — all tests pass
- [ ] `make format && make lint && make check-docs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FREE_TRIAL offer codes may be created without prices; requests omit the prices relationship.

* **Bug Fixes**
  * CLI and client now require prices for non-FREE_TRIAL modes and reject provided prices for FREE_TRIAL.

* **Tests**
  * Added/updated API and CLI tests covering FREE_TRIAL vs non-FREE_TRIAL payloads, validation, and error messages.

* **Documentation**
  * API notes updated to document the FREE_TRIAL pricing-omission requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->