### PR TITLE
apps wall: add Squeaker - Dog Training Sounds

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1172,6 +1172,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/43/63/bd/4363bd1c-3f2d-017b-f15c-d06d89736a88/AppIcon_1-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Squeaker - Dog Training Sounds",
+    "link": "https://apps.apple.com/us/app/squeaker-dog-training-sounds/id6751776211?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/87/d5/10/87d51098-4022-e6e4-1c8d-7d8a8a545538/Squeaker-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SquishPic: Image Compressor",
     "link": "https://apps.apple.com/us/app/squishpic-image-compressor/id6757522104?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/65/d1/ae/65d1ae1f-5f97-acb6-5458-79560afb84ab/AppIcon-0-0-85-220-0-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Squeaker - Dog Training Sounds` to the Wall of Apps

## Entry

- App ID: 6751776211
- App: Squeaker - Dog Training Sounds
- Link: https://apps.apple.com/us/app/squeaker-dog-training-sounds/id6751776211?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new app entry for "Squeaker - Dog Training Sounds" to the app catalog, including its App Store link and icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->