### PR TITLE
feat(background-assets): add submit-for-review command

### DIFF
--- a/internal/cli/backgroundassets/background_assets.go
+++ b/internal/cli/backgroundassets/background_assets.go
@@ -32,7 +32,7 @@ Examples:
   asc background-assets versions list --background-asset-id "ASSET_ID"
   asc background-assets app-store-releases get --id "RELEASE_ID"
   asc background-assets upload-files create --version-id "VERSION_ID" --file "./asset.zip" --asset-type ASSET
-  asc background-assets submit --app "APP_ID" --all --confirm`,
+  asc background-assets submit --app "APP_ID" --background-asset-id "ASSET_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{

--- a/internal/cli/backgroundassets/background_assets.go
+++ b/internal/cli/backgroundassets/background_assets.go
@@ -31,7 +31,8 @@ Examples:
   asc background-assets update --id "ASSET_ID" --archived true
   asc background-assets versions list --background-asset-id "ASSET_ID"
   asc background-assets app-store-releases get --id "RELEASE_ID"
-  asc background-assets upload-files create --version-id "VERSION_ID" --file "./asset.zip" --asset-type ASSET`,
+  asc background-assets upload-files create --version-id "VERSION_ID" --file "./asset.zip" --asset-type ASSET
+  asc background-assets submit --app "APP_ID" --all --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -44,6 +45,7 @@ Examples:
 			BackgroundAssetsExternalBetaReleasesCommand(),
 			BackgroundAssetsInternalBetaReleasesCommand(),
 			BackgroundAssetsUploadFilesCommand(),
+			BackgroundAssetsSubmitCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/backgroundassets/background_assets_submit.go
+++ b/internal/cli/backgroundassets/background_assets_submit.go
@@ -2,6 +2,7 @@ package backgroundassets
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -170,7 +171,7 @@ Examples:
 						if _, cancelErr := client.CancelReviewSubmission(requestCtx, currentSubmissionID); cancelErr == nil {
 							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rolled back the submission: %w", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, err)
 						} else {
-							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rollback also failed (submission %q is leaked with %d partial item(s); rollback err=%v): %w", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, currentSubmissionID, result.AttachedItems, cancelErr, err)
+							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rollback also failed (submission %q is leaked with %d partial item(s)): %w", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, currentSubmissionID, result.AttachedItems, errors.Join(err, cancelErr))
 						}
 					}
 					return fmt.Errorf("background-assets submit: attach version %q (index %d) to submission %q: %w", item.BackgroundAssetVersionID, i, currentSubmissionID, err)

--- a/internal/cli/backgroundassets/background_assets_submit.go
+++ b/internal/cli/backgroundassets/background_assets_submit.go
@@ -170,7 +170,7 @@ Examples:
 						if _, cancelErr := client.CancelReviewSubmission(requestCtx, currentSubmissionID); cancelErr == nil {
 							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rolled back the submission: %w", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, err)
 						} else {
-							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rollback also failed (submission %q is leaked with %d partial item(s)): attach err=%v; rollback err=%v", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, currentSubmissionID, result.AttachedItems, err, cancelErr)
+							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rollback also failed (submission %q is leaked with %d partial item(s); rollback err=%v): %w", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, currentSubmissionID, result.AttachedItems, cancelErr, err)
 						}
 					}
 					return fmt.Errorf("background-assets submit: attach version %q (index %d) to submission %q: %w", item.BackgroundAssetVersionID, i, currentSubmissionID, err)
@@ -397,8 +397,10 @@ func versionSupportsPlatform(v ascBackgroundAssetVersionItem, platform string) b
 	return false
 }
 
