### PR TITLE
[codex] fix apps wall fork parent validation

### DIFF
--- a/internal/cli/apps/community_wall_submit.go
+++ b/internal/cli/apps/community_wall_submit.go
@@ -31,6 +31,7 @@ import (
 const (
 	communityWallUpstreamOwner        = "rorkai"
 	communityWallUpstreamRepo         = "App-Store-Connect-CLI"
+	communityWallTransferredFromOwner = "rudrankriyam"
 	communityWallUpstreamBranch       = "main"
 	communityWallGitHubMaxBodyBytes   = 8192
 	defaultCommunityWallSubmitOutput  = "json"
@@ -994,7 +995,20 @@ func (repo *communityWallGitHubRepo) isForkOf(upstreamFullName string) bool {
 	if repo == nil || !repo.Fork || repo.Parent == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(repo.Parent.FullName), strings.TrimSpace(upstreamFullName))
+	parent := strings.TrimSpace(repo.Parent.FullName)
+	for _, allowed := range communityWallAcceptedForkParents(upstreamFullName) {
+		if strings.EqualFold(parent, allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+func communityWallAcceptedForkParents(upstreamFullName string) []string {
+	return []string{
+		strings.TrimSpace(upstreamFullName),
+		communityWallTransferredFromOwner + "/" + communityWallUpstreamRepo,
+	}
 }
 
 func (repo *communityWallGitHubRepo) displayName(owner, name string) string {

--- a/internal/cli/apps/community_wall_submit_test.go
+++ b/internal/cli/apps/community_wall_submit_test.go
@@ -522,6 +522,80 @@ func TestSubmitCommunityWallEntryRejectsDuplicateAppID(t *testing.T) {
 	}
 }
 
+func TestSubmitCommunityWallEntryAcceptsTransferredForkParent(t *testing.T) {
+	sourceJSON := `[
+  {
+    "app": "Alpha",
+    "link": "https://example.com/alpha",
+    "creator": "alpha-dev",
+    "platform": ["iOS"]
+  }
+]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/tester/App-Store-Connect-CLI":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"full_name":"tester/App-Store-Connect-CLI","fork":true,"parent":{"full_name":"rudrankriyam/App-Store-Connect-CLI"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/git/ref/heads/main":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": map[string]any{
+					"sha": "base-sha-123",
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/rorkai/App-Store-Connect-CLI/contents/docs/wall-of-apps.json":
+			if got := r.URL.Query().Get("ref"); got != "base-sha-123" {
+				t.Fatalf("expected ref=base-sha-123, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sha":      "blob123",
+				"encoding": "base64",
+				"content":  base64.StdEncoding.EncodeToString([]byte(sourceJSON)),
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	previousAPIBase := communityWallGitHubAPIBase
+	previousHTTPClient := communityWallGitHubClient
+	previousLookupDetails := communityWallLookupAppDetails
+	communityWallGitHubAPIBase = server.URL
+	communityWallGitHubClient = func() *http.Client { return server.Client() }
+	communityWallLookupAppDetails = func(ctx context.Context, ids []string, country string) (map[string]communityWallAppDetails, error) {
+		return map[string]communityWallAppDetails{
+			"1234567890": {
+				Name: "Beta",
+				Link: "https://apps.apple.com/us/app/beta/id1234567890",
+			},
+		}, nil
+	}
+	t.Cleanup(func() {
+		communityWallGitHubAPIBase = previousAPIBase
+		communityWallGitHubClient = previousHTTPClient
+		communityWallLookupAppDetails = previousLookupDetails
+	})
+
+	result, err := submitCommunityWallEntry(context.Background(), communityWallSubmitRequest{
+		Input: communityWallSubmitInput{
+			AppID: "1234567890",
+		},
+		GitHubToken: "token",
+		GitHubLogin: "tester",
+		DryRun:      true,
+	})
+	if err != nil {
+		t.Fatalf("submit dry-run with transferred parent: %v", err)
+	}
+	if result.WillCreateFork {
+		t.Fatalf("expected existing transferred fork to be reused")
+	}
+	if result.UpstreamRepo != "rorkai/App-Store-Connect-CLI" {
+		t.Fatalf("UpstreamRepo = %q, want rorkai/App-Store-Connect-CLI", result.UpstreamRepo)
+	}
+}
+
 func TestSubmitCommunityWallEntryRejectsMalformedExistingSource(t *testing.T) {
 	sourceJSON := `[
   {


### PR DESCRIPTION
## Summary

- Accept transferred fork parents for `asc apps wall submit` fork validation.
- Keep PR/base operations pointed at the configured `rorkai/App-Store-Connect-CLI` upstream.
- Add regression coverage for an existing fork whose GitHub parent is `rudrankriyam/App-Store-Connect-CLI`.

## Root Cause

The Wall of Apps submit flow strictly compared an existing fork parent against the configured upstream full name. After the repository rename/transfer, GitHub can report the fork parent as `rudrankriyam/App-Store-Connect-CLI` while the CLI targets `rorkai/App-Store-Connect-CLI`, causing valid forks to be rejected.

## Validation

- `go run . --help`
- `go run . apps wall submit --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/apps -run 'TestSubmitCommunityWallEntry(AcceptsTransferredForkParent|RejectsExistingNonForkRepo|RejectsDuplicateAppID)' -count=1`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced community wall submission validation to properly handle and accept forks whose parent repositories have been transferred or reassigned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->