### PR TITLE
apps wall: add FishLogger

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -389,6 +389,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8d/e5/c9/8de5c9bd-5ad9-3371-378a-b30f074a671a/AppIcon-0-0-1x_U007epad-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "FishLogger: Fishing Journal",
+    "link": "https://apps.apple.com/us/app/fishlogger-fishing-journal/id6757573416?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/fe/d7/e8/fed7e84b-41b9-35f9-efbc-9ac785c708c2/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Fitnit: Health & Fitness",
     "link": "https://apps.apple.com/us/app/fitnit-health-fitness/id6757887175?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/57/64/b6/5764b6e3-f3fb-9a70-925d-00e39f893263/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add FishLogger: Fishing Journal to the Wall of Apps

## Entry

- App ID: 6757573416
- App: FishLogger: Fishing Journal
- Link: https://apps.apple.com/us/app/fishlogger-fishing-journal/id6757573416?uo=4

## Notes

- Public App Store listing, free iPhone fishing journal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added FishLogger: Fishing Journal to the app showcase gallery with App Store link and icon information, expanding the featured application collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->