### PR TITLE
Add agent-oriented command search

### DIFF
--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -70,7 +70,7 @@ var rootUsageGroups = []rootCommandGroup{
 	},
 	{
 		title:    "UTILITY COMMANDS",
-		commands: []string{"diff", "capabilities", "snitch", "version", "completion", "schema"},
+		commands: []string{"diff", "capabilities", "search", "snitch", "version", "completion", "schema"},
 	},
 }
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -136,6 +136,7 @@ asc <subcommand> [flags]
 
 - `diff` - Generate deterministic non-mutating diff plans.
 - `capabilities` - Show CLI, API, web-only, and public-API-limited capability coverage.
+- `search` - Search asc commands and examples for agent-oriented command discovery.
 - `snitch` - Report CLI friction as a GitHub issue.
 - `version` - Print version information and exit.
 - `completion` - Print shell completion scripts.

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -400,6 +400,23 @@ func TestSearchInvalidOutputExitsWithUsageCode(t *testing.T) {
 	}
 }
 
+func TestSearchInvalidMixedOrderOutputExitsWithUsageCode(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "builds", "--output", "yaml"}, "1.2.3")
+	})
+
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unsupported format: yaml") {
+		t.Fatalf("expected unsupported format error, got %q", stderr)
+	}
+}
+
 func searchResultsContain(results []searchResult, commandPrefix string) bool {
 	for _, result := range results {
 		if strings.HasPrefix(result.Command, commandPrefix) {

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -270,6 +270,34 @@ func TestSearchFlagValueCanMatchSubcommandName(t *testing.T) {
 	}
 }
 
+func TestSearchSupportsMixedFlagOrder(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "build", "--limit", "1"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if response.Query != "build" {
+		t.Fatalf("expected build query, got %q", response.Query)
+	}
+	if response.Count != 1 || len(response.Results) != 1 {
+		t.Fatalf("expected one limited result, got %#v", response)
+	}
+	if !searchResultsContain(response.Results, "asc build") {
+		t.Fatalf("expected build command in results, got %#v", response.Results)
+	}
+}
+
 func TestSearchRequiresQuery(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -206,6 +206,51 @@ func TestSearchSupportsLimitFlag(t *testing.T) {
 	}
 }
 
+func TestSearchDoesNotLeakFlagsAcrossRepeatedRuns(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "json", "--limit", "1", "build"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var limited searchResponse
+	if err := json.Unmarshal([]byte(stdout), &limited); err != nil {
+		t.Fatalf("failed to unmarshal limited search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if limited.Count != 1 || len(limited.Results) != 1 {
+		t.Fatalf("expected one limited result, got %#v", limited)
+	}
+
+	stdout, stderr = captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "json", "build"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var defaultLimit searchResponse
+	if err := json.Unmarshal([]byte(stdout), &defaultLimit); err != nil {
+		t.Fatalf("failed to unmarshal default-limit search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if defaultLimit.Count <= 1 || len(defaultLimit.Results) <= 1 {
+		t.Fatalf("expected default limit after repeated run, got %#v", defaultLimit)
+	}
+}
+
 func TestSearchRejectsNonPositiveLimit(t *testing.T) {
 	var code int
 	stdout, stderr := captureOutput(t, func() {

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -184,6 +184,92 @@ func TestSearchReturnsEmptyResultsForNoMatches(t *testing.T) {
 	}
 }
 
+func TestSearchSupportsLimitFlag(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "--limit", "2", "build"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if response.Count > 2 || len(response.Results) > 2 {
+		t.Fatalf("expected at most 2 results, got %#v", response)
+	}
+}
+
+func TestSearchRejectsNonPositiveLimit(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--limit", "0", "build"}, "1.2.3")
+	})
+
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--limit must be greater than 0") {
+		t.Fatalf("expected limit validation error, got %q", stderr)
+	}
+}
+
+func TestSearchAcceptsRootFlagsBeforeSubcommand(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"--profile", "ci", "search", "--output", "json", "--limit", "1", "build"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if response.Count != 1 || len(response.Results) != 1 {
+		t.Fatalf("expected one limited result, got %#v", response)
+	}
+}
+
+func TestSearchFlagValueCanMatchSubcommandName(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "--limit", "3", "completion"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if response.Query != "completion" {
+		t.Fatalf("expected completion query, got %q", response.Query)
+	}
+	if !searchResultsContain(response.Results, "asc completion") {
+		t.Fatalf("expected completion command in results, got %#v", response.Results)
+	}
+}
+
 func TestSearchRequiresQuery(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -198,6 +284,23 @@ func TestSearchRequiresQuery(t *testing.T) {
 
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "search query is required") {
+		t.Fatalf("expected missing query error, got %q", stderr)
+	}
+}
+
+func TestSearchRejectsBlankQuery(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "   "}, "1.2.3")
+	})
+
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -1,0 +1,245 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+type searchResponse struct {
+	Query   string         `json:"query"`
+	Count   int            `json:"count"`
+	Results []searchResult `json:"results"`
+}
+
+type searchResult struct {
+	Command  string   `json:"command"`
+	Summary  string   `json:"summary"`
+	Usage    string   `json:"usage"`
+	Score    int      `json:"score"`
+	Matched  []string `json:"matched"`
+	Examples []string `json:"examples"`
+}
+
+func TestSearchFindsCommandsFromTaskWordsAsJSON(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "json", "external", "testers"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+
+	if response.Query != "external testers" {
+		t.Fatalf("expected normalized query, got %q", response.Query)
+	}
+	if response.Count == 0 || len(response.Results) == 0 {
+		t.Fatalf("expected search results, got %#v", response)
+	}
+	if !searchResultsContain(response.Results, "asc testflight testers") {
+		t.Fatalf("expected TestFlight tester command in results, got %#v", response.Results)
+	}
+	for _, result := range response.Results {
+		if strings.TrimSpace(result.Command) == "" {
+			t.Fatalf("expected command path in result: %#v", result)
+		}
+		if strings.TrimSpace(result.Summary) == "" {
+			t.Fatalf("expected summary in result: %#v", result)
+		}
+		if result.Score <= 0 {
+			t.Fatalf("expected positive score in result: %#v", result)
+		}
+		if len(result.Matched) == 0 {
+			t.Fatalf("expected match reasons in result: %#v", result)
+		}
+	}
+}
+
+func TestSearchUsesAliasesForAgentVocabulary(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "json", "ship", "app", "review"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+
+	if !searchResultsContain(response.Results, "asc publish appstore") && !searchResultsContain(response.Results, "asc review submit") {
+		t.Fatalf("expected publish or review submission command for ship app review, got %#v", response.Results)
+	}
+	if !searchResultsMention(response.Results, "alias:ship") {
+		t.Fatalf("expected alias match reason for ship query, got %#v", response.Results)
+	}
+}
+
+func TestSearchUsesTypoToleranceAsFallback(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "json", "testfligth", "testers"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+
+	if !searchResultsContain(response.Results, "asc testflight testers") {
+		t.Fatalf("expected TestFlight tester command for typo query, got %#v", response.Results)
+	}
+	if !searchResultsMention(response.Results, "fuzzy:testflight") {
+		t.Fatalf("expected fuzzy match reason for testfligth typo, got %#v", response.Results)
+	}
+}
+
+func TestSearchSupportsTableOutput(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "table", "build", "upload"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "command") || !strings.Contains(stdout, "summary") {
+		t.Fatalf("expected table headers, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "asc builds upload") {
+		t.Fatalf("expected build upload command in table output, got %q", stdout)
+	}
+}
+
+func TestSearchReturnsEmptyResultsForNoMatches(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search", "--output", "json", "zzzz-not-real"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if response.Count != 0 || len(response.Results) != 0 {
+		t.Fatalf("expected empty result set, got %#v", response)
+	}
+}
+
+func TestSearchRequiresQuery(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"search"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "search query is required") {
+		t.Fatalf("expected missing query error, got %q", stderr)
+	}
+}
+
+func TestSearchInvalidOutputExitsWithUsageCode(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "yaml", "builds"}, "1.2.3")
+	})
+
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unsupported format: yaml") {
+		t.Fatalf("expected unsupported format error, got %q", stderr)
+	}
+}
+
+func searchResultsContain(results []searchResult, commandPrefix string) bool {
+	for _, result := range results {
+		if strings.HasPrefix(result.Command, commandPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func searchResultsMention(results []searchResult, match string) bool {
+	for _, result := range results {
+		for _, item := range result.Matched {
+			if item == match {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -131,6 +131,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `docs` - Generate asc cli reference docs for a repo.
 - `diff` - Generate deterministic non-mutating diff plans.
 - `capabilities` - Show CLI, API, web-only, and public-API-limited capability coverage.
+- `search` - Search asc commands and examples for agent-oriented command discovery.
 - `status` - Show a release pipeline dashboard for an app.
 - `insights` - Generate weekly insights from App Store data sources.
 - `release-notes` - Generate and manage App Store release notes.

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -61,6 +61,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/sandbox"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/schema"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/screenshots"
+	searchcmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/search"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/signing"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/snitch"
@@ -101,7 +102,8 @@ func Subcommands(version string) []*ffcli.Command {
 		"asc pricing availability set":   {},
 	}
 
-	subs := []*ffcli.Command{
+	var subs []*ffcli.Command
+	subs = []*ffcli.Command{
 		auth.AuthCommand(),
 		auth.AuthDoctorCommand(),
 		web.WebCommand(),
@@ -174,6 +176,7 @@ func Subcommands(version string) []*ffcli.Command {
 		gamecenter.GameCenterCommand(),
 		capabilities.Command(),
 		schema.SchemaCommand(),
+		searchcmd.SearchCommand(func() []*ffcli.Command { return subs }),
 		snitch.SnitchCommand(version),
 		VersionCommand(version),
 	}

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -1,0 +1,452 @@
+package search
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared/suggest"
+)
+
+const defaultLimit = 10
+
+var tokenPattern = regexp.MustCompile(`[a-z0-9][a-z0-9-]*`)
+
+// SearchResponse is the machine-readable output for command discovery.
+type SearchResponse struct {
+	Query   string         `json:"query"`
+	Count   int            `json:"count"`
+	Results []SearchResult `json:"results"`
+}
+
+// SearchResult describes a matching CLI command.
+type SearchResult struct {
+	Command  string   `json:"command"`
+	Summary  string   `json:"summary"`
+	Usage    string   `json:"usage,omitempty"`
+	Score    int      `json:"score"`
+	Matched  []string `json:"matched"`
+	Examples []string `json:"examples,omitempty"`
+}
+
+type commandDoc struct {
+	Command     string
+	Summary     string
+	Usage       string
+	LongHelp    string
+	Examples    []string
+	Flags       []string
+	PathTokens  []string
+	TextTokens  []string
+	FlagTokens  []string
+	AllTokens   []string
+	CommandRank int
+}
+
+type scoredResult struct {
+	result SearchResult
+	rank   int
+}
+
+// SearchCommand returns the command-discovery search command.
+func SearchCommand(commands func() []*ffcli.Command) *ffcli.Command {
+	fs := flag.NewFlagSet("search", flag.ExitOnError)
+	output := shared.BindOutputFlags(fs)
+	limit := fs.Int("limit", defaultLimit, "Maximum number of results to return")
+
+	return &ffcli.Command{
+		Name:       "search",
+		ShortUsage: "asc search [flags] <query>",
+		ShortHelp:  "Search asc commands and examples for agent-oriented command discovery.",
+		LongHelp: `Search asc commands and examples for agent-oriented command discovery.
+
+Search is local and deterministic. It indexes the registered command tree,
+including command paths, summaries, usage strings, examples, and flag names.
+It does not search App Store Connect data.
+
+Examples:
+  asc search "external testers"
+  asc search --output json "submit app for review"
+  asc search --output table "upload build"
+  asc search --limit 5 "cert profiles"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			_ = ctx
+			if len(args) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: search query is required")
+				return flag.ErrHelp
+			}
+			if *limit <= 0 {
+				fmt.Fprintln(os.Stderr, "Error: --limit must be greater than 0")
+				return flag.ErrHelp
+			}
+
+			query := strings.Join(args, " ")
+			response := SearchCommands(commands(), query, *limit)
+			return shared.PrintOutputWithRenderers(
+				response,
+				*output.Output,
+				*output.Pretty,
+				func() error {
+					asc.RenderTable([]string{"score", "command", "summary", "matched"}, searchRows(response.Results))
+					return nil
+				},
+				func() error {
+					asc.RenderMarkdown([]string{"score", "command", "summary", "matched"}, searchRows(response.Results))
+					return nil
+				},
+			)
+		},
+	}
+}
+
+// SearchCommands searches a command tree and returns ranked results.
+func SearchCommands(commands []*ffcli.Command, query string, limit int) SearchResponse {
+	normalizedQuery := normalizeQuery(query)
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	docs := collectCommandDocs(commands)
+	scored := scoreCommandDocs(docs, normalizedQuery)
+	if len(scored) > limit {
+		scored = scored[:limit]
+	}
+
+	results := make([]SearchResult, 0, len(scored))
+	for _, item := range scored {
+		results = append(results, item.result)
+	}
+	return SearchResponse{
+		Query:   normalizedQuery,
+		Count:   len(results),
+		Results: results,
+	}
+}
+
+func collectCommandDocs(commands []*ffcli.Command) []commandDoc {
+	docs := make([]commandDoc, 0)
+	for _, cmd := range commands {
+		collectCommandDoc(&docs, cmd, nil)
+	}
+	return docs
+}
+
+func collectCommandDoc(docs *[]commandDoc, cmd *ffcli.Command, parents []string) {
+	if cmd == nil || hiddenCommand(cmd) {
+		return
+	}
+
+	pathParts := append(append([]string{"asc"}, parents...), cmd.Name)
+	command := strings.Join(pathParts, " ")
+	usage := strings.TrimSpace(cmd.ShortUsage)
+	if usage == "" {
+		usage = command
+	}
+	summary := strings.TrimSpace(cmd.ShortHelp)
+	longHelp := strings.TrimSpace(cmd.LongHelp)
+	examples := extractExamples(longHelp)
+	flags := commandFlags(cmd)
+	pathTokens := uniqueTokens(strings.Join(pathParts[1:], " "))
+	textTokens := uniqueTokens(strings.Join([]string{summary, usage, longHelp, strings.Join(examples, " ")}, " "))
+	flagTokens := uniqueTokens(strings.Join(flags, " "))
+
+	all := append(append(append([]string{}, pathTokens...), textTokens...), flagTokens...)
+	*docs = append(*docs, commandDoc{
+		Command:     command,
+		Summary:     summary,
+		Usage:       usage,
+		LongHelp:    longHelp,
+		Examples:    examples,
+		Flags:       flags,
+		PathTokens:  pathTokens,
+		TextTokens:  textTokens,
+		FlagTokens:  flagTokens,
+		AllTokens:   uniqueStrings(all),
+		CommandRank: len(pathParts),
+	})
+
+	nextParents := append(append([]string{}, parents...), cmd.Name)
+	for _, sub := range cmd.Subcommands {
+		collectCommandDoc(docs, sub, nextParents)
+	}
+}
+
+func scoreCommandDocs(docs []commandDoc, query string) []scoredResult {
+	queryTokens := uniqueTokens(query)
+	if len(queryTokens) == 0 {
+		return nil
+	}
+
+	results := make([]scoredResult, 0)
+	for _, doc := range docs {
+		score, matched := scoreCommandDoc(doc, queryTokens)
+		if score <= 0 {
+			continue
+		}
+		results = append(results, scoredResult{
+			result: SearchResult{
+				Command:  doc.Command,
+				Summary:  doc.Summary,
+				Usage:    doc.Usage,
+				Score:    score,
+				Matched:  matched,
+				Examples: doc.Examples,
+			},
+			rank: doc.CommandRank,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].result.Score != results[j].result.Score {
+			return results[i].result.Score > results[j].result.Score
+		}
+		if results[i].rank != results[j].rank {
+			return results[i].rank < results[j].rank
+		}
+		return results[i].result.Command < results[j].result.Command
+	})
+	return results
+}
+
+func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {
+	score := 0
+	reasons := make([]string, 0)
+	seenReasons := make(map[string]struct{})
+
+	for _, token := range queryTokens {
+		tokenScore, tokenReasons := scoreTerm(doc, token, "query:"+token)
+		score += tokenScore
+		for _, reason := range tokenReasons {
+			addReason(&reasons, seenReasons, reason)
+		}
+
+		for _, alias := range aliasesFor(token) {
+			aliasScore, aliasReasons := scoreTerm(doc, alias, "alias:"+token)
+			if aliasScore == 0 {
+				continue
+			}
+			score += max(1, aliasScore/2)
+			addReason(&reasons, seenReasons, "alias:"+token)
+			for _, reason := range aliasReasons {
+				addReason(&reasons, seenReasons, reason)
+			}
+		}
+	}
+
+	return score, reasons
+}
+
+func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
+	if strings.TrimSpace(term) == "" {
+		return 0, nil
+	}
+
+	score := 0
+	reasons := make([]string, 0, 4)
+	commandWithoutASC := strings.TrimPrefix(doc.Command, "asc ")
+
+	if commandWithoutASC == term || doc.Command == term {
+		score += 120
+		reasons = append(reasons, reason, "command:"+term)
+	}
+	if tokenContains(doc.PathTokens, term) {
+		score += 60
+		reasons = append(reasons, reason, "command:"+term)
+	}
+	if strings.Contains(strings.ToLower(doc.Command), term) && !tokenContains(doc.PathTokens, term) {
+		score += 40
+		reasons = append(reasons, reason, "command:"+term)
+	}
+	if strings.Contains(strings.ToLower(doc.Summary), term) {
+		score += 35
+		reasons = append(reasons, reason, "summary:"+term)
+	}
+	if strings.Contains(strings.ToLower(doc.Usage), term) {
+		score += 25
+		reasons = append(reasons, reason, "usage:"+term)
+	}
+	if tokenContains(doc.FlagTokens, term) {
+		score += 20
+		reasons = append(reasons, reason, "flag:"+term)
+	}
+	if strings.Contains(strings.ToLower(strings.Join(doc.Examples, "\n")), term) {
+		score += 18
+		reasons = append(reasons, reason, "example:"+term)
+	}
+	if strings.Contains(strings.ToLower(doc.LongHelp), term) {
+		score += 10
+		reasons = append(reasons, reason, "help:"+term)
+	}
+
+	if score == 0 && len(term) >= 4 && !strings.Contains(term, "-") {
+		for _, suggestion := range suggest.Commands(term, doc.AllTokens) {
+			if tokenContains(doc.AllTokens, suggestion) {
+				score += 8
+				reasons = append(reasons, reason, "fuzzy:"+suggestion)
+				break
+			}
+		}
+	}
+
+	return score, uniqueStrings(reasons)
+}
+
+func aliasesFor(token string) []string {
+	switch token {
+	case "ship", "shipping":
+		return []string{"publish", "submit", "release"}
+	case "submission", "submissions":
+		return []string{"submit", "review", "appstore"}
+	case "review":
+		return []string{"submit", "submission", "appstore"}
+	case "beta":
+		return []string{"testflight"}
+	case "tester", "testers", "user", "users":
+		return []string{"tester", "testers", "beta-testers", "testflight"}
+	case "external":
+		return []string{"testflight", "beta", "tester", "testers", "group", "groups"}
+	case "cert", "certs":
+		return []string{"certificate", "certificates"}
+	case "provisioning":
+		return []string{"profiles", "profile"}
+	case "ipa", "binary":
+		return []string{"build", "upload", "uploads"}
+	case "appstore", "store":
+		return []string{"appstore", "app", "review", "publish"}
+	default:
+		return nil
+	}
+}
+
+func commandFlags(cmd *ffcli.Command) []string {
+	if cmd.FlagSet == nil {
+		return nil
+	}
+	flags := make([]string, 0)
+	cmd.FlagSet.VisitAll(func(f *flag.Flag) {
+		if f == nil {
+			return
+		}
+		flags = append(flags, f.Name)
+		if strings.TrimSpace(f.Usage) != "" {
+			flags = append(flags, f.Usage)
+		}
+	})
+	return flags
+}
+
+func extractExamples(longHelp string) []string {
+	lines := strings.Split(longHelp, "\n")
+	examples := make([]string, 0)
+	inExamples := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.EqualFold(trimmed, "Examples:") {
+			inExamples = true
+			continue
+		}
+		if !inExamples {
+			continue
+		}
+		if trimmed == "" {
+			if len(examples) > 0 {
+				break
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "asc ") {
+			examples = append(examples, trimmed)
+		}
+	}
+	return examples
+}
+
+func hiddenCommand(cmd *ffcli.Command) bool {
+	shortHelp := strings.TrimSpace(cmd.ShortHelp)
+	return strings.HasPrefix(shortHelp, "DEPRECATED:") ||
+		strings.HasPrefix(shortHelp, "REMOVED:") ||
+		strings.HasPrefix(shortHelp, "Compatibility alias:")
+}
+
+func searchRows(results []SearchResult) [][]string {
+	rows := make([][]string, 0, len(results))
+	for _, result := range results {
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", result.Score),
+			result.Command,
+			result.Summary,
+			summarizeMatches(result.Matched),
+		})
+	}
+	return rows
+}
+
+func summarizeMatches(matches []string) string {
+	const maxMatches = 6
+	if len(matches) <= maxMatches {
+		return strings.Join(matches, ", ")
+	}
+	return strings.Join(matches[:maxMatches], ", ") + fmt.Sprintf(", +%d more", len(matches)-maxMatches)
+}
+
+func normalizeQuery(query string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(query)), " ")
+}
+
+func uniqueTokens(text string) []string {
+	matches := tokenPattern.FindAllString(strings.ToLower(text), -1)
+	return uniqueStrings(matches)
+}
+
+func tokenContains(tokens []string, term string) bool {
+	for _, token := range tokens {
+		if token == term {
+			return true
+		}
+		if len(term) >= 3 && strings.Contains(token, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func addReason(reasons *[]string, seen map[string]struct{}, reason string) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return
+	}
+	if _, ok := seen[reason]; ok {
+		return
+	}
+	seen[reason] = struct{}{}
+	*reasons = append(*reasons, reason)
+}

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -230,6 +230,9 @@ func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {
 		}
 
 		for _, alias := range aliasesFor(token) {
+			if alias == token {
+				continue
+			}
 			aliasScore, aliasReasons := scoreTerm(doc, alias, "alias:"+token)
 			if aliasScore == 0 {
 				continue
@@ -254,11 +257,12 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 	reasons := make([]string, 0, 4)
 	commandWithoutASC := strings.TrimPrefix(doc.Command, "asc ")
 
-	if commandWithoutASC == term || doc.Command == term {
+	exactCommandMatch := commandWithoutASC == term || doc.Command == term
+	if exactCommandMatch {
 		score += 120
 		reasons = append(reasons, reason, "command:"+term)
 	}
-	if tokenContains(doc.PathTokens, term) {
+	if !exactCommandMatch && tokenContains(doc.PathTokens, term) {
 		score += 60
 		reasons = append(reasons, reason, "command:"+term)
 	}

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -90,7 +90,11 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			query := strings.Join(args, " ")
+			query := normalizeQuery(strings.Join(args, " "))
+			if query == "" {
+				fmt.Fprintln(os.Stderr, "Error: search query is required")
+				return flag.ErrHelp
+			}
 			response := SearchCommands(commands(), query, *limit)
 			return shared.PrintOutputWithRenderers(
 				response,

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -95,8 +95,8 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			query := normalizeQuery(strings.Join(args, " "))
-			if query == "" {
+			query := strings.Join(args, " ")
+			if strings.TrimSpace(query) == "" {
 				fmt.Fprintln(os.Stderr, "Error: search query is required")
 				return flag.ErrHelp
 			}
@@ -348,8 +348,7 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 
 	exactCommandMatch := commandWithoutASC == term || doc.Command == term
 	if exactCommandMatch {
-		score += 120
-		reasons = append(reasons, reason, "command:"+term)
+		return 120, []string{reason, "command:" + term}
 	}
 	if !exactCommandMatch && tokenContains(doc.PathTokens, term) {
 		score += 60

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -107,7 +107,7 @@ Examples:
 			selectedLimit := *limit
 
 			response := SearchCommands(commands(), query, selectedLimit)
-			return shared.PrintOutputWithRenderers(
+			if err := shared.PrintOutputWithRenderers(
 				response,
 				selectedOutput,
 				selectedPretty,
@@ -119,7 +119,10 @@ Examples:
 					asc.RenderMarkdown([]string{"score", "command", "summary", "matched"}, searchRows(response.Results))
 					return nil
 				},
-			)
+			); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			return nil
 		},
 	}
 }

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -81,6 +81,8 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			_ = ctx
+			defer resetFlagSet(fs)
+
 			args, err := parseInterspersedSearchFlags(fs, args)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -100,11 +102,15 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: search query is required")
 				return flag.ErrHelp
 			}
-			response := SearchCommands(commands(), query, *limit)
+			selectedOutput := *output.Output
+			selectedPretty := *output.Pretty
+			selectedLimit := *limit
+
+			response := SearchCommands(commands(), query, selectedLimit)
 			return shared.PrintOutputWithRenderers(
 				response,
-				*output.Output,
-				*output.Pretty,
+				selectedOutput,
+				selectedPretty,
 				func() error {
 					asc.RenderTable([]string{"score", "command", "summary", "matched"}, searchRows(response.Results))
 					return nil
@@ -116,6 +122,18 @@ Examples:
 			)
 		},
 	}
+}
+
+func resetFlagSet(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	fs.VisitAll(func(f *flag.Flag) {
+		if f == nil {
+			return
+		}
+		_ = f.Value.Set(f.DefValue)
+	})
 }
 
 func parseInterspersedSearchFlags(fs *flag.FlagSet, args []string) ([]string, error) {
@@ -270,7 +288,7 @@ func collectCommandDoc(docs *[]commandDoc, cmd *ffcli.Command, parents []string)
 }
 
 func scoreCommandDocs(docs []commandDoc, query string) []scoredResult {
-	queryTokens := uniqueTokens(query)
+	queryTokens := dropLeadingRootToken(uniqueTokens(query))
 	if len(queryTokens) == 0 {
 		return nil
 	}
@@ -304,6 +322,13 @@ func scoreCommandDocs(docs []commandDoc, query string) []scoredResult {
 		return results[i].result.Command < results[j].result.Command
 	})
 	return results
+}
+
+func dropLeadingRootToken(tokens []string) []string {
+	if len(tokens) == 0 || tokens[0] != "asc" {
+		return tokens
+	}
+	return tokens[1:]
 }
 
 func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -81,6 +81,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			_ = ctx
+			args, err := parseInterspersedSearchFlags(fs, args)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				return flag.ErrHelp
+			}
 			if len(args) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: search query is required")
 				return flag.ErrHelp
@@ -111,6 +116,86 @@ Examples:
 			)
 		},
 	}
+}
+
+func parseInterspersedSearchFlags(fs *flag.FlagSet, args []string) ([]string, error) {
+	if fs == nil || len(args) == 0 {
+		return args, nil
+	}
+
+	queryArgs := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			queryArgs = append(queryArgs, args[i+1:]...)
+			break
+		}
+
+		name, value, hasValue, ok := splitSearchFlagArg(arg)
+		if !ok {
+			queryArgs = append(queryArgs, arg)
+			continue
+		}
+
+		f := fs.Lookup(name)
+		if f == nil {
+			queryArgs = append(queryArgs, arg)
+			continue
+		}
+
+		if isBoolSearchFlag(f) && !hasValue {
+			if err := f.Value.Set("true"); err != nil {
+				return nil, fmt.Errorf("invalid value %q for --%s: %w", "true", name, err)
+			}
+			continue
+		}
+
+		if !hasValue {
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("flag needs an argument: --%s", name)
+			}
+			i++
+			value = args[i]
+		}
+
+		if err := f.Value.Set(value); err != nil {
+			return nil, fmt.Errorf("invalid value %q for --%s: %w", value, name, err)
+		}
+	}
+
+	return queryArgs, nil
+}
+
+func splitSearchFlagArg(arg string) (name, value string, hasValue, ok bool) {
+	if arg == "" || arg == "-" || !strings.HasPrefix(arg, "-") {
+		return "", "", false, false
+	}
+
+	trimmed := strings.TrimPrefix(arg, "--")
+	if trimmed == arg {
+		trimmed = strings.TrimPrefix(arg, "-")
+	}
+	if trimmed == "" {
+		return "", "", false, false
+	}
+
+	name, value, hasValue = strings.Cut(trimmed, "=")
+	if name == "" {
+		return "", "", false, false
+	}
+	return name, value, hasValue, true
+}
+
+func isBoolSearchFlag(f *flag.Flag) bool {
+	type boolFlag interface {
+		IsBoolFlag() bool
+	}
+
+	if f == nil {
+		return false
+	}
+	boolValue, ok := f.Value.(boolFlag)
+	return ok && boolValue.IsBoolFlag()
 }
 
 // SearchCommands searches a command tree and returns ranked results.

--- a/internal/cli/search/search_test.go
+++ b/internal/cli/search/search_test.go
@@ -1,0 +1,35 @@
+package search
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestScoreCommandDocSkipsSelfReferentialAliases(t *testing.T) {
+	doc := commandDoc{
+		Command:    "asc foo",
+		PathTokens: []string{"tester"},
+	}
+
+	score, matched := scoreCommandDoc(doc, []string{"tester"})
+
+	if score != 60 {
+		t.Fatalf("expected direct path-token score only, got %d with matches %v", score, matched)
+	}
+	if slices.Contains(matched, "alias:tester") {
+		t.Fatalf("expected self alias to be skipped, got matches %v", matched)
+	}
+}
+
+func TestScoreTermDoesNotStackExactCommandAndPathTokenScores(t *testing.T) {
+	doc := commandDoc{
+		Command:    "asc search",
+		PathTokens: []string{"search"},
+	}
+
+	score, matched := scoreTerm(doc, "search", "query:search")
+
+	if score != 120 {
+		t.Fatalf("expected exact command score only, got %d with matches %v", score, matched)
+	}
+}

--- a/internal/cli/search/search_test.go
+++ b/internal/cli/search/search_test.go
@@ -57,3 +57,34 @@ func TestScoreTermDoesNotStackExactCommandWithSelfReferentialHelpText(t *testing
 		}
 	}
 }
+
+func TestScoreCommandDocsIgnoresLeadingASCToken(t *testing.T) {
+	docs := []commandDoc{
+		{
+			Command:    "asc builds upload",
+			Summary:    "Upload a build.",
+			Usage:      "asc builds upload [flags]",
+			PathTokens: []string{"builds", "upload"},
+			AllTokens:  []string{"builds", "upload"},
+		},
+		{
+			Command:    "asc apps list",
+			Summary:    "List apps.",
+			Usage:      "asc apps list [flags]",
+			PathTokens: []string{"apps", "list"},
+			AllTokens:  []string{"apps", "list"},
+		},
+	}
+
+	results := scoreCommandDocs(docs, "asc build upload")
+
+	if len(results) != 1 {
+		t.Fatalf("expected only the build upload result, got %#v", results)
+	}
+	if results[0].result.Command != "asc builds upload" {
+		t.Fatalf("expected build upload result, got %#v", results[0].result)
+	}
+	if slices.Contains(results[0].result.Matched, "command:asc") {
+		t.Fatalf("expected leading asc token to be ignored, got matches %v", results[0].result.Matched)
+	}
+}

--- a/internal/cli/search/search_test.go
+++ b/internal/cli/search/search_test.go
@@ -33,3 +33,27 @@ func TestScoreTermDoesNotStackExactCommandAndPathTokenScores(t *testing.T) {
 		t.Fatalf("expected exact command score only, got %d with matches %v", score, matched)
 	}
 }
+
+func TestScoreTermDoesNotStackExactCommandWithSelfReferentialHelpText(t *testing.T) {
+	doc := commandDoc{
+		Command:    "asc search",
+		Summary:    "Search asc commands and examples.",
+		Usage:      "asc search [flags] <query>",
+		LongHelp:   "Search asc commands and examples.\n\nExamples:\n  asc search \"external testers\"",
+		Examples:   []string{`asc search "external testers"`},
+		PathTokens: []string{"search"},
+		FlagTokens: []string{"search"},
+	}
+
+	score, matched := scoreTerm(doc, "search", "query:search")
+
+	if score != 120 {
+		t.Fatalf("expected exact command score only, got %d with matches %v", score, matched)
+	}
+
+	for _, unexpected := range []string{"summary:search", "usage:search", "flag:search", "example:search", "help:search"} {
+		if slices.Contains(matched, unexpected) {
+			t.Fatalf("expected exact command match to skip %q, got matches %v", unexpected, matched)
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a top-level `asc search` command for deterministic local command discovery over the registered CLI tree.
- Return agent-friendly JSON with command path, summary, usage, score, match reasons, and examples, plus table/markdown renderers.
- Cover direct token search, curated agent vocabulary aliases, typo-tolerant fallback, empty results, required query validation, and invalid output handling.
- Regenerate `docs/COMMANDS.md` and sync the embedded `ASC.md` template so help/reference surfaces include the new utility command.

## Validation

- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I used `asc apps wall submit --app "1234567890" --confirm` (or made the equivalent single-file update manually)
- [ ] This PR only updates `docs/wall-of-apps.json`
- [ ] I ran `make check-wall-of-apps`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.

Additional commands run:

```bash
ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestSearch -count=1
go build -o /tmp/asc .
/tmp/asc search --help
/tmp/asc search --output json external testers
/tmp/asc search --output table upload build
/tmp/asc search --output yaml builds
/tmp/asc search --output json testfligth testers
make generate-command-docs
ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/docs -run TestASCTemplateIncludesAllRootSubcommands -count=1
```

Key exit-code scenarios validated:

```bash
/tmp/asc search --output yaml builds # exit 2
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f5250b-3fde-4026-84a0-5c7097986827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f5250b-3fde-4026-84a0-5c7097986827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level search command to find commands and examples by keyword; supports JSON and table output, fuzzy typo-tolerance, alias-aware matching, relevance scoring, and a configurable result limit.

* **Documentation**
  * Help and command-reference docs updated to include the new search command and description.

* **Tests**
  * Added extensive CLI and unit tests covering outputs, matching semantics, flag parsing/validation, limits, error cases, and repeated-run regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->