### PR TITLE
apps wall: add PixelMemo

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -877,6 +877,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/87/1d/91/871d9134-d427-2469-ce00-dd1f5929519b/PillcaseIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "PixelMemo",
+    "link": "https://apps.apple.com/us/app/pixelmemo/id6751750096?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/aa/bf/39/aabf392c-3af4-a6f3-a778-79276a17542d/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "PixShrink - HEIF Conv.",
     "link": "https://apps.apple.com/us/app/pixshrink-heif-conv/id6744530166?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a9/b8/c7/a9b8c739-32a1-a66d-9b5c-208089c2a66b/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `PixelMemo` to the Wall of Apps

## Entry

- App ID: 6751750096
- App: PixelMemo
- Link: https://apps.apple.com/us/app/pixelmemo/id6751750096?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added PixelMemo to the featured apps showcase with its App Store link and icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1530)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->