### PR TITLE
Add screenshot upload cap and Xcode export timeout guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Uploading screenshots for a single locale:
 asc apps list
 asc versions list --app "APP_ID"
 asc localizations list --version "VERSION_ID" --output json --locale "en-US" | jsonpp
-asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/en-US" --device-type "IPHONE_65" --replace
+asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/en-US" --device-type "IPHONE_65" --replace --max-screenshots 10
 ```
 
 `VERSION_LOCALIZATION_ID` is the App Store version localization resource ID
@@ -282,7 +282,7 @@ asc workflow run --dry-run testflight_beta VERSION:1.2.3
 
 See [docs/WORKFLOWS.md](docs/WORKFLOWS.md) for a copyable `.asc/workflow.json`
 and `ExportOptions.plist` that use `asc builds next-build-number`, `asc xcode archive`,
-`asc xcode export`, and `asc publish testflight --group ... --wait`. Add
+`asc xcode export --timeout 10m`, and `asc publish testflight --group ... --wait`. Add
 `--submit --confirm` when distributing to an external TestFlight group that needs
 beta app review submission.
 

--- a/commands/screenshots.mdx
+++ b/commands/screenshots.mdx
@@ -183,6 +183,12 @@ asc screenshots upload --version-localization "LOC_ID" \
   --path "./screenshots/iphone" \
   --device-type "IPHONE_65"
 
+# Upload the first 10 sorted files when the source folder has extras
+asc screenshots upload --version-localization "LOC_ID" \
+  --path "./screenshots/iphone" \
+  --device-type "IPHONE_65" \
+  --max-screenshots 10
+
 # Fan out across locale directories in one run
 asc screenshots upload --app "123456789" \
   --version "1.2.3" \
@@ -202,6 +208,8 @@ uploaded from each locale subtree. A device-rooted layout such as
 
 * Format: PNG or JPEG
 * Exact dimensions must match the device type specification
+* A screenshot set can contain at most 10 images; use `--max-screenshots 10`
+  to upload the first 10 sorted files when a source folder contains extras
 * Use `asc screenshots sizes` to verify required dimensions
 * Partial failures write a retry artifact under `.asc/reports/screenshots-upload/`
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -79,7 +79,7 @@ Create `.asc/workflow.json`:
         },
         {
           "name": "export",
-          "run": "asc xcode export --archive-path ${steps.archive.ARCHIVE_PATH} --export-options \"$EXPORT_OPTIONS\" --ipa-path \".asc/artifacts/App-$VERSION-${steps.archive.BUILD_NUMBER}.ipa\" --overwrite --xcodebuild-flag=-allowProvisioningUpdates --output json",
+          "run": "asc xcode export --archive-path ${steps.archive.ARCHIVE_PATH} --export-options \"$EXPORT_OPTIONS\" --ipa-path \".asc/artifacts/App-$VERSION-${steps.archive.BUILD_NUMBER}.ipa\" --overwrite --timeout 10m --xcodebuild-flag=-allowProvisioningUpdates --output json",
           "outputs": {
             "IPA_PATH": "$.ipa_path",
             "VERSION": "$.version",

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -78,6 +78,7 @@ type screenshotUploadConfig[T any] struct {
 	SkipExisting   bool
 	Replace        bool
 	DryRun         bool
+	MaxScreenshots int
 	RequestContext func(context.Context) (context.Context, context.CancelFunc)
 	UploadContext  func(context.Context) (context.Context, context.CancelFunc)
 	Access         ScreenshotSetAccess
@@ -120,6 +121,7 @@ type screenshotUploadFanoutConfig struct {
 	SkipExisting          bool
 	Replace               bool
 	DryRun                bool
+	MaxScreenshots        int
 
 	RequestContext   func(context.Context) (context.Context, context.CancelFunc)
 	UploadScreenshot func(context.Context, *asc.Client, string, string, []string, bool, bool, bool) (asc.AppScreenshotUploadResult, error)
@@ -612,6 +614,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 			SkipExisting:   opts.SkipExisting,
 			Replace:        opts.Replace,
 			DryRun:         opts.DryRun,
+			MaxScreenshots: opts.MaxScreenshots,
 			RequestContext: deps.RequestContext,
 			UploadContext:  contextWithAssetUploadTimeout,
 			Access:         appStoreVersionScreenshotSetAccess,
@@ -663,6 +666,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		SkipExisting:          opts.SkipExisting,
 		Replace:               opts.Replace,
 		DryRun:                opts.DryRun,
+		MaxScreenshots:        opts.MaxScreenshots,
 		RequestContext:        deps.RequestContext,
 		UploadScreenshot:      deps.UploadScreenshot,
 		ExecuteUpload:         deps.ExecuteUpload,
@@ -726,6 +730,40 @@ func limitScreenshotFanoutUploadFiles(localeAssets []screenshotLocaleAssetFiles,
 		limited = append(limited, item)
 	}
 	return limited, nil
+}
+
+func limitScreenshotUploadFilesForExistingSet(files []string, maxScreenshots int, existingScreenshots []asc.Resource[asc.AppScreenshotAttributes], replace bool, setID string) ([]string, error) {
+	if maxScreenshots <= 0 {
+		return files, nil
+	}
+	if replace {
+		if len(files) > maxScreenshots {
+			return append([]string(nil), files[:maxScreenshots]...), nil
+		}
+		return files, nil
+	}
+
+	remaining := maxScreenshots - len(existingScreenshots)
+	if remaining <= 0 {
+		if len(files) == 0 {
+			return files, nil
+		}
+		setLabel := strings.TrimSpace(setID)
+		if setLabel == "" {
+			setLabel = "target set"
+		}
+		return nil, fmt.Errorf(
+			"%s already has %d screenshot(s); --max-screenshots %d leaves no upload slots. Pass --replace to replace existing screenshots or choose a higher limit up to %d",
+			setLabel,
+			len(existingScreenshots),
+			maxScreenshots,
+			appScreenshotSetMaxScreenshots,
+		)
+	}
+	if len(files) > remaining {
+		return append([]string(nil), files[:remaining]...), nil
+	}
+	return files, nil
 }
 
 func uploadScreenshotsFanout(ctx context.Context, cfg screenshotUploadFanoutConfig) (asc.AppScreenshotFanoutUploadResult, error) {
@@ -802,6 +840,7 @@ func uploadScreenshotsFanout(ctx context.Context, cfg screenshotUploadFanoutConf
 			SkipExisting:   cfg.SkipExisting,
 			Replace:        cfg.Replace,
 			DryRun:         cfg.DryRun,
+			MaxScreenshots: cfg.MaxScreenshots,
 			RequestContext: cfg.RequestContext,
 			UploadContext:  contextWithAssetUploadTimeout,
 			Access:         appStoreVersionScreenshotSetAccess,
@@ -1650,7 +1689,7 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 	}
 
 	existingScreenshots := make([]asc.Resource[asc.AppScreenshotAttributes], 0)
-	if (cfg.SkipExisting || cfg.Replace) && set.ID != "" {
+	if (cfg.SkipExisting || cfg.Replace || (cfg.MaxScreenshots > 0 && !cfg.Replace)) && set.ID != "" {
 		fetchCtx, fetchCancel := cfg.RequestContext(ctx)
 		existingResp, err := cfg.Client.GetAppScreenshots(fetchCtx, set.ID)
 		fetchCancel()
@@ -1668,6 +1707,10 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 		if filterErr != nil {
 			return zero, filterErr
 		}
+	}
+	files, err = limitScreenshotUploadFilesForExistingSet(files, cfg.MaxScreenshots, existingScreenshots, cfg.Replace, set.ID)
+	if err != nil {
+		return zero, err
 	}
 
 	if cfg.DryRun {

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -904,12 +904,10 @@ func collectLocaleAssetFilesWithLimit(rootPath, displayType string, maxScreensho
 type screenshotMatchWalkOptions struct {
 	ignoreInvalidFiles bool
 	ignoreSymlinks     bool
-	maxMatches         int
 	onMatch            func(path string) error
 }
 
 func walkMatchingScreenshotFiles(rootPath, displayType string, opts screenshotMatchWalkOptions) error {
-	matchCount := 0
 	return filepath.WalkDir(rootPath, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -937,9 +935,6 @@ func walkMatchingScreenshotFiles(rootPath, displayType string, opts screenshotMa
 		if !info.Mode().IsRegular() || !isSupportedScreenshotUploadFile(path) {
 			return nil
 		}
-		if opts.maxMatches > 0 && matchCount >= opts.maxMatches {
-			return nil
-		}
 		if err := asc.ValidateImageFile(path); err != nil {
 			if opts.ignoreInvalidFiles {
 				return nil
@@ -959,7 +954,6 @@ func walkMatchingScreenshotFiles(rootPath, displayType string, opts screenshotMa
 		if err := opts.onMatch(path); err != nil {
 			return err
 		}
-		matchCount++
 		return nil
 	})
 }
@@ -969,9 +963,12 @@ func collectLocaleAssetFilesRecursive(rootPath, displayType string) ([]string, e
 }
 
 func collectLocaleAssetFilesRecursiveWithLimit(rootPath, displayType string, maxScreenshots int) ([]string, error) {
+	if maxScreenshots > 0 {
+		return collectLimitedLocaleAssetFilesRecursive(rootPath, displayType, maxScreenshots)
+	}
+
 	files := make([]string, 0)
 	err := walkMatchingScreenshotFiles(rootPath, displayType, screenshotMatchWalkOptions{
-		maxMatches: maxScreenshots,
 		onMatch: func(path string) error {
 			files = append(files, path)
 			return nil
@@ -982,6 +979,69 @@ func collectLocaleAssetFilesRecursiveWithLimit(rootPath, displayType string, max
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no screenshot files matching %s found in %q", displayType, rootPath)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func collectLimitedLocaleAssetFilesRecursive(rootPath, displayType string, maxScreenshots int) ([]string, error) {
+	candidates, err := collectSupportedScreenshotCandidateFiles(rootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]string, 0, min(maxScreenshots, len(candidates)))
+	for _, path := range candidates {
+		if len(files) >= maxScreenshots {
+			break
+		}
+		if err := asc.ValidateImageFile(path); err != nil {
+			return nil, err
+		}
+		matches, err := screenshotMatchesDisplayType(path, displayType)
+		if err != nil {
+			return nil, err
+		}
+		if matches {
+			files = append(files, path)
+		}
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no screenshot files matching %s found in %q", displayType, rootPath)
+	}
+	return files, nil
+}
+
+func collectSupportedScreenshotCandidateFiles(rootPath string) ([]string, error) {
+	files := make([]string, 0)
+	err := filepath.WalkDir(rootPath, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path != rootPath && shouldIgnoreFanoutEntryName(entry.Name()) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to read symlink %q", path)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || !isSupportedScreenshotUploadFile(path) {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Strings(files)
 	return files, nil

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -593,11 +593,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 	apiDisplayType := asc.CanonicalScreenshotDisplayTypeForAPI(displayType)
 
 	if locID != "" {
-		files, err := collectAssetFiles(pathValue)
-		if err != nil {
-			return nil, err
-		}
-		files, err = limitScreenshotUploadFiles(files, opts.MaxScreenshots, pathValue)
+		files, err := collectScreenshotUploadFiles(pathValue, opts.MaxScreenshots)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +624,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		return nil, shared.UsageError(err.Error())
 	}
 
-	localeAssets, err := collectLocaleAssetFiles(pathValue, apiDisplayType)
+	localeAssets, err := collectLocaleAssetFilesWithLimit(pathValue, apiDisplayType, opts.MaxScreenshots)
 	if err != nil {
 		return nil, err
 	}
@@ -675,6 +671,27 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		return &result, err
 	}
 	return &result, nil
+}
+
+func collectScreenshotUploadFiles(path string, maxScreenshots int) ([]string, error) {
+	files, err := collectAssetPaths(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files found in %q", path)
+	}
+
+	files, err = limitScreenshotUploadFiles(files, maxScreenshots, path)
+	if err != nil {
+		return nil, err
+	}
+	for _, filePath := range files {
+		if err := asc.ValidateImageFile(filePath); err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
 }
 
 func limitScreenshotUploadFiles(files []string, maxScreenshots int, source string) ([]string, error) {
@@ -802,6 +819,10 @@ func uploadScreenshotsFanout(ctx context.Context, cfg screenshotUploadFanoutConf
 }
 
 func collectLocaleAssetFiles(rootPath, displayType string) ([]screenshotLocaleAssetFiles, error) {
+	return collectLocaleAssetFilesWithLimit(rootPath, displayType, 0)
+}
+
+func collectLocaleAssetFilesWithLimit(rootPath, displayType string, maxScreenshots int) ([]screenshotLocaleAssetFiles, error) {
 	info, err := os.Lstat(rootPath)
 	if err != nil {
 		return nil, err
@@ -857,7 +878,7 @@ func collectLocaleAssetFiles(rootPath, displayType string) ([]screenshotLocaleAs
 				continue
 			}
 		}
-		files, err := collectLocaleAssetFilesRecursive(entryPath, displayType)
+		files, err := collectLocaleAssetFilesRecursiveWithLimit(entryPath, displayType, maxScreenshots)
 		if err != nil {
 			return nil, fmt.Errorf("locale %s: %w", locale, err)
 		}
@@ -883,10 +904,12 @@ func collectLocaleAssetFiles(rootPath, displayType string) ([]screenshotLocaleAs
 type screenshotMatchWalkOptions struct {
 	ignoreInvalidFiles bool
 	ignoreSymlinks     bool
+	maxMatches         int
 	onMatch            func(path string) error
 }
 
 func walkMatchingScreenshotFiles(rootPath, displayType string, opts screenshotMatchWalkOptions) error {
+	matchCount := 0
 	return filepath.WalkDir(rootPath, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -914,29 +937,41 @@ func walkMatchingScreenshotFiles(rootPath, displayType string, opts screenshotMa
 		if !info.Mode().IsRegular() || !isSupportedScreenshotUploadFile(path) {
 			return nil
 		}
+		if opts.maxMatches > 0 && matchCount >= opts.maxMatches {
+			return nil
+		}
 		if err := asc.ValidateImageFile(path); err != nil {
 			if opts.ignoreInvalidFiles {
 				return nil
 			}
 			return err
 		}
-		matches, err := screenshotMatchesDisplayType(path, displayType)
+		isMatch, err := screenshotMatchesDisplayType(path, displayType)
 		if err != nil {
 			if opts.ignoreInvalidFiles {
 				return nil
 			}
 			return err
 		}
-		if !matches || opts.onMatch == nil {
+		if !isMatch || opts.onMatch == nil {
 			return nil
 		}
-		return opts.onMatch(path)
+		if err := opts.onMatch(path); err != nil {
+			return err
+		}
+		matchCount++
+		return nil
 	})
 }
 
 func collectLocaleAssetFilesRecursive(rootPath, displayType string) ([]string, error) {
+	return collectLocaleAssetFilesRecursiveWithLimit(rootPath, displayType, 0)
+}
+
+func collectLocaleAssetFilesRecursiveWithLimit(rootPath, displayType string, maxScreenshots int) ([]string, error) {
 	files := make([]string, 0)
 	err := walkMatchingScreenshotFiles(rootPath, displayType, screenshotMatchWalkOptions{
+		maxMatches: maxScreenshots,
 		onMatch: func(path string) error {
 			files = append(files, path)
 			return nil

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -457,8 +457,8 @@ Examples:
 					strings.TrimSpace(*deviceType) != "" {
 					return shared.UsageError("--resume cannot be combined with --version-localization, --app, --version, --version-id, --platform, --path, or --device-type")
 				}
-				if *skipExisting || *replace || *dryRun {
-					return shared.UsageError("--resume cannot be combined with --skip-existing, --replace, or --dry-run")
+				if *skipExisting || *replace || *dryRun || *maxScreenshots != 0 {
+					return shared.UsageError("--resume cannot be combined with --skip-existing, --replace, --dry-run, or --max-screenshots")
 				}
 
 				client, err := shared.GetASCClient()

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -733,12 +733,31 @@ func limitScreenshotFanoutUploadFiles(localeAssets []screenshotLocaleAssetFiles,
 }
 
 func limitScreenshotUploadFilesForExistingSet(files []string, maxScreenshots int, existingScreenshots []asc.Resource[asc.AppScreenshotAttributes], replace bool, setID string) ([]string, error) {
-	if maxScreenshots <= 0 {
-		return files, nil
-	}
 	if replace {
+		if maxScreenshots <= 0 {
+			return files, nil
+		}
 		if len(files) > maxScreenshots {
 			return append([]string(nil), files[:maxScreenshots]...), nil
+		}
+		return files, nil
+	}
+
+	setLabel := strings.TrimSpace(setID)
+	if setLabel == "" {
+		setLabel = "target set"
+	}
+	if maxScreenshots <= 0 {
+		total := len(existingScreenshots) + len(files)
+		if total > appScreenshotSetMaxScreenshots {
+			return nil, fmt.Errorf(
+				"%s already has %d screenshot(s); uploading %d more would exceed App Store screenshot set limit %d. Pass --replace to replace existing screenshots or --max-screenshots %d to upload only the remaining slot(s)",
+				setLabel,
+				len(existingScreenshots),
+				len(files),
+				appScreenshotSetMaxScreenshots,
+				max(0, appScreenshotSetMaxScreenshots-len(existingScreenshots)),
+			)
 		}
 		return files, nil
 	}
@@ -747,10 +766,6 @@ func limitScreenshotUploadFilesForExistingSet(files []string, maxScreenshots int
 	if remaining <= 0 {
 		if len(files) == 0 {
 			return files, nil
-		}
-		setLabel := strings.TrimSpace(setID)
-		if setLabel == "" {
-			setLabel = "target set"
 		}
 		return nil, fmt.Errorf(
 			"%s already has %d screenshot(s); --max-screenshots %d leaves no upload slots. Pass --replace to replace existing screenshots or choose a higher limit up to %d",
@@ -1689,7 +1704,7 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 	}
 
 	existingScreenshots := make([]asc.Resource[asc.AppScreenshotAttributes], 0)
-	if (cfg.SkipExisting || cfg.Replace || (cfg.MaxScreenshots > 0 && !cfg.Replace)) && set.ID != "" {
+	if (cfg.SkipExisting || cfg.Replace || (!cfg.Replace && len(cfg.Files) > 0)) && set.ID != "" {
 		fetchCtx, fetchCancel := cfg.RequestContext(ctx)
 		existingResp, err := cfg.Client.GetAppScreenshots(fetchCtx, set.ID)
 		fetchCancel()

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -597,11 +597,11 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		if err != nil {
 			return nil, err
 		}
-		if err := validateScreenshotDimensions(files, apiDisplayType); err != nil {
-			return nil, err
-		}
 		files, err = limitScreenshotUploadFiles(files, opts.MaxScreenshots, pathValue)
 		if err != nil {
+			return nil, err
+		}
+		if err := validateScreenshotDimensions(files, apiDisplayType); err != nil {
 			return nil, err
 		}
 		client, err := deps.GetClient()

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -21,6 +21,8 @@ var focusedScreenshotDisplayTypes = []string{
 	"APP_IPAD_PRO_3GEN_129",
 }
 
+const appScreenshotSetMaxScreenshots = 10
+
 var focusedScreenshotDisplayTypesByPlatform = map[string][]string{
 	"IOS":       focusedScreenshotDisplayTypes,
 	"MAC_OS":    {"APP_DESKTOP"},
@@ -93,6 +95,7 @@ type screenshotUploadCommandOptions struct {
 	SkipExisting          bool
 	Replace               bool
 	DryRun                bool
+	MaxScreenshots        int
 }
 
 type screenshotUploadDependencies struct {
@@ -407,6 +410,7 @@ func AssetsScreenshotsUploadCommand() *ffcli.Command {
 	skipExisting := fs.Bool("skip-existing", false, "Skip files whose MD5 checksum already exists in the target screenshot set")
 	replace := fs.Bool("replace", false, "Delete all existing screenshots from the target set before uploading")
 	dryRun := fs.Bool("dry-run", false, "Show what would be uploaded, skipped, or deleted without making changes")
+	maxScreenshots := fs.Int("max-screenshots", 0, "Upload only the first N sorted screenshots per set; must be 10 or less")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -432,6 +436,7 @@ Examples:
   asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65"
   asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --skip-existing
   asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --replace
+  asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --max-screenshots 10
   asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPHONE_65" --skip-existing --dry-run
   asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots" --device-type "IPAD_PRO_3GEN_129"
   asc screenshots upload --version-localization "VERSION_LOCALIZATION_ID" --path "./screenshots/en-US.png" --device-type "IPHONE_65"
@@ -481,6 +486,7 @@ Examples:
 				SkipExisting:          *skipExisting,
 				Replace:               *replace,
 				DryRun:                *dryRun,
+				MaxScreenshots:        *maxScreenshots,
 			}, screenshotUploadDependencies{
 				GetClient:        shared.GetASCClient,
 				RequestContext:   shared.ContextWithTimeout,
@@ -573,6 +579,12 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		fmt.Fprintln(os.Stderr, "Error: --skip-existing and --replace are mutually exclusive")
 		return nil, flag.ErrHelp
 	}
+	if opts.MaxScreenshots < 0 {
+		return nil, shared.UsageError("--max-screenshots must be zero or greater")
+	}
+	if opts.MaxScreenshots > appScreenshotSetMaxScreenshots {
+		return nil, shared.UsageError(fmt.Sprintf("--max-screenshots cannot exceed %d; App Store screenshot sets allow at most %d images", appScreenshotSetMaxScreenshots, appScreenshotSetMaxScreenshots))
+	}
 
 	displayType, err := normalizeScreenshotDisplayType(deviceValue)
 	if err != nil {
@@ -586,6 +598,10 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 			return nil, err
 		}
 		if err := validateScreenshotDimensions(files, apiDisplayType); err != nil {
+			return nil, err
+		}
+		files, err = limitScreenshotUploadFiles(files, opts.MaxScreenshots, pathValue)
+		if err != nil {
 			return nil, err
 		}
 		client, err := deps.GetClient()
@@ -613,6 +629,10 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 	}
 
 	localeAssets, err := collectLocaleAssetFiles(pathValue, apiDisplayType)
+	if err != nil {
+		return nil, err
+	}
+	localeAssets, err = limitScreenshotFanoutUploadFiles(localeAssets, opts.MaxScreenshots)
 	if err != nil {
 		return nil, err
 	}
@@ -655,6 +675,40 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		return &result, err
 	}
 	return &result, nil
+}
+
+func limitScreenshotUploadFiles(files []string, maxScreenshots int, source string) ([]string, error) {
+	if maxScreenshots > 0 {
+		if len(files) > maxScreenshots {
+			return append([]string(nil), files[:maxScreenshots]...), nil
+		}
+		return files, nil
+	}
+
+	if len(files) > appScreenshotSetMaxScreenshots {
+		return nil, fmt.Errorf(
+			"%q contains %d screenshots for one screenshot set; App Store screenshot sets allow at most %d images. Remove extra files or pass --max-screenshots %d to upload the first %d sorted files",
+			source,
+			len(files),
+			appScreenshotSetMaxScreenshots,
+			appScreenshotSetMaxScreenshots,
+			appScreenshotSetMaxScreenshots,
+		)
+	}
+	return files, nil
+}
+
+func limitScreenshotFanoutUploadFiles(localeAssets []screenshotLocaleAssetFiles, maxScreenshots int) ([]screenshotLocaleAssetFiles, error) {
+	limited := make([]screenshotLocaleAssetFiles, 0, len(localeAssets))
+	for _, item := range localeAssets {
+		files, err := limitScreenshotUploadFiles(item.Files, maxScreenshots, item.Locale)
+		if err != nil {
+			return nil, err
+		}
+		item.Files = files
+		limited = append(limited, item)
+	}
+	return limited, nil
 }
 
 func uploadScreenshotsFanout(ctx context.Context, cfg screenshotUploadFanoutConfig) (asc.AppScreenshotFanoutUploadResult, error) {

--- a/internal/cli/assets/assets_screenshots_fanout_test.go
+++ b/internal/cli/assets/assets_screenshots_fanout_test.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -510,6 +511,30 @@ func TestCollectLocaleAssetFilesRecursiveSkipsNonImageFiles(t *testing.T) {
 	}
 	if filepath.Base(files[0]) != "01-home.png" {
 		t.Fatalf("expected 01-home.png, got %q", files[0])
+	}
+}
+
+func TestCollectLocaleAssetFilesRecursiveWithLimitSortsBeforeValidation(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	for i := 1; i <= 10; i++ {
+		writeAssetsTestPNGWithSize(t, rootDir, fmt.Sprintf("%02d-home.png", i), 1242, 2688)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "11-corrupt.png"), []byte("not an image"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	files, err := collectLocaleAssetFilesRecursiveWithLimit(rootDir, asc.CanonicalScreenshotDisplayTypeForAPI("APP_IPHONE_65"), 10)
+	if err != nil {
+		t.Fatalf("collectLocaleAssetFilesRecursiveWithLimit() error: %v", err)
+	}
+	if len(files) != 10 {
+		t.Fatalf("expected 10 matching screenshot files, got %d", len(files))
+	}
+	if filepath.Base(files[0]) != "01-home.png" || filepath.Base(files[9]) != "10-home.png" {
+		t.Fatalf("expected first 10 sorted screenshots, got %#v", files)
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -144,7 +144,7 @@ func prepareAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	}
 
 	existingScreenshots := make([]asc.Resource[asc.AppScreenshotAttributes], 0)
-	if (cfg.SkipExisting || cfg.Replace) && set.ID != "" {
+	if (cfg.SkipExisting || cfg.Replace || (cfg.MaxScreenshots > 0 && !cfg.Replace)) && set.ID != "" {
 		fetchCtx, fetchCancel := cfg.RequestContext(ctx)
 		existingResp, err := cfg.Client.GetAppScreenshots(fetchCtx, set.ID)
 		fetchCancel()
@@ -162,6 +162,10 @@ func prepareAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 		if filterErr != nil {
 			return screenshotUploadPreparedState{}, filterErr
 		}
+	}
+	files, err = limitScreenshotUploadFilesForExistingSet(files, cfg.MaxScreenshots, existingScreenshots, cfg.Replace, set.ID)
+	if err != nil {
+		return screenshotUploadPreparedState{}, err
 	}
 
 	orderedIDs := make([]string, 0)
@@ -193,6 +197,9 @@ func prepareAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 }
 
 func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[asc.AppScreenshotUploadResult], artifactPath string) (asc.AppScreenshotUploadResult, error) {
+	if cfg.UploadContext == nil {
+		cfg.UploadContext = contextWithAssetUploadTimeout
+	}
 	prepared, err := prepareAppScreenshotUpload(ctx, cfg)
 	if err != nil {
 		return asc.AppScreenshotUploadResult{}, err

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -144,7 +144,7 @@ func prepareAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	}
 
 	existingScreenshots := make([]asc.Resource[asc.AppScreenshotAttributes], 0)
-	if (cfg.SkipExisting || cfg.Replace || (cfg.MaxScreenshots > 0 && !cfg.Replace)) && set.ID != "" {
+	if (cfg.SkipExisting || cfg.Replace || (!cfg.Replace && len(cfg.Files) > 0)) && set.ID != "" {
 		fetchCtx, fetchCancel := cfg.RequestContext(ctx)
 		existingResp, err := cfg.Client.GetAppScreenshots(fetchCtx, set.ID)
 		fetchCancel()

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -174,6 +174,8 @@ func TestExecuteAppScreenshotUploadOrderSyncFailureSurfacesOrderingError(t *test
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
 			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -383,6 +384,43 @@ func TestExecuteScreenshotUploadCommandMaxScreenshotsCapsBeforeDimensionValidati
 	for _, file := range gotFiles {
 		if strings.HasSuffix(file, "11-wrong-size.png") {
 			t.Fatalf("expected capped files to exclude wrong-size screenshot, got %#v", gotFiles)
+		}
+	}
+}
+
+func TestExecuteScreenshotUploadCommandMaxScreenshotsCapsBeforeImageValidation(t *testing.T) {
+	dir := t.TempDir()
+	for i := 1; i <= 10; i++ {
+		writeAssetsTestPNGWithSize(t, dir, fmt.Sprintf("%02d-home.png", i), 1242, 2688)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "11-corrupt.png"), []byte("not an image"), 0o644); err != nil {
+		t.Fatalf("write corrupt screenshot: %v", err)
+	}
+
+	var gotFiles []string
+	_, err := executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
+		VersionLocalizationID: "LOC_ID",
+		Path:                  dir,
+		DeviceType:            "IPHONE_65",
+		MaxScreenshots:        10,
+	}, screenshotUploadDependencies{
+		GetClient: func() (*asc.Client, error) {
+			return &asc.Client{}, nil
+		},
+		ExecuteUpload: func(_ context.Context, cfg screenshotUploadConfig[asc.AppScreenshotUploadResult], _ string) (asc.AppScreenshotUploadResult, error) {
+			gotFiles = append([]string(nil), cfg.Files...)
+			return asc.AppScreenshotUploadResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("executeScreenshotUploadCommand() error: %v", err)
+	}
+	if len(gotFiles) != 10 {
+		t.Fatalf("expected 10 capped files, got %d", len(gotFiles))
+	}
+	for _, file := range gotFiles {
+		if strings.HasSuffix(file, "11-corrupt.png") {
+			t.Fatalf("expected capped files to exclude corrupt screenshot, got %#v", gotFiles)
 		}
 	}
 }

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -219,6 +220,107 @@ func TestAssetsScreenshotsUploadCommandRejectsSkipExistingWithReplace(t *testing
 	}
 	if !strings.Contains(stderr, "--skip-existing and --replace are mutually exclusive") {
 		t.Fatalf("expected mutually exclusive error in stderr, got %q", stderr)
+	}
+}
+
+func TestExecuteScreenshotUploadCommandRejectsMoreThanTenScreenshotsBeforeAuth(t *testing.T) {
+	dir := t.TempDir()
+	for i := 1; i <= 11; i++ {
+		writeAssetsTestPNGWithSize(t, dir, fmt.Sprintf("%02d-home.png", i), 1242, 2688)
+	}
+
+	clientCalled := false
+	_, err := executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
+		VersionLocalizationID: "LOC_ID",
+		Path:                  dir,
+		DeviceType:            "IPHONE_65",
+	}, screenshotUploadDependencies{
+		GetClient: func() (*asc.Client, error) {
+			clientCalled = true
+			return &asc.Client{}, nil
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected screenshot-count error")
+	}
+	if !strings.Contains(err.Error(), "allow at most 10 images") {
+		t.Fatalf("expected max screenshot guidance, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "--max-screenshots 10") {
+		t.Fatalf("expected --max-screenshots guidance, got %v", err)
+	}
+	if clientCalled {
+		t.Fatal("expected local screenshot-count validation before auth/client creation")
+	}
+}
+
+func TestExecuteScreenshotUploadCommandRejectsMaxScreenshotsAboveAppleLimit(t *testing.T) {
+	clientCalled := false
+	_, err := executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
+		VersionLocalizationID: "LOC_ID",
+		Path:                  "unused",
+		DeviceType:            "IPHONE_65",
+		MaxScreenshots:        11,
+	}, screenshotUploadDependencies{
+		GetClient: func() (*asc.Client, error) {
+			clientCalled = true
+			return &asc.Client{}, nil
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected --max-screenshots validation error")
+	}
+	if !strings.Contains(err.Error(), "--max-screenshots cannot exceed 10") {
+		t.Fatalf("expected max-screenshots limit error, got %v", err)
+	}
+	if clientCalled {
+		t.Fatal("expected max-screenshots validation before auth/client creation")
+	}
+}
+
+func TestExecuteScreenshotUploadCommandMaxScreenshotsCapsSortedFiles(t *testing.T) {
+	dir := t.TempDir()
+	for i := 1; i <= 11; i++ {
+		writeAssetsTestPNGWithSize(t, dir, fmt.Sprintf("%02d-home.png", i), 1242, 2688)
+	}
+
+	var gotFiles []string
+	result, err := executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
+		VersionLocalizationID: "LOC_ID",
+		Path:                  dir,
+		DeviceType:            "IPHONE_65",
+		MaxScreenshots:        10,
+	}, screenshotUploadDependencies{
+		GetClient: func() (*asc.Client, error) {
+			return &asc.Client{}, nil
+		},
+		ExecuteUpload: func(_ context.Context, cfg screenshotUploadConfig[asc.AppScreenshotUploadResult], _ string) (asc.AppScreenshotUploadResult, error) {
+			gotFiles = append([]string(nil), cfg.Files...)
+			return asc.AppScreenshotUploadResult{
+				VersionLocalizationID: cfg.LocalizationID,
+				DisplayType:           cfg.DisplayType,
+				Total:                 len(cfg.Files),
+			}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("executeScreenshotUploadCommand() error: %v", err)
+	}
+	uploadResult, ok := result.(*asc.AppScreenshotUploadResult)
+	if !ok {
+		t.Fatalf("expected *asc.AppScreenshotUploadResult, got %T", result)
+	}
+	if uploadResult.Total != 10 {
+		t.Fatalf("expected capped result total 10, got %d", uploadResult.Total)
+	}
+	if len(gotFiles) != 10 {
+		t.Fatalf("expected 10 files passed to upload, got %d", len(gotFiles))
+	}
+	if !strings.HasSuffix(gotFiles[0], "01-home.png") || !strings.HasSuffix(gotFiles[9], "10-home.png") {
+		t.Fatalf("expected first 10 sorted screenshots, got %#v", gotFiles)
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -223,6 +223,32 @@ func TestAssetsScreenshotsUploadCommandRejectsSkipExistingWithReplace(t *testing
 	}
 }
 
+func TestAssetsScreenshotsUploadCommandRejectsMaxScreenshotsWithResume(t *testing.T) {
+	cmd := AssetsScreenshotsUploadCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--resume", ".asc/reports/screenshots-upload/failures.json",
+		"--max-screenshots", "10",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), cmd.FlagSet.Args())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "--resume cannot be combined with --skip-existing, --replace, --dry-run, or --max-screenshots") {
+		t.Fatalf("expected max-screenshots resume error in stderr, got %q", stderr)
+	}
+}
+
 func TestExecuteScreenshotUploadCommandRejectsMoreThanTenScreenshotsBeforeAuth(t *testing.T) {
 	dir := t.TempDir()
 	for i := 1; i <= 11; i++ {

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -257,23 +257,26 @@ func TestExecuteScreenshotUploadCommandRejectsMoreThanTenScreenshotsBeforeAuth(t
 
 func TestExecuteScreenshotUploadCommandRejectsMaxScreenshotsAboveAppleLimit(t *testing.T) {
 	clientCalled := false
-	_, err := executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
-		VersionLocalizationID: "LOC_ID",
-		Path:                  "unused",
-		DeviceType:            "IPHONE_65",
-		MaxScreenshots:        11,
-	}, screenshotUploadDependencies{
-		GetClient: func() (*asc.Client, error) {
-			clientCalled = true
-			return &asc.Client{}, nil
-		},
+	var err error
+	_, stderr := captureOutput(t, func() {
+		_, err = executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
+			VersionLocalizationID: "LOC_ID",
+			Path:                  "unused",
+			DeviceType:            "IPHONE_65",
+			MaxScreenshots:        11,
+		}, screenshotUploadDependencies{
+			GetClient: func() (*asc.Client, error) {
+				clientCalled = true
+				return &asc.Client{}, nil
+			},
+		})
 	})
 
-	if err == nil {
-		t.Fatal("expected --max-screenshots validation error")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "--max-screenshots cannot exceed 10") {
-		t.Fatalf("expected max-screenshots limit error, got %v", err)
+	if !strings.Contains(stderr, "--max-screenshots cannot exceed 10") {
+		t.Fatalf("expected max-screenshots limit error, got %q", stderr)
 	}
 	if clientCalled {
 		t.Fatal("expected max-screenshots validation before auth/client creation")
@@ -305,7 +308,6 @@ func TestExecuteScreenshotUploadCommandMaxScreenshotsCapsSortedFiles(t *testing.
 			}, nil
 		},
 	})
-
 	if err != nil {
 		t.Fatalf("executeScreenshotUploadCommand() error: %v", err)
 	}

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -326,6 +326,41 @@ func TestExecuteScreenshotUploadCommandMaxScreenshotsCapsSortedFiles(t *testing.
 	}
 }
 
+func TestExecuteScreenshotUploadCommandMaxScreenshotsCapsBeforeDimensionValidation(t *testing.T) {
+	dir := t.TempDir()
+	for i := 1; i <= 10; i++ {
+		writeAssetsTestPNGWithSize(t, dir, fmt.Sprintf("%02d-home.png", i), 1242, 2688)
+	}
+	writeAssetsTestPNGWithSize(t, dir, "11-wrong-size.png", 100, 100)
+
+	var gotFiles []string
+	_, err := executeScreenshotUploadCommand(context.Background(), screenshotUploadCommandOptions{
+		VersionLocalizationID: "LOC_ID",
+		Path:                  dir,
+		DeviceType:            "IPHONE_65",
+		MaxScreenshots:        10,
+	}, screenshotUploadDependencies{
+		GetClient: func() (*asc.Client, error) {
+			return &asc.Client{}, nil
+		},
+		ExecuteUpload: func(_ context.Context, cfg screenshotUploadConfig[asc.AppScreenshotUploadResult], _ string) (asc.AppScreenshotUploadResult, error) {
+			gotFiles = append([]string(nil), cfg.Files...)
+			return asc.AppScreenshotUploadResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("executeScreenshotUploadCommand() error: %v", err)
+	}
+	if len(gotFiles) != 10 {
+		t.Fatalf("expected 10 capped files, got %d", len(gotFiles))
+	}
+	for _, file := range gotFiles {
+		if strings.HasSuffix(file, "11-wrong-size.png") {
+			t.Fatalf("expected capped files to exclude wrong-size screenshot, got %#v", gotFiles)
+		}
+	}
+}
+
 func TestNormalizeScreenshotDisplayTypeAliasIPhone69Variants(t *testing.T) {
 	testCases := []struct {
 		input string

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestUploadScreenshotsSkipExistingStartsUploadTimeoutAfterChecksumFiltering(t *testing.T) {
@@ -230,5 +234,74 @@ func TestUploadScreenshotsDryRunWithSkipExistingReportsSkipped(t *testing.T) {
 	}
 	if !result.Results[0].Skipped {
 		t.Fatal("expected Skipped=true")
+	}
+}
+
+func TestExecuteAppScreenshotUploadMaxScreenshotsAccountsForExistingRemoteScreenshots(t *testing.T) {
+	dir := t.TempDir()
+	files := make([]string, 0, appScreenshotSetMaxScreenshots)
+	sizes := make(map[string]int64, appScreenshotSetMaxScreenshots)
+	for i := 1; i <= appScreenshotSetMaxScreenshots; i++ {
+		filePath := writeAssetsTestPNG(t, dir, fmt.Sprintf("%02d-home.png", i))
+		files = append(files, filePath)
+		sizes[filepath.Base(filePath)] = fileSize(t, filePath)
+	}
+
+	createCount := 0
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1","attributes":{"fileName":"old.png","fileSize":100}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1"}],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			createCount++
+			if createCount > appScreenshotSetMaxScreenshots-1 {
+				t.Fatalf("max-screenshots with one existing remote screenshot must upload at most 9 new files; got create %d", createCount)
+			}
+			name := fmt.Sprintf("%02d-home.png", createCount)
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"new-%d","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/new-%d","length":%d,"offset":0}]}}}`, createCount, createCount, sizes[name]))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/appScreenshots/"):
+			id := strings.TrimPrefix(req.URL.Path, "/v1/appScreenshots/")
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"uploaded":true}}}`, id))
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/appScreenshots/"):
+			id := strings.TrimPrefix(req.URL.Path, "/v1/appScreenshots/")
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"%s","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`, id))
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          files,
+		MaxScreenshots: appScreenshotSetMaxScreenshots,
+		Access:         appStoreVersionScreenshotSetAccess,
+		BuildResult: func(localizationID string, set asc.Resource[asc.AppScreenshotSetAttributes], dryRun bool, results []asc.AssetUploadResultItem) asc.AppScreenshotUploadResult {
+			return buildAppScreenshotUploadResult(localizationID, set, dryRun, results)
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("executeAppScreenshotUpload() error: %v", err)
+	}
+	if createCount != appScreenshotSetMaxScreenshots-1 {
+		t.Fatalf("expected 9 uploaded screenshots, got %d", createCount)
+	}
+	if result.Uploaded != appScreenshotSetMaxScreenshots-1 {
+		t.Fatalf("expected uploaded count 9, got %d", result.Uploaded)
 	}
 }

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -83,6 +83,8 @@ func TestUploadScreenshotsDryRunReportsWouldUpload(t *testing.T) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
 			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
 		default:
 			t.Fatalf("unexpected request in dry-run: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -303,5 +305,47 @@ func TestExecuteAppScreenshotUploadMaxScreenshotsAccountsForExistingRemoteScreen
 	}
 	if result.Uploaded != appScreenshotSetMaxScreenshots-1 {
 		t.Fatalf("expected uploaded count 9, got %d", result.Uploaded)
+	}
+}
+
+func TestExecuteAppScreenshotUploadRejectsAppendAboveScreenshotLimit(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		writeAssetsTestPNG(t, dir, "01-home.png"),
+		writeAssetsTestPNG(t, dir, "02-home.png"),
+	}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1"},{"type":"appScreenshots","id":"old-2"},{"type":"appScreenshots","id":"old-3"},{"type":"appScreenshots","id":"old-4"},{"type":"appScreenshots","id":"old-5"},{"type":"appScreenshots","id":"old-6"},{"type":"appScreenshots","id":"old-7"},{"type":"appScreenshots","id":"old-8"},{"type":"appScreenshots","id":"old-9"}],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			t.Fatal("must reject before creating screenshots when append would exceed the set limit")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	_, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          files,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, "")
+	if err == nil {
+		t.Fatal("expected screenshot set limit error")
+	}
+	if !strings.Contains(err.Error(), "would exceed App Store screenshot set limit 10") {
+		t.Fatalf("expected screenshot set limit error, got %v", err)
 	}
 }

