### PR TITLE
[codex] Add batch customer review replies

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -451,6 +451,7 @@ func TestRootCommand_ReleaseHelpMentionsCanonicalPathAndStatus(t *testing.T) {
 	}
 	if releaseCmd == nil {
 		t.Fatal("expected release subcommand to be registered")
+		return
 	}
 
 	usage := releaseCmd.UsageFunc(releaseCmd)
@@ -492,6 +493,7 @@ func TestRootCommand_WorkflowHelpMentionsReleaseAndStatusMonitoring(t *testing.T
 	}
 	if workflowCmd == nil {
 		t.Fatal("expected workflow subcommand to be registered")
+		return
 	}
 
 	usage := workflowCmd.UsageFunc(workflowCmd)

--- a/internal/appleauth/twofactor_test.go
+++ b/internal/appleauth/twofactor_test.go
@@ -51,6 +51,7 @@ func TestAuthOptionsResponseAuthOptionsCopiesTrustedPhoneNumbers(t *testing.T) {
 	got := resp.AuthOptions()
 	if got == nil {
 		t.Fatal("expected auth options response conversion result")
+		return
 	}
 	if !got.NoTrustedDevices {
 		t.Fatal("expected noTrustedDevices to be preserved")
@@ -73,6 +74,7 @@ func TestNilAuthOptionsResponseReturnsEmptyOptions(t *testing.T) {
 	got := resp.AuthOptions()
 	if got == nil {
 		t.Fatal("expected empty auth options for nil response")
+		return
 	}
 	if got.NoTrustedDevices {
 		t.Fatal("did not expect noTrustedDevices on nil response")

--- a/internal/asc/client_core_auth_test.go
+++ b/internal/asc/client_core_auth_test.go
@@ -19,6 +19,7 @@ func TestNewClientFromPEM(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if client.privateKey == nil {
 		t.Fatal("expected private key to be initialized")

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -2266,6 +2266,7 @@ func TestUpdateBuild_RefetchesCurrentStateAfterPatchError(t *testing.T) {
 	}
 	if resp == nil {
 		t.Fatal("expected response")
+		return
 	}
 	if resp.Data.Attributes.UsesNonExemptEncryption == nil || *resp.Data.Attributes.UsesNonExemptEncryption != false {
 		t.Fatalf("expected usesNonExemptEncryption=false, got %+v", resp.Data.Attributes.UsesNonExemptEncryption)

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -1019,6 +1019,21 @@ func WithReviewSort(sort string) ReviewOption {
 	}
 }
 
+// WithPublishedResponseExists filters reviews by whether a published response exists.
+func WithPublishedResponseExists(exists bool) ReviewOption {
+	return func(r *reviewQuery) {
+		value := exists
+		r.publishedResponseExists = &value
+	}
+}
+
+// WithReviewIncludeResponse includes review response relationships in review results.
+func WithReviewIncludeResponse() ReviewOption {
+	return func(r *reviewQuery) {
+		r.includeResponse = true
+	}
+}
+
 // WithLimit sets the max number of reviews to return.
 func WithLimit(limit int) ReviewOption {
 	return func(r *reviewQuery) {

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -39,9 +39,11 @@ type crashQuery struct {
 
 type reviewQuery struct {
 	listQuery
-	rating    int
-	territory string
-	sort      string
+	rating                  int
+	territory               string
+	sort                    string
+	publishedResponseExists *bool
+	includeResponse         bool
 }
 
 type appsQuery struct {
@@ -625,6 +627,12 @@ func buildReviewQuery(opts []ReviewOption) string {
 	}
 	if query.sort != "" {
 		values.Set("sort", query.sort)
+	}
+	if query.publishedResponseExists != nil {
+		values.Set("exists[publishedResponse]", strconv.FormatBool(*query.publishedResponseExists))
+	}
+	if query.includeResponse {
+		values.Set("include", "response")
 	}
 	addLimit(values, query.limit)
 

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -19,6 +19,8 @@ func TestBuildReviewQuery(t *testing.T) {
 		WithTerritory("us"),
 		WithLimit(25),
 		WithReviewSort("-createdDate"),
+		WithPublishedResponseExists(false),
+		WithReviewIncludeResponse(),
 	})
 
 	values, err := url.ParseQuery(query)
@@ -40,6 +42,14 @@ func TestBuildReviewQuery(t *testing.T) {
 
 	if got := values.Get("sort"); got != "-createdDate" {
 		t.Fatalf("expected sort=-createdDate, got %q", got)
+	}
+
+	if got := values.Get("exists[publishedResponse]"); got != "false" {
+		t.Fatalf("expected exists[publishedResponse]=false, got %q", got)
+	}
+
+	if got := values.Get("include"); got != "response" {
+		t.Fatalf("expected include=response, got %q", got)
 	}
 }
 

--- a/internal/asc/review_responses.go
+++ b/internal/asc/review_responses.go
@@ -73,6 +73,29 @@ const ResourceTypeCustomerReviewResponses ResourceType = "customerReviewResponse
 // ResourceTypeCustomerReviews is the resource type for customer reviews.
 const ResourceTypeCustomerReviews ResourceType = "customerReviews"
 
+// CustomerReviewPublishedResponseID extracts the response relationship from a customer review resource.
+func CustomerReviewPublishedResponseID(review Resource[ReviewAttributes]) (string, bool) {
+	if len(review.Relationships) == 0 {
+		return "", false
+	}
+
+	var relationships struct {
+		Response *Relationship `json:"response"`
+	}
+	if err := json.Unmarshal(review.Relationships, &relationships); err != nil {
+		return "", false
+	}
+	if relationships.Response == nil {
+		return "", false
+	}
+
+	id := strings.TrimSpace(relationships.Response.Data.ID)
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
 // CreateCustomerReviewResponse creates a response to a customer review.
 func (c *Client) CreateCustomerReviewResponse(ctx context.Context, reviewID, responseBody string) (*CustomerReviewResponseResponse, error) {
 	reviewID = strings.TrimSpace(reviewID)

--- a/internal/asc/review_responses_test.go
+++ b/internal/asc/review_responses_test.go
@@ -298,3 +298,41 @@ func TestGetCustomerReviewResponseForReview_ValidationErrors(t *testing.T) {
 		t.Fatalf("expected error for whitespace reviewID, got nil")
 	}
 }
+
+func TestCustomerReviewPublishedResponseID(t *testing.T) {
+	review := Resource[ReviewAttributes]{
+		ID: "review-1",
+		Relationships: json.RawMessage(`{
+			"response": {
+				"data": {
+					"type": "customerReviewResponses",
+					"id": "response-1"
+				}
+			}
+		}`),
+	}
+
+	got, ok := CustomerReviewPublishedResponseID(review)
+	if !ok {
+		t.Fatal("expected response relationship")
+	}
+	if got != "response-1" {
+		t.Fatalf("expected response-1, got %q", got)
+	}
+}
+
+func TestCustomerReviewPublishedResponseIDReturnsFalseWhenUnset(t *testing.T) {
+	review := Resource[ReviewAttributes]{
+		ID: "review-1",
+		Relationships: json.RawMessage(`{
+			"response": {
+				"data": null
+			}
+		}`),
+	}
+
+	got, ok := CustomerReviewPublishedResponseID(review)
+	if ok {
+		t.Fatalf("expected no response relationship, got %q", got)
+	}
+}

--- a/internal/asc/review_submissions_test.go
+++ b/internal/asc/review_submissions_test.go
@@ -405,6 +405,7 @@ func TestCreateReviewSubmissionItem_SupportedItemTypes(t *testing.T) {
 				relationship := test.getRelationship(payload.Data.Relationships)
 				if relationship == nil {
 					t.Fatalf("expected relationship for item type %q", test.itemType)
+					return
 				}
 				if relationship.Data.Type != test.wantType {
 					t.Fatalf("expected relationship type %q, got %q", test.wantType, relationship.Data.Type)

--- a/internal/cli/accessibility/accessibility_test.go
+++ b/internal/cli/accessibility/accessibility_test.go
@@ -11,6 +11,7 @@ func TestAccessibilityCommandShape(t *testing.T) {
 	cmd := AccessibilityCommand()
 	if cmd == nil {
 		t.Fatal("expected accessibility command")
+		return
 	}
 	if cmd.Name != "accessibility" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/actors/actors_test.go
+++ b/internal/cli/actors/actors_test.go
@@ -11,6 +11,7 @@ func TestActorsCommandShape(t *testing.T) {
 	cmd := ActorsCommand()
 	if cmd == nil {
 		t.Fatal("expected actors command")
+		return
 	}
 	if cmd.Name != "actors" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -14,6 +14,7 @@ func TestAgeRatingCommandShape(t *testing.T) {
 	cmd := AgeRatingCommand()
 	if cmd == nil {
 		t.Fatal("expected age-rating command")
+		return
 	}
 	if cmd.Name != "age-rating" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/agreements/agreements_test.go
+++ b/internal/cli/agreements/agreements_test.go
@@ -11,6 +11,7 @@ func TestAgreementsCommandShape(t *testing.T) {
 	cmd := AgreementsCommand()
 	if cmd == nil {
 		t.Fatal("expected agreements command")
+		return
 	}
 	if cmd.Name != "agreements" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/androidiosmapping/android_ios_mapping_test.go
+++ b/internal/cli/androidiosmapping/android_ios_mapping_test.go
@@ -6,6 +6,7 @@ func TestAndroidIosMappingCommandConstructors(t *testing.T) {
 	cmd := AndroidIosMappingCommand()
 	if cmd == nil {
 		t.Fatal("expected android-ios-mapping command")
+		return
 	}
 	if cmd.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/app_events/app_events_test.go
+++ b/internal/cli/app_events/app_events_test.go
@@ -6,6 +6,7 @@ func TestAppEventsCommandConstructors(t *testing.T) {
 	top := AppEventsCommand()
 	if top == nil {
 		t.Fatal("expected app-events command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected top-level command name")

--- a/internal/cli/appclips/app_clips_test.go
+++ b/internal/cli/appclips/app_clips_test.go
@@ -6,6 +6,7 @@ func TestAppClipsCommandConstructors(t *testing.T) {
 	top := AppClipsCommand()
 	if top == nil {
 		t.Fatal("expected app-clips command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected top-level command name")

--- a/internal/cli/apps/app_setup_test.go
+++ b/internal/cli/apps/app_setup_test.go
@@ -194,6 +194,7 @@ func TestAppSetupCommands_DefaultOutputJSON(t *testing.T) {
 			f := cmd.FlagSet.Lookup("output")
 			if f == nil {
 				t.Fatalf("expected --output flag to be defined")
+				return
 			}
 			if f.DefValue != "json" {
 				t.Fatalf("expected --output default to be 'json', got %q", f.DefValue)

--- a/internal/cli/apps/community_wall_submit_help_test.go
+++ b/internal/cli/apps/community_wall_submit_help_test.go
@@ -10,6 +10,7 @@ func TestAppsWallSubmitHelpMentionsPublicAppStoreLookup(t *testing.T) {
 	cmd := AppsWallSubmitCommand(flag.NewFlagSet("wall", flag.ContinueOnError))
 	if cmd == nil {
 		t.Fatal("expected apps wall submit command")
+		return
 	}
 
 	usage := cmd.UsageFunc(cmd)

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -25,6 +25,7 @@ func TestCommandWrapperReturnsAuthCommand(t *testing.T) {
 	cmd := AuthCommand()
 	if cmd == nil {
 		t.Fatal("AuthCommand() returned nil")
+		return
 	}
 	if cmd.Name != "auth" {
 		t.Fatalf("AuthCommand().Name = %q, want %q", cmd.Name, "auth")

--- a/internal/cli/betaapplocalizations/beta_app_localizations_test.go
+++ b/internal/cli/betaapplocalizations/beta_app_localizations_test.go
@@ -6,6 +6,7 @@ func TestBetaAppLocalizationsCommandConstructors(t *testing.T) {
 	top := BetaAppLocalizationsCommand()
 	if top == nil {
 		t.Fatal("expected beta-app-localizations command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/betabuildlocalizations/beta_build_localizations_test.go
+++ b/internal/cli/betabuildlocalizations/beta_build_localizations_test.go
@@ -14,6 +14,7 @@ func TestBetaBuildLocalizationsCommandConstructors(t *testing.T) {
 	top := BetaBuildLocalizationsCommand()
 	if top == nil {
 		t.Fatal("expected beta-build-localizations command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")
@@ -34,11 +35,13 @@ func TestBetaBuildLocalizationsCreateCommandUpsertFlag(t *testing.T) {
 	cmd := BetaBuildLocalizationsCreateCommand()
 	if cmd == nil {
 		t.Fatal("expected create command")
+		return
 	}
 
 	upsertFlag := cmd.FlagSet.Lookup("upsert")
 	if upsertFlag == nil {
 		t.Fatal("expected --upsert flag")
+		return
 	}
 	if !strings.Contains(upsertFlag.Usage, "Create-or-update") {
 		t.Fatalf("expected --upsert usage text, got %q", upsertFlag.Usage)

--- a/internal/cli/buildbundles/build_bundles_test.go
+++ b/internal/cli/buildbundles/build_bundles_test.go
@@ -6,6 +6,7 @@ func TestBuildBundlesCommandConstructors(t *testing.T) {
 	top := BuildBundlesCommand()
 	if top == nil {
 		t.Fatal("expected build-bundles command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/buildlocalizations/build_localizations_test.go
+++ b/internal/cli/buildlocalizations/build_localizations_test.go
@@ -6,6 +6,7 @@ func TestBuildLocalizationsCommandConstructors(t *testing.T) {
 	top := BuildLocalizationsCommand()
 	if top == nil {
 		t.Fatal("expected build-localizations command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -17,6 +17,7 @@ func TestBuildsListCommand_VersionAndBuildNumberDescriptions(t *testing.T) {
 	versionFlag := cmd.FlagSet.Lookup("version")
 	if versionFlag == nil {
 		t.Fatal("expected --version flag to be defined")
+		return
 	}
 	if !strings.Contains(versionFlag.Usage, "CFBundleShortVersionString") {
 		t.Fatalf("expected --version usage to mention marketing version, got %q", versionFlag.Usage)
@@ -25,6 +26,7 @@ func TestBuildsListCommand_VersionAndBuildNumberDescriptions(t *testing.T) {
 	buildNumberFlag := cmd.FlagSet.Lookup("build-number")
 	if buildNumberFlag == nil {
 		t.Fatal("expected --build-number flag to be defined")
+		return
 	}
 	if !strings.Contains(buildNumberFlag.Usage, "CFBundleVersion") {
 		t.Fatalf("expected --build-number usage to mention build number, got %q", buildNumberFlag.Usage)
@@ -44,6 +46,7 @@ func TestBuildsListCommand_ProcessingStateFlagDescription(t *testing.T) {
 	processingStateFlag := cmd.FlagSet.Lookup("processing-state")
 	if processingStateFlag == nil {
 		t.Fatal("expected --processing-state flag to be defined")
+		return
 	}
 	if !strings.Contains(processingStateFlag.Usage, "VALID") || !strings.Contains(processingStateFlag.Usage, "all") {
 		t.Fatalf("expected --processing-state usage to mention supported values, got %q", processingStateFlag.Usage)

--- a/internal/cli/builds/builds_dsyms_test.go
+++ b/internal/cli/builds/builds_dsyms_test.go
@@ -10,6 +10,7 @@ func TestDsymsCommandShape(t *testing.T) {
 	cmd := BuildsDsymsCommand()
 	if cmd == nil {
 		t.Fatal("expected dsyms command")
+		return
 	}
 	if cmd.Name != "dsyms" {
 		t.Errorf("expected name dsyms, got %s", cmd.Name)

--- a/internal/cli/builds/builds_latest_test.go
+++ b/internal/cli/builds/builds_latest_test.go
@@ -154,6 +154,7 @@ func TestBuildsLatestCommand_ProcessingStateFlagDescription(t *testing.T) {
 	processingStateFlag := cmd.FlagSet.Lookup("processing-state")
 	if processingStateFlag == nil {
 		t.Fatal("expected --processing-state flag to be defined")
+		return
 	}
 	if !strings.Contains(processingStateFlag.Usage, "VALID") || !strings.Contains(processingStateFlag.Usage, "all") {
 		t.Fatalf("expected --processing-state usage to mention supported values, got %q", processingStateFlag.Usage)
@@ -232,6 +233,7 @@ func TestSelectNewestBuild(t *testing.T) {
 
 	if newestBuild == nil {
 		t.Fatal("expected to find a newest build")
+		return
 	}
 	if newestBuild.ID != "build-newest" {
 		t.Errorf("expected build-newest to be selected, got %s", newestBuild.ID)

--- a/internal/cli/categories/categories_test.go
+++ b/internal/cli/categories/categories_test.go
@@ -11,6 +11,7 @@ func TestCategoriesCommandShape(t *testing.T) {
 	cmd := CategoriesCommand()
 	if cmd == nil {
 		t.Fatal("expected categories command")
+		return
 	}
 	if cmd.Name != "categories" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/cmdtest/apps_content_rights_surface_test.go
+++ b/internal/cli/cmdtest/apps_content_rights_surface_test.go
@@ -16,6 +16,7 @@ func TestAppsContentRightsCommandSurface(t *testing.T) {
 	group := findSubcommand(root, "apps", "content-rights")
 	if group == nil {
 		t.Fatal("expected apps content-rights command")
+		return
 	}
 	if findSubcommand(root, "apps", "content-rights", "view") == nil {
 		t.Fatal("expected apps content-rights view command")

--- a/internal/cli/cmdtest/apps_public_surface_test.go
+++ b/internal/cli/cmdtest/apps_public_surface_test.go
@@ -82,6 +82,7 @@ func TestAppsPublicHelpShowsSubcommands(t *testing.T) {
 	publicCmd := findSubcommand(root, "apps", "public")
 	if publicCmd == nil {
 		t.Fatal("expected apps public command")
+		return
 	}
 
 	usage := publicCmd.UsageFunc(publicCmd)

--- a/internal/cli/cmdtest/apps_wall_test.go
+++ b/internal/cli/cmdtest/apps_wall_test.go
@@ -39,11 +39,13 @@ func TestAppsWallFlagDefaults(t *testing.T) {
 	cmd := findSubcommand(root, "apps", "wall")
 	if cmd == nil {
 		t.Fatal("expected apps wall command")
+		return
 	}
 
 	outputFlag := cmd.FlagSet.Lookup("output")
 	if outputFlag == nil {
 		t.Fatal("expected --output flag")
+		return
 	}
 	if got := outputFlag.DefValue; got != "table" {
 		t.Fatalf("expected --output default table, got %q", got)
@@ -52,6 +54,7 @@ func TestAppsWallFlagDefaults(t *testing.T) {
 	sortFlag := cmd.FlagSet.Lookup("sort")
 	if sortFlag == nil {
 		t.Fatal("expected --sort flag")
+		return
 	}
 	if got := sortFlag.DefValue; got != "name" {
 		t.Fatalf("expected --sort default name, got %q", got)
@@ -63,11 +66,13 @@ func TestAppsWallSubmitCommandExists(t *testing.T) {
 	cmd := findSubcommand(root, "apps", "wall", "submit")
 	if cmd == nil {
 		t.Fatal("expected apps wall submit command")
+		return
 	}
 
 	outputFlag := cmd.FlagSet.Lookup("output")
 	if outputFlag == nil {
 		t.Fatal("expected --output flag")
+		return
 	}
 	if got := outputFlag.DefValue; got != "json" {
 		t.Fatalf("expected --output default json, got %q", got)

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -125,6 +125,7 @@ func TestCertificatesCSRGenerate_GeneratesKeyAndCSR(t *testing.T) {
 	block, _ := pem.Decode(keyPEM)
 	if block == nil {
 		t.Fatalf("failed to decode private key PEM")
+		return
 	}
 	privAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
@@ -141,6 +142,7 @@ func TestCertificatesCSRGenerate_GeneratesKeyAndCSR(t *testing.T) {
 	csrBlock, _ := pem.Decode(csrPEM)
 	if csrBlock == nil {
 		t.Fatalf("failed to decode CSR PEM")
+		return
 	}
 	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
 	if err != nil {

--- a/internal/cli/cmdtest/default_output_test.go
+++ b/internal/cli/cmdtest/default_output_test.go
@@ -41,11 +41,13 @@ func TestDefaultOutputEnvSetsFlagDefault(t *testing.T) {
 	cmd := findCommand(root, "categories", "list")
 	if cmd == nil {
 		t.Fatal("expected categories list command")
+		return
 	}
 
 	outputFlag := cmd.FlagSet.Lookup("output")
 	if outputFlag == nil {
 		t.Fatal("expected --output flag")
+		return
 	}
 	if got := outputFlag.DefValue; got != "table" {
 		t.Fatalf("expected default output to be table, got %q", got)
@@ -65,11 +67,13 @@ func TestDefaultOutputEnvOverriddenByExplicitFlag(t *testing.T) {
 	cmd := findCommand(root, "categories", "list")
 	if cmd == nil {
 		t.Fatal("expected categories list command")
+		return
 	}
 
 	outputFlag := cmd.FlagSet.Lookup("output")
 	if outputFlag == nil {
 		t.Fatal("expected --output flag")
+		return
 	}
 	if got := outputFlag.Value.String(); got != "json" {
 		t.Fatalf("expected parsed output to be json, got %q", got)
@@ -84,10 +88,12 @@ func TestDefaultOutputEnvIsReevaluatedAcrossRootCommandBuilds(t *testing.T) {
 	firstCmd := findCommand(firstRoot, "categories", "list")
 	if firstCmd == nil {
 		t.Fatal("expected categories list command")
+		return
 	}
 	firstOutputFlag := firstCmd.FlagSet.Lookup("output")
 	if firstOutputFlag == nil {
 		t.Fatal("expected --output flag on first root")
+		return
 	}
 	if got := firstOutputFlag.DefValue; got != "table" {
 		t.Fatalf("expected first default output to be table, got %q", got)
@@ -99,10 +105,12 @@ func TestDefaultOutputEnvIsReevaluatedAcrossRootCommandBuilds(t *testing.T) {
 	secondCmd := findCommand(secondRoot, "categories", "list")
 	if secondCmd == nil {
 		t.Fatal("expected categories list command on rebuilt root")
+		return
 	}
 	secondOutputFlag := secondCmd.FlagSet.Lookup("output")
 	if secondOutputFlag == nil {
 		t.Fatal("expected --output flag on rebuilt root")
+		return
 	}
 	if got := secondOutputFlag.DefValue; got != "json" {
 		t.Fatalf("expected rebuilt root default output to be json, got %q", got)

--- a/internal/cli/cmdtest/iap_offer_code_code_generation_test.go
+++ b/internal/cli/cmdtest/iap_offer_code_code_generation_test.go
@@ -519,6 +519,7 @@ func TestIAPOfferCodesOneTimeCodesCreateHelpShowsEnvironmentFlag(t *testing.T) {
 	cmd := findSubcommand(root, "iap", "offer-codes", "one-time-codes", "create")
 	if cmd == nil {
 		t.Fatal("expected iap offer-codes one-time-codes create command")
+		return
 	}
 
 	usage := cmd.UsageFunc(cmd)

--- a/internal/cli/cmdtest/iap_setup_test.go
+++ b/internal/cli/cmdtest/iap_setup_test.go
@@ -52,6 +52,7 @@ func TestIAPHelpShowsSetupCommand(t *testing.T) {
 	iapCmd := findSubcommand(root, "iap")
 	if iapCmd == nil {
 		t.Fatal("expected iap command")
+		return
 	}
 	iapUsage := iapCmd.UsageFunc(iapCmd)
 	if !usageListsSubcommand(iapUsage, "setup") {
@@ -61,6 +62,7 @@ func TestIAPHelpShowsSetupCommand(t *testing.T) {
 	setupCmd := findSubcommand(root, "iap", "setup")
 	if setupCmd == nil {
 		t.Fatal("expected iap setup command")
+		return
 	}
 	setupUsage := setupCmd.UsageFunc(setupCmd)
 	if !strings.Contains(setupUsage, "--reference-name") {

--- a/internal/cli/cmdtest/metadata_keywords_test.go
+++ b/internal/cli/cmdtest/metadata_keywords_test.go
@@ -19,6 +19,7 @@ func TestMetadataHelpShowsKeywordsWorkflow(t *testing.T) {
 	metadataCmd := findSubcommand(root, "metadata")
 	if metadataCmd == nil {
 		t.Fatal("expected metadata command")
+		return
 	}
 
 	metadataUsage := metadataCmd.UsageFunc(metadataCmd)
@@ -32,6 +33,7 @@ func TestMetadataHelpShowsKeywordsWorkflow(t *testing.T) {
 	keywordsCmd := findSubcommand(root, "metadata", "keywords")
 	if keywordsCmd == nil {
 		t.Fatal("expected metadata keywords command")
+		return
 	}
 	keywordsUsage := keywordsCmd.UsageFunc(keywordsCmd)
 	for _, subcommand := range []string{"import", "audit", "plan", "diff", "localize", "apply", "push", "sync"} {
@@ -50,6 +52,7 @@ func TestRawSearchKeywordsHelpPointsToMetadataKeywords(t *testing.T) {
 	appsCmd := findSubcommand(root, "apps", "search-keywords")
 	if appsCmd == nil {
 		t.Fatal("expected apps search-keywords command")
+		return
 	}
 	appsUsage := appsCmd.UsageFunc(appsCmd)
 	if !strings.Contains(appsUsage, "asc metadata keywords") {
@@ -59,6 +62,7 @@ func TestRawSearchKeywordsHelpPointsToMetadataKeywords(t *testing.T) {
 	localizationsCmd := findSubcommand(root, "localizations", "search-keywords")
 	if localizationsCmd == nil {
 		t.Fatal("expected localizations search-keywords command")
+		return
 	}
 	localizationsUsage := localizationsCmd.UsageFunc(localizationsCmd)
 	if !strings.Contains(localizationsUsage, "asc metadata keywords") {

--- a/internal/cli/cmdtest/reviews_responses_test.go
+++ b/internal/cli/cmdtest/reviews_responses_test.go
@@ -7,9 +7,12 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestReviewsRespondValidationErrors(t *testing.T) {
@@ -52,6 +55,436 @@ func TestReviewsRespondValidationErrors(t *testing.T) {
 				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
 			}
 		})
+	}
+}
+
+func writeReviewBatchFile(t *testing.T, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "replies.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write batch file: %v", err)
+	}
+	return path
+}
+
+func TestReviewsRespondBatchCreatesGroupedReplies(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := writeReviewBatchFile(t, `{
+		"replies": [
+			{"response": "Thanks for the feedback.", "reviewIds": ["review-1", "review-2"]}
+		]
+	}`)
+
+	var postBodies []string
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/customerReviews":
+			if got := req.URL.Query().Get("include"); got != "response" {
+				t.Fatalf("expected include=response, got %q", got)
+			}
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected limit=200, got %q", got)
+			}
+			return jsonResponse(http.StatusOK, `{
+				"data": [
+					{"type":"customerReviews","id":"review-1","attributes":{"rating":5}},
+					{"type":"customerReviews","id":"review-2","attributes":{"rating":4}}
+				],
+				"links": {"self": "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviews"}
+			}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/customerReviewResponses":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			postBodies = append(postBodies, string(body))
+			id := "response-1"
+			if len(postBodies) == 2 {
+				id = "response-2"
+			}
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"customerReviewResponses","id":"`+id+`","attributes":{"responseBody":"Thanks for the feedback.","state":"PENDING_PUBLISH"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if len(postBodies) != 2 {
+		t.Fatalf("expected two create requests, got %d", len(postBodies))
+	}
+	var payload struct {
+		AppID   string `json:"appId"`
+		DryRun  bool   `json:"dryRun"`
+		Summary struct {
+			Total   int `json:"total"`
+			Created int `json:"created"`
+			Skipped int `json:"skipped"`
+			Failed  int `json:"failed"`
+			Planned int `json:"planned"`
+		} `json:"summary"`
+		Results []struct {
+			ReviewID   string `json:"reviewId"`
+			Status     string `json:"status"`
+			ResponseID string `json:"responseId"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	if payload.AppID != "app-1" || payload.DryRun {
+		t.Fatalf("unexpected payload header: %+v", payload)
+	}
+	if payload.Summary.Total != 2 || payload.Summary.Created != 2 || payload.Summary.Skipped != 0 || payload.Summary.Failed != 0 || payload.Summary.Planned != 0 {
+		t.Fatalf("unexpected summary: %+v", payload.Summary)
+	}
+	if len(payload.Results) != 2 || payload.Results[0].Status != "created" || payload.Results[0].ResponseID != "response-1" {
+		t.Fatalf("unexpected results: %+v", payload.Results)
+	}
+	if !strings.Contains(postBodies[0], `"id":"review-1"`) || !strings.Contains(postBodies[1], `"id":"review-2"`) {
+		t.Fatalf("expected create requests for both reviews, got %#v", postBodies)
+	}
+}
+
+func TestReviewsRespondBatchDryRunDoesNotPost(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := writeReviewBatchFile(t, `{"replies":[{"response":"Thanks","reviewIds":["review-1","review-2"]}]}`)
+	requests := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/customerReviews" {
+			t.Fatalf("dry-run should only fetch reviews, got %s %s", req.Method, req.URL.Path)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[{"type":"customerReviews","id":"review-1"},{"type":"customerReviews","id":"review-2"}]}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--dry-run", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one preflight request, got %d", requests)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	summary := payload["summary"].(map[string]any)
+	if int(summary["planned"].(float64)) != 2 || int(summary["created"].(float64)) != 0 {
+		t.Fatalf("unexpected dry-run summary: %+v", summary)
+	}
+}
+
+func TestReviewsRespondBatchSkipExisting(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := writeReviewBatchFile(t, `{"replies":[{"response":"Thanks","reviewIds":["review-1","review-2"]}]}`)
+	posts := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/customerReviews":
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"customerReviews","id":"review-1","relationships":{"response":{"data":{"type":"customerReviewResponses","id":"existing-response"}}}},
+				{"type":"customerReviews","id":"review-2","relationships":{"response":{"data":null}}}
+			]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/customerReviewResponses":
+			posts++
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if !strings.Contains(string(body), `"id":"review-2"`) {
+				t.Fatalf("expected only review-2 to be posted, got %s", body)
+			}
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"customerReviewResponses","id":"response-2"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--skip-existing", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if posts != 1 {
+		t.Fatalf("expected one create request, got %d", posts)
+	}
+	if !strings.Contains(stdout, `"skipped":1`) || !strings.Contains(stdout, `"existingResponseId":"existing-response"`) {
+		t.Fatalf("expected skip-existing result in stdout, got %s", stdout)
+	}
+}
+
+func TestReviewsRespondBatchResponseStateUnrespondedSkipsRespondedReviews(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := writeReviewBatchFile(t, `{"replies":[{"response":"Thanks","reviewIds":["review-1","review-2"]}]}`)
+	posts := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/customerReviews":
+			return jsonResponse(http.StatusOK, `{"data":[
+				{"type":"customerReviews","id":"review-1","relationships":{"response":{"data":{"type":"customerReviewResponses","id":"existing-response"}}}},
+				{"type":"customerReviews","id":"review-2","relationships":{"response":{"data":null}}}
+			]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/customerReviewResponses":
+			posts++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"customerReviewResponses","id":"response-2"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--response-state", "unresponded", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if posts != 1 {
+		t.Fatalf("expected one create request, got %d", posts)
+	}
+	if !strings.Contains(stdout, `"reason":"response-state-mismatch"`) || !strings.Contains(stdout, `"created":1`) {
+		t.Fatalf("expected response-state skip and one create, got %s", stdout)
+	}
+}
+
+func TestReviewsRespondBatchValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "missing app",
+			args:    []string{"reviews", "respond-batch", "--file", "FILE"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "missing file",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1"},
+			wantErr: "--file is required",
+		},
+		{
+			name:    "invalid response state",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE", "--response-state", "maybe"},
+			body:    `{"replies":[{"response":"Thanks","reviewIds":["review-1"]}]}`,
+			wantErr: "--response-state must be one of: any, unresponded, responded",
+		},
+		{
+			name:    "bad json",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE"},
+			body:    `{"replies":[`,
+			wantErr: "failed to parse",
+		},
+		{
+			name:    "trailing json",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE"},
+			body:    `{"replies":[{"response":"Thanks","reviewIds":["review-1"]}]} {"extra":true}`,
+			wantErr: "multiple JSON values are not allowed",
+		},
+		{
+			name:    "duplicate review id",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE"},
+			body:    `{"replies":[{"response":"Thanks","reviewIds":["review-1","review-1"]}]}`,
+			wantErr: "duplicate review id",
+		},
+		{
+			name:    "empty response",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE"},
+			body:    `{"replies":[{"response":" ","reviewIds":["review-1"]}]}`,
+			wantErr: "response is required",
+		},
+		{
+			name:    "empty review id",
+			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE"},
+			body:    `{"replies":[{"response":"Thanks","reviewIds":[" "]}]}`,
+			wantErr: "reviewIds[0] is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := append([]string(nil), test.args...)
+			if strings.Contains(strings.Join(args, " "), "FILE") {
+				path := writeReviewBatchFile(t, test.body)
+				for i := range args {
+					if args[i] == "FILE" {
+						args[i] = path
+					}
+				}
+			}
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/customerReviews" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("exists[publishedResponse]"); got != "false" {
+			t.Fatalf("expected exists[publishedResponse]=false, got %q", got)
+		}
+		if got := req.URL.Query().Get("include"); got != "response" {
+			t.Fatalf("expected include=response, got %q", got)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[{"type":"customerReviews","id":"review-1"}]}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "list", "--app", "app-1", "--response-state", "unresponded", "--include-response", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"review-1"`) {
+		t.Fatalf("expected review output, got %q", stdout)
+	}
+}
+
+func TestReviewsListRejectsInvalidResponseState(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "list", "--app", "app-1", "--response-state", "maybe"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--response-state must be one of: any, unresponded, responded") {
+		t.Fatalf("expected response-state validation, got %q", stderr)
+	}
+}
+
+func TestRunReviewsRespondBatchPartialFailureReturnsExitError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := writeReviewBatchFile(t, `{"replies":[{"response":"Thanks","reviewIds":["review-1","review-2"]}]}`)
+	posts := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/customerReviews":
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"customerReviews","id":"review-1"},{"type":"customerReviews","id":"review-2"}]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/customerReviewResponses":
+			posts++
+			if posts == 1 {
+				return jsonResponse(http.StatusCreated, `{"data":{"type":"customerReviewResponses","id":"response-1"}}`)
+			}
+			return jsonResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","title":"Invalid","detail":"review response failed"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--output", "json"}, "1.2.3")
+		if code != cmd.ExitError {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitError, code)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"created":1`) || !strings.Contains(stdout, `"failed":1`) || !strings.Contains(stdout, `"error":`) {
+		t.Fatalf("expected partial result on stdout, got %s", stdout)
 	}
 }
 

--- a/internal/cli/cmdtest/reviews_responses_test.go
+++ b/internal/cli/cmdtest/reviews_responses_test.go
@@ -68,6 +68,50 @@ func writeReviewBatchFile(t *testing.T, body string) string {
 	return path
 }
 
+type reviewBatchTestOutput struct {
+	Summary reviewBatchTestSummary  `json:"summary"`
+	Results []reviewBatchTestResult `json:"results"`
+}
+
+type reviewBatchTestSummary struct {
+	Total   int `json:"total"`
+	Created int `json:"created"`
+	Skipped int `json:"skipped"`
+	Failed  int `json:"failed"`
+	Planned int `json:"planned"`
+}
+
+type reviewBatchTestResult struct {
+	ReviewID           string `json:"reviewId"`
+	Status             string `json:"status"`
+	ResponseID         string `json:"responseId"`
+	ExistingResponseID string `json:"existingResponseId"`
+	Reason             string `json:"reason"`
+	Error              string `json:"error"`
+}
+
+func decodeReviewBatchTestOutput(t *testing.T, stdout string) reviewBatchTestOutput {
+	t.Helper()
+
+	var payload reviewBatchTestOutput
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	return payload
+}
+
+func findReviewBatchTestResult(t *testing.T, payload reviewBatchTestOutput, reviewID string) reviewBatchTestResult {
+	t.Helper()
+
+	for _, result := range payload.Results {
+		if result.ReviewID == reviewID {
+			return result
+		}
+	}
+	t.Fatalf("expected result for review %q, got %+v", reviewID, payload.Results)
+	return reviewBatchTestResult{}
+}
+
 func TestReviewsRespondBatchCreatesGroupedReplies(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -252,8 +296,13 @@ func TestReviewsRespondBatchSkipExisting(t *testing.T) {
 	if posts != 1 {
 		t.Fatalf("expected one create request, got %d", posts)
 	}
-	if !strings.Contains(stdout, `"skipped":1`) || !strings.Contains(stdout, `"existingResponseId":"existing-response"`) {
-		t.Fatalf("expected skip-existing result in stdout, got %s", stdout)
+	payload := decodeReviewBatchTestOutput(t, stdout)
+	if payload.Summary.Skipped != 1 || payload.Summary.Created != 1 {
+		t.Fatalf("unexpected skip-existing summary: %+v", payload.Summary)
+	}
+	skipped := findReviewBatchTestResult(t, payload, "review-1")
+	if skipped.Status != "skipped" || skipped.ExistingResponseID != "existing-response" || skipped.Reason != "existing-response" {
+		t.Fatalf("unexpected skipped result: %+v", skipped)
 	}
 }
 
@@ -297,8 +346,13 @@ func TestReviewsRespondBatchResponseStateUnrespondedSkipsRespondedReviews(t *tes
 	if posts != 1 {
 		t.Fatalf("expected one create request, got %d", posts)
 	}
-	if !strings.Contains(stdout, `"reason":"response-state-mismatch"`) || !strings.Contains(stdout, `"created":1`) {
-		t.Fatalf("expected response-state skip and one create, got %s", stdout)
+	payload := decodeReviewBatchTestOutput(t, stdout)
+	if payload.Summary.Created != 1 || payload.Summary.Skipped != 1 {
+		t.Fatalf("unexpected response-state summary: %+v", payload.Summary)
+	}
+	skipped := findReviewBatchTestResult(t, payload, "review-1")
+	if skipped.Status != "skipped" || skipped.Reason != "response-state-mismatch" {
+		t.Fatalf("unexpected response-state skipped result: %+v", skipped)
 	}
 }
 
@@ -318,12 +372,6 @@ func TestReviewsRespondBatchValidationErrors(t *testing.T) {
 			name:    "missing file",
 			args:    []string{"reviews", "respond-batch", "--app", "app-1"},
 			wantErr: "--file is required",
-		},
-		{
-			name:    "invalid response state",
-			args:    []string{"reviews", "respond-batch", "--app", "app-1", "--file", "FILE", "--response-state", "maybe"},
-			body:    `{"replies":[{"response":"Thanks","reviewIds":["review-1"]}]}`,
-			wantErr: "--response-state must be one of: any, unresponded, responded",
 		},
 		{
 			name:    "bad json",
@@ -392,6 +440,24 @@ func TestReviewsRespondBatchValidationErrors(t *testing.T) {
 	}
 }
 
+func TestRunReviewsRespondBatchInvalidResponseStateReturnsUsageExit(t *testing.T) {
+	inputPath := writeReviewBatchFile(t, `{"replies":[{"response":"Thanks","reviewIds":["review-1"]}]}`)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--response-state", "maybe"}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--response-state must be one of: any, unresponded, responded") {
+		t.Fatalf("expected response-state validation, got %q", stderr)
+	}
+}
+
 func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -424,22 +490,24 @@ func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"review-1"`) {
-		t.Fatalf("expected review output, got %q", stdout)
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].ID != "review-1" {
+		t.Fatalf("unexpected review output: %+v", payload.Data)
 	}
 }
 
 func TestReviewsListRejectsInvalidResponseState(t *testing.T) {
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"reviews", "list", "--app", "app-1", "--response-state", "maybe"}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		err := root.Run(context.Background())
-		if !errors.Is(err, flag.ErrHelp) {
-			t.Fatalf("expected ErrHelp, got %v", err)
+		code := cmd.Run([]string{"reviews", "list", "--app", "app-1", "--response-state", "maybe"}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
 		}
 	})
 
@@ -483,8 +551,13 @@ func TestRunReviewsRespondBatchPartialFailureReturnsExitError(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"created":1`) || !strings.Contains(stdout, `"failed":1`) || !strings.Contains(stdout, `"error":`) {
-		t.Fatalf("expected partial result on stdout, got %s", stdout)
+	payload := decodeReviewBatchTestOutput(t, stdout)
+	if payload.Summary.Created != 1 || payload.Summary.Failed != 1 {
+		t.Fatalf("unexpected partial failure summary: %+v", payload.Summary)
+	}
+	failed := findReviewBatchTestResult(t, payload, "review-2")
+	if failed.Status != "failed" || failed.Error == "" {
+		t.Fatalf("unexpected failed result: %+v", failed)
 	}
 }
 

--- a/internal/cli/cmdtest/submit_preflight_test.go
+++ b/internal/cli/cmdtest/submit_preflight_test.go
@@ -12,6 +12,7 @@ func TestSubmitPreflightCommandIsRemoved(t *testing.T) {
 	cmd := findSubcommand(root, "submit", "preflight")
 	if cmd == nil {
 		t.Fatal("expected removed submit preflight shim to remain for migration guidance")
+		return
 	}
 	if !strings.Contains(cmd.ShortHelp, "removed") {
 		t.Fatalf("expected removed submit preflight shim, got short help %q", cmd.ShortHelp)

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -13,6 +13,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	subscriptionsCmd := findSubcommand(root, "subscriptions")
 	if subscriptionsCmd == nil {
 		t.Fatal("expected subscriptions command")
+		return
 	}
 	subscriptionsUsage := subscriptionsCmd.UsageFunc(subscriptionsCmd)
 	for _, expected := range []string{"pricing", "offers", "review", "promoted-purchases"} {
@@ -41,6 +42,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	groupsCmd := findSubcommand(root, "subscriptions", "groups")
 	if groupsCmd == nil {
 		t.Fatal("expected subscriptions groups command")
+		return
 	}
 	groupsUsage := groupsCmd.UsageFunc(groupsCmd)
 	if usageListsSubcommand(groupsUsage, "submit") {
@@ -50,6 +52,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	pricingCmd := findSubcommand(root, "subscriptions", "pricing")
 	if pricingCmd == nil {
 		t.Fatal("expected subscriptions pricing command")
+		return
 	}
 	pricingUsage := pricingCmd.UsageFunc(pricingCmd)
 	for _, expected := range []string{"summary", "prices", "price-points", "availability"} {
@@ -64,6 +67,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	pricesCmd := findSubcommand(root, "subscriptions", "pricing", "prices")
 	if pricesCmd == nil {
 		t.Fatal("expected subscriptions pricing prices command")
+		return
 	}
 	pricesUsage := pricesCmd.UsageFunc(pricesCmd)
 	if !strings.Contains(pricesUsage, `asc subscriptions pricing prices list --subscription-id "SUB_ID"`) {
@@ -75,6 +79,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	pricesListCmd := findSubcommand(root, "subscriptions", "pricing", "prices", "list")
 	if pricesListCmd == nil {
 		t.Fatal("expected subscriptions pricing prices list command")
+		return
 	}
 	pricesListUsage := pricesListCmd.UsageFunc(pricesListCmd)
 	if !strings.Contains(pricesListUsage, "--resolved") {
@@ -84,6 +89,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	availabilityCmd := findSubcommand(root, "subscriptions", "pricing", "availability")
 	if availabilityCmd == nil {
 		t.Fatal("expected subscriptions pricing availability command")
+		return
 	}
 	availabilityUsage := availabilityCmd.UsageFunc(availabilityCmd)
 	if !strings.Contains(availabilityUsage, `asc subscriptions pricing availability view --availability-id "AVAILABILITY_ID"`) {
@@ -102,6 +108,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	pricePointsCmd := findSubcommand(root, "subscriptions", "pricing", "price-points")
 	if pricePointsCmd == nil {
 		t.Fatal("expected subscriptions pricing price-points command")
+		return
 	}
 	pricePointsUsage := pricePointsCmd.UsageFunc(pricePointsCmd)
 	if !strings.Contains(pricePointsUsage, `asc subscriptions pricing price-points view --price-point-id "PRICE_POINT_ID"`) {
@@ -117,6 +124,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	offersCmd := findSubcommand(root, "subscriptions", "offers")
 	if offersCmd == nil {
 		t.Fatal("expected subscriptions offers command")
+		return
 	}
 	offersUsage := offersCmd.UsageFunc(offersCmd)
 	for _, expected := range []string{"introductory", "promotional", "offer-codes", "win-back"} {
@@ -128,6 +136,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	offerCodesCmd := findSubcommand(root, "subscriptions", "offers", "offer-codes")
 	if offerCodesCmd == nil {
 		t.Fatal("expected subscriptions offers offer-codes command")
+		return
 	}
 	offerCodesUsage := offerCodesCmd.UsageFunc(offerCodesCmd)
 	if !strings.Contains(offerCodesUsage, "  generate") {
@@ -146,6 +155,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	reviewCmd := findSubcommand(root, "subscriptions", "review")
 	if reviewCmd == nil {
 		t.Fatal("expected subscriptions review command")
+		return
 	}
 	reviewUsage := reviewCmd.UsageFunc(reviewCmd)
 	for _, expected := range []string{"screenshots", "app-store-screenshot", "submit", "submit-group"} {
@@ -157,6 +167,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	promotedPurchasesCreateCmd := findSubcommand(root, "subscriptions", "promoted-purchases", "create")
 	if promotedPurchasesCreateCmd == nil {
 		t.Fatal("expected subscriptions promoted-purchases create command")
+		return
 	}
 	promotedPurchasesCreateUsage := promotedPurchasesCreateCmd.UsageFunc(promotedPurchasesCreateCmd)
 	if strings.Contains(promotedPurchasesCreateUsage, "--product-type") {
@@ -166,6 +177,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	subscriptionsPromotedPurchasesCmd := findSubcommand(root, "subscriptions", "promoted-purchases")
 	if subscriptionsPromotedPurchasesCmd == nil {
 		t.Fatal("expected subscriptions promoted-purchases command")
+		return
 	}
 	subscriptionsPromotedPurchasesUsage := subscriptionsPromotedPurchasesCmd.UsageFunc(subscriptionsPromotedPurchasesCmd)
 	if strings.Contains(subscriptionsPromotedPurchasesUsage, "subscriptions and in-app purchases") {
@@ -181,6 +193,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	iapCmd := findSubcommand(root, "iap")
 	if iapCmd == nil {
 		t.Fatal("expected iap command")
+		return
 	}
 	iapUsage := iapCmd.UsageFunc(iapCmd)
 	if !strings.Contains(iapUsage, "  promoted-purchases") {
@@ -193,6 +206,7 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	iapPromotedPurchasesCmd := findSubcommand(root, "iap", "promoted-purchases")
 	if iapPromotedPurchasesCmd == nil {
 		t.Fatal("expected iap promoted-purchases command")
+		return
 	}
 	iapPromotedPurchasesUsage := iapPromotedPurchasesCmd.UsageFunc(iapPromotedPurchasesCmd)
 	if strings.Contains(iapPromotedPurchasesUsage, "subscriptions and in-app purchases") {

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -18,6 +18,7 @@ func TestSubscriptionsPricingMonthlyCommitmentHelp(t *testing.T) {
 	cmd := findSubcommand(root, "subscriptions", "pricing")
 	if cmd == nil {
 		t.Fatal("expected subscriptions pricing command")
+		return
 	}
 	usage := cmd.UsageFunc(cmd)
 	if !strings.Contains(usage, "monthly-commitment") {
@@ -27,6 +28,7 @@ func TestSubscriptionsPricingMonthlyCommitmentHelp(t *testing.T) {
 	monthlyCmd := findSubcommand(root, "subscriptions", "pricing", "monthly-commitment")
 	if monthlyCmd == nil {
 		t.Fatal("expected monthly-commitment command")
+		return
 	}
 	monthlyUsage := monthlyCmd.UsageFunc(monthlyCmd)
 	if !strings.Contains(monthlyUsage, "April 27, 2026") {

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -49,6 +49,7 @@ func TestSubscriptionsHelpShowsSetupCommand(t *testing.T) {
 	subscriptionsCmd := findSubcommand(root, "subscriptions")
 	if subscriptionsCmd == nil {
 		t.Fatal("expected subscriptions command")
+		return
 	}
 	subscriptionsUsage := subscriptionsCmd.UsageFunc(subscriptionsCmd)
 	if !usageListsSubcommand(subscriptionsUsage, "setup") {
@@ -58,6 +59,7 @@ func TestSubscriptionsHelpShowsSetupCommand(t *testing.T) {
 	setupCmd := findSubcommand(root, "subscriptions", "setup")
 	if setupCmd == nil {
 		t.Fatal("expected subscriptions setup command")
+		return
 	}
 	setupUsage := setupCmd.UsageFunc(setupCmd)
 	if !strings.Contains(setupUsage, "--group-reference-name") {

--- a/internal/cli/cmdtest/validate_subscriptions_test.go
+++ b/internal/cli/cmdtest/validate_subscriptions_test.go
@@ -430,6 +430,7 @@ func TestValidateSubscriptionsFallsBackToCountWhenAppTerritoryIDsAreIncomplete(t
 	}
 	if coverageCheck == nil {
 		t.Fatalf("expected pricing coverage warning when app territory IDs are incomplete, got %+v", report.Checks)
+		return
 	}
 	if !strings.Contains(coverageCheck.Message, "1 of 2 available territories") {
 		t.Fatalf("expected count-based fallback coverage warning, got %+v", *coverageCheck)
@@ -513,6 +514,7 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenAvailabilityRateLimited(t 
 	}
 	if skipCheck == nil {
 		t.Fatalf("expected pricing coverage skip info check, got %+v", report.Checks)
+		return
 	}
 	if !strings.Contains(skipCheck.Remediation, "temporarily unavailable or rate limited") {
 		t.Fatalf("expected retryable remediation, got %+v", *skipCheck)
@@ -567,6 +569,7 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityRateL
 	}
 	if skipCheck == nil {
 		t.Fatalf("expected pricing coverage skip info check, got %+v", report.Checks)
+		return
 	}
 	if !strings.Contains(skipCheck.Remediation, "temporarily unavailable or rate limited") {
 		t.Fatalf("expected retryable remediation, got %+v", *skipCheck)

--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -2094,6 +2094,7 @@ func TestValidateNamesMissingSubscriptionPricingTerritoriesWhenAppTerritoryIDsAr
 	}
 	if coverageCheck == nil {
 		t.Fatalf("expected pricing coverage warning, got %+v", report.Checks)
+		return
 	}
 	if !strings.Contains(coverageCheck.Message, "missing: CAN") {
 		t.Fatalf("expected exact missing territory in coverage warning, got %+v", *coverageCheck)

--- a/internal/cli/cmdtest/web_auth_apps_test.go
+++ b/internal/cli/cmdtest/web_auth_apps_test.go
@@ -67,6 +67,7 @@ func TestWebAppsCreateHelpMentionsInteractiveContract(t *testing.T) {
 	cmd := findSubcommand(root, "web", "apps", "create")
 	if cmd == nil {
 		t.Fatal("expected web apps create command")
+		return
 	}
 
 	usage := cmd.UsageFunc(cmd)

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -26,6 +26,7 @@ func TestWebCommandIncludesWarningContract(t *testing.T) {
 	webCmd := findSubcommand(root, "web")
 	if webCmd == nil {
 		t.Fatal("expected web command")
+		return
 	}
 
 	usage := webCmd.UsageFunc(webCmd)
@@ -99,6 +100,7 @@ func TestWebAppsCreateExposesPasswordCompatibilityFlag(t *testing.T) {
 	cmd := findSubcommand(root, "web", "apps", "create")
 	if cmd == nil {
 		t.Fatal("expected web apps create command")
+		return
 	}
 	if cmd.FlagSet.Lookup("password") == nil {
 		t.Fatal("expected temporary password compatibility flag on web apps create")
@@ -150,6 +152,7 @@ func TestWebAuthLoginExposesDeprecatedTwoFactorAliasWithoutPlaintextPasswordFlag
 	cmd := findSubcommand(root, "web", "auth", "login")
 	if cmd == nil {
 		t.Fatal("expected web auth login command")
+		return
 	}
 	if cmd.FlagSet.Lookup("password") != nil {
 		t.Fatal("did not expect --password flag on web auth login")
@@ -160,6 +163,7 @@ func TestWebAuthLoginExposesDeprecatedTwoFactorAliasWithoutPlaintextPasswordFlag
 	twoFactorCodeFlag := cmd.FlagSet.Lookup("two-factor-code")
 	if twoFactorCodeFlag == nil {
 		t.Fatal("expected deprecated --two-factor-code flag on web auth login")
+		return
 	}
 	if !strings.Contains(twoFactorCodeFlag.Usage, "Deprecated:") {
 		t.Fatalf("expected deprecated help text for --two-factor-code, got %q", twoFactorCodeFlag.Usage)
@@ -174,11 +178,13 @@ func TestWebAppsCreateExposesDeprecatedTwoFactorAlias(t *testing.T) {
 	cmd := findSubcommand(root, "web", "apps", "create")
 	if cmd == nil {
 		t.Fatal("expected web apps create command")
+		return
 	}
 
 	twoFactorCodeFlag := cmd.FlagSet.Lookup("two-factor-code")
 	if twoFactorCodeFlag == nil {
 		t.Fatal("expected deprecated --two-factor-code flag on web apps create")
+		return
 	}
 	if !strings.Contains(twoFactorCodeFlag.Usage, "Deprecated:") {
 		t.Fatalf("expected deprecated help text for --two-factor-code, got %q", twoFactorCodeFlag.Usage)
@@ -193,11 +199,13 @@ func TestWebSandboxCreateExposesDeprecatedTwoFactorAlias(t *testing.T) {
 	cmd := findSubcommand(root, "web", "sandbox", "create")
 	if cmd == nil {
 		t.Fatal("expected web sandbox create command")
+		return
 	}
 
 	twoFactorCodeFlag := cmd.FlagSet.Lookup("two-factor-code")
 	if twoFactorCodeFlag == nil {
 		t.Fatal("expected deprecated --two-factor-code flag on web sandbox create")
+		return
 	}
 	if !strings.Contains(twoFactorCodeFlag.Usage, "Deprecated:") {
 		t.Fatalf("expected deprecated help text for --two-factor-code, got %q", twoFactorCodeFlag.Usage)

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -15,6 +15,7 @@ func TestXcodeCommandExists(t *testing.T) {
 	xcodeCmd := findSubcommand(root, "xcode")
 	if xcodeCmd == nil {
 		t.Fatal("expected xcode command")
+		return
 	}
 	if strings.HasPrefix(xcodeCmd.ShortHelp, "[experimental]") {
 		t.Fatalf("expected xcode command not to be experimental, got %q", xcodeCmd.ShortHelp)
@@ -35,12 +36,17 @@ func TestXcodeCommandExists(t *testing.T) {
 		t.Fatal("expected xcode version view command")
 	}
 	viewCmd := findSubcommand(root, "xcode", "version", "view")
+	if viewCmd == nil {
+		t.Fatal("expected xcode version view command")
+		return
+	}
 	if viewCmd.FlagSet.Lookup("project") == nil {
 		t.Fatal("expected xcode version view to expose --project")
 	}
 	editCmd := findSubcommand(root, "xcode", "version", "edit")
 	if editCmd == nil {
 		t.Fatal("expected xcode version edit command")
+		return
 	}
 	if editCmd.FlagSet.Lookup("project") == nil {
 		t.Fatal("expected xcode version edit to expose --project")
@@ -51,6 +57,7 @@ func TestXcodeCommandExists(t *testing.T) {
 	bumpCmd := findSubcommand(root, "xcode", "version", "bump")
 	if bumpCmd == nil {
 		t.Fatal("expected xcode version bump command")
+		return
 	}
 	if bumpCmd.FlagSet.Lookup("project") == nil {
 		t.Fatal("expected xcode version bump to expose --project")
@@ -101,6 +108,7 @@ func TestXcodeExportHelpMentionsDirectUploadMode(t *testing.T) {
 	exportCmd := findSubcommand(root, "xcode", "export")
 	if exportCmd == nil {
 		t.Fatal("expected xcode export command")
+		return
 	}
 	if !strings.Contains(exportCmd.ShortHelp, "direct upload") {
 		t.Fatalf("expected short help to mention direct upload, got %q", exportCmd.ShortHelp)
@@ -122,6 +130,7 @@ func TestXcodeValidateHelpMentionsAltool(t *testing.T) {
 	validateCmd := findSubcommand(root, "xcode", "validate")
 	if validateCmd == nil {
 		t.Fatal("expected xcode validate command")
+		return
 	}
 	if !strings.Contains(validateCmd.LongHelp, "xcrun altool --validate-app") {
 		t.Fatalf("expected long help to mention altool validation, got %q", validateCmd.LongHelp)

--- a/internal/cli/encryption/encryption_test.go
+++ b/internal/cli/encryption/encryption_test.go
@@ -11,6 +11,7 @@ func TestEncryptionCommandConstructors(t *testing.T) {
 	top := EncryptionCommand()
 	if top == nil {
 		t.Fatal("expected encryption command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/eula/eula_test.go
+++ b/internal/cli/eula/eula_test.go
@@ -11,6 +11,7 @@ func TestEULACommandShape(t *testing.T) {
 	cmd := EULACommand()
 	if cmd == nil {
 		t.Fatal("expected eula command")
+		return
 	}
 	if cmd.Name != "eula" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/gamecenter/game_center_test.go
+++ b/internal/cli/gamecenter/game_center_test.go
@@ -6,6 +6,7 @@ func TestGameCenterCommandConstructors(t *testing.T) {
 	top := GameCenterCommand()
 	if top == nil {
 		t.Fatal("expected game-center command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/initcmd/init_test.go
+++ b/internal/cli/initcmd/init_test.go
@@ -15,6 +15,7 @@ func TestInitCommandMetadata(t *testing.T) {
 	cmd := InitCommand()
 	if cmd == nil {
 		t.Fatal("expected init command")
+		return
 	}
 	if cmd.Name != "init" {
 		t.Fatalf("expected command name init, got %q", cmd.Name)

--- a/internal/cli/localizations/localizations_test.go
+++ b/internal/cli/localizations/localizations_test.go
@@ -13,6 +13,7 @@ func TestLocalizationsCommandConstructors(t *testing.T) {
 	top := LocalizationsCommand()
 	if top == nil {
 		t.Fatal("expected localizations command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/merchantids/merchant_ids_test.go
+++ b/internal/cli/merchantids/merchant_ids_test.go
@@ -13,6 +13,7 @@ func TestMerchantIDsCommandShape(t *testing.T) {
 	cmd := MerchantIDsCommand()
 	if cmd == nil {
 		t.Fatal("expected merchant-ids command")
+		return
 	}
 	if cmd.Name != "merchant-ids" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/metadata/init_test.go
+++ b/internal/cli/metadata/init_test.go
@@ -19,6 +19,7 @@ func TestMetadataInitCommandDefaultsLocale(t *testing.T) {
 	f := cmd.FlagSet.Lookup("locale")
 	if f == nil {
 		t.Fatal("expected --locale flag to be defined")
+		return
 	}
 	if f.DefValue != "en-US" {
 		t.Fatalf("expected --locale default en-US, got %q", f.DefValue)

--- a/internal/cli/metadata/keywords_audit_test.go
+++ b/internal/cli/metadata/keywords_audit_test.go
@@ -11,6 +11,7 @@ func TestMetadataKeywordsAuditCommandHelpMentionsBlockedTerms(t *testing.T) {
 	cmd := MetadataKeywordsAuditCommand()
 	if cmd == nil {
 		t.Fatal("expected audit command")
+		return
 	}
 	if !strings.Contains(cmd.LongHelp, "--app-info") {
 		t.Fatalf("expected long help to mention --app-info, got %q", cmd.LongHelp)

--- a/internal/cli/metadata/pull_test.go
+++ b/internal/cli/metadata/pull_test.go
@@ -17,6 +17,7 @@ func TestMetadataPullCommand_AppInfoFlagDefault(t *testing.T) {
 	f := cmd.FlagSet.Lookup("app-info")
 	if f == nil {
 		t.Fatal("expected --app-info flag to be defined")
+		return
 	}
 	if f.DefValue != "" {
 		t.Fatalf("expected --app-info default to be empty, got %q", f.DefValue)

--- a/internal/cli/migrate/review_information_test.go
+++ b/internal/cli/migrate/review_information_test.go
@@ -35,6 +35,7 @@ func TestReadFastlaneReviewInformation_ParsesFiles(t *testing.T) {
 	}
 	if info == nil {
 		t.Fatal("expected review information, got nil")
+		return
 	}
 	if info.ContactFirstName == nil || *info.ContactFirstName != "Rita" {
 		t.Fatalf("expected contact first name Rita, got %#v", info.ContactFirstName)

--- a/internal/cli/nominations/nominations_test.go
+++ b/internal/cli/nominations/nominations_test.go
@@ -13,6 +13,7 @@ func TestNominationsCommandShape(t *testing.T) {
 	cmd := NominationsCommand()
 	if cmd == nil {
 		t.Fatal("expected nominations command")
+		return
 	}
 	if cmd.Name != "nominations" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/notarization/notarization_test.go
+++ b/internal/cli/notarization/notarization_test.go
@@ -11,6 +11,7 @@ func TestNotarizationCommandConstructors(t *testing.T) {
 	top := NotarizationCommand()
 	if top == nil {
 		t.Fatal("expected notarization command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/passtypeids/pass_type_ids_test.go
+++ b/internal/cli/passtypeids/pass_type_ids_test.go
@@ -11,6 +11,7 @@ func TestPassTypeIDsCommandShape(t *testing.T) {
 	cmd := PassTypeIDsCommand()
 	if cmd == nil {
 		t.Fatal("expected pass-type-ids command")
+		return
 	}
 	if cmd.Name != "pass-type-ids" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/performance/performance_test.go
+++ b/internal/cli/performance/performance_test.go
@@ -6,6 +6,7 @@ func TestPerformanceCommandConstructors(t *testing.T) {
 	top := PerformanceCommand()
 	if top == nil {
 		t.Fatal("expected performance command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/preorders/pre_orders_test.go
+++ b/internal/cli/preorders/pre_orders_test.go
@@ -211,6 +211,7 @@ func TestPreOrdersCommand_DefaultOutputJSON(t *testing.T) {
 			f := cmd.FlagSet.Lookup("output")
 			if f == nil {
 				t.Fatal("expected --output flag to be defined")
+				return
 			}
 			if f.DefValue != "json" {
 				t.Errorf("expected --output default to be 'json', got %q", f.DefValue)

--- a/internal/cli/prerelease/prerelease_test.go
+++ b/internal/cli/prerelease/prerelease_test.go
@@ -6,6 +6,7 @@ func TestPreReleaseCommandConstructors(t *testing.T) {
 	top := PreReleaseVersionsCommand()
 	if top == nil {
 		t.Fatal("expected pre-release command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -335,6 +335,7 @@ func TestPricingCommands_DefaultOutputJSON(t *testing.T) {
 			f := cmd.FlagSet.Lookup("output")
 			if f == nil {
 				t.Fatalf("expected --output flag to be defined")
+				return
 			}
 			if f.DefValue != "json" {
 				t.Fatalf("expected --output default to be 'json', got %q", f.DefValue)

--- a/internal/cli/productpages/product_pages_test.go
+++ b/internal/cli/productpages/product_pages_test.go
@@ -6,6 +6,7 @@ func TestProductPagesCommandConstructors(t *testing.T) {
 	top := ProductPagesCommand()
 	if top == nil {
 		t.Fatal("expected product-pages command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/promotedpurchases/promoted_purchases_test.go
+++ b/internal/cli/promotedpurchases/promoted_purchases_test.go
@@ -11,6 +11,7 @@ func TestPromotedPurchasesCommandConstructors(t *testing.T) {
 	top := PromotedPurchasesCommand()
 	if top == nil {
 		t.Fatal("expected promoted-purchases command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/registry/registry_test.go
+++ b/internal/cli/registry/registry_test.go
@@ -10,6 +10,7 @@ func TestVersionCommand(t *testing.T) {
 	cmd := VersionCommand("v1.2.3")
 	if cmd == nil {
 		t.Fatal("expected non-nil version command")
+		return
 	}
 	if cmd.Name != "version" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)
@@ -29,6 +30,7 @@ func TestSubcommandsIncludesCoreEntries(t *testing.T) {
 	for _, sub := range subs {
 		if sub == nil {
 			t.Fatal("expected no nil root subcommands")
+			return
 		}
 		name := strings.TrimSpace(sub.Name)
 		if name == "" {

--- a/internal/cli/registry/view_edit_surface_test.go
+++ b/internal/cli/registry/view_edit_surface_test.go
@@ -93,6 +93,7 @@ func TestHelpHidesDeprecatedLegacyVerbs(t *testing.T) {
 			cmd := findCommandByPath(subs, tt.path)
 			if cmd == nil {
 				t.Fatalf("expected command %q", tt.path)
+				return
 			}
 
 			usage := cmd.UsageFunc(cmd)
@@ -132,6 +133,7 @@ func TestHelpRetainsCanonicalCommandsThatMentionLegacyAliases(t *testing.T) {
 			cmd := findCommandByPath(subs, tt.path)
 			if cmd == nil {
 				t.Fatalf("expected command %q", tt.path)
+				return
 			}
 
 			usage := cmd.UsageFunc(cmd)

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -94,6 +94,7 @@ func TestReleaseCommandShape(t *testing.T) {
 	cmd := ReleaseCommand()
 	if cmd == nil {
 		t.Fatal("expected release command")
+		return
 	}
 	if cmd.Name != "release" {
 		t.Fatalf("expected command name release, got %q", cmd.Name)

--- a/internal/cli/reviews/review_overview_test.go
+++ b/internal/cli/reviews/review_overview_test.go
@@ -287,6 +287,7 @@ func TestSelectRelevantReviewSubmissionPrefersActiveSubmissionWithoutSubmittedDa
 	selected := selectRelevantReviewSubmission(submissions, "ver-1")
 	if selected == nil {
 		t.Fatal("expected selected submission, got nil")
+		return
 	}
 	if selected.ID != "review-sub-ready" {
 		t.Fatalf("expected active ready-for-review submission to win, got %q", selected.ID)

--- a/internal/cli/reviews/reviews.go
+++ b/internal/cli/reviews/reviews.go
@@ -25,6 +25,8 @@ func ReviewsCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	responseState := fs.String("response-state", "any", "Filter by response state: any, unresponded, responded")
+	includeResponse := fs.Bool("include-response", false, "Include customer review response relationships")
 
 	return &ffcli.Command{
 		Name:       "reviews",
@@ -41,6 +43,7 @@ Examples:
   asc reviews --app "123456789"
   asc reviews --app "123456789" --stars 1 --territory US
   asc reviews --app "123456789" --sort -createdDate --limit 5
+  asc reviews --app "123456789" --response-state unresponded --include-response
   asc reviews --next "<links.next>"
   asc reviews --app "123456789" --paginate
   asc reviews get --id "REVIEW_ID"
@@ -48,6 +51,7 @@ Examples:
   asc reviews ratings --app "123456789" --all
   asc reviews summarizations --app "123456789" --platform IOS --territory US
   asc reviews respond --review-id "REVIEW_ID" --response "Thanks!"
+  asc reviews respond-batch --app "123456789" --file replies.json --dry-run
   asc reviews response get --id "RESPONSE_ID"
   asc reviews response delete --id "RESPONSE_ID" --confirm
   asc reviews response for-review --review-id "REVIEW_ID"`,
@@ -59,6 +63,7 @@ Examples:
 			ReviewsRatingsCommand(),
 			ReviewsSummarizationsCommand(),
 			ReviewsRespondCommand(),
+			ReviewsRespondBatchCommand(),
 			ReviewsResponseCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -70,7 +75,7 @@ Examples:
 			}
 
 			// Execute the list functionality directly
-			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate)
+			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *includeResponse)
 		},
 	}
 }
@@ -87,6 +92,8 @@ func ReviewsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	responseState := fs.String("response-state", "any", "Filter by response state: any, unresponded, responded")
+	includeResponse := fs.Bool("include-response", false, "Include customer review response relationships")
 
 	return &ffcli.Command{
 		Name:       "list",
@@ -98,6 +105,7 @@ Examples:
   asc reviews list --app "123456789"
   asc reviews list --app "123456789" --stars 5
   asc reviews list --app "123456789" --territory US --sort -createdDate
+  asc reviews list --app "123456789" --response-state unresponded --include-response
   asc reviews list --next "<links.next>"
   asc reviews list --app "123456789" --paginate`,
 		FlagSet:   fs,
@@ -109,12 +117,12 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate)
+			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *includeResponse)
 		},
 	}
 }
 
-func executeReviewsList(ctx context.Context, appID, output string, pretty bool, stars int, territory, sort string, limit int, next string, paginate bool) error {
+func executeReviewsList(ctx context.Context, appID, output string, pretty bool, stars int, territory, sort string, limit int, next string, paginate bool, responseState string, includeResponse bool) error {
 	if limit != 0 && (limit < 1 || limit > 200) {
 		return fmt.Errorf("reviews: --limit must be between 1 and 200")
 	}
@@ -126,6 +134,10 @@ func executeReviewsList(ctx context.Context, appID, output string, pretty bool, 
 	}
 	if err := shared.ValidateSort(sort, "rating", "-rating", "createdDate", "-createdDate"); err != nil {
 		return fmt.Errorf("reviews: %w", err)
+	}
+	normalizedResponseState, err := normalizeReviewResponseState(responseState)
+	if err != nil {
+		return shared.UsageError(err.Error())
 	}
 
 	client, err := shared.GetASCClient()
@@ -144,6 +156,12 @@ func executeReviewsList(ctx context.Context, appID, output string, pretty bool, 
 	}
 	if strings.TrimSpace(sort) != "" {
 		opts = append(opts, asc.WithReviewSort(sort))
+	}
+	if exists, ok := publishedResponseExistsFilter(normalizedResponseState); ok {
+		opts = append(opts, asc.WithPublishedResponseExists(exists))
+	}
+	if includeResponse {
+		opts = append(opts, asc.WithReviewIncludeResponse())
 	}
 
 	if paginate {

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -1,0 +1,431 @@
+package reviews
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const (
+	reviewResponseStateAny         = "any"
+	reviewResponseStateUnresponded = "unresponded"
+	reviewResponseStateResponded   = "responded"
+
+	reviewBatchStatusCreated = "created"
+	reviewBatchStatusFailed  = "failed"
+	reviewBatchStatusPlanned = "planned"
+	reviewBatchStatusSkipped = "skipped"
+)
+
+type reviewBatchInput struct {
+	Replies []reviewBatchReplyInput `json:"replies"`
+}
+
+type reviewBatchReplyInput struct {
+	Response  string   `json:"response"`
+	ReviewIDs []string `json:"reviewIds"`
+}
+
+type reviewBatchTarget struct {
+	ReviewID string
+	Response string
+}
+
+type reviewBatchResult struct {
+	AppID   string                    `json:"appId"`
+	DryRun  bool                      `json:"dryRun"`
+	Summary reviewBatchSummary        `json:"summary"`
+	Results []reviewBatchReviewResult `json:"results"`
+}
+
+type reviewBatchSummary struct {
+	Total   int `json:"total"`
+	Created int `json:"created"`
+	Skipped int `json:"skipped"`
+	Failed  int `json:"failed"`
+	Planned int `json:"planned"`
+}
+
+type reviewBatchReviewResult struct {
+	ReviewID           string `json:"reviewId"`
+	Status             string `json:"status"`
+	ResponseID         string `json:"responseId,omitempty"`
+	ExistingResponseID string `json:"existingResponseId,omitempty"`
+	Reason             string `json:"reason,omitempty"`
+	Error              string `json:"error,omitempty"`
+}
+
+type reviewBatchReviewInfo struct {
+	ReviewID           string
+	ExistingResponseID string
+}
+
+// ReviewsRespondBatchCommand returns the reviews respond-batch subcommand.
+func ReviewsRespondBatchCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("respond-batch", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	filePath := fs.String("file", "", "Path to grouped JSON replies file (required)")
+	dryRun := fs.Bool("dry-run", false, "Preview responses without creating them")
+	skipExisting := fs.Bool("skip-existing", false, "Skip reviews that already have a published response")
+	responseState := fs.String("response-state", reviewResponseStateAny, "Filter by response state: any, unresponded, responded")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "respond-batch",
+		ShortUsage: "asc reviews respond-batch [flags]",
+		ShortHelp:  "Create responses for multiple customer reviews. Experimental.",
+		LongHelp: `Create responses for multiple customer reviews from a grouped JSON file.
+
+This command is experimental.
+
+The input file must contain a top-level replies array. Each reply has one
+response body and one or more reviewIds.
+
+Example input:
+  {
+    "replies": [
+      {
+        "response": "Thanks for the feedback.",
+        "reviewIds": ["REVIEW_ID_1", "REVIEW_ID_2"]
+      }
+    ]
+  }
+
+Examples:
+  asc reviews respond-batch --app "123456789" --file replies.json --dry-run
+  asc reviews respond-batch --app "123456789" --file replies.json --skip-existing --output json
+  asc reviews respond-batch --app "123456789" --file replies.json --response-state unresponded`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if strings.TrimSpace(resolvedAppID) == "" {
+				return shared.UsageError("--app is required (or set ASC_APP_ID)")
+			}
+			if strings.TrimSpace(*filePath) == "" {
+				return shared.UsageError("--file is required")
+			}
+
+			normalizedResponseState, err := normalizeReviewResponseState(*responseState)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			targets, err := loadReviewBatchTargets(*filePath)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("reviews respond-batch: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			result, err := executeReviewsRespondBatch(
+				requestCtx,
+				client,
+				resolvedAppID,
+				targets,
+				*dryRun,
+				*skipExisting,
+				normalizedResponseState,
+			)
+			if err != nil {
+				return err
+			}
+
+			if err := printReviewBatchResult(result, *output.Output, *output.Pretty); err != nil {
+				return err
+			}
+			if result.Summary.Failed > 0 {
+				return shared.NewReportedError(fmt.Errorf("reviews respond-batch: %d review(s) failed", result.Summary.Failed))
+			}
+			return nil
+		},
+	}
+}
+
+func normalizeReviewResponseState(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		normalized = reviewResponseStateAny
+	}
+	switch normalized {
+	case reviewResponseStateAny, reviewResponseStateUnresponded, reviewResponseStateResponded:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("--response-state must be one of: any, unresponded, responded")
+	}
+}
+
+func publishedResponseExistsFilter(responseState string) (bool, bool) {
+	switch responseState {
+	case reviewResponseStateUnresponded:
+		return false, true
+	case reviewResponseStateResponded:
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read --file: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("--file must not be empty")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var input reviewBatchInput
+	if err := decoder.Decode(&input); err != nil {
+		return nil, fmt.Errorf("failed to parse --file: %w", err)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("failed to parse --file: multiple JSON values are not allowed")
+		}
+		return nil, fmt.Errorf("failed to parse --file: %w", err)
+	}
+	if len(input.Replies) == 0 {
+		return nil, fmt.Errorf("replies must contain at least one item")
+	}
+
+	seen := map[string]struct{}{}
+	targets := make([]reviewBatchTarget, 0)
+	for replyIndex, reply := range input.Replies {
+		response := strings.TrimSpace(reply.Response)
+		if response == "" {
+			return nil, fmt.Errorf("replies[%d].response is required", replyIndex)
+		}
+		if len(reply.ReviewIDs) == 0 {
+			return nil, fmt.Errorf("replies[%d].reviewIds must contain at least one review id", replyIndex)
+		}
+		for reviewIndex, reviewID := range reply.ReviewIDs {
+			trimmedReviewID := strings.TrimSpace(reviewID)
+			if trimmedReviewID == "" {
+				return nil, fmt.Errorf("replies[%d].reviewIds[%d] is required", replyIndex, reviewIndex)
+			}
+			if _, ok := seen[trimmedReviewID]; ok {
+				return nil, fmt.Errorf("duplicate review id %q", trimmedReviewID)
+			}
+			seen[trimmedReviewID] = struct{}{}
+			targets = append(targets, reviewBatchTarget{
+				ReviewID: trimmedReviewID,
+				Response: response,
+			})
+		}
+	}
+
+	return targets, nil
+}
+
+func executeReviewsRespondBatch(ctx context.Context, client *asc.Client, appID string, targets []reviewBatchTarget, dryRun bool, skipExisting bool, responseState string) (reviewBatchResult, error) {
+	result := reviewBatchResult{
+		AppID:  appID,
+		DryRun: dryRun,
+		Summary: reviewBatchSummary{
+			Total: len(targets),
+		},
+		Results: make([]reviewBatchReviewResult, 0, len(targets)),
+	}
+
+	reviews, err := fetchReviewBatchReviewInfo(ctx, client, appID, targets)
+	if err != nil {
+		return result, fmt.Errorf("reviews respond-batch: failed to fetch reviews: %w", err)
+	}
+
+	for _, target := range targets {
+		info, ok := reviews[target.ReviewID]
+		if !ok {
+			result.append(reviewBatchReviewResult{
+				ReviewID: target.ReviewID,
+				Status:   reviewBatchStatusFailed,
+				Error:    "review not found for app",
+			})
+			continue
+		}
+
+		if skip, reason := shouldSkipForResponseState(responseState, info.ExistingResponseID != ""); skip {
+			result.append(reviewBatchReviewResult{
+				ReviewID:           target.ReviewID,
+				Status:             reviewBatchStatusSkipped,
+				ExistingResponseID: info.ExistingResponseID,
+				Reason:             reason,
+			})
+			continue
+		}
+
+		if skipExisting && info.ExistingResponseID != "" {
+			result.append(reviewBatchReviewResult{
+				ReviewID:           target.ReviewID,
+				Status:             reviewBatchStatusSkipped,
+				ExistingResponseID: info.ExistingResponseID,
+				Reason:             "existing-response",
+			})
+			continue
+		}
+
+		if dryRun {
+			result.append(reviewBatchReviewResult{
+				ReviewID:           target.ReviewID,
+				Status:             reviewBatchStatusPlanned,
+				ExistingResponseID: info.ExistingResponseID,
+			})
+			continue
+		}
+
+		created, err := client.CreateCustomerReviewResponse(ctx, target.ReviewID, target.Response)
+		if err != nil {
+			result.append(reviewBatchReviewResult{
+				ReviewID:           target.ReviewID,
+				Status:             reviewBatchStatusFailed,
+				ExistingResponseID: info.ExistingResponseID,
+				Error:              err.Error(),
+			})
+			continue
+		}
+
+		result.append(reviewBatchReviewResult{
+			ReviewID:           target.ReviewID,
+			Status:             reviewBatchStatusCreated,
+			ResponseID:         created.Data.ID,
+			ExistingResponseID: info.ExistingResponseID,
+		})
+	}
+
+	return result, nil
+}
+
+func fetchReviewBatchReviewInfo(ctx context.Context, client *asc.Client, appID string, targets []reviewBatchTarget) (map[string]reviewBatchReviewInfo, error) {
+	wanted := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		wanted[target.ReviewID] = struct{}{}
+	}
+
+	found := make(map[string]reviewBatchReviewInfo, len(targets))
+	nextURL := ""
+	for {
+		var (
+			response *asc.ReviewsResponse
+			err      error
+		)
+		if nextURL != "" {
+			response, err = client.GetReviews(ctx, appID, asc.WithNextURL(nextURL))
+		} else {
+			response, err = client.GetReviews(ctx, appID, asc.WithLimit(200), asc.WithReviewIncludeResponse())
+		}
+		if err != nil {
+			return found, err
+		}
+
+		for _, review := range response.Data {
+			if _, ok := wanted[review.ID]; !ok {
+				continue
+			}
+			existingResponseID, _ := asc.CustomerReviewPublishedResponseID(review)
+			found[review.ID] = reviewBatchReviewInfo{
+				ReviewID:           review.ID,
+				ExistingResponseID: existingResponseID,
+			}
+		}
+
+		if len(found) == len(wanted) || strings.TrimSpace(response.Links.Next) == "" {
+			break
+		}
+		nextURL = response.Links.Next
+	}
+
+	return found, nil
+}
+
+func shouldSkipForResponseState(responseState string, hasResponse bool) (bool, string) {
+	switch responseState {
+	case reviewResponseStateUnresponded:
+		if hasResponse {
+			return true, "response-state-mismatch"
+		}
+	case reviewResponseStateResponded:
+		if !hasResponse {
+			return true, "response-state-mismatch"
+		}
+	}
+	return false, ""
+}
+
+func (r *reviewBatchResult) append(item reviewBatchReviewResult) {
+	r.Results = append(r.Results, item)
+	switch item.Status {
+	case reviewBatchStatusCreated:
+		r.Summary.Created++
+	case reviewBatchStatusFailed:
+		r.Summary.Failed++
+	case reviewBatchStatusPlanned:
+		r.Summary.Planned++
+	case reviewBatchStatusSkipped:
+		r.Summary.Skipped++
+	}
+}
+
+func printReviewBatchResult(result reviewBatchResult, output string, pretty bool) error {
+	return shared.PrintOutputWithRenderers(
+		result,
+		output,
+		pretty,
+		func() error {
+			renderReviewBatchResult(result, false)
+			return nil
+		},
+		func() error {
+			renderReviewBatchResult(result, true)
+			return nil
+		},
+	)
+}
+
+func renderReviewBatchResult(result reviewBatchResult, markdown bool) {
+	headers := []string{"Review ID", "Status", "Response ID", "Existing Response ID", "Reason", "Error"}
+	rows := make([][]string, 0, len(result.Results)+1)
+	rows = append(rows, []string{
+		"summary",
+		fmt.Sprintf("created=%d skipped=%d failed=%d planned=%d", result.Summary.Created, result.Summary.Skipped, result.Summary.Failed, result.Summary.Planned),
+		"",
+		"",
+		fmt.Sprintf("total=%d dryRun=%t", result.Summary.Total, result.DryRun),
+		"",
+	})
+	for _, item := range result.Results {
+		rows = append(rows, []string{
+			item.ReviewID,
+			item.Status,
+			item.ResponseID,
+			item.ExistingResponseID,
+			item.Reason,
+			item.Error,
+		})
+	}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return
+	}
+	asc.RenderTable(headers, rows)
+}

--- a/internal/cli/reviews/reviews_test.go
+++ b/internal/cli/reviews/reviews_test.go
@@ -6,6 +6,7 @@ func TestReviewsCommandConstructors(t *testing.T) {
 	top := ReviewsCommand()
 	if top == nil {
 		t.Fatal("expected reviews command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")
@@ -24,6 +25,7 @@ func TestReviewsCommandConstructors(t *testing.T) {
 		func() any { return ReviewDoctorCommand() },
 		func() any { return ReviewsGetCommand() },
 		func() any { return ReviewsRatingsCommand() },
+		func() any { return ReviewsRespondBatchCommand() },
 		func() any { return ReviewsResponseCommand() },
 		func() any { return ReviewDetailsAttachmentsListCommand() },
 	}

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -11,6 +11,7 @@ func TestRoutingCoverageCommandShape(t *testing.T) {
 	cmd := RoutingCoverageCommand()
 	if cmd == nil {
 		t.Fatal("expected routing-coverage command")
+		return
 	}
 	if cmd.Name != "routing-coverage" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)

--- a/internal/cli/screenshots/screenshots_test.go
+++ b/internal/cli/screenshots/screenshots_test.go
@@ -6,6 +6,7 @@ func TestScreenshotsCommandConstructors(t *testing.T) {
 	cmd := ScreenshotsCommand()
 	if cmd == nil {
 		t.Fatal("expected screenshots command")
+		return
 	}
 	if cmd.Name != "screenshots" {
 		t.Fatalf("expected command name screenshots, got %q", cmd.Name)

--- a/internal/cli/shared/app_keywords_test.go
+++ b/internal/cli/shared/app_keywords_test.go
@@ -11,6 +11,7 @@ func TestBuildAppKeywordsResponse(t *testing.T) {
 	resp := BuildAppKeywordsResponse(keywords)
 	if resp == nil {
 		t.Fatal("expected non-nil response")
+		return
 	}
 	if len(resp.Data) != len(keywords) {
 		t.Fatalf("expected %d keywords, got %d", len(keywords), len(resp.Data))

--- a/internal/cli/shared/build_wait_test.go
+++ b/internal/cli/shared/build_wait_test.go
@@ -188,6 +188,7 @@ func TestWaitForBuildByNumberOrUploadFailureReturnsBuildLinkedFromUpload(t *test
 	}
 	if buildResp == nil {
 		t.Fatal("expected linked build response")
+		return
 	}
 	if buildResp.Data.ID != "build-123" {
 		t.Fatalf("expected linked build ID build-123, got %q", buildResp.Data.ID)
@@ -298,6 +299,7 @@ func TestWaitForBuildByNumberOrUploadFailureFallsBackWhenUploadLookupFails(t *te
 	}
 	if buildResp == nil {
 		t.Fatal("expected build response after falling back to build discovery")
+		return
 	}
 	if buildResp.Data.ID != "build-123" {
 		t.Fatalf("expected build ID build-123, got %q", buildResp.Data.ID)
@@ -387,6 +389,7 @@ func TestWaitForBuildByNumberOrUploadFailureFallsBackWhenLinkedBuildLookupFails(
 	}
 	if buildResp == nil {
 		t.Fatal("expected build response after falling back from linked build lookup")
+		return
 	}
 	if buildResp.Data.ID != "build-123" {
 		t.Fatalf("expected build ID build-123, got %q", buildResp.Data.ID)

--- a/internal/cli/shared/command_tree_test.go
+++ b/internal/cli/shared/command_tree_test.go
@@ -37,6 +37,7 @@ func TestRewriteCommandTreePathRewritesRuntimeErrorPrefix(t *testing.T) {
 	rewritten := RewriteCommandTreePath(cmd, "asc offer-codes", "asc subscriptions offer-codes")
 	if rewritten == nil {
 		t.Fatal("expected rewritten command")
+		return
 	}
 
 	err := rewritten.Exec(context.Background(), nil)

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -373,6 +373,7 @@ func TestBindPrettyJSONFlagDefaultsFalseAndParses(t *testing.T) {
 	pretty := BindPrettyJSONFlag(fs)
 	if pretty == nil {
 		t.Fatal("expected pretty flag pointer to be set")
+		return
 	}
 	if *pretty {
 		t.Fatal("expected pretty default false")

--- a/internal/cli/shared/view_edit_command_tree_test.go
+++ b/internal/cli/shared/view_edit_command_tree_test.go
@@ -68,6 +68,7 @@ func TestNormalizeViewEditCommandTreeRemovesLegacyVerbPath(t *testing.T) {
 	}
 	if canonical == nil {
 		t.Fatal("expected canonical view command to remain in tree")
+		return
 	}
 	for _, sub := range root.Subcommands {
 		if sub != nil && sub.Name == "get" {

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -197,6 +197,7 @@ func TestSelectLatestAppStoreVersion_DeterministicTieBreak(t *testing.T) {
 	selected := selectLatestAppStoreVersion(versions)
 	if selected == nil {
 		t.Fatal("expected selected version, got nil")
+		return
 	}
 	if selected.ID != "ver-2" {
 		t.Fatalf("expected deterministic tie-break to choose ver-2, got %q", selected.ID)
@@ -222,6 +223,7 @@ func TestSelectLatestAppStoreVersion_ParsesRFC3339Offsets(t *testing.T) {
 	selected := selectLatestAppStoreVersion(versions)
 	if selected == nil {
 		t.Fatal("expected selected version, got nil")
+		return
 	}
 	if selected.ID != "ver-newer" {
 		t.Fatalf("expected ver-newer to be selected, got %q", selected.ID)
@@ -247,6 +249,7 @@ func TestSelectLatestReviewSubmission_DeterministicTieBreak(t *testing.T) {
 	selected := selectLatestReviewSubmission(submissions)
 	if selected == nil {
 		t.Fatal("expected selected submission, got nil")
+		return
 	}
 	if selected.ID != "sub-2" {
 		t.Fatalf("expected deterministic tie-break to choose sub-2, got %q", selected.ID)
@@ -272,6 +275,7 @@ func TestSelectLatestReviewSubmission_ParsesRFC3339Offsets(t *testing.T) {
 	selected := selectLatestReviewSubmission(submissions)
 	if selected == nil {
 		t.Fatal("expected selected submission, got nil")
+		return
 	}
 	if selected.ID != "sub-newer" {
 		t.Fatalf("expected sub-newer to be selected, got %q", selected.ID)
@@ -299,6 +303,7 @@ func TestSelectLatestReviewSubmission_PrefersActiveSubmissionWithoutSubmittedDat
 	selected := selectLatestReviewSubmission(submissions)
 	if selected == nil {
 		t.Fatal("expected selected submission, got nil")
+		return
 	}
 	if selected.ID != "sub-ready" {
 		t.Fatalf("expected active ready-for-review submission to win, got %q", selected.ID)
@@ -324,6 +329,7 @@ func TestSelectLatestBetaReviewSubmission_ParsesRFC3339Offsets(t *testing.T) {
 	selected := selectLatestBetaReviewSubmission(submissions)
 	if selected == nil {
 		t.Fatal("expected selected submission, got nil")
+		return
 	}
 	if selected.ID != "beta-sub-newer" {
 		t.Fatalf("expected beta-sub-newer to be selected, got %q", selected.ID)

--- a/internal/cli/submit/submit_test.go
+++ b/internal/cli/submit/submit_test.go
@@ -30,6 +30,7 @@ func TestSubmitCommandShape(t *testing.T) {
 	cmd := SubmitCommand()
 	if cmd == nil {
 		t.Fatal("expected submit command")
+		return
 	}
 	if cmd.Name != "submit" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)
@@ -1979,6 +1980,7 @@ func TestFindReviewSubmissionForVersion_FallsBackToSubmissionItems(t *testing.T)
 	}
 	if submission == nil {
 		t.Fatal("expected review submission match, got nil")
+		return
 	}
 	if submission.ID != "review-submission-123" {
 		t.Fatalf("expected review submission ID review-submission-123, got %q", submission.ID)
@@ -2045,6 +2047,7 @@ func TestFindReviewSubmissionForVersion_ContinuesAfterPerSubmissionLookupErrors(
 	}
 	if submission == nil {
 		t.Fatal("expected review submission match, got nil")
+		return
 	}
 	if submission.ID != "current-submission" {
 		t.Fatalf("expected current-submission, got %q", submission.ID)
@@ -2102,6 +2105,7 @@ func TestFindReviewSubmissionForVersion_PrefersCurrentSubmissionOverHistoricalMa
 	}
 	if submission == nil {
 		t.Fatal("expected review submission match, got nil")
+		return
 	}
 	if submission.ID != "current-submission" {
 		t.Fatalf("expected current-submission, got %q", submission.ID)

--- a/internal/cli/subscriptions/subscriptions_update_test.go
+++ b/internal/cli/subscriptions/subscriptions_update_test.go
@@ -31,6 +31,7 @@ func TestSubscriptionsUpdateCommand_GroupLevelHelpOmitsSentinelDefault(t *testin
 	groupLevelFlag := cmd.FlagSet.Lookup("group-level")
 	if groupLevelFlag == nil {
 		t.Fatal("expected --group-level flag to be defined")
+		return
 	}
 	if groupLevelFlag.DefValue != "" {
 		t.Fatalf("expected --group-level to have no displayed default, got %q", groupLevelFlag.DefValue)

--- a/internal/cli/users/users_test.go
+++ b/internal/cli/users/users_test.go
@@ -318,6 +318,7 @@ func TestUsersCommands_DefaultOutputJSON(t *testing.T) {
 			f := cmd.FlagSet.Lookup("output")
 			if f == nil {
 				t.Fatalf("expected --output flag to be defined")
+				return
 			}
 			if f.DefValue != "json" {
 				t.Fatalf("expected --output default to be 'json', got %q", f.DefValue)

--- a/internal/cli/versions/phased_release_test.go
+++ b/internal/cli/versions/phased_release_test.go
@@ -212,6 +212,7 @@ func TestPhasedReleaseCommand_DefaultOutputJSON(t *testing.T) {
 			f := cmd.FlagSet.Lookup("output")
 			if f == nil {
 				t.Fatal("expected --output flag to be defined")
+				return
 			}
 			if f.DefValue != "json" {
 				t.Errorf("expected --output default to be 'json', got %q", f.DefValue)

--- a/internal/cli/versions/versions_release_test.go
+++ b/internal/cli/versions/versions_release_test.go
@@ -46,6 +46,7 @@ func TestVersionsReleaseCommand_DefaultOutputJSON(t *testing.T) {
 	f := cmd.FlagSet.Lookup("output")
 	if f == nil {
 		t.Fatal("expected --output flag to be defined")
+		return
 	}
 	if f.DefValue != "json" {
 		t.Errorf("expected --output default to be 'json', got %q", f.DefValue)

--- a/internal/cli/videopreviews/video_previews_test.go
+++ b/internal/cli/videopreviews/video_previews_test.go
@@ -6,6 +6,7 @@ func TestVideoPreviewsCommandConstructors(t *testing.T) {
 	cmd := VideoPreviewsCommand()
 	if cmd == nil {
 		t.Fatal("expected video-previews command")
+		return
 	}
 	if cmd.Name != "video-previews" {
 		t.Fatalf("expected command name video-previews, got %q", cmd.Name)

--- a/internal/cli/web/web_session_flags_test.go
+++ b/internal/cli/web/web_session_flags_test.go
@@ -20,6 +20,7 @@ func TestBindWebSessionFlagsIncludesDeprecatedTwoFactorAlias(t *testing.T) {
 	twoFactorCodeFlag := fs.Lookup(deprecatedTwoFactorCodeFlagName)
 	if twoFactorCodeFlag == nil {
 		t.Fatalf("expected --%s to be registered", deprecatedTwoFactorCodeFlagName)
+		return
 	}
 	if !strings.Contains(twoFactorCodeFlag.Usage, "Deprecated:") {
 		t.Fatalf("expected deprecated help text, got %q", twoFactorCodeFlag.Usage)

--- a/internal/cli/web/web_xcode_cloud_envvars_test.go
+++ b/internal/cli/web/web_xcode_cloud_envvars_test.go
@@ -18,6 +18,7 @@ func TestEnvVarsCommandHierarchy(t *testing.T) {
 	envVarsCmd := findSub(cmd, "env-vars")
 	if envVarsCmd == nil {
 		t.Fatal("expected 'env-vars' subcommand")
+		return
 	}
 	if len(envVarsCmd.Subcommands) != 4 {
 		t.Fatalf("expected 4 subcommands (list, set, delete, shared), got %d", len(envVarsCmd.Subcommands))

--- a/internal/cli/web/web_xcode_cloud_shared_envvars_test.go
+++ b/internal/cli/web/web_xcode_cloud_shared_envvars_test.go
@@ -22,6 +22,7 @@ func TestSharedEnvVarsCommandHierarchy(t *testing.T) {
 	sharedCmd := findSub(envVarsCmd, "shared")
 	if sharedCmd == nil {
 		t.Fatal("expected 'shared' subcommand under env-vars")
+		return
 	}
 	if len(sharedCmd.Subcommands) != 3 {
 		t.Fatalf("expected 3 subcommands (list, set, delete), got %d", len(sharedCmd.Subcommands))

--- a/internal/cli/web/web_xcode_cloud_test.go
+++ b/internal/cli/web/web_xcode_cloud_test.go
@@ -92,6 +92,7 @@ func TestWebXcodeCloudUsageSubcommands(t *testing.T) {
 	usageCmd := findSub(cmd, "usage")
 	if usageCmd == nil {
 		t.Fatal("could not find 'usage' subcommand")
+		return
 	}
 	if len(usageCmd.Subcommands) != 5 {
 		t.Fatalf("expected 5 usage subcommands, got %d", len(usageCmd.Subcommands))
@@ -561,11 +562,13 @@ func TestWebXcodeCloudUsageDaysFlagSet(t *testing.T) {
 	daysCmd := findSub(findSub(cmd, "usage"), "days")
 	if daysCmd == nil {
 		t.Fatal("could not find 'usage days' subcommand")
+		return
 	}
 
 	fs := daysCmd.FlagSet
 	if fs == nil {
 		t.Fatal("expected flag set on days command")
+		return
 	}
 
 	for _, name := range []string{"product-ids", "start", "end"} {
@@ -580,6 +583,7 @@ func TestWebXcodeCloudUsageMonthsFlagSet(t *testing.T) {
 	monthsCmd := findSub(findSub(cmd, "usage"), "months")
 	if monthsCmd == nil {
 		t.Fatal("could not find 'usage months' subcommand")
+		return
 	}
 
 	fs := monthsCmd.FlagSet
@@ -609,6 +613,7 @@ func TestWebXcodeCloudUsageMonthsDefaultsLast12Months(t *testing.T) {
 	endYear := fs.Lookup("end-year")
 	if startMonth == nil || startYear == nil || endMonth == nil || endYear == nil {
 		t.Fatal("expected start/end month/year flags")
+		return
 	}
 
 	expectedStart := fixedNow.AddDate(0, -11, 0)
@@ -1094,6 +1099,7 @@ func TestWebXcodeCloudUsageWorkflowsFlagSet(t *testing.T) {
 	workflowsCmd := findSub(findSub(cmd, "usage"), "workflows")
 	if workflowsCmd == nil {
 		t.Fatal("could not find 'usage workflows' subcommand")
+		return
 	}
 
 	fs := workflowsCmd.FlagSet

--- a/internal/cli/web/web_xcode_cloud_workflow_options_test.go
+++ b/internal/cli/web/web_xcode_cloud_workflow_options_test.go
@@ -31,6 +31,7 @@ func TestWorkflowsOptionsCommandHierarchy(t *testing.T) {
 	optionsCmd := findSub(cmd, "options")
 	if optionsCmd == nil {
 		t.Fatal("expected 'options' subcommand")
+		return
 	}
 	if len(optionsCmd.Subcommands) != 7 {
 		t.Fatalf("expected 7 options subcommands, got %d", len(optionsCmd.Subcommands))

--- a/internal/cli/web/web_xcode_cloud_workflows_test.go
+++ b/internal/cli/web/web_xcode_cloud_workflows_test.go
@@ -19,6 +19,7 @@ func TestWorkflowsCommandHierarchy(t *testing.T) {
 	workflowsCmd := findSub(cmd, "workflows")
 	if workflowsCmd == nil {
 		t.Fatal("expected 'workflows' subcommand")
+		return
 	}
 	if len(workflowsCmd.Subcommands) != 6 {
 		t.Fatalf("expected 6 subcommands (describe, create, options, edit, enable, disable), got %d", len(workflowsCmd.Subcommands))

--- a/internal/cli/winbackoffers/win_back_offers_test.go
+++ b/internal/cli/winbackoffers/win_back_offers_test.go
@@ -6,6 +6,7 @@ func TestWinBackOffersCommandConstructors(t *testing.T) {
 	top := WinBackOffersCommand()
 	if top == nil {
 		t.Fatal("expected win-back-offers command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/cli/xcodecloud/xcode_cloud_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_test.go
@@ -6,6 +6,7 @@ func TestXcodeCloudCommandConstructors(t *testing.T) {
 	top := XcodeCloudCommand()
 	if top == nil {
 		t.Fatal("expected xcode-cloud command")
+		return
 	}
 	if top.Name == "" {
 		t.Fatal("expected command name")

--- a/internal/screenshots/frame_test.go
+++ b/internal/screenshots/frame_test.go
@@ -173,6 +173,7 @@ screenshots:
 	metadata := parseKoubouConfigMetadata(configPath)
 	if metadata == nil {
 		t.Fatal("expected parsed metadata")
+		return
 	}
 	if metadata.FrameRef != "iPhone 17 Pro - Silver - Portrait" {
 		t.Fatalf("unexpected frame ref %q", metadata.FrameRef)

--- a/internal/web/analytics_pages_test.go
+++ b/internal/web/analytics_pages_test.go
@@ -405,6 +405,7 @@ func TestGetAnalyticsBenchmarksMergesAppAndPercentiles(t *testing.T) {
 	}
 	if conversion == nil {
 		t.Fatalf("expected conversionRate metric, got %#v", resp.Metrics)
+		return
 	}
 	if conversion.AppValue == nil || *conversion.AppValue != 0.62 {
 		t.Fatalf("unexpected app value: %#v", conversion)

--- a/internal/web/app_availability_test.go
+++ b/internal/web/app_availability_test.go
@@ -110,6 +110,7 @@ func TestCreateAppAvailabilityBuildsExpectedRequest(t *testing.T) {
 	}
 	if created == nil {
 		t.Fatal("expected created app availability")
+		return
 	}
 	if created.ID != "avail-123" {
 		t.Fatalf("expected id avail-123, got %q", created.ID)
@@ -156,6 +157,7 @@ func TestGetAppAvailabilityBuildsExpectedRequest(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected app availability")
+		return
 	}
 	if got.ID != "avail-123" || !got.AvailableInNewTerritories {
 		t.Fatalf("unexpected app availability payload: %#v", got)

--- a/internal/web/medical_device_test.go
+++ b/internal/web/medical_device_test.go
@@ -127,6 +127,7 @@ func TestSetMedicalDeviceDeclarationPostsExpectedRequest(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected result")
+		return
 	}
 	if got.AppID != "app-123" {
 		t.Fatalf("expected app id app-123, got %q", got.AppID)
@@ -227,6 +228,7 @@ func TestSetMedicalDeviceDeclarationPrefersExactContentIDRequirements(t *testing
 	}
 	if got == nil {
 		t.Fatal("expected result")
+		return
 	}
 	if got.RequirementID != "req-app" {
 		t.Fatalf("expected exact app requirement id req-app, got %q", got.RequirementID)

--- a/internal/web/privacy_test.go
+++ b/internal/web/privacy_test.go
@@ -248,6 +248,7 @@ func TestCreateAppDataUsageBuildsExpectedRequest(t *testing.T) {
 	}
 	if created == nil {
 		t.Fatal("expected created usage")
+		return
 	}
 	if created.ID != "usage-new" || created.Category != "NAME" || created.Purpose != "APP_FUNCTIONALITY" || created.DataProtection != "DATA_LINKED_TO_YOU" {
 		t.Fatalf("unexpected created usage: %#v", created)
@@ -329,6 +330,7 @@ func TestUpdateAppDataUsageBuildsExpectedRequest(t *testing.T) {
 	}
 	if updated == nil {
 		t.Fatal("expected updated usage")
+		return
 	}
 	if updated.ID != "usage-1" || updated.Category != "NAME" || updated.Purpose != "APP_FUNCTIONALITY" || updated.DataProtection != "DATA_NOT_LINKED_TO_YOU" {
 		t.Fatalf("unexpected updated usage: %#v", updated)
@@ -385,6 +387,7 @@ func TestGetAppDataUsagesPublishStateParsesResponse(t *testing.T) {
 	}
 	if state == nil {
 		t.Fatal("expected non-nil publish state")
+		return
 	}
 	if state.ID != "publish-state-1" || state.Published {
 		t.Fatalf("unexpected publish state: %#v", state)
@@ -436,6 +439,7 @@ func TestSetAppDataUsagesPublishedBuildsPatchRequest(t *testing.T) {
 	}
 	if state == nil {
 		t.Fatal("expected non-nil publish state")
+		return
 	}
 	if state.ID != "publish-state-1" || !state.Published {
 		t.Fatalf("unexpected publish state: %#v", state)

--- a/internal/workflow/execute_test.go
+++ b/internal/workflow/execute_test.go
@@ -479,6 +479,7 @@ func TestRun_ResumeSkipsCompletedStepsAndReusesOutputs(t *testing.T) {
 	}
 	if firstResult == nil {
 		t.Fatal("expected structured result on failure")
+		return
 	}
 	if firstResult.Status != "error" {
 		t.Fatalf("expected status error, got %q", firstResult.Status)
@@ -577,6 +578,7 @@ func TestRun_ResumeReusesOriginalParams(t *testing.T) {
 	}
 	if firstResult == nil {
 		t.Fatal("expected structured result on failure")
+		return
 	}
 	if !firstResult.Recoverable {
 		t.Fatal("expected first failure to be recoverable")


### PR DESCRIPTION
## Summary
- add experimental `asc reviews respond-batch` for grouped JSON customer review replies
- add review list response-state filtering and response relationship inclusion support
- return structured per-review batch results and preserve partial output before nonzero failure exits
- fix batch JSON parsing to reject trailing JSON before mutating
- clean up staticcheck nil-guard findings in tests so lint passes

## Validation
- `make format`
- `make generate-command-docs`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

Closes #1533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New reviews respond-batch command to create customer review responses in bulk from a JSON file, with dry-run, skip-existing, and response-state filtering.
  * Added --response-state flag (any, unresponded, responded) and --include-response flag for review listings.

* **Tests**
  * Added explicit early returns after fatal test failures across many test suites to improve test clarity and robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->