### PR TITLE
[codex] Reject duplicate screenshot fan-out names

### DIFF
--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -1152,6 +1152,9 @@ func canonicalizeUniqueScreenshotFanoutLocaleAssets(localeAssets []screenshotLoc
 		if err := registerUniqueCanonicalFanoutLocale(canonicalLocale, item.Locale, "fan-out upload", "inputs", seen); err != nil {
 			return nil, err
 		}
+		if err := validateUniqueScreenshotUploadFileNames(item.Files); err != nil {
+			return nil, fmt.Errorf("locale %s: %w", canonicalLocale, err)
+		}
 		result = append(result, screenshotLocaleAssetFiles{
 			Locale: canonicalLocale,
 			Files:  item.Files,

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -1035,6 +1035,9 @@ func collectLocaleAssetFilesRecursiveWithLimit(rootPath, displayType string, max
 		return nil, fmt.Errorf("no screenshot files matching %s found in %q", displayType, rootPath)
 	}
 	sort.Strings(files)
+	if err := validateUniqueScreenshotUploadFileNames(files); err != nil {
+		return nil, err
+	}
 	return files, nil
 }
 
@@ -1063,7 +1066,28 @@ func collectLimitedLocaleAssetFilesRecursive(rootPath, displayType string, maxSc
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no screenshot files matching %s found in %q", displayType, rootPath)
 	}
+	if err := validateUniqueScreenshotUploadFileNames(files); err != nil {
+		return nil, err
+	}
 	return files, nil
+}
+
+func validateUniqueScreenshotUploadFileNames(files []string) error {
+	seen := make(map[string]string, len(files))
+	for _, filePath := range files {
+		fileName := filepath.Base(filePath)
+		key := strings.ToLower(fileName)
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf(
+				"duplicate screenshot file name %q (%q, %q); App Store screenshot ordering uses uploaded file names, so rename one file before uploading",
+				fileName,
+				previous,
+				filePath,
+			)
+		}
+		seen[key] = filePath
+	}
+	return nil
 }
 
 func collectSupportedScreenshotCandidateFiles(rootPath string) ([]string, error) {

--- a/internal/cli/assets/assets_screenshots_fanout_test.go
+++ b/internal/cli/assets/assets_screenshots_fanout_test.go
@@ -652,3 +652,47 @@ func TestUploadScreenshotsFanoutRejectsDuplicateLocaleAssets(t *testing.T) {
 		t.Fatalf("expected duplicate locale upload error, got %v", err)
 	}
 }
+
+func TestUploadScreenshotsFanoutRejectsDuplicateLocaleAssetFileNames(t *testing.T) {
+	rootDir := t.TempDir()
+	firstDir := filepath.Join(rootDir, "iphone-a")
+	secondDir := filepath.Join(rootDir, "iphone-b")
+	if err := os.MkdirAll(firstDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.MkdirAll(secondDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	firstPath := writeAssetsTestPNGWithSize(t, firstDir, "01-home.png", 1242, 2688)
+	secondPath := writeAssetsTestPNGWithSize(t, secondDir, "01-home.png", 1242, 2688)
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request before duplicate file name validation: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	_, err := uploadScreenshotsFanout(context.Background(), screenshotUploadFanoutConfig{
+		Client:    newAssetsUploadTestClient(t),
+		VersionID: "version-1",
+		LocaleAssets: []screenshotLocaleAssetFiles{
+			{Locale: "en-US", Files: []string{firstPath, secondPath}},
+		},
+		DisplayType: asc.CanonicalScreenshotDisplayTypeForAPI("APP_IPHONE_65"),
+	})
+	if err == nil {
+		t.Fatal("expected duplicate screenshot file name error")
+	}
+	for _, want := range []string{
+		`locale en-US: duplicate screenshot file name "01-home.png"`,
+		firstPath,
+		secondPath,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+}

--- a/internal/cli/assets/assets_screenshots_fanout_test.go
+++ b/internal/cli/assets/assets_screenshots_fanout_test.go
@@ -514,6 +514,37 @@ func TestCollectLocaleAssetFilesRecursiveSkipsNonImageFiles(t *testing.T) {
 	}
 }
 
+func TestCollectLocaleAssetFilesRecursiveRejectsDuplicateFileNames(t *testing.T) {
+	rootDir := t.TempDir()
+	firstDir := filepath.Join(rootDir, "iphone-a")
+	secondDir := filepath.Join(rootDir, "iphone-b")
+	if err := os.MkdirAll(firstDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.MkdirAll(secondDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	firstPath := filepath.Join(firstDir, "01-home.png")
+	secondPath := filepath.Join(secondDir, "01-home.png")
+	writeAssetsTestPNGWithSize(t, firstDir, "01-home.png", 1242, 2688)
+	writeAssetsTestPNGWithSize(t, secondDir, "01-home.png", 1242, 2688)
+
+	_, err := collectLocaleAssetFilesRecursive(rootDir, asc.CanonicalScreenshotDisplayTypeForAPI("APP_IPHONE_65"))
+	if err == nil {
+		t.Fatal("expected duplicate screenshot file name error")
+	}
+	for _, want := range []string{
+		`duplicate screenshot file name "01-home.png"`,
+		firstPath,
+		secondPath,
+		"rename one file",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+}
+
 func TestCollectLocaleAssetFilesRecursiveWithLimitSortsBeforeValidation(t *testing.T) {
 	rootDir := t.TempDir()
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- Reject recursive screenshot fan-out inputs that would upload multiple files with the same filename.
- Catch the ambiguity before client/auth/API work so upload ordering cannot become name-ambiguous.
- Add a regression covering two matching screenshots in different nested folders with the same basename.

## Validation
- `go run . screenshots upload --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets -run TestCollectLocaleAssetFilesRecursiveRejectsDuplicateFileNames`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets -run 'TestCollectLocaleAssetFilesRecursive|TestExecuteScreenshotUploadCommand'`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot uploads now validate for duplicate filenames using case-insensitive comparison during collection and upload processes. When duplicate filenames are detected, submissions are rejected with detailed error messages identifying the conflicting files and their locations, helping users resolve the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->