### PR TITLE
apps wall: add ReaderFlow | Read Later

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1032,6 +1032,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7b/a4/47/7ba447d5-d934-754b-3f42-2b03670f82b7/AppIcon-0-0-1x_U007epad-0-5-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "ReaderFlow | Read Later",
+    "link": "https://apps.apple.com/us/app/readerflow-read-later/id6739498537?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/67/1d/d7/671dd77c-6284-7b5e-b3d2-ede360d76269/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Receipts Manager: Receipteka",
     "link": "https://apps.apple.com/us/app/receipts-manager-receipteka/id6474066806?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3c/f7/5a/3cf75a8b-78f9-010e-906d-011849ab7ee2/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `ReaderFlow | Read Later` to the Wall of Apps

## Entry

- App ID: 6739498537
- App: ReaderFlow | Read Later
- Link: https://apps.apple.com/us/app/readerflow-read-later/id6739498537?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ReaderFlow | Read Later to the application directory, including App Store information and icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->