### PR TITLE
apps wall: add RecipeBee: Recipes & Meal Plan

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1062,6 +1062,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3c/f7/5a/3cf75a8b-78f9-010e-906d-011849ab7ee2/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "RecipeBee: Recipes & Meal Plan",
+    "link": "https://apps.apple.com/us/app/recipebee-recipes-meal-plan/id6757370845?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/86/0e/52/860e52e1-9c23-7868-1f43-b43739700fae/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "RegexMate",
     "link": "https://apps.apple.com/us/app/regexmate/id6479819388?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6f/b7/29/6fb72938-5335-c724-e9f9-eaea5533a531/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- Add RecipeBee: Recipes & Meal Plan to the Wall of Apps

## Entry

- App ID: 6757370845
- App: RecipeBee: Recipes & Meal Plan
- Link: https://apps.apple.com/us/app/recipebee-recipes-meal-plan/id6757370845?uo=4

## Notes

- Submitted manually because `asc apps wall submit --confirm` rejects forks whose GitHub parent is `rorkai/App-Store-Connect-CLI` instead of `rudrankriyam/App-Store-Connect-CLI` (same upstream repo after rename).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added **RecipeBee: Recipes & Meal Plan** to the app directory with its App Store link and icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->