### PR TITLE
Improve localization update error context

### DIFF
--- a/internal/cli/cmdtest/localizations_update_test.go
+++ b/internal/cli/cmdtest/localizations_update_test.go
@@ -440,8 +440,71 @@ func TestLocalizationsUpdateVersionErrorIncludesAttemptedFields(t *testing.T) {
 	}
 	for _, want := range []string{
 		`localizations update: update version localization "fr-FR"`,
+		"PATCH /v1/appStoreVersionLocalizations/loc-fr",
 		"description",
 		"supportUrl",
+		"(-50)",
+	} {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, runErr)
+		}
+	}
+}
+
+func TestLocalizationsUpdateAppInfoErrorIncludesResolvedEndpoint(t *testing.T) {
+	setupLocUpdateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = locUpdateRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appInfos":
+			return locUpdateJSONResponse(`{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return locUpdateJSONResponse(`{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Old Name"}}],"links":{}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/loc-en":
+			body := `{"errors":[{"status":"409","code":"ENTITY_ERROR.INVALID","title":"One or more parameters passed to the function were not valid.","detail":"(-50)"}]}`
+			return &http.Response{
+				StatusCode: http.StatusConflict,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"localizations", "update",
+			"--type", "app-info",
+			"--app", "app-1",
+			"--locale", "en-US",
+			"--name", "New Name",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected run error, got nil")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		`localizations update: update app-info localization "en-US"`,
+		"PATCH /v1/appInfoLocalizations/loc-en",
+		"name",
 		"(-50)",
 	} {
 		if !strings.Contains(runErr.Error(), want) {

--- a/internal/cli/localizations/update.go
+++ b/internal/cli/localizations/update.go
@@ -178,8 +178,9 @@ func updateAppInfoLocalization(ctx context.Context, p updateAppInfoParams) error
 	resp, err := client.UpdateAppInfoLocalization(requestCtx, localizationID, attrs)
 	if err != nil {
 		return fmt.Errorf(
-			"localizations update: update app-info localization %q (fields: %s): %w",
+			"localizations update: update app-info localization %q via PATCH /v1/appInfoLocalizations/%s (fields: %s): %w",
 			p.locale,
+			localizationID,
 			formatAttemptedFields(appInfoAttemptedFields(p)),
 			err,
 		)
@@ -250,8 +251,9 @@ func updateVersionLocalization(ctx context.Context, p updateVersionParams) error
 	resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, localizationID, attrs)
 	if err != nil {
 		return fmt.Errorf(
-			"localizations update: update version localization %q (fields: %s): %w",
+			"localizations update: update version localization %q via PATCH /v1/appStoreVersionLocalizations/%s (fields: %s): %w",
 			p.locale,
+			localizationID,
 			formatAttemptedFields(versionAttemptedFields(p)),
 			err,
 		)


### PR DESCRIPTION
## Summary
- include the resolved PATCH endpoint in localizations update failures for app-info and version metadata
- add regression coverage for App Store Connect (-50) responses on app-info localization updates
- extend existing version localization failure coverage to assert the endpoint appears in the error

## Testing
- go test ./internal/cli/cmdtest -run LocalizationsUpdate
- go test ./internal/cli/localizations ./internal/cli/cmdtest -run Localizations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for localization updates. When updates fail, error messages now include the specific endpoint and localization resource ID along with the locale and attempted fields, providing clearer diagnostics for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->