### PR TITLE
Add `asc web review iaps attach` for first-IAP submission

### DIFF
--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -19,30 +19,12 @@ import (
 )
 
 func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
-	setupAuth(t)
 	setupCachedWebReviewIAPSession(t, "user@example.com")
 
 	requests := newRequestLog(3)
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests.Add(req.Method + " " + req.URL.Host + req.URL.Path)
 		switch {
-		case req.Method == http.MethodGet &&
-			req.URL.Host == "api.appstoreconnect.apple.com" &&
-			req.URL.Path == "/v1/apps/123456789/inAppPurchasesV2":
-			if got := req.URL.Query().Get("limit"); got != "200" {
-				t.Fatalf("expected IAP verification limit=200, got %q", got)
-			}
-			return webReviewIAPJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "inAppPurchases",
-					"id": "9000000001",
-					"attributes": {
-						"name": "Remove Ads",
-						"productId": "com.example.removeads",
-						"inAppPurchaseType": "NON_CONSUMABLE"
-					}
-				}]
-			}`, req), nil
 		case req.Method == http.MethodGet &&
 			req.URL.Host == "appstoreconnect.apple.com" &&
 			req.URL.Path == "/olympus/v1/session":
@@ -55,6 +37,24 @@ func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 				"user": {
 					"emailAddress": "user@example.com"
 				}
+			}`, req), nil
+		case req.Method == http.MethodGet &&
+			req.URL.Host == "appstoreconnect.apple.com" &&
+			req.URL.Path == "/iris/v1/apps/123456789/inAppPurchases":
+			if got := req.URL.Query().Get("limit"); got != "300" {
+				t.Fatalf("expected web IAP lookup limit=300, got %q", got)
+			}
+			return webReviewIAPJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "inAppPurchases",
+					"id": "9000000001",
+					"attributes": {
+						"name": "Remove Ads",
+						"productId": "com.example.removeads",
+						"inAppPurchaseType": "NON_CONSUMABLE",
+						"state": "READY_TO_SUBMIT"
+					}
+				}]
 			}`, req), nil
 		case req.Method == http.MethodPost &&
 			req.URL.Host == "appstoreconnect.apple.com" &&
@@ -139,8 +139,8 @@ func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 	}
 
 	wantRequests := []string{
-		"GET api.appstoreconnect.apple.com/v1/apps/123456789/inAppPurchasesV2",
 		"GET appstoreconnect.apple.com/olympus/v1/session",
+		"GET appstoreconnect.apple.com/iris/v1/apps/123456789/inAppPurchases",
 		"POST appstoreconnect.apple.com/iris/v1/inAppPurchaseSubmissions",
 	}
 	if got := requests.Snapshot(); strings.Join(got, "\n") != strings.Join(wantRequests, "\n") {

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -213,6 +213,17 @@ func TestWebReviewIAPsAttachArgumentParsingEdges(t *testing.T) {
 		args []string
 	}{
 		{
+			name: "root flag before subcommand",
+			args: []string{
+				"--profile", "ci",
+				"web", "review", "iaps", "attach",
+				"--app", "123456789",
+				"--iap-id", "9000000001",
+				"--apple-id", "attach",
+				"--confirm",
+			},
+		},
+		{
 			name: "mixed flag order",
 			args: []string{
 				"web", "review", "iaps", "attach",
@@ -236,11 +247,21 @@ func TestWebReviewIAPsAttachArgumentParsingEdges(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			root := RootCommand("1.2.3")
-			root.FlagSet.SetOutput(io.Discard)
+			setupCachedWebReviewIAPSession(t, "attach")
+			installSuccessfulWebReviewIAPAttachTransport(t, "attach")
 
-			if err := root.Parse(test.args); err != nil {
-				t.Fatalf("parse error: %v", err)
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = rootcmd.Run(test.args, "1.2.3")
+			})
+			if code != rootcmd.ExitSuccess {
+				t.Fatalf("exit code = %d, want %d\nstderr=%s", code, rootcmd.ExitSuccess, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if !strings.Contains(stdout, `"operation":"attach"`) {
+				t.Fatalf("expected attach JSON output, got %q", stdout)
 			}
 		})
 	}
@@ -303,6 +324,14 @@ func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
 func setupCachedWebReviewIAPSession(t *testing.T, email string) {
 	t.Helper()
 
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
 	t.Setenv("ASC_WEB_SESSION_CACHE", "1")
 	t.Setenv("ASC_WEB_SESSION_CACHE_BACKEND", "file")
 	t.Setenv("ASC_WEB_SESSION_CACHE_DIR", t.TempDir())
@@ -330,6 +359,63 @@ func setupCachedWebReviewIAPSession(t *testing.T, email string) {
 	}); err != nil {
 		t.Fatalf("persist cached web session: %v", err)
 	}
+}
+
+func installSuccessfulWebReviewIAPAttachTransport(t *testing.T, email string) {
+	t.Helper()
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet &&
+			req.URL.Host == "appstoreconnect.apple.com" &&
+			req.URL.Path == "/olympus/v1/session":
+			return webReviewIAPJSONResponse(http.StatusOK, `{
+				"provider": {
+					"providerId": 123456,
+					"publicProviderId": "team-1",
+					"name": "Team"
+				},
+				"user": {
+					"emailAddress": "`+email+`"
+				}
+			}`, req), nil
+		case req.Method == http.MethodGet &&
+			req.URL.Host == "appstoreconnect.apple.com" &&
+			req.URL.Path == "/iris/v1/apps/123456789/inAppPurchases":
+			return webReviewIAPJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "inAppPurchases",
+					"id": "9000000001",
+					"attributes": {
+						"name": "Remove Ads",
+						"productId": "com.example.removeads",
+						"inAppPurchaseType": "NON_CONSUMABLE",
+						"state": "READY_TO_SUBMIT"
+					}
+				}]
+			}`, req), nil
+		case req.Method == http.MethodPost &&
+			req.URL.Host == "appstoreconnect.apple.com" &&
+			req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
+			return webReviewIAPJSONResponse(http.StatusCreated, `{
+				"data": {
+					"type": "inAppPurchaseSubmissions",
+					"id": "submission-1",
+					"attributes": {
+						"submitWithNextAppStoreVersion": true
+					},
+					"relationships": {
+						"inAppPurchaseV2": {
+							"data": {"type": "inAppPurchases", "id": "9000000001"}
+						}
+					}
+				}
+			}`, req), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
 }
 
 func webReviewIAPJSONResponse(status int, body string, req *http.Request) *http.Response {

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -1,0 +1,342 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
+	setupAuth(t)
+	setupCachedWebReviewIAPSession(t, "user@example.com")
+
+	requests := newRequestLog(3)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(req.Method + " " + req.URL.Host + req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet &&
+			req.URL.Host == "api.appstoreconnect.apple.com" &&
+			req.URL.Path == "/v1/apps/123456789/inAppPurchasesV2":
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected IAP verification limit=200, got %q", got)
+			}
+			return webReviewIAPJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "inAppPurchases",
+					"id": "9000000001",
+					"attributes": {
+						"name": "Remove Ads",
+						"productId": "com.example.removeads",
+						"inAppPurchaseType": "NON_CONSUMABLE"
+					}
+				}]
+			}`, req), nil
+		case req.Method == http.MethodGet &&
+			req.URL.Host == "appstoreconnect.apple.com" &&
+			req.URL.Path == "/olympus/v1/session":
+			return webReviewIAPJSONResponse(http.StatusOK, `{
+				"provider": {
+					"providerId": 123456,
+					"publicProviderId": "team-1",
+					"name": "Team"
+				},
+				"user": {
+					"emailAddress": "user@example.com"
+				}
+			}`, req), nil
+		case req.Method == http.MethodPost &&
+			req.URL.Host == "appstoreconnect.apple.com" &&
+			req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
+			bodyBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			body := string(bodyBytes)
+			for _, want := range []string{
+				`"id":"9000000001"`,
+				`"submitWithNextAppStoreVersion":true`,
+				`"inAppPurchaseV2"`,
+			} {
+				if !strings.Contains(body, want) {
+					t.Fatalf("expected request body to contain %q, got %s", want, body)
+				}
+			}
+			return webReviewIAPJSONResponse(http.StatusCreated, `{
+				"data": {
+					"type": "inAppPurchaseSubmissions",
+					"id": "submission-1",
+					"attributes": {
+						"submitWithNextAppStoreVersion": true
+					},
+					"relationships": {
+						"inAppPurchaseV2": {
+							"data": {"type": "inAppPurchases", "id": "9000000001"}
+						}
+					}
+				}
+			}`, req), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"web", "review", "iaps", "attach",
+			"--app", "123456789",
+			"--iap-id", "9000000001",
+			"--confirm",
+			"--apple-id", "user@example.com",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run error: %v\nstderr=%s", runErr, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		AppID      string `json:"appId"`
+		IAPID      string `json:"iapId"`
+		Operation  string `json:"operation"`
+		Changed    bool   `json:"changed"`
+		Submission struct {
+			ID              string `json:"id"`
+			InAppPurchaseID string `json:"inAppPurchaseId"`
+		} `json:"submission"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.AppID != "123456789" || payload.IAPID != "9000000001" || payload.Operation != "attach" || !payload.Changed {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if payload.Submission.ID != "submission-1" || payload.Submission.InAppPurchaseID != "9000000001" {
+		t.Fatalf("unexpected submission: %#v", payload.Submission)
+	}
+
+	wantRequests := []string{
+		"GET api.appstoreconnect.apple.com/v1/apps/123456789/inAppPurchasesV2",
+		"GET appstoreconnect.apple.com/olympus/v1/session",
+		"POST appstoreconnect.apple.com/iris/v1/inAppPurchaseSubmissions",
+	}
+	if got := requests.Snapshot(); strings.Join(got, "\n") != strings.Join(wantRequests, "\n") {
+		t.Fatalf("unexpected requests:\nwant=%v\ngot=%v", wantRequests, got)
+	}
+}
+
+func TestWebReviewIAPsAttachValidationErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "missing app",
+			args:       []string{"web", "review", "iaps", "attach", "--iap-id", "9000000001", "--confirm"},
+			wantStderr: "--app is required",
+		},
+		{
+			name:       "missing iap id",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--confirm"},
+			wantStderr: "--iap-id is required",
+		},
+		{
+			name:       "missing confirm",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "9000000001"},
+			wantStderr: "--confirm is required",
+		},
+		{
+			name:       "non numeric app",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "com.example.app", "--iap-id", "9000000001", "--confirm"},
+			wantStderr: "--app must be a numeric App Store Connect app ID",
+		},
+		{
+			name:       "non numeric iap",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "com.example.pro", "--confirm"},
+			wantStderr: "--iap-id must be a numeric App Store Connect in-app purchase ID",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr)
+			}
+		})
+	}
+}
+
+func TestWebReviewIAPsAttachArgumentParsingEdges(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "mixed flag order",
+			args: []string{
+				"web", "review", "iaps", "attach",
+				"--iap-id", "9000000001",
+				"--apple-id", "attach",
+				"--app", "123456789",
+				"--confirm",
+			},
+		},
+		{
+			name: "flag value matching subcommand",
+			args: []string{
+				"web", "review", "iaps", "attach",
+				"--app", "123456789",
+				"--iap-id", "9000000001",
+				"--apple-id", "attach",
+				"--confirm",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			if err := root.Parse(test.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+		})
+	}
+}
+
+func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
+	bin := buildCLIBinary(t)
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "invalid app selector",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "com.example.app", "--iap-id", "9000000001", "--confirm"},
+			wantStderr: "--app must be a numeric App Store Connect app ID",
+		},
+		{
+			name:       "invalid iap selector",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "com.example.pro", "--confirm"},
+			wantStderr: "--iap-id must be a numeric App Store Connect in-app purchase ID",
+		},
+		{
+			name:       "invalid confirm value",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "9000000001", "--confirm=maybe"},
+			wantStderr: `invalid boolean value "maybe" for -confirm`,
+		},
+		{
+			name:       "subcommand flag before attach rejected",
+			args:       []string{"web", "review", "iaps", "--app", "123456789", "attach", "--iap-id", "9000000001", "--confirm"},
+			wantStderr: "flag provided but not defined: -app",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(bin, test.args...)
+			var stdout, stderr strings.Builder
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected exit error, got %v", err)
+			}
+			if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+			}
+			if stdout.String() != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.wantStderr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr.String())
+			}
+		})
+	}
+}
+
+func setupCachedWebReviewIAPSession(t *testing.T, email string) {
+	t.Helper()
+
+	t.Setenv("ASC_WEB_SESSION_CACHE", "1")
+	t.Setenv("ASC_WEB_SESSION_CACHE_BACKEND", "file")
+	t.Setenv("ASC_WEB_SESSION_CACHE_DIR", t.TempDir())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("create cookie jar: %v", err)
+	}
+	appStoreURL, err := url.Parse("https://appstoreconnect.apple.com/")
+	if err != nil {
+		t.Fatalf("parse app store URL: %v", err)
+	}
+	jar.SetCookies(appStoreURL, []*http.Cookie{
+		{
+			Name:    "myacinfo",
+			Value:   "test-token",
+			Path:    "/",
+			Domain:  "appstoreconnect.apple.com",
+			Expires: time.Now().Add(time.Hour),
+		},
+	})
+	if err := webcore.PersistSession(&webcore.AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: email,
+	}); err != nil {
+		t.Fatalf("persist cached web session: %v", err)
+	}
+}
+
+func webReviewIAPJSONResponse(status int, body string, req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -260,8 +260,14 @@ func TestWebReviewIAPsAttachArgumentParsingEdges(t *testing.T) {
 			if stderr != "" {
 				t.Fatalf("expected empty stderr, got %q", stderr)
 			}
-			if !strings.Contains(stdout, `"operation":"attach"`) {
-				t.Fatalf("expected attach JSON output, got %q", stdout)
+			var payload struct {
+				Operation string `json:"operation"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+				t.Fatalf("expected valid JSON output, parse error: %v\nstdout=%q", err, stdout)
+			}
+			if payload.Operation != "attach" {
+				t.Fatalf("expected operation=attach, got %#v", payload)
 			}
 		})
 	}

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -698,6 +698,7 @@ Subcommands:
   list  List review submissions for an app
   show  Show one submission with threads/messages/rejections and auto-download screenshots
   subscriptions  Inspect and mutate next-version subscription review selection
+  iaps  Attach non-renewing IAPs to the next app version review
 
 ` + webWarningText,
 		FlagSet:   fs,

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -706,6 +706,7 @@ Subcommands:
 			WebReviewListCommand(),
 			WebReviewShowCommand(),
 			WebReviewSubscriptionsCommand(),
+			WebReviewIAPsCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -2,88 +2,162 @@ package web
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
+	"strconv"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
+
+type reviewIAPMutationOutput struct {
+	AppID      string                      `json:"appId"`
+	IAPID      string                      `json:"iapId"`
+	Operation  string                      `json:"operation"`
+	Changed    bool                        `json:"changed"`
+	Submission webcore.ReviewIAPSubmission `json:"submission"`
+}
+
+func reviewIAPValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "n/a"
+	}
+	return trimmed
+}
+
+func buildReviewIAPMutationRows(payload reviewIAPMutationOutput) [][]string {
+	return [][]string{
+		{"Mutation", "App ID", reviewIAPValue(payload.AppID)},
+		{"Mutation", "IAP ID", reviewIAPValue(payload.IAPID)},
+		{"Mutation", "Operation", reviewIAPValue(payload.Operation)},
+		{"Mutation", "Changed", strconv.FormatBool(payload.Changed)},
+		{"Submission", "Submission ID", reviewIAPValue(payload.Submission.ID)},
+		{"Submission", "Next Version", strconv.FormatBool(payload.Submission.SubmitWithNextAppStoreVersion)},
+	}
+}
+
+func renderReviewIAPMutationTable(payload reviewIAPMutationOutput) error {
+	headers := []string{"Section", "Field", "Value"}
+	asc.RenderTable(headers, buildReviewIAPMutationRows(payload))
+	return nil
+}
+
+func renderReviewIAPMutationMarkdown(payload reviewIAPMutationOutput) error {
+	headers := []string{"Section", "Field", "Value"}
+	asc.RenderMarkdown(headers, buildReviewIAPMutationRows(payload))
+	return nil
+}
 
 // WebReviewIAPsCommand groups iris-API operations that attach a non-renewing
 // in-app purchase to the next app version review. Mirrors
 // `asc web review subscriptions` but routes to the IAP iris endpoint.
-//
-// Apple's public REST API does not expose this — for the first IAP on an app,
-// the only path is the App Store Connect web UI's "Add App In-App Purchase or
-// Subscription" dialog (which POSTs to /iris/v1/inAppPurchaseSubmissions with
-// submitWithNextAppStoreVersion=true). This command exposes that same flow
-// programmatically so the first-time-IAP submission can be scripted alongside
-// the version submission, instead of requiring a manual web click.
 func WebReviewIAPsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web review iaps", flag.ExitOnError)
 	return &ffcli.Command{
 		Name:       "iaps",
 		ShortUsage: "asc web review iaps <subcommand> [flags]",
 		ShortHelp:  "[experimental] Attach non-renewing IAPs to the next app version review.",
-		FlagSet:    fs,
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Attach a non-renewing in-app purchase to the next app version review. This
+uses private Apple web-session /iris endpoints and may break without notice.
+
+Subcommands:
+  attach  Attach one non-renewing IAP to the next app version review
+
+Apple's public REST API does not expose this flow for non-renewing purchases:
+POST /v1/reviewSubmissionItems rejects all IAP relationship variants, and a
+standalone POST /v1/inAppPurchaseSubmissions returns
+FIRST_IAP_MUST_BE_SUBMITTED_ON_VERSION. The web UI's "Add App In-App Purchase
+or Subscription" dialog posts to /iris/v1/inAppPurchaseSubmissions with
+submitWithNextAppStoreVersion=true; this command exposes that same call.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
-			webReviewIAPsAttachCommand(),
+			WebReviewIAPsAttachCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
-			return fmt.Errorf("subcommand required (try: attach)")
+			return flag.ErrHelp
 		},
 	}
 }
 
