### PR TITLE
chore: ignore Python bytecode from scripts/ helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ worktrees/
 # ASC Studio generated artifacts
 /apps/studio/build/bin/
 /apps/studio/frontend/package.json.md5
+
+# Python bytecode (scripts/ helpers compile these when run)
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- The Python helper scripts under `scripts/` compile `__pycache__/*.pyc` bytecode whenever they run (e.g. via `make check-docs`, `make check-repo-docs`, or `python3 scripts/test_check_docs.py`).
- `__pycache__` was not in `.gitignore`, so these compiled files repeatedly surfaced as untracked changes and could be accidentally staged with `git add -A`.
- Adds a minimal `__pycache__/` + `*.pyc` ignore rule.

## Test plan
- [x] `make format`
- [x] `make check-docs`
- [x] `make lint` (0 issues)
- [x] `ASC_BYPASS_KEYCHAIN=1 make test` (all pass)
- [x] Ran `make check-repo-docs` to regenerate `.pyc` files, then confirmed `git status` shows a clean working tree (no `scripts/__pycache__/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore patterns to exclude Python bytecode and build artifacts from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->