### PR TITLE
docs: add macOS TestFlight distribution example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,14 @@ the processed build to a beta group:
 
 ```bash
 asc builds upload --app "123456789" --pkg "./build/MyMacApp.pkg" --version "1.2.3" --build-number "42" --wait --output json
-asc publish testflight --app "123456789" --build "BUILD_ID" --platform MAC_OS --group "Internal Testers" --wait
+asc builds add-groups --app "123456789" --build-number "42" --version "1.2.3" --platform MAC_OS --group "Internal Testers"
 ```
 
 `--app` is the App Store Connect app ID. If you use local Xcode build flags such
 as `--archive-path`, also pass exactly one of `--workspace` or `--project` plus
-`--scheme`; otherwise use a pre-exported `.ipa` or `.pkg` upload.
+`--scheme`; otherwise use a pre-exported `.ipa` or `.pkg` upload. Add
+`--submit --confirm` to `asc builds add-groups` when distributing to an external
+TestFlight group that needs beta app review submission.
 
 ### Release (high-level App Store publish flow)
 


### PR DESCRIPTION
## Summary
- add a README macOS TestFlight example using `.pkg` upload followed by `builds add-groups` distribution
- clarify that `--archive-path` local-build flags require `--workspace` or `--project` plus `--scheme`
- mention `--submit --confirm` for external beta review submission

## Verification
- `go run . --help`
- `go run . xcode --help`
- `go run . xcode archive --help`
- `go run . xcode export --help`
- `go run . publish --help`
- `go run . publish testflight --help`
- `go run . builds upload --help`
- `go run . builds add-groups --help`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/builds ./internal/cli/cmdtest -run 'TestBuildsUpload|TestBuildsAddGroups|TestBuildsUploadWait|TestBuildsWait|TestResolveBuildOptions|TestBuildsInfo'`