### PR TITLE
Show offer-code follow-up hints

### DIFF
--- a/internal/cli/cmdtest/subscriptions_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/subscriptions_offer_codes_output_test.go
@@ -637,6 +637,15 @@ func TestSubscriptionsOfferCodesListTableOutput(t *testing.T) {
 			t.Fatalf("expected table output to contain %q, got %q", want, stdout)
 		}
 	}
+	for _, want := range []string{
+		"Follow-up commands",
+		`asc subscriptions offers offer-codes one-time-codes list --offer-code-id "sub-code-table-1"`,
+		`asc subscriptions offers offer-codes values --batch-id "ONE_TIME_USE_CODE_ID" --output "./offer-codes.csv" --format csv`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected table output to contain follow-up hint %q, got %q", want, stdout)
+		}
+	}
 }
 
 func TestSubscriptionsOfferCodesListMarkdownOutput(t *testing.T) {
@@ -687,5 +696,8 @@ func TestSubscriptionsOfferCodesListMarkdownOutput(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "sub-code-md-1") {
 		t.Fatalf("expected markdown output to contain offer code id, got %q", stdout)
+	}
+	if strings.Contains(stdout, "Follow-up commands") {
+		t.Fatalf("expected markdown output without follow-up hints, got %q", stdout)
 	}
 }

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -122,7 +122,7 @@ Examples:
 					return fmt.Errorf("subscriptions offer-codes list: %w", err)
 				}
 
-				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+				return printSubscriptionOfferCodesListOutput(resp, *output.Output, *output.Pretty)
 			}
 
 			resp, err := client.GetSubscriptionOfferCodes(requestCtx, id, opts...)
@@ -130,9 +130,45 @@ Examples:
 				return fmt.Errorf("subscriptions offer-codes list: failed to fetch: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			return printSubscriptionOfferCodesListOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func printSubscriptionOfferCodesListOutput(data any, format string, pretty bool) error {
+	resp, ok := data.(*asc.SubscriptionOfferCodesResponse)
+	if !ok {
+		return shared.PrintOutput(data, format, pretty)
+	}
+	return shared.PrintOutputWithRenderers(
+		resp,
+		format,
+		pretty,
+		func() error {
+			if err := asc.PrintTable(resp); err != nil {
+				return err
+			}
+			printSubscriptionOfferCodesFollowUps(resp)
+			return nil
+		},
+		func() error {
+			return asc.PrintMarkdown(resp)
+		},
+	)
+}
+
+func printSubscriptionOfferCodesFollowUps(resp *asc.SubscriptionOfferCodesResponse) {
+	if resp == nil || len(resp.Data) == 0 {
+		return
+	}
+	id := strings.TrimSpace(resp.Data[0].ID)
+	if id == "" {
+		return
+	}
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Follow-up commands:")
+	fmt.Fprintf(os.Stdout, "  asc subscriptions offers offer-codes one-time-codes list --offer-code-id %q\n", id)
+	fmt.Fprintln(os.Stdout, `  asc subscriptions offers offer-codes values --batch-id "ONE_TIME_USE_CODE_ID" --output "./offer-codes.csv" --format csv`)
 }
 
 // SubscriptionsOfferCodesGetCommand returns the offer codes get subcommand.


### PR DESCRIPTION
## Summary
- show copy-paste follow-up commands after subscription offer-code table output
- keep JSON and markdown output unchanged for automation-friendly consumers
- cover the table hint and markdown no-hint behavior in cmdtest

Closes #1554

## Tests
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestSubscriptionsOfferCodesList(TableOutput|MarkdownOutput)' -count=1`\n- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestSubscriptionsOfferCodes|TestOfferCodesValues' -count=1`