### PR TITLE
[codex] Add voice 2FA phone mode regression coverage

### DIFF
--- a/internal/appleauth/twofactor_test.go
+++ b/internal/appleauth/twofactor_test.go
@@ -343,3 +343,70 @@ func TestSubmitTwoFactorCodeRejectsPreparedPhoneFlowWithoutPhoneID(t *testing.T)
 		t.Fatal("did not expect finalize after rejected phone submission")
 	}
 }
+
+func TestSubmitTwoFactorCodeUsesVoicePushModeFromAuthOptions(t *testing.T) {
+	session := &stubSessionState{}
+	requestedPhoneCode := false
+	submittedPhoneCode := false
+	finalized := false
+
+	err := SubmitTwoFactorCode(
+		context.Background(),
+		session,
+		"123456",
+		func(context.Context) (*AuthOptions, error) {
+			return &AuthOptions{
+				NoTrustedDevices: true,
+				TrustedPhoneNumbers: []TrustedPhoneNumber{
+					{ID: 7, PushMode: "voice", NumberWithDialCode: "+1 (•••) •••-••66"},
+				},
+			}, nil
+		},
+		func(ctx context.Context, phoneID int, mode string) error {
+			requestedPhoneCode = true
+			if phoneID != 7 {
+				t.Fatalf("expected phone id 7, got %d", phoneID)
+			}
+			if mode != "voice" {
+				t.Fatalf("expected phone request mode voice, got %q", mode)
+			}
+			return nil
+		},
+		func(context.Context, string) error {
+			t.Fatal("did not expect trusted-device submission for phone-only flow")
+			return nil
+		},
+		func(ctx context.Context, code string, phoneID int, mode string) error {
+			submittedPhoneCode = true
+			if code != "123456" {
+				t.Fatalf("expected 2fa code 123456, got %q", code)
+			}
+			if phoneID != 7 {
+				t.Fatalf("expected phone id 7, got %d", phoneID)
+			}
+			if mode != "voice" {
+				t.Fatalf("expected phone verification mode voice, got %q", mode)
+			}
+			return nil
+		},
+		func(context.Context) error {
+			finalized = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected successful phone verification, got %v", err)
+	}
+	if !requestedPhoneCode {
+		t.Fatal("expected phone delivery request")
+	}
+	if !submittedPhoneCode {
+		t.Fatal("expected phone verification submission")
+	}
+	if !finalized {
+		t.Fatal("expected finalize after phone verification")
+	}
+	if session.phoneMode != "voice" {
+		t.Fatalf("expected session to remember voice mode, got %q", session.phoneMode)
+	}
+}

--- a/internal/iris/auth_test.go
+++ b/internal/iris/auth_test.go
@@ -357,12 +357,16 @@ func TestSubmitTwoFactorCodeUsesPreparedPhoneFlow(t *testing.T) {
 						PhoneNumber struct {
 							ID int `json:"id"`
 						} `json:"phoneNumber"`
+						Mode string `json:"mode"`
 					}
 					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 						t.Fatalf("decode phone delivery payload: %v", err)
 					}
 					if payload.PhoneNumber.ID != 7 {
 						t.Fatalf("expected delivery phone id 7, got %d", payload.PhoneNumber.ID)
+					}
+					if payload.Mode != "voice" {
+						t.Fatalf("expected delivery mode voice, got %q", payload.Mode)
 					}
 					return &http.Response{
 						StatusCode: http.StatusNoContent,
@@ -388,8 +392,8 @@ func TestSubmitTwoFactorCodeUsesPreparedPhoneFlow(t *testing.T) {
 					if payload.SecurityCode.Code != "123456" {
 						t.Fatalf("expected 2fa code 123456, got %q", payload.SecurityCode.Code)
 					}
-					if payload.Mode != "sms" {
-						t.Fatalf("expected sms mode, got %q", payload.Mode)
+					if payload.Mode != "voice" {
+						t.Fatalf("expected voice mode, got %q", payload.Mode)
 					}
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -422,7 +426,7 @@ func TestSubmitTwoFactorCodeUsesPreparedPhoneFlow(t *testing.T) {
 		SCNT:                 "scnt-token",
 		twoFactorMethod:      twoFactorMethodPhone,
 		twoFactorPhoneID:     7,
-		twoFactorPhoneMode:   "sms",
+		twoFactorPhoneMode:   "voice",
 		twoFactorDestination: "+1 (•••) •••-••66",
 	}
 

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -421,12 +421,16 @@ func TestSubmitTwoFactorCodeUsesPreparedPhoneFlow(t *testing.T) {
 						PhoneNumber struct {
 							ID int `json:"id"`
 						} `json:"phoneNumber"`
+						Mode string `json:"mode"`
 					}
 					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 						t.Fatalf("decode phone delivery payload: %v", err)
 					}
 					if payload.PhoneNumber.ID != 7 {
 						t.Fatalf("expected delivery phone id 7, got %d", payload.PhoneNumber.ID)
+					}
+					if payload.Mode != "voice" {
+						t.Fatalf("expected delivery mode voice, got %q", payload.Mode)
 					}
 					return &http.Response{
 						StatusCode: http.StatusNoContent,
@@ -452,8 +456,8 @@ func TestSubmitTwoFactorCodeUsesPreparedPhoneFlow(t *testing.T) {
 					if payload.SecurityCode.Code != "123456" {
 						t.Fatalf("expected 2fa code 123456, got %q", payload.SecurityCode.Code)
 					}
-					if payload.Mode != "sms" {
-						t.Fatalf("expected sms mode, got %q", payload.Mode)
+					if payload.Mode != "voice" {
+						t.Fatalf("expected voice mode, got %q", payload.Mode)
 					}
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -486,7 +490,7 @@ func TestSubmitTwoFactorCodeUsesPreparedPhoneFlow(t *testing.T) {
 		SCNT:                 "scnt-token",
 		twoFactorMethod:      twoFactorMethodPhone,
 		twoFactorPhoneID:     7,
-		twoFactorPhoneMode:   "sms",
+		twoFactorPhoneMode:   "voice",
 		twoFactorDestination: "+1 (•••) •••-••66",
 	}
 


### PR DESCRIPTION
## Summary

- Add a shared Apple 2FA regression test proving `trustedPhoneNumbers[].pushMode = "voice"` is preserved from auth options through phone-code request and verification.
- Update web and IRIS prepared phone-flow tests to assert both `PUT /verify/phone` and `POST /verify/phone/securitycode` send `mode: "voice"`.

## Validation

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/appleauth ./internal/web ./internal/iris`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added and updated two-factor authentication tests to verify voice delivery mode for sending authentication codes instead of SMS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->