### PR TITLE
apps wall: add 홀로워크 - 집중 타이머

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1444,5 +1444,10 @@
     "app": "시선 - 사진 한 장, 시 한 줄",
     "link": "https://apps.apple.com/app/id6748271659",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4e/a3/3b/4ea33b80-8dcb-11ec-4699-6ccff7efcfa9/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
+  },
+  {
+    "app": "홀로워크 - 집중 타이머",
+    "link": "https://apps.apple.com/us/app/%ED%99%80%EB%A1%9C%EC%9B%8C%ED%81%AC-%EC%A7%91%EC%A4%91-%ED%83%80%EC%9D%B4%EB%A8%B8/id6742745490?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/10/b1/15/10b1150d-d3cc-5861-83ac-881c0d0c0cac/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   }
 ]


### PR DESCRIPTION
## Summary

- add `홀로워크 - 집중 타이머` to the Wall of Apps

## Entry

- App ID: 6742745490
- App: 홀로워크 - 집중 타이머
- Link: https://apps.apple.com/us/app/%ED%99%80%EB%A1%9C%EC%9B%8C%ED%81%AC-%EC%A7%91%EC%A4%91-%ED%83%80%EC%9D%B4%EB%A8%B8/id6742745490?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new app entry to the Wall of Apps collection, featuring a focus timer application with its corresponding App Store link and icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->