--- a/internal/cli/cmdtest/assets_screenshots_upload_resume_test.go
+++ b/internal/cli/cmdtest/assets_screenshots_upload_resume_test.go
@@ -52,6 +52,10 @@ func TestRunScreenshotsUploadResumeRejectsExecutionModeFlags(t *testing.T) {
 			name: "dry-run",
 			args: []string{"--dry-run"},
 		},
+		{
+			name: "max-screenshots",
+			args: []string{"--max-screenshots", "5"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/cmdtest/assets_screenshots_upload_resume_test.go
+++ b/internal/cli/cmdtest/assets_screenshots_upload_resume_test.go
@@ -118,6 +118,11 @@ func TestRunScreenshotsUploadWritesFailureArtifactAndResumeCompletes(t *testing.
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
 			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			if phase == "resume" {
+				return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"new-1"}],"links":{}}`)
+			}
+			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			if phase == "resume" {
 				return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"new-1"}],"links":{}}`)
@@ -327,7 +332,11 @@ func TestRunScreenshotsUploadFanoutPrintsPartialResultsOnLocaleFailure(t *testin
 			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-fr","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-en/relationships/appScreenshots":
 			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-en/appScreenshots":
+			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-fr/relationships/appScreenshots":
+			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-fr/appScreenshots":
 			return screenshotsUploadJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
 			createCount++

--- a/internal/cli/cmdtest/assets_screenshots_upload_resume_test.go
+++ b/internal/cli/cmdtest/assets_screenshots_upload_resume_test.go
@@ -67,7 +67,7 @@ func TestRunScreenshotsUploadResumeRejectsExecutionModeFlags(t *testing.T) {
 				}
 			})
 
-			if !strings.Contains(stderr, "--resume cannot be combined with --skip-existing, --replace, or --dry-run") {
+			if !strings.Contains(stderr, "--resume cannot be combined with --skip-existing, --replace, --dry-run, or --max-screenshots") {
 				t.Fatalf("expected resume execution-mode conflict message, got %q", stderr)
 			}
 		})

--- a/internal/cli/cmdtest/product_pages_ppo_screenshot_sets_test.go
+++ b/internal/cli/cmdtest/product_pages_ppo_screenshot_sets_test.go
@@ -112,6 +112,8 @@ func TestProductPagesExperimentTreatmentLocalizationScreenshotSetsUploadSuccessJ
 				t.Fatalf("expected PPO relationship in body, got %s", string(body))
 			}
 			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":

--- a/internal/cli/cmdtest/screenshots_plan_apply_test.go
+++ b/internal/cli/cmdtest/screenshots_plan_apply_test.go
@@ -252,6 +252,8 @@ func TestScreenshotsApplyUploadsApprovedArtifacts(t *testing.T) {
 			return statusJSONResponse(`{"data":[{"type":"appStoreVersionLocalizations","id":"LOC_123","attributes":{"locale":"en-US"}}]}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
 			return statusJSONResponse(`{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return statusJSONResponse(`{"data":[],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			return statusJSONResponse(`{"data":[],"links":{}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -119,8 +119,14 @@ func TestXcodeExportHelpMentionsDirectUploadMode(t *testing.T) {
 	if !strings.Contains(exportCmd.LongHelp, "without writing a local") {
 		t.Fatalf("expected long help to explain no local IPA is written, got %q", exportCmd.LongHelp)
 	}
+	if !strings.Contains(exportCmd.LongHelp, "--timeout 10m") {
+		t.Fatalf("expected long help to show local export timeout usage, got %q", exportCmd.LongHelp)
+	}
 	if got := exportCmd.FlagSet.Lookup("ipa-path").Usage; !strings.Contains(got, "when one is produced") {
 		t.Fatalf("expected ipa-path usage to mention produced IPA behavior, got %q", got)
+	}
+	if exportCmd.FlagSet.Lookup("timeout") == nil {
+		t.Fatal("expected xcode export to expose --timeout")
 	}
 }
 

--- a/internal/cli/productpages/experiment_treatment_localization_media_upload_test.go
+++ b/internal/cli/productpages/experiment_treatment_localization_media_upload_test.go
@@ -40,6 +40,8 @@ func TestExecuteExperimentTreatmentLocalizationScreenshotUpload_UploadCreatesSet
 				t.Fatalf("expected PPO treatment-localization relationship in body, got %s", string(body))
 			}
 			return customPageJSONResponse(http.StatusCreated, `{"data":{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return customPageJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			return customPageJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
@@ -135,6 +137,8 @@ func TestExecuteExperimentTreatmentLocalizationScreenshotUpload_CanonicalizesAli
 			}
 			createdSetDisplayType = payload.Data.Attributes.ScreenshotDisplayType
 			return customPageJSONResponse(http.StatusCreated, `{"data":{"type":"appScreenshotSets","id":"set-69","attributes":{"screenshotDisplayType":"APP_IPHONE_67"}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-69/appScreenshots":
+			return customPageJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-69/relationships/appScreenshots":
 			return customPageJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
@@ -190,6 +194,8 @@ func TestExecuteExperimentTreatmentLocalizationScreenshotUpload_UploadPreservesE
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionExperimentTreatmentLocalizations/tloc-1/appScreenshotSets":
 			return customPageJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return customPageJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1"},{"type":"appScreenshots","id":"old-2"}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			return customPageJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"old-1"},{"type":"appScreenshots","id":"old-2"}]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
@@ -373,6 +379,8 @@ func TestExecuteExperimentTreatmentLocalizationScreenshotUpload_UsesRequestTimeo
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionExperimentTreatmentLocalizations/tloc-1/appScreenshotSets":
 			metadataRemaining = time.Until(deadline)
 			return customPageJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return customPageJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			return customPageJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -2,6 +2,7 @@ package xcode
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -172,6 +173,7 @@ func XcodeExportCommand() *ffcli.Command {
 	overwrite := fs.Bool("overwrite", false, "Replace an existing IPA at --ipa-path")
 	wait := fs.Bool("wait", false, "Wait for App Store Connect build discovery and processing when export uploads directly")
 	pollInterval := fs.Duration("poll-interval", shared.PublishDefaultPollInterval, "Polling interval for --wait when waiting for uploaded builds")
+	timeout := fs.Duration("timeout", 0, "Maximum duration for xcodebuild -exportArchive (0 disables local export timeout)")
 	var xcodebuildFlags shared.MultiStringFlag
 	fs.Var(&xcodebuildFlags, "xcodebuild-flag", "Pass a raw argument through to xcodebuild (repeatable)")
 	output := shared.BindOutputFlags(fs)
@@ -191,6 +193,7 @@ finishes processing.
 
 Examples:
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options ExportOptions.plist --ipa-path .asc/artifacts/App.ipa
+  asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options ExportOptions.plist --ipa-path .asc/artifacts/App.ipa --timeout 10m
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options UploadExportOptions.plist --ipa-path .asc/artifacts/App.ipa --wait
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options ExportOptions.plist --ipa-path .asc/artifacts/App.ipa --xcodebuild-flag=-allowProvisioningUpdates --output json`,
 		FlagSet:   fs,
@@ -215,13 +218,25 @@ Examples:
 			if *wait && *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
 			}
+			if *timeout < 0 {
+				return shared.UsageError("--timeout must be zero or greater")
+			}
 			exportOptionsPath := strings.TrimSpace(*exportOptions)
 			if *wait && !isDirectUploadExportOptionsFn(exportOptionsPath) {
 				return shared.UsageError("--wait requires ExportOptions.plist with destination=upload")
 			}
 
+			exportCtx := ctx
+			var exportCancel context.CancelFunc
+			if *timeout > 0 {
+				exportCtx, exportCancel = context.WithTimeout(ctx, *timeout)
+			}
+			if exportCancel != nil {
+				defer exportCancel()
+			}
+
 			exportStartedAt := time.Now()
-			result, err := runExport(ctx, localxcode.ExportOptions{
+			result, err := runExport(exportCtx, localxcode.ExportOptions{
 				ArchivePath:    strings.TrimSpace(*archivePath),
 				ExportOptions:  exportOptionsPath,
 				IPAPath:        strings.TrimSpace(*ipaPath),
@@ -230,6 +245,9 @@ Examples:
 				LogWriter:      os.Stderr,
 			})
 			if err != nil {
+				if *timeout > 0 && errors.Is(err, context.DeadlineExceeded) {
+					return fmt.Errorf("xcode export: timed out after %s while running xcodebuild -exportArchive: %w", timeout.String(), err)
+				}
 				return fmt.Errorf("xcode export: %w", err)
 			}
 			exportCompletedAt := time.Now()

--- a/internal/cli/xcode/xcode_test.go
+++ b/internal/cli/xcode/xcode_test.go
@@ -247,6 +247,116 @@ func TestXcodeExportAllowsPollIntervalWithoutWait(t *testing.T) {
 	}
 }
 
+func TestXcodeExportRejectsNegativeTimeout(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--export-options", "ExportOptions.plist",
+		"--ipa-path", "Demo.ipa",
+		"--timeout", "-1s",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatal("expected flag.ErrHelp for negative timeout")
+	}
+	if !strings.Contains(stderr, "Error: --timeout must be zero or greater") {
+		t.Fatalf("expected timeout usage error, got %q", stderr)
+	}
+}
+
+func TestXcodeExportPassesTimeoutContextToLocalExport(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runExport = func(ctx context.Context, opts localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected export context deadline")
+		}
+		if time.Until(deadline) <= 0 {
+			t.Fatalf("expected future deadline, got %s", deadline)
+		}
+		return &localxcode.ExportResult{
+			ArchivePath: opts.ArchivePath,
+			IPAPath:     opts.IPAPath,
+			BundleID:    "com.example.demo",
+			Version:     "1.2.3",
+			BuildNumber: "42",
+		}, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--export-options", "ExportOptions.plist",
+		"--ipa-path", "Demo.ipa",
+		"--timeout", "10s",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr != nil {
+		t.Fatalf("Exec() error: %v", runErr)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatal("expected JSON output")
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+}
+
+func TestXcodeExportReportsTimeout(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runExport = func(ctx context.Context, _ localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--export-options", "ExportOptions.plist",
+		"--ipa-path", "Demo.ipa",
+		"--timeout", "1ms",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	_, _ = captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(runErr.Error(), "timed out after 1ms while running xcodebuild -exportArchive") {
+		t.Fatalf("expected timeout guidance, got %v", runErr)
+	}
+}
+
 func TestXcodeExportWaitPollsForUploadedBuild(t *testing.T) {
 	restore := overrideXcodeCommandTestHooks(t)
 	defer restore()

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -993,6 +993,22 @@ func runCommandWithTail(ctx context.Context, name string, args []string, logWrit
 	cmd.Stderr = writer
 	if err := cmd.Run(); err != nil {
 		detail := strings.TrimSpace(outputTail.String())
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if detail != "" {
+				if outputTail.Truncated() {
+					return fmt.Errorf(
+						"%s %s timed out or was canceled (showing last %d bytes): %s: %w",
+						commandLabel,
+						action,
+						xcodebuildErrorTailLimit,
+						detail,
+						ctxErr,
+					)
+				}
+				return fmt.Errorf("%s %s timed out or was canceled: %s: %w", commandLabel, action, detail, ctxErr)
+			}
+			return fmt.Errorf("%s %s timed out or was canceled: %w", commandLabel, action, ctxErr)
+		}
 		if detail != "" {
 			if outputTail.Truncated() {
 				return fmt.Errorf(


### PR DESCRIPTION
## Summary

- 

## Validation

- [ ] `make format`
- [ ] `make check-docs`
- [ ] `make lint`
- [ ] `ASC_BYPASS_KEYCHAIN=1 make test`

If this PR only updates `docs/wall-of-apps.json`, use `make check-wall-of-apps` instead of the full checklist above.

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I used `asc apps wall submit --app "1234567890" --confirm` (or made the equivalent single-file update manually)
- [ ] This PR only updates `docs/wall-of-apps.json`
- [ ] I ran `make check-wall-of-apps`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforce a 10-image per App Store screenshot set and add --max-screenshots to upload only the first N (N≤10), accounting for existing remote screenshots.

* **Bug Fixes**
  * Improved validation and clearer error messages for exceeding screenshot limits and for incompatible flags (e.g., --resume with execution-mode flags).
  * Local export now supports a --timeout to bound Xcode export duration and reports timeouts clearly.

* **Documentation**
  * Updated examples and workflows to show screenshot limits and export timeout usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rorkai/App-Store-Connect-CLI/pull/1583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->