### PR TITLE
Fix analytics report links for prefixed report IDs

### DIFF
--- a/internal/cli/analytics/analytics_reports.go
+++ b/internal/cli/analytics/analytics_reports.go
@@ -110,11 +110,6 @@ Examples:
 			}
 
 			id := strings.TrimSpace(*reportID)
-			if id != "" {
-				if err := validateUUIDFlag("--report-id", id); err != nil {
-					return fmt.Errorf("analytics reports links: %w", err)
-				}
-			}
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --report-id is required")
 				return flag.ErrHelp

--- a/internal/cli/cmdtest/analytics_next_validation_test.go
+++ b/internal/cli/cmdtest/analytics_next_validation_test.go
@@ -198,6 +198,52 @@ func TestAnalyticsReportsRelationshipsRejectsInvalidNextURL(t *testing.T) {
 	)
 }
 
+func TestAnalyticsReportsRelationshipsAcceptsPrefixedReportID(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const reportID = "r39-11111111-1111-1111-1111-111111111111"
+	const expectedPath = "/v1/analyticsReports/" + reportID + "/relationships/instances"
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != expectedPath {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		body := `{"data":[{"type":"analyticsReportInstances","id":"inst-1"}],"links":{}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"analytics", "reports", "links", "--report-id", reportID}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"inst-1"`) {
+		t.Fatalf("expected output to contain instance ID, got %q", stdout)
+	}
+}
+
 func TestAnalyticsReportsRelationshipsPaginateFromNextWithoutReportID(t *testing.T) {
 	const firstURL = "https://api.appstoreconnect.apple.com/v1/analyticsReports/report-1/relationships/instances?cursor=AQ&limit=200"
 	const secondURL = "https://api.appstoreconnect.apple.com/v1/analyticsReports/report-1/relationships/instances?cursor=BQ&limit=200"


### PR DESCRIPTION
## Summary
- Fixes #1494
- Allows `asc analytics reports links` to use the same prefixed analytics report IDs that `analytics view` emits and `analytics reports view` accepts
- Keeps missing `--report-id` validation and `--next` URL validation unchanged

## Root cause
`analytics reports links` had an extra local `--report-id` UUID-only validator. Real analytics report IDs are prefixed, for example `r39-<uuid>`, so the command failed before it could call App Store Connect.

## Validation
- `go run . analytics reports links --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestAnalyticsReportsRelationshipsAcceptsPrefixedReportID -count=1` (failed before fix, passed after fix)
- `make format`
- `make check-command-docs`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/analytics ./internal/cli/cmdtest ./internal/asc -run 'Analytics' -count=1`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `/tmp/asc analytics reports links --report-id r39-11111111-1111-1111-1111-111111111111` with auth env cleared, confirming the prefixed ID now passes local validation and reaches auth resolution instead of the old UUID-only error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `asc analytics reports links` command now properly handles prefixed report IDs without strict UUID validation.

* **Tests**
  * Added validation test for prefixed report ID support in analytics reports links command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->