-type ascBackgroundAssetItem = asc.Resource[asc.BackgroundAssetAttributes]
-type ascBackgroundAssetVersionItem = asc.Resource[asc.BackgroundAssetVersionAttributes]
+type (
+	ascBackgroundAssetItem        = asc.Resource[asc.BackgroundAssetAttributes]
+	ascBackgroundAssetVersionItem = asc.Resource[asc.BackgroundAssetVersionAttributes]
+)
 
 func fetchAllBackgroundAssets(ctx context.Context, client backgroundAssetSubmitClient, appID string, opts ...asc.BackgroundAssetsOption) ([]ascBackgroundAssetItem, error) {
 	first, err := client.GetBackgroundAssets(ctx, appID, opts...)

--- a/internal/cli/backgroundassets/background_assets_submit.go
+++ b/internal/cli/backgroundassets/background_assets_submit.go
@@ -22,7 +22,7 @@ func BackgroundAssetsSubmitCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
 	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
-	all := fs.Bool("all", false, "Submit the latest COMPLETE version of every non-archived asset pack for the app")
+	all := fs.Bool("all", false, "Submit the latest COMPLETE version of every non-archived background asset for the app")
 	assetPackIdentifiers := fs.String("asset-pack-identifier", "", "Comma-separated asset pack identifiers to submit")
 	backgroundAssetIDs := fs.String("background-asset-id", "", "Comma-separated background asset IDs to submit")
 	versionIDs := fs.String("version-id", "", "Comma-separated background asset version IDs to submit (skips lookup)")
@@ -34,26 +34,26 @@ func BackgroundAssetsSubmitCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "submit",
-		ShortUsage: "asc background-assets submit --app \"APP_ID\" --all --confirm",
-		ShortHelp:  "Submit background asset packs for App Store review.",
-		LongHelp: `Submit background asset packs for App Store review.
+		ShortUsage: "asc background-assets submit --app \"APP_ID\" --background-asset-id \"ASSET_ID\" --confirm",
+		ShortHelp:  "Submit background asset versions for App Store review.",
+		LongHelp: `Submit one or more background asset versions for App Store review.
 
 This is a wrapper around the generic review submission flow:
   - asc review submissions-create
   - asc review items-add (for each background asset version)
   - asc review submissions-submit
 
-Pack selection is mutually exclusive: --all, --asset-pack-identifier,
+Selection is mutually exclusive: --all, --asset-pack-identifier,
 --background-asset-id, or --version-id.
 
 For --all, --asset-pack-identifier, and --background-asset-id the newest
-version in state COMPLETE is selected per pack; an error is returned if a
-pack has no COMPLETE version.
+version in state COMPLETE is selected per background asset; an error is
+returned if a selected background asset has no COMPLETE version.
 
 Examples:
-  asc background-assets submit --app "APP_ID" --all --confirm
-  asc background-assets submit --app "APP_ID" --asset-pack-identifier "com.example.stamps.us,com.example.stamps.de" --confirm
-  asc background-assets submit --app "APP_ID" --version-id "VID_A,VID_B" --review-submission-id "SUB" --confirm
+  asc background-assets submit --app "APP_ID" --background-asset-id "ASSET_ID" --confirm
+  asc background-assets submit --app "APP_ID" --asset-pack-identifier "com.example.assetpack" --confirm
+  asc background-assets submit --app "APP_ID" --version-id "VERSION_ID" --review-submission-id "SUBMISSION_ID" --confirm
   asc background-assets submit --app "APP_ID" --all --dry-run`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -247,11 +247,16 @@ type backgroundAssetSubmitResolver struct {
 func resolveBackgroundAssetSubmitItems(ctx context.Context, r backgroundAssetSubmitResolver, sel backgroundAssetSubmitSelection) ([]backgroundAssetsSubmitResultItem, error) {
 	if len(sel.explicitVersionIDs) > 0 {
 		items := make([]backgroundAssetsSubmitResultItem, 0, len(sel.explicitVersionIDs))
+		seen := make(map[string]struct{}, len(sel.explicitVersionIDs))
 		for _, vid := range sel.explicitVersionIDs {
 			vid = strings.TrimSpace(vid)
 			if vid == "" {
 				continue
 			}
+			if _, ok := seen[vid]; ok {
+				continue
+			}
+			seen[vid] = struct{}{}
 			items = append(items, backgroundAssetsSubmitResultItem{BackgroundAssetVersionID: vid})
 		}
 		return items, nil

--- a/internal/cli/backgroundassets/background_assets_submit.go
+++ b/internal/cli/backgroundassets/background_assets_submit.go
@@ -1,0 +1,471 @@
+package backgroundassets
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const backgroundAssetVersionStateComplete = "COMPLETE"
+
+func BackgroundAssetsSubmitCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("submit", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
+	all := fs.Bool("all", false, "Submit the latest COMPLETE version of every non-archived asset pack for the app")
+	assetPackIdentifiers := fs.String("asset-pack-identifier", "", "Comma-separated asset pack identifiers to submit")
+	backgroundAssetIDs := fs.String("background-asset-id", "", "Comma-separated background asset IDs to submit")
+	versionIDs := fs.String("version-id", "", "Comma-separated background asset version IDs to submit (skips lookup)")
+	submissionID := fs.String("review-submission-id", "", "Attach items to this existing review submission instead of creating a new one")
+	confirm := fs.Bool("confirm", false, "Confirm submission (required unless --dry-run)")
+	dryRun := fs.Bool("dry-run", false, "Preview the submission flow without mutating")
+	noSubmit := fs.Bool("no-submit", false, "Create the submission and attach items but do not submit; useful when chaining additional items")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "submit",
+		ShortUsage: "asc background-assets submit --app \"APP_ID\" --all --confirm",
+		ShortHelp:  "Submit background asset packs for App Store review.",
+		LongHelp: `Submit background asset packs for App Store review.
+
+This is a wrapper around the generic review submission flow:
+  - asc review submissions-create
+  - asc review items-add (for each background asset version)
+  - asc review submissions-submit
+
+Pack selection is mutually exclusive: --all, --asset-pack-identifier,
+--background-asset-id, or --version-id.
+
+For --all, --asset-pack-identifier, and --background-asset-id the newest
+version in state COMPLETE is selected per pack; an error is returned if a
+pack has no COMPLETE version.
+
+Examples:
+  asc background-assets submit --app "APP_ID" --all --confirm
+  asc background-assets submit --app "APP_ID" --asset-pack-identifier "com.example.stamps.us,com.example.stamps.de" --confirm
+  asc background-assets submit --app "APP_ID" --version-id "VID_A,VID_B" --review-submission-id "SUB" --confirm
+  asc background-assets submit --app "APP_ID" --all --dry-run`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return flag.ErrHelp
+			}
+			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			packIDs := shared.SplitCSV(*assetPackIdentifiers)
+			assetIDs := shared.SplitCSV(*backgroundAssetIDs)
+			explicitVersionIDs := shared.SplitCSV(*versionIDs)
+
+			selectionCount := 0
+			if *all {
+				selectionCount++
+			}
+			if len(packIDs) > 0 {
+				selectionCount++
+			}
+			if len(assetIDs) > 0 {
+				selectionCount++
+			}
+			if len(explicitVersionIDs) > 0 {
+				selectionCount++
+			}
+			if selectionCount == 0 {
+				return shared.UsageError("one of --all, --asset-pack-identifier, --background-asset-id, or --version-id is required")
+			}
+			if selectionCount > 1 {
+				return shared.UsageError("--all, --asset-pack-identifier, --background-asset-id, and --version-id are mutually exclusive")
+			}
+			if !*confirm && !*dryRun {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required unless --dry-run is set")
+				return flag.ErrHelp
+			}
+			if *noSubmit && *dryRun {
+				return shared.UsageError("--no-submit and --dry-run are mutually exclusive")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			needsClientForResolve := len(explicitVersionIDs) == 0
+			var client backgroundAssetSubmitClient
+			if needsClientForResolve || !*dryRun {
+				realClient, err := shared.GetASCClient()
+				if err != nil {
+					return fmt.Errorf("background-assets submit: %w", err)
+				}
+				client = realClient
+			}
+
+			items, err := resolveBackgroundAssetSubmitItems(requestCtx, backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+				appID:                resolvedAppID,
+				platform:             normalizedPlatform,
+				all:                  *all,
+				assetPackIdentifiers: packIDs,
+				backgroundAssetIDs:   assetIDs,
+				explicitVersionIDs:   explicitVersionIDs,
+			})
+			if err != nil {
+				return fmt.Errorf("background-assets submit: %w", err)
+			}
+			if len(items) == 0 {
+				return shared.UsageError("no matching background asset versions found to submit")
+			}
+
+			result := backgroundAssetsSubmitResult{
+				AppID:    resolvedAppID,
+				Platform: normalizedPlatform,
+				Items:    items,
+				DryRun:   *dryRun,
+				NoSubmit: *noSubmit,
+			}
+
+			if *dryRun {
+				result.Messages = append(result.Messages, fmt.Sprintf("dry-run: would submit %d background asset version(s) for review", len(items)))
+				return shared.PrintOutput(result, *output.Output, *output.Pretty)
+			}
+
+			currentSubmissionID := strings.TrimSpace(*submissionID)
+			createdHere := false
+			if currentSubmissionID == "" {
+				createResp, err := client.CreateReviewSubmission(requestCtx, resolvedAppID, asc.Platform(normalizedPlatform))
+				if err != nil {
+					return fmt.Errorf("background-assets submit: create review submission: %w", err)
+				}
+				currentSubmissionID = createResp.Data.ID
+				createdHere = true
+			}
+			result.SubmissionID = currentSubmissionID
+
+			alreadyAttached := map[string]struct{}{}
+			if !createdHere {
+				existing, err := fetchAlreadyAttachedBackgroundAssetVersions(requestCtx, client, currentSubmissionID)
+				if err != nil {
+					return fmt.Errorf("background-assets submit: inspect existing items on submission %q: %w", currentSubmissionID, err)
+				}
+				alreadyAttached = existing
+			}
+
+			for i, item := range items {
+				if _, skip := alreadyAttached[item.BackgroundAssetVersionID]; skip {
+					result.SkippedAlreadyAttached = append(result.SkippedAlreadyAttached, item)
+					continue
+				}
+				if _, err := client.CreateReviewSubmissionItem(requestCtx, currentSubmissionID, asc.ReviewSubmissionItemTypeBackgroundAssetVersion, item.BackgroundAssetVersionID); err != nil {
+					if createdHere {
+						if _, cancelErr := client.CancelReviewSubmission(requestCtx, currentSubmissionID); cancelErr == nil {
+							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rolled back the submission: %w", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, err)
+						} else {
+							return fmt.Errorf("background-assets submit: attach version %q (index %d, %d already attached) to submission %q failed; rollback also failed (submission %q is leaked with %d partial item(s)): attach err=%v; rollback err=%v", item.BackgroundAssetVersionID, i, result.AttachedItems, currentSubmissionID, currentSubmissionID, result.AttachedItems, err, cancelErr)
+						}
+					}
+					return fmt.Errorf("background-assets submit: attach version %q (index %d) to submission %q: %w", item.BackgroundAssetVersionID, i, currentSubmissionID, err)
+				}
+				result.AttachedItems++
+			}
+
+			if *noSubmit {
+				result.Messages = append(result.Messages, fmt.Sprintf("--no-submit set; submission %s left open with %d item(s) attached", currentSubmissionID, result.AttachedItems))
+				return shared.PrintOutput(result, *output.Output, *output.Pretty)
+			}
+
+			submitResp, err := client.SubmitReviewSubmission(requestCtx, currentSubmissionID)
+			if err != nil {
+				return fmt.Errorf("background-assets submit: submit review submission %q: %w", currentSubmissionID, err)
+			}
+			if submitResp != nil {
+				result.SubmittedDate = submitResp.Data.Attributes.SubmittedDate
+				if submitResp.Data.Attributes.SubmissionState != "" {
+					result.SubmissionState = string(submitResp.Data.Attributes.SubmissionState)
+				}
+			}
+
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+type backgroundAssetsSubmitResult struct {
+	AppID                  string                             `json:"appId"`
+	Platform               string                             `json:"platform"`
+	SubmissionID           string                             `json:"submissionId,omitempty"`
+	SubmissionState        string                             `json:"submissionState,omitempty"`
+	SubmittedDate          string                             `json:"submittedDate,omitempty"`
+	AttachedItems          int                                `json:"attachedItems"`
+	DryRun                 bool                               `json:"dryRun,omitempty"`
+	NoSubmit               bool                               `json:"noSubmit,omitempty"`
+	Items                  []backgroundAssetsSubmitResultItem `json:"items"`
+	SkippedAlreadyAttached []backgroundAssetsSubmitResultItem `json:"skippedAlreadyAttached,omitempty"`
+	Messages               []string                           `json:"messages,omitempty"`
+}
+
+type backgroundAssetsSubmitResultItem struct {
+	BackgroundAssetID        string `json:"backgroundAssetId,omitempty"`
+	AssetPackIdentifier      string `json:"assetPackIdentifier,omitempty"`
+	BackgroundAssetVersionID string `json:"backgroundAssetVersionId"`
+	VersionNumber            string `json:"versionNumber,omitempty"`
+}
+
+type backgroundAssetSubmitSelection struct {
+	appID                string
+	platform             string
+	all                  bool
+	assetPackIdentifiers []string
+	backgroundAssetIDs   []string
+	explicitVersionIDs   []string
+}
+
+type backgroundAssetSubmitClient interface {
+	GetBackgroundAssets(ctx context.Context, appID string, opts ...asc.BackgroundAssetsOption) (*asc.BackgroundAssetsResponse, error)
+	GetBackgroundAssetVersions(ctx context.Context, backgroundAssetID string, opts ...asc.BackgroundAssetVersionsOption) (*asc.BackgroundAssetVersionsResponse, error)
+	GetReviewSubmissionItems(ctx context.Context, submissionID string, opts ...asc.ReviewSubmissionItemsOption) (*asc.ReviewSubmissionItemsResponse, error)
+	CreateReviewSubmission(ctx context.Context, appID string, platform asc.Platform) (*asc.ReviewSubmissionResponse, error)
+	CreateReviewSubmissionItem(ctx context.Context, submissionID string, itemType asc.ReviewSubmissionItemType, itemID string) (*asc.ReviewSubmissionItemResponse, error)
+	SubmitReviewSubmission(ctx context.Context, submissionID string) (*asc.ReviewSubmissionResponse, error)
+	CancelReviewSubmission(ctx context.Context, submissionID string) (*asc.ReviewSubmissionResponse, error)
+}
+
+type backgroundAssetSubmitResolver struct {
+	client backgroundAssetSubmitClient
+}
+
+func resolveBackgroundAssetSubmitItems(ctx context.Context, r backgroundAssetSubmitResolver, sel backgroundAssetSubmitSelection) ([]backgroundAssetsSubmitResultItem, error) {
+	if len(sel.explicitVersionIDs) > 0 {
+		items := make([]backgroundAssetsSubmitResultItem, 0, len(sel.explicitVersionIDs))
+		for _, vid := range sel.explicitVersionIDs {
+			vid = strings.TrimSpace(vid)
+			if vid == "" {
+				continue
+			}
+			items = append(items, backgroundAssetsSubmitResultItem{BackgroundAssetVersionID: vid})
+		}
+		return items, nil
+	}
+
+	assets, err := r.listAssets(ctx, sel)
+	if err != nil {
+		return nil, err
+	}
+	if len(assets) == 0 {
+		return nil, nil
+	}
+
+	items := make([]backgroundAssetsSubmitResultItem, 0, len(assets))
+	for _, asset := range assets {
+		if asset.Attributes.Archived {
+			continue
+		}
+		version, err := r.latestCompleteVersion(ctx, asset.ID, sel.platform)
+		if err != nil {
+			return nil, fmt.Errorf("resolve newest COMPLETE version for asset %q (%s): %w", asset.Attributes.AssetPackIdentifier, asset.ID, err)
+		}
+		if version == nil {
+			return nil, fmt.Errorf("asset %q (%s) has no version in state %s for platform %s; upload files and wait for processing before submitting", asset.Attributes.AssetPackIdentifier, asset.ID, backgroundAssetVersionStateComplete, sel.platform)
+		}
+		items = append(items, backgroundAssetsSubmitResultItem{
+			BackgroundAssetID:        asset.ID,
+			AssetPackIdentifier:      asset.Attributes.AssetPackIdentifier,
+			BackgroundAssetVersionID: version.ID,
+			VersionNumber:            version.Attributes.Version,
+		})
+	}
+	return items, nil
+}
+
+func (r backgroundAssetSubmitResolver) listAssets(ctx context.Context, sel backgroundAssetSubmitSelection) ([]ascBackgroundAssetItem, error) {
+	if len(sel.backgroundAssetIDs) > 0 {
+		assets := make([]ascBackgroundAssetItem, 0, len(sel.backgroundAssetIDs))
+		filter := make(map[string]struct{}, len(sel.backgroundAssetIDs))
+		for _, id := range sel.backgroundAssetIDs {
+			filter[strings.TrimSpace(id)] = struct{}{}
+		}
+		opts := []asc.BackgroundAssetsOption{
+			asc.WithBackgroundAssetsLimit(backgroundAssetsMaxLimit),
+			asc.WithBackgroundAssetsFilterArchived([]string{"false"}),
+		}
+		all, err := fetchAllBackgroundAssets(ctx, r.client, sel.appID, opts...)
+		if err != nil {
+			return nil, err
+		}
+		for _, asset := range all {
+			if _, ok := filter[asset.ID]; ok {
+				assets = append(assets, asset)
+			}
+		}
+		if len(assets) != len(filter) {
+			missing := make([]string, 0, len(filter)-len(assets))
+			seen := make(map[string]struct{}, len(assets))
+			for _, a := range assets {
+				seen[a.ID] = struct{}{}
+			}
+			for id := range filter {
+				if _, ok := seen[id]; !ok {
+					missing = append(missing, id)
+				}
+			}
+			sort.Strings(missing)
+			return nil, fmt.Errorf("background asset id(s) not found for app %q: %s", sel.appID, strings.Join(missing, ", "))
+		}
+		return assets, nil
+	}
+
+	opts := []asc.BackgroundAssetsOption{
+		asc.WithBackgroundAssetsLimit(backgroundAssetsMaxLimit),
+		asc.WithBackgroundAssetsFilterArchived([]string{"false"}),
+	}
+	if len(sel.assetPackIdentifiers) > 0 {
+		opts = append(opts, asc.WithBackgroundAssetsFilterAssetPackIdentifier(sel.assetPackIdentifiers))
+	}
+	assets, err := fetchAllBackgroundAssets(ctx, r.client, sel.appID, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(sel.assetPackIdentifiers) > 0 {
+		wanted := make(map[string]struct{}, len(sel.assetPackIdentifiers))
+		for _, id := range sel.assetPackIdentifiers {
+			wanted[strings.TrimSpace(id)] = struct{}{}
+		}
+		seen := make(map[string]struct{}, len(assets))
+		for _, a := range assets {
+			seen[a.Attributes.AssetPackIdentifier] = struct{}{}
+		}
+		var missing []string
+		for id := range wanted {
+			if _, ok := seen[id]; !ok {
+				missing = append(missing, id)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			return nil, fmt.Errorf("asset pack identifier(s) not found for app %q: %s", sel.appID, strings.Join(missing, ", "))
+		}
+	}
+	return assets, nil
+}
+
+func (r backgroundAssetSubmitResolver) latestCompleteVersion(ctx context.Context, backgroundAssetID, platform string) (*ascBackgroundAssetVersionItem, error) {
+	versions, err := fetchAllBackgroundAssetVersions(ctx, r.client, backgroundAssetID)
+	if err != nil {
+		return nil, err
+	}
+	complete := versions[:0]
+	for _, v := range versions {
+		if !strings.EqualFold(v.Attributes.State, backgroundAssetVersionStateComplete) {
+			continue
+		}
+		if !versionSupportsPlatform(v, platform) {
+			continue
+		}
+		complete = append(complete, v)
+	}
+	if len(complete) == 0 {
+		return nil, nil
+	}
+	sort.Slice(complete, func(i, j int) bool {
+		if complete[i].Attributes.CreatedDate != complete[j].Attributes.CreatedDate {
+			return complete[i].Attributes.CreatedDate > complete[j].Attributes.CreatedDate
+		}
+		return complete[i].Attributes.Version > complete[j].Attributes.Version
+	})
+	chosen := complete[0]
+	return &chosen, nil
+}
+
+func versionSupportsPlatform(v ascBackgroundAssetVersionItem, platform string) bool {
+	if strings.TrimSpace(platform) == "" || len(v.Attributes.Platforms) == 0 {
+		return true
+	}
+	for _, p := range v.Attributes.Platforms {
+		if strings.EqualFold(string(p), platform) {
+			return true
+		}
+	}
+	return false
+}
+
+type ascBackgroundAssetItem = asc.Resource[asc.BackgroundAssetAttributes]
+type ascBackgroundAssetVersionItem = asc.Resource[asc.BackgroundAssetVersionAttributes]
+
+func fetchAllBackgroundAssets(ctx context.Context, client backgroundAssetSubmitClient, appID string, opts ...asc.BackgroundAssetsOption) ([]ascBackgroundAssetItem, error) {
+	first, err := client.GetBackgroundAssets(ctx, appID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("list background assets: %w", err)
+	}
+	resp, err := asc.PaginateAll(ctx, first, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetBackgroundAssets(ctx, appID, asc.WithBackgroundAssetsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate background assets: %w", err)
+	}
+	if aggregate, ok := resp.(*asc.BackgroundAssetsResponse); ok {
+		return aggregate.Data, nil
+	}
+	return first.Data, nil
+}
+
+func fetchAlreadyAttachedBackgroundAssetVersions(ctx context.Context, client backgroundAssetSubmitClient, submissionID string) (map[string]struct{}, error) {
+	attached := map[string]struct{}{}
+	opts := []asc.ReviewSubmissionItemsOption{
+		asc.WithReviewSubmissionItemsLimit(backgroundAssetsMaxLimit),
+		asc.WithReviewSubmissionItemsInclude([]string{"backgroundAssetVersion"}),
+	}
+	first, err := client.GetReviewSubmissionItems(ctx, submissionID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("list submission items: %w", err)
+	}
+	resp, err := asc.PaginateAll(ctx, first, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetReviewSubmissionItems(ctx, submissionID, asc.WithReviewSubmissionItemsNextURL(nextURL), asc.WithReviewSubmissionItemsInclude([]string{"backgroundAssetVersion"}))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate submission items: %w", err)
+	}
+	aggregate, ok := resp.(*asc.ReviewSubmissionItemsResponse)
+	if !ok {
+		aggregate = first
+	}
+	for _, item := range aggregate.Data {
+		if item.Relationships == nil || item.Relationships.BackgroundAssetVersion == nil {
+			continue
+		}
+		if strings.EqualFold(string(item.Attributes.State), "REMOVED") {
+			continue
+		}
+		bgVer := item.Relationships.BackgroundAssetVersion.Data.ID
+		if bgVer != "" {
+			attached[bgVer] = struct{}{}
+		}
+	}
+	return attached, nil
+}
+
+func fetchAllBackgroundAssetVersions(ctx context.Context, client backgroundAssetSubmitClient, backgroundAssetID string) ([]ascBackgroundAssetVersionItem, error) {
+	opts := []asc.BackgroundAssetVersionsOption{asc.WithBackgroundAssetVersionsLimit(backgroundAssetsMaxLimit)}
+	first, err := client.GetBackgroundAssetVersions(ctx, backgroundAssetID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("list versions: %w", err)
+	}
+	resp, err := asc.PaginateAll(ctx, first, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetBackgroundAssetVersions(ctx, backgroundAssetID, asc.WithBackgroundAssetVersionsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate versions: %w", err)
+	}
+	if aggregate, ok := resp.(*asc.BackgroundAssetVersionsResponse); ok {
+		return aggregate.Data, nil
+	}
+	return first.Data, nil
+}

--- a/internal/cli/backgroundassets/background_assets_submit_test.go
+++ b/internal/cli/backgroundassets/background_assets_submit_test.go
@@ -146,13 +146,13 @@ func TestResolveBackgroundAssetSubmitItems_ExplicitVersionIDs(t *testing.T) {
 	client := newFakeSubmitClient()
 	items, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
 		appID:              "APP",
-		explicitVersionIDs: []string{"vid-1", " vid-2 ", ""},
+		explicitVersionIDs: []string{"vid-1", " vid-2 ", "", "vid-1"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(items) != 2 {
-		t.Fatalf("expected 2 items after trimming blanks, got %d", len(items))
+		t.Fatalf("expected 2 items after trimming blanks and duplicates, got %d", len(items))
 	}
 	if items[0].BackgroundAssetVersionID != "vid-1" || items[1].BackgroundAssetVersionID != "vid-2" {
 		t.Errorf("unexpected resolved version IDs: %+v", items)

--- a/internal/cli/backgroundassets/background_assets_submit_test.go
+++ b/internal/cli/backgroundassets/background_assets_submit_test.go
@@ -2,75 +2,11 @@ package backgroundassets
 
 import (
 	"context"
-	"errors"
-	"flag"
 	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
-
-func TestBackgroundAssetsSubmitCommand_MissingApp(t *testing.T) {
-	t.Setenv("ASC_APP_ID", "")
-
-	cmd := BackgroundAssetsSubmitCommand()
-	if err := cmd.FlagSet.Parse([]string{"--all", "--confirm"}); err != nil {
-		t.Fatalf("failed to parse flags: %v", err)
-	}
-
-	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
-	}
-}
-
-func TestBackgroundAssetsSubmitCommand_RequiresSelection(t *testing.T) {
-	cmd := BackgroundAssetsSubmitCommand()
-	if err := cmd.FlagSet.Parse([]string{"--app", "APP_ID", "--confirm"}); err != nil {
-		t.Fatalf("failed to parse flags: %v", err)
-	}
-
-	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf("expected flag.ErrHelp when no selection flag is provided, got %v", err)
-	}
-}
-
-func TestBackgroundAssetsSubmitCommand_MutuallyExclusiveSelection(t *testing.T) {
-	cmd := BackgroundAssetsSubmitCommand()
-	if err := cmd.FlagSet.Parse([]string{
-		"--app", "APP_ID",
-		"--all",
-		"--asset-pack-identifier", "stamps.us",
-		"--confirm",
-	}); err != nil {
-		t.Fatalf("failed to parse flags: %v", err)
-	}
-
-	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf("expected flag.ErrHelp for mutually-exclusive selection, got %v", err)
-	}
-}
-
-func TestBackgroundAssetsSubmitCommand_RequiresConfirmOrDryRun(t *testing.T) {
-	cmd := BackgroundAssetsSubmitCommand()
-	if err := cmd.FlagSet.Parse([]string{"--app", "APP_ID", "--all"}); err != nil {
-		t.Fatalf("failed to parse flags: %v", err)
-	}
-
-	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf("expected flag.ErrHelp without --confirm or --dry-run, got %v", err)
-	}
-}
-
-func TestBackgroundAssetsSubmitCommand_DryRunAndNoSubmitMutuallyExclusive(t *testing.T) {
-	cmd := BackgroundAssetsSubmitCommand()
-	if err := cmd.FlagSet.Parse([]string{"--app", "APP_ID", "--all", "--dry-run", "--no-submit"}); err != nil {
-		t.Fatalf("failed to parse flags: %v", err)
-	}
-
-	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf("expected flag.ErrHelp for --dry-run + --no-submit, got %v", err)
-	}
-}
 
 type fakeSubmitClient struct {
 	assets             []ascBackgroundAssetItem

--- a/internal/cli/backgroundassets/background_assets_submit_test.go
+++ b/internal/cli/backgroundassets/background_assets_submit_test.go
@@ -1,0 +1,352 @@
+package backgroundassets
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestBackgroundAssetsSubmitCommand_MissingApp(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	cmd := BackgroundAssetsSubmitCommand()
+	if err := cmd.FlagSet.Parse([]string{"--all", "--confirm"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp when --app is missing, got %v", err)
+	}
+}
+
+func TestBackgroundAssetsSubmitCommand_RequiresSelection(t *testing.T) {
+	cmd := BackgroundAssetsSubmitCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", "APP_ID", "--confirm"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp when no selection flag is provided, got %v", err)
+	}
+}
+
+func TestBackgroundAssetsSubmitCommand_MutuallyExclusiveSelection(t *testing.T) {
+	cmd := BackgroundAssetsSubmitCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "APP_ID",
+		"--all",
+		"--asset-pack-identifier", "stamps.us",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp for mutually-exclusive selection, got %v", err)
+	}
+}
+
+func TestBackgroundAssetsSubmitCommand_RequiresConfirmOrDryRun(t *testing.T) {
+	cmd := BackgroundAssetsSubmitCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", "APP_ID", "--all"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp without --confirm or --dry-run, got %v", err)
+	}
+}
+
+func TestBackgroundAssetsSubmitCommand_DryRunAndNoSubmitMutuallyExclusive(t *testing.T) {
+	cmd := BackgroundAssetsSubmitCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", "APP_ID", "--all", "--dry-run", "--no-submit"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp for --dry-run + --no-submit, got %v", err)
+	}
+}
+
+type fakeSubmitClient struct {
+	assets             []ascBackgroundAssetItem
+	versions           map[string][]ascBackgroundAssetVersionItem
+	assetErr           error
+	verErrs            map[string]error
+	existingItems      map[string][]asc.ReviewSubmissionItemResource
+	createSubmissionID string
+	createErr          error
+	createItemErrFor   map[string]error
+	canceled           []string
+	submitted          []string
+	attached           []string
+}
+
+func (f *fakeSubmitClient) GetBackgroundAssets(_ context.Context, _ string, _ ...asc.BackgroundAssetsOption) (*asc.BackgroundAssetsResponse, error) {
+	if f.assetErr != nil {
+		return nil, f.assetErr
+	}
+	return &asc.BackgroundAssetsResponse{Data: f.assets}, nil
+}
+
+func (f *fakeSubmitClient) GetBackgroundAssetVersions(_ context.Context, backgroundAssetID string, _ ...asc.BackgroundAssetVersionsOption) (*asc.BackgroundAssetVersionsResponse, error) {
+	if err, ok := f.verErrs[backgroundAssetID]; ok {
+		return nil, err
+	}
+	return &asc.BackgroundAssetVersionsResponse{Data: f.versions[backgroundAssetID]}, nil
+}
+
+func (f *fakeSubmitClient) GetReviewSubmissionItems(_ context.Context, submissionID string, _ ...asc.ReviewSubmissionItemsOption) (*asc.ReviewSubmissionItemsResponse, error) {
+	return &asc.ReviewSubmissionItemsResponse{Data: f.existingItems[submissionID]}, nil
+}
+
+func (f *fakeSubmitClient) CreateReviewSubmission(_ context.Context, _ string, platform asc.Platform) (*asc.ReviewSubmissionResponse, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	id := f.createSubmissionID
+	if id == "" {
+		id = "new-submission"
+	}
+	return &asc.ReviewSubmissionResponse{Data: asc.ReviewSubmissionResource{ID: id, Attributes: asc.ReviewSubmissionAttributes{Platform: platform}}}, nil
+}
+
+func (f *fakeSubmitClient) CreateReviewSubmissionItem(_ context.Context, submissionID string, _ asc.ReviewSubmissionItemType, itemID string) (*asc.ReviewSubmissionItemResponse, error) {
+	if err, ok := f.createItemErrFor[itemID]; ok {
+		return nil, err
+	}
+	f.attached = append(f.attached, submissionID+"|"+itemID)
+	return &asc.ReviewSubmissionItemResponse{Data: asc.ReviewSubmissionItemResource{ID: submissionID + "|" + itemID}}, nil
+}
+
+func (f *fakeSubmitClient) SubmitReviewSubmission(_ context.Context, submissionID string) (*asc.ReviewSubmissionResponse, error) {
+	f.submitted = append(f.submitted, submissionID)
+	return &asc.ReviewSubmissionResponse{Data: asc.ReviewSubmissionResource{ID: submissionID, Attributes: asc.ReviewSubmissionAttributes{SubmissionState: asc.ReviewSubmissionStateWaitingForReview, SubmittedDate: "2026-05-14T13:00:00Z"}}}, nil
+}
+
+func (f *fakeSubmitClient) CancelReviewSubmission(_ context.Context, submissionID string) (*asc.ReviewSubmissionResponse, error) {
+	f.canceled = append(f.canceled, submissionID)
+	return &asc.ReviewSubmissionResponse{Data: asc.ReviewSubmissionResource{ID: submissionID}}, nil
+}
+
+func newFakeSubmitClient() *fakeSubmitClient {
+	return &fakeSubmitClient{
+		assets: []ascBackgroundAssetItem{
+			{
+				Type:       asc.ResourceTypeBackgroundAssets,
+				ID:         "asset-1",
+				Attributes: asc.BackgroundAssetAttributes{AssetPackIdentifier: "stamps.us"},
+			},
+			{
+				Type:       asc.ResourceTypeBackgroundAssets,
+				ID:         "asset-2",
+				Attributes: asc.BackgroundAssetAttributes{AssetPackIdentifier: "stamps.de"},
+			},
+			{
+				Type:       asc.ResourceTypeBackgroundAssets,
+				ID:         "asset-archived",
+				Attributes: asc.BackgroundAssetAttributes{AssetPackIdentifier: "stamps.archived", Archived: true},
+			},
+		},
+		versions: map[string][]ascBackgroundAssetVersionItem{
+			"asset-1": {
+				{
+					Type:       asc.ResourceTypeBackgroundAssetVersions,
+					ID:         "ver-us-1",
+					Attributes: asc.BackgroundAssetVersionAttributes{State: "COMPLETE", Version: "1", CreatedDate: "2026-01-01T00:00:00Z"},
+				},
+				{
+					Type:       asc.ResourceTypeBackgroundAssetVersions,
+					ID:         "ver-us-2",
+					Attributes: asc.BackgroundAssetVersionAttributes{State: "COMPLETE", Version: "2", CreatedDate: "2026-02-01T00:00:00Z"},
+				},
+				{
+					Type:       asc.ResourceTypeBackgroundAssetVersions,
+					ID:         "ver-us-3-pending",
+					Attributes: asc.BackgroundAssetVersionAttributes{State: "AWAITING_UPLOAD", Version: "3", CreatedDate: "2026-03-01T00:00:00Z"},
+				},
+			},
+			"asset-2": {
+				{
+					Type:       asc.ResourceTypeBackgroundAssetVersions,
+					ID:         "ver-de-1",
+					Attributes: asc.BackgroundAssetVersionAttributes{State: "COMPLETE", Version: "1", CreatedDate: "2026-01-15T00:00:00Z"},
+				},
+			},
+		},
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_All(t *testing.T) {
+	client := newFakeSubmitClient()
+	items, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{appID: "APP", all: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 non-archived items, got %d (%v)", len(items), items)
+	}
+	for _, item := range items {
+		switch item.BackgroundAssetID {
+		case "asset-1":
+			if item.BackgroundAssetVersionID != "ver-us-2" {
+				t.Errorf("asset-1 should resolve to newest COMPLETE version ver-us-2, got %q", item.BackgroundAssetVersionID)
+			}
+		case "asset-2":
+			if item.BackgroundAssetVersionID != "ver-de-1" {
+				t.Errorf("asset-2 should resolve to ver-de-1, got %q", item.BackgroundAssetVersionID)
+			}
+		default:
+			t.Errorf("unexpected asset id %q in result", item.BackgroundAssetID)
+		}
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_ExplicitVersionIDs(t *testing.T) {
+	client := newFakeSubmitClient()
+	items, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+		appID:              "APP",
+		explicitVersionIDs: []string{"vid-1", " vid-2 ", ""},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items after trimming blanks, got %d", len(items))
+	}
+	if items[0].BackgroundAssetVersionID != "vid-1" || items[1].BackgroundAssetVersionID != "vid-2" {
+		t.Errorf("unexpected resolved version IDs: %+v", items)
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_AssetPackIdentifierMissing(t *testing.T) {
+	client := newFakeSubmitClient()
+	_, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+		appID:                "APP",
+		assetPackIdentifiers: []string{"stamps.us", "stamps.fr"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "stamps.fr") {
+		t.Fatalf("expected error mentioning missing pack stamps.fr, got %v", err)
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_NoCompleteVersion(t *testing.T) {
+	client := newFakeSubmitClient()
+	client.versions["asset-2"] = []ascBackgroundAssetVersionItem{
+		{
+			Type:       asc.ResourceTypeBackgroundAssetVersions,
+			ID:         "ver-pending",
+			Attributes: asc.BackgroundAssetVersionAttributes{State: "AWAITING_UPLOAD", Version: "1"},
+		},
+	}
+	_, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+		appID:                "APP",
+		assetPackIdentifiers: []string{"stamps.de"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no version in state COMPLETE") {
+		t.Fatalf("expected error about missing COMPLETE version, got %v", err)
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_FilterByID(t *testing.T) {
+	client := newFakeSubmitClient()
+	items, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+		appID:              "APP",
+		backgroundAssetIDs: []string{"asset-2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].BackgroundAssetID != "asset-2" {
+		t.Fatalf("expected only asset-2, got %+v", items)
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_PlatformFilter(t *testing.T) {
+	client := newFakeSubmitClient()
+	client.versions["asset-1"] = []ascBackgroundAssetVersionItem{
+		{
+			Type:       asc.ResourceTypeBackgroundAssetVersions,
+			ID:         "ver-us-mac",
+			Attributes: asc.BackgroundAssetVersionAttributes{State: "COMPLETE", Version: "5", CreatedDate: "2026-04-01T00:00:00Z", Platforms: []asc.Platform{asc.PlatformMacOS}},
+		},
+		{
+			Type:       asc.ResourceTypeBackgroundAssetVersions,
+			ID:         "ver-us-ios",
+			Attributes: asc.BackgroundAssetVersionAttributes{State: "COMPLETE", Version: "2", CreatedDate: "2026-02-01T00:00:00Z", Platforms: []asc.Platform{asc.PlatformIOS}},
+		},
+	}
+	items, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+		appID:              "APP",
+		platform:           "IOS",
+		backgroundAssetIDs: []string{"asset-1"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].BackgroundAssetVersionID != "ver-us-ios" {
+		t.Fatalf("expected IOS version ver-us-ios, got %+v", items)
+	}
+}
+
+func TestFetchAlreadyAttachedBackgroundAssetVersions(t *testing.T) {
+	client := newFakeSubmitClient()
+	client.existingItems = map[string][]asc.ReviewSubmissionItemResource{
+		"sub-1": {
+			{
+				ID: "item-a",
+				Relationships: &asc.ReviewSubmissionItemRelationships{
+					BackgroundAssetVersion: &asc.Relationship{Data: asc.ResourceData{Type: asc.ResourceTypeBackgroundAssetVersions, ID: "ver-a"}},
+				},
+			},
+			{
+				ID: "item-b",
+				Relationships: &asc.ReviewSubmissionItemRelationships{
+					BackgroundAssetVersion: &asc.Relationship{Data: asc.ResourceData{Type: asc.ResourceTypeBackgroundAssetVersions, ID: "ver-b"}},
+				},
+			},
+			{
+				ID: "item-app-version",
+				Relationships: &asc.ReviewSubmissionItemRelationships{
+					AppStoreVersion: &asc.Relationship{Data: asc.ResourceData{Type: asc.ResourceTypeAppStoreVersions, ID: "asv-1"}},
+				},
+			},
+		},
+	}
+	attached, err := fetchAlreadyAttachedBackgroundAssetVersions(context.Background(), client, "sub-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(attached) != 2 {
+		t.Fatalf("expected 2 background-asset versions, got %d (%v)", len(attached), attached)
+	}
+	if _, ok := attached["ver-a"]; !ok {
+		t.Errorf("missing ver-a")
+	}
+	if _, ok := attached["ver-b"]; !ok {
+		t.Errorf("missing ver-b")
+	}
+}
+
+func TestResolveBackgroundAssetSubmitItems_PlatformMismatchProducesError(t *testing.T) {
+	client := newFakeSubmitClient()
+	client.versions["asset-1"] = []ascBackgroundAssetVersionItem{
+		{
+			Type:       asc.ResourceTypeBackgroundAssetVersions,
+			ID:         "ver-mac-only",
+			Attributes: asc.BackgroundAssetVersionAttributes{State: "COMPLETE", Version: "1", Platforms: []asc.Platform{asc.PlatformMacOS}},
+		},
+	}
+	_, err := resolveBackgroundAssetSubmitItems(context.Background(), backgroundAssetSubmitResolver{client: client}, backgroundAssetSubmitSelection{
+		appID:              "APP",
+		platform:           "IOS",
+		backgroundAssetIDs: []string{"asset-1"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "for platform IOS") {
+		t.Fatalf("expected error for platform mismatch, got %v", err)
+	}
+}

--- a/internal/cli/backgroundassets/background_assets_submit_test.go
+++ b/internal/cli/backgroundassets/background_assets_submit_test.go
@@ -246,6 +246,13 @@ func TestFetchAlreadyAttachedBackgroundAssetVersions(t *testing.T) {
 				},
 			},
 			{
+				ID:         "item-removed",
+				Attributes: asc.ReviewSubmissionItemAttributes{State: "REMOVED"},
+				Relationships: &asc.ReviewSubmissionItemRelationships{
+					BackgroundAssetVersion: &asc.Relationship{Data: asc.ResourceData{Type: asc.ResourceTypeBackgroundAssetVersions, ID: "ver-removed"}},
+				},
+			},
+			{
 				ID: "item-app-version",
 				Relationships: &asc.ReviewSubmissionItemRelationships{
 					AppStoreVersion: &asc.Relationship{Data: asc.ResourceData{Type: asc.ResourceTypeAppStoreVersions, ID: "asv-1"}},
@@ -265,6 +272,9 @@ func TestFetchAlreadyAttachedBackgroundAssetVersions(t *testing.T) {
 	}
 	if _, ok := attached["ver-b"]; !ok {
 		t.Errorf("missing ver-b")
+	}
+	if _, ok := attached["ver-removed"]; ok {
+		t.Errorf("expected REMOVED item ver-removed to be excluded")
 	}
 }
 

--- a/internal/cli/cmdtest/background_assets_submit_test.go
+++ b/internal/cli/cmdtest/background_assets_submit_test.go
@@ -1,0 +1,522 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBackgroundAssetsSubmitValidationErrors(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing app",
+			args:    []string{"background-assets", "submit", "--all", "--confirm"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "missing selection",
+			args:    []string{"background-assets", "submit", "--app", "123456789", "--confirm"},
+			wantErr: "one of --all, --asset-pack-identifier, --background-asset-id, or --version-id is required",
+		},
+		{
+			name:    "mutually exclusive selection: --all + --asset-pack-identifier",
+			args:    []string{"background-assets", "submit", "--app", "123456789", "--all", "--asset-pack-identifier", "stamps.us", "--confirm"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "mutually exclusive selection: --background-asset-id + --version-id",
+			args:    []string{"background-assets", "submit", "--app", "123456789", "--background-asset-id", "AID", "--version-id", "VID", "--confirm"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "missing confirm and dry-run",
+			args:    []string{"background-assets", "submit", "--app", "123456789", "--all"},
+			wantErr: "--confirm is required unless --dry-run is set",
+		},
+		{
+			name:    "no-submit conflicts with dry-run",
+			args:    []string{"background-assets", "submit", "--app", "123456789", "--all", "--dry-run", "--no-submit"},
+			wantErr: "--no-submit and --dry-run are mutually exclusive",
+		},
+		{
+			name:    "invalid platform",
+			args:    []string{"background-assets", "submit", "--app", "123456789", "--all", "--platform", "WEBOS", "--confirm"},
+			wantErr: "platform",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestBackgroundAssetsSubmitDryRunWithExplicitVersionIDsDoesNotCallNetwork(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var calls int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		t.Fatalf("unexpected network call during dry-run: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	args := []string{
+		"background-assets", "submit",
+		"--app", "123456789",
+		"--version-id", "ver-a, ver-b",
+		"--dry-run",
+		"--output", "json",
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if atomic.LoadInt32(&calls) != 0 {
+		t.Fatalf("expected zero network calls, got %d", calls)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var parsed struct {
+		AppID         string `json:"appId"`
+		DryRun        bool   `json:"dryRun"`
+		AttachedItems int    `json:"attachedItems"`
+		Items         []struct {
+			BackgroundAssetVersionID string `json:"backgroundAssetVersionId"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("expected valid JSON on stdout, got %q (err=%v)", stdout, err)
+	}
+	if !parsed.DryRun {
+		t.Fatalf("expected dryRun=true, got %+v", parsed)
+	}
+	if parsed.AppID != "123456789" {
+		t.Fatalf("expected appId=123456789, got %q", parsed.AppID)
+	}
+	if len(parsed.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(parsed.Items))
+	}
+	if parsed.Items[0].BackgroundAssetVersionID != "ver-a" || parsed.Items[1].BackgroundAssetVersionID != "ver-b" {
+		t.Fatalf("expected items [ver-a ver-b], got %+v", parsed.Items)
+	}
+}
+
+func TestBackgroundAssetsSubmitAllHappyPath(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	type counters struct {
+		listAssets       int32
+		listVersionsByID map[string]*int32
+		createSubmission int32
+		createItem       int32
+		patchSubmit      int32
+	}
+	c := &counters{listVersionsByID: map[string]*int32{
+		"asset-1": new(int32),
+		"asset-2": new(int32),
+	}}
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		path := req.URL.Path
+		switch {
+		case req.Method == http.MethodGet && path == "/v1/apps/123456789/backgroundAssets":
+			atomic.AddInt32(&c.listAssets, 1)
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"backgroundAssets","id":"asset-1","attributes":{"assetPackIdentifier":"pack.one"}},
+				{"type":"backgroundAssets","id":"asset-2","attributes":{"assetPackIdentifier":"pack.two"}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && strings.HasPrefix(path, "/v1/backgroundAssets/") && strings.HasSuffix(path, "/versions"):
+			assetID := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/backgroundAssets/"), "/versions")
+			counter, ok := c.listVersionsByID[assetID]
+			if !ok {
+				t.Fatalf("unexpected versions list for asset %q", assetID)
+			}
+			atomic.AddInt32(counter, 1)
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"backgroundAssetVersions","id":"`+assetID+`-v1","attributes":{"state":"COMPLETE","version":"1","platforms":["IOS"],"createdDate":"2026-05-01T00:00:00Z"}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodPost && path == "/v1/reviewSubmissions":
+			atomic.AddInt32(&c.createSubmission, 1)
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"sub-xyz","attributes":{"platform":"IOS","state":"READY_FOR_REVIEW"}}}`)
+		case req.Method == http.MethodPost && path == "/v1/reviewSubmissionItems":
+			atomic.AddInt32(&c.createItem, 1)
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissionItems","id":"item-`+req.URL.Path+`"}}`)
+		case req.Method == http.MethodPatch && path == "/v1/reviewSubmissions/sub-xyz":
+			atomic.AddInt32(&c.patchSubmit, 1)
+			return jsonResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"sub-xyz","attributes":{"platform":"IOS","state":"WAITING_FOR_REVIEW","submittedDate":"2026-05-14T18:33:37Z"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	args := []string{
+		"background-assets", "submit",
+		"--app", "123456789",
+		"--all",
+		"--confirm",
+		"--output", "json",
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if got := atomic.LoadInt32(&c.listAssets); got != 1 {
+		t.Errorf("expected 1 listAssets call, got %d", got)
+	}
+	if got := atomic.LoadInt32(c.listVersionsByID["asset-1"]); got != 1 {
+		t.Errorf("expected 1 listVersions call for asset-1, got %d", got)
+	}
+	if got := atomic.LoadInt32(c.listVersionsByID["asset-2"]); got != 1 {
+		t.Errorf("expected 1 listVersions call for asset-2, got %d", got)
+	}
+	if got := atomic.LoadInt32(&c.createSubmission); got != 1 {
+		t.Errorf("expected 1 createSubmission call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&c.createItem); got != 2 {
+		t.Errorf("expected 2 createItem calls, got %d", got)
+	}
+	if got := atomic.LoadInt32(&c.patchSubmit); got != 1 {
+		t.Errorf("expected 1 patchSubmit call, got %d", got)
+	}
+
+	var parsed struct {
+		SubmissionID    string `json:"submissionId"`
+		SubmissionState string `json:"submissionState"`
+		AttachedItems   int    `json:"attachedItems"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("invalid JSON on stdout: %v\n%s", err, stdout)
+	}
+	if parsed.SubmissionID != "sub-xyz" {
+		t.Errorf("expected submissionId sub-xyz, got %q", parsed.SubmissionID)
+	}
+	if parsed.SubmissionState != "WAITING_FOR_REVIEW" {
+		t.Errorf("expected submissionState WAITING_FOR_REVIEW, got %q", parsed.SubmissionState)
+	}
+	if parsed.AttachedItems != 2 {
+		t.Errorf("expected 2 attached items, got %d", parsed.AttachedItems)
+	}
+}
+
+func TestBackgroundAssetsSubmitReuseExistingSkipsAttached(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var (
+		createSubmission int32
+		createItem       int32
+		patchSubmit      int32
+		listItems        int32
+	)
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		path := req.URL.Path
+		switch {
+		case req.Method == http.MethodGet && path == "/v1/apps/123456789/backgroundAssets":
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"backgroundAssets","id":"asset-1","attributes":{"assetPackIdentifier":"pack.one"}},
+				{"type":"backgroundAssets","id":"asset-2","attributes":{"assetPackIdentifier":"pack.two"}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && strings.HasPrefix(path, "/v1/backgroundAssets/") && strings.HasSuffix(path, "/versions"):
+			assetID := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/backgroundAssets/"), "/versions")
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"backgroundAssetVersions","id":"`+assetID+`-v1","attributes":{"state":"COMPLETE","version":"1","platforms":["IOS"]}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && path == "/v1/reviewSubmissions/sub-existing/items":
+			atomic.AddInt32(&listItems, 1)
+			if include := req.URL.Query().Get("include"); !strings.Contains(include, "backgroundAssetVersion") {
+				t.Errorf("expected include=backgroundAssetVersion on items list, got %q", include)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"reviewSubmissionItems","id":"existing-item-1","attributes":{"state":"READY_FOR_REVIEW"},"relationships":{"backgroundAssetVersion":{"data":{"type":"backgroundAssetVersions","id":"asset-1-v1"}}}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodPost && path == "/v1/reviewSubmissions":
+			atomic.AddInt32(&createSubmission, 1)
+			t.Errorf("CreateReviewSubmission should not be called when reusing")
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"unexpected"}}`)
+		case req.Method == http.MethodPost && path == "/v1/reviewSubmissionItems":
+			atomic.AddInt32(&createItem, 1)
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissionItems","id":"item-new"}}`)
+		case req.Method == http.MethodPatch && path == "/v1/reviewSubmissions/sub-existing":
+			atomic.AddInt32(&patchSubmit, 1)
+			return jsonResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"sub-existing","attributes":{"state":"WAITING_FOR_REVIEW","submittedDate":"2026-05-14T18:33:37Z"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	args := []string{
+		"background-assets", "submit",
+		"--app", "123456789",
+		"--all",
+		"--review-submission-id", "sub-existing",
+		"--confirm",
+		"--output", "json",
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if got := atomic.LoadInt32(&listItems); got != 1 {
+		t.Errorf("expected 1 listItems call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&createSubmission); got != 0 {
+		t.Errorf("expected 0 createSubmission calls when reusing, got %d", got)
+	}
+	if got := atomic.LoadInt32(&createItem); got != 1 {
+		t.Errorf("expected 1 createItem call (asset-1 already attached, asset-2 new), got %d", got)
+	}
+	if got := atomic.LoadInt32(&patchSubmit); got != 1 {
+		t.Errorf("expected 1 patchSubmit call, got %d", got)
+	}
+
+	var parsed struct {
+		AttachedItems          int `json:"attachedItems"`
+		SkippedAlreadyAttached []struct {
+			BackgroundAssetVersionID string `json:"backgroundAssetVersionId"`
+		} `json:"skippedAlreadyAttached"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("invalid JSON on stdout: %v\n%s", err, stdout)
+	}
+	if parsed.AttachedItems != 1 {
+		t.Errorf("expected 1 newly attached item, got %d", parsed.AttachedItems)
+	}
+	if len(parsed.SkippedAlreadyAttached) != 1 || parsed.SkippedAlreadyAttached[0].BackgroundAssetVersionID != "asset-1-v1" {
+		t.Errorf("expected 1 skipped item asset-1-v1, got %+v", parsed.SkippedAlreadyAttached)
+	}
+}
+
+func TestBackgroundAssetsSubmitRollsBackEmptySubmissionOnFirstAttachFailure(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var (
+		createSubmission int32
+		patchCancel      int32
+	)
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		path := req.URL.Path
+		switch {
+		case req.Method == http.MethodGet && path == "/v1/apps/123456789/backgroundAssets":
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"backgroundAssets","id":"asset-1","attributes":{"assetPackIdentifier":"pack.one"}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && strings.HasPrefix(path, "/v1/backgroundAssets/") && strings.HasSuffix(path, "/versions"):
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"backgroundAssetVersions","id":"asset-1-v1","attributes":{"state":"COMPLETE","version":"1","platforms":["IOS"]}}
+			],"links":{"next":""}}`)
+		case req.Method == http.MethodPost && path == "/v1/reviewSubmissions":
+			atomic.AddInt32(&createSubmission, 1)
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"sub-doomed","attributes":{"platform":"IOS","state":"READY_FOR_REVIEW"}}}`)
+		case req.Method == http.MethodPost && path == "/v1/reviewSubmissionItems":
+			return jsonResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.STATE_NOT_ALLOWED","detail":"already attached to another submission"}]}`)
+		case req.Method == http.MethodPatch && path == "/v1/reviewSubmissions/sub-doomed":
+			atomic.AddInt32(&patchCancel, 1)
+			return jsonResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"sub-doomed","attributes":{"state":"CANCELING"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	args := []string{
+		"background-assets", "submit",
+		"--app", "123456789",
+		"--all",
+		"--confirm",
+		"--output", "json",
+	}
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatalf("expected error when first attach fails, got nil")
+	}
+	if !strings.Contains(runErr.Error(), "rolled back the submission") {
+		t.Fatalf("expected error to mention rollback, got %v", runErr)
+	}
+	if got := atomic.LoadInt32(&createSubmission); got != 1 {
+		t.Errorf("expected 1 createSubmission call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&patchCancel); got != 1 {
+		t.Errorf("expected 1 cancel call (rollback), got %d", got)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout on failure, got %q", stdout)
+	}
+}
+
+func TestBackgroundAssetsSubmitFlagOrderEdgeCases(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("dry-run should not call the network: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "all flags before subcommand-style positionals",
+			args: []string{
+				"background-assets", "submit",
+				"--app", "123456789",
+				"--version-id", "v1",
+				"--platform", "IOS",
+				"--dry-run",
+				"--output", "json",
+			},
+		},
+		{
+			name: "flag values that look like subcommand names",
+			args: []string{
+				"background-assets", "submit",
+				"--app", "123456789",
+				"--version-id", "submit",
+				"--dry-run",
+				"--output", "json",
+			},
+		},
+		{
+			name: "mixed-order: dry-run before app, output last",
+			args: []string{
+				"background-assets", "submit",
+				"--dry-run",
+				"--version-id", "vx",
+				"--app", "123456789",
+				"--output", "json",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(c.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if err != nil && !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("unexpected run error: %v", err)
+				}
+			})
+
+			if !strings.Contains(stdout, `"dryRun": true`) && !strings.Contains(stdout, `"dryRun":true`) {
+				if stderr == "" {
+					t.Fatalf("expected dry-run JSON on stdout or a recognizable validation error on stderr; got stdout=%q stderr=%q", stdout, stderr)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/background_assets_submit_test.go
+++ b/internal/cli/cmdtest/background_assets_submit_test.go
@@ -97,7 +97,7 @@ func TestBackgroundAssetsSubmitDryRunWithExplicitVersionIDsDoesNotCallNetwork(t 
 	args := []string{
 		"background-assets", "submit",
 		"--app", "123456789",
-		"--version-id", "ver-a, ver-b",
+		"--version-id", "ver-a, ver-a, ver-b",
 		"--dry-run",
 		"--output", "json",
 	}

--- a/internal/cli/cmdtest/background_assets_submit_test.go
+++ b/internal/cli/cmdtest/background_assets_submit_test.go
@@ -3,14 +3,14 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestBackgroundAssetsSubmitValidationErrors(t *testing.T) {
@@ -60,16 +60,9 @@ func TestBackgroundAssetsSubmitValidationErrors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			root := RootCommand("1.2.3")
-			root.FlagSet.SetOutput(io.Discard)
-
 			stdout, stderr := captureOutput(t, func() {
-				if err := root.Parse(test.args); err != nil {
-					t.Fatalf("parse error: %v", err)
-				}
-				err := root.Run(context.Background())
-				if !errors.Is(err, flag.ErrHelp) {
-					t.Fatalf("expected ErrHelp, got %v", err)
+				if code := rootcmd.Run(test.args, "1.2.3"); code != rootcmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", rootcmd.ExitUsage, code)
 				}
 			})
 
@@ -465,6 +458,17 @@ func TestBackgroundAssetsSubmitFlagOrderEdgeCases(t *testing.T) {
 		args []string
 	}{
 		{
+			name: "global flag before subcommands",
+			args: []string{
+				"--profile", "review-edge",
+				"background-assets", "submit",
+				"--app", "123456789",
+				"--version-id", "v-before",
+				"--dry-run",
+				"--output", "json",
+			},
+		},
+		{
 			name: "all flags before subcommand-style positionals",
 			args: []string{
 				"background-assets", "submit",
@@ -506,16 +510,22 @@ func TestBackgroundAssetsSubmitFlagOrderEdgeCases(t *testing.T) {
 				if err := root.Parse(c.args); err != nil {
 					t.Fatalf("parse error: %v", err)
 				}
-				err := root.Run(context.Background())
-				if err != nil && !errors.Is(err, flag.ErrHelp) {
+				if err := root.Run(context.Background()); err != nil {
 					t.Fatalf("unexpected run error: %v", err)
 				}
 			})
 
-			if !strings.Contains(stdout, `"dryRun": true`) && !strings.Contains(stdout, `"dryRun":true`) {
-				if stderr == "" {
-					t.Fatalf("expected dry-run JSON on stdout or a recognizable validation error on stderr; got stdout=%q stderr=%q", stdout, stderr)
-				}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			var out struct {
+				DryRun bool `json:"dryRun"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+				t.Fatalf("expected valid dry-run JSON on stdout, got %q (err=%v)", stdout, err)
+			}
+			if !out.DryRun {
+				t.Fatalf("expected dryRun=true in stdout JSON, got %q", stdout)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds `asc background-assets submit` to submit background-asset pack versions for App Store review via the existing `reviewSubmissions` flow. Wraps `create` + `items-add(backgroundAssetVersion)` + `submit` into one verb so callers don't have to drive the three primitives manually, especially when submitting many packs.

The new command lives in `internal/cli/backgroundassets/` and **adds no new HTTP client code** — it composes the existing `{Create,Cancel,Submit}ReviewSubmission` and `CreateReviewSubmissionItem(backgroundAssetVersion)` primitives.

## Why

Submitting background-asset packs for review today requires manually driving:
1. `asc review submissions-create --app … --platform IOS`
2. `asc review items-add --submission … --item-type backgroundAssetVersions --item-id …` (per pack)
3. `asc review submissions-submit --id … --confirm`

For apps with many packs that's `N + 2` commands plus manually resolving each pack's latest COMPLETE version. There was also no discoverable verb under `asc background-assets …` for this — users naturally look there first.

## Behavior

```
asc background-assets submit --app APP_ID [flags]
```

**Selection (mutually exclusive):**
- `--all` — every non-archived pack on the app
- `--asset-pack-identifier "id1,id2"` — specific packs by identifier
- `--background-asset-id "UUID,UUID"` — specific assets by ID
- `--version-id "VID,VID"` — explicit version IDs (skips lookup)

**Other flags:** `--platform IOS|MAC_OS|TV_OS|VISION_OS` (default IOS), `--review-submission-id` (attach to existing submission instead of creating one), `--dry-run`, `--no-submit`, `--confirm`.

**Resolution rule:** for selection modes that look up versions, the newest `COMPLETE` version per pack is picked, filtered by `--platform` if the version reports `Platforms`. Errors if a pack has no eligible COMPLETE version.

**Reuse + skip:** when `--review-submission-id` is provided, items already attached to that submission are detected (with `include=backgroundAssetVersion`) and skipped, reporting them under `skippedAlreadyAttached`. Items in state `REMOVED` are ignored so previously-removed versions are re-attachable.

**Rollback:** if `CreateReviewSubmissionItem` fails for a submission this command created, the partial submission is rolled back via `CancelReviewSubmission` so callers aren't left with an empty or half-filled submission in ASC.

**Auth:** the ASC client is created lazily — `--version-id … --dry-run` is fully offline (no auth required).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full suite passes
- [x] `make format-check` — clean (gofumpt)
- [x] `asc background-assets --help` shows the new subcommand
- [x] `asc background-assets submit --help` renders flags + examples correctly
- [x] Resolver unit tests cover: `--all` (skips archived), `--asset-pack-identifier` (missing-pack error), `--background-asset-id` (missing-id error), `--version-id` (trims/skips blanks), platform filter, no-COMPLETE-version error, already-attached skipping, REMOVED-state items ignored
- [x] Flag-validation tests cover: missing `--app`, missing selection, mutually-exclusive selection, missing `--confirm`/`--dry-run`, `--no-submit` + `--dry-run` conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `background-assets submit` CLI command with dry-run support, comprehensive flag validation, multiple selection modes, platform-aware version resolution, attach/rollback behavior, reuse of existing submissions, and optional no-submit mode.
* **Documentation**
  * Help text updated with new example usages for creating upload-files requests (version id, file path, asset type).
* **Tests**
  * Added unit and integration tests covering validation, resolution logic, dry-run behavior, submission lifecycle, rollback, and flag-order edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1532)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->