### PR TITLE
[codex] Add inline CSR generation for certificate create

### DIFF
--- a/commands/certificates.mdx
+++ b/commands/certificates.mdx
@@ -123,6 +123,15 @@ asc certificates create --certificate-type IOS_DISTRIBUTION \
   --csr ./cert.csr
 ```
 
+Or generate the private key and CSR as part of the create command:
+
+```bash  theme={null}
+asc certificates create --certificate-type IOS_DISTRIBUTION \
+  --generate-csr \
+  --key-out ./signing/dist.key \
+  --csr-out ./signing/dist.csr
+```
+
 ### Generate CSR (Certificate Signing Request)
 
 Before creating a certificate, generate a CSR:

--- a/internal/cli/certificates/certificates.go
+++ b/internal/cli/certificates/certificates.go
@@ -16,6 +16,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+var getCertificatesASCClient = shared.GetASCClient
+
 // CertificatesCommand returns the certificates command with subcommands.
 func CertificatesCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("certificates", flag.ExitOnError)
@@ -188,16 +190,28 @@ func CertificatesCreateCommand() *ffcli.Command {
 
 	certificateType := fs.String("certificate-type", "", "Certificate type (e.g., IOS_DISTRIBUTION)")
 	csrPath := fs.String("csr", "", "CSR file path")
+	generateCSR := fs.Bool("generate-csr", false, "Generate a private key and CSR before creating the certificate")
+	keyOut := fs.String("key-out", "", "Private key output path for --generate-csr (PEM)")
+	csrOut := fs.String("csr-out", "", "CSR output path for --generate-csr (PEM)")
+	commonName := fs.String("common-name", "asc", "CSR subject Common Name (CN) for --generate-csr")
+	email := fs.String("email", "", "CSR subject email address for --generate-csr")
+	organization := fs.String("organization", "", "CSR subject organization (O) for --generate-csr")
+	orgUnit := fs.String("organizational-unit", "", "CSR subject organizational unit (OU) for --generate-csr")
+	country := fs.String("country", "", "CSR subject country (C) for --generate-csr")
+	keyType := fs.String("key-type", "rsa", "CSR key type for --generate-csr: rsa")
+	keySize := fs.Int("key-size", 2048, "CSR RSA key size in bits for --generate-csr")
+	force := fs.Bool("force", false, "Overwrite generated CSR/key output files")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "create",
-		ShortUsage: "asc certificates create --certificate-type TYPE --csr ./cert.csr",
+		ShortUsage: "asc certificates create --certificate-type TYPE (--csr ./cert.csr | --generate-csr --key-out ./cert.key --csr-out ./cert.csr)",
 		ShortHelp:  "Create a signing certificate.",
 		LongHelp: `Create a signing certificate.
 
 Examples:
-  asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"`,
+  asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"
+  asc certificates create --certificate-type IOS_DISTRIBUTION --generate-csr --key-out "./signing/dist.key" --csr-out "./signing/dist.csr"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -207,17 +221,59 @@ Examples:
 				return flag.ErrHelp
 			}
 			csrValue := strings.TrimSpace(*csrPath)
-			if csrValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --csr is required")
-				return flag.ErrHelp
+
+			var csrContent string
+			if *generateCSR {
+				if csrValue != "" {
+					return shared.UsageError("--csr cannot be used with --generate-csr")
+				}
+				keyOutValue := strings.TrimSpace(*keyOut)
+				if keyOutValue == "" {
+					fmt.Fprintln(os.Stderr, "Error: --key-out is required with --generate-csr")
+					return flag.ErrHelp
+				}
+				csrOutValue := strings.TrimSpace(*csrOut)
+				if csrOutValue == "" {
+					fmt.Fprintln(os.Stderr, "Error: --csr-out is required with --generate-csr")
+					return flag.ErrHelp
+				}
+
+				_, csrPEM, err := generateCSRFiles(csrGenerateOptions{
+					KeyOut:             keyOutValue,
+					CSROut:             csrOutValue,
+					CommonName:         *commonName,
+					Email:              *email,
+					Organization:       *organization,
+					OrganizationalUnit: *orgUnit,
+					Country:            *country,
+					KeyType:            *keyType,
+					KeySize:            *keySize,
+					Force:              *force,
+				})
+				if err != nil {
+					return fmt.Errorf("certificates create: generate csr: %w", err)
+				}
+				csrContent, err = encodeCSRContent(csrPEM)
+				if err != nil {
+					return fmt.Errorf("certificates create: generate csr: %w", err)
+				}
+			} else {
+				if csrCreateOnlyFlagsSet(keyOut, csrOut, commonName, email, organization, orgUnit, country, keyType, keySize, force) {
+					return shared.UsageError("--key-out, --csr-out, CSR subject flags, --key-type, --key-size, and --force require --generate-csr")
+				}
+				if csrValue == "" {
+					fmt.Fprintln(os.Stderr, "Error: --csr is required (or use --generate-csr with --key-out and --csr-out)")
+					return flag.ErrHelp
+				}
+
+				var err error
+				csrContent, err = readCSRContent(csrValue)
+				if err != nil {
+					return fmt.Errorf("certificates create: %w", err)
+				}
 			}
 
