### PR TITLE
[codex] inspect local provisioning profiles

### DIFF
--- a/commands/profiles.mdx
+++ b/commands/profiles.mdx
@@ -176,6 +176,28 @@ The downloaded `.mobileprovision` file can be:
 * Copied to `~/Library/MobileDevice/Provisioning Profiles/`
 * Used in CI/CD pipelines
 
+## Inspect Profile
+
+Inspect a downloaded `.mobileprovision` file:
+
+```bash  theme={null}
+asc profiles inspect --path "./profile.mobileprovision"
+```
+
+Use JSON when scripts need to validate the embedded bundle ID, team ID, certificates, or entitlements:
+
+```bash  theme={null}
+asc profiles inspect --path "./profile.mobileprovision" --output json
+```
+
+Print entitlement key/value rows for quick terminal checks:
+
+```bash  theme={null}
+asc profiles inspect --path "./profile.mobileprovision" --entitlements
+```
+
+This command reads local disk only. It decodes the signed provisioning profile payload and reports identifiers, expiration, certificate fingerprints, device counts, and entitlement values.
+
 ### Install Profile
 
 ```bash  theme={null}

--- a/internal/cli/cmdtest/profiles_local_test.go
+++ b/internal/cli/cmdtest/profiles_local_test.go
@@ -67,6 +67,137 @@ func TestProfilesLocalInstall_ForceActionIsInstalledWhenNoExisting(t *testing.T)
 	}
 }
 
+func TestProfilesInspect_JSONIncludesEntitlements(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "profile.mobileprovision")
+	sourceBytes := buildMobileprovisionWithEntitlements(
+		t,
+		"00000000-0000-0000-0000-0000000000AD",
+		"Inspect Profile",
+		time.Now().Add(24*time.Hour),
+		map[string]any{
+			"com.apple.developer.family-controls":                       true,
+			"com.apple.developer.family-controls.app-and-website-usage": true,
+		},
+	)
+	if err := os.WriteFile(sourcePath, sourceBytes, 0o600); err != nil {
+		t.Fatalf("WriteFile(sourcePath) error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"profiles", "inspect",
+			"--path", sourcePath,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		UUID                  string         `json:"uuid"`
+		Name                  string         `json:"name"`
+		TeamID                string         `json:"teamId"`
+		BundleID              string         `json:"bundleId"`
+		ApplicationIdentifier string         `json:"applicationIdentifier"`
+		Entitlements          map[string]any `json:"entitlements"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode JSON: %v (stdout=%q)", err, stdout)
+	}
+	if result.UUID != "00000000-0000-0000-0000-0000000000AD" {
+		t.Fatalf("uuid=%q", result.UUID)
+	}
+	if result.Name != "Inspect Profile" {
+		t.Fatalf("name=%q", result.Name)
+	}
+	if result.TeamID != "TEAM12345" {
+		t.Fatalf("teamId=%q", result.TeamID)
+	}
+	if result.BundleID != "com.example.app" {
+		t.Fatalf("bundleId=%q", result.BundleID)
+	}
+	if result.ApplicationIdentifier != "TEAM12345.com.example.app" {
+		t.Fatalf("applicationIdentifier=%q", result.ApplicationIdentifier)
+	}
+	if got, ok := result.Entitlements["com.apple.developer.family-controls"].(bool); !ok || !got {
+		t.Fatalf("expected family-controls entitlement true, got %#v", result.Entitlements["com.apple.developer.family-controls"])
+	}
+}
+
+func TestProfilesInspect_EntitlementsFlagRendersEntitlementRows(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "profile.mobileprovision")
+	sourceBytes := buildMobileprovisionWithEntitlements(
+		t,
+		"00000000-0000-0000-0000-0000000000AE",
+		"Entitlements Profile",
+		time.Now().Add(24*time.Hour),
+		map[string]any{
+			"com.apple.developer.family-controls": true,
+		},
+	)
+	if err := os.WriteFile(sourcePath, sourceBytes, 0o600); err != nil {
+		t.Fatalf("WriteFile(sourcePath) error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"profiles", "inspect",
+			"--path", sourcePath,
+			"--entitlements",
+			"--output", "table",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "com.apple.developer.family-controls") {
+		t.Fatalf("expected entitlement key in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "true") {
+		t.Fatalf("expected entitlement value in output, got %q", stdout)
+	}
+}
+
+func TestProfilesInspect_MissingPath(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"profiles", "inspect"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "--path is required") {
+		t.Fatalf("expected --path error, got %q", stderr)
+	}
+}
+
 func TestProfilesLocalInstall_ForceActionIsReplacedWhenExisting(t *testing.T) {
 	installDir := t.TempDir()
 	uuid := "00000000-0000-0000-0000-0000000000AC"
@@ -402,19 +533,29 @@ func TestProfilesLocalInstall_ByID_DownloadsAndInstalls(t *testing.T) {
 func buildMobileprovision(t *testing.T, uuid, name string, expires time.Time) []byte {
 	t.Helper()
 
+	return buildMobileprovisionWithEntitlements(t, uuid, name, expires, nil)
+}
+
+func buildMobileprovisionWithEntitlements(t *testing.T, uuid, name string, expires time.Time, extraEntitlements map[string]any) []byte {
+	t.Helper()
+
 	const teamID = "TEAM12345"
 	const bundleID = "com.example.app"
 	now := time.Now().UTC()
+	entitlements := map[string]any{
+		"application-identifier":              teamID + "." + bundleID,
+		"com.apple.developer.team-identifier": teamID,
+	}
+	for key, value := range extraEntitlements {
+		entitlements[key] = value
+	}
 	payload := map[string]any{
 		"UUID":           uuid,
 		"Name":           name,
 		"TeamIdentifier": []string{teamID},
 		"CreationDate":   now.Add(-1 * time.Hour),
 		"ExpirationDate": expires.UTC(),
-		"Entitlements": map[string]any{
-			"application-identifier":              teamID + "." + bundleID,
-			"com.apple.developer.team-identifier": teamID,
-		},
+		"Entitlements":   entitlements,
 	}
 
 	plistBytes, err := plist.Marshal(payload, plist.XMLFormat)

--- a/internal/cli/profiles/inspect.go
+++ b/internal/cli/profiles/inspect.go
@@ -1,0 +1,290 @@
+package profiles
+
+import (
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type profileCertificate struct {
+	CommonName   string    `json:"commonName,omitempty"`
+	SerialNumber string    `json:"serialNumber,omitempty"`
+	SHA1         string    `json:"sha1"`
+	SHA256       string    `json:"sha256"`
+	NotBefore    time.Time `json:"notBefore,omitempty"`
+	NotAfter     time.Time `json:"notAfter,omitempty"`
+}
+
+type profileInspectResult struct {
+	Path                   string               `json:"path"`
+	UUID                   string               `json:"uuid,omitempty"`
+	Name                   string               `json:"name,omitempty"`
+	AppIDName              string               `json:"appIdName,omitempty"`
+	TeamID                 string               `json:"teamId,omitempty"`
+	TeamName               string               `json:"teamName,omitempty"`
+	BundleID               string               `json:"bundleId,omitempty"`
+	ApplicationIdentifier  string               `json:"applicationIdentifier,omitempty"`
+	Platforms              []string             `json:"platforms,omitempty"`
+	CreatedAt              time.Time            `json:"createdAt,omitempty"`
+	ExpiresAt              time.Time            `json:"expiresAt,omitempty"`
+	Expired                bool                 `json:"expired"`
+	TimeToLive             int                  `json:"timeToLive,omitempty"`
+	ProvisionedDevices     []string             `json:"provisionedDevices,omitempty"`
+	ProvisionedDeviceCount int                  `json:"provisionedDeviceCount"`
+	ProvisionsAllDevices   bool                 `json:"provisionsAllDevices"`
+	Certificates           []profileCertificate `json:"certificates,omitempty"`
+	Entitlements           map[string]any       `json:"entitlements,omitempty"`
+}
+
+// ProfilesInspectCommand returns the profiles inspect subcommand.
+func ProfilesInspectCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("inspect", flag.ExitOnError)
+
+	sourcePath := fs.String("path", "", "Path to a .mobileprovision file to inspect")
+	showEntitlements := fs.Bool("entitlements", false, "Include entitlement key/value rows in table or markdown output")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "inspect",
+		ShortUsage: "asc profiles inspect --path \"./profile.mobileprovision\" [flags]",
+		ShortHelp:  "Inspect a local provisioning profile.",
+		LongHelp: `Inspect a local provisioning profile.
+
+This command decodes the embedded plist from a .mobileprovision file and prints
+the profile identifiers, dates, certificate fingerprints, devices, and
+entitlements.
+
+Examples:
+  asc profiles inspect --path "./profile.mobileprovision"
+  asc profiles inspect --path "./profile.mobileprovision" --output json
+  asc profiles inspect --path "./profile.mobileprovision" --entitlements`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			pathValue := strings.TrimSpace(*sourcePath)
+			if pathValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --path is required")
+				return flag.ErrHelp
+			}
+
+			file, err := shared.OpenExistingNoFollow(pathValue)
+			if err != nil {
+				return fmt.Errorf("profiles inspect: open input: %w", err)
+			}
+			defer file.Close()
+
+			data, err := io.ReadAll(file)
+			if err != nil {
+				return fmt.Errorf("profiles inspect: read input: %w", err)
+			}
+
+			parsed, err := parseMobileProvision(data)
+			if err != nil {
+				return fmt.Errorf("profiles inspect: %w", err)
+			}
+
+			result := buildProfileInspectResult(pathValue, parsed, time.Now())
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderProfileInspectResult(result, *showEntitlements, false) },
+				func() error { return renderProfileInspectResult(result, *showEntitlements, true) },
+			)
+		},
+	}
+}
+
+func buildProfileInspectResult(path string, parsed *mobileProvision, now time.Time) *profileInspectResult {
+	result := &profileInspectResult{
+		Path:                   path,
+		UUID:                   strings.TrimSpace(parsed.UUID),
+		Name:                   strings.TrimSpace(parsed.Name),
+		AppIDName:              strings.TrimSpace(parsed.AppIDName),
+		TeamID:                 strings.TrimSpace(parsed.TeamID()),
+		TeamName:               strings.TrimSpace(parsed.TeamName),
+		BundleID:               strings.TrimSpace(parsed.BundleID()),
+		ApplicationIdentifier:  strings.TrimSpace(parsed.ApplicationIdentifier()),
+		Platforms:              append([]string(nil), parsed.Platform...),
+		CreatedAt:              parsed.CreationDate,
+		ExpiresAt:              parsed.ExpirationDate,
+		Expired:                isExpired(parsed.ExpirationDate, now),
+		TimeToLive:             parsed.TimeToLive,
+		ProvisionedDevices:     append([]string(nil), parsed.ProvisionedDevices...),
+		ProvisionedDeviceCount: len(parsed.ProvisionedDevices),
+		ProvisionsAllDevices:   parsed.ProvisionsAllDevices,
+		Entitlements:           sanitizeMap(parsed.Entitlements),
+	}
+	sort.Strings(result.Platforms)
+	sort.Strings(result.ProvisionedDevices)
+
+	for _, certData := range parsed.DeveloperCertificates {
+		if len(certData) == 0 {
+			continue
+		}
+		result.Certificates = append(result.Certificates, inspectDeveloperCertificate(certData))
+	}
+	return result
+}
+
+func renderProfileInspectResult(result *profileInspectResult, showEntitlements bool, markdown bool) error {
+	if result == nil {
+		return fmt.Errorf("result is nil")
+	}
+
+	render := asc.RenderTable
+	if markdown {
+		render = asc.RenderMarkdown
+	}
+
+	render(
+		[]string{"Field", "Value"},
+		[][]string{
+			{"Path", result.Path},
+			{"UUID", result.UUID},
+			{"Name", result.Name},
+			{"App ID Name", result.AppIDName},
+			{"Team ID", result.TeamID},
+			{"Team Name", result.TeamName},
+			{"Bundle ID", result.BundleID},
+			{"Application Identifier", result.ApplicationIdentifier},
+			{"Platforms", strings.Join(result.Platforms, ", ")},
+			{"Created At", formatInspectTime(result.CreatedAt)},
+			{"Expires At", formatInspectTime(result.ExpiresAt)},
+			{"Expired", fmt.Sprintf("%t", result.Expired)},
+			{"Provisioned Devices", fmt.Sprintf("%d", result.ProvisionedDeviceCount)},
+			{"Provisions All Devices", fmt.Sprintf("%t", result.ProvisionsAllDevices)},
+			{"Certificates", fmt.Sprintf("%d", len(result.Certificates))},
+		},
+	)
+
+	if len(result.Certificates) > 0 {
+		rows := make([][]string, 0, len(result.Certificates))
+		for _, cert := range result.Certificates {
+			rows = append(rows, []string{
+				cert.CommonName,
+				cert.SHA256,
+				formatInspectTime(cert.NotAfter),
+			})
+		}
+		render([]string{"Certificate", "SHA-256", "Not After"}, rows)
+	}
+
+	if showEntitlements {
+		render([]string{"Entitlement", "Value"}, entitlementRows(result.Entitlements))
+	}
+	return nil
+}
+
+func entitlementRows(entitlements map[string]any) [][]string {
+	keys := make([]string, 0, len(entitlements))
+	for key := range entitlements {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	rows := make([][]string, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, []string{key, formatInspectValue(entitlements[key])})
+	}
+	return rows
+}
+
+func formatInspectTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func formatInspectValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	case []string:
+		return strings.Join(v, ", ")
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			parts = append(parts, formatInspectValue(item))
+		}
+		return strings.Join(parts, ", ")
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, key := range keys {
+			parts = append(parts, key+"="+formatInspectValue(v[key]))
+		}
+		return strings.Join(parts, ", ")
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func sanitizeMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		out[key] = sanitizeValue(value)
+	}
+	return out
+}
+
+func sanitizeValue(value any) any {
+	switch v := value.(type) {
+	case nil, string, bool, float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return v
+	case []byte:
+		return base64.StdEncoding.EncodeToString(v)
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			out = append(out, sanitizeValue(item))
+		}
+		return out
+	case map[string]any:
+		return sanitizeMap(v)
+	}
+
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		out := make([]any, 0, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out = append(out, sanitizeValue(rv.Index(i).Interface()))
+		}
+		return out
+	case reflect.Map:
+		out := make(map[string]any, rv.Len())
+		for _, key := range rv.MapKeys() {
+			out[fmt.Sprint(key.Interface())] = sanitizeValue(rv.MapIndex(key).Interface())
+		}
+		return out
+	default:
+		return fmt.Sprint(value)
+	}
+}

