### PR TITLE
docs: clarify version localization IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ and optional blocked terms from repeated `--blocked-term` flags or a text file.
 ```bash
 asc screenshots plan --app "123456789" --version "1.2.3" --review-output-dir "./screenshots/review"
 asc screenshots apply --app "123456789" --version "1.2.3" --review-output-dir "./screenshots/review" --confirm
-asc screenshots list --version-localization "LOC_ID"
+asc screenshots list --version-localization "VERSION_LOCALIZATION_ID"
 asc video-previews list --app "123456789"
 ```
 
@@ -244,6 +244,9 @@ asc versions list --app "APP_ID"
 asc localizations list --version "VERSION_ID" --output json --locale "en-US" | jsonpp
 asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/en-US" --device-type "IPHONE_65" --replace
 ```
+
+`VERSION_LOCALIZATION_ID` is the App Store version localization resource ID
+from `data[].id`, not the locale code from `attributes.locale`.
 
 ### Signing and bundle IDs
 

--- a/internal/cli/assets/assets_previews.go
+++ b/internal/cli/assets/assets_previews.go
@@ -25,12 +25,17 @@ func AssetsPreviewsListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc video-previews list --version-localization \"LOC_ID\"",
+		ShortUsage: "asc video-previews list --version-localization \"VERSION_LOCALIZATION_ID\"",
 		ShortHelp:  "List previews for a localization.",
 		LongHelp: `List previews for a localization.
 
+--version-localization is the App Store version localization resource ID
+returned as data[].id by "asc localizations list --version VERSION_ID --output json".
+It is not the locale code such as en-US.
+
 Examples:
-  asc video-previews list --version-localization "LOC_ID"`,
+  asc localizations list --version "VERSION_ID" --output json --locale "en-US"
+  asc video-previews list --version-localization "VERSION_LOCALIZATION_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -88,16 +93,21 @@ func AssetsPreviewsUploadCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "upload",
-		ShortUsage: "asc video-previews upload --version-localization \"LOC_ID\" --path \"./previews\" --device-type \"IPHONE_65\"",
+		ShortUsage: "asc video-previews upload --version-localization \"VERSION_LOCALIZATION_ID\" --path \"./previews\" --device-type \"IPHONE_65\"",
 		ShortHelp:  "Upload previews for a localization.",
 		LongHelp: `Upload previews for a localization.
 
+--version-localization is the App Store version localization resource ID
+returned as data[].id by "asc localizations list --version VERSION_ID --output json".
+It is not the locale code such as en-US.
+
 Examples:
-  asc video-previews upload --version-localization "LOC_ID" --path "./previews" --device-type "IPHONE_65"
-  asc video-previews upload --version-localization "LOC_ID" --path "./previews/preview.mov" --device-type "IPHONE_65"
-  asc video-previews upload --version-localization "LOC_ID" --path "./previews" --device-type "IPHONE_65" --skip-existing
-  asc video-previews upload --version-localization "LOC_ID" --path "./previews" --device-type "IPHONE_65" --replace
-  asc video-previews upload --version-localization "LOC_ID" --path "./previews" --device-type "IPHONE_65" --skip-existing --dry-run`,
+  asc localizations list --version "VERSION_ID" --output json --locale "en-US"
+  asc video-previews upload --version-localization "VERSION_LOCALIZATION_ID" --path "./previews" --device-type "IPHONE_65"
+  asc video-previews upload --version-localization "VERSION_LOCALIZATION_ID" --path "./previews/preview.mov" --device-type "IPHONE_65"
+  asc video-previews upload --version-localization "VERSION_LOCALIZATION_ID" --path "./previews" --device-type "IPHONE_65" --skip-existing
+  asc video-previews upload --version-localization "VERSION_LOCALIZATION_ID" --path "./previews" --device-type "IPHONE_65" --replace
+  asc video-previews upload --version-localization "VERSION_LOCALIZATION_ID" --path "./previews" --device-type "IPHONE_65" --skip-existing --dry-run`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -191,14 +201,19 @@ func AssetsPreviewsDownloadCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "download",
-		ShortUsage: "asc video-previews download (--id \"PREVIEW_ID\" --output \"./preview.mov\") | (--version-localization \"LOC_ID\" --output-dir \"./previews\")",
+		ShortUsage: "asc video-previews download (--id \"PREVIEW_ID\" --output \"./preview.mov\") | (--version-localization \"VERSION_LOCALIZATION_ID\" --output-dir \"./previews\")",
 		ShortHelp:  "Download App Store app preview videos to disk.",
 		LongHelp: `Download App Store app preview videos to disk.
 
+--version-localization is the App Store version localization resource ID
+returned as data[].id by "asc localizations list --version VERSION_ID --output json".
+It is not the locale code such as en-US.
+
 Examples:
   asc video-previews download --id "PREVIEW_ID" --output "./preview.mov"
-  asc video-previews download --version-localization "LOC_ID" --output-dir "./previews"
-  asc video-previews download --version-localization "LOC_ID" --output-dir "./previews" --overwrite`,
+  asc localizations list --version "VERSION_ID" --output json --locale "en-US"
+  asc video-previews download --version-localization "VERSION_LOCALIZATION_ID" --output-dir "./previews"
+  asc video-previews download --version-localization "VERSION_LOCALIZATION_ID" --output-dir "./previews" --overwrite`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -285,12 +285,17 @@ func AssetsScreenshotsListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc screenshots list --version-localization \"LOC_ID\"",
+		ShortUsage: "asc screenshots list --version-localization \"VERSION_LOCALIZATION_ID\"",
 		ShortHelp:  "List screenshots for a localization.",
 		LongHelp: `List screenshots for a localization.
 
