### PR TITLE
[codex] Validate review demo password length

### DIFF
--- a/internal/cli/cmdtest/review_details_validation_test.go
+++ b/internal/cli/cmdtest/review_details_validation_test.go
@@ -239,6 +239,54 @@ func TestReviewDetailsUpdateRejectsOverlongDemoAccountPassword(t *testing.T) {
 	}
 }
 
+func TestReviewDetailsUpdateAcceptsMaxLengthDemoAccountPassword(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreReviewDetails/detail-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		body := string(payload)
+		if !strings.Contains(body, `"demoAccountPassword":"`+strings.Repeat("p", 100)+`"`) {
+			t.Fatalf("expected max-length demo account password in body, got %s", body)
+		}
+		return jsonResponse(http.StatusOK, `{"data":{"type":"appStoreReviewDetails","id":"detail-1","attributes":{"demoAccountPassword":"`+strings.Repeat("p", 100)+`"}}}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"review", "details-update",
+			"--id", "detail-1",
+			"--demo-account-password", strings.Repeat("p", 100),
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"detail-1"`) {
+		t.Fatalf("expected detail id in output, got %q", stdout)
+	}
+}
+
 func TestRunReviewDetailsRejectsOverlongDemoAccountPasswordWithUsageExit(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_KEY_ID", "")

--- a/internal/cli/cmdtest/review_details_validation_test.go
+++ b/internal/cli/cmdtest/review_details_validation_test.go
@@ -111,6 +111,46 @@ func TestReviewDetailsCreateAllowsDemoAccountRequiredWithBothCredentials(t *test
 	}
 }
 
+func TestReviewDetailsCreateRejectsOverlongDemoAccountPassword(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"review", "details-create",
+			"--version-id", "version-1",
+			"--demo-account-password", strings.Repeat("p", 101),
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--demo-account-password must be 100 characters or fewer") {
+		t.Fatalf("expected local demo account password length error, got %q", stderr)
+	}
+}
+
 func TestReviewDetailsUpdateRejectsDemoAccountRequiredWhenExistingCredentialsAreIncomplete(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -154,6 +194,46 @@ func TestReviewDetailsUpdateRejectsDemoAccountRequiredWhenExistingCredentialsAre
 	}
 	if !strings.Contains(stderr, "--demo-account-required=true requires both --demo-account-name and --demo-account-password") {
 		t.Fatalf("expected local demo credential validation error, got %q", stderr)
+	}
+}
+
+func TestReviewDetailsUpdateRejectsOverlongDemoAccountPassword(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"review", "details-update",
+			"--id", "detail-1",
+			"--demo-account-password", strings.Repeat("p", 101),
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--demo-account-password must be 100 characters or fewer") {
+		t.Fatalf("expected local demo account password length error, got %q", stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/review_details_validation_test.go
+++ b/internal/cli/cmdtest/review_details_validation_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestReviewDetailsCreateRejectsDemoAccountRequiredWithoutCredentials(t *testing.T) {
@@ -234,6 +236,54 @@ func TestReviewDetailsUpdateRejectsOverlongDemoAccountPassword(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "--demo-account-password must be 100 characters or fewer") {
 		t.Fatalf("expected local demo account password length error, got %q", stderr)
+	}
+}
+
+func TestRunReviewDetailsRejectsOverlongDemoAccountPasswordWithUsageExit(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "details-create",
+			args: []string{
+				"review", "details-create",
+				"--version-id", "version-1",
+				"--demo-account-password", strings.Repeat("p", 101),
+			},
+		},
+		{
+			name: "details-update",
+			args: []string{
+				"review", "details-update",
+				"--id", "detail-1",
+				"--demo-account-password", strings.Repeat("p", 101),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				code := cmd.Run(test.args, "1.2.3")
+				if code != cmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "--demo-account-password must be 100 characters or fewer") {
+				t.Fatalf("expected local demo account password length error, got %q", stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/reviews/review_details.go
+++ b/internal/cli/reviews/review_details.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -19,6 +20,8 @@ const (
 	reviewDetailDemoAccountRequiredUsage = "Set true only when App Review needs demo credentials; leave false when reviewer guidance in --notes is enough"
 	reviewDetailNotesUsage               = "Review notes for reviewer instructions or context; supplemental when demo credentials are required"
 	reviewDetailDemoCredentialsError     = "Error: --demo-account-required=true requires both --demo-account-name and --demo-account-password"
+	reviewDetailDemoPasswordLengthError  = "Error: --demo-account-password must be 100 characters or fewer"
+	reviewDetailDemoPasswordMaxLength    = 100
 )
 
 // ReviewDetailsGetCommand returns the review details get subcommand.
@@ -176,6 +179,10 @@ Examples:
 				if err := validateReviewDetailDemoCredentialValues(strings.TrimSpace(*demoAccountName), strings.TrimSpace(*demoAccountPassword)); err != nil {
 					return err
 				}
+			} else if visited["demo-account-password"] {
+				if err := validateReviewDetailDemoPasswordLength(strings.TrimSpace(*demoAccountPassword)); err != nil {
+					return err
+				}
 			}
 
 			var attrsPtr *asc.AppStoreReviewDetailCreateAttributes
@@ -279,6 +286,11 @@ Examples:
 			if !hasReviewDetailUpdates(visited) {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
 				return flag.ErrHelp
+			}
+			if visited["demo-account-password"] {
+				if err := validateReviewDetailDemoPasswordLength(strings.TrimSpace(*demoAccountPassword)); err != nil {
+					return err
+				}
 			}
 
 			client, err := shared.GetASCClient()
@@ -391,10 +403,19 @@ func validateReviewDetailUpdateDemoCredentials(
 }
 
 func validateReviewDetailDemoCredentialValues(demoAccountName, demoAccountPassword string) error {
-	if strings.TrimSpace(demoAccountName) != "" && strings.TrimSpace(demoAccountPassword) != "" {
+	if strings.TrimSpace(demoAccountName) == "" || strings.TrimSpace(demoAccountPassword) == "" {
+		fmt.Fprintln(os.Stderr, reviewDetailDemoCredentialsError)
+		return flag.ErrHelp
+	}
+
+	return validateReviewDetailDemoPasswordLength(demoAccountPassword)
+}
+
+func validateReviewDetailDemoPasswordLength(demoAccountPassword string) error {
+	if utf8.RuneCountInString(strings.TrimSpace(demoAccountPassword)) <= reviewDetailDemoPasswordMaxLength {
 		return nil
 	}
 
-	fmt.Fprintln(os.Stderr, reviewDetailDemoCredentialsError)
+	fmt.Fprintln(os.Stderr, reviewDetailDemoPasswordLengthError)
 	return flag.ErrHelp
 }

--- a/internal/cli/reviews/review_details.go
+++ b/internal/cli/reviews/review_details.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	reviewDetailDemoAccountNameUsage     = "Demo account name when demo credentials are required"
-	reviewDetailDemoAccountPasswordUsage = "Demo account password when demo credentials are required"
+	reviewDetailDemoAccountPasswordUsage = "Demo account password when demo credentials are required; 100 characters or fewer"
 	reviewDetailDemoAccountRequiredUsage = "Set true only when App Review needs demo credentials; leave false when reviewer guidance in --notes is enough"
 	reviewDetailNotesUsage               = "Review notes for reviewer instructions or context; supplemental when demo credentials are required"
 	reviewDetailDemoCredentialsError     = "Error: --demo-account-required=true requires both --demo-account-name and --demo-account-password"


### PR DESCRIPTION
## Summary
- Reject App Store review demo account passwords longer than 100 characters in `review details-create` and `review details-update`.
- Keep the validation local so the CLI returns usage exit code 2 before auth or API work.
- Add command-level regression tests that assert stdout, stderr, exit behavior, and no HTTP request.

## Validation
- `go run . review details-create --help`
- `go run . review details-update --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestReviewDetails(Create|Update)RejectsOverlongDemoAccountPassword'`\n- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/reviews ./internal/cli/cmdtest -run 'TestReviewDetails'`\n- `make format`\n- `make check-command-docs`\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n- `go build -o /tmp/asc . && /tmp/asc review details-create --version-id version-1 --demo-account-password <101 chars>` exits 2 with the local validation error\n\n## Notes\n- `docs/openapi/latest.json` lists `demoAccountPassword` as a string/nullable string without `maxLength`, so this covers Apple runtime validation that is not encoded in the OpenAPI snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demo account passwords are now validated with a strict 100-character maximum length limit in review details commands.
  * Improved error messages for password validation failures to provide clearer feedback.

* **Tests**
  * Added comprehensive test coverage for demo account password validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->