### PR TITLE
Fix iris IAP listing fields + accept productId for --iap-id

### DIFF
--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -306,6 +306,11 @@ func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
 			wantStderr: `invalid boolean value "maybe" for -confirm`,
 		},
 		{
+			name:       "blank iap selector",
+			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "   ", "--confirm"},
+			wantStderr: "--iap-id is required",
+		},
+		{
 			name:       "subcommand flag before attach rejected",
 			args:       []string{"web", "review", "iaps", "--app", "123456789", "attach", "--iap-id", "9000000001", "--confirm"},
 			wantStderr: "flag provided but not defined: -app",

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -174,11 +174,6 @@ func TestWebReviewIAPsAttachValidationErrors(t *testing.T) {
 			args:       []string{"web", "review", "iaps", "attach", "--app", "com.example.app", "--iap-id", "9000000001", "--confirm"},
 			wantStderr: "--app must be a numeric App Store Connect app ID",
 		},
-		{
-			name:       "non numeric iap",
-			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "com.example.pro", "--confirm"},
-			wantStderr: "--iap-id must be a numeric App Store Connect in-app purchase ID",
-		},
 	}
 
 	for _, test := range tests {
@@ -284,11 +279,6 @@ func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
 			name:       "invalid app selector",
 			args:       []string{"web", "review", "iaps", "attach", "--app", "com.example.app", "--iap-id", "9000000001", "--confirm"},
 			wantStderr: "--app must be a numeric App Store Connect app ID",
-		},
-		{
-			name:       "invalid iap selector",
-			args:       []string{"web", "review", "iaps", "attach", "--app", "123456789", "--iap-id", "com.example.pro", "--confirm"},
-			wantStderr: "--iap-id must be a numeric App Store Connect in-app purchase ID",
 		},
 		{
 			name:       "invalid confirm value",

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -21,6 +21,11 @@ import (
 func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 	setupCachedWebReviewIAPSession(t, "user@example.com")
 
+	const (
+		irisResourceID = "11111111-2222-3333-4444-555555555555"
+		productID      = "com.example.removeads"
+	)
+
 	requests := newRequestLog(3)
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests.Add(req.Method + " " + req.URL.Host + req.URL.Path)
@@ -45,17 +50,16 @@ func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 				t.Fatalf("expected web IAP lookup limit=300, got %q", got)
 			}
 			return webReviewIAPJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "inAppPurchases",
-					"id": "9000000001",
-					"attributes": {
-						"name": "Remove Ads",
-						"productId": "com.example.removeads",
-						"inAppPurchaseType": "NON_CONSUMABLE",
-						"state": "READY_TO_SUBMIT"
-					}
-				}]
-			}`, req), nil
+					"data": [{
+						"type": "inAppPurchases",
+						"id": "`+irisResourceID+`",
+						"attributes": {
+							"productId": "`+productID+`",
+							"referenceName": "Remove Ads",
+							"state": "READY_TO_SUBMIT"
+						}
+					}]
+				}`, req), nil
 		case req.Method == http.MethodPost &&
 			req.URL.Host == "appstoreconnect.apple.com" &&
 			req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
@@ -63,29 +67,45 @@ func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read request body: %v", err)
 			}
-			body := string(bodyBytes)
-			for _, want := range []string{
-				`"id":"9000000001"`,
-				`"submitWithNextAppStoreVersion":true`,
-				`"inAppPurchaseV2"`,
-			} {
-				if !strings.Contains(body, want) {
-					t.Fatalf("expected request body to contain %q, got %s", want, body)
-				}
+			var post struct {
+				Data struct {
+					Attributes struct {
+						SubmitWithNextAppStoreVersion bool `json:"submitWithNextAppStoreVersion"`
+					} `json:"attributes"`
+					Relationships struct {
+						InAppPurchaseV2 struct {
+							Data struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"inAppPurchaseV2"`
+					} `json:"relationships"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(bodyBytes, &post); err != nil {
+				t.Fatalf("decode request body: %v; body=%s", err, bodyBytes)
+			}
+			if got := post.Data.Relationships.InAppPurchaseV2.Data.ID; got != irisResourceID {
+				t.Fatalf("expected request body relationship id %q, got %q", irisResourceID, got)
+			}
+			if got := post.Data.Relationships.InAppPurchaseV2.Data.ID; got == productID {
+				t.Fatalf("request body must not use productId as relationship id; body=%s", bodyBytes)
+			}
+			if !post.Data.Attributes.SubmitWithNextAppStoreVersion {
+				t.Fatalf("expected request body to submit with next app store version; body=%s", bodyBytes)
 			}
 			return webReviewIAPJSONResponse(http.StatusCreated, `{
-				"data": {
+					"data": {
 					"type": "inAppPurchaseSubmissions",
 					"id": "submission-1",
 					"attributes": {
 						"submitWithNextAppStoreVersion": true
-					},
-					"relationships": {
-						"inAppPurchaseV2": {
-							"data": {"type": "inAppPurchases", "id": "9000000001"}
+						},
+						"relationships": {
+							"inAppPurchaseV2": {
+								"data": {"type": "inAppPurchases", "id": "`+irisResourceID+`"}
+							}
 						}
 					}
-				}
 			}`, req), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -101,7 +121,7 @@ func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 		if err := root.Parse([]string{
 			"web", "review", "iaps", "attach",
 			"--app", "123456789",
-			"--iap-id", "9000000001",
+			"--iap-id", productID,
 			"--confirm",
 			"--apple-id", "user@example.com",
 			"--output", "json",
@@ -131,10 +151,10 @@ func TestWebReviewIAPsAttachRootSuccess(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
 		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
 	}
-	if payload.AppID != "123456789" || payload.IAPID != "9000000001" || payload.Operation != "attach" || !payload.Changed {
+	if payload.AppID != "123456789" || payload.IAPID != productID || payload.Operation != "attach" || !payload.Changed {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
-	if payload.Submission.ID != "submission-1" || payload.Submission.InAppPurchaseID != "9000000001" {
+	if payload.Submission.ID != "submission-1" || payload.Submission.InAppPurchaseID != irisResourceID {
 		t.Fatalf("unexpected submission: %#v", payload.Submission)
 	}
 

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -65,8 +65,6 @@ func validateReviewIAPAttachInputs(appID, iapID string, confirm bool) error {
 		return shared.UsageError("--app must be a numeric App Store Connect app ID")
 	case strings.TrimSpace(iapID) == "":
 		return shared.UsageError("--iap-id is required")
-	case shared.SelectorNeedsLookup(iapID):
-		return shared.UsageError("--iap-id must be a numeric App Store Connect in-app purchase ID")
 	case !confirm:
 		return shared.UsageError("--confirm is required")
 	default:

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -160,6 +160,12 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 			if err != nil {
 				return fmt.Errorf("web review iaps attach: %w", err)
 			}
+			// The iris attach POST takes the iris resource id, not the
+			// caller's selector — `--iap-id` may have been a bundle-style
+			// productId that matched via `attributes.productId`, in which
+			// case posting the selector as the relationship id would be
+			// wrong. Always use the resolved iris UUID.
+			resolvedIrisID := reviewIAP.ID
 			if reviewIAP.SubmitWithNextAppStoreVersion {
 				payload := reviewIAPMutationOutput{
 					AppID:     trimmedAppID,
@@ -167,7 +173,7 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 					Operation: "attach",
 					Changed:   false,
 					Submission: webcore.ReviewIAPSubmission{
-						InAppPurchaseID:               trimmedIAPID,
+						InAppPurchaseID:               resolvedIrisID,
 						SubmitWithNextAppStoreVersion: true,
 					},
 				}
@@ -181,7 +187,7 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 			}
 
 			submission, err := withWebSpinnerValue("Attaching IAP to next app version", func() (webcore.ReviewIAPSubmission, error) {
-				return client.CreateInAppPurchaseSubmission(requestCtx, trimmedIAPID)
+				return client.CreateInAppPurchaseSubmission(requestCtx, resolvedIrisID)
 			})
 			if err != nil {
 				return withWebAuthHint(

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -84,6 +84,9 @@ func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPFinder, ap
 	if !found {
 		return webcore.ReviewIAP{}, fmt.Errorf("in-app purchase %q was not found under app %q; refusing to attach", iapID, appID)
 	}
+	if strings.TrimSpace(iap.ID) == "" {
+		return webcore.ReviewIAP{}, fmt.Errorf("in-app purchase %q under app %q is missing an iris resource id; refusing to attach", iapID, appID)
+	}
 	return iap, nil
 }
 
@@ -129,7 +132,7 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web review iaps attach", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App ID")
-	iapID := fs.String("iap-id", "", "Iris IAP UUID or product ID")
+	iapID := fs.String("iap-id", "", "Iris IAP resource ID or product ID")
 	confirm := fs.Bool("confirm", false, "Confirm the attach operation")
 	authFlags := bindWebSessionFlags(fs)
 	output := shared.BindOutputFlags(fs)
@@ -138,8 +141,17 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 		Name:       "attach",
 		ShortUsage: "asc web review iaps attach --app APP_ID --iap-id IAP_ID_OR_PRODUCT_ID --confirm [flags]",
 		ShortHelp:  "[experimental] Attach a non-renewing IAP to the next app version review.",
-		FlagSet:    fs,
-		UsageFunc:  shared.DefaultUsageFunc,
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Attach a non-renewing in-app purchase to the next app version review.
+
+The --iap-id selector accepts the private Iris resource id or the bundle-style
+productId from ` + "`asc iap list`" + `. Apple's Iris listing does not expose the
+public numeric ASC IAP id, so that numeric id is not resolved by this command.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			trimmedAppID := strings.TrimSpace(*appID)
 			trimmedIAPID := strings.TrimSpace(*iapID)
@@ -165,7 +177,7 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 			// productId that matched via `attributes.productId`, in which
 			// case posting the selector as the relationship id would be
 			// wrong. Always use the resolved iris UUID.
-			resolvedIrisID := reviewIAP.ID
+			resolvedIrisID := strings.TrimSpace(reviewIAP.ID)
 			if reviewIAP.SubmitWithNextAppStoreVersion {
 				payload := reviewIAPMutationOutput{
 					AppID:     trimmedAppID,

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -129,14 +129,14 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web review iaps attach", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App ID")
-	iapID := fs.String("iap-id", "", "Non-renewing IAP ID")
+	iapID := fs.String("iap-id", "", "Iris IAP UUID or product ID")
 	confirm := fs.Bool("confirm", false, "Confirm the attach operation")
 	authFlags := bindWebSessionFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "attach",
-		ShortUsage: "asc web review iaps attach --app APP_ID --iap-id IAP_ID --confirm [flags]",
+		ShortUsage: "asc web review iaps attach --app APP_ID --iap-id IAP_ID_OR_PRODUCT_ID --confirm [flags]",
 		ShortHelp:  "[experimental] Attach a non-renewing IAP to the next app version review.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
@@ -190,6 +190,25 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 				return client.CreateInAppPurchaseSubmission(requestCtx, resolvedIrisID)
 			})
 			if err != nil {
+				if webcore.IsAlreadyExistsConflict(err) {
+					payload := reviewIAPMutationOutput{
+						AppID:     trimmedAppID,
+						IAPID:     trimmedIAPID,
+						Operation: "attach",
+						Changed:   false,
+						Submission: webcore.ReviewIAPSubmission{
+							InAppPurchaseID:               resolvedIrisID,
+							SubmitWithNextAppStoreVersion: true,
+						},
+					}
+					return shared.PrintOutputWithRenderers(
+						payload,
+						*output.Output,
+						*output.Pretty,
+						func() error { return renderReviewIAPMutationTable(payload) },
+						func() error { return renderReviewIAPMutationMarkdown(payload) },
+					)
+				}
 				return withWebAuthHint(
 					fmt.Errorf("web review iaps attach for app %q, iap %q: %w", trimmedAppID, trimmedIAPID, err),
 					"web review iaps attach",

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -307,6 +307,71 @@ func TestWebReviewIAPsAttachTreatsAlreadyAttachedConflictAsNoChange(t *testing.T
 	}
 }
 
+func TestWebReviewIAPsAttachRejectsMatchedIAPWithoutIrisResourceID(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+	})
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					switch {
+					case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/123456789/inAppPurchases":
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body: io.NopCloser(strings.NewReader(`{
+								"data": [{
+									"type": "inAppPurchases",
+									"id": "   ",
+									"attributes": {
+										"productId": "com.example.lifetime",
+										"referenceName": "Lifetime",
+										"state": "READY_TO_SUBMIT"
+									}
+								}]
+							}`)),
+							Request: req,
+						}, nil
+					case req.Method == http.MethodPost && req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
+						t.Fatal("attach POST must not run when the matched IAP has no iris resource id")
+						return nil, nil
+					default:
+						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+						return nil, nil
+					}
+				}),
+			},
+		}, "cache", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", "com.example.lifetime",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		err := cmd.Exec(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected missing iris id error, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing an iris resource id") {
+			t.Fatalf("expected missing iris id error, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
 func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) {
 	_ = stubWebProgressLabels(t)
 

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -139,10 +139,25 @@ func TestWebReviewIAPsAttachPostsIrisResourceIDWhenSelectorWasProductID(t *testi
 						if err != nil {
 							t.Fatalf("read POST body: %v", err)
 						}
-						if !strings.Contains(string(body), `"id":"`+irisResourceID+`"`) {
-							t.Fatalf("expected attach POST to carry iris resource id %q, got %s", irisResourceID, body)
+						var post struct {
+							Data struct {
+								Relationships struct {
+									InAppPurchaseV2 struct {
+										Data struct {
+											ID string `json:"id"`
+										} `json:"data"`
+									} `json:"inAppPurchaseV2"`
+								} `json:"relationships"`
+							} `json:"data"`
 						}
-						if strings.Contains(string(body), `"id":"`+productID+`"`) {
+						if err := json.Unmarshal(body, &post); err != nil {
+							t.Fatalf("decode POST body: %v; body=%s", err, body)
+						}
+						gotID := post.Data.Relationships.InAppPurchaseV2.Data.ID
+						if gotID != irisResourceID {
+							t.Fatalf("expected attach POST to carry iris resource id %q, got %q", irisResourceID, gotID)
+						}
+						if gotID == productID {
 							t.Fatalf("attach POST must not carry productId as relationship id; body=%s", body)
 						}
 						return &http.Response{
@@ -198,6 +213,97 @@ func TestWebReviewIAPsAttachPostsIrisResourceIDWhenSelectorWasProductID(t *testi
 	// Submission.InAppPurchaseID is the iris-resolved id (from the POST response relationship).
 	if payload.Submission.InAppPurchaseID != irisResourceID {
 		t.Fatalf("expected Submission.InAppPurchaseID = %q, got %q", irisResourceID, payload.Submission.InAppPurchaseID)
+	}
+}
+
+func TestWebReviewIAPsAttachTreatsAlreadyAttachedConflictAsNoChange(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+	})
+
+	const (
+		irisResourceID = "ae6d89d7-15c5-4a3d-9041-663a4d40638e"
+		productID      = "com.example.lifetime"
+	)
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					switch {
+					case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/123456789/inAppPurchases":
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body: io.NopCloser(strings.NewReader(`{
+								"data": [{
+									"type": "inAppPurchases",
+									"id": "` + irisResourceID + `",
+									"attributes": {
+										"productId": "` + productID + `",
+										"referenceName": "Lifetime",
+										"state": "READY_TO_SUBMIT"
+									}
+								}]
+							}`)),
+							Request: req,
+						}, nil
+					case req.Method == http.MethodPost && req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
+						return &http.Response{
+							StatusCode: http.StatusConflict,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body: io.NopCloser(strings.NewReader(`{
+								"errors": [{
+									"status": "409",
+									"code": "ENTITY_ERROR.ATTRIBUTE.INVALID.ALREADY_EXISTS",
+									"title": "The request entity conflicts with the current state."
+								}]
+							}`)),
+							Request: req,
+						}, nil
+					default:
+						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+						return nil, nil
+					}
+				}),
+			},
+		}, "cache", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", productID,
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	var payload reviewIAPMutationOutput
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.IAPID != productID {
+		t.Fatalf("expected IAPID to echo caller selector %q, got %q", productID, payload.IAPID)
+	}
+	if payload.Changed {
+		t.Fatalf("expected already-attached conflict to report changed=false, got %#v", payload)
+	}
+	if payload.Submission.ID != "" {
+		t.Fatalf("expected no submission id for idempotent conflict, got %#v", payload.Submission)
+	}
+	if payload.Submission.InAppPurchaseID != irisResourceID || !payload.Submission.SubmitWithNextAppStoreVersion {
+		t.Fatalf("unexpected idempotent submission output: %#v", payload.Submission)
 	}
 }
 

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -94,6 +94,113 @@ func TestWebReviewIAPsAttachRejectsNonNumericAppID(t *testing.T) {
 	}
 }
 
+// TestWebReviewIAPsAttachPostsIrisResourceIDWhenSelectorWasProductID guards
+// the subtle correctness property requested in PR review: when --iap-id is a
+// bundle-style productId (matched against attributes.productId), the
+// /iris/v1/inAppPurchaseSubmissions POST must still carry the iris resource
+// id in the relationship, not the productId selector.
+func TestWebReviewIAPsAttachPostsIrisResourceIDWhenSelectorWasProductID(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+	})
+
+	const (
+		irisResourceID = "ae6d89d7-15c5-4a3d-9041-663a4d40638e"
+		productID      = "com.example.lifetime"
+	)
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					switch {
+					case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/123456789/inAppPurchases":
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body: io.NopCloser(strings.NewReader(`{
+								"data": [{
+									"type": "inAppPurchases",
+									"id": "` + irisResourceID + `",
+									"attributes": {
+										"productId": "` + productID + `",
+										"referenceName": "Lifetime",
+										"state": "READY_TO_SUBMIT"
+									}
+								}]
+							}`)),
+							Request: req,
+						}, nil
+					case req.Method == http.MethodPost && req.URL.Path == "/iris/v1/inAppPurchaseSubmissions":
+						body, err := io.ReadAll(req.Body)
+						if err != nil {
+							t.Fatalf("read POST body: %v", err)
+						}
+						if !strings.Contains(string(body), `"id":"`+irisResourceID+`"`) {
+							t.Fatalf("expected attach POST to carry iris resource id %q, got %s", irisResourceID, body)
+						}
+						if strings.Contains(string(body), `"id":"`+productID+`"`) {
+							t.Fatalf("attach POST must not carry productId as relationship id; body=%s", body)
+						}
+						return &http.Response{
+							StatusCode: http.StatusCreated,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body: io.NopCloser(strings.NewReader(`{
+								"data": {
+									"type": "inAppPurchaseSubmissions",
+									"id": "submission-1",
+									"attributes": {"submitWithNextAppStoreVersion": true},
+									"relationships": {
+										"inAppPurchaseV2": {
+											"data": {"type": "inAppPurchases", "id": "` + irisResourceID + `"}
+										}
+									}
+								}
+							}`)),
+							Request: req,
+						}, nil
+					default:
+						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+						return nil, nil
+					}
+				}),
+			},
+		}, "cache", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", productID,
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	var payload reviewIAPMutationOutput
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	// IAPID in the output preserves what the caller passed (the selector).
+	if payload.IAPID != productID {
+		t.Fatalf("expected IAPID to echo caller selector %q, got %q", productID, payload.IAPID)
+	}
+	// Submission.InAppPurchaseID is the iris-resolved id (from the POST response relationship).
+	if payload.Submission.InAppPurchaseID != irisResourceID {
+		t.Fatalf("expected Submission.InAppPurchaseID = %q, got %q", irisResourceID, payload.Submission.InAppPurchaseID)
+	}
+}
+
 func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) {
 	_ = stubWebProgressLabels(t)
 

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -94,27 +94,6 @@ func TestWebReviewIAPsAttachRejectsNonNumericAppID(t *testing.T) {
 	}
 }
 
-func TestWebReviewIAPsAttachRejectsNonNumericIAPID(t *testing.T) {
-	cmd := WebReviewIAPsAttachCommand()
-	if err := cmd.FlagSet.Parse([]string{
-		"--app", "123456789",
-		"--iap-id", "com.example.pro",
-		"--confirm",
-	}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-
-	_, stderr := captureOutput(t, func() {
-		err := cmd.Exec(context.Background(), nil)
-		if !errors.Is(err, flag.ErrHelp) {
-			t.Fatalf("expected flag.ErrHelp, got %v", err)
-		}
-	})
-	if !strings.Contains(stderr, "--iap-id must be a numeric App Store Connect in-app purchase ID") {
-		t.Fatalf("expected numeric --iap-id guidance in stderr, got %q", stderr)
-	}
-}
-
 func TestWebReviewIAPsAttachVerifiesIAPBelongsToAppBeforeMutating(t *testing.T) {
 	_ = stubWebProgressLabels(t)
 

--- a/internal/web/errors.go
+++ b/internal/web/errors.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 )
 
@@ -34,6 +35,38 @@ func IsDuplicateAppNameError(err error) bool {
 			return true
 		}
 		if strings.Contains(detail, "app name you entered is already being used") {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAlreadyExistsConflict reports whether an internal API error is a 409 caused
+// by trying to create a resource that already exists.
+func IsAlreadyExistsConflict(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr == nil || apiErr.Status != http.StatusConflict {
+		return false
+	}
+
+	var payload struct {
+		Errors []struct {
+			Code   string `json:"code"`
+			Detail string `json:"detail"`
+			Title  string `json:"title"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal(apiErr.rawResponseBody(), &payload) != nil {
+		body := strings.ToLower(string(apiErr.rawResponseBody()))
+		return strings.Contains(body, "already") && (strings.Contains(body, "exist") || strings.Contains(body, "attached") || strings.Contains(body, "submitted"))
+	}
+
+	for _, e := range payload.Errors {
+		code := strings.ToUpper(strings.TrimSpace(e.Code))
+		detail := strings.ToLower(strings.TrimSpace(e.Detail))
+		title := strings.ToLower(strings.TrimSpace(e.Title))
+		text := detail + " " + title
+		if strings.Contains(code, "ALREADY") || (strings.Contains(text, "already") && (strings.Contains(text, "exist") || strings.Contains(text, "attached") || strings.Contains(text, "submitted"))) {
 			return true
 		}
 	}

--- a/internal/web/errors.go
+++ b/internal/web/errors.go
@@ -42,7 +42,8 @@ func IsDuplicateAppNameError(err error) bool {
 }
 
 // IsAlreadyExistsConflict reports whether an internal API error is a 409 caused
-// by trying to create a resource that already exists.
+// by an exact already-exists response. It intentionally avoids treating broader
+// "already attached/submitted" wording as idempotent success.
 func IsAlreadyExistsConflict(err error) bool {
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) || apiErr == nil || apiErr.Status != http.StatusConflict {
@@ -58,7 +59,7 @@ func IsAlreadyExistsConflict(err error) bool {
 	}
 	if json.Unmarshal(apiErr.rawResponseBody(), &payload) != nil {
 		body := strings.ToLower(string(apiErr.rawResponseBody()))
-		return strings.Contains(body, "already") && (strings.Contains(body, "exist") || strings.Contains(body, "attached") || strings.Contains(body, "submitted"))
+		return strings.Contains(body, "already exists") && !conflictTextMentionsDifferentTarget(body)
 	}
 
 	for _, e := range payload.Errors {
@@ -66,9 +67,13 @@ func IsAlreadyExistsConflict(err error) bool {
 		detail := strings.ToLower(strings.TrimSpace(e.Detail))
 		title := strings.ToLower(strings.TrimSpace(e.Title))
 		text := detail + " " + title
-		if strings.Contains(code, "ALREADY") || (strings.Contains(text, "already") && (strings.Contains(text, "exist") || strings.Contains(text, "attached") || strings.Contains(text, "submitted"))) {
+		if strings.Contains(code, "ALREADY_EXISTS") && !conflictTextMentionsDifferentTarget(text) {
 			return true
 		}
 	}
 	return false
+}
+
+func conflictTextMentionsDifferentTarget(text string) bool {
+	return strings.Contains(text, "another") || strings.Contains(text, "different")
 }

--- a/internal/web/errors.go
+++ b/internal/web/errors.go
@@ -62,16 +62,19 @@ func IsAlreadyExistsConflict(err error) bool {
 		return strings.Contains(body, "already exists") && !conflictTextMentionsDifferentTarget(body)
 	}
 
+	if len(payload.Errors) == 0 {
+		return false
+	}
 	for _, e := range payload.Errors {
 		code := strings.ToUpper(strings.TrimSpace(e.Code))
 		detail := strings.ToLower(strings.TrimSpace(e.Detail))
 		title := strings.ToLower(strings.TrimSpace(e.Title))
 		text := detail + " " + title
-		if strings.Contains(code, "ALREADY_EXISTS") && !conflictTextMentionsDifferentTarget(text) {
-			return true
+		if !strings.Contains(code, "ALREADY_EXISTS") || conflictTextMentionsDifferentTarget(text) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func conflictTextMentionsDifferentTarget(text string) bool {

--- a/internal/web/errors_test.go
+++ b/internal/web/errors_test.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -56,6 +58,73 @@ func TestIsDuplicateAppNameError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsDuplicateAppNameError(tc.err); got != tc.wantDup {
 				t.Fatalf("IsDuplicateAppNameError()=%v want %v", got, tc.wantDup)
+			}
+		})
+	}
+}
+
+func TestIsAlreadyExistsConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "already exists code",
+			err: &APIError{
+				Status: http.StatusConflict,
+				rawBody: []byte(`{
+					"errors":[{
+						"code":"ENTITY_ERROR.ATTRIBUTE.INVALID.ALREADY_EXISTS",
+						"title":"The request entity conflicts with the current state."
+					}]
+				}`),
+			},
+			want: true,
+		},
+		{
+			name: "already attached detail",
+			err: &APIError{
+				Status:  http.StatusConflict,
+				rawBody: []byte(`{"errors":[{"detail":"This in-app purchase is already attached to the app version."}]}`),
+			},
+			want: true,
+		},
+		{
+			name: "other conflict",
+			err: &APIError{
+				Status:  http.StatusConflict,
+				rawBody: []byte(`{"errors":[{"code":"STATE_ERROR","detail":"Invalid state transition."}]}`),
+			},
+			want: false,
+		},
+		{
+			name: "non conflict",
+			err: &APIError{
+				Status:  http.StatusBadRequest,
+				rawBody: []byte(`{"errors":[{"code":"ENTITY_ERROR.ATTRIBUTE.INVALID.ALREADY_EXISTS"}]}`),
+			},
+			want: false,
+		},
+		{
+			name: "wrapped",
+			err: fmt.Errorf("wrapped: %w", &APIError{
+				Status:  http.StatusConflict,
+				rawBody: []byte(`already exists`),
+			}),
+			want: true,
+		},
+		{
+			name: "non api error",
+			err:  errors.New("nope"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAlreadyExistsConflict(tc.err); got != tc.want {
+				t.Fatalf("IsAlreadyExistsConflict()=%v want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/web/errors_test.go
+++ b/internal/web/errors_test.go
@@ -88,7 +88,20 @@ func TestIsAlreadyExistsConflict(t *testing.T) {
 				Status:  http.StatusConflict,
 				rawBody: []byte(`{"errors":[{"detail":"This in-app purchase is already attached to the app version."}]}`),
 			},
-			want: true,
+			want: false,
+		},
+		{
+			name: "already exists for another target",
+			err: &APIError{
+				Status: http.StatusConflict,
+				rawBody: []byte(`{
+						"errors":[{
+							"code":"ENTITY_ERROR.ATTRIBUTE.INVALID.ALREADY_EXISTS",
+							"detail":"This in-app purchase is already attached to another submission."
+						}]
+					}`),
+			},
+			want: false,
 		},
 		{
 			name: "other conflict",

--- a/internal/web/errors_test.go
+++ b/internal/web/errors_test.go
@@ -104,6 +104,22 @@ func TestIsAlreadyExistsConflict(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "mixed already exists and blocking conflict",
+			err: &APIError{
+				Status: http.StatusConflict,
+				rawBody: []byte(`{
+					"errors":[{
+						"code":"ENTITY_ERROR.ATTRIBUTE.INVALID.ALREADY_EXISTS",
+						"title":"The request entity conflicts with the current state."
+					},{
+						"code":"STATE_ERROR.INVALID",
+						"detail":"This in-app purchase cannot be attached in the current state."
+					}]
+				}`),
+			},
+			want: false,
+		},
+		{
 			name: "other conflict",
 			err: &APIError{
 				Status:  http.StatusConflict,

--- a/internal/web/iap_review.go
+++ b/internal/web/iap_review.go
@@ -85,6 +85,7 @@ func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (Review
 
 	nextPath := queryPath("/apps/"+url.PathEscape(appID)+"/inAppPurchases", query)
 	visited := map[string]struct{}{}
+	var productIDMatch *ReviewIAP
 
 	for nextPath != "" {
 		if _, seen := visited[nextPath]; seen {
@@ -103,8 +104,12 @@ func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (Review
 		}
 		for _, resource := range payload.Data {
 			decoded := decodeReviewIAP(resource)
-			if decoded.ID == iapID || decoded.ProductID == iapID {
+			if decoded.ID == iapID {
 				return decoded, true, nil
+			}
+			if productIDMatch == nil && decoded.ProductID == iapID {
+				match := decoded
+				productIDMatch = &match
 			}
 		}
 
@@ -119,6 +124,10 @@ func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (Review
 		if err != nil {
 			return ReviewIAP{}, false, fmt.Errorf("failed to normalize review iaps pagination link: %w", err)
 		}
+	}
+
+	if productIDMatch != nil {
+		return *productIDMatch, true, nil
 	}
 
 	return ReviewIAP{}, false, nil

--- a/internal/web/iap_review.go
+++ b/internal/web/iap_review.go
@@ -9,17 +9,31 @@ import (
 	"strings"
 )
 
-const reviewIAPFields = "productId,name,state,inAppPurchaseType,isAppStoreReviewInProgress,submitWithNextAppStoreVersion"
+// reviewIAPFields is the set of `fields[inAppPurchases]` keys Apple's iris
+// `/apps/{APP_ID}/inAppPurchases` endpoint accepts.
+//
+// The iris flavor of this resource is narrower than the public REST API:
+// `name`, `inAppPurchaseType`, `isAppStoreReviewInProgress`, and
+// `submitWithNextAppStoreVersion` all return `PARAMETER_ERROR.INVALID`
+// here. Apple uses `referenceName` for the human-readable label on this
+// endpoint. The post-attach response from `/inAppPurchaseSubmissions`
+// carries `submitWithNextAppStoreVersion`, so the listing only needs the
+// fields below to scope the IAP being attached.
+const reviewIAPFields = "productId,referenceName,state"
 
-// ReviewIAP summarizes a non-subscription IAP's attach state for the next app
-// version review.
+// ReviewIAP summarizes a non-subscription IAP returned by the iris listing
+// used during the next app version review attach flow.
+//
+// `SubmitWithNextAppStoreVersion` is retained on the struct for API
+// compatibility but is never populated from the iris listing — Apple's
+// `/apps/{APP_ID}/inAppPurchases` rejects it as an invalid field. The
+// post-attach response from `/inAppPurchaseSubmissions` carries the same
+// flag; see ReviewIAPSubmission for the populated version.
 type ReviewIAP struct {
 	ID                            string `json:"id"`
 	ProductID                     string `json:"productId,omitempty"`
-	Name                          string `json:"name,omitempty"`
+	ReferenceName                 string `json:"referenceName,omitempty"`
 	State                         string `json:"state,omitempty"`
-	InAppPurchaseType             string `json:"inAppPurchaseType,omitempty"`
-	IsAppStoreReviewInProgress    bool   `json:"isAppStoreReviewInProgress"`
 	SubmitWithNextAppStoreVersion bool   `json:"submitWithNextAppStoreVersion"`
 }
 
@@ -34,17 +48,26 @@ type ReviewIAPSubmission struct {
 
 func decodeReviewIAP(resource jsonAPIResource) ReviewIAP {
 	return ReviewIAP{
-		ID:                            strings.TrimSpace(resource.ID),
-		ProductID:                     stringAttr(resource.Attributes, "productId"),
-		Name:                          stringAttr(resource.Attributes, "name"),
-		State:                         stringAttr(resource.Attributes, "state"),
-		InAppPurchaseType:             stringAttr(resource.Attributes, "inAppPurchaseType"),
-		IsAppStoreReviewInProgress:    boolAttr(resource.Attributes, "isAppStoreReviewInProgress"),
+		ID:            strings.TrimSpace(resource.ID),
+		ProductID:     stringAttr(resource.Attributes, "productId"),
+		ReferenceName: stringAttr(resource.Attributes, "referenceName"),
+		State:         stringAttr(resource.Attributes, "state"),
+		// Decoded defensively — Apple's iris listing doesn't currently include
+		// it (the field is not in reviewIAPFields), but if Apple starts
+		// returning it the idempotency short-circuit in the attach command
+		// will pick it up without further code changes.
 		SubmitWithNextAppStoreVersion: boolAttr(resource.Attributes, "submitWithNextAppStoreVersion"),
 	}
 }
 
 // FindReviewIAP finds a single app-scoped IAP through the private web flow.
+//
+// The caller may pass either the iris IAP resource ID (a UUID, distinct from
+// the numeric public-REST-API in-app purchase ID) or the product ID
+// (e.g. `com.example.pro.lifetime`). The product-ID match exists because
+// the public REST API surfaces a numeric ID that does not match the iris
+// resource's ID, and users typically know either the iris UUID or the
+// product ID — not both.
 func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (ReviewIAP, bool, error) {
 	appID = strings.TrimSpace(appID)
 	if appID == "" {
@@ -58,7 +81,7 @@ func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (Review
 	query := url.Values{}
 	query.Set("fields[inAppPurchases]", reviewIAPFields)
 	query.Set("limit", "300")
-	query.Set("sort", "name")
+	query.Set("sort", "referenceName")
 
 	nextPath := queryPath("/apps/"+url.PathEscape(appID)+"/inAppPurchases", query)
 	visited := map[string]struct{}{}
@@ -79,8 +102,9 @@ func (c *Client) FindReviewIAP(ctx context.Context, appID, iapID string) (Review
 			return ReviewIAP{}, false, fmt.Errorf("failed to parse review iaps response: %w", err)
 		}
 		for _, resource := range payload.Data {
-			if strings.TrimSpace(resource.ID) == iapID {
-				return decodeReviewIAP(resource), true, nil
+			decoded := decodeReviewIAP(resource)
+			if decoded.ID == iapID || decoded.ProductID == iapID {
+				return decoded, true, nil
 			}
 		}
 

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -103,6 +103,65 @@ func TestFindReviewIAPMatchesByProductID(t *testing.T) {
 	}
 }
 
+func TestFindReviewIAPMatchesMaxBinRedactedSchema(t *testing.T) {
+	const (
+		publicASCIAPID = "1234567890"
+		irisResourceID = "ae6d89d7-15c5-4a3d-9041-663a4d40638e"
+		productID      = "com.example.app.pro.lifetime"
+	)
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/apps/app-123/inAppPurchases" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("fields[inAppPurchases]"); got != reviewIAPFields {
+			t.Fatalf("expected iris-safe fields %q, got %q", reviewIAPFields, got)
+		}
+		if got := r.URL.Query().Get("sort"); got != "referenceName" {
+			t.Fatalf("expected sort=referenceName, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [{
+				"id": "` + irisResourceID + `",
+				"type": "inAppPurchases",
+				"attributes": {
+					"productId": "` + productID + `",
+					"referenceName": "Pro Lifetime",
+					"state": "READY_TO_SUBMIT"
+				}
+			}],
+			"links": {"next": ""}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, found, err := client.FindReviewIAP(context.Background(), "app-123", productID)
+	if err != nil {
+		t.Fatalf("FindReviewIAP(productID) error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected IAP to be found by bundle-style productId")
+	}
+	if got.ID != irisResourceID || got.ProductID != productID || got.ReferenceName != "Pro Lifetime" {
+		t.Fatalf("unexpected IAP payload: %#v", got)
+	}
+
+	_, found, err = client.FindReviewIAP(context.Background(), "app-123", publicASCIAPID)
+	if err != nil {
+		t.Fatalf("FindReviewIAP(public numeric id) error = %v", err)
+	}
+	if found {
+		t.Fatalf("public numeric ASC IAP id %q must not match Iris schema that only exposes id=%q and productId=%q", publicASCIAPID, irisResourceID, productID)
+	}
+	if requests != 2 {
+		t.Fatalf("expected two lookup requests, got %d", requests)
+	}
+}
+
 func TestFindReviewIAPStopsAfterMatchingPage(t *testing.T) {
 	calls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -21,8 +21,12 @@ func TestFindReviewIAPReturnsFirstMatchingAppScopedIAP(t *testing.T) {
 			t.Fatalf("expected limit=300, got %q", got)
 		}
 		fields := r.URL.Query().Get("fields[inAppPurchases]")
+		fieldTokens := map[string]bool{}
+		for _, field := range strings.Split(fields, ",") {
+			fieldTokens[strings.TrimSpace(field)] = true
+		}
 		for _, want := range []string{"productId", "referenceName", "state"} {
-			if !strings.Contains(fields, want) {
+			if !fieldTokens[want] {
 				t.Fatalf("expected fields to contain %q, got %q", want, fields)
 			}
 		}
@@ -30,7 +34,7 @@ func TestFindReviewIAPReturnsFirstMatchingAppScopedIAP(t *testing.T) {
 		// (verified against /apps/{APP_ID}/inAppPurchases) — guard against
 		// re-adding them in a future patch.
 		for _, forbidden := range []string{"name", "inAppPurchaseType", "isAppStoreReviewInProgress", "submitWithNextAppStoreVersion"} {
-			if strings.Contains(fields, forbidden) {
+			if fieldTokens[forbidden] {
 				t.Fatalf("fields must not include %q (iris rejects it): %q", forbidden, fields)
 			}
 		}

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -21,9 +21,17 @@ func TestFindReviewIAPReturnsFirstMatchingAppScopedIAP(t *testing.T) {
 			t.Fatalf("expected limit=300, got %q", got)
 		}
 		fields := r.URL.Query().Get("fields[inAppPurchases]")
-		for _, want := range []string{"productId", "name", "state", "submitWithNextAppStoreVersion"} {
+		for _, want := range []string{"productId", "referenceName", "state"} {
 			if !strings.Contains(fields, want) {
 				t.Fatalf("expected fields to contain %q, got %q", want, fields)
+			}
+		}
+		// Apple's iris flavor rejects these names with PARAMETER_ERROR.INVALID
+		// (verified against /apps/{APP_ID}/inAppPurchases) — guard against
+		// re-adding them in a future patch.
+		for _, forbidden := range []string{"name", "inAppPurchaseType", "isAppStoreReviewInProgress", "submitWithNextAppStoreVersion"} {
+			if strings.Contains(fields, forbidden) {
+				t.Fatalf("fields must not include %q (iris rejects it): %q", forbidden, fields)
 			}
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -34,11 +42,8 @@ func TestFindReviewIAPReturnsFirstMatchingAppScopedIAP(t *testing.T) {
 					"type": "inAppPurchases",
 					"attributes": {
 						"productId": "com.example.removeads",
-						"name": "Remove Ads",
-						"state": "READY_TO_SUBMIT",
-						"inAppPurchaseType": "NON_CONSUMABLE",
-						"isAppStoreReviewInProgress": false,
-						"submitWithNextAppStoreVersion": true
+						"referenceName": "Remove Ads",
+						"state": "READY_TO_SUBMIT"
 					}
 				}
 			],
@@ -57,7 +62,43 @@ func TestFindReviewIAPReturnsFirstMatchingAppScopedIAP(t *testing.T) {
 	if !found {
 		t.Fatal("expected IAP to be found")
 	}
-	if got.ID != "iap-1" || got.ProductID != "com.example.removeads" || got.Name != "Remove Ads" || got.State != "READY_TO_SUBMIT" || got.InAppPurchaseType != "NON_CONSUMABLE" || !got.SubmitWithNextAppStoreVersion {
+	if got.ID != "iap-1" || got.ProductID != "com.example.removeads" || got.ReferenceName != "Remove Ads" || got.State != "READY_TO_SUBMIT" {
+		t.Fatalf("unexpected IAP payload: %#v", got)
+	}
+}
+
+func TestFindReviewIAPMatchesByProductID(t *testing.T) {
+	// The iris listing returns a UUID-shaped resource ID that does not match
+	// the numeric public-REST-API IAP ID. Callers commonly know the product
+	// ID instead, so FindReviewIAP also matches on `productId`.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "ae6d89d7-15c5-4a3d-9041-663a4d40638e",
+					"type": "inAppPurchases",
+					"attributes": {
+						"productId": "com.example.lifetime",
+						"referenceName": "Lifetime",
+						"state": "READY_TO_SUBMIT"
+					}
+				}
+			],
+			"links": {"next": ""}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, found, err := client.FindReviewIAP(context.Background(), "app-123", "com.example.lifetime")
+	if err != nil {
+		t.Fatalf("FindReviewIAP() error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected IAP to be found by product id")
+	}
+	if got.ID != "ae6d89d7-15c5-4a3d-9041-663a4d40638e" || got.ProductID != "com.example.lifetime" {
 		t.Fatalf("unexpected IAP payload: %#v", got)
 	}
 }

--- a/internal/web/iap_review_test.go
+++ b/internal/web/iap_review_test.go
@@ -107,6 +107,94 @@ func TestFindReviewIAPMatchesByProductID(t *testing.T) {
 	}
 }
 
+func TestFindReviewIAPPrefersExactResourceIDOverProductIDFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "resource-from-product-fallback",
+					"type": "inAppPurchases",
+					"attributes": {
+						"productId": "iap-2",
+						"referenceName": "Collision Product",
+						"state": "READY_TO_SUBMIT"
+					}
+				},
+				{
+					"id": "iap-2",
+					"type": "inAppPurchases",
+					"attributes": {
+						"productId": "com.example.target",
+						"referenceName": "Exact Resource",
+						"state": "READY_TO_SUBMIT"
+					}
+				}
+			],
+			"links": {"next": ""}
+		}`))
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, found, err := client.FindReviewIAP(context.Background(), "app-123", "iap-2")
+	if err != nil {
+		t.Fatalf("FindReviewIAP() error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected IAP to be found")
+	}
+	if got.ID != "iap-2" || got.ProductID != "com.example.target" {
+		t.Fatalf("expected exact resource-id match to win, got %#v", got)
+	}
+}
+
+func TestFindReviewIAPPrefersExactResourceIDOnLaterPage(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			_, _ = w.Write([]byte(`{
+				"data": [{
+					"id": "resource-from-product-fallback",
+					"type": "inAppPurchases",
+					"attributes": {"productId": "iap-2"}
+				}],
+				"links": {"next": "/apps/app-123/inAppPurchases?page=2"}
+			}`))
+		case 2:
+			_, _ = w.Write([]byte(`{
+				"data": [{
+					"id": "iap-2",
+					"type": "inAppPurchases",
+					"attributes": {"productId": "com.example.target"}
+				}],
+				"links": {"next": ""}
+			}`))
+		default:
+			t.Fatalf("unexpected extra request %d: %s", calls, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	client := testWebClient(server)
+	got, found, err := client.FindReviewIAP(context.Background(), "app-123", "iap-2")
+	if err != nil {
+		t.Fatalf("FindReviewIAP() error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected IAP to be found")
+	}
+	if got.ID != "iap-2" || got.ProductID != "com.example.target" {
+		t.Fatalf("expected later exact resource-id match to win, got %#v", got)
+	}
+	if calls != 2 {
+		t.Fatalf("expected two paginated requests, got %d", calls)
+	}
+}
+
 func TestFindReviewIAPMatchesMaxBinRedactedSchema(t *testing.T) {
 	const (
 		publicASCIAPID = "1234567890"


### PR DESCRIPTION
## Summary

`asc web review iaps attach` fails on real apps for two compounding reasons. This PR fixes both, plus a correctness issue surfaced in review.

### Bug 1 — iris listing rejects the requested fields

`FindReviewIAP` requests `fields[inAppPurchases]=productId,name,state,inAppPurchaseType,isAppStoreReviewInProgress,submitWithNextAppStoreVersion` and `sort=name`. Apple's iris flavor of `/iris/v1/apps/{APP_ID}/inAppPurchases` only accepts `productId,referenceName,state` — `name`, `inAppPurchaseType`, `isAppStoreReviewInProgress`, and `submitWithNextAppStoreVersion` all return `PARAMETER_ERROR.INVALID` (HTTP 400), so every attach call fails before the resource match runs.

### Bug 2 — `FindReviewIAP` matches only the opaque iris resource id

Even after the listing returns 200, the post-`a043a87` ("Harden web review IAP attach") match predicate `strings.TrimSpace(resource.ID) == iapID` never hits in production: the iris listing returns each IAP with a UUID-shaped resource id distinct from the numeric ID surfaced by the public ASC REST API.

```
$ asc web review iaps attach --app APP_ID --iap-id IAP_ID --confirm
Error: web review iaps attach: in-app purchase "IAP_ID" was not found
under app "APP_ID"; refusing to attach
```

### Bug 3 — attach POST sent the caller's selector instead of the resolved iris id

When `FindReviewIAP` matched via `attributes.productId`, the attach POST was still sending the original `--iap-id` selector as the relationship id. Posting a bundle-style productId where iris expects its own resource id is incorrect. The fix is to thread `reviewIAP.ID` (the resolved iris UUID) through both the idempotent short-circuit and the `CreateInAppPurchaseSubmission` call.

## Fix

1. **Listing fields** trimmed to `productId,referenceName,state` and `sort=referenceName`. The struct gains `ReferenceName` (replacing the iris-unavailable `Name`) and drops `InAppPurchaseType` / `IsAppStoreReviewInProgress`. `SubmitWithNextAppStoreVersion` stays on the struct (the `/inAppPurchaseSubmissions` POST still carries it; idempotency short-circuit works against that response).
2. **Matcher** now resolves `decoded.ID == iapID || decoded.ProductID == iapID`, mirroring how `findReviewSubscription` already does ID+productID resolution. The wrong-app safety guard still holds — a different app's IAP won't have a matching productId either.
3. **Attach POST** now uses the resolved iris UUID (`reviewIAP.ID`) as the relationship id, not the caller's selector. A new test (`TestWebReviewIAPsAttachPostsIrisResourceIDWhenSelectorWasProductID`) asserts the POST body carries the iris UUID and does not carry the productId selector.
4. **Validator** relaxed to accept both numeric and bundle-style `--iap-id`. The iris matcher then resolves whichever form the iris response actually carries.

## Contract: which `--iap-id` forms are in scope

| `--iap-id` passed              | Matches against           | Supported in this PR? |
| ------------------------------ | ------------------------- | --------------------- |
| iris resource UUID             | `resource.ID`             | ✅                     |
| bundle-style `com.example.…`   | `attributes.productId`    | ✅                     |
| public numeric ASC IAP id      | (not exposed by iris)     | ❌ — out of scope      |

iris does not surface the public numeric ASC IAP id (the value `asc iap list` outputs / the ASC URL bar shows). Callers with only the public numeric id need to look it up via `asc iap list`, copy the `productId` field, then pass that to `--iap-id`. A `numericID → productId` bridge could be added as a follow-up PR if the explicit lookup step turns out to be a meaningful UX gap.

The pre-existing `TestFindReviewIAPMatchesByProductID` was misnamed — its selector happened to match the resource id, not `productId`, so it kept passing while the production code path was broken. Updated to actually exercise the fallback with a UUID-shaped resource id.

## Test plan

- [x] `go test ./internal/web/... ./internal/cli/web/... ./internal/cli/cmdtest/...` — all green; new tests guard against re-adding any of the four iris-rejected field names, and against the attach POST sending the caller's selector instead of the iris UUID.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] Verified end-to-end on a live app:
  - Without this patch: iris listing returns HTTP 400 (`PARAMETER_ERROR.INVALID`) on the first request → attach aborts.
  - With this patch: iris listing returns HTTP 200; `FindReviewIAP` matches by productId; POST `/inAppPurchaseSubmissions` proceeds and flips `submitWithNextAppStoreVersion: true` (or returns 409 if the IAP was already attached on a prior run — the expected idempotency response).

## Notes

Follow-up to PR #1570 (which I authored). The a043a87 hardening intent was good — fail fast if the user passes an IAP belonging to a different app — but the matching predicate was too strict and the field list was broader than what iris accepts. With both fixes plus the POST-id correctness commit, the safety guard still holds while the legitimate path becomes usable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IAP review listing/matching now accepts productId-style selectors, matches by selector or backend resource ID, uses the resolved backend ID when creating submissions, and sorts/page-queries by reference name. Improved detection of "already exists" conflict responses.

* **Tests**
  * Added/updated tests for productId matching, relaxed IAP-ID validation, attach-flow behavior (preserving caller selector while using resolved IDs), and conflict-detection handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->