+--version-localization is the App Store version localization resource ID
+returned as data[].id by "asc localizations list --version VERSION_ID --output json".
+It is not the locale code such as en-US.
+
 Examples:
-  asc screenshots list --version-localization "LOC_ID"`,
+  asc localizations list --version "VERSION_ID" --output json --locale "en-US"
+  asc screenshots list --version-localization "VERSION_LOCALIZATION_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -406,7 +411,7 @@ func AssetsScreenshotsUploadCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "upload",
-		ShortUsage: "asc screenshots upload (--version-localization \"LOC_ID\" | --app \"APP_ID\" (--version \"1.2.3\" | --version-id \"VERSION_ID\")) --path \"./screenshots\" --device-type \"IPHONE_65\"",
+		ShortUsage: "asc screenshots upload (--version-localization \"VERSION_LOCALIZATION_ID\" | --app \"APP_ID\" (--version \"1.2.3\" | --version-id \"VERSION_ID\")) --path \"./screenshots\" --device-type \"IPHONE_65\"",
 		ShortHelp:  "Upload screenshots for one or more localizations.",
 		LongHelp: `Upload screenshots for one or more localizations.
 
@@ -418,13 +423,18 @@ matching --device-type are uploaded. This supports layouts like
 ./screenshots/en-US/iphone/*.png, or ./screenshots/iphone/en-US/*.png when
 --path points to ./screenshots/iphone.
 
+--version-localization is the App Store version localization resource ID
+returned as data[].id by "asc localizations list --version VERSION_ID --output json".
+It is not the locale code such as en-US.
+
 Examples:
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_65"
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_65" --skip-existing
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_65" --replace
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPHONE_65" --skip-existing --dry-run
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots" --device-type "IPAD_PRO_3GEN_129"
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/en-US.png" --device-type "IPHONE_65"
+  asc localizations list --version "VERSION_ID" --output json --locale "en-US"
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65"
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --skip-existing
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --replace
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --skip-existing --dry-run
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPAD_PRO_3GEN_129"
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/en-US.png" --device-type "IPHONE_65"
   asc screenshots upload --app "123456789" --version "1.2.3" --path "./screenshots" --device-type "IPHONE_65"
   asc screenshots upload --app "123456789" --version-id "VERSION_ID" --path "./screenshots/ipad" --device-type "IPAD_PRO_3GEN_129" --dry-run
   asc screenshots upload --resume ".asc/reports/screenshots-upload/failures-123.json"`,
@@ -1018,14 +1028,19 @@ func AssetsScreenshotsDownloadCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "download",
-		ShortUsage: "asc screenshots download (--id \"SCREENSHOT_ID\" --output \"./screenshot.png\") | (--version-localization \"LOC_ID\" --output-dir \"./screenshots\")",
+		ShortUsage: "asc screenshots download (--id \"SCREENSHOT_ID\" --output \"./screenshot.png\") | (--version-localization \"VERSION_LOCALIZATION_ID\" --output-dir \"./screenshots\")",
 		ShortHelp:  "Download App Store screenshots to disk.",
 		LongHelp: `Download App Store screenshots to disk.
 
+--version-localization is the App Store version localization resource ID
+returned as data[].id by "asc localizations list --version VERSION_ID --output json".
+It is not the locale code such as en-US.
+
 Examples:
   asc screenshots download --id "SCREENSHOT_ID" --output "./screenshot.png"
-  asc screenshots download --version-localization "LOC_ID" --output-dir "./screenshots"
-  asc screenshots download --version-localization "LOC_ID" --output-dir "./screenshots" --overwrite`,
+  asc localizations list --version "VERSION_ID" --output json --locale "en-US"
+  asc screenshots download --version-localization "VERSION_LOCALIZATION_ID" --output-dir "./screenshots"
+  asc screenshots download --version-localization "VERSION_LOCALIZATION_ID" --output-dir "./screenshots" --overwrite`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/screenshots/screenshots.go
+++ b/internal/cli/screenshots/screenshots.go
@@ -37,14 +37,14 @@ Local workflow (experimental):
   asc screenshots list-frame-devices --output json
 
 App Store workflow:
-  asc screenshots list --version-localization "LOC_ID"
+  asc screenshots list --version-localization "VERSION_LOCALIZATION_ID"
   asc screenshots sizes
   asc screenshots sizes --all
   asc screenshots validate --path "./screenshots/iphone" --device-type "IPHONE_65"
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/iphone" --device-type "IPHONE_65"
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/iphone" --device-type "IPHONE_65"
   asc screenshots upload --app "123456789" --version "1.2.3" --path "./screenshots" --device-type "IPHONE_65"
-  asc screenshots upload --version-localization "LOC_ID" --path "./screenshots/ipad" --device-type "IPAD_PRO_3GEN_129"
-  asc screenshots download --version-localization "LOC_ID" --output-dir "./screenshots/downloaded"
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/ipad" --device-type "IPAD_PRO_3GEN_129"
+  asc screenshots download --version-localization "VERSION_LOCALIZATION_ID" --output-dir "./screenshots/downloaded"
   asc screenshots delete --id "SCREENSHOT_ID" --confirm
 
 For most iOS submissions, one iPhone set (IPHONE_65) and one iPad set

--- a/internal/cli/videopreviews/video_previews.go
+++ b/internal/cli/videopreviews/video_previews.go
@@ -21,9 +21,9 @@ func VideoPreviewsCommand() *ffcli.Command {
 		LongHelp: `Manage App Store app preview videos for a version localization.
 
 Examples:
-  asc video-previews list --version-localization "LOC_ID"
-  asc video-previews upload --version-localization "LOC_ID" --path "./previews" --device-type "IPHONE_69"
-  asc video-previews download --version-localization "LOC_ID" --output-dir "./previews/downloaded"
+  asc video-previews list --version-localization "VERSION_LOCALIZATION_ID"
+  asc video-previews upload --version-localization "VERSION_LOCALIZATION_ID" --path "./previews" --device-type "IPHONE_69"
+  asc video-previews download --version-localization "VERSION_LOCALIZATION_ID" --output-dir "./previews/downloaded"
   asc video-previews delete --id "PREVIEW_ID" --confirm
   asc video-previews set-poster-frame --id "PREVIEW_ID" --time-code "00:00:05:00"`,
 		FlagSet:   fs,


### PR DESCRIPTION
## Summary
- replace ambiguous `LOC_ID` placeholders with `VERSION_LOCALIZATION_ID` in screenshot and video preview help
- document that `--version-localization` expects `data[].id` from `asc localizations list`, not `attributes.locale` like `en-US`
- add the lookup flow to the README screenshot upload example

Closes #1514

## Why
Apple models screenshots and previews under `appStoreVersionLocalizations/{id}`, so the command needs the App Store version localization resource ID.

## Commands run
- `make generate-command-docs`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go run . screenshots upload --help`
- `go run . video-previews upload --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated CLI help text and README documentation for screenshot and video preview commands to use consistent parameter naming (`VERSION_LOCALIZATION_ID`).
* Enhanced usage examples and clarifications throughout command documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1515)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->