-func webReviewIAPsAttachCommand() *ffcli.Command {
+// WebReviewIAPsAttachCommand attaches a non-renewing IAP to the next app
+// version review via the private iris endpoint.
+//
+// The iris attach call itself accepts only the IAP ID — non-renewing IAPs are
+// globally addressable within a developer account, unlike subscriptions which
+// are grouped. --app is still required here for symmetry with
+// `asc web review subscriptions attach` and so the JSON payload and error
+// messages carry app context. A future ListReviewIAPs helper would let us
+// pre-verify the IAP's state (READY_TO_SUBMIT etc.) the way subscriptions does.
+func WebReviewIAPsAttachCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web review iaps attach", flag.ExitOnError)
-	appID := fs.String("app", "", "App ID")
-	iapID := fs.String("iap-id", "", "Non-renewing IAP ID (or product ID)")
-	confirm := fs.Bool("confirm", false, "Confirm the attach")
+
+	appID := fs.String("app", "", "App ID (used for output and error context)")
+	iapID := fs.String("iap-id", "", "Non-renewing IAP ID")
+	confirm := fs.Bool("confirm", false, "Confirm the attach operation")
 	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
 	return &ffcli.Command{
 		Name:       "attach",
 		ShortUsage: "asc web review iaps attach --app APP_ID --iap-id IAP_ID --confirm [flags]",
 		ShortHelp:  "[experimental] Attach a non-renewing IAP to the next app version review.",
 		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			a := strings.TrimSpace(*appID)
-			i := strings.TrimSpace(*iapID)
+			trimmedAppID := strings.TrimSpace(*appID)
+			trimmedIAPID := strings.TrimSpace(*iapID)
 			switch {
-			case a == "":
-				return fmt.Errorf("--app is required")
-			case i == "":
-				return fmt.Errorf("--iap-id is required")
+			case trimmedAppID == "":
+				return shared.UsageError("--app is required")
+			case trimmedIAPID == "":
+				return shared.UsageError("--iap-id is required")
 			case !*confirm:
-				return fmt.Errorf("--confirm is required")
+				return shared.UsageError("--confirm is required")
 			}
 
-			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
 			if err != nil {
 				return err
 			}
 			client := newWebClientFn(session)
 
-			sub, err := client.CreateInAppPurchaseSubmission(ctx, i)
+			submission, err := withWebSpinnerValue("Attaching IAP to next app version", func() (webcore.ReviewIAPSubmission, error) {
+				return client.CreateInAppPurchaseSubmission(requestCtx, trimmedIAPID)
+			})
 			if err != nil {
-				return withWebAuthHint(err, "web review iaps attach")
+				return withWebAuthHint(
+					fmt.Errorf("web review iaps attach for app %q, iap %q: %w", trimmedAppID, trimmedIAPID, err),
+					"web review iaps attach",
+				)
 			}
 
-			out := map[string]any{
-				"appId":      a,
-				"iapId":      i,
-				"submission": sub,
-				"changed":    true,
-				"operation":  "attach",
+			payload := reviewIAPMutationOutput{
+				AppID:      trimmedAppID,
+				IAPID:      trimmedIAPID,
+				Operation:  "attach",
+				Changed:    submission.SubmitWithNextAppStoreVersion,
+				Submission: submission,
 			}
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(out)
+			return shared.PrintOutputWithRenderers(
+				payload,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderReviewIAPMutationTable(payload) },
+				func() error { return renderReviewIAPMutationMarkdown(payload) },
+			)
 		},
 	}
 }
