### PR TITLE
Add metadata init templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ asc review doctor --app "123456789"
 
 ```bash
 asc localizations list --app "123456789" --type app-info
+asc metadata init --dir "./metadata" --version "1.2.3" --locale "en-US"
 asc metadata apply --app "123456789" --version "1.2.3" --dir "./metadata" --dry-run
 asc metadata keywords audit --app "123456789" --version "1.2.3" --blocked-terms-file "./blocked-terms.txt"
 asc apps info view --app "123456789" --output json --pretty

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -296,7 +296,7 @@ func capabilityRows() []Capability {
 			Area:       "metadata",
 			Capability: "Metadata and localization sync",
 			Status:     statusCLISupported,
-			Commands:   []string{"asc metadata pull", "asc metadata apply", "asc localizations update"},
+			Commands:   []string{"asc metadata init", "asc metadata pull", "asc metadata validate", "asc metadata apply", "asc localizations update"},
 			APIResources: []string{
 				"appInfos",
 				"appInfoLocalizations",

--- a/internal/cli/cmdtest/capabilities_command_test.go
+++ b/internal/cli/cmdtest/capabilities_command_test.go
@@ -56,6 +56,8 @@ func TestRun_CapabilitiesJSONReportsKnownGaps(t *testing.T) {
 
 	assertCapability(t, resp, "App Store release submission", "cli-supported", "asc publish appstore --submit")
 	assertCapability(t, resp, "App creation", "experimental-web", "asc web apps create")
+	assertCapability(t, resp, "Metadata and localization sync", "cli-supported", "asc metadata init")
+	assertCapability(t, resp, "Metadata and localization sync", "cli-supported", "asc metadata validate")
 	assertCapability(t, resp, "App privacy data-use declarations", "experimental-web", "asc web privacy")
 	assertCapability(t, resp, "Transaction tax reports", "not-public-api", "")
 }

--- a/internal/cli/cmdtest/metadata_init_test.go
+++ b/internal/cli/cmdtest/metadata_init_test.go
@@ -1,0 +1,268 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMetadataInitValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing dir",
+			args:    []string{"metadata", "init"},
+			wantErr: "Error: --dir is required",
+		},
+		{
+			name:    "invalid locale",
+			args:    []string{"metadata", "init", "--dir", "./metadata", "--locale", "../en-US"},
+			wantErr: `invalid locale "../en-US"`,
+		},
+		{
+			name:    "invalid version",
+			args:    []string{"metadata", "init", "--dir", "./metadata", "--version", "../1.0"},
+			wantErr: `invalid version "../1.0"`,
+		},
+		{
+			name:    "positional args",
+			args:    []string{"metadata", "init", "--dir", "./metadata", "extra"},
+			wantErr: "metadata init does not accept positional arguments",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected ErrHelp, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected %q in stderr, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestMetadataInitWritesCanonicalTemplates(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "metadata")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "init",
+			"--dir", outputDir,
+			"--version", "1.2.3",
+			"--locale", "en-US",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	appInfoPath := filepath.Join(outputDir, "app-info", "en-US.json")
+	appInfoData, err := os.ReadFile(appInfoPath)
+	if err != nil {
+		t.Fatalf("read app-info file: %v", err)
+	}
+	wantAppInfo := `{"name":"","subtitle":"","privacyPolicyUrl":"","privacyChoicesUrl":"","privacyPolicyText":""}`
+	if string(appInfoData) != wantAppInfo {
+		t.Fatalf("app-info file = %q, want %q", string(appInfoData), wantAppInfo)
+	}
+
+	versionPath := filepath.Join(outputDir, "version", "1.2.3", "en-US.json")
+	versionData, err := os.ReadFile(versionPath)
+	if err != nil {
+		t.Fatalf("read version file: %v", err)
+	}
+	wantVersion := `{"description":"","keywords":"","marketingUrl":"","promotionalText":"","supportUrl":"","whatsNew":""}`
+	if string(versionData) != wantVersion {
+		t.Fatalf("version file = %q, want %q", string(versionData), wantVersion)
+	}
+
+	var payload struct {
+		Locale    string   `json:"locale"`
+		Version   string   `json:"version"`
+		FileCount int      `json:"fileCount"`
+		Files     []string `json:"files"`
+		NextSteps []string `json:"nextSteps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%q", err, stdout)
+	}
+
+	if payload.Locale != "en-US" || payload.Version != "1.2.3" {
+		t.Fatalf("unexpected locale/version in payload: %+v", payload)
+	}
+	if payload.FileCount != 2 || len(payload.Files) != 2 {
+		t.Fatalf("expected 2 files in output, got %+v", payload)
+	}
+	sortedFiles := append([]string(nil), payload.Files...)
+	slices.Sort(sortedFiles)
+	if !slices.Equal(payload.Files, sortedFiles) {
+		t.Fatalf("expected deterministic sorted file list, got %v", payload.Files)
+	}
+	if len(payload.NextSteps) == 0 {
+		t.Fatalf("expected next steps in payload, got %+v", payload)
+	}
+}
+
+func TestMetadataInitCanCreateAppInfoOnly(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "metadata")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "init",
+			"--dir", outputDir,
+			"--locale", "en-US",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "app-info", "en-US.json")); err != nil {
+		t.Fatalf("expected app-info template: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "version")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no version directory, got err=%v", err)
+	}
+
+	var payload struct {
+		Version   string `json:"version"`
+		FileCount int    `json:"fileCount"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%q", err, stdout)
+	}
+	if payload.Version != "" || payload.FileCount != 1 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestMetadataInitRequiresForceToOverwriteExistingFiles(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "metadata")
+	appInfoDir := filepath.Join(outputDir, "app-info")
+	if err := os.MkdirAll(appInfoDir, 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	existingPath := filepath.Join(appInfoDir, "en-US.json")
+	if err := os.WriteFile(existingPath, []byte(`{"name":"existing"}`), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "init",
+			"--dir", outputDir,
+			"--locale", "en-US",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "refusing to overwrite existing file") {
+		t.Fatalf("expected overwrite refusal, got %q", stderr)
+	}
+
+	data, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("read existing file: %v", err)
+	}
+	if string(data) != `{"name":"existing"}` {
+		t.Fatalf("expected existing file to remain unchanged, got %q", string(data))
+	}
+}
+
+func TestMetadataInitForceOverwritesExistingFiles(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "metadata")
+	appInfoDir := filepath.Join(outputDir, "app-info")
+	if err := os.MkdirAll(appInfoDir, 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	existingPath := filepath.Join(appInfoDir, "en-US.json")
+	if err := os.WriteFile(existingPath, []byte(`{"name":"existing"}`), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "init",
+			"--dir", outputDir,
+			"--locale", "en-US",
+			"--force",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	data, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("read existing file: %v", err)
+	}
+	want := `{"name":"","subtitle":"","privacyPolicyUrl":"","privacyChoicesUrl":"","privacyPolicyText":""}`
+	if string(data) != want {
+		t.Fatalf("expected force overwrite, got %q", string(data))
+	}
+}

--- a/internal/cli/cmdtest/metadata_validate_test.go
+++ b/internal/cli/cmdtest/metadata_validate_test.go
@@ -126,6 +126,45 @@ func TestMetadataValidateReportsMissingRequiredFields(t *testing.T) {
 	}
 }
 
+func TestMetadataValidateRejectsEmptyTemplateKeys(t *testing.T) {
+	dir := t.TempDir()
+	appInfoDir := filepath.Join(dir, "app-info")
+	versionDir := filepath.Join(dir, "version", "1.2.3")
+	if err := os.MkdirAll(appInfoDir, 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appInfoDir, "en-US.json"), []byte(`{"name":"App","subtitle":""}`), 0o644); err != nil {
+		t.Fatalf("write app-info file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "en-US.json"), []byte(`{"description":"Description","keywords":""}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "validate", "--dir", dir}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `field "subtitle" cannot be empty`) {
+		t.Fatalf("expected empty-field schema error, got %q", stderr)
+	}
+}
+
 func TestMetadataValidatePassesForValidFiles(t *testing.T) {
 	dir := t.TempDir()
 	appInfoDir := filepath.Join(dir, "app-info")

--- a/internal/cli/metadata/command.go
+++ b/internal/cli/metadata/command.go
@@ -34,12 +34,14 @@ Not yet included in this group:
 Note: copyright is managed via "asc versions create --copyright" or "asc versions update --copyright".
 
 Examples:
+  asc metadata init --dir "./metadata" --version "1.2.3" --locale "en-US"
   asc metadata pull --app "APP_ID" --version "1.2.3" --dir "./metadata"
   asc metadata pull --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
   asc metadata keywords import --dir "./metadata" --version "1.2.3" --locale "en-US" --input "./keywords.csv"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			MetadataInitCommand(),
 			MetadataPullCommand(),
 			MetadataApplyCommand(),
 			MetadataKeywordsCommand(),

--- a/internal/cli/metadata/init.go
+++ b/internal/cli/metadata/init.go
@@ -1,0 +1,245 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// InitResult is the structured output artifact for metadata init.
+type InitResult struct {
+	Dir       string   `json:"dir"`
+	Locale    string   `json:"locale"`
+	Version   string   `json:"version,omitempty"`
+	FileCount int      `json:"fileCount"`
+	Files     []string `json:"files"`
+	NextSteps []string `json:"nextSteps,omitempty"`
+}
+
+type appInfoLocalizationTemplate struct {
+	Name              string `json:"name"`
+	Subtitle          string `json:"subtitle"`
+	PrivacyPolicyURL  string `json:"privacyPolicyUrl"`
+	PrivacyChoicesURL string `json:"privacyChoicesUrl"`
+	PrivacyPolicyText string `json:"privacyPolicyText"`
+}
+
+type versionLocalizationTemplate struct {
+	Description     string `json:"description"`
+	Keywords        string `json:"keywords"`
+	MarketingURL    string `json:"marketingUrl"`
+	PromotionalText string `json:"promotionalText"`
+	SupportURL      string `json:"supportUrl"`
+	WhatsNew        string `json:"whatsNew"`
+}
+
+// MetadataInitCommand returns the metadata init subcommand.
+func MetadataInitCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metadata init", flag.ExitOnError)
+
+	dir := fs.String("dir", "", "Metadata root directory (required)")
+	version := fs.String("version", "", "Optional app version string; when set, writes a version localization template")
+	locale := fs.String("locale", "en-US", "Metadata locale to scaffold")
+	force := fs.Bool("force", false, "Overwrite existing metadata template files in --dir")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "init",
+		ShortUsage: "asc metadata init --dir \"./metadata\" [--version \"1.2.3\"] [--locale \"en-US\"] [flags]",
+		ShortHelp:  "Create canonical metadata template files.",
+		LongHelp: `Create canonical metadata template files.
+
+The generated files include blank string values for every supported Phase 1
+metadata field. Fill the values you want to apply and remove keys you want to
+leave unset before running validate, apply, or push.
+
+Examples:
+  asc metadata init --dir "./metadata"
+  asc metadata init --dir "./metadata" --locale "en-US"
+  asc metadata init --dir "./metadata" --version "1.2.3" --locale "en-US"
+  asc metadata init --dir "./metadata" --version "1.2.3" --locale "en-US" --force`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("metadata init does not accept positional arguments")
+			}
+
+			dirValue := strings.TrimSpace(*dir)
+			if dirValue == "" {
+				return shared.UsageError("--dir is required")
+			}
+
+			localeValue, err := validateLocale(*locale)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			versionValue := strings.TrimSpace(*version)
+			if versionValue != "" {
+				var versionErr error
+				versionValue, versionErr = validatePathSegment("version", versionValue)
+				if versionErr != nil {
+					return shared.UsageError(versionErr.Error())
+				}
+			}
+
+			plans, err := BuildInitWritePlans(dirValue, localeValue, versionValue)
+			if err != nil {
+				return fmt.Errorf("metadata init: %w", err)
+			}
+			if !*force {
+				if err := ensureNoExistingInitTargets(plans); err != nil {
+					return err
+				}
+			}
+			if err := ApplyWritePlans(plans); err != nil {
+				return fmt.Errorf("metadata init: %w", err)
+			}
+
+			files := make([]string, 0, len(plans))
+			for _, plan := range plans {
+				files = append(files, plan.Path)
+			}
+			sort.Strings(files)
+
+			result := InitResult{
+				Dir:       dirValue,
+				Locale:    localeValue,
+				Version:   versionValue,
+				FileCount: len(files),
+				Files:     files,
+				NextSteps: []string{
+					"Fill values you want to apply.",
+					"Remove keys you want to leave unset.",
+					"Run asc metadata validate --dir \"" + dirValue + "\" before applying.",
+				},
+			}
+
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return printInitResultTable(result) },
+				func() error { return printInitResultMarkdown(result) },
+			)
+		},
+	}
+}
+
+// BuildInitWritePlans creates deterministic write plans for blank metadata templates.
+func BuildInitWritePlans(rootDir, locale, version string) ([]WritePlan, error) {
+	resolvedLocale, err := validateLocale(locale)
+	if err != nil {
+		return nil, err
+	}
+
+	appInfoPath, err := AppInfoLocalizationFilePath(rootDir, resolvedLocale)
+	if err != nil {
+		return nil, err
+	}
+	appInfoData, err := encodeCanonicalJSON(appInfoLocalizationTemplate{})
+	if err != nil {
+		return nil, err
+	}
+
+	plans := []WritePlan{{Path: appInfoPath, Contents: appInfoData}}
+
+	versionValue := strings.TrimSpace(version)
+	if versionValue != "" {
+		resolvedVersion, err := validatePathSegment("version", versionValue)
+		if err != nil {
+			return nil, err
+		}
+		versionPath, err := VersionLocalizationFilePath(rootDir, resolvedVersion, resolvedLocale)
+		if err != nil {
+			return nil, err
+		}
+		versionData, err := encodeCanonicalJSON(versionLocalizationTemplate{})
+		if err != nil {
+			return nil, err
+		}
+		plans = append(plans, WritePlan{Path: versionPath, Contents: versionData})
+	}
+
+	sort.Slice(plans, func(i, j int) bool {
+		return plans[i].Path < plans[j].Path
+	})
+	return plans, nil
+}
+
+func ensureNoExistingInitTargets(plans []WritePlan) error {
+	for _, plan := range plans {
+		if _, err := os.Lstat(plan.Path); err == nil {
+			return shared.UsageErrorf("refusing to overwrite existing file %s (use --force)", plan.Path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("metadata init: failed to inspect %s: %w", plan.Path, err)
+		}
+	}
+	return nil
+}
+
+func printInitResultTable(result InitResult) error {
+	fmt.Printf("Dir: %s\n", result.Dir)
+	fmt.Printf("Locale: %s\n", result.Locale)
+	if result.Version != "" {
+		fmt.Printf("Version: %s\n", result.Version)
+	}
+	fmt.Printf("File Count: %d\n\n", result.FileCount)
+
+	rows := make([][]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		rows = append(rows, []string{file})
+	}
+	if len(rows) == 0 {
+		rows = append(rows, []string{"(none)"})
+	}
+	asc.RenderTable([]string{"file"}, rows)
+
+	if len(result.NextSteps) > 0 {
+		fmt.Println()
+		stepRows := make([][]string, 0, len(result.NextSteps))
+		for i, step := range result.NextSteps {
+			stepRows = append(stepRows, []string{fmt.Sprintf("%d", i+1), step})
+		}
+		asc.RenderTable([]string{"step", "next"}, stepRows)
+	}
+	return nil
+}
+
+func printInitResultMarkdown(result InitResult) error {
+	fmt.Printf("**Dir:** %s\n\n", result.Dir)
+	fmt.Printf("**Locale:** %s\n\n", result.Locale)
+	if result.Version != "" {
+		fmt.Printf("**Version:** %s\n\n", result.Version)
+	}
+	fmt.Printf("**File Count:** %d\n\n", result.FileCount)
+
+	rows := make([][]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		rows = append(rows, []string{file})
+	}
+	if len(rows) == 0 {
+		rows = append(rows, []string{"(none)"})
+	}
+	asc.RenderMarkdown([]string{"file"}, rows)
+
+	if len(result.NextSteps) > 0 {
+		fmt.Println()
+		stepRows := make([][]string, 0, len(result.NextSteps))
+		for i, step := range result.NextSteps {
+			stepRows = append(stepRows, []string{fmt.Sprintf("%d", i+1), step})
+		}
+		asc.RenderMarkdown([]string{"step", "next"}, stepRows)
+	}
+	return nil
+}

--- a/internal/cli/metadata/init_test.go
+++ b/internal/cli/metadata/init_test.go
@@ -1,0 +1,74 @@
+package metadata
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetadataInitCommandFlags(t *testing.T) {
+	cmd := MetadataInitCommand()
+	for _, name := range []string{"dir", "version", "locale", "force"} {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Fatalf("expected --%s flag to be defined", name)
+		}
+	}
+}
+
+func TestMetadataInitCommandDefaultsLocale(t *testing.T) {
+	cmd := MetadataInitCommand()
+	f := cmd.FlagSet.Lookup("locale")
+	if f == nil {
+		t.Fatal("expected --locale flag to be defined")
+	}
+	if f.DefValue != "en-US" {
+		t.Fatalf("expected --locale default en-US, got %q", f.DefValue)
+	}
+}
+
+func TestMetadataInitCommandUsageMentionsVersionAndLocale(t *testing.T) {
+	cmd := MetadataInitCommand()
+	for _, want := range []string{"metadata init", "--version", "--locale"} {
+		if !strings.Contains(cmd.ShortUsage, want) {
+			t.Fatalf("expected ShortUsage to mention %q, got %q", want, cmd.ShortUsage)
+		}
+	}
+}
+
+func TestBuildInitWritePlansWritesBlankTemplates(t *testing.T) {
+	plans, err := BuildInitWritePlans("/tmp/metadata", "en-US", "1.2.3")
+	if err != nil {
+		t.Fatalf("BuildInitWritePlans() error: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("expected 2 plans, got %d", len(plans))
+	}
+
+	if got, want := plans[0].Path, "/tmp/metadata/app-info/en-US.json"; got != want {
+		t.Fatalf("app-info path = %q, want %q", got, want)
+	}
+	wantAppInfo := `{"name":"","subtitle":"","privacyPolicyUrl":"","privacyChoicesUrl":"","privacyPolicyText":""}`
+	if string(plans[0].Contents) != wantAppInfo {
+		t.Fatalf("app-info template = %q, want %q", string(plans[0].Contents), wantAppInfo)
+	}
+
+	if got, want := plans[1].Path, "/tmp/metadata/version/1.2.3/en-US.json"; got != want {
+		t.Fatalf("version path = %q, want %q", got, want)
+	}
+	wantVersion := `{"description":"","keywords":"","marketingUrl":"","promotionalText":"","supportUrl":"","whatsNew":""}`
+	if string(plans[1].Contents) != wantVersion {
+		t.Fatalf("version template = %q, want %q", string(plans[1].Contents), wantVersion)
+	}
+}
+
+func TestBuildInitWritePlansCanWriteAppInfoOnly(t *testing.T) {
+	plans, err := BuildInitWritePlans("/tmp/metadata", "en-US", "")
+	if err != nil {
+		t.Fatalf("BuildInitWritePlans() error: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(plans))
+	}
+	if got, want := plans[0].Path, "/tmp/metadata/app-info/en-US.json"; got != want {
+		t.Fatalf("app-info path = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -266,7 +266,8 @@ func rejectBlankMetadataFieldsWithContent(data []byte, allowed []string) error {
 
 	hasContent := false
 	blankField := ""
-	for key, rawValue := range raw {
+	for _, key := range sortedKeys(raw) {
+		rawValue := raw[key]
 		canonicalKey, err := canonicalStringFieldPatchKey(key, allowed)
 		if err != nil {
 			return err

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -131,7 +132,14 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 			}
 			filePath := filepath.Join(appInfoDir, entry.Name())
 
-			loc, readErr := ReadAppInfoLocalizationFile(filePath)
+			data, readErr := readFileNoFollow(filePath)
+			if readErr != nil {
+				return ValidateResult{}, shared.UsageErrorf("invalid metadata schema in %s: %v", filePath, readErr)
+			}
+			if blankErr := rejectBlankMetadataFieldsWithContent(data, appInfoPlanFields); blankErr != nil {
+				return ValidateResult{}, shared.UsageErrorf("invalid metadata schema in %s: %v", filePath, blankErr)
+			}
+			loc, readErr := DecodeAppInfoLocalization(data)
 			if readErr != nil {
 				return ValidateResult{}, shared.UsageErrorf("invalid metadata schema in %s: %v", filePath, readErr)
 			}
@@ -185,7 +193,14 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 				}
 				filePath := filepath.Join(versionPath, localeEntry.Name())
 
-				loc, readErr := ReadVersionLocalizationFile(filePath)
+				data, readErr := readFileNoFollow(filePath)
+				if readErr != nil {
+					return ValidateResult{}, shared.UsageErrorf("invalid metadata schema in %s: %v", filePath, readErr)
+				}
+				if blankErr := rejectBlankMetadataFieldsWithContent(data, versionPlanFields); blankErr != nil {
+					return ValidateResult{}, shared.UsageErrorf("invalid metadata schema in %s: %v", filePath, blankErr)
+				}
+				loc, readErr := DecodeVersionLocalization(data)
 				if readErr != nil {
 					return ValidateResult{}, shared.UsageErrorf("invalid metadata schema in %s: %v", filePath, readErr)
 				}
@@ -241,6 +256,41 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 	result.Valid = result.ErrorCount == 0
 
 	return result, nil
+}
+
+func rejectBlankMetadataFieldsWithContent(data []byte, allowed []string) error {
+	var raw map[string]json.RawMessage
+	if err := decodeStrictJSON(data, &raw); err != nil {
+		return err
+	}
+
+	hasContent := false
+	blankField := ""
+	for key, rawValue := range raw {
+		canonicalKey, err := canonicalStringFieldPatchKey(key, allowed)
+		if err != nil {
+			return err
+		}
+		var value string
+		if err := json.Unmarshal(rawValue, &value); err != nil {
+			return err
+		}
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "__ASC_DELETE__" {
+			return fmt.Errorf("field %q uses unsupported clear token __ASC_DELETE__; omit the key to keep the remote value", canonicalKey)
+		}
+		if trimmed == "" {
+			if blankField == "" {
+				blankField = canonicalKey
+			}
+			continue
+		}
+		hasContent = true
+	}
+	if hasContent && blankField != "" {
+		return fmt.Errorf("field %q cannot be empty; omit the key to leave the remote value unchanged", blankField)
+	}
+	return nil
 }
 
 func versionLengthIssues(filePath, version, locale string, loc VersionLocalization) []ValidateIssue {


### PR DESCRIPTION
## Summary
- Adds `asc metadata init` to scaffold canonical blank app-info metadata and optional version metadata JSON for a locale.
- Registers the new metadata subcommand and README example without changing `metadata pull` sparse remote-mirror behavior.
- Tightens `metadata validate` so half-filled scaffold files with blank template keys fail before `apply`/`push` would fail later.

Fixes #1516.

## Design Note
- Command placement: `metadata init` sits under the existing metadata workflow, before pull/apply/push/validate, as a local scaffolding command.
- OpenAPI/schema validation: this command does not call the API; generated fields are limited to the existing Phase 1 app-info and app-version metadata fields already supported by apply/push patch builders.
- UX shape: `--dir` is required, `--locale` defaults to `en-US`, `--version` optionally adds `version/<version>/<locale>.json`, `--force` overwrites existing template files, and usage failures return exit code 2.
- Compatibility: this is additive; it does not make `metadata pull` synthesize remote fields that do not exist.
- RED -> GREEN plan: added CLI-level tests for validation/write/overwrite behavior, unit tests for deterministic write plans, then implemented the command and validate guard.

## Alternatives Considered
- Expanding `metadata pull` to emit every possible field: rejected because pull should stay a faithful remote snapshot and keep sparse patch semantics clear.
- Adding comments or placeholder prose inside JSON templates: rejected because the files should remain valid, machine-readable JSON that users can fill without cleaning extra scaffolding text.

## Expected Invocation
```bash
asc metadata init --dir "./metadata" --version "1.2.3" --locale "en-US"
```

This writes:
- `metadata/app-info/en-US.json`
- `metadata/version/1.2.3/en-US.json`

## Edge Cases Tested
- Missing `--dir`, invalid locale, invalid version, and unexpected positional args return usage errors.
- Existing files are preserved unless `--force` is passed.
- App-info-only scaffolding works when `--version` is omitted.
- Partially filled scaffold files with remaining blank keys are rejected by `metadata validate` before apply/push.

## Checks
- `go run . metadata --help`
- `go run . metadata pull --help`
- `go run . metadata validate --help`
- `go run . metadata init --help`
- `make format`
- `make generate-command-docs`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/metadata ./internal/cli/cmdtest -run 'TestMetadataInit|TestMetadataValidate|TestValidateDirNormalizesVersionDefaultLocaleInIssues'`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- Black-box `/tmp/asc metadata init` checks for valid scaffold creation plus exit-code-2 failures for missing dir, invalid locale, invalid version, overwrite refusal, and positional args.