-			csrContent, err := readCSRContent(csrValue)
-			if err != nil {
-				return fmt.Errorf("certificates create: %w", err)
-			}
-
-			client, err := shared.GetASCClient()
+			client, err := getCertificatesASCClient()
 			if err != nil {
 				return fmt.Errorf("certificates create: %w", err)
 			}
@@ -233,6 +289,30 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func csrCreateOnlyFlagsSet(
+	keyOut *string,
+	csrOut *string,
+	commonName *string,
+	email *string,
+	organization *string,
+	orgUnit *string,
+	country *string,
+	keyType *string,
+	keySize *int,
+	force *bool,
+) bool {
+	return strings.TrimSpace(*keyOut) != "" ||
+		strings.TrimSpace(*csrOut) != "" ||
+		strings.TrimSpace(*commonName) != "asc" ||
+		strings.TrimSpace(*email) != "" ||
+		strings.TrimSpace(*organization) != "" ||
+		strings.TrimSpace(*orgUnit) != "" ||
+		strings.TrimSpace(*country) != "" ||
+		strings.TrimSpace(*keyType) != "rsa" ||
+		*keySize != 2048 ||
+		*force
 }
 
 // CertificatesUpdateCommand returns the certificates update subcommand.
@@ -346,6 +426,10 @@ func readCSRContent(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return encodeCSRContent(data)
+}
+
+func encodeCSRContent(data []byte) (string, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return "", fmt.Errorf("CSR file is empty")
 	}

--- a/internal/cli/certificates/certificates.go
+++ b/internal/cli/certificates/certificates.go
@@ -258,7 +258,7 @@ Examples:
 					return fmt.Errorf("certificates create: generate csr: %w", err)
 				}
 			} else {
-				if csrCreateOnlyFlagsSet(keyOut, csrOut, commonName, email, organization, orgUnit, country, keyType, keySize, force) {
+				if csrCreateOnlyFlagsSet(fs) {
 					return shared.UsageError("--key-out, --csr-out, CSR subject flags, --key-type, --key-size, and --force require --generate-csr")
 				}
 				if csrValue == "" {
@@ -291,28 +291,15 @@ Examples:
 	}
 }
 
-func csrCreateOnlyFlagsSet(
-	keyOut *string,
-	csrOut *string,
-	commonName *string,
-	email *string,
-	organization *string,
-	orgUnit *string,
-	country *string,
-	keyType *string,
-	keySize *int,
-	force *bool,
-) bool {
-	return strings.TrimSpace(*keyOut) != "" ||
-		strings.TrimSpace(*csrOut) != "" ||
-		strings.TrimSpace(*commonName) != "asc" ||
-		strings.TrimSpace(*email) != "" ||
-		strings.TrimSpace(*organization) != "" ||
-		strings.TrimSpace(*orgUnit) != "" ||
-		strings.TrimSpace(*country) != "" ||
-		strings.TrimSpace(*keyType) != "rsa" ||
-		*keySize != 2048 ||
-		*force
+func csrCreateOnlyFlagsSet(fs *flag.FlagSet) bool {
+	seen := false
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "key-out", "csr-out", "common-name", "email", "organization", "organizational-unit", "country", "key-type", "key-size", "force":
+			seen = true
+		}
+	})
+	return seen
 }
 
 // CertificatesUpdateCommand returns the certificates update subcommand.

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -137,6 +137,69 @@ func TestCertificatesCreateCommand_GenerateCSRCreatesFilesAndPostsCSR(t *testing
 	}
 }
 