-
-var _ = (*webcore.Client)(nil)

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -14,12 +14,8 @@ import (
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
-type reviewIAPIAPListClient interface {
-	GetInAppPurchasesV2(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error)
-}
-
-var newReviewIAPASCClientFn = func() (reviewIAPIAPListClient, error) {
-	return shared.GetASCClient()
+type reviewIAPFinder interface {
+	FindReviewIAP(ctx context.Context, appID, iapID string) (webcore.ReviewIAP, bool, error)
 }
 
 type reviewIAPMutationOutput struct {
@@ -78,37 +74,13 @@ func validateReviewIAPAttachInputs(appID, iapID string, confirm bool) error {
 	}
 }
 
-func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPIAPListClient, appID, iapID string) error {
+func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPFinder, appID, iapID string) error {
 	if client == nil {
 		return fmt.Errorf("app-scoped IAP verification client is required")
 	}
 
-	resp, err := client.GetInAppPurchasesV2(ctx, appID, asc.WithIAPLimit(200))
+	_, found, err := client.FindReviewIAP(ctx, appID, iapID)
 	if err != nil {
-		return fmt.Errorf("verify in-app purchase %q under app %q: %w", iapID, appID, err)
-	}
-
-	found := false
-	if err := asc.PaginateEach(
-		ctx,
-		resp,
-		func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			return client.GetInAppPurchasesV2(ctx, appID, asc.WithIAPNextURL(nextURL))
-		},
-		func(page asc.PaginatedResponse) error {
-			iaps, ok := page.(*asc.InAppPurchasesV2Response)
-			if !ok {
-				return fmt.Errorf("unexpected in-app purchases pagination type %T", page)
-			}
-			for _, iap := range iaps.Data {
-				if strings.TrimSpace(iap.ID) == iapID {
-					found = true
-					return nil
-				}
-			}
-			return nil
-		},
-	); err != nil {
 		return fmt.Errorf("verify in-app purchase %q under app %q: %w", iapID, appID, err)
 	}
 	if !found {
@@ -180,19 +152,15 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			ascClient, err := newReviewIAPASCClientFn()
-			if err != nil {
-				return fmt.Errorf("web review iaps attach: app-scoped IAP verification requires App Store Connect API credentials: %w", err)
-			}
-			if err := verifyReviewIAPBelongsToApp(requestCtx, ascClient, trimmedAppID, trimmedIAPID); err != nil {
-				return fmt.Errorf("web review iaps attach: %w", err)
-			}
-
 			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
 			if err != nil {
 				return err
 			}
 			client := newWebClientFn(session)
+
+			if err := verifyReviewIAPBelongsToApp(requestCtx, client, trimmedAppID, trimmedIAPID); err != nil {
+				return fmt.Errorf("web review iaps attach: %w", err)
+			}
 
 			submission, err := withWebSpinnerValue("Attaching IAP to next app version", func() (webcore.ReviewIAPSubmission, error) {
 				return client.CreateInAppPurchaseSubmission(requestCtx, trimmedIAPID)

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -74,19 +74,19 @@ func validateReviewIAPAttachInputs(appID, iapID string, confirm bool) error {
 	}
 }
 
-func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPFinder, appID, iapID string) error {
+func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPFinder, appID, iapID string) (webcore.ReviewIAP, error) {
 	if client == nil {
-		return fmt.Errorf("app-scoped IAP verification client is required")
+		return webcore.ReviewIAP{}, fmt.Errorf("app-scoped IAP verification client is required")
 	}
 
-	_, found, err := client.FindReviewIAP(ctx, appID, iapID)
+	iap, found, err := client.FindReviewIAP(ctx, appID, iapID)
 	if err != nil {
-		return fmt.Errorf("verify in-app purchase %q under app %q: %w", iapID, appID, err)
+		return webcore.ReviewIAP{}, fmt.Errorf("verify in-app purchase %q under app %q: %w", iapID, appID, err)
 	}
 	if !found {
-		return fmt.Errorf("in-app purchase %q was not found under app %q; refusing to attach", iapID, appID)
+		return webcore.ReviewIAP{}, fmt.Errorf("in-app purchase %q was not found under app %q; refusing to attach", iapID, appID)
 	}
-	return nil
+	return iap, nil
 }
 
 // WebReviewIAPsCommand groups iris-API operations that attach a non-renewing
@@ -158,8 +158,28 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 			}
 			client := newWebClientFn(session)
 
-			if err := verifyReviewIAPBelongsToApp(requestCtx, client, trimmedAppID, trimmedIAPID); err != nil {
+			reviewIAP, err := verifyReviewIAPBelongsToApp(requestCtx, client, trimmedAppID, trimmedIAPID)
+			if err != nil {
 				return fmt.Errorf("web review iaps attach: %w", err)
+			}
+			if reviewIAP.SubmitWithNextAppStoreVersion {
+				payload := reviewIAPMutationOutput{
+					AppID:     trimmedAppID,
+					IAPID:     trimmedIAPID,
+					Operation: "attach",
+					Changed:   false,
+					Submission: webcore.ReviewIAPSubmission{
+						InAppPurchaseID:               trimmedIAPID,
+						SubmitWithNextAppStoreVersion: true,
+					},
+				}
+				return shared.PrintOutputWithRenderers(
+					payload,
+					*output.Output,
+					*output.Pretty,
+					func() error { return renderReviewIAPMutationTable(payload) },
+					func() error { return renderReviewIAPMutationMarkdown(payload) },
+				)
 			}
 
 			submission, err := withWebSpinnerValue("Attaching IAP to next app version", func() (webcore.ReviewIAPSubmission, error) {

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -14,6 +14,14 @@ import (
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
+type reviewIAPIAPListClient interface {
+	GetInAppPurchasesV2(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error)
+}
+
+var newReviewIAPASCClientFn = func() (reviewIAPIAPListClient, error) {
+	return shared.GetASCClient()
+}
+
 type reviewIAPMutationOutput struct {
 	AppID      string                      `json:"appId"`
 	IAPID      string                      `json:"iapId"`
@@ -50,6 +58,62 @@ func renderReviewIAPMutationTable(payload reviewIAPMutationOutput) error {
 func renderReviewIAPMutationMarkdown(payload reviewIAPMutationOutput) error {
 	headers := []string{"Section", "Field", "Value"}
 	asc.RenderMarkdown(headers, buildReviewIAPMutationRows(payload))
+	return nil
+}
+
+func validateReviewIAPAttachInputs(appID, iapID string, confirm bool) error {
+	switch {
+	case strings.TrimSpace(appID) == "":
+		return shared.UsageError("--app is required")
+	case shared.SelectorNeedsLookup(appID):
+		return shared.UsageError("--app must be a numeric App Store Connect app ID")
+	case strings.TrimSpace(iapID) == "":
+		return shared.UsageError("--iap-id is required")
+	case shared.SelectorNeedsLookup(iapID):
+		return shared.UsageError("--iap-id must be a numeric App Store Connect in-app purchase ID")
+	case !confirm:
+		return shared.UsageError("--confirm is required")
+	default:
+		return nil
+	}
+}
+
+func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPIAPListClient, appID, iapID string) error {
+	if client == nil {
+		return fmt.Errorf("app-scoped IAP verification client is required")
+	}
+
+	resp, err := client.GetInAppPurchasesV2(ctx, appID, asc.WithIAPLimit(200))
+	if err != nil {
+		return fmt.Errorf("verify in-app purchase %q under app %q: %w", iapID, appID, err)
+	}
+
+	found := false
+	if err := asc.PaginateEach(
+		ctx,
+		resp,
+		func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetInAppPurchasesV2(ctx, appID, asc.WithIAPNextURL(nextURL))
+		},
+		func(page asc.PaginatedResponse) error {
+			iaps, ok := page.(*asc.InAppPurchasesV2Response)
+			if !ok {
+				return fmt.Errorf("unexpected in-app purchases pagination type %T", page)
+			}
+			for _, iap := range iaps.Data {
+				if strings.TrimSpace(iap.ID) == iapID {
+					found = true
+					return nil
+				}
+			}
+			return nil
+		},
+	); err != nil {
+		return fmt.Errorf("verify in-app purchase %q under app %q: %w", iapID, appID, err)
+	}
+	if !found {
+		return fmt.Errorf("in-app purchase %q was not found under app %q; refusing to attach", iapID, appID)
+	}
 	return nil
 }
 
@@ -91,17 +155,10 @@ submitWithNextAppStoreVersion=true; this command exposes that same call.
 
 // WebReviewIAPsAttachCommand attaches a non-renewing IAP to the next app
 // version review via the private iris endpoint.
-//
-// The iris attach call itself accepts only the IAP ID — non-renewing IAPs are
-// globally addressable within a developer account, unlike subscriptions which
-// are grouped. --app is still required here for symmetry with
-// `asc web review subscriptions attach` and so the JSON payload and error
-// messages carry app context. A future ListReviewIAPs helper would let us
-// pre-verify the IAP's state (READY_TO_SUBMIT etc.) the way subscriptions does.
 func WebReviewIAPsAttachCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web review iaps attach", flag.ExitOnError)
 
-	appID := fs.String("app", "", "App ID (used for output and error context)")
+	appID := fs.String("app", "", "App ID")
 	iapID := fs.String("iap-id", "", "Non-renewing IAP ID")
 	confirm := fs.Bool("confirm", false, "Confirm the attach operation")
 	authFlags := bindWebSessionFlags(fs)
@@ -116,17 +173,20 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 		Exec: func(ctx context.Context, args []string) error {
 			trimmedAppID := strings.TrimSpace(*appID)
 			trimmedIAPID := strings.TrimSpace(*iapID)
-			switch {
-			case trimmedAppID == "":
-				return shared.UsageError("--app is required")
-			case trimmedIAPID == "":
-				return shared.UsageError("--iap-id is required")
-			case !*confirm:
-				return shared.UsageError("--confirm is required")
+			if err := validateReviewIAPAttachInputs(trimmedAppID, trimmedIAPID, *confirm); err != nil {
+				return err
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
+
+			ascClient, err := newReviewIAPASCClientFn()
+			if err != nil {
+				return fmt.Errorf("web review iaps attach: app-scoped IAP verification requires App Store Connect API credentials: %w", err)
+			}
+			if err := verifyReviewIAPBelongsToApp(requestCtx, ascClient, trimmedAppID, trimmedIAPID); err != nil {
+				return fmt.Errorf("web review iaps attach: %w", err)
+			}
 
 			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
 			if err != nil {

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -1,0 +1,89 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+// WebReviewIAPsCommand groups iris-API operations that attach a non-renewing
+// in-app purchase to the next app version review. Mirrors
+// `asc web review subscriptions` but routes to the IAP iris endpoint.
+//
+// Apple's public REST API does not expose this — for the first IAP on an app,
+// the only path is the App Store Connect web UI's "Add App In-App Purchase or
+// Subscription" dialog (which POSTs to /iris/v1/inAppPurchaseSubmissions with
+// submitWithNextAppStoreVersion=true). This command exposes that same flow
+// programmatically so the first-time-IAP submission can be scripted alongside
+// the version submission, instead of requiring a manual web click.
+func WebReviewIAPsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web review iaps", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "iaps",
+		ShortUsage: "asc web review iaps <subcommand> [flags]",
+		ShortHelp:  "[experimental] Attach non-renewing IAPs to the next app version review.",
+		FlagSet:    fs,
+		Subcommands: []*ffcli.Command{
+			webReviewIAPsAttachCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return fmt.Errorf("subcommand required (try: attach)")
+		},
+	}
+}
+
+func webReviewIAPsAttachCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web review iaps attach", flag.ExitOnError)
+	appID := fs.String("app", "", "App ID")
+	iapID := fs.String("iap-id", "", "Non-renewing IAP ID (or product ID)")
+	confirm := fs.Bool("confirm", false, "Confirm the attach")
+	authFlags := bindWebSessionFlags(fs)
+	return &ffcli.Command{
+		Name:       "attach",
+		ShortUsage: "asc web review iaps attach --app APP_ID --iap-id IAP_ID --confirm [flags]",
+		ShortHelp:  "[experimental] Attach a non-renewing IAP to the next app version review.",
+		FlagSet:    fs,
+		Exec: func(ctx context.Context, args []string) error {
+			a := strings.TrimSpace(*appID)
+			i := strings.TrimSpace(*iapID)
+			switch {
+			case a == "":
+				return fmt.Errorf("--app is required")
+			case i == "":
+				return fmt.Errorf("--iap-id is required")
+			case !*confirm:
+				return fmt.Errorf("--confirm is required")
+			}
+
+			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			sub, err := client.CreateInAppPurchaseSubmission(ctx, i)
+			if err != nil {
+				return withWebAuthHint(err, "web review iaps attach")
+			}
+
+			out := map[string]any{
+				"appId":      a,
+				"iapId":      i,
+				"submission": sub,
+				"changed":    true,
+				"operation":  "attach",
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(out)
+		},
+	}
+}
+
+var _ = (*webcore.Client)(nil)

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -1,0 +1,75 @@
+package web
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestWebReviewIAPsAttachRequiresApp(t *testing.T) {
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--iap-id", "iap-1",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err == nil {
+			t.Fatal("expected missing --app error")
+		}
+	})
+	if !strings.Contains(stderr, "--app is required") {
+		t.Fatalf("expected --app guidance in stderr, got %q", stderr)
+	}
+}
+
+func TestWebReviewIAPsAttachRequiresIAPID(t *testing.T) {
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "app-1",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err == nil {
+			t.Fatal("expected missing --iap-id error")
+		}
+	})
+	if !strings.Contains(stderr, "--iap-id is required") {
+		t.Fatalf("expected --iap-id guidance in stderr, got %q", stderr)
+	}
+}
+
+func TestWebReviewIAPsAttachRequiresConfirm(t *testing.T) {
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "app-1",
+		"--iap-id", "iap-1",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err == nil {
+			t.Fatal("expected missing --confirm error")
+		}
+	})
+	if !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("expected --confirm guidance in stderr, got %q", stderr)
+	}
+}
+
+func TestWebReviewIAPsGroupCommandReturnsHelpWhenNoSubcommand(t *testing.T) {
+	cmd := WebReviewIAPsCommand()
+	if cmd.UsageFunc == nil {
+		t.Fatal("WebReviewIAPsCommand should set UsageFunc for consistent rendering")
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected flag.ErrHelp from group Exec with no subcommand")
+	}
+}

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -10,15 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
-
-type reviewIAPIAPListClientFunc func(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error)
-
-func (fn reviewIAPIAPListClientFunc) GetInAppPurchasesV2(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error) {
-	return fn(ctx, appID, opts...)
-}
 
 func TestWebReviewIAPsAttachRequiresApp(t *testing.T) {
 	cmd := WebReviewIAPsAttachCommand()
@@ -125,36 +118,42 @@ func TestWebReviewIAPsAttachRejectsNonNumericIAPID(t *testing.T) {
 func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) {
 	_ = stubWebProgressLabels(t)
 
-	origASCClient := newReviewIAPASCClientFn
 	origResolveSession := resolveSessionFn
 	t.Cleanup(func() {
-		newReviewIAPASCClientFn = origASCClient
 		resolveSessionFn = origResolveSession
 	})
 
 	verified := false
-	newReviewIAPASCClientFn = func() (reviewIAPIAPListClient, error) {
-		return reviewIAPIAPListClientFunc(func(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error) {
-			if appID != "123456789" {
-				t.Fatalf("expected app ID 123456789, got %q", appID)
-			}
-			verified = true
-			return &asc.InAppPurchasesV2Response{
-				Data: []asc.Resource[asc.InAppPurchaseV2Attributes]{
-					{Type: asc.ResourceTypeInAppPurchases, ID: "9000000001"},
-				},
-			}, nil
-		}), nil
-	}
-
 	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
 		return &webcore.AuthSession{
 			Client: &http.Client{
 				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-					if !verified {
-						t.Fatal("expected app-scoped IAP verification before web mutation")
-					}
-					if req.Method != http.MethodPost || req.URL.Path != "/iris/v1/inAppPurchaseSubmissions" {
+					switch {
+					case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/123456789/inAppPurchases":
+						verified = true
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body: io.NopCloser(strings.NewReader(`{
+								"data": [{
+									"type": "inAppPurchases",
+									"id": "9000000001",
+									"attributes": {
+										"name": "Remove Ads",
+										"productId": "com.example.removeads",
+										"inAppPurchaseType": "NON_CONSUMABLE",
+										"state": "READY_TO_SUBMIT",
+										"submitWithNextAppStoreVersion": false
+									}
+								}]
+							}`)),
+							Request: req,
+						}, nil
+					case req.Method == http.MethodPost && req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
+						if !verified {
+							t.Fatal("expected app-scoped IAP verification before web mutation")
+						}
+					default:
 						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 					}
 					requestBody, err := io.ReadAll(req.Body)
@@ -224,21 +223,27 @@ func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) 
 }
 
 func TestWebReviewIAPsAttachRefusesIAPOutsideApp(t *testing.T) {
-	origASCClient := newReviewIAPASCClientFn
 	origResolveSession := resolveSessionFn
 	t.Cleanup(func() {
-		newReviewIAPASCClientFn = origASCClient
 		resolveSessionFn = origResolveSession
 	})
 
-	newReviewIAPASCClientFn = func() (reviewIAPIAPListClient, error) {
-		return reviewIAPIAPListClientFunc(func(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error) {
-			return &asc.InAppPurchasesV2Response{}, nil
-		}), nil
-	}
 	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
-		t.Fatal("web session should not resolve when IAP is outside the app")
-		return nil, "", nil
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method != http.MethodGet || req.URL.Path != "/iris/v1/apps/123456789/inAppPurchases" {
+						t.Fatalf("unexpected request before app-scoping refusal: %s %s", req.Method, req.URL.Path)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+						Request:    req,
+					}, nil
+				}),
+			},
+		}, "cache", nil
 	}
 
 	cmd := WebReviewIAPsAttachCommand()

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -2,22 +2,37 @@ package web
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
+
+type reviewIAPIAPListClientFunc func(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error)
+
+func (fn reviewIAPIAPListClientFunc) GetInAppPurchasesV2(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error) {
+	return fn(ctx, appID, opts...)
+}
 
 func TestWebReviewIAPsAttachRequiresApp(t *testing.T) {
 	cmd := WebReviewIAPsAttachCommand()
 	if err := cmd.FlagSet.Parse([]string{
-		"--iap-id", "iap-1",
+		"--iap-id", "9000000001",
 		"--confirm",
 	}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 
 	_, stderr := captureOutput(t, func() {
-		if err := cmd.Exec(context.Background(), nil); err == nil {
-			t.Fatal("expected missing --app error")
+		err := cmd.Exec(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
 		}
 	})
 	if !strings.Contains(stderr, "--app is required") {
@@ -28,15 +43,16 @@ func TestWebReviewIAPsAttachRequiresApp(t *testing.T) {
 func TestWebReviewIAPsAttachRequiresIAPID(t *testing.T) {
 	cmd := WebReviewIAPsAttachCommand()
 	if err := cmd.FlagSet.Parse([]string{
-		"--app", "app-1",
+		"--app", "123456789",
 		"--confirm",
 	}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 
 	_, stderr := captureOutput(t, func() {
-		if err := cmd.Exec(context.Background(), nil); err == nil {
-			t.Fatal("expected missing --iap-id error")
+		err := cmd.Exec(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
 		}
 	})
 	if !strings.Contains(stderr, "--iap-id is required") {
@@ -47,19 +63,199 @@ func TestWebReviewIAPsAttachRequiresIAPID(t *testing.T) {
 func TestWebReviewIAPsAttachRequiresConfirm(t *testing.T) {
 	cmd := WebReviewIAPsAttachCommand()
 	if err := cmd.FlagSet.Parse([]string{
-		"--app", "app-1",
-		"--iap-id", "iap-1",
+		"--app", "123456789",
+		"--iap-id", "9000000001",
 	}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 
 	_, stderr := captureOutput(t, func() {
-		if err := cmd.Exec(context.Background(), nil); err == nil {
-			t.Fatal("expected missing --confirm error")
+		err := cmd.Exec(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
 		}
 	})
 	if !strings.Contains(stderr, "--confirm is required") {
 		t.Fatalf("expected --confirm guidance in stderr, got %q", stderr)
+	}
+}
+
+func TestWebReviewIAPsAttachRejectsNonNumericAppID(t *testing.T) {
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "com.example.app",
+		"--iap-id", "9000000001",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		err := cmd.Exec(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "--app must be a numeric App Store Connect app ID") {
+		t.Fatalf("expected numeric --app guidance in stderr, got %q", stderr)
+	}
+}
+
+func TestWebReviewIAPsAttachRejectsNonNumericIAPID(t *testing.T) {
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", "com.example.pro",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		err := cmd.Exec(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "--iap-id must be a numeric App Store Connect in-app purchase ID") {
+		t.Fatalf("expected numeric --iap-id guidance in stderr, got %q", stderr)
+	}
+}
+
+func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+
+	origASCClient := newReviewIAPASCClientFn
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		newReviewIAPASCClientFn = origASCClient
+		resolveSessionFn = origResolveSession
+	})
+
+	verified := false
+	newReviewIAPASCClientFn = func() (reviewIAPIAPListClient, error) {
+		return reviewIAPIAPListClientFunc(func(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error) {
+			if appID != "123456789" {
+				t.Fatalf("expected app ID 123456789, got %q", appID)
+			}
+			verified = true
+			return &asc.InAppPurchasesV2Response{
+				Data: []asc.Resource[asc.InAppPurchaseV2Attributes]{
+					{Type: asc.ResourceTypeInAppPurchases, ID: "9000000001"},
+				},
+			}, nil
+		}), nil
+	}
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if !verified {
+						t.Fatal("expected app-scoped IAP verification before web mutation")
+					}
+					if req.Method != http.MethodPost || req.URL.Path != "/iris/v1/inAppPurchaseSubmissions" {
+						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+					}
+					requestBody, err := io.ReadAll(req.Body)
+					if err != nil {
+						t.Fatalf("read request body: %v", err)
+					}
+					body := string(requestBody)
+					for _, want := range []string{
+						`"id":"9000000001"`,
+						`"submitWithNextAppStoreVersion":true`,
+						`"inAppPurchaseV2"`,
+					} {
+						if !strings.Contains(body, want) {
+							t.Fatalf("expected request body to contain %q, got %s", want, body)
+						}
+					}
+					return &http.Response{
+						StatusCode: http.StatusCreated,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body: io.NopCloser(strings.NewReader(`{
+							"data": {
+								"type": "inAppPurchaseSubmissions",
+								"id": "submission-1",
+								"attributes": {
+									"submitWithNextAppStoreVersion": true
+								},
+								"relationships": {
+									"inAppPurchaseV2": {
+										"data": {"type": "inAppPurchases", "id": "9000000001"}
+									}
+								}
+							}
+						}`)),
+						Request: req,
+					}, nil
+				}),
+			},
+		}, "cache", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", "9000000001",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	var payload reviewIAPMutationOutput
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.AppID != "123456789" || payload.IAPID != "9000000001" || payload.Operation != "attach" || !payload.Changed {
+		t.Fatalf("unexpected mutation output: %#v", payload)
+	}
+	if payload.Submission.ID != "submission-1" || payload.Submission.InAppPurchaseID != "9000000001" {
+		t.Fatalf("unexpected submission output: %#v", payload.Submission)
+	}
+}
+
+func TestWebReviewIAPsAttachRefusesIAPOutsideApp(t *testing.T) {
+	origASCClient := newReviewIAPASCClientFn
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		newReviewIAPASCClientFn = origASCClient
+		resolveSessionFn = origResolveSession
+	})
+
+	newReviewIAPASCClientFn = func() (reviewIAPIAPListClient, error) {
+		return reviewIAPIAPListClientFunc(func(ctx context.Context, appID string, opts ...asc.IAPOption) (*asc.InAppPurchasesV2Response, error) {
+			return &asc.InAppPurchasesV2Response{}, nil
+		}), nil
+	}
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		t.Fatal("web session should not resolve when IAP is outside the app")
+		return nil, "", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", "9000000001",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected app-scoping error")
+	}
+	if !strings.Contains(err.Error(), `in-app purchase "9000000001" was not found under app "123456789"`) {
+		t.Fatalf("expected app-scoping error, got %v", err)
 	}
 }
 
