### PR TITLE
ci: run govulncheck with patched Go

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,9 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Scan Go dependencies and reachable code paths
-        id: govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
-          go-package: ./...
+          go-version: '1.26.3'
+          go-download-base-url: https://dl.google.com/go
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Scan Go dependencies and reachable code paths
+        run: govulncheck -format text ./...


### PR DESCRIPTION
## Summary
- pin the Govulncheck action to Go 1.26.3 so the scan uses the standard-library fixes it reports as required

## Why
The latest main Govulncheck runs were using Go 1.26.2 and failing on reachable standard-library vulnerabilities fixed in Go 1.26.3.

## Verification
- /Users/rudrank/sdk/go1.26.3/bin/go run golang.org/x/vuln/cmd/govulncheck@latest ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal CI workflow to run vulnerability scanning with govulncheck and to use an explicit Go toolchain version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->