+func TestCertificatesCreateCommand_GenerateCSRWriteFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		key  func(dir string, parentFile string) string
+		csr  func(dir string, parentFile string) string
+	}{
+		{
+			name: "key output parent is file",
+			key:  func(dir string, parentFile string) string { return filepath.Join(parentFile, "dist.key") },
+			csr:  func(dir string, parentFile string) string { return filepath.Join(dir, "dist.csr") },
+		},
+		{
+			name: "csr output parent is file",
+			key:  func(dir string, parentFile string) string { return filepath.Join(dir, "dist.key") },
+			csr:  func(dir string, parentFile string) string { return filepath.Join(parentFile, "dist.csr") },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			parentFile := filepath.Join(dir, "parent")
+			if err := os.WriteFile(parentFile, []byte{}, 0o644); err != nil {
+				t.Fatalf("write parent file: %v", err)
+			}
+			keyOut := test.key(dir, parentFile)
+			csrOut := test.csr(dir, parentFile)
+
+			client := newCertificatesTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				t.Fatalf("ASC request should not be sent when CSR artifacts cannot be written")
+				return nil, nil
+			}))
+			originalGetClient := getCertificatesASCClient
+			getCertificatesASCClient = func() (*asc.Client, error) { return client, nil }
+			t.Cleanup(func() { getCertificatesASCClient = originalGetClient })
+
+			cmd := CertificatesCreateCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--certificate-type", "IOS_DISTRIBUTION",
+				"--generate-csr",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+			}); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			err := cmd.Exec(context.Background(), []string{})
+			if err == nil {
+				t.Fatalf("expected write failure")
+			}
+			if !strings.Contains(err.Error(), parentFile) {
+				t.Fatalf("expected error to mention parent path %q, got %v", parentFile, err)
+			}
+			if _, err := os.Stat(keyOut); err == nil {
+				t.Fatalf("expected key output to not be created")
+			}
+			if _, err := os.Stat(csrOut); err == nil {
+				t.Fatalf("expected CSR output to not be created")
+			}
+		})
+	}
+}
+
 func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 	cmd := CertificatesRevokeCommand()
 

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -2,9 +2,23 @@ package certificates
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestCertificatesCreateCommand_MissingType(t *testing.T) {
@@ -31,6 +45,98 @@ func TestCertificatesCreateCommand_MissingCSR(t *testing.T) {
 	}
 }
 
+func TestCertificatesCreateCommand_CSRAndGenerateCSRAreMutuallyExclusive(t *testing.T) {
+	cmd := CertificatesCreateCommand()
+
+	if err := cmd.FlagSet.Parse([]string{
+		"--certificate-type", "IOS_DISTRIBUTION",
+		"--csr", "./cert.csr",
+		"--generate-csr",
+		"--key-out", "./cert.key",
+		"--csr-out", "./generated.csr",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), []string{})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp for mutually exclusive CSR flags, got %v", err)
+	}
+}
+
+func TestCertificatesCreateCommand_GenerateCSRCreatesFilesAndPostsCSR(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "dist.key")
+	csrOut := filepath.Join(dir, "dist.csr")
+
+	var got asc.CertificateCreateRequest
+	client := newCertificatesTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/certificates" {
+			t.Fatalf("expected /v1/certificates, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"certificates","id":"cert-1","attributes":{"name":"Cert","certificateType":"IOS_DISTRIBUTION"}}}`), nil
+	}))
+
+	originalGetClient := getCertificatesASCClient
+	getCertificatesASCClient = func() (*asc.Client, error) { return client, nil }
+	t.Cleanup(func() { getCertificatesASCClient = originalGetClient })
+
+	cmd := CertificatesCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--certificate-type", "IOS_DISTRIBUTION",
+		"--generate-csr",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+		"--common-name", "ASC Signing",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); err != nil {
+		t.Fatalf("exec error: %v", err)
+	}
+
+	if got.Data.Attributes.CertificateType != "IOS_DISTRIBUTION" {
+		t.Fatalf("expected certificate type IOS_DISTRIBUTION, got %q", got.Data.Attributes.CertificateType)
+	}
+	csrPEM, err := os.ReadFile(csrOut)
+	if err != nil {
+		t.Fatalf("read generated CSR: %v", err)
+	}
+	csrBlock, _ := pem.Decode(csrPEM)
+	if csrBlock == nil {
+		t.Fatalf("generated CSR is not PEM")
+	}
+	if want := base64.StdEncoding.EncodeToString(csrBlock.Bytes); got.Data.Attributes.CSRContent != want {
+		t.Fatalf("expected generated CSR content to be posted")
+	}
+	if _, err := os.Stat(keyOut); err != nil {
+		t.Fatalf("expected generated private key: %v", err)
+	}
+
+	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse generated CSR: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		t.Fatalf("generated CSR signature invalid: %v", err)
+	}
+	if csr.Subject.CommonName != "ASC Signing" {
+		t.Fatalf("expected generated CSR CN ASC Signing, got %q", csr.Subject.CommonName)
+	}
+}
+
 func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 	cmd := CertificatesRevokeCommand()
 
