### PR TITLE
apps wall: add Allergy Translate

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -35,6 +35,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6a/d6/06/6ad6063e-a7c4-ef18-dd4e-afecc0c3ba14/AppIcon_Akari-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Allergy Translate",
+    "link": "https://apps.apple.com/us/app/allergy-translate/id1366620257?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6f/d5/6b/6fd56b58-41da-7aa7-4737-04bee755418d/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Appboard: Find Apps · Rankings",
     "link": "https://apps.apple.com/us/app/appboard-find-apps-rankings/id1667492380?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b8/86/4e/b8864eea-7c79-4b57-dc58-4a208fc28863/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Allergy Translate` to the Wall of Apps

## Entry

- App ID: 1366620257
- App: Allergy Translate
- Link: https://apps.apple.com/us/app/allergy-translate/id1366620257?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Allergy Translate" app entry to the app directory with App Store link and icon information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->