### PR TITLE
[codex] Fix Xcode Cloud secret env-var key endpoint

### DIFF
--- a/internal/web/ci.go
+++ b/internal/web/ci.go
@@ -21,6 +21,14 @@ func NewCIClient(session *AuthSession) *Client {
 	}
 }
 
+func (c *Client) ciAuthBaseURL() string {
+	baseURL := strings.TrimRight(strings.TrimSpace(c.baseURL), "/")
+	if baseURL == "" {
+		return appStoreBaseURL
+	}
+	return strings.TrimSuffix(baseURL, "/ci/api")
+}
+
 // NOTE: The CI API (/ci/api) uses snake_case JSON keys and query parameters,
 // unlike the IRIS API (/iris/v1) which uses camelCase. Confirmed via browser
 // network inspection of the ASC web UI.
@@ -359,7 +367,7 @@ type CIWorkflowConfig struct {
 	ProductEnvironmentVariables []string        `json:"product_environment_variables,omitempty"`
 }
 
-// CIEncryptionKeyResponse is the response from /auth/keys/client-encryption.
+// CIEncryptionKeyResponse is the response from /ci/auth/keys/client-encryption.
 type CIEncryptionKeyResponse struct {
 	Key string `json:"key"`
 }
@@ -574,9 +582,9 @@ func (c *Client) GetCISlackChannels(ctx context.Context, teamID string) (json.Ra
 }
 
 // GetCIEncryptionKey fetches the P-256 public key for secret encryption.
-// GET /auth/keys/client-encryption (relative to /ci/api base URL)
+// GET /ci/auth/keys/client-encryption
 func (c *Client) GetCIEncryptionKey(ctx context.Context) (*CIEncryptionKeyResponse, error) {
-	body, err := c.doRequest(ctx, "GET", "/auth/keys/client-encryption", nil)
+	body, err := c.doRequest(ctx, "GET", c.ciAuthBaseURL()+"/ci/auth/keys/client-encryption", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/web/ci_test.go
+++ b/internal/web/ci_test.go
@@ -613,7 +613,7 @@ func TestUpdateCIWorkflowRejectsEmptyInputs(t *testing.T) {
 
 func TestGetCIEncryptionKeyParsesResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/auth/keys/client-encryption" {
+		if r.URL.Path != "/ci/auth/keys/client-encryption" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -622,6 +622,7 @@ func TestGetCIEncryptionKeyParsesResponse(t *testing.T) {
 	defer server.Close()
 
 	client := testWebClient(server)
+	client.baseURL = server.URL + "/ci/api"
 	result, err := client.GetCIEncryptionKey(context.Background())
 	if err != nil {
 		t.Fatalf("GetCIEncryptionKey() error = %v", err)


### PR DESCRIPTION
## Summary
- route the Xcode Cloud secret encryption-key fetch to `/ci/auth/keys/client-encryption` instead of `/ci/api/auth/keys/client-encryption`
- add a regression test that starts from a `/ci/api` CI client base and asserts the auth endpoint escapes that prefix
- leave ordinary Xcode Cloud `/ci/api` endpoints unchanged

## What went wrong
The env-var secret flow needs a public encryption key before writing the secret. The original discovery in #817 identified that key endpoint as `GET /ci/auth/keys/client-encryption`, separate from normal CI API calls under `/ci/api`.

PR #820 introduced the env-var commands. Mithilesh's first pass used the actual discovered endpoint, but through the CI client base, which made the assembled URL `/ci/api/ci/auth/keys/client-encryption`. A follow-up changed it to `/auth/keys/client-encryption`, which assembled as `/ci/api/auth/keys/client-encryption`. That is the path now failing in #1512.

The nearby endpoint audit matched this pattern: PRs #812, #825, and #1064 use `/ci/api` for ordinary Xcode Cloud calls, while the encryption key is the odd auth endpoint outside `/ci/api`.

Fixes #1512

## Validation
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/web -run 'Test(NewCIClientSetsBaseURL|GetCIEncryptionKeyParsesResponse)' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/web -run 'Test(EnvVars|SharedEnvVars)' -count=1`
- `git diff --check`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI authentication endpoint routing to properly retrieve client encryption keys from the CI authentication service.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1520)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->