@@ -40,6 +146,44 @@ func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 
 	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --id is missing, got %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func newCertificatesTestClient(t *testing.T, transport http.RoundTripper) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey_TEST.p8")
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(keyPath) error: %v", err)
+	}
+
+	client, err := asc.NewClientWithHTTPClient("TESTKEY123", "TESTISSUER", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
+	}
+	return client
+}
+
+func jsonHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }
 

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -36,6 +36,19 @@ type csrGenerateResult struct {
 	Subject csrGenerateSubject `json:"subject"`
 }
 
+type csrGenerateOptions struct {
+	KeyOut             string
+	CSROut             string
+	CommonName         string
+	Email              string
+	Organization       string
+	OrganizationalUnit string
+	Country            string
+	KeyType            string
+	KeySize            int
+	Force              bool
+}
+
 // CertificatesCSRCommand returns the certificates csr command group.
 func CertificatesCSRCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("csr", flag.ExitOnError)
@@ -105,99 +118,20 @@ Examples:
 				return shared.UsageError("--key-out and --csr-out must be different paths")
 			}
 
-			normalizedKeyType := strings.ToLower(strings.TrimSpace(*keyType))
-			if normalizedKeyType == "" {
-				normalizedKeyType = "rsa"
-			}
-			if normalizedKeyType != "rsa" {
-				return shared.UsageError("--key-type must be one of: rsa")
-			}
-			if *keySize < 2048 {
-				return shared.UsageError("--key-size must be at least 2048")
-			}
-
-			subject := csrGenerateSubject{
-				CommonName:         strings.TrimSpace(*commonName),
-				Email:              strings.TrimSpace(*email),
-				Organization:       strings.TrimSpace(*organization),
-				OrganizationalUnit: strings.TrimSpace(*orgUnit),
-				Country:            strings.TrimSpace(*country),
-			}
-			if subject.CommonName == "" {
-				subject.CommonName = "asc"
-			}
-
-			// Pre-check output paths to avoid leaving an orphaned key when CSR write fails.
-			// This is not atomic (TOCTOU), but it prevents the common confusing case.
-			if !*force {
-				if _, err := os.Lstat(keyOutValue); err == nil {
-					return fmt.Errorf("certificates csr generate: write --key-out: output file already exists: %w", os.ErrExist)
-				} else if !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("certificates csr generate: write --key-out: %w", err)
-				}
-				if _, err := os.Lstat(csrOutValue); err == nil {
-					return fmt.Errorf("certificates csr generate: write --csr-out: output file already exists: %w", os.ErrExist)
-				} else if !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("certificates csr generate: write --csr-out: %w", err)
-				}
-			}
-
-			// Generate RSA private key.
-			privateKey, err := rsa.GenerateKey(rand.Reader, *keySize)
+			result, _, err := generateCSRFiles(csrGenerateOptions{
+				KeyOut:             keyOutValue,
+				CSROut:             csrOutValue,
+				CommonName:         *commonName,
+				Email:              *email,
+				Organization:       *organization,
+				OrganizationalUnit: *orgUnit,
+				Country:            *country,
+				KeyType:            *keyType,
+				KeySize:            *keySize,
+				Force:              *force,
+			})
 			if err != nil {
-				return fmt.Errorf("certificates csr generate: generate key: %w", err)
-			}
-			keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
-			if err != nil {
-				return fmt.Errorf("certificates csr generate: marshal key: %w", err)
-			}
-			keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
-			if keyPEM == nil {
-				return fmt.Errorf("certificates csr generate: encode key PEM failed")
-			}
-
-			req := &x509.CertificateRequest{
-				SignatureAlgorithm: x509.SHA256WithRSA,
-				Subject: pkix.Name{
-					CommonName: subject.CommonName,
-				},
-			}
-			if subject.Organization != "" {
-				req.Subject.Organization = []string{subject.Organization}
-			}
-			if subject.OrganizationalUnit != "" {
-				req.Subject.OrganizationalUnit = []string{subject.OrganizationalUnit}
-			}
-			if subject.Country != "" {
-				req.Subject.Country = []string{subject.Country}
-			}
-			if subject.Email != "" {
-				req.EmailAddresses = []string{subject.Email}
-			}
-
-			csrDER, err := x509.CreateCertificateRequest(rand.Reader, req, privateKey)
-			if err != nil {
-				return fmt.Errorf("certificates csr generate: create csr: %w", err)
-			}
-			csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
-			if csrPEM == nil {
-				return fmt.Errorf("certificates csr generate: encode csr PEM failed")
-			}
-
-			// Write key first: if anything fails, do not leave a CSR without its key.
-			if err := writeFileBytesNoSymlink(keyOutValue, keyPEM, 0o600, *force); err != nil {
-				return fmt.Errorf("certificates csr generate: write --key-out: %w", err)
-			}
-			if err := writeFileBytesNoSymlink(csrOutValue, csrPEM, 0o644, *force); err != nil {
-				return fmt.Errorf("certificates csr generate: write --csr-out: %w", err)
-			}
-
-			result := &csrGenerateResult{
-				KeyOut:  keyOutValue,
-				CSROut:  csrOutValue,
-				KeyType: normalizedKeyType,
-				KeySize: *keySize,
-				Subject: subject,
+				return fmt.Errorf("certificates csr generate: %w", err)
 			}
 
 			return shared.PrintOutputWithRenderers(
@@ -209,6 +143,115 @@ Examples:
 			)
 		},
 	}