@@ -69,7 +265,7 @@ func TestWebReviewIAPsGroupCommandReturnsHelpWhenNoSubcommand(t *testing.T) {
 		t.Fatal("WebReviewIAPsCommand should set UsageFunc for consistent rendering")
 	}
 	err := cmd.Exec(context.Background(), nil)
-	if err == nil {
-		t.Fatal("expected flag.ErrHelp from group Exec with no subcommand")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp from group Exec with no subcommand, got %v", err)
 	}
 }

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -222,6 +222,75 @@ func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) 
 	}
 }
 
+func TestWebReviewIAPsAttachSkipsAlreadyAttachedIAP(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+	})
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method != http.MethodGet || req.URL.Path != "/iris/v1/apps/123456789/inAppPurchases" {
+						t.Fatalf("unexpected request for already-attached IAP: %s %s", req.Method, req.URL.Path)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body: io.NopCloser(strings.NewReader(`{
+							"data": [{
+								"type": "inAppPurchases",
+								"id": "9000000001",
+								"attributes": {
+									"name": "Remove Ads",
+									"productId": "com.example.removeads",
+									"inAppPurchaseType": "NON_CONSUMABLE",
+									"state": "READY_TO_SUBMIT",
+									"submitWithNextAppStoreVersion": true
+								}
+							}]
+						}`)),
+						Request: req,
+					}, nil
+				}),
+			},
+		}, "cache", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", "9000000001",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	var payload reviewIAPMutationOutput
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.AppID != "123456789" || payload.IAPID != "9000000001" || payload.Operation != "attach" {
+		t.Fatalf("unexpected mutation output: %#v", payload)
+	}
+	if payload.Changed {
+		t.Fatalf("expected already-attached IAP to report changed=false, got %#v", payload)
+	}
+	if payload.Submission.ID != "" || payload.Submission.InAppPurchaseID != "9000000001" || !payload.Submission.SubmitWithNextAppStoreVersion {
+		t.Fatalf("unexpected idempotent submission output: %#v", payload.Submission)
+	}
+}
+
 func TestWebReviewIAPsAttachRefusesIAPOutsideApp(t *testing.T) {
 	origResolveSession := resolveSessionFn
 	t.Cleanup(func() {

--- a/internal/web/iap_review.go
+++ b/internal/web/iap_review.go
@@ -1,0 +1,74 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ReviewIAPSubmission captures the hidden submission resource returned by the
+// web flow that attaches a non-renewing in-app purchase to the next app version
+// review. Mirrors ReviewSubscriptionSubmission but for non-subscription IAPs.
+type ReviewIAPSubmission struct {
+	ID                            string `json:"id"`
+	InAppPurchaseID               string `json:"inAppPurchaseId,omitempty"`
+	SubmitWithNextAppStoreVersion bool   `json:"submitWithNextAppStoreVersion"`
+}
+
+// CreateInAppPurchaseSubmission attaches a non-renewing in-app purchase to the
+// next app version review via the private web flow.
+//
+// This is the iris-API equivalent of clicking the IAP checkbox in
+// "Add App In-App Purchase or Subscription" on the version submission page
+// in App Store Connect. POST /iris/v1/inAppPurchaseSubmissions with the
+// `submitWithNextAppStoreVersion` attribute set; the public ASC REST API
+// has no equivalent for non-subscription IAPs.
+func (c *Client) CreateInAppPurchaseSubmission(ctx context.Context, iapID string) (ReviewIAPSubmission, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return ReviewIAPSubmission{}, fmt.Errorf("iap id is required")
+	}
+
+	body := map[string]any{
+		"data": map[string]any{
+			"type": "inAppPurchaseSubmissions",
+			"attributes": map[string]any{
+				"submitWithNextAppStoreVersion": true,
+			},
+			"relationships": map[string]any{
+				"inAppPurchaseV2": map[string]any{
+					"data": map[string]string{
+						"type": "inAppPurchases",
+						"id":   iapID,
+					},
+				},
+			},
+		},
+	}
+
+	responseBody, err := c.doRequest(ctx, http.MethodPost, "/inAppPurchaseSubmissions", body)
+	if err != nil {
+		return ReviewIAPSubmission{}, fmt.Errorf("iris POST /inAppPurchaseSubmissions: %w", err)
+	}
+
+	var payload struct {
+		Data jsonAPIResource `json:"data"`
+	}
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return ReviewIAPSubmission{}, fmt.Errorf("failed to parse iap submission response: %w", err)
+	}
+
+	result := ReviewIAPSubmission{
+		ID:                            strings.TrimSpace(payload.Data.ID),
+		SubmitWithNextAppStoreVersion: boolAttr(payload.Data.Attributes, "submitWithNextAppStoreVersion"),
+	}
+	if ref := firstRelationshipRef(payload.Data, "inAppPurchaseV2"); ref != nil {
+		result.InAppPurchaseID = strings.TrimSpace(ref.ID)
+	}
+	if result.InAppPurchaseID == "" {
+		result.InAppPurchaseID = iapID
+	}
+	return result, nil
+}

--- a/internal/web/iap_review.go
+++ b/internal/web/iap_review.go
@@ -142,6 +142,12 @@ func (c *Client) CreateInAppPurchaseSubmission(ctx context.Context, iapID string
 	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return ReviewIAPSubmission{}, fmt.Errorf("failed to parse iap submission response: %w", err)
 	}
+	if strings.TrimSpace(payload.Data.ID) == "" {
+		return ReviewIAPSubmission{}, fmt.Errorf("failed to parse iap submission response: missing submission id")
+	}
+	if payload.Data.Type != "" && payload.Data.Type != "inAppPurchaseSubmissions" {
+		return ReviewIAPSubmission{}, fmt.Errorf("failed to parse iap submission response: unexpected resource type %q", payload.Data.Type)
+	}
 
 	result := ReviewIAPSubmission{
 		ID:                            strings.TrimSpace(payload.Data.ID),

--- a/internal/web/iap_review.go
+++ b/internal/web/iap_review.go
@@ -5,8 +5,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
+
+const reviewIAPFields = "productId,name,state,inAppPurchaseType,isAppStoreReviewInProgress,submitWithNextAppStoreVersion"
+
+// ReviewIAP summarizes a non-subscription IAP's attach state for the next app
+// version review.
+type ReviewIAP struct {
+	ID                            string `json:"id"`
+	ProductID                     string `json:"productId,omitempty"`
+	Name                          string `json:"name,omitempty"`
+	State                         string `json:"state,omitempty"`
+	InAppPurchaseType             string `json:"inAppPurchaseType,omitempty"`
+	IsAppStoreReviewInProgress    bool   `json:"isAppStoreReviewInProgress"`
+	SubmitWithNextAppStoreVersion bool   `json:"submitWithNextAppStoreVersion"`
+}
 
 // ReviewIAPSubmission captures the hidden submission resource returned by the
 // web flow that attaches a non-renewing in-app purchase to the next app version
@@ -15,6 +30,74 @@ type ReviewIAPSubmission struct {
 	ID                            string `json:"id"`
 	InAppPurchaseID               string `json:"inAppPurchaseId,omitempty"`
 	SubmitWithNextAppStoreVersion bool   `json:"submitWithNextAppStoreVersion"`
+}
+
+func decodeReviewIAP(resource jsonAPIResource) ReviewIAP {
+	return ReviewIAP{
+		ID:                            strings.TrimSpace(resource.ID),
+		ProductID:                     stringAttr(resource.Attributes, "productId"),
+		Name:                          stringAttr(resource.Attributes, "name"),
+		State:                         stringAttr(resource.Attributes, "state"),
+		InAppPurchaseType:             stringAttr(resource.Attributes, "inAppPurchaseType"),
+		IsAppStoreReviewInProgress:    boolAttr(resource.Attributes, "isAppStoreReviewInProgress"),
+		SubmitWithNextAppStoreVersion: boolAttr(resource.Attributes, "submitWithNextAppStoreVersion"),
+	}
+}
+
+// FindReviewIAP finds a single app-scoped IAP through the private web flow.
+func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (ReviewIAP, bool, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return ReviewIAP{}, false, fmt.Errorf("app id is required")
+	}
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return ReviewIAP{}, false, fmt.Errorf("iap id is required")
+	}
+
+	query := url.Values{}
+	query.Set("fields[inAppPurchases]", reviewIAPFields)
+	query.Set("limit", "300")
+	query.Set("sort", "name")
+
+	nextPath := queryPath("/apps/"+url.PathEscape(appID)+"/inAppPurchases", query)
+	visited := map[string]struct{}{}
+
+	for nextPath != "" {
+		if _, seen := visited[nextPath]; seen {
+			return ReviewIAP{}, false, fmt.Errorf("review iaps pagination loop detected")
+		}
+		visited[nextPath] = struct{}{}
+
+		responseBody, err := c.doRequest(ctx, http.MethodGet, nextPath, nil)
+		if err != nil {
+			return ReviewIAP{}, false, err
+		}
+
+		var payload jsonAPIListPayload
+		if err := json.Unmarshal(responseBody, &payload); err != nil {
+			return ReviewIAP{}, false, fmt.Errorf("failed to parse review iaps response: %w", err)
+		}
+		for _, resource := range payload.Data {
+			if strings.TrimSpace(resource.ID) == iapID {
+				return decodeReviewIAP(resource), true, nil
+			}
+		}
+
+		nextLink, err := extractNextLink(payload.Links)
+		if err != nil {
+			return ReviewIAP{}, false, fmt.Errorf("failed to parse review iaps pagination links: %w", err)
+		}
+		if strings.TrimSpace(nextLink) == "" {
+			break
+		}
+		nextPath, err = normalizeNextPath(nextLink, c.baseURL)
+		if err != nil {
+			return ReviewIAP{}, false, fmt.Errorf("failed to normalize review iaps pagination link: %w", err)
+		}
+	}
+
+	return ReviewIAP{}, false, nil
 }
 
 // CreateInAppPurchaseSubmission attaches a non-renewing in-app purchase to the

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -5,8 +5,113 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestFindReviewIAPReturnsFirstMatchingAppScopedIAP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/apps/app-123/inAppPurchases" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.URL.Query().Get("limit"); got != "300" {
+			t.Fatalf("expected limit=300, got %q", got)
+		}
+		fields := r.URL.Query().Get("fields[inAppPurchases]")
+		for _, want := range []string{"productId", "name", "state", "submitWithNextAppStoreVersion"} {
+			if !strings.Contains(fields, want) {
+				t.Fatalf("expected fields to contain %q, got %q", want, fields)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "iap-1",
+					"type": "inAppPurchases",
+					"attributes": {
+						"productId": "com.example.removeads",
+						"name": "Remove Ads",
+						"state": "READY_TO_SUBMIT",
+						"inAppPurchaseType": "NON_CONSUMABLE",
+						"isAppStoreReviewInProgress": false,
+						"submitWithNextAppStoreVersion": true
+					}
+				}
+			],
+			"links": {
+				"next": ""
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, found, err := client.FindReviewIAP(context.Background(), "app-123", "iap-1")
+	if err != nil {
+		t.Fatalf("FindReviewIAP() error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected IAP to be found")
+	}
+	if got.ID != "iap-1" || got.ProductID != "com.example.removeads" || got.Name != "Remove Ads" || got.State != "READY_TO_SUBMIT" || got.InAppPurchaseType != "NON_CONSUMABLE" || !got.SubmitWithNextAppStoreVersion {
+		t.Fatalf("unexpected IAP payload: %#v", got)
+	}
+}
+
+func TestFindReviewIAPStopsAfterMatchingPage(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 1 {
+			t.Fatalf("expected lookup to stop after finding target, got request %s", r.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [{
+				"id": "iap-1",
+				"type": "inAppPurchases",
+				"attributes": {"productId": "com.example.removeads"}
+			}],
+			"links": {
+				"next": "https://example.com/should-not-fetch"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, found, err := client.FindReviewIAP(context.Background(), "app-123", "iap-1")
+	if err != nil {
+		t.Fatalf("FindReviewIAP() error = %v", err)
+	}
+	if !found || got.ID != "iap-1" {
+		t.Fatalf("expected target IAP, got found=%t payload=%#v", found, got)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one request, got %d", calls)
+	}
+}
+
+func TestFindReviewIAPReturnsFalseWhenMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	_, found, err := client.FindReviewIAP(context.Background(), "app-123", "missing-iap")
+	if err != nil {
+		t.Fatalf("FindReviewIAP() error = %v", err)
+	}
+	if found {
+		t.Fatal("expected missing IAP")
+	}
+}
 
 func TestCreateInAppPurchaseSubmissionSendsHiddenAttachPayload(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -113,6 +113,28 @@ func TestFindReviewIAPReturnsFalseWhenMissing(t *testing.T) {
 	}
 }
 
+func TestFindReviewIAPRejectsEmptyAppID(t *testing.T) {
+	client := &Client{}
+	_, found, err := client.FindReviewIAP(context.Background(), "   ", "iap-1")
+	if err == nil {
+		t.Fatal("expected error for empty app id, got nil")
+	}
+	if found {
+		t.Fatal("expected empty app id to return found=false")
+	}
+}
+
+func TestFindReviewIAPRejectsEmptyIAPID(t *testing.T) {
+	client := &Client{}
+	_, found, err := client.FindReviewIAP(context.Background(), "app-123", "   ")
+	if err == nil {
+		t.Fatal("expected error for empty iap id, got nil")
+	}
+	if found {
+		t.Fatal("expected empty iap id to return found=false")
+	}
+}
+
 func TestCreateInAppPurchaseSubmissionSendsHiddenAttachPayload(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/inAppPurchaseSubmissions" {
@@ -193,6 +215,43 @@ func TestCreateInAppPurchaseSubmissionFallsBackToRequestedIDWhenRelationshipMiss
 	}
 	if got.ID != "submission-2" || !got.SubmitWithNextAppStoreVersion {
 		t.Fatalf("unexpected payload: %#v", got)
+	}
+}
+
+func TestCreateInAppPurchaseSubmissionRejectsMissingSubmissionID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"type": "inAppPurchaseSubmissions",
+				"attributes": {"submitWithNextAppStoreVersion": true}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	if _, err := client.CreateInAppPurchaseSubmission(context.Background(), "iap-1"); err == nil {
+		t.Fatal("expected error for missing submission id, got nil")
+	}
+}
+
+func TestCreateInAppPurchaseSubmissionRejectsUnexpectedResourceType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"id": "submission-1",
+				"type": "unexpectedResources",
+				"attributes": {"submitWithNextAppStoreVersion": true}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	if _, err := client.CreateInAppPurchaseSubmission(context.Background(), "iap-1"); err == nil {
+		t.Fatal("expected error for unexpected resource type, got nil")
 	}
 }
 

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateInAppPurchaseSubmissionSendsHiddenAttachPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/inAppPurchaseSubmissions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		var payload struct {
+			Data struct {
+				Type          string `json:"type"`
+				Attributes    map[string]bool
+				Relationships map[string]struct {
+					Data struct {
+						Type string `json:"type"`
+						ID   string `json:"id"`
+					} `json:"data"`
+				} `json:"relationships"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if payload.Data.Type != "inAppPurchaseSubmissions" {
+			t.Fatalf("expected type inAppPurchaseSubmissions, got %q", payload.Data.Type)
+		}
+		if !payload.Data.Attributes["submitWithNextAppStoreVersion"] {
+			t.Fatalf("expected hidden attach flag to be true, got %#v", payload.Data.Attributes)
+		}
+		relationship := payload.Data.Relationships["inAppPurchaseV2"].Data
+		if relationship.Type != "inAppPurchases" || relationship.ID != "iap-1" {
+			t.Fatalf("unexpected inAppPurchaseV2 relationship: %#v", relationship)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"id": "submission-1",
+				"type": "inAppPurchaseSubmissions",
+				"attributes": {"submitWithNextAppStoreVersion": true},
+				"relationships": {
+					"inAppPurchaseV2": {"data": {"type": "inAppPurchases", "id": "iap-1"}}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, err := client.CreateInAppPurchaseSubmission(context.Background(), "iap-1")
+	if err != nil {
+		t.Fatalf("CreateInAppPurchaseSubmission() error = %v", err)
+	}
+	if got.ID != "submission-1" || got.InAppPurchaseID != "iap-1" || !got.SubmitWithNextAppStoreVersion {
+		t.Fatalf("unexpected submission payload: %#v", got)
+	}
+}
+
+func TestCreateInAppPurchaseSubmissionFallsBackToRequestedIDWhenRelationshipMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"id": "submission-2",
+				"type": "inAppPurchaseSubmissions",
+				"attributes": {"submitWithNextAppStoreVersion": true}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, err := client.CreateInAppPurchaseSubmission(context.Background(), "iap-fallback")
+	if err != nil {
+		t.Fatalf("CreateInAppPurchaseSubmission() error = %v", err)
+	}
+	if got.InAppPurchaseID != "iap-fallback" {
+		t.Fatalf("expected fallback InAppPurchaseID, got %q", got.InAppPurchaseID)
+	}
+	if got.ID != "submission-2" || !got.SubmitWithNextAppStoreVersion {
+		t.Fatalf("unexpected payload: %#v", got)
+	}
+}
+
+func TestCreateInAppPurchaseSubmissionRejectsEmptyID(t *testing.T) {
+	client := &Client{}
+	if _, err := client.CreateInAppPurchaseSubmission(context.Background(), "  "); err == nil {
+		t.Fatal("expected error for empty iap id, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a CLI command that attaches a non-renewing in-app purchase to the next app version review — the iris-API equivalent of clicking the "Remove Ads" checkbox in App Store Connect's **Add App In-App Purchase or Subscription** dialog on a version submission.

```
asc web review iaps attach --app APP_ID --iap-id IAP_ID --confirm
```

Output:
```json
{
  "appId": "",
  "iapId": "",
  "submission": {
    "id": "submission-1",
    "inAppPurchaseId": "",
    "submitWithNextAppStoreVersion": true
  },
  "changed": true,
  "operation": "attach"
}
```

## Motivation

Apple's public ASC REST API does not let you attach a first-time non-renewing IAP to a review submission:

- `POST /v1/reviewSubmissionItems` rejects `inAppPurchaseV2` / `inAppPurchase` / `inAppPurchases` as unknown relationships (the documented item types are `appStoreVersions`, `appCustomProductPageVersions`, `appEvents`, the experiment variants, `backgroundAssetVersions`, and the `gameCenter*` set — no IAP).
- Standalone `POST /v1/inAppPurchaseSubmissions` fails first-time submissions with `STATE_ERROR.FIRST_IAP_MUST_BE_SUBMITTED_ON_VERSION`.

So today the only way to submit the **first** IAP for an app is to open the ASC web UI, find the in-flight submission, and tick the IAP in the "Add App In-App Purchase or Subscription" dialog. This blocks CI automation for accounts shipping their first version+IAP together (a very common case for new apps).

The web UI's dialog posts to a private iris endpoint that sets a hidden `submitWithNextAppStoreVersion: true` attribute on the IAP. The `asc web review subscriptions attach` command already exposes the same pattern for subscriptions — this PR mirrors it for non-renewing IAPs.

## Endpoint

```
POST /iris/v1/inAppPurchaseSubmissions
Content-Type: application/json

{
  "data": {
    "type": "inAppPurchaseSubmissions",
    "attributes": { "submitWithNextAppStoreVersion": true },
    "relationships": {
      "inAppPurchaseV2": { "data": { "type": "inAppPurchases", "id": "<iap-id>" } }
    }
  }
}
```

After the flag is set, the IAP rides along with the next review submission Apple processes for that app version, exactly as if you'd clicked the checkbox.

## Changes

| File | What |
|---|---|
| `internal/web/iap_review.go` | New `CreateInAppPurchaseSubmission(ctx, iapID)` on `*Client`. Same shape as `CreateSubscriptionSubmission`. |
| `internal/cli/web/web_review_iaps.go` | New `asc web review iaps attach` ffcli command. |
| `internal/cli/web/web_review.go` | Wire the new subcommand into `WebReviewCommand()`. |
| `internal/web/iap_review_test.go` | Tests covering the payload shape, the relationship-missing fallback, and the empty-id guard. Mirrors `subscription_review_test.go`. |

## Test plan

- [x] `go test ./internal/web/...` — all green (3 new tests + existing suite).
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] Manually verified end-to-end against a live ASC account: ran the new command on a fresh app with a `READY_TO_SUBMIT` Remove Ads IAP, confirmed the IAP state transitions to `WAITING_FOR_REVIEW` and Apple bundles it into the in-flight submission on the next review pass.

## Out of scope

- A matching `asc web review iaps remove` to undo the flag (the equivalent of `asc web review subscriptions remove`) — straightforward to add as a follow-up once the attach path is in.
- Bulk `attach-all` semantics for apps with multiple `READY_TO_SUBMIT` IAPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental CLI command: "web review iaps attach" to attach a non‑renewing in‑app purchase to the next app review; required flags (--app, --iap-id, --confirm), input trimming/validation, app-scoping verification, and human/markdown output.

* **Tests**
  * Expanded unit and integration tests covering lookup and submission flows, request/response mapping and fallbacks, flag/usage validation, argument-parsing edges, and end-to-end attach behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->