### PR TITLE
apps wall: add Vaultaire: Photo Vault

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1416,6 +1416,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c0/a4/8e/c0a48e40-32c3-8e31-6779-9b75593d9e38/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Vaultaire: Photo Vault",
+    "link": "https://apps.apple.com/us/app/vaultaire-photo-vault/id6758529311?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3f/90/6f/3f906ff7-be78-e596-b72c-c5dee3bb0b7c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Video Annotation",
     "link": "https://apps.apple.com/us/app/video-annotation/id6758316355",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/c3/a9/43c3a9e9-e32b-081c-8a8b-a4f401846771/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Vaultaire: Photo Vault` to the Wall of Apps

## Entry

- App ID: 6758529311
- App: Vaultaire: Photo Vault
- Link: https://apps.apple.com/us/app/vaultaire-photo-vault/id6758529311?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Vaultaire: Photo Vault" application entry to the featured apps list, including App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->