+}
+
+func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, error) {
+	keyOutValue := strings.TrimSpace(opts.KeyOut)
+	if keyOutValue == "" {
+		return nil, nil, fmt.Errorf("--key-out is required")
+	}
+	csrOutValue := strings.TrimSpace(opts.CSROut)
+	if csrOutValue == "" {
+		return nil, nil, fmt.Errorf("--csr-out is required")
+	}
+	if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
+		return nil, nil, shared.UsageError("--key-out and --csr-out must be different paths")
+	}
+
+	normalizedKeyType := strings.ToLower(strings.TrimSpace(opts.KeyType))
+	if normalizedKeyType == "" {
+		normalizedKeyType = "rsa"
+	}
+	if normalizedKeyType != "rsa" {
+		return nil, nil, shared.UsageError("--key-type must be one of: rsa")
+	}
+	if opts.KeySize < 2048 {
+		return nil, nil, shared.UsageError("--key-size must be at least 2048")
+	}
+
+	subject := csrGenerateSubject{
+		CommonName:         strings.TrimSpace(opts.CommonName),
+		Email:              strings.TrimSpace(opts.Email),
+		Organization:       strings.TrimSpace(opts.Organization),
+		OrganizationalUnit: strings.TrimSpace(opts.OrganizationalUnit),
+		Country:            strings.TrimSpace(opts.Country),
+	}
+	if subject.CommonName == "" {
+		subject.CommonName = "asc"
+	}
+
+	// Pre-check output paths to avoid leaving an orphaned key when CSR write fails.
+	// This is not atomic (TOCTOU), but it prevents the common confusing case.
+	if !opts.Force {
+		if _, err := os.Lstat(keyOutValue); err == nil {
+			return nil, nil, fmt.Errorf("write --key-out: output file already exists: %w", os.ErrExist)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("write --key-out: %w", err)
+		}
+		if _, err := os.Lstat(csrOutValue); err == nil {
+			return nil, nil, fmt.Errorf("write --csr-out: output file already exists: %w", os.ErrExist)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("write --csr-out: %w", err)
+		}
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, opts.KeySize)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if keyPEM == nil {
+		return nil, nil, fmt.Errorf("encode key PEM failed")
+	}
+
+	req := &x509.CertificateRequest{
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		Subject: pkix.Name{
+			CommonName: subject.CommonName,
+		},
+	}
+	if subject.Organization != "" {
+		req.Subject.Organization = []string{subject.Organization}
+	}
+	if subject.OrganizationalUnit != "" {
+		req.Subject.OrganizationalUnit = []string{subject.OrganizationalUnit}
+	}
+	if subject.Country != "" {
+		req.Subject.Country = []string{subject.Country}
+	}
+	if subject.Email != "" {
+		req.EmailAddresses = []string{subject.Email}
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, req, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create csr: %w", err)
+	}
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+	if csrPEM == nil {
+		return nil, nil, fmt.Errorf("encode csr PEM failed")
+	}
+
+	// Write key first: if anything fails, do not leave a CSR without its key.
+	if err := writeFileBytesNoSymlink(keyOutValue, keyPEM, 0o600, opts.Force); err != nil {
+		return nil, nil, fmt.Errorf("write --key-out: %w", err)
+	}
+	if err := writeFileBytesNoSymlink(csrOutValue, csrPEM, 0o644, opts.Force); err != nil {
+		return nil, nil, fmt.Errorf("write --csr-out: %w", err)
+	}
+
+	result := &csrGenerateResult{
+		KeyOut:  keyOutValue,
+		CSROut:  csrOutValue,
+		KeyType: normalizedKeyType,
+		KeySize: opts.KeySize,
+		Subject: subject,
+	}
+	return result, csrPEM, nil
 }
 
 func renderCSRGenerateResult(result *csrGenerateResult, markdown bool) error {

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -2036,6 +2036,78 @@ func TestCertificatesValidationErrors(t *testing.T) {
 	}
 }
 
+func TestCertificatesCreateGenerateCSRFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "generate csr missing key out value",
+			args:    []string{"certificates", "create", "--certificate-type", "IOS_DISTRIBUTION", "--generate-csr", "--key-out"},
+			wantErr: "flag needs an argument: -key-out",
+		},
+		{
+			name:    "generate csr invalid bool value",
+			args:    []string{"certificates", "create", "--certificate-type", "IOS_DISTRIBUTION", "--generate-csr=maybe", "--key-out", "./dist.key", "--csr-out", "./dist.csr"},
+			wantErr: "invalid boolean value",
+		},
+		{
+			name:    "generate csr missing csr out value",
+			args:    []string{"certificates", "create", "--certificate-type", "IOS_DISTRIBUTION", "--generate-csr", "--key-out", "./dist.key", "--csr-out"},
+			wantErr: "flag needs an argument: -csr-out",
+		},
+		{
+			name:    "generation only default key type still requires generate csr",
+			args:    []string{"certificates", "create", "--certificate-type", "IOS_DISTRIBUTION", "--csr", "./dist.csr", "--key-type", "rsa"},
+			wantErr: "--key-out, --csr-out, CSR subject flags, --key-type, --key-size, and --force require --generate-csr",
+		},
+		{
+			name:    "generation only flag mixed order still requires generate csr",
+			args:    []string{"certificates", "create", "--certificate-type", "IOS_DISTRIBUTION", "--key-out", "./dist.key", "--csr", "./dist.csr"},
+			wantErr: "--key-out, --csr-out, CSR subject flags, --key-type, --key-size, and --force require --generate-csr",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestCertificatesCreateGenerateCSRFlagValidationHelper", "--"}, test.args...)...)
+			cmd.Env = append(os.Environ(), "ASC_CERT_CREATE_FLAG_HELPER=1")
+			stdout, err := cmd.Output()
+			stderr := ""
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				stderr = string(exitErr.Stderr)
+				if exitErr.ExitCode() != 2 {
+					t.Fatalf("expected exit code 2, got %d with stderr %q", exitErr.ExitCode(), stderr)
+				}
+			} else if err != nil {
+				t.Fatalf("helper command failed: %v", err)
+			} else {
+				t.Fatalf("expected exit code 2, got 0")
+			}
+			if string(stdout) != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestCertificatesCreateGenerateCSRFlagValidationHelper(t *testing.T) {
+	if os.Getenv("ASC_CERT_CREATE_FLAG_HELPER") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Exit(rootcmd.Run(os.Args[i+1:], "1.2.3"))
+		}
+	}
+	os.Exit(2)
+}
+
 func TestDevicesListLimitValidation(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)


### PR DESCRIPTION
## Summary
- add `asc certificates create --generate-csr` with required `--key-out` and `--csr-out` paths
- reuse the existing CSR generation path so inline create keeps the same key/CSR validation and file-safety behavior
- document the one-command certificate create flow

Fixes #1562

## Validation
- `go test ./internal/cli/certificates`
- `go test ./internal/cli/cmdtest -run 'Certificates|commands' -count=1 -timeout=90s`\n- `make check-command-docs`\n- `make check-website-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --generate-csr to the asc certificates create command to generate private keys and CSRs on-the-fly, with options to write key and CSR outputs and specify CSR subject and key parameters.

* **Documentation**
  * Updated certificate creation docs and examples to demonstrate the new generate-and-write CSR/key workflow.

* **Tests**
  * Expanded test coverage for CSR generation, mutual-exclusion of flags, output-write failure cases, request payload validation, and CLI flag validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->