### PR TITLE
apps wall: add Fitnit: Health & Fitness

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -364,6 +364,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8d/e5/c9/8de5c9bd-5ad9-3371-378a-b30f074a671a/AppIcon-0-0-1x_U007epad-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Fitnit: Health & Fitness",
+    "link": "https://apps.apple.com/us/app/fitnit-health-fitness/id6757887175?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/57/64/b6/5764b6e3-f3fb-9a70-925d-00e39f893263/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "FitPretty",
     "link": "https://apps.apple.com/app/id6654895919",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7f/a8/5a/7fa85a04-f258-17dd-f120-63c68061241b/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Fitnit: Health & Fitness` to the Wall of Apps

## Entry

- App ID: 6757887175
- App: Fitnit: Health & Fitness
- Link: https://apps.apple.com/us/app/fitnit-health-fitness/id6757887175?uo=4

## Notes

- Submitted via `asc apps wall submit` (manual completion after the CLI's upstream-fork validator hit a stale `rudrankriyam/...` reference; the upstream is now `rorkai/...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Fitnit: Health & Fitness" app to the app gallery with its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->