### PR TITLE
apps wall: add Sam Webpage Summarizer

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1057,6 +1057,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/86/a6/a286a647-d984-7f1d-6f2b-7d4fda64c3e2/App_Icon-marketing.lsr/512x512bb.jpg"
   },
   {
+    "app": "Sam Webpage Summarizer",
+    "link": "https://apps.apple.com/us/app/sam-webpage-summarizer/id6769648029?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/09/1e/b6/091eb6fc-de14-9b7c-e7f6-b1e59b8be9ac/AppIcon-0-0-1x_U007emarketing-0-8-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Scap: Screenshot & Markup Edit",
     "link": "https://apps.apple.com/us/app/scap-screenshot-markup-edit/id6758053530?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/95/ed/7c/95ed7cad-90a7-5d3b-8742-444542d3dc55/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Sam Webpage Summarizer` to the Wall of Apps

## Entry

- App ID: 6769648029
- App: Sam Webpage Summarizer
- Link: https://apps.apple.com/us/app/sam-webpage-summarizer/id6769648029?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Sam Webpage Summarizer" to the app directory with its App Store link and icon. The new entry expands the available app options for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->