--- a/internal/cli/profiles/local_parser.go
+++ b/internal/cli/profiles/local_parser.go
@@ -2,6 +2,10 @@ package profiles
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -11,12 +15,19 @@ import (
 )
 
 type mobileProvision struct {
-	UUID           string         `plist:"UUID"`
-	Name           string         `plist:"Name"`
-	TeamIdentifier []string       `plist:"TeamIdentifier"`
-	CreationDate   time.Time      `plist:"CreationDate"`
-	ExpirationDate time.Time      `plist:"ExpirationDate"`
-	Entitlements   map[string]any `plist:"Entitlements"`
+	UUID                  string         `plist:"UUID"`
+	Name                  string         `plist:"Name"`
+	AppIDName             string         `plist:"AppIDName"`
+	TeamName              string         `plist:"TeamName"`
+	TeamIdentifier        []string       `plist:"TeamIdentifier"`
+	Platform              []string       `plist:"Platform"`
+	ProvisionedDevices    []string       `plist:"ProvisionedDevices"`
+	ProvisionsAllDevices  bool           `plist:"ProvisionsAllDevices"`
+	CreationDate          time.Time      `plist:"CreationDate"`
+	ExpirationDate        time.Time      `plist:"ExpirationDate"`
+	TimeToLive            int            `plist:"TimeToLive"`
+	Entitlements          map[string]any `plist:"Entitlements"`
+	DeveloperCertificates [][]byte       `plist:"DeveloperCertificates"`
 }
 
 func parseMobileProvision(data []byte) (*mobileProvision, error) {
@@ -95,4 +106,23 @@ func coerceAnyToString(value any) string {
 	default:
 		return ""
 	}
+}
+
+func inspectDeveloperCertificate(data []byte) profileCertificate {
+	sumSHA1 := sha1.Sum(data)
+	sumSHA256 := sha256.Sum256(data)
+
+	cert := profileCertificate{
+		SHA1:   strings.ToUpper(hex.EncodeToString(sumSHA1[:])),
+		SHA256: strings.ToUpper(hex.EncodeToString(sumSHA256[:])),
+	}
+	parsed, err := x509.ParseCertificate(data)
+	if err != nil {
+		return cert
+	}
+	cert.CommonName = strings.TrimSpace(parsed.Subject.CommonName)
+	cert.SerialNumber = strings.TrimSpace(parsed.SerialNumber.String())
+	cert.NotBefore = parsed.NotBefore
+	cert.NotAfter = parsed.NotAfter
+	return cert
 }

--- a/internal/cli/profiles/profiles.go
+++ b/internal/cli/profiles/profiles.go
@@ -32,6 +32,7 @@ Examples:
   asc profiles create --name "Profile" --profile-type IOS_APP_DEVELOPMENT --bundle "BUNDLE_ID" --certificate "CERT_ID"
   asc profiles delete --id "PROFILE_ID" --confirm
   asc profiles download --id "PROFILE_ID" --output "./profile.mobileprovision"
+  asc profiles inspect --path "./profile.mobileprovision"
   asc profiles links bundle-id --id "PROFILE_ID"
   asc profiles links certificates --id "PROFILE_ID"
   asc profiles links devices --id "PROFILE_ID"`,
@@ -44,6 +45,7 @@ Examples:
 			ProfilesCreateCommand(),
 			ProfilesDeleteCommand(),
 			ProfilesDownloadCommand(),
+			ProfilesInspectCommand(),
 			ProfilesLocalCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {


### PR DESCRIPTION
## Summary
- Add `asc profiles inspect --path ./profile.mobileprovision` for local `.mobileprovision` inspection.
- Support JSON output with profile metadata, certificate fingerprints, device counts, and entitlements.
- Add `--entitlements` to include entitlement rows in table/markdown output.
- Document the new workflow in `commands/profiles.mdx`.

## Design notes
- Command placement: under `profiles` because it inspects provisioning profiles and reuses the existing local profile parser surface.
- API/schema validation: no App Store Connect endpoint is involved; this decodes the CMS-wrapped embedded plist locally.
- UX shape: `--path` is required; output uses existing `--output`/`--pretty`; table output is summary-first and `--entitlements` expands local entitlement rows.
- Compatibility: additive command only; no existing command or flag changed.
- Tests: CLI-level tests cover JSON entitlements, table entitlement rendering, and missing `--path` error behavior.

## Example invocations
```bash
asc profiles inspect --path ./profile.mobileprovision
asc profiles inspect --path ./profile.mobileprovision --output json
asc profiles inspect --path ./profile.mobileprovision --entitlements
```

## Local smoke test
Validated against a locally available `.mobileprovision` fixture outside the repository. No profile file or account-specific identifiers are committed.

## Validation
```bash
go build -o /tmp/asc-profiles-inspect .
/tmp/asc-profiles-inspect profiles inspect --help
/tmp/asc-profiles-inspect profiles inspect --path <local-profile.mobileprovision> --output json --pretty
/tmp/asc-profiles-inspect profiles inspect --path <local-profile.mobileprovision> --entitlements --output table
ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestProfilesInspect'
ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/profiles ./internal/cli/cmdtest -run 'TestProfiles'
make format
make check-command-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `asc profiles inspect` command to examine local provisioning profile files. Displays profile identifiers, platforms, creation and expiration dates, device provisioning details, entitlements, and developer certificate information including SHA-256 hashes. Supports JSON output and entitlements table display via `--entitlements` flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->