### PR TITLE
apps wall: add Embers to Dyson

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -334,6 +334,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/60/71/236071d7-7827-efd9-4c8f-03db0cee6aa9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Embers to Dyson",
+    "link": "https://apps.apple.com/us/app/embers-to-dyson/id6756216261?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5c/b3/ab/5cb3ab34-60e5-81f8-c555-518185d61f87/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Expense Tracker: ExpenseKit",
     "link": "https://apps.apple.com/us/app/expense-tracker-expensekit/id6756433597?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a5/14/d8/a514d826-9475-8c8e-b4f5-6fe7b4fa660c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Embers to Dyson` to the Wall of Apps

## Entry

- App ID: 6756216261
- App: Embers to Dyson
- Link: https://apps.apple.com/us/app/embers-to-dyson/id6756216261?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Embers to Dyson" app entry to the app directory, including App Store link and icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->