### PR TITLE
Skip iris attach POST when IAP state shows it is already in flight

### DIFF
--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -72,6 +72,29 @@ func validateReviewIAPAttachInputs(appID, iapID string, confirm bool) error {
 	}
 }
 
+// iapStateIndicatesAlreadyAttached reports whether the IAP's current ASC
+// state implies it is already enrolled in the next app version review.
+//
+// The iris listing returns `state` (per `reviewIAPFields`) but does not
+// return the otherwise-authoritative `submitWithNextAppStoreVersion` field,
+// so state is the only signal available pre-POST. When the IAP is in one
+// of these states, iris POST `/inAppPurchaseSubmissions` returns a 409
+// whose error code varies with the IAP-id form used: a re-attach with the
+// iris resource UUID surfaces `ENTITY_ERROR.RELATIONSHIP.INVALID` because
+// iris's internal UUID→numeric-id translation fails for in-flight IAPs,
+// while a re-attach with the public numeric id surfaces
+// `ENTITY_ERROR.ATTRIBUTE.INVALID.UNMODIFIABLE` on
+// `/data/attributes/submitWithNextAppStoreVersion`. Short-circuiting before
+// the POST avoids both error shapes and keeps the CLI's exit semantics
+// stable across the two id-form code paths.
+func iapStateIndicatesAlreadyAttached(state string) bool {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL":
+		return true
+	}
+	return false
+}
+
 func verifyReviewIAPBelongsToApp(ctx context.Context, client reviewIAPFinder, appID, iapID string) (webcore.ReviewIAP, error) {
 	if client == nil {
 		return webcore.ReviewIAP{}, fmt.Errorf("app-scoped IAP verification client is required")
@@ -178,7 +201,7 @@ public numeric ASC IAP id, so that numeric id is not resolved by this command.
 			// case posting the selector as the relationship id would be
 			// wrong. Always use the resolved iris UUID.
 			resolvedIrisID := strings.TrimSpace(reviewIAP.ID)
-			if reviewIAP.SubmitWithNextAppStoreVersion {
+			if reviewIAP.SubmitWithNextAppStoreVersion || iapStateIndicatesAlreadyAttached(reviewIAP.State) {
 				payload := reviewIAPMutationOutput{
 					AppID:     trimmedAppID,
 					IAPID:     trimmedIAPID,

--- a/internal/cli/web/web_review_iaps_test.go
+++ b/internal/cli/web/web_review_iaps_test.go
@@ -548,6 +548,119 @@ func TestWebReviewIAPsAttachSkipsAlreadyAttachedIAP(t *testing.T) {
 	}
 }
 
+// In production, iris never returns `submitWithNextAppStoreVersion` in the
+// listing (it is filtered out via `reviewIAPFields`), so the existing
+// short-circuit above never fires. The fallback signal is `state`, which iris
+// does return. When state is one of the in-flight values, the IAP is already
+// enrolled in the next app version review and the CLI must short-circuit
+// before POSTing — otherwise iris answers a re-attach with
+// `ENTITY_ERROR.RELATIONSHIP.INVALID` (UUID form) or
+// `ENTITY_ERROR.ATTRIBUTE.INVALID.UNMODIFIABLE` (numeric form). This test
+// asserts no POST is made.
+func TestWebReviewIAPsAttachShortCircuitsWhenStateIsWaitingForReview(t *testing.T) {
+	_ = stubWebProgressLabels(t)
+
+	origResolveSession := resolveSessionFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+	})
+
+	const (
+		irisResourceID = "ae6d89d7-15c5-4a3d-9041-663a4d40638e"
+		productID      = "com.example.lifetime"
+	)
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method == http.MethodPost {
+						t.Fatalf("unexpected POST while IAP is already in flight: %s %s", req.Method, req.URL.Path)
+					}
+					if req.Method != http.MethodGet || req.URL.Path != "/iris/v1/apps/123456789/inAppPurchases" {
+						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body: io.NopCloser(strings.NewReader(`{
+							"data": [{
+								"type": "inAppPurchases",
+								"id": "` + irisResourceID + `",
+								"attributes": {
+									"productId": "` + productID + `",
+									"referenceName": "Lifetime",
+									"state": "WAITING_FOR_REVIEW"
+								}
+							}]
+						}`)),
+						Request: req,
+					}, nil
+				}),
+			},
+		}, "cache", nil
+	}
+
+	cmd := WebReviewIAPsAttachCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--iap-id", productID,
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+
+	var payload reviewIAPMutationOutput
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.IAPID != productID {
+		t.Fatalf("expected IAPID to echo caller selector %q, got %q", productID, payload.IAPID)
+	}
+	if payload.Changed {
+		t.Fatalf("expected in-flight IAP to report changed=false, got %#v", payload)
+	}
+	if payload.Submission.ID != "" {
+		t.Fatalf("expected no submission id when short-circuiting, got %#v", payload.Submission)
+	}
+	if payload.Submission.InAppPurchaseID != irisResourceID || !payload.Submission.SubmitWithNextAppStoreVersion {
+		t.Fatalf("unexpected idempotent submission output: %#v", payload.Submission)
+	}
+}
+
+func TestIAPStateIndicatesAlreadyAttached(t *testing.T) {
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{"WAITING_FOR_REVIEW", true},
+		{"IN_REVIEW", true},
+		{"PENDING_BINARY_APPROVAL", true},
+		{"waiting_for_review", true},     // case-insensitive
+		{"  WAITING_FOR_REVIEW  ", true}, // trimmed
+		{"READY_TO_SUBMIT", false},
+		{"MISSING_METADATA", false},
+		{"REJECTED", false},
+		{"DEVELOPER_ACTION_NEEDED", false},
+		{"APPROVED", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.state, func(t *testing.T) {
+			if got := iapStateIndicatesAlreadyAttached(tc.state); got != tc.want {
+				t.Fatalf("iapStateIndicatesAlreadyAttached(%q)=%v want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWebReviewIAPsAttachRefusesIAPOutsideApp(t *testing.T) {
 	origResolveSession := resolveSessionFn
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

Follow-up to #1571. The pre-POST idempotency short-circuit added there
gates on `reviewIAP.SubmitWithNextAppStoreVersion`, but the iris listing
filters that field out — Apple's iris flavor of
`/apps/{APP_ID}/inAppPurchases` returns `PARAMETER_ERROR.INVALID` for it,
so `reviewIAPFields` drops it. The short-circuit therefore never fires
for IAPs the listing actually surfaces, and a re-run of `attach` after
the IAP transitions out of `READY_TO_SUBMIT` exits non-zero on a 409.

### Reproduction

```text
# First run — IAP is READY_TO_SUBMIT, attach succeeds:
$ asc web review iaps attach --app APP_ID --iap-id com.example.lifetime --confirm
{"changed":true,...}
# IAP is now WAITING_FOR_REVIEW.

# Second run — attach is logically a no-op, but exits 1:
$ asc web review iaps attach --app APP_ID --iap-id com.example.lifetime --confirm
Error: web review iaps attach failed: web review iaps attach for app
"APP_ID", iap "com.example.lifetime": iris POST /inAppPurchaseSubmissions:
web api error (status 409), request_id=..., correlation_key=...
```

### The two 409 shapes

iris answers a duplicate attach with a 409 whose error code depends on
which id form the relationship carries:

| `--iap-id` resolved to | iris 409 code |
| --- | --- |
| iris resource UUID (what `FindReviewIAP` returns today) | `ENTITY_ERROR.RELATIONSHIP.INVALID` — iris's internal UUID→numeric-id translation fails for in-flight IAPs and surfaces as `Invalid relationship id <UUID>` |
| public numeric ASC IAP id | `ENTITY_ERROR.ATTRIBUTE.INVALID.UNMODIFIABLE` on `/data/attributes/submitWithNextAppStoreVersion` |

Both are functionally "the IAP is already enrolled in the next app
version review." `IsAlreadyExistsConflict` (added in #1571 for symmetry
with subscriptions) intentionally matches only
`ENTITY_ERROR.ATTRIBUTE.INVALID.ALREADY_EXISTS`, so neither shape is
covered by the post-POST recovery either.

## Fix

Use `state` — the iris listing does return it (see `reviewIAPFields =
"productId,referenceName,state"`) — as the pre-POST signal. Extend the
existing short-circuit so it also fires when state is one of:

- `WAITING_FOR_REVIEW`
- `IN_REVIEW`
- `PENDING_BINARY_APPROVAL`

The POST is skipped entirely; output preserves the existing idempotent
shape: `changed=false`, `inAppPurchaseId=<iris UUID>`,
`submitWithNextAppStoreVersion=true`. Other states
(`READY_TO_SUBMIT`, `MISSING_METADATA`, `REJECTED`,
`DEVELOPER_ACTION_NEEDED`, `APPROVED`, …) fall through to the POST so a
re-attach after the IAP returns to an editable state still proceeds.

Pattern-matching the post-POST 409 was considered and rejected: both
error shapes are brittle (the detail-string `Invalid relationship id
<UUID>` would need substring-matching against the UUID we just POSTed,
and the `UNMODIFIABLE` shape only surfaces if the caller bypassed the
CLI and used the numeric id directly). State is a cleaner gate.

## Test plan

- [x] `go test ./internal/web/... ./internal/cli/web/... ./internal/cli/cmdtest/...` — all green; new tests:
  - `TestWebReviewIAPsAttachShortCircuitsWhenStateIsWaitingForReview` —
    asserts the round-tripper sees no POST when state is
    `WAITING_FOR_REVIEW`, output `changed=false`, submission carries the
    iris resource id (not the productId selector).
  - `TestIAPStateIndicatesAlreadyAttached` — table of in-flight states
    (`WAITING_FOR_REVIEW`, `IN_REVIEW`, `PENDING_BINARY_APPROVAL`,
    case-insensitive, trimmed) and negative states (`READY_TO_SUBMIT`,
    `MISSING_METADATA`, `REJECTED`, `DEVELOPER_ACTION_NEEDED`,
    `APPROVED`, empty).
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] Verified end-to-end on a live app whose IAP is currently in
  `WAITING_FOR_REVIEW` state:
  - Before this patch: iris POST returns 409
    (`ENTITY_ERROR.RELATIONSHIP.INVALID`), CLI exits 1.
  - With this patch: no POST is sent, CLI exits 0 with
    `{"changed":false,"submission":{"submitWithNextAppStoreVersion":true,...}}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `web review iaps attach` command now correctly prevents resubmitting an in-app purchase that's already enrolled in the next app version review by detecting its enrollment state.

* **Tests**
  * Added test coverage for in-app purchase enrollment state detection and improved command short-circuit behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->