### PR TITLE
apps wall: add MealMate: Calorie Counter

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -663,6 +663,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/2f/ca/21/2fca210d-91ad-8736-575b-d729d3002f17/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "MealMate: Calorie Counter",
+    "link": "https://apps.apple.com/us/app/mealmate-calorie-counter/id6740268220?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0f/f1/68/0ff1684f-f3fd-35c5-b6b3-5ef10b84d907/Icon-0-1x_U007ephone-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Menuist: Right-Click & MenuBar",
     "link": "https://apps.apple.com/us/app/menuist-right-click-menubar/id6737160756?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7e/f5/ee/7ef5eea0-ae74-a4a1-475a-4df5b8bab935/AppIcon-0-0-85-220-0-5-0-2x-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `MealMate: Calorie Counter` to the Wall of Apps

## Entry

- App ID: 6740268220
- App: MealMate: Calorie Counter
- Link: https://apps.apple.com/us/app/mealmate-calorie-counter/id6740268220?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "MealMate: Calorie Counter" to the app directory listing. This new entry includes the App Store link and corresponding app icon, enabling users to discover and access this calorie tracking application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->