### PR TITLE
Add platform filter to status dashboard

### DIFF
--- a/internal/cli/cmdtest/status_test.go
+++ b/internal/cli/cmdtest/status_test.go
@@ -241,6 +241,159 @@ func TestStatusDefaultJSONIncludesAllSections(t *testing.T) {
 	}
 }
 
+func TestStatusPlatformFiltersPlatformScopedSections(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps":
+			return statusJSONResponse(`{
+				"data": [{"type":"apps","id":"app-1","attributes":{"name":"My App","bundleId":"app-1"}}]
+			}`), nil
+		case "/v1/builds":
+			query := req.URL.Query()
+			if query.Get("filter[app]") != "app-1" {
+				t.Fatalf("expected filter[app]=app-1, got %q", query.Get("filter[app]"))
+			}
+			if query.Get("filter[preReleaseVersion.platform]") != "MAC_OS" {
+				t.Fatalf("expected build platform filter MAC_OS, got %q", query.Get("filter[preReleaseVersion.platform]"))
+			}
+			return statusJSONResponse(`{
+				"data":[{"type":"builds","id":"build-mac","attributes":{"version":"45","uploadedDate":"2026-02-20T00:00:00Z","processingState":"VALID"}}],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/builds/build-mac/preReleaseVersion":
+			return statusJSONResponse(`{
+				"data":{"type":"preReleaseVersions","id":"prv-mac","attributes":{"version":"1.2.3","platform":"MAC_OS"}}
+			}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			query := req.URL.Query()
+			if query.Get("filter[platform]") != "MAC_OS" {
+				t.Fatalf("expected app store versions platform filter MAC_OS, got %q", query.Get("filter[platform]"))
+			}
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"appStoreVersions",
+						"id":"ver-mac",
+						"attributes":{
+							"platform":"MAC_OS",
+							"versionString":"1.2.3",
+							"appVersionState":"READY_FOR_SALE",
+							"createdDate":"2026-02-20T02:00:00Z"
+						}
+					}
+				],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/apps/app-1/reviewSubmissions":
+			query := req.URL.Query()
+			if query.Get("filter[platform]") != "MAC_OS" {
+				t.Fatalf("expected review submissions platform filter MAC_OS, got %q", query.Get("filter[platform]"))
+			}
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"reviewSubmissions",
+						"id":"review-sub-mac",
+						"attributes":{"state":"COMPLETE","platform":"MAC_OS","submittedDate":"2026-02-20T03:00:00Z"}
+					}
+				],
+				"links":{"next":""}
+			}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	for _, tt := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "canonical order",
+			args: []string{"status", "--app", "app-1", "--platform", "mac_os", "--include", "builds,appstore,review"},
+		},
+		{
+			name: "platform before app",
+			args: []string{"status", "--platform", "mac_os", "--app", "app-1", "--include", "builds,appstore,review"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(tt.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+				t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+			}
+
+			summary := payload["summary"].(map[string]any)
+			if summary["platform"] != "MAC_OS" {
+				t.Fatalf("expected summary.platform MAC_OS, got %v", summary["platform"])
+			}
+
+			builds := payload["builds"].(map[string]any)
+			latestBuild := builds["latest"].(map[string]any)
+			if latestBuild["platform"] != "MAC_OS" {
+				t.Fatalf("expected builds.latest.platform MAC_OS, got %v", latestBuild["platform"])
+			}
+
+			appStore := payload["appstore"].(map[string]any)
+			if appStore["platform"] != "MAC_OS" || appStore["versionId"] != "ver-mac" {
+				t.Fatalf("expected macOS appstore version, got %v", appStore)
+			}
+
+			review := payload["review"].(map[string]any)
+			if review["platform"] != "MAC_OS" || review["latestSubmissionId"] != "review-sub-mac" {
+				t.Fatalf("expected macOS review submission, got %v", review)
+			}
+		})
+	}
+}
+
+func TestStatusRejectsUnknownPlatform(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"status", "--app", "app-1", "--platform", "IPAD_OS"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp usage error, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "--platform must be one of: IOS, MAC_OS, TV_OS, VISION_OS") {
+		t.Fatalf("expected platform validation error in stderr, got %q", stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}
+
 func TestStatusAppStorePaginatesBeforeChoosingLatestVersion(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -51,6 +51,7 @@ type statusSummary struct {
 	Health     string   `json:"health"`
 	NextAction string   `json:"nextAction"`
 	Blockers   []string `json:"blockers"`
+	Platform   string   `json:"platform,omitempty"`
 }
 
 type buildsSection struct {
@@ -133,6 +134,7 @@ func StatusCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID, bundle ID, or exact app name (required, or ASC_APP_ID env)")
+	platform := fs.String("platform", "", "Filter release status by platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	include := fs.String("include", "", "Comma-separated sections: app,builds,testflight,appstore,submission,review,phased-release,links")
 	watch := fs.Bool("watch", false, "Poll and emit snapshots when status changes")
 	pollInterval := fs.Duration("poll-interval", 30*time.Second, "Polling interval for --watch")
@@ -152,6 +154,7 @@ Examples:
   asc status --app "123456789"
   asc status --app "com.example.app"
   asc status --app "My App"
+  asc status --app "123456789" --platform MAC_OS
   asc status --app "123456789" --include builds,testflight,submission
   asc status --app "123456789" --watch --poll-interval 15s
   asc status --app "123456789" --output table`,
@@ -182,6 +185,13 @@ Examples:
 			if *maxPolls > 0 && !*watch {
 				return shared.UsageError("--max-polls requires --watch")
 			}
+			normalizedPlatform := ""
+			if strings.TrimSpace(*platform) != "" {
+				normalizedPlatform, err = shared.NormalizeAppStoreVersionPlatform(*platform)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -196,13 +206,13 @@ Examples:
 			}
 
 			if *watch {
-				return watchDashboard(ctx, client, resolvedAppID, includes, *output.Output, *output.Pretty, *pollInterval, *maxPolls)
+				return watchDashboard(ctx, client, resolvedAppID, normalizedPlatform, includes, *output.Output, *output.Pretty, *pollInterval, *maxPolls)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := collectDashboard(requestCtx, client, resolvedAppID, includes, false)
+			resp, err := collectDashboard(requestCtx, client, resolvedAppID, normalizedPlatform, includes, false)
 			if err != nil {
 				return fmt.Errorf("status: %w", err)
 			}
@@ -218,12 +228,12 @@ Examples:
 	}
 }
 
-func watchDashboard(ctx context.Context, client *asc.Client, appID string, includes includeSet, output string, pretty bool, pollInterval time.Duration, maxPolls int) error {
+func watchDashboard(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, output string, pretty bool, pollInterval time.Duration, maxPolls int) error {
 	seen := ""
 
 	for poll := 1; maxPolls == 0 || poll <= maxPolls; poll++ {
 		requestCtx, cancel := shared.ContextWithTimeout(ctx)
-		resp, err := collectDashboard(requestCtx, client, appID, includes, true)
+		resp, err := collectDashboard(requestCtx, client, appID, platform, includes, true)
 		cancel()
 		if err != nil {
 			if watchContextDone(ctx) {
@@ -393,7 +403,7 @@ func parseInclude(value string) (includeSet, error) {
 	return includes, nil
 }
 
-func collectDashboard(ctx context.Context, client *asc.Client, appID string, includes includeSet, watchMode bool) (*dashboardResponse, error) {
+func collectDashboard(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, watchMode bool) (*dashboardResponse, error) {
 	resp := &dashboardResponse{}
 	if includes.app {
 		appResp, err := client.GetApp(ctx, appID)
@@ -421,7 +431,7 @@ func collectDashboard(ctx context.Context, client *asc.Client, appID string, inc
 		tasks = append(tasks, sectionTask{
 			name: "builds/testflight",
 			run: func() error {
-				return fillBuildsAndTestFlight(ctx, client, appID, includes, resp)
+				return fillBuildsAndTestFlight(ctx, client, appID, platform, includes, resp)
 			},
 		})
 	}
@@ -429,7 +439,7 @@ func collectDashboard(ctx context.Context, client *asc.Client, appID string, inc
 		tasks = append(tasks, sectionTask{
 			name: "appstore/phased-release",
 			run: func() error {
-				return fillAppStoreAndPhasedRelease(ctx, client, appID, includes, resp)
+				return fillAppStoreAndPhasedRelease(ctx, client, appID, platform, includes, resp)
 			},
 		})
 	}
@@ -437,7 +447,7 @@ func collectDashboard(ctx context.Context, client *asc.Client, appID string, inc
 		tasks = append(tasks, sectionTask{
 			name: "submission/review",
 			run: func() error {
-				return fillSubmissionAndReview(ctx, client, appID, includes, resp, watchMode)
+				return fillSubmissionAndReview(ctx, client, appID, platform, includes, resp, watchMode)
 			},
 		})
 	}
@@ -446,6 +456,7 @@ func collectDashboard(ctx context.Context, client *asc.Client, appID string, inc
 		return nil, err
 	}
 	resp.Summary = buildStatusSummary(resp)
+	resp.Summary.Platform = platform
 
 	return resp, nil
 }
@@ -486,8 +497,12 @@ func runTasks(tasks []sectionTask, limit int) error {
 	return nil
 }
 
-func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID string, includes includeSet, resp *dashboardResponse) error {
-	buildsResp, err := client.GetBuilds(ctx, appID, asc.WithBuildsSort("-uploadedDate"), asc.WithBuildsLimit(50))
+func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, resp *dashboardResponse) error {
+	buildOpts := []asc.BuildsOption{asc.WithBuildsSort("-uploadedDate"), asc.WithBuildsLimit(50)}
+	if platform != "" {
+		buildOpts = append(buildOpts, asc.WithBuildsPreReleaseVersionPlatforms([]string{platform}))
+	}
+	buildsResp, err := client.GetBuilds(ctx, appID, buildOpts...)
 	if err != nil {
 		return err
 	}
@@ -622,8 +637,12 @@ func optionalRelationshipResourceID(relationships json.RawMessage, key string) (
 	return id, true
 }
 
-func fillAppStoreAndPhasedRelease(ctx context.Context, client *asc.Client, appID string, includes includeSet, resp *dashboardResponse) error {
-	versions, err := shared.FetchAllAppStoreVersions(ctx, client, appID, asc.WithAppStoreVersionsLimit(200))
+func fillAppStoreAndPhasedRelease(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, resp *dashboardResponse) error {
+	versionOpts := []asc.AppStoreVersionsOption{asc.WithAppStoreVersionsLimit(200)}
+	if platform != "" {
+		versionOpts = append(versionOpts, asc.WithAppStoreVersionsPlatforms([]string{platform}))
+	}
+	versions, err := shared.FetchAllAppStoreVersions(ctx, client, appID, versionOpts...)
 	if err != nil {
 		return err
 	}
@@ -666,8 +685,8 @@ func fillAppStoreAndPhasedRelease(ctx context.Context, client *asc.Client, appID
 	return nil
 }
 
-func fillSubmissionAndReview(ctx context.Context, client *asc.Client, appID string, includes includeSet, resp *dashboardResponse, watchMode bool) error {
-	submissions, err := fetchStatusReviewSubmissions(ctx, client, appID, watchMode)
+func fillSubmissionAndReview(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, resp *dashboardResponse, watchMode bool) error {
+	submissions, err := fetchStatusReviewSubmissions(ctx, client, appID, platform, watchMode)
 	if err != nil {
 		return err
 	}
@@ -706,13 +725,17 @@ func fillSubmissionAndReview(ctx context.Context, client *asc.Client, appID stri
 	return nil
 }
 
-func fetchStatusReviewSubmissions(ctx context.Context, client *asc.Client, appID string, watchMode bool) ([]asc.ReviewSubmissionResource, error) {
+func fetchStatusReviewSubmissions(ctx context.Context, client *asc.Client, appID string, platform string, watchMode bool) ([]asc.ReviewSubmissionResource, error) {
+	opts := []asc.ReviewSubmissionsOption{asc.WithReviewSubmissionsLimit(200)}
+	if platform != "" {
+		opts = append(opts, asc.WithReviewSubmissionsPlatforms([]string{platform}))
+	}
 	if !watchMode {
-		return shared.FetchAllReviewSubmissions(ctx, client, appID, asc.WithReviewSubmissionsLimit(200))
+		return shared.FetchAllReviewSubmissions(ctx, client, appID, opts...)
 	}
 
 	// Watch mode uses a bounded recent snapshot instead of walking submission history on every poll.
-	resp, err := client.GetReviewSubmissions(ctx, appID, asc.WithReviewSubmissionsLimit(200))
+	resp, err := client.GetReviewSubmissions(ctx, appID, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -968,11 +991,15 @@ func renderDashboard(resp *dashboardResponse, markdown bool) {
 		summary = buildStatusSummary(resp)
 	}
 
-	shared.RenderSection("Summary", []string{"field", "value"}, [][]string{
+	summaryRows := [][]string{
 		{"health", fmt.Sprintf("%s %s", healthSymbol(summary.Health), shared.OrNA(summary.Health))},
 		{"nextAction", shared.OrNA(summary.NextAction)},
 		{"blockerCount", fmt.Sprintf("%d", len(summary.Blockers))},
-	}, markdown)
+	}
+	if summary.Platform != "" {
+		summaryRows = append(summaryRows, []string{"platform", summary.Platform})
+	}
+	shared.RenderSection("Summary", []string{"field", "value"}, summaryRows, markdown)
 
 	if len(summary.Blockers) > 0 {
 		attentionRows := make([][]string, 0, len(summary.Blockers))


### PR DESCRIPTION
## Summary
- Add `asc status --platform` for IOS, MAC_OS, TV_OS, and VISION_OS
- Apply the platform to builds, App Store version, and review submission status queries
- Surface the selected platform in the status summary plus existing section platform fields

## Design note
- Command placement: existing top-level `asc status`; this is a scoped filter, not a new command
- OpenAPI: `/v1/apps/{id}/appStoreVersions` supports `filter[platform]`; builds already support `filter[preReleaseVersion.platform]`; review submissions already support `filter[platform]`
- UX: optional `--platform MAC_OS`; invalid values return usage error / exit code 2
- Compatibility: no behavior change when `--platform` is omitted
- Tests: add CLI-level valid MAC_OS filtering and invalid platform coverage

## Validation
- `asc status --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/status`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestStatus'`\n- `make generate-command-docs`\n- `make format`\n- `make check-command-docs`\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n- `go build -o /tmp/asc .`\n- `/tmp/asc status --app app-1 --platform IPAD_OS` exits 2 with the expected platform validation error\n\nCloses #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status command adds a --platform flag to filter dashboard data and includes platform info in results; watch mode respects the selected platform.

* **Tests**
  * Added tests confirming platform-specific filtering across dashboard sections and that unsupported platform values produce a validation error and no stdout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->