### PR TITLE
apps wall: add ZenJournal:Stress-free Journal

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1361,6 +1361,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4b/f4/13/4bf4138d-b804-9563-f684-92a9a2845b16/zfc-glass-icon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "ZenJournal:Stress-free Journal",
+    "link": "https://apps.apple.com/us/app/zenjournal-stress-free-journal/id1399816360?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/33/eb/e1/33ebe137-a850-63be-ef48-7a7a804ec151/ZenJournalIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "ZenShelf",
     "link": "https://apps.apple.com/app/id6670147622",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/61/5a/dc/615adc54-4abd-f5f0-34a8-0ee239868470/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `ZenJournal:Stress-free Journal` to the Wall of Apps

## Entry

- App ID: 1399816360
- App: ZenJournal:Stress-free Journal
- Link: https://apps.apple.com/us/app/zenjournal-stress-free-journal/id1399816360?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ZenJournal: Stress-free Journal to the app directory with App Store link and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->