### PR TITLE
fix(signing): scope profile fetch to bundle id

### DIFF
--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -215,10 +215,10 @@ func findCertificates(ctx context.Context, client *asc.Client, profileType, cert
 func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResourceID, bundleIdentifier, profileType string, certIDs, deviceIDs []string, createMissing bool) (*asc.ProfileResponse, bool, error) {
 	next := ""
 	for {
-		profiles, err := client.GetProfiles(
+		profiles, err := client.GetBundleIDProfiles(
 			ctx,
-			asc.WithProfilesFilterType(profileType),
-			asc.WithProfilesNextURL(next),
+			bundleIDResourceID,
+			asc.WithBundleIDProfilesNextURL(next),
 		)
 		if err != nil {
 			return nil, false, err
@@ -228,15 +228,7 @@ func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResour
 			if profile.Attributes.ProfileState != asc.ProfileStateActive {
 				continue
 			}
-			content := strings.TrimSpace(profile.Attributes.ProfileContent)
-			if content == "" {
-				continue
-			}
-			decoded, err := decodeBase64Content("profile", content)
-			if err != nil {
-				return nil, false, err
-			}
-			if strings.Contains(string(decoded), bundleIdentifier) {
+			if strings.EqualFold(strings.TrimSpace(profile.Attributes.ProfileType), profileType) {
 				return &asc.ProfileResponse{Data: profile}, false, nil
 			}
 		}
@@ -248,7 +240,7 @@ func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResour
 	}
 
 	if !createMissing {
-		return nil, false, fmt.Errorf("no active profile found for bundle ID; use --create-missing to create one")
+		return nil, false, fmt.Errorf("no active %s profile found for bundle ID %s; use --create-missing to create one", profileType, bundleIdentifier)
 	}
 	if len(certIDs) == 0 {
 		return nil, false, fmt.Errorf("no certificates available to create profile")

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -3,15 +3,23 @@ package signing
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -168,5 +176,100 @@ func TestSigningFetchWriteFiles_NoOverwrite(t *testing.T) {
 		t.Fatal("expected error when overwriting certificate file")
 	} else if !errors.Is(err, os.ErrExist) {
 		t.Fatalf("expected ErrExist, got %v", err)
+	}
+}
+
+func TestFindOrCreateProfileUsesBundleIDRelationship(t *testing.T) {
+	widgetProfileContent := base64.StdEncoding.EncodeToString([]byte("application-identifier=TEAM.com.example.signing.profile.widget"))
+	mainProfileContent := base64.StdEncoding.EncodeToString([]byte("application-identifier=TEAM.com.example.signing.profile"))
+	requestPaths := []string{}
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		requestPaths = append(requestPaths, req.URL.Path)
+
+		switch req.URL.Path {
+		case "/v1/profiles":
+			return signingFetchJSONResponse(
+				http.StatusOK,
+				fmt.Sprintf(
+					`{"data":[{"type":"profiles","id":"profile-widget","attributes":{"name":"Widget-stamped main profile","profileType":"IOS_APP_STORE","profileState":"ACTIVE","profileContent":%q}}]}`,
+					widgetProfileContent,
+				),
+			)
+		case "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(
+				http.StatusOK,
+				fmt.Sprintf(
+					`{"data":[{"type":"profiles","id":"profile-main","attributes":{"name":"Main App Store","profileType":"IOS_APP_STORE","profileState":"ACTIVE","profileContent":%q}}]}`,
+					mainProfileContent,
+				),
+			)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, created, err := findOrCreateProfile(
+		context.Background(),
+		client,
+		"bundle-main",
+		"com.example.signing.profile",
+		"IOS_APP_STORE",
+		[]string{"cert-1"},
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("findOrCreateProfile() error: %v", err)
+	}
+	if created {
+		t.Fatal("expected existing profile, got created profile")
+	}
+	if profile.Data.ID != "profile-main" {
+		t.Fatalf("expected exact bundle profile, got %s", profile.Data.ID)
+	}
+
+	if len(requestPaths) != 1 || requestPaths[0] != "/v1/bundleIds/bundle-main/profiles" {
+		t.Fatalf("expected Bundle ID scoped profile lookup, got %v", requestPaths)
+	}
+}
+
+type signingFetchRoundTripFunc func(*http.Request) *http.Response
+
+func (fn signingFetchRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req), nil
+}
+
+func newSigningFetchTestClient(t *testing.T, fn signingFetchRoundTripFunc) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "key.p8")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{
+		Transport: fn,
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
+	}
+	return client
+}
+
+func signingFetchJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `asc signing fetch` to look up provisioning profiles through the exact Bundle ID relationship endpoint instead of scanning all profiles by type.
- Filter the related profiles to active profiles with the requested profile type.
- Add a regression test where `com.example.signing.profile` must not select a `com.example.signing.profile.widget` profile.

## Root Cause
`signing fetch` previously decoded profile content and used `strings.Contains(decodedProfile, bundleIdentifier)`. That lets a main app bundle ID match an extension/widget App ID prefix, so an extension-stamped profile could be returned for the main target.

## Verification
- Red: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/signing -run TestFindOrCreateProfileUsesBundleIDRelationship -count=1` failed before the fix with `expected exact bundle profile, got profile-widget`.
- Green: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/signing -run TestFindOrCreateProfileUsesBundleIDRelationship -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/signing -count=1`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile lookup by scoping queries to the app bundle, reducing unnecessary matches.
  * Profile type matching is now case-insensitive, preventing mismatches due to capitalization.
  * Error messages now include both profile type and bundle identifier for clearer diagnostics.

* **Tests**
  * Added tests validating bundle-scoped profile lookup and matching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->