### PR TITLE
Schedule equalized subscription pricing

### DIFF
--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -8,9 +8,12 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
@@ -33,6 +36,11 @@ func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
 			name:    "invalid start date",
 			args:    []string{"subscriptions", "pricing", "equalize", "--subscription-id", "8000000001", "--base-price", "3.49", "--start-date", "tomorrow", "--dry-run"},
 			wantErr: "Error: --start-date must be in YYYY-MM-DD format",
+		},
+		{
+			name:    "past start date",
+			args:    []string{"subscriptions", "pricing", "equalize", "--subscription-id", "8000000001", "--base-price", "3.49", "--start-date", time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02"), "--dry-run"},
+			wantErr: "Error: --start-date must be a future date",
 		},
 	}
 
@@ -59,6 +67,75 @@ func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubscriptionsPricingEqualizeBooleanFlagExitCodes(t *testing.T) {
+	bin := buildCLIBinary(t)
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name: "invalid auto start date",
+			args: []string{
+				"subscriptions", "pricing", "equalize",
+				"--subscription-id", "8000000001",
+				"--base-price", "3.49",
+				"--dry-run",
+				"--auto-start-date=maybe",
+			},
+			wantStderr: `invalid boolean value "maybe" for -auto-start-date`,
+		},
+		{
+			name: "invalid preserved",
+			args: []string{
+				"subscriptions", "pricing", "equalize",
+				"--subscription-id", "8000000001",
+				"--base-price", "3.49",
+				"--dry-run",
+				"--preserved=maybe",
+			},
+			wantStderr: `invalid boolean value "maybe" for -preserved`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(bin, test.args...)
+			var stdout, stderr strings.Builder
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected exit error, got %v", err)
+			}
+			if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+			}
+			if stdout.String() != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.wantStderr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr.String())
+			}
+		})
+	}
+}
+
+func buildCLIBinary(t *testing.T) string {
+	t.Helper()
+
+	bin := t.TempDir() + "/asc"
+	cmd := exec.Command("go", "build", "-o", bin, "../../..")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, output)
+	}
+	return bin
 }
 
 func TestSubscriptionsPricingEqualize_RequiresConfirmUnlessDryRun(t *testing.T) {
@@ -674,6 +751,7 @@ func TestSubscriptionsPricingEqualize_StartDateAppliesToInitialAndFollowUpPrices
 
 	basePricePointID := testSubscriptionPricePointID("USA")
 	canPricePointID := testSubscriptionPricePointID("CAN")
+	startDate := time.Now().UTC().AddDate(0, 0, 30).Format("2006-01-02")
 
 	patchChecked := false
 	postChecked := false
@@ -700,7 +778,7 @@ func TestSubscriptionsPricingEqualize_StartDateAppliesToInitialAndFollowUpPrices
 				t.Fatalf("ReadAll() error: %v", err)
 			}
 			got := string(body)
-			if !strings.Contains(got, `"startDate":"2026-04-01"`) {
+			if !strings.Contains(got, `"startDate":"`+startDate+`"`) {
 				t.Fatalf("expected startDate on initial price PATCH, got %s", got)
 			}
 			if !strings.Contains(got, `"preserveCurrentPrice":true`) {
@@ -714,7 +792,7 @@ func TestSubscriptionsPricingEqualize_StartDateAppliesToInitialAndFollowUpPrices
 				t.Fatalf("ReadAll() error: %v", err)
 			}
 			got := string(body)
-			if !strings.Contains(got, `"startDate":"2026-04-01"`) {
+			if !strings.Contains(got, `"startDate":"`+startDate+`"`) {
 				t.Fatalf("expected startDate on follow-up price POST, got %s", got)
 			}
 			if !strings.Contains(got, `"preserveCurrentPrice":true`) {
@@ -736,7 +814,7 @@ func TestSubscriptionsPricingEqualize_StartDateAppliesToInitialAndFollowUpPrices
 			"subscriptions", "pricing", "equalize",
 			"--subscription-id", "8000000001",
 			"--base-price", "0.99",
-			"--start-date", "2026-04-01",
+			"--start-date", startDate,
 			"--preserved",
 			"--confirm",
 			"--workers", "1",
@@ -759,7 +837,7 @@ func TestSubscriptionsPricingEqualize_StartDateAppliesToInitialAndFollowUpPrices
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("parse JSON result: %v", err)
 	}
-	if result.StartDate != "2026-04-01" || !result.Preserved {
+	if result.StartDate != startDate || !result.Preserved {
 		t.Fatalf("expected scheduled preserved result, got %+v", result)
 	}
 }
@@ -844,6 +922,90 @@ func TestSubscriptionsPricingEqualize_AutoSchedulesApprovedSubscriptions(t *test
 	}
 	if result.StartDate != wantStartDate || !result.AutoScheduled || result.SubscriptionState != "APPROVED" {
 		t.Fatalf("expected auto-scheduled approved result, got %+v", result)
+	}
+}
+
+func TestSubscriptionsPricingEqualize_AutoStartDateFalseLeavesExistingPricesImmediate(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	basePricePointID := testSubscriptionPricePointID("USA")
+	canPricePointID := testSubscriptionPricePointID("CAN")
+	postChecked := false
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/territories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/pricePoints":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"existing-price"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			t.Fatalf("did not expect subscription state lookup when --auto-start-date=false")
+			return nil, nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			got := string(body)
+			if strings.Contains(got, `"startDate"`) {
+				t.Fatalf("did not expect startDate on price POST, got %s", got)
+			}
+			postChecked = true
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-created"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "equalize",
+			"--subscription-id", "8000000001",
+			"--base-price", "0.99",
+			"--auto-start-date=false",
+			"--confirm",
+			"--workers", "1",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !postChecked {
+		t.Fatal("expected immediate price POST")
+	}
+
+	var result struct {
+		StartDate         string `json:"startDate"`
+		AutoScheduled     bool   `json:"autoScheduled"`
+		SubscriptionState string `json:"subscriptionState"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON result: %v", err)
+	}
+	if result.StartDate != "" || result.AutoScheduled || result.SubscriptionState != "" {
+		t.Fatalf("expected immediate non-auto-scheduled result, got %+v", result)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -245,6 +245,8 @@ func TestSubscriptionsPricingEqualize_DryRunMatchesBasePriceNumerically(t *testi
 			}
 			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"4.49"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -318,6 +320,8 @@ func TestSubscriptionsPricingEqualize_NormalizesBaseTerritory(t *testing.T) {
 			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -365,6 +369,8 @@ func TestSubscriptionsPricingEqualize_DryRunUsesTerritoryRelationshipForOpaquePr
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
 			body := `{"data":[{"type":"subscriptionPricePoints","id":"opaque-eq-1","attributes":{"customerPrice":"4.49"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -922,6 +928,76 @@ func TestSubscriptionsPricingEqualize_AutoSchedulesApprovedSubscriptions(t *test
 	}
 	if result.StartDate != wantStartDate || !result.AutoScheduled || result.SubscriptionState != "APPROVED" {
 		t.Fatalf("expected auto-scheduled approved result, got %+v", result)
+	}
+}
+
+func TestSubscriptionsPricingEqualize_DryRunShowsAutoScheduledApprovedSubscriptions(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	basePricePointID := testSubscriptionPricePointID("USA")
+	canPricePointID := testSubscriptionPricePointID("CAN")
+	wantStartDate := time.Now().UTC().AddDate(0, 0, 1).Format("2006-01-02")
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/territories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/pricePoints":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"existing-price"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"APPROVED"}}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			t.Fatal("dry-run must not create subscription prices")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "equalize",
+			"--subscription-id", "8000000001",
+			"--base-price", "0.99",
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		StartDate         string `json:"startDate"`
+		AutoScheduled     bool   `json:"autoScheduled"`
+		SubscriptionState string `json:"subscriptionState"`
+		DryRun            bool   `json:"dryRun"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON result: %v", err)
+	}
+	if result.StartDate != wantStartDate || !result.AutoScheduled || result.SubscriptionState != "APPROVED" || !result.DryRun {
+		t.Fatalf("expected dry-run auto-scheduled approved result, got %+v", result)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
@@ -27,6 +28,11 @@ func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
 			name:    "missing base price",
 			args:    []string{"subscriptions", "pricing", "equalize", "--subscription-id", "8000000001"},
 			wantErr: "Error: --base-price is required",
+		},
+		{
+			name:    "invalid start date",
+			args:    []string{"subscriptions", "pricing", "equalize", "--subscription-id", "8000000001", "--base-price", "3.49", "--start-date", "tomorrow", "--dry-run"},
+			wantErr: "Error: --start-date must be in YYYY-MM-DD format",
 		},
 	}
 
@@ -658,6 +664,189 @@ func TestSubscriptionsPricingEqualize_InitialPriceUsesPatchThenCreatesRemainingT
 	}
 }
 
+func TestSubscriptionsPricingEqualize_StartDateAppliesToInitialAndFollowUpPrices(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	basePricePointID := testSubscriptionPricePointID("USA")
+	canPricePointID := testSubscriptionPricePointID("CAN")
+
+	patchChecked := false
+	postChecked := false
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/territories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/pricePoints":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/8000000001":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			got := string(body)
+			if !strings.Contains(got, `"startDate":"2026-04-01"`) {
+				t.Fatalf("expected startDate on initial price PATCH, got %s", got)
+			}
+			if !strings.Contains(got, `"preserveCurrentPrice":true`) {
+				t.Fatalf("expected preserveCurrentPrice on initial price PATCH, got %s", got)
+			}
+			patchChecked = true
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001"}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			got := string(body)
+			if !strings.Contains(got, `"startDate":"2026-04-01"`) {
+				t.Fatalf("expected startDate on follow-up price POST, got %s", got)
+			}
+			if !strings.Contains(got, `"preserveCurrentPrice":true`) {
+				t.Fatalf("expected preserveCurrentPrice on follow-up price POST, got %s", got)
+			}
+			postChecked = true
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-1"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "equalize",
+			"--subscription-id", "8000000001",
+			"--base-price", "0.99",
+			"--start-date", "2026-04-01",
+			"--preserved",
+			"--confirm",
+			"--workers", "1",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !patchChecked || !postChecked {
+		t.Fatalf("expected PATCH and POST payload checks, patch=%v post=%v", patchChecked, postChecked)
+	}
+
+	var result struct {
+		StartDate string `json:"startDate"`
+		Preserved bool   `json:"preserved"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON result: %v", err)
+	}
+	if result.StartDate != "2026-04-01" || !result.Preserved {
+		t.Fatalf("expected scheduled preserved result, got %+v", result)
+	}
+}
+
+func TestSubscriptionsPricingEqualize_AutoSchedulesApprovedSubscriptions(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	basePricePointID := testSubscriptionPricePointID("USA")
+	canPricePointID := testSubscriptionPricePointID("CAN")
+	wantStartDate := time.Now().UTC().AddDate(0, 0, 1).Format("2006-01-02")
+	postChecked := false
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/territories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/pricePoints":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/"+basePricePointID+"/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"existing-price"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"APPROVED"}}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			got := string(body)
+			if !strings.Contains(got, `"startDate":"`+wantStartDate+`"`) {
+				t.Fatalf("expected auto startDate %s on price POST, got %s", wantStartDate, got)
+			}
+			postChecked = true
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-created"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "equalize",
+			"--subscription-id", "8000000001",
+			"--base-price", "0.99",
+			"--confirm",
+			"--workers", "1",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !postChecked {
+		t.Fatal("expected scheduled price POST")
+	}
+
+	var result struct {
+		StartDate         string `json:"startDate"`
+		AutoScheduled     bool   `json:"autoScheduled"`
+		SubscriptionState string `json:"subscriptionState"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON result: %v", err)
+	}
+	if result.StartDate != wantStartDate || !result.AutoScheduled || result.SubscriptionState != "APPROVED" {
+		t.Fatalf("expected auto-scheduled approved result, got %+v", result)
+	}
+}
+
 func TestSubscriptionsPricingEqualize_FailedInitialPriceStopsBeforePostingRemainingTerritories(t *testing.T) {
 	setupAuth(t)
 
@@ -779,6 +968,8 @@ func TestSubscriptionsPricingEqualize_ReturnsReportedErrorWhenAnyTerritoryFails(
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"READY_TO_SUBMIT"}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
 			body := `{
 				"data":[
@@ -879,6 +1070,8 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableTerritoryFailures(t *testi
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"READY_TO_SUBMIT"}}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
@@ -980,6 +1173,8 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableFailuresButKeepsNonRetryab
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"},{"type":"territories","id":"MEX"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"READY_TO_SUBMIT"}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
 			body := `{
 				"data":[
@@ -1102,6 +1297,8 @@ func TestSubscriptionsPricingEqualize_ReconcilesConflictAfterRetryableFailure(t 
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"READY_TO_SUBMIT"}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
 			verifyReads++
 			body := `{
@@ -1324,6 +1521,8 @@ func TestSubscriptionsPricingEqualize_ApplyPaginatesAvailabilityTerritories(t *t
 			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"existing-price"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"READY_TO_SUBMIT"}}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-created"}}`), nil
 		default:

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -146,16 +146,44 @@ Examples:
 			})
 			allTerritories = append(allTerritories, equalizations...)
 
+			priceAttrs := asc.SubscriptionPriceCreateAttributes{
+				StartDate: explicitStartDate,
+			}
+			if *preserved {
+				priceAttrs.Preserved = preserved
+			}
+
+			subscriptionState := ""
+			autoScheduled := false
+
 			if *dryRun {
+				if priceAttrs.StartDate == "" && *autoStartDate {
+					existingCtx, existingCancel := shared.ContextWithTimeout(ctx)
+					existingPrices, err := client.GetSubscriptionPricesRelationships(existingCtx, subID)
+					existingCancel()
+					if err != nil {
+						return fmt.Errorf("equalize: failed to check existing prices: %w", err)
+					}
+					if len(existingPrices.Data) > 0 {
+						var scheduleErr error
+						priceAttrs.StartDate, subscriptionState, autoScheduled, _, scheduleErr = autoScheduleEqualizeStartDate(ctx, client, subID)
+						if scheduleErr != nil {
+							return fmt.Errorf("equalize: %w", scheduleErr)
+						}
+					}
+				}
+
 				return printEqualizeResult(&equalizeResult{
-					SubscriptionID: subID,
-					BaseTerritory:  territory,
-					BasePrice:      price,
-					StartDate:      explicitStartDate,
-					Preserved:      *preserved,
-					DryRun:         true,
-					Territories:    allTerritories,
-					Total:          len(allTerritories),
+					SubscriptionID:    subID,
+					BaseTerritory:     territory,
+					BasePrice:         price,
+					StartDate:         priceAttrs.StartDate,
+					AutoScheduled:     autoScheduled,
+					Preserved:         *preserved,
+					SubscriptionState: subscriptionState,
+					DryRun:            true,
+					Territories:       allTerritories,
+					Total:             len(allTerritories),
 				}, *output.Output, *output.Pretty)
 			}
 
@@ -171,15 +199,6 @@ Examples:
 				return fmt.Errorf("equalize: failed to check existing prices: %w", err)
 			}
 
-			priceAttrs := asc.SubscriptionPriceCreateAttributes{
-				StartDate: explicitStartDate,
-			}
-			if *preserved {
-				priceAttrs.Preserved = preserved
-			}
-
-			subscriptionState := ""
-			autoScheduled := false
 			if priceAttrs.StartDate == "" && *autoStartDate && len(existingPrices.Data) > 0 {
 				var scheduleErr error
 				priceAttrs.StartDate, subscriptionState, autoScheduled, effectiveAt, scheduleErr = autoScheduleEqualizeStartDate(ctx, client, subID)

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -453,6 +453,9 @@ func normalizeEqualizeStartDate(value string) (string, time.Time, error) {
 	if err != nil {
 		return "", time.Time{}, err
 	}
+	if !parsed.After(dateOnlyUTC(equalizeNow())) {
+		return "", time.Time{}, shared.UsageError("--start-date must be a future date")
+	}
 	return normalized, parsed, nil
 }
 

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -22,10 +22,13 @@ import (
 const (
 	defaultEqualizeWorkers    = 8
 	equalizeRecoveryWorkers   = 1
+	equalizeDateLayout        = "2006-01-02"
 	maxEqualizeRecoveryPasses = 2
 )
 
 var errEqualizePricePointFound = errors.New("equalize price point found")
+
+var equalizeNow = time.Now
 
 // SubscriptionsPricingEqualizeCommand returns the equalize subcommand.
 func SubscriptionsPricingEqualizeCommand() *ffcli.Command {
@@ -35,6 +38,9 @@ func SubscriptionsPricingEqualizeCommand() *ffcli.Command {
 	appID := addSubscriptionLookupAppFlag(fs)
 	baseTerritory := fs.String("base-territory", "USA", "Pricing base territory (accepts alpha-2, alpha-3, or exact English country name)")
 	basePrice := fs.String("base-price", "", "Customer price in the base territory (required)")
+	startDate := fs.String("start-date", "", "Start date (YYYY-MM-DD) for scheduled price changes")
+	preserved := fs.Bool("preserved", false, "Preserve existing prices")
+	autoStartDate := fs.Bool("auto-start-date", true, "Automatically schedule approved/live subscriptions for tomorrow when --start-date is omitted")
 	dryRun := fs.Bool("dry-run", false, "Show equalized prices without applying them")
 	confirm := fs.Bool("confirm", false, "Confirm applying equalized prices (required unless --dry-run)")
 	workers := fs.Int("workers", defaultEqualizeWorkers, "Number of concurrent API requests")
@@ -53,6 +59,7 @@ importing a CSV.
 
 Examples:
   asc subscriptions pricing equalize --subscription-id "SUB_ID" --base-price "3.49" --confirm
+  asc subscriptions pricing equalize --subscription-id "SUB_ID" --base-price "3.49" --start-date "2026-04-01" --confirm
   asc subscriptions pricing equalize --subscription-id "SUB_ID" --base-price "38.49" --base-territory "United States" --confirm
   asc subscriptions pricing equalize --subscription-id "SUB_ID" --base-price "3.49" --dry-run
   asc subscriptions pricing equalize --subscription-id "SUB_ID" --base-price "3.49" --confirm --workers 16`,
@@ -74,6 +81,10 @@ Examples:
 			}
 			if err := shared.ValidateFinitePriceFlag("--base-price", price); err != nil {
 				return shared.UsageError(err.Error())
+			}
+			explicitStartDate, effectiveAt, err := normalizeEqualizeStartDate(*startDate)
+			if err != nil {
+				return err
 			}
 			territoryInput := strings.TrimSpace(*baseTerritory)
 			if territoryInput == "" {
@@ -140,6 +151,8 @@ Examples:
 					SubscriptionID: subID,
 					BaseTerritory:  territory,
 					BasePrice:      price,
+					StartDate:      explicitStartDate,
+					Preserved:      *preserved,
 					DryRun:         true,
 					Territories:    allTerritories,
 					Total:          len(allTerritories),
@@ -158,20 +171,40 @@ Examples:
 				return fmt.Errorf("equalize: failed to check existing prices: %w", err)
 			}
 
+			priceAttrs := asc.SubscriptionPriceCreateAttributes{
+				StartDate: explicitStartDate,
+			}
+			if *preserved {
+				priceAttrs.Preserved = preserved
+			}
+
+			subscriptionState := ""
+			autoScheduled := false
+			if priceAttrs.StartDate == "" && *autoStartDate && len(existingPrices.Data) > 0 {
+				var scheduleErr error
+				priceAttrs.StartDate, subscriptionState, autoScheduled, effectiveAt, scheduleErr = autoScheduleEqualizeStartDate(ctx, client, subID)
+				if scheduleErr != nil {
+					return fmt.Errorf("equalize: %w", scheduleErr)
+				}
+				if autoScheduled {
+					fmt.Fprintf(os.Stderr, "Subscription state is %s; scheduling price changes for %s\n", subscriptionState, priceAttrs.StartDate)
+				}
+			}
+
 			remainingTerritories := allTerritories
 			if len(existingPrices.Data) == 0 && len(allTerritories) > 0 {
 				fmt.Fprintf(os.Stderr, "Subscription has no prices; setting initial price in %s first...\n", territory)
 
 				baseTarget := allTerritories[0]
 				initialCtx, initialCancel := shared.ContextWithTimeout(ctx)
-				_, err := client.SetSubscriptionInitialPrice(initialCtx, subID, baseTarget.PricePointID, baseTarget.Territory, asc.SubscriptionPriceCreateAttributes{})
+				_, err := client.SetSubscriptionInitialPrice(initialCtx, subID, baseTarget.PricePointID, baseTarget.Territory, priceAttrs)
 				initialCancel()
 				if err != nil {
 					initialFailures := []equalizeAttemptFailure{{
 						Target: baseTarget,
 						Err:    err,
 					}}
-					reconciled, remaining, verifyErr := reconcileEqualizeFailures(ctx, client, subID, initialFailures)
+					reconciled, remaining, verifyErr := reconcileEqualizeFailures(ctx, client, subID, initialFailures, effectiveAt)
 					if verifyErr != nil {
 						fmt.Fprintf(os.Stderr, "Warning: could not verify failed initial price update: %v\n", verifyErr)
 					}
@@ -181,14 +214,18 @@ Examples:
 					} else {
 						failures = append(failures, remaining...)
 						result := &equalizeResult{
-							SubscriptionID: subID,
-							BaseTerritory:  territory,
-							BasePrice:      price,
-							DryRun:         false,
-							Total:          len(allTerritories),
-							Succeeded:      succeeded,
-							Failed:         len(failures),
-							Failures:       renderEqualizeFailures(failures),
+							SubscriptionID:    subID,
+							BaseTerritory:     territory,
+							BasePrice:         price,
+							StartDate:         priceAttrs.StartDate,
+							AutoScheduled:     autoScheduled,
+							Preserved:         *preserved,
+							SubscriptionState: subscriptionState,
+							DryRun:            false,
+							Total:             len(allTerritories),
+							Succeeded:         succeeded,
+							Failed:            len(failures),
+							Failures:          renderEqualizeFailures(failures),
 						}
 						fmt.Fprintf(os.Stderr, "Done: %d succeeded, %d failed\n", result.Succeeded, result.Failed)
 						if err := printEqualizeResult(result, *output.Output, *output.Pretty); err != nil {
@@ -202,21 +239,25 @@ Examples:
 				}
 			}
 
-			passSucceeded, passFailures := applyEqualizedPrices(ctx, client, subID, remainingTerritories, numWorkers)
+			passSucceeded, passFailures := applyEqualizedPrices(ctx, client, subID, remainingTerritories, numWorkers, priceAttrs, effectiveAt)
 			succeeded += passSucceeded
 			if len(passFailures) > 0 {
 				failures = append(failures, passFailures...)
 			}
 
 			result := &equalizeResult{
-				SubscriptionID: subID,
-				BaseTerritory:  territory,
-				BasePrice:      price,
-				DryRun:         false,
-				Total:          len(allTerritories),
-				Succeeded:      succeeded,
-				Failed:         len(failures),
-				Failures:       renderEqualizeFailures(failures),
+				SubscriptionID:    subID,
+				BaseTerritory:     territory,
+				BasePrice:         price,
+				StartDate:         priceAttrs.StartDate,
+				AutoScheduled:     autoScheduled,
+				Preserved:         *preserved,
+				SubscriptionState: subscriptionState,
+				DryRun:            false,
+				Total:             len(allTerritories),
+				Succeeded:         succeeded,
+				Failed:            len(failures),
+				Failures:          renderEqualizeFailures(failures),
 			}
 
 			fmt.Fprintf(os.Stderr, "Done: %d succeeded, %d failed\n", result.Succeeded, result.Failed)
@@ -250,19 +291,23 @@ type equalizeAttemptFailure struct {
 }
 
 type equalizeResult struct {
-	SubscriptionID string            `json:"subscriptionId"`
-	BaseTerritory  string            `json:"baseTerritory"`
-	BasePrice      string            `json:"basePrice"`
-	DryRun         bool              `json:"dryRun"`
-	Total          int               `json:"total"`
-	Succeeded      int               `json:"succeeded,omitempty"`
-	Failed         int               `json:"failed,omitempty"`
-	Territories    []equalization    `json:"territories,omitempty"`
-	Failures       []equalizeFailure `json:"failures,omitempty"`
+	SubscriptionID    string            `json:"subscriptionId"`
+	BaseTerritory     string            `json:"baseTerritory"`
+	BasePrice         string            `json:"basePrice"`
+	StartDate         string            `json:"startDate,omitempty"`
+	AutoScheduled     bool              `json:"autoScheduled,omitempty"`
+	Preserved         bool              `json:"preserved,omitempty"`
+	SubscriptionState string            `json:"subscriptionState,omitempty"`
+	DryRun            bool              `json:"dryRun"`
+	Total             int               `json:"total"`
+	Succeeded         int               `json:"succeeded,omitempty"`
+	Failed            int               `json:"failed,omitempty"`
+	Territories       []equalization    `json:"territories,omitempty"`
+	Failures          []equalizeFailure `json:"failures,omitempty"`
 }
 
-func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string, targets []equalization, workers int) (int, []equalizeAttemptFailure) {
-	succeeded, failures := runEqualizePricePass(ctx, client, subID, targets, workers)
+func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string, targets []equalization, workers int, attrs asc.SubscriptionPriceCreateAttributes, effectiveAt time.Time) (int, []equalizeAttemptFailure) {
+	succeeded, failures := runEqualizePricePass(ctx, client, subID, targets, workers, attrs)
 	retryable, finalFailures := partitionEqualizeFailures(failures)
 
 	for pass := 1; len(retryable) > 0 && pass <= maxEqualizeRecoveryPasses; pass++ {
@@ -274,7 +319,7 @@ func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string,
 			}
 		}
 		fmt.Fprintf(os.Stderr, "Retrying %d retryable territory update(s) with %d worker...\n", len(retryable), equalizeRecoveryWorkers)
-		retrySucceeded, retryFailures := runEqualizePricePass(ctx, client, subID, equalizeTargetsFromFailures(retryable), equalizeRecoveryWorkers)
+		retrySucceeded, retryFailures := runEqualizePricePass(ctx, client, subID, equalizeTargetsFromFailures(retryable), equalizeRecoveryWorkers, attrs)
 		succeeded += retrySucceeded
 
 		retryable, failures = partitionEqualizeFailures(retryFailures)
@@ -285,7 +330,7 @@ func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string,
 		finalFailures = append(finalFailures, retryable...)
 	}
 
-	reconciled, remaining, err := reconcileEqualizeFailures(ctx, client, subID, finalFailures)
+	reconciled, remaining, err := reconcileEqualizeFailures(ctx, client, subID, finalFailures, effectiveAt)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not verify %d failed territory update(s): %v\n", len(finalFailures), err)
 		return succeeded, finalFailures
@@ -294,7 +339,7 @@ func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string,
 	return succeeded, remaining
 }
 
-func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string, targets []equalization, workers int) (int, []equalizeAttemptFailure) {
+func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string, targets []equalization, workers int, attrs asc.SubscriptionPriceCreateAttributes) (int, []equalizeAttemptFailure) {
 	if len(targets) == 0 {
 		return 0, nil
 	}
@@ -306,7 +351,7 @@ func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string,
 		failures := make([]equalizeAttemptFailure, 0)
 		for _, target := range targets {
 			setCtx, setCancel := shared.ContextWithTimeout(ctx)
-			_, err := client.CreateSubscriptionPrice(setCtx, subID, target.PricePointID, target.Territory, asc.SubscriptionPriceCreateAttributes{})
+			_, err := client.CreateSubscriptionPrice(setCtx, subID, target.PricePointID, target.Territory, attrs)
 			setCancel()
 			if err != nil {
 				failures = append(failures, equalizeAttemptFailure{
@@ -339,7 +384,7 @@ func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string,
 			setCtx, setCancel := shared.ContextWithTimeout(ctx)
 			defer setCancel()
 
-			_, err := client.CreateSubscriptionPrice(setCtx, subID, t.PricePointID, t.Territory, asc.SubscriptionPriceCreateAttributes{})
+			_, err := client.CreateSubscriptionPrice(setCtx, subID, t.PricePointID, t.Territory, attrs)
 			results <- priceUpdateResult{target: t, err: err}
 		}(target)
 	}
@@ -394,7 +439,62 @@ func renderEqualizeFailures(failures []equalizeAttemptFailure) []equalizeFailure
 	return rendered
 }
 
-func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID string, failures []equalizeAttemptFailure) (int, []equalizeAttemptFailure, error) {
+func normalizeEqualizeStartDate(value string) (string, time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", equalizeNow(), nil
+	}
+
+	normalized, err := shared.NormalizeDate(trimmed, "--start-date")
+	if err != nil {
+		return "", time.Time{}, shared.UsageError(err.Error())
+	}
+	parsed, err := time.Parse(equalizeDateLayout, normalized)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return normalized, parsed, nil
+}
+
+func autoScheduleEqualizeStartDate(ctx context.Context, client *asc.Client, subID string) (string, string, bool, time.Time, error) {
+	state, err := fetchEqualizeSubscriptionState(ctx, client, subID)
+	if err != nil {
+		return "", "", false, time.Time{}, fmt.Errorf("failed to inspect subscription state for auto scheduling: %w", err)
+	}
+	if !isApprovedOrLiveSubscriptionState(state) {
+		return "", state, false, equalizeNow(), nil
+	}
+
+	effectiveAt := equalizeNow().UTC().AddDate(0, 0, 1)
+	startDate := effectiveAt.Format(equalizeDateLayout)
+	parsed, err := time.Parse(equalizeDateLayout, startDate)
+	if err != nil {
+		return "", state, false, time.Time{}, err
+	}
+	return startDate, state, true, parsed, nil
+}
+
+func fetchEqualizeSubscriptionState(ctx context.Context, client *asc.Client, subID string) (string, error) {
+	getCtx, getCancel := shared.ContextWithTimeout(ctx)
+	defer getCancel()
+
+	resp, err := client.GetSubscription(getCtx, subID)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToUpper(strings.TrimSpace(resp.Data.Attributes.State)), nil
+}
+
+func isApprovedOrLiveSubscriptionState(state string) bool {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "APPROVED", "READY_FOR_SALE":
+		return true
+	default:
+		return false
+	}
+}
+
+func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID string, failures []equalizeAttemptFailure, effectiveAt time.Time) (int, []equalizeAttemptFailure, error) {
 	if len(failures) == 0 {
 		return 0, nil, nil
 	}
@@ -404,7 +504,7 @@ func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID st
 	verifyCtx, verifyCancel := shared.ContextWithTimeout(ctx)
 	defer verifyCancel()
 
-	resolved, err := fetchResolvedSubscriptionPrices(verifyCtx, client, subID, 200, "", time.Now())
+	resolved, err := fetchResolvedSubscriptionPrices(verifyCtx, client, subID, 200, "", effectiveAt)
 	if err != nil {
 		return 0, failures, err
 	}
@@ -770,6 +870,15 @@ func printEqualizeTable(result *equalizeResult) error {
 
 	fmt.Printf("Subscription: %s\n", result.SubscriptionID)
 	fmt.Printf("Base: %s @ %s\n", result.BaseTerritory, result.BasePrice)
+	if result.StartDate != "" {
+		fmt.Printf("Start Date: %s\n", result.StartDate)
+	}
+	if result.AutoScheduled {
+		fmt.Printf("Auto Scheduled: true (%s)\n", result.SubscriptionState)
+	}
+	if result.Preserved {
+		fmt.Println("Preserved: true")
+	}
 	fmt.Printf("Total: %d, Succeeded: %d, Failed: %d\n", result.Total, result.Succeeded, result.Failed)
 
 	if len(result.Failures) > 0 {
@@ -799,6 +908,15 @@ func printEqualizeMarkdown(result *equalizeResult) error {
 	fmt.Printf("## Equalize Results\n\n")
 	fmt.Printf("- **Subscription:** %s\n", result.SubscriptionID)
 	fmt.Printf("- **Base:** %s @ %s\n", result.BaseTerritory, result.BasePrice)
+	if result.StartDate != "" {
+		fmt.Printf("- **Start Date:** %s\n", result.StartDate)
+	}
+	if result.AutoScheduled {
+		fmt.Printf("- **Auto Scheduled:** true (%s)\n", result.SubscriptionState)
+	}
+	if result.Preserved {
+		fmt.Printf("- **Preserved:** true\n")
+	}
 	fmt.Printf("- **Total:** %d, **Succeeded:** %d, **Failed:** %d\n\n", result.Total, result.Succeeded, result.Failed)
 
 	if len(result.Failures) > 0 {


### PR DESCRIPTION
## Summary
- Add `--start-date` and `--preserved` to `asc subscriptions pricing equalize` so PPP/equalize runs can schedule subscription price changes instead of applying immediately.
- Automatically inspect existing-price subscriptions and schedule approved/live subscription changes for tomorrow when `--start-date` is omitted (`--auto-start-date=false` keeps the old immediate behavior).
- Carry the scheduled effective date into retry/reconciliation so future-dated conflicts verify against the intended date, not today.

Fixes #1555

## Why
The lower-level subscription price commands already supported scheduled pricing attributes, but `pricing equalize` always passed empty `SubscriptionPriceCreateAttributes`. Approved/live subscriptions can reject immediate price mutation, which forced manual PPP workarounds. This wires the existing API capability into the bulk PPP path.

## Validation
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestSubscriptionsPricingEqualize -count=1`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc-ppp-scheduling .`
- `/tmp/asc-ppp-scheduling subscriptions pricing equalize --subscription-id 8000000001 --base-price 3.49 --start-date tomorrow --dry-run` exits `2` with `Error: --start-date must be in YYYY-MM-DD format`
- `/tmp/asc-ppp-scheduling subscriptions pricing equalize --help 2>&1 | rg -- '--start-date|--auto-start-date|--preserved'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduling options: --start-date, --preserved and --auto-start-date; output shows startDate, autoScheduled, preserved and subscriptionState.
  * Equalization now verifies prices at a resolved effective start time rather than always using the current time.

* **Bug Fixes**
  * Improved validation and error reporting for invalid or past --start-date and invalid boolean flag values.

* **Tests**
  * Added end-to-end and scheduling tests covering start-date behavior, auto-scheduling, and boolean flag exit codes; updated existing tests' subscription-state stubs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->