### PR TITLE
fix(apps/wall/submit): add `--country` flag for non-US storefront lookups

### DIFF
--- a/internal/cli/apps/community_wall_submit.go
+++ b/internal/cli/apps/community_wall_submit.go
@@ -47,7 +47,8 @@ var (
 	communityWallPromptEnabled   = func() bool {
 		return term.IsTerminal(int(os.Stdin.Fd()))
 	}
-	communityWallNow = func() time.Time {
+	communityWallPromptSubmitText = promptCommunityWallSubmitText
+	communityWallNow              = func() time.Time {
 		return time.Now().UTC()
 	}
 	communityWallSleep            = time.Sleep
@@ -193,17 +194,17 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			token, ghLogin, err := resolveCommunityWallGitHubIdentity(ctx)
-			if err != nil {
-				return fmt.Errorf("apps wall submit: %w", err)
-			}
-
 			input, err := collectCommunityWallSubmitInput(*appID, *name, *link, *country)
 			if err != nil {
 				if errors.Is(err, errCommunityWallUsage) {
 					fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 					return flag.ErrHelp
 				}
+				return fmt.Errorf("apps wall submit: %w", err)
+			}
+
+			token, ghLogin, err := resolveCommunityWallGitHubIdentity(ctx)
+			if err != nil {
 				return fmt.Errorf("apps wall submit: %w", err)
 			}
 
@@ -303,22 +304,17 @@ func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue, countryVa
 		return communityWallSubmitInput{}, communityWallUsageError{message: "use either --app or --link, not both"}
 	}
 
-	if countryValue != "" {
-		if linkValue != "" {
-			return communityWallSubmitInput{}, communityWallUsageError{message: "--country is only valid with --app; the storefront is read from the URL when --link is used"}
-		}
-		normalizedCountry, err := itunes.NormalizeCountryCode(countryValue)
-		if err != nil {
-			return communityWallSubmitInput{}, communityWallUsageError{message: fmt.Sprintf("--country %q is not a supported App Store storefront", countryValue)}
-		}
-		countryValue = normalizedCountry
+	var err error
+	countryValue, err = normalizeCommunityWallCountryFlag(countryValue, linkValue)
+	if err != nil {
+		return communityWallSubmitInput{}, err
 	}
 
 	if appIDValue == "" && linkValue == "" {
 		if !canPrompt {
 			return communityWallSubmitInput{}, communityWallUsageError{message: "--app is required"}
 		}
-		prompted, err := promptCommunityWallSubmitText(
+		prompted, err := communityWallPromptSubmitText(
 			"App ID:",
 			"Paste the App Store or App Store Connect app ID. Leave blank to use a manual link instead.",
 			validateCommunityWallOptionalAppIDValue,
@@ -333,7 +329,7 @@ func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue, countryVa
 		if !canPrompt {
 			return communityWallSubmitInput{}, communityWallUsageError{message: "--app or --link is required"}
 		}
-		prompted, err := promptCommunityWallSubmitText(
+		prompted, err := communityWallPromptSubmitText(
 			"Manual link:",
 			"Paste the TestFlight, GitHub, or product URL for entries that are not on the public App Store yet.",
 			validateCommunityWallLinkValue,
@@ -356,7 +352,7 @@ func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue, countryVa
 			if !canPrompt {
 				return communityWallSubmitInput{}, communityWallUsageError{message: "--name is required when --link is used"}
 			}
-			prompted, err := promptCommunityWallSubmitText(
+			prompted, err := communityWallPromptSubmitText(
 				"App name:",
 				"The name that should appear on the Wall of Apps",
 				validateCommunityWallRequiredValue,
@@ -366,6 +362,11 @@ func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue, countryVa
 			}
 			nameValue = prompted
 		}
+	}
+
+	countryValue, err = normalizeCommunityWallCountryFlag(countryValue, linkValue)
+	if err != nil {
+		return communityWallSubmitInput{}, err
 	}
 
 	input := communityWallSubmitInput{
@@ -380,6 +381,21 @@ func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue, countryVa
 	}
 
 	return input, nil
+}
+
+func normalizeCommunityWallCountryFlag(countryValue, linkValue string) (string, error) {
+	countryValue = strings.TrimSpace(countryValue)
+	if countryValue == "" {
+		return "", nil
+	}
+	if strings.TrimSpace(linkValue) != "" {
+		return "", communityWallUsageError{message: "--country is only valid with --app; the storefront is read from the URL when --link is used"}
+	}
+	normalizedCountry, err := itunes.NormalizeCountryCode(countryValue)
+	if err != nil {
+		return "", communityWallUsageError{message: fmt.Sprintf("--country %q is not a supported App Store storefront", countryValue)}
+	}
+	return normalizedCountry, nil
 }
 
 func promptCommunityWallSubmitText(message, help string, validator survey.Validator) (string, error) {

--- a/internal/cli/apps/community_wall_submit.go
+++ b/internal/cli/apps/community_wall_submit.go
@@ -62,9 +62,10 @@ var (
 )
 
 type communityWallSubmitInput struct {
-	AppID string
-	Name  string
-	Link  string
+	AppID   string
+	Name    string
+	Link    string
+	Country string
 }
 
 type communityWallSubmitRequest struct {
@@ -153,6 +154,7 @@ func AppsWallSubmitCommand(parentWallFlags *flag.FlagSet) *ffcli.Command {
 	appID := fs.String("app", "", "App Store or App Store Connect app ID")
 	name := fs.String("name", "", "Override the app name resolved from the App Store lookup")
 	link := fs.String("link", "", "Manual app URL for non-App-Store entries")
+	country := fs.String("country", "", "Storefront country code for the App Store lookup (e.g. \"jp\", \"kr\"); defaults to the US storefront")
 	confirm := fs.Bool("confirm", false, defaultCommunityWallSubmitMessage)
 	dryRun := fs.Bool("dry-run", false, "Preview the fork, branch, and pull request plan without creating anything")
 	output := shared.BindOutputFlagsWithAllowed(fs, "output", defaultCommunityWallSubmitOutput, "Output format: json (default)", "json")
@@ -173,6 +175,7 @@ docs/wall-of-apps.json so community submissions stay focused to a single file.
 Examples:
   asc apps wall submit --app "1234567890" --dry-run
   asc apps wall submit --app "1234567890" --confirm
+  asc apps wall submit --app "1435783608" --country "jp" --confirm
   asc apps wall submit --link "https://testflight.apple.com/join/ABCDEFG" --name "My Beta App" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -195,7 +198,7 @@ Examples:
 				return fmt.Errorf("apps wall submit: %w", err)
 			}
 
-			input, err := collectCommunityWallSubmitInput(*appID, *name, *link)
+			input, err := collectCommunityWallSubmitInput(*appID, *name, *link, *country)
 			if err != nil {
 				if errors.Is(err, errCommunityWallUsage) {
 					fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
@@ -288,15 +291,27 @@ func resolveCommunityWallGitHubIdentity(ctx context.Context) (string, string, er
 	return token, login, nil
 }
 
-func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue string) (communityWallSubmitInput, error) {
+func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue, countryValue string) (communityWallSubmitInput, error) {
 	canPrompt := communityWallPromptEnabled()
 
 	appIDValue = normalizeCommunityWallAppID(appIDValue)
 	nameValue = strings.TrimSpace(nameValue)
 	linkValue = strings.TrimSpace(linkValue)
+	countryValue = strings.TrimSpace(countryValue)
 
 	if appIDValue != "" && linkValue != "" {
 		return communityWallSubmitInput{}, communityWallUsageError{message: "use either --app or --link, not both"}
+	}
+
+	if countryValue != "" {
+		if linkValue != "" {
+			return communityWallSubmitInput{}, communityWallUsageError{message: "--country is only valid with --app; the storefront is read from the URL when --link is used"}
+		}
+		normalizedCountry, err := itunes.NormalizeCountryCode(countryValue)
+		if err != nil {
+			return communityWallSubmitInput{}, communityWallUsageError{message: fmt.Sprintf("--country %q is not a supported App Store storefront", countryValue)}
+		}
+		countryValue = normalizedCountry
 	}
 
 	if appIDValue == "" && linkValue == "" {
@@ -354,9 +369,10 @@ func collectCommunityWallSubmitInput(appIDValue, nameValue, linkValue string) (c
 	}
 
 	input := communityWallSubmitInput{
-		AppID: appIDValue,
-		Name:  nameValue,
-		Link:  linkValue,
+		AppID:   appIDValue,
+		Name:    nameValue,
+		Link:    linkValue,
+		Country: countryValue,
 	}
 
 	if input.AppID == "" && input.Link == "" {
@@ -425,13 +441,16 @@ func resolveCommunityWallCandidate(ctx context.Context, input communityWallSubmi
 	warnings := []string{}
 
 	if input.AppID != "" {
-		detailsByID, err := communityWallLookupAppDetails(ctx, []string{input.AppID})
+		detailsByID, err := communityWallLookupAppDetails(ctx, []string{input.AppID}, input.Country)
 		if err != nil {
 			return communityWallEntry{}, nil, fmt.Errorf("failed to resolve app %q from the App Store lookup: %w", input.AppID, err)
 		}
 		details, ok := detailsByID[input.AppID]
 		if !ok {
-			return communityWallEntry{}, nil, fmt.Errorf("app %q was not found in the App Store lookup; use --link with --name for non-App-Store entries", input.AppID)
+			if input.Country == "" {
+				return communityWallEntry{}, nil, fmt.Errorf("app %q was not found in the App Store lookup; pass --country if the app is only published in a non-US storefront (e.g. --country jp), or use --link with --name for non-App-Store entries", input.AppID)
+			}
+			return communityWallEntry{}, nil, fmt.Errorf("app %q was not found in the %q App Store storefront; verify the storefront or use --link with --name for non-App-Store entries", input.AppID, strings.ToUpper(input.Country))
 		}
 
 		candidate.App = strings.TrimSpace(input.Name)
@@ -830,8 +849,9 @@ func extractCommunityWallAppStoreCountry(link string) string {
 	return country
 }
 
-func fetchCommunityWallAppDetails(ctx context.Context, ids []string) (map[string]communityWallAppDetails, error) {
+func fetchCommunityWallAppDetails(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
 	return fetchCommunityWallAppDetailsWithOptions(ctx, ids, itunes.LookupOptions{
+		Country:               country,
 		IncludeSoftwareEntity: true,
 	})
 }

--- a/internal/cli/apps/community_wall_submit_test.go
+++ b/internal/cli/apps/community_wall_submit_test.go
@@ -20,6 +20,7 @@ func TestCollectCommunityWallSubmitInputAllowsAppIDOnlyWhenNonInteractive(t *tes
 		"1234567890",
 		"",
 		"",
+		"",
 	)
 	if err != nil {
 		t.Fatalf("collect input: %v", err)
@@ -35,7 +36,7 @@ func TestCollectCommunityWallSubmitInputNormalizesAppStoreIDPrefix(t *testing.T)
 	communityWallPromptEnabled = func() bool { return false }
 	t.Cleanup(func() { communityWallPromptEnabled = previousPromptEnabled })
 
-	input, err := collectCommunityWallSubmitInput("id1234567890", "", "")
+	input, err := collectCommunityWallSubmitInput("id1234567890", "", "", "")
 	if err != nil {
 		t.Fatalf("collect input: %v", err)
 	}
@@ -98,9 +99,108 @@ func TestCommunityWallAppStoreURLCanonicalizesZeroPaddedID(t *testing.T) {
 	}
 }
 
+func TestResolveCommunityWallCandidatePassesCountryToLookup(t *testing.T) {
+	var capturedCountry string
+	previousLookupDetails := communityWallLookupAppDetails
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
+		capturedCountry = country
+		return map[string]communityWallAppDetails{
+			"1435783608": {
+				Name: "PayPay-ペイペイ",
+				Link: "https://apps.apple.com/jp/app/paypay/id1435783608",
+			},
+		}, nil
+	}
+	t.Cleanup(func() {
+		communityWallLookupAppDetails = previousLookupDetails
+	})
+
+	candidate, warnings, err := resolveCommunityWallCandidate(context.Background(), communityWallSubmitInput{
+		AppID:   "1435783608",
+		Country: "jp",
+	})
+	if err != nil {
+		t.Fatalf("resolve candidate: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %+v", warnings)
+	}
+	if capturedCountry != "jp" {
+		t.Fatalf("lookup country = %q, want %q", capturedCountry, "jp")
+	}
+	if candidate.App != "PayPay-ペイペイ" {
+		t.Fatalf("App = %q, want PayPay-ペイペイ", candidate.App)
+	}
+	if candidate.Link != "https://apps.apple.com/jp/app/paypay/id1435783608" {
+		t.Fatalf("Link = %q, want the JP storefront URL", candidate.Link)
+	}
+}
+
+func TestResolveCommunityWallCandidateMentionsCountryFlagWhenLookupMissesInDefaultStorefront(t *testing.T) {
+	previousLookupDetails := communityWallLookupAppDetails
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
+		return map[string]communityWallAppDetails{}, nil
+	}
+	t.Cleanup(func() {
+		communityWallLookupAppDetails = previousLookupDetails
+	})
+
+	_, _, err := resolveCommunityWallCandidate(context.Background(), communityWallSubmitInput{
+		AppID: "1435783608",
+	})
+	if err == nil {
+		t.Fatalf("expected an error when the lookup returns no results")
+	}
+	if !strings.Contains(err.Error(), "--country") {
+		t.Fatalf("expected error to suggest --country, got: %v", err)
+	}
+}
+
+func TestCollectCommunityWallSubmitInputNormalizesCountry(t *testing.T) {
+	previousPromptEnabled := communityWallPromptEnabled
+	communityWallPromptEnabled = func() bool { return false }
+	t.Cleanup(func() { communityWallPromptEnabled = previousPromptEnabled })
+
+	input, err := collectCommunityWallSubmitInput("1234567890", "", "", "JP")
+	if err != nil {
+		t.Fatalf("collect input: %v", err)
+	}
+	if input.Country != "jp" {
+		t.Fatalf("Country = %q, want %q", input.Country, "jp")
+	}
+}
+
+func TestCollectCommunityWallSubmitInputRejectsInvalidCountry(t *testing.T) {
+	previousPromptEnabled := communityWallPromptEnabled
+	communityWallPromptEnabled = func() bool { return false }
+	t.Cleanup(func() { communityWallPromptEnabled = previousPromptEnabled })
+
+	_, err := collectCommunityWallSubmitInput("1234567890", "", "", "zz")
+	if err == nil {
+		t.Fatalf("expected an error for an unsupported country code")
+	}
+	if !strings.Contains(err.Error(), "--country") {
+		t.Fatalf("expected error to mention --country, got: %v", err)
+	}
+}
+
+func TestCollectCommunityWallSubmitInputRejectsCountryWithLink(t *testing.T) {
+	previousPromptEnabled := communityWallPromptEnabled
+	communityWallPromptEnabled = func() bool { return false }
+	t.Cleanup(func() { communityWallPromptEnabled = previousPromptEnabled })
+
+	_, err := collectCommunityWallSubmitInput("", "My Beta", "https://example.com/beta", "jp")
+	if err == nil {
+		t.Fatalf("expected an error when --country is combined with --link")
+	}
+	if !strings.Contains(err.Error(), "--country") {
+		t.Fatalf("expected error to mention --country, got: %v", err)
+	}
+}
+
 func TestResolveCommunityWallCandidateCanonicalizesFallbackAppStoreURL(t *testing.T) {
 	previousLookupDetails := communityWallLookupAppDetails
-	communityWallLookupAppDetails = func(ctx context.Context, ids []string) (map[string]communityWallAppDetails, error) {
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
 		return map[string]communityWallAppDetails{
 			"00123": {
 				Name: "Beta",
@@ -170,7 +270,7 @@ func TestSubmitCommunityWallEntryDryRunReturnsPlan(t *testing.T) {
 	previousNow := communityWallNow
 	communityWallGitHubAPIBase = server.URL
 	communityWallGitHubClient = func() *http.Client { return server.Client() }
-	communityWallLookupAppDetails = func(ctx context.Context, ids []string) (map[string]communityWallAppDetails, error) {
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
 		return map[string]communityWallAppDetails{
 			"1234567890": {
 				Name: "Beta",
@@ -265,7 +365,7 @@ func TestSubmitCommunityWallEntryRejectsDuplicateAppID(t *testing.T) {
 	previousLookupDetails := communityWallLookupAppDetails
 	communityWallGitHubAPIBase = server.URL
 	communityWallGitHubClient = func() *http.Client { return server.Client() }
-	communityWallLookupAppDetails = func(ctx context.Context, ids []string) (map[string]communityWallAppDetails, error) {
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
 		return map[string]communityWallAppDetails{
 			"1234567890": {
 				Name: "Beta 2",
@@ -336,7 +436,7 @@ func TestSubmitCommunityWallEntryRejectsMalformedExistingSource(t *testing.T) {
 	previousLookupDetails := communityWallLookupAppDetails
 	communityWallGitHubAPIBase = server.URL
 	communityWallGitHubClient = func() *http.Client { return server.Client() }
-	communityWallLookupAppDetails = func(ctx context.Context, ids []string) (map[string]communityWallAppDetails, error) {
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
 		return map[string]communityWallAppDetails{
 			"1234567890": {
 				Name: "Beta",
@@ -380,7 +480,7 @@ func TestSubmitCommunityWallEntryRejectsExistingNonForkRepo(t *testing.T) {
 	previousLookupDetails := communityWallLookupAppDetails
 	communityWallGitHubAPIBase = server.URL
 	communityWallGitHubClient = func() *http.Client { return server.Client() }
-	communityWallLookupAppDetails = func(ctx context.Context, ids []string) (map[string]communityWallAppDetails, error) {
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
 		return map[string]communityWallAppDetails{
 			"1234567890": {
 				Name: "Beta",
@@ -521,7 +621,7 @@ func TestFetchCommunityWallAppDetailsOmitsCountryFilter(t *testing.T) {
 		communityWallAppStoreLookupURL = previousLookupURL
 	})
 
-	details, err := fetchCommunityWallAppDetails(context.Background(), []string{"1234567890"})
+	details, err := fetchCommunityWallAppDetails(context.Background(), []string{"1234567890"}, "")
 	if err != nil {
 		t.Fatalf("fetch app details: %v", err)
 	}
@@ -548,7 +648,7 @@ func TestFetchCommunityWallAppDetailsPreservesZeroPaddedRequestKey(t *testing.T)
 		communityWallAppStoreLookupURL = previousLookupURL
 	})
 
-	details, err := fetchCommunityWallAppDetails(context.Background(), []string{"00123"})
+	details, err := fetchCommunityWallAppDetails(context.Background(), []string{"00123"}, "")
 	if err != nil {
 		t.Fatalf("fetch app details: %v", err)
 	}

--- a/internal/cli/apps/community_wall_submit_test.go
+++ b/internal/cli/apps/community_wall_submit_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"flag"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/AlecAivazis/survey/v2"
 )
 
 func TestCollectCommunityWallSubmitInputAllowsAppIDOnlyWhenNonInteractive(t *testing.T) {
@@ -195,6 +199,129 @@ func TestCollectCommunityWallSubmitInputRejectsCountryWithLink(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--country") {
 		t.Fatalf("expected error to mention --country, got: %v", err)
+	}
+}
+
+func TestCollectCommunityWallSubmitInputRejectsPromptedManualLinkWithCountry(t *testing.T) {
+	previousPromptEnabled := communityWallPromptEnabled
+	previousPromptText := communityWallPromptSubmitText
+	communityWallPromptEnabled = func() bool { return true }
+	responses := []string{"", "https://example.com/beta"}
+	communityWallPromptSubmitText = func(message, help string, validator survey.Validator) (string, error) {
+		if len(responses) == 0 {
+			t.Fatalf("unexpected prompt %q", message)
+		}
+		response := responses[0]
+		responses = responses[1:]
+		if validator != nil {
+			if err := validator(response); err != nil {
+				return "", err
+			}
+		}
+		return response, nil
+	}
+	t.Cleanup(func() {
+		communityWallPromptEnabled = previousPromptEnabled
+		communityWallPromptSubmitText = previousPromptText
+	})
+
+	_, err := collectCommunityWallSubmitInput("", "My Beta", "", "jp")
+	if err == nil {
+		t.Fatal("expected an error when --country is kept after prompting for a manual link")
+	}
+	if !strings.Contains(err.Error(), "--country") {
+		t.Fatalf("expected error to mention --country, got: %v", err)
+	}
+}
+
+func TestAppsWallSubmitCommandPassesCountryFlagToDryRunLookup(t *testing.T) {
+	previousPromptEnabled := communityWallPromptEnabled
+	previousRunner := communityWallGHCommandRunner
+	previousAPIBase := communityWallGitHubAPIBase
+	previousHTTPClient := communityWallGitHubClient
+	previousLookupDetails := communityWallLookupAppDetails
+	previousNow := communityWallNow
+	communityWallPromptEnabled = func() bool { return false }
+	communityWallGHCommandRunner = func(ctx context.Context, args ...string) ([]byte, []byte, error) {
+		switch strings.Join(args, " ") {
+		case "auth status":
+			return nil, nil, nil
+		case "auth token":
+			return []byte("token"), nil, nil
+		default:
+			t.Fatalf("unexpected gh command: %v", args)
+			return nil, nil, nil
+		}
+	}
+	var capturedCountry string
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
+		capturedCountry = country
+		return map[string]communityWallAppDetails{
+			"1435783608": {
+				Name: "PayPay-ペイペイ",
+				Link: "https://apps.apple.com/jp/app/paypay/id1435783608",
+				Icon: "https://example.com/paypay.png",
+			},
+		}, nil
+	}
+	communityWallNow = func() time.Time {
+		return time.Date(2026, time.March, 10, 12, 0, 0, 0, time.UTC)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/user":
+			_ = json.NewEncoder(w).Encode(map[string]string{"login": "tester"})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/tester/App-Store-Connect-CLI":
+			http.NotFound(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/git/ref/heads/main":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": map[string]any{
+					"sha": "base-sha-123",
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
+			if got := r.URL.Query().Get("ref"); got != "base-sha-123" {
+				t.Fatalf("expected ref=base-sha-123, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sha":      "blob123",
+				"encoding": "base64",
+				"content":  base64.StdEncoding.EncodeToString([]byte(`[{"app":"Alpha","link":"https://example.com/alpha"}]`)),
+			})
+		default:
+			t.Fatalf("unexpected request during command dry-run: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+	communityWallGitHubAPIBase = server.URL
+	communityWallGitHubClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() {
+		communityWallPromptEnabled = previousPromptEnabled
+		communityWallGHCommandRunner = previousRunner
+		communityWallGitHubAPIBase = previousAPIBase
+		communityWallGitHubClient = previousHTTPClient
+		communityWallLookupAppDetails = previousLookupDetails
+		communityWallNow = previousNow
+	})
+
+	cmd := AppsWallSubmitCommand(flag.NewFlagSet("wall", flag.ContinueOnError))
+	cmd.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stderr := captureAppsCreateOutput(t, func() {
+		if err := cmd.Parse([]string{"--dry-run", "--country", "JP", "--app", "1435783608"}); err != nil {
+			t.Fatalf("parse command: %v", err)
+		}
+		runErr = cmd.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run command: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if capturedCountry != "jp" {
+		t.Fatalf("lookup country = %q, want %q", capturedCountry, "jp")
 	}
 }
 

--- a/internal/cli/cmdtest/apps_wall_test.go
+++ b/internal/cli/cmdtest/apps_wall_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func findSubcommand(root *ffcli.Command, path ...string) *ffcli.Command {
@@ -160,6 +162,50 @@ func TestAppsWallSubmitRejectsMultipleParentWallFlags(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "--limit, --output") {
 		t.Fatalf("expected sorted offending flags in stderr, got %q", stderr)
+	}
+}
+
+func TestAppsWallSubmitInvalidCountryReturnsUsageExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "country before app",
+			args: []string{
+				"apps", "wall", "submit",
+				"--country", "zz",
+				"--app", "1234567890",
+				"--dry-run",
+			},
+		},
+		{
+			name: "country after dry run",
+			args: []string{
+				"apps", "wall", "submit",
+				"--app", "1234567890",
+				"--dry-run",
+				"--country", "zz",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				code := rootcmd.Run(test.args, "1.2.3")
+				if code != rootcmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", rootcmd.ExitUsage, code)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "--country") {
+				t.Fatalf("expected --country guidance in stderr, got %q", stderr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

\`asc apps wall submit --app <id>\` always queries the iTunes Lookup API without a \`country\` parameter, so Apple resolves it against the US storefront. Apps published only in non-US storefronts (e.g. PayPay-ペイペイ in Japan, app ID \`1435783608\`) fail with:

\`\`\`
Error: apps wall submit: app "1435783608" was not found in the App Store lookup; use --link with --name for non-App-Store entries
\`\`\`

The app is published — just not in the US store. Verifiable directly against the lookup API:

\`\`\`
$ curl -s 'https://itunes.apple.com/lookup?id=1435783608' | jq .resultCount        # 0
$ curl -s 'https://itunes.apple.com/lookup?id=1435783608&country=jp' | jq .resultCount   # 1
\`\`\`

This is an existing gap in the \`--app\` flow specifically: the sibling helper \`communityWallIconForLink\` (\`internal/cli/apps/community_wall_submit.go:769-772\`) already extracts the country code from a manual \`--link\` URL and passes it through to the same lookup. The \`--app\` path just never had a way to specify a storefront.

## Fix

- Add a \`--country\` flag to \`asc apps wall submit\`, validated against \`itunes.NormalizeCountryCode\` (so unsupported codes are rejected up front).
- Thread it through \`communityWallSubmitInput\` → \`resolveCommunityWallCandidate\` → \`communityWallLookupAppDetails\` → \`itunes.LookupOptions.Country\`.
- Improve the \"not found\" error: when no storefront was specified, suggest \`--country\`; when one was, mention which storefront missed.
- Reject \`--country\` combined with \`--link\` — the storefront is already baked into the URL in that flow, so passing both is a user error worth catching.

## Tests

Five new tests in \`internal/cli/apps/community_wall_submit_test.go\`:

- \`TestResolveCommunityWallCandidatePassesCountryToLookup\` — country is propagated through to the lookup mock.
- \`TestResolveCommunityWallCandidateMentionsCountryFlagWhenLookupMissesInDefaultStorefront\` — the improved error suggests \`--country\` when none was set.
- \`TestCollectCommunityWallSubmitInputNormalizesCountry\` — \`JP\` becomes \`jp\` via \`itunes.NormalizeCountryCode\`.
- \`TestCollectCommunityWallSubmitInputRejectsInvalidCountry\` — \`zz\` is rejected before any network call.
- \`TestCollectCommunityWallSubmitInputRejectsCountryWithLink\` — combining \`--country\` and \`--link\` errors out.

All five existing lookup-mock test signatures were updated (\`(ctx, ids)\` → \`(ctx, ids, country)\`), and the two \`fetchCommunityWallAppDetails\` callers passing the test server URL got a \`\"\"\` country argument to preserve their existing behavior. The pre-existing \`TestFetchCommunityWallAppDetailsOmitsCountryFilter\` still passes (\`country=\"\"\` ⇒ no \`country=\` query param), so the default-storefront contract is unchanged.

## Verified locally

\`\`\`
make build            # clean
ASC_BYPASS_KEYCHAIN=1 make test
make format
make lint             # 0 issues
make check-command-docs
\`\`\`

End-to-end against PayPay:

\`\`\`
$ asc apps wall submit --app 1435783608 --dry-run
Error: ... pass --country if the app is only published in a non-US storefront (e.g. --country jp) ...

$ asc apps wall submit --app 1435783608 --country jp --dry-run
{ ..., "app": "PayPay-ペイペイ", "link": "https://apps.apple.com/jp/app/.../id1435783608?uo=4", ... }
\`\`\`

## Notes

- The example list in the long help text gains one line: \`asc apps wall submit --app "1435783608" --country "jp" --confirm\`. \`docs/COMMANDS.md\` only renders the top-level help, so it didn't need regenerating; \`make check-command-docs\` is clean.
- Bisecting through \`itunes.NormalizeCountryCode\` means inputs like \`Jp\`, \`JP\`, \` jp \` are all accepted and stored as the canonical \`jp\`.

## Disclosure

Drafted with assistance from Claude (Anthropic). I hit this myself trying to submit our Korean apps to the Wall of Apps — none of which were actually live on the App Store, but verifying against PayPay (50M-user Japan-only fintech app) made the actual gap obvious. \`make test / format / lint / check-command-docs\` were all clean before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--country` flag to community wall app submissions to perform country-specific App Store lookups; input is normalized.

* **Bug Fixes / Validation**
  * `--country` is validated and only allowed with `--app` (errors when used with `--link`); lookup miss messages now reference the storefront when provided.

* **Tests**
  * Added unit and CLI tests covering country normalization, invalid country handling, and storefront-aware lookup behavior.

* **Documentation**
  * Updated command help/examples to show `--country` usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->