### PR TITLE
Add customer review response filters

### DIFF
--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -1034,6 +1034,13 @@ func WithReviewIncludeResponse() ReviewOption {
 	}
 }
 
+// WithReviewResponseFields limits fields returned for included review responses.
+func WithReviewResponseFields(fields []string) ReviewOption {
+	return func(r *reviewQuery) {
+		r.responseFields = normalizeList(fields)
+	}
+}
+
 // WithLimit sets the max number of reviews to return.
 func WithLimit(limit int) ReviewOption {
 	return func(r *reviewQuery) {

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -44,6 +44,7 @@ type reviewQuery struct {
 	sort                    string
 	publishedResponseExists *bool
 	includeResponse         bool
+	responseFields          []string
 }
 
 type appsQuery struct {
@@ -634,6 +635,7 @@ func buildReviewQuery(opts []ReviewOption) string {
 	if query.includeResponse {
 		values.Set("include", "response")
 	}
+	addCSV(values, "fields[customerReviewResponses]", query.responseFields)
 	addLimit(values, query.limit)
 
 	return values.Encode()

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -21,6 +21,7 @@ func TestBuildReviewQuery(t *testing.T) {
 		WithReviewSort("-createdDate"),
 		WithPublishedResponseExists(false),
 		WithReviewIncludeResponse(),
+		WithReviewResponseFields([]string{"responseBody", "state"}),
 	})
 
 	values, err := url.ParseQuery(query)
@@ -50,6 +51,10 @@ func TestBuildReviewQuery(t *testing.T) {
 
 	if got := values.Get("include"); got != "response" {
 		t.Fatalf("expected include=response, got %q", got)
+	}
+
+	if got := values.Get("fields[customerReviewResponses]"); got != "responseBody,state" {
+		t.Fatalf("expected fields[customerReviewResponses]=responseBody,state, got %q", got)
 	}
 }
 

--- a/internal/cli/cmdtest/reviews_responses_test.go
+++ b/internal/cli/cmdtest/reviews_responses_test.go
@@ -357,6 +357,8 @@ func TestReviewsRespondBatchResponseStateUnrespondedSkipsRespondedReviews(t *tes
 }
 
 func TestReviewsRespondBatchValidationErrors(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
 	tests := []struct {
 		name    string
 		args    []string
@@ -453,12 +455,12 @@ func TestRunReviewsRespondBatchInvalidResponseStateReturnsUsageExit(t *testing.T
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "--response-state must be one of: any, unresponded, responded") {
+	if !strings.Contains(stderr, "--response-state must be one of: any, unresponded, unreplied, responded, replied") {
 		t.Fatalf("expected response-state validation, got %q", stderr)
 	}
 }
 
-func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
+func TestReviewsListResponseStateIncludeResponseAndResponseFields(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -472,6 +474,9 @@ func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
 		if got := req.URL.Query().Get("include"); got != "response" {
 			t.Fatalf("expected include=response, got %q", got)
 		}
+		if got := req.URL.Query().Get("fields[customerReviewResponses]"); got != "responseBody,state" {
+			t.Fatalf("expected response response fields, got %q", got)
+		}
 		return jsonResponse(http.StatusOK, `{"data":[{"type":"customerReviews","id":"review-1"}]}`)
 	}))
 
@@ -479,7 +484,7 @@ func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"reviews", "list", "--app", "app-1", "--response-state", "unresponded", "--include-response", "--output", "json"}); err != nil {
+		if err := root.Parse([]string{"reviews", "list", "--app", "app-1", "--response-state", "unreplied", "--include-response", "--response-fields", "responseBody,state", "--output", "json"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -503,6 +508,40 @@ func TestReviewsListResponseStateAndIncludeResponse(t *testing.T) {
 	}
 }
 
+func TestReviewsListOnlyUnrespondedMapsToPublishedResponseFilter(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/customerReviews" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("exists[publishedResponse]"); got != "false" {
+			t.Fatalf("expected exists[publishedResponse]=false, got %q", got)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[]}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "list", "--app", "app-1", "--only-unresponded", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"data":[]`) {
+		t.Fatalf("expected empty reviews output, got %q", stdout)
+	}
+}
+
 func TestReviewsListRejectsInvalidResponseState(t *testing.T) {
 	stdout, stderr := captureOutput(t, func() {
 		code := cmd.Run([]string{"reviews", "list", "--app", "app-1", "--response-state", "maybe"}, "1.2.3")
@@ -514,8 +553,24 @@ func TestReviewsListRejectsInvalidResponseState(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "--response-state must be one of: any, unresponded, responded") {
+	if !strings.Contains(stderr, "--response-state must be one of: any, unresponded, unreplied, responded, replied") {
 		t.Fatalf("expected response-state validation, got %q", stderr)
+	}
+}
+
+func TestReviewsListRejectsInvalidResponseFields(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"reviews", "list", "--app", "app-1", "--response-fields", "bogus"}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--response-fields must be a comma-separated list of: responseBody,lastModifiedDate,state,review") {
+		t.Fatalf("expected response-fields validation, got %q", stderr)
 	}
 }
 

--- a/internal/cli/reviews/review_filters.go
+++ b/internal/cli/reviews/review_filters.go
@@ -1,0 +1,66 @@
+package reviews
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	reviewResponseStateAny         = "any"
+	reviewResponseStateUnresponded = "unresponded"
+	reviewResponseStateResponded   = "responded"
+)
+
+func normalizeReviewResponseState(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		normalized = reviewResponseStateAny
+	}
+	switch normalized {
+	case reviewResponseStateAny, reviewResponseStateUnresponded, reviewResponseStateResponded:
+		return normalized, nil
+	case "unreplied":
+		return reviewResponseStateUnresponded, nil
+	case "replied":
+		return reviewResponseStateResponded, nil
+	default:
+		return "", fmt.Errorf("--response-state must be one of: any, unresponded, unreplied, responded, replied")
+	}
+}
+
+func normalizeReviewResponseFields(value string) ([]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	allowed := map[string]bool{
+		"responseBody":     true,
+		"lastModifiedDate": true,
+		"state":            true,
+		"review":           true,
+	}
+	fields := strings.Split(value, ",")
+	normalized := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if !allowed[field] {
+			return nil, fmt.Errorf("--response-fields must be a comma-separated list of: responseBody,lastModifiedDate,state,review")
+		}
+		normalized = append(normalized, field)
+	}
+	return normalized, nil
+}
+
+func publishedResponseExistsFilter(responseState string) (bool, bool) {
+	switch responseState {
+	case reviewResponseStateUnresponded:
+		return false, true
+	case reviewResponseStateResponded:
+		return true, true
+	default:
+		return false, false
+	}
+}

--- a/internal/cli/reviews/reviews.go
+++ b/internal/cli/reviews/reviews.go
@@ -25,8 +25,10 @@ func ReviewsCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
-	responseState := fs.String("response-state", "any", "Filter by response state: any, unresponded, responded")
+	responseState := fs.String("response-state", "any", "Filter by response state: any, unresponded/unreplied, responded/replied")
+	onlyUnresponded := fs.Bool("only-unresponded", false, "Only list reviews without a published response")
 	includeResponse := fs.Bool("include-response", false, "Include customer review response relationships")
+	responseFields := fs.String("response-fields", "", "Comma-separated customer review response fields: responseBody,lastModifiedDate,state,review")
 
 	return &ffcli.Command{
 		Name:       "reviews",
@@ -43,7 +45,8 @@ Examples:
   asc reviews --app "123456789"
   asc reviews --app "123456789" --stars 1 --territory US
   asc reviews --app "123456789" --sort -createdDate --limit 5
-  asc reviews --app "123456789" --response-state unresponded --include-response
+  asc reviews --app "123456789" --response-state unreplied --include-response
+  asc reviews --app "123456789" --only-unresponded
   asc reviews --next "<links.next>"
   asc reviews --app "123456789" --paginate
   asc reviews get --id "REVIEW_ID"
@@ -75,7 +78,7 @@ Examples:
 			}
 
 			// Execute the list functionality directly
-			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *includeResponse)
+			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *onlyUnresponded, *includeResponse, *responseFields)
 		},
 	}
 }
@@ -92,8 +95,10 @@ func ReviewsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
-	responseState := fs.String("response-state", "any", "Filter by response state: any, unresponded, responded")
+	responseState := fs.String("response-state", "any", "Filter by response state: any, unresponded/unreplied, responded/replied")
+	onlyUnresponded := fs.Bool("only-unresponded", false, "Only list reviews without a published response")
 	includeResponse := fs.Bool("include-response", false, "Include customer review response relationships")
+	responseFields := fs.String("response-fields", "", "Comma-separated customer review response fields: responseBody,lastModifiedDate,state,review")
 
 	return &ffcli.Command{
 		Name:       "list",
@@ -105,7 +110,8 @@ Examples:
   asc reviews list --app "123456789"
   asc reviews list --app "123456789" --stars 5
   asc reviews list --app "123456789" --territory US --sort -createdDate
-  asc reviews list --app "123456789" --response-state unresponded --include-response
+  asc reviews list --app "123456789" --response-state unreplied --include-response
+  asc reviews list --app "123456789" --only-unresponded
   asc reviews list --next "<links.next>"
   asc reviews list --app "123456789" --paginate`,
 		FlagSet:   fs,
@@ -117,12 +123,12 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *includeResponse)
+			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *onlyUnresponded, *includeResponse, *responseFields)
 		},
 	}
 }
 
-func executeReviewsList(ctx context.Context, appID, output string, pretty bool, stars int, territory, sort string, limit int, next string, paginate bool, responseState string, includeResponse bool) error {
+func executeReviewsList(ctx context.Context, appID, output string, pretty bool, stars int, territory, sort string, limit int, next string, paginate bool, responseState string, onlyUnresponded bool, includeResponse bool, responseFields string) error {
 	if limit != 0 && (limit < 1 || limit > 200) {
 		return fmt.Errorf("reviews: --limit must be between 1 and 200")
 	}
@@ -136,6 +142,16 @@ func executeReviewsList(ctx context.Context, appID, output string, pretty bool, 
 		return fmt.Errorf("reviews: %w", err)
 	}
 	normalizedResponseState, err := normalizeReviewResponseState(responseState)
+	if err != nil {
+		return shared.UsageError(err.Error())
+	}
+	if onlyUnresponded {
+		if normalizedResponseState == reviewResponseStateResponded {
+			return shared.UsageError("--only-unresponded cannot be combined with --response-state responded")
+		}
+		normalizedResponseState = reviewResponseStateUnresponded
+	}
+	normalizedResponseFields, err := normalizeReviewResponseFields(responseFields)
 	if err != nil {
 		return shared.UsageError(err.Error())
 	}
@@ -162,6 +178,9 @@ func executeReviewsList(ctx context.Context, appID, output string, pretty bool, 
 	}
 	if includeResponse {
 		opts = append(opts, asc.WithReviewIncludeResponse())
+	}
+	if len(normalizedResponseFields) > 0 {
+		opts = append(opts, asc.WithReviewIncludeResponse(), asc.WithReviewResponseFields(normalizedResponseFields))
 	}
 
 	if paginate {

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -17,10 +17,6 @@ import (
 )
 
 const (
-	reviewResponseStateAny         = "any"
-	reviewResponseStateUnresponded = "unresponded"
-	reviewResponseStateResponded   = "responded"
-
 	reviewBatchStatusCreated = "created"
 	reviewBatchStatusFailed  = "failed"
 	reviewBatchStatusPlanned = "planned"
@@ -78,7 +74,7 @@ func ReviewsRespondBatchCommand() *ffcli.Command {
 	filePath := fs.String("file", "", "Path to grouped JSON replies file (required)")
 	dryRun := fs.Bool("dry-run", false, "Preview responses without creating them")
 	skipExisting := fs.Bool("skip-existing", false, "Skip reviews that already have a published response")
-	responseState := fs.String("response-state", reviewResponseStateAny, "Filter by response state: any, unresponded, responded")
+	responseState := fs.String("response-state", reviewResponseStateAny, "Filter by response state: any, unresponded/unreplied, responded/replied")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -156,30 +152,6 @@ Examples:
 			}
 			return nil
 		},
-	}
-}
-
-func normalizeReviewResponseState(value string) (string, error) {
-	normalized := strings.ToLower(strings.TrimSpace(value))
-	if normalized == "" {
-		normalized = reviewResponseStateAny
-	}
-	switch normalized {
-	case reviewResponseStateAny, reviewResponseStateUnresponded, reviewResponseStateResponded:
-		return normalized, nil
-	default:
-		return "", fmt.Errorf("--response-state must be one of: any, unresponded, responded")
-	}
-}
-
-func publishedResponseExistsFilter(responseState string) (bool, bool) {
-	switch responseState {
-	case reviewResponseStateUnresponded:
-		return false, true
-	case reviewResponseStateResponded:
-		return true, true
-	default:
-		return false, false
 	}
 }
 


### PR DESCRIPTION
## Summary
- adds `--only-unresponded` and `replied`/`unreplied` aliases for review response-state filtering
- adds `--response-fields` for `fields[customerReviewResponses]` and auto-includes response data when used
- extends review list/query tests and isolates respond-batch validation from ambient `ASC_APP_ID`

Fixes #1534

## Design note
1. Command placement: kept this on `asc reviews list` and the root `asc reviews --app` list shortcut, matching the existing reviews taxonomy.
2. OpenAPI validation: `GET /v1/apps/{id}/customerReviews` supports `exists[publishedResponse]`, `include=response`, and `fields[customerReviewResponses]` with `responseBody,lastModifiedDate,state,review`.
3. UX shape: `--response-state replied|unreplied` are aliases for the existing responded/unresponded states; `--only-unresponded` is convenience sugar for unreplied reviews; invalid field names return usage exit 2.
4. Compatibility: existing `any|unresponded|responded` values still work.
5. Test plan: covered query generation, CLI request mapping, invalid response-state, invalid response-fields, and built-binary usage behavior.

## Alternatives considered
- Only keep `--response-state unresponded/responded`: smaller, but misses the issue's requested wording.
- Require `--include-response` with `--response-fields`: stricter, but less ergonomic; response fields now imply `include=response`.

## Commands run
- `go run . reviews list --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run 'TestBuildReviewQuery|TestGetReviews'`\n- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestReviewsList|TestRunReviewsRespondBatchInvalidResponseState'`\n- `make generate-command-docs`\n- `make format`\n- `make check-command-docs`\n- `go build -o /tmp/asc .`\n- `/tmp/asc reviews list --app app-1 --response-fields bogus` -> exit 2\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n\n## Key exit-code scenarios\n- invalid `--response-fields bogus` returns usage exit 2 with a specific field-list error\n- invalid `--response-state maybe` returns usage exit 2 with the accepted values\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --response-fields to select specific response fields
  * Added --only-unresponded to filter unresponded reviews
  * Added aliases for --response-state: unreplied and replied; help text updated

* **Improvements**
  * Enforced flag compatibility (reject incompatible response-state + only-unresponded)
  * Normalized and validated response-state and response-fields inputs

* **Tests**
  * Added/expanded tests for response field selection, validation, and filtering logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->