### PR TITLE
[codex] Sync screenshot order for skipped uploads

### DIFF
--- a/internal/cli/assets/assets_screenshot_order.go
+++ b/internal/cli/assets/assets_screenshot_order.go
@@ -27,14 +27,14 @@ func UploadScreenshotsToSet(ctx context.Context, client *asc.Client, setID strin
 		orderedIDs = append(orderedIDs, existingIDs...)
 	}
 
-	progress, err := uploadScreenshotsWithOrderState(ctx, client, setID, orderedIDs, files, false)
+	progress, err := uploadScreenshotsWithOrderState(ctx, client, setID, orderedIDs, files, false, true)
 	if err != nil {
 		return nil, err
 	}
 	return progress.Results, nil
 }
 
-func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, syncIfNoNew bool) (screenshotUploadProgress, error) {
+func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, syncIfNoNew, syncAfterUpload bool) (screenshotUploadProgress, error) {
 	progress := screenshotUploadProgress{
 		Results:    make([]asc.AssetUploadResultItem, 0, len(files)),
 		OrderedIDs: append([]string(nil), orderedIDs...),
@@ -55,6 +55,9 @@ func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 		return progress, nil
 	}
 	if len(progress.Results) == 0 && !syncIfNoNew {
+		return progress, nil
+	}
+	if !syncAfterUpload {
 		return progress, nil
 	}
 	if err := SetOrderedAppScreenshots(ctx, client, setID, progress.OrderedIDs); err != nil {

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -1828,6 +1828,11 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 		}
 		results = append(results, uploadedResults...)
 	}
+	if cfg.SkipExisting && len(skippedResults) > 0 {
+		if err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, set.ID, cfg.Files, skippedResults, results); err != nil {
+			return zero, err
+		}
+	}
 	results = append(skippedResults, results...)
 
 	return cfg.BuildResult(cfg.LocalizationID, set, false, results), nil
@@ -1843,13 +1848,15 @@ func deleteExistingScreenshots(ctx context.Context, client *asc.Client, screensh
 }
 
 func filterExistingScreenshotFiles(files []string, screenshots []asc.Resource[asc.AppScreenshotAttributes]) ([]string, []asc.AssetUploadResultItem, error) {
-	existingChecksums := make(map[string]struct{}, len(screenshots))
+	existingByChecksum := make(map[string]asc.Resource[asc.AppScreenshotAttributes], len(screenshots))
 	for _, screenshot := range screenshots {
 		checksum := strings.TrimSpace(screenshot.Attributes.SourceFileChecksum)
 		if checksum == "" {
 			continue
 		}
-		existingChecksums[checksum] = struct{}{}
+		if _, exists := existingByChecksum[checksum]; !exists {
+			existingByChecksum[checksum] = screenshot
+		}
 	}
 
 	filtered := make([]string, 0, len(files))
@@ -1859,10 +1866,11 @@ func filterExistingScreenshotFiles(files []string, screenshots []asc.Resource[as
 		if err != nil {
 			return nil, nil, err
 		}
-		if _, exists := existingChecksums[checksum]; exists {
+		if existing, exists := existingByChecksum[checksum]; exists {
 			skipped = append(skipped, asc.AssetUploadResultItem{
 				FileName: filepath.Base(filePath),
 				FilePath: filePath,
+				AssetID:  existing.ID,
 				State:    "skipped",
 				Skipped:  true,
 			})
@@ -1872,6 +1880,76 @@ func filterExistingScreenshotFiles(files []string, screenshots []asc.Resource[as
 	}
 
 	return filtered, skipped, nil
+}
+
+func syncSkippedScreenshotOrder(ctx context.Context, client *asc.Client, setID string, files []string, skippedResults, uploadedResults []asc.AssetUploadResultItem) error {
+	currentOrder, err := GetOrderedAppScreenshotIDs(ctx, client, setID)
+	if err != nil {
+		return err
+	}
+
+	skippedByPath := make(map[string]string, len(skippedResults))
+	for _, item := range skippedResults {
+		if strings.TrimSpace(item.AssetID) == "" {
+			continue
+		}
+		skippedByPath[item.FilePath] = item.AssetID
+	}
+	uploadedByPath := make(map[string]string, len(uploadedResults))
+	for _, item := range uploadedResults {
+		if strings.TrimSpace(item.AssetID) == "" {
+			continue
+		}
+		uploadedByPath[item.FilePath] = item.AssetID
+	}
+
+	orderedIDs := make([]string, 0, len(currentOrder)+len(uploadedResults))
+	seen := make(map[string]struct{}, len(currentOrder)+len(uploadedResults))
+	for _, filePath := range files {
+		id := skippedByPath[filePath]
+		if id == "" {
+			id = uploadedByPath[filePath]
+		}
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		orderedIDs = append(orderedIDs, id)
+	}
+	for _, id := range currentOrder {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		orderedIDs = append(orderedIDs, id)
+	}
+
+	if sameScreenshotIDOrder(currentOrder, orderedIDs) {
+		return nil
+	}
+	return SetOrderedAppScreenshots(ctx, client, setID, orderedIDs)
+}
+
+func sameScreenshotIDOrder(a, b []string) bool {
+	a = normalizeScreenshotIDs(a)
+	b = normalizeScreenshotIDs(b)
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func computeFileChecksum(filePath string) (string, error) {

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -1888,6 +1888,14 @@ func syncSkippedScreenshotOrder(ctx context.Context, client *asc.Client, setID s
 		return err
 	}
 
+	orderedIDs := orderScreenshotIDsForLocalFiles(currentOrder, files, skippedResults, uploadedResults)
+	if sameScreenshotIDOrder(currentOrder, orderedIDs) {
+		return nil
+	}
+	return SetOrderedAppScreenshots(ctx, client, setID, orderedIDs)
+}
+
+func orderScreenshotIDsForLocalFiles(currentOrder []string, files []string, skippedResults, uploadedResults []asc.AssetUploadResultItem) []string {
 	skippedByPath := make(map[string]string, len(skippedResults))
 	for _, item := range skippedResults {
 		if strings.TrimSpace(item.AssetID) == "" {
@@ -1932,10 +1940,7 @@ func syncSkippedScreenshotOrder(ctx context.Context, client *asc.Client, setID s
 		orderedIDs = append(orderedIDs, id)
 	}
 
-	if sameScreenshotIDOrder(currentOrder, orderedIDs) {
-		return nil
-	}
-	return SetOrderedAppScreenshots(ctx, client, setID, orderedIDs)
+	return orderedIDs
 }
 
 func sameScreenshotIDOrder(a, b []string) bool {

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -1829,8 +1829,9 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 		results = append(results, uploadedResults...)
 	}
 	if cfg.SkipExisting && len(skippedResults) > 0 {
-		if err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, set.ID, cfg.Files, skippedResults, results); err != nil {
-			return zero, err
+		if _, err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, set.ID, cfg.Files, skippedResults, results); err != nil {
+			results = append(skippedResults, results...)
+			return cfg.BuildResult(cfg.LocalizationID, set, false, results), err
 		}
 	}
 	results = append(skippedResults, results...)
@@ -1882,17 +1883,17 @@ func filterExistingScreenshotFiles(files []string, screenshots []asc.Resource[as
 	return filtered, skipped, nil
 }
 
-func syncSkippedScreenshotOrder(ctx context.Context, client *asc.Client, setID string, files []string, skippedResults, uploadedResults []asc.AssetUploadResultItem) error {
+func syncSkippedScreenshotOrder(ctx context.Context, client *asc.Client, setID string, files []string, skippedResults, uploadedResults []asc.AssetUploadResultItem) ([]string, error) {
 	currentOrder, err := GetOrderedAppScreenshotIDs(ctx, client, setID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	orderedIDs := orderScreenshotIDsForLocalFiles(currentOrder, files, skippedResults, uploadedResults)
 	if sameScreenshotIDOrder(currentOrder, orderedIDs) {
-		return nil
+		return orderedIDs, nil
 	}
-	return SetOrderedAppScreenshots(ctx, client, setID, orderedIDs)
+	return orderedIDs, SetOrderedAppScreenshots(ctx, client, setID, orderedIDs)
 }
 
 func orderScreenshotIDsForLocalFiles(currentOrder []string, files []string, skippedResults, uploadedResults []asc.AssetUploadResultItem) []string {

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -298,7 +298,8 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	if strings.TrimSpace(artifact.SetID) == "" {
 		return asc.AppScreenshotUploadResult{}, fmt.Errorf("resume artifact %q is missing setId", artifactPath)
 	}
-	if len(artifact.PendingFiles) == 0 && len(artifact.OrderedIDs) == 0 {
+	canRetrySkippedOrdering := artifact.SkipExisting && len(artifact.Files) > 0 && len(artifact.Results) > 0
+	if len(artifact.PendingFiles) == 0 && len(artifact.OrderedIDs) == 0 && !canRetrySkippedOrdering {
 		return asc.AppScreenshotUploadResult{}, fmt.Errorf("resume artifact %q has no pending files or ordering work", artifactPath)
 	}
 

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -231,10 +231,10 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	uploadCtx, cancel := cfg.UploadContext(ctx)
 	defer cancel()
 
-	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, cfg.Client, prepared.Set.ID, prepared.OrderedIDs, prepared.Files, false)
+	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, cfg.Client, prepared.Set.ID, prepared.OrderedIDs, prepared.Files, false, true)
 	if uploadErr == nil && cfg.SkipExisting && len(prepared.SkippedResults) > 0 {
-		desiredIDs := orderScreenshotIDsForLocalFiles(prepared.OrderedIDs, cfg.Files, prepared.SkippedResults, progress.Results)
-		if err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, prepared.Set.ID, cfg.Files, prepared.SkippedResults, progress.Results); err != nil {
+		desiredIDs, err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, prepared.Set.ID, cfg.Files, prepared.SkippedResults, progress.Results)
+		if err != nil {
 			if len(desiredIDs) > 0 {
 				progress.OrderedIDs = desiredIDs
 			}
@@ -255,7 +255,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	finalizeAppScreenshotUploadResult(&result)
 
 	orderedIDs := append([]string(nil), progress.OrderedIDs...)
-	if cfg.SkipExisting && len(prepared.SkippedResults) > 0 {
+	if cfg.SkipExisting && len(prepared.SkippedResults) > 0 && (len(prepared.Files) > 0 || strings.TrimSpace(progress.FailedFile) != "") {
 		desiredIDs := orderScreenshotIDsForLocalFiles(prepared.OrderedIDs, cfg.Files, prepared.SkippedResults, progress.Results)
 		if len(desiredIDs) > 0 {
 			orderedIDs = desiredIDs
@@ -305,7 +305,8 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	uploadCtx, cancel := contextWithAssetUploadTimeout(ctx)
 	defer cancel()
 
-	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, true)
+	syncAfterUpload := !artifact.SkipExisting || len(artifact.Files) == 0
+	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, true, syncAfterUpload)
 
 	result := asc.AppScreenshotUploadResult{
 		VersionLocalizationID: artifact.VersionLocalizationID,
@@ -317,8 +318,10 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 
 	if uploadErr == nil && artifact.SkipExisting && len(artifact.Files) > 0 {
 		skippedResults, uploadedResults := splitSkippedScreenshotResults(result.Results)
-		desiredIDs := orderScreenshotIDsForLocalFiles(progress.OrderedIDs, artifact.Files, skippedResults, uploadedResults)
-		if len(desiredIDs) > 0 && !sameScreenshotIDOrder(progress.OrderedIDs, desiredIDs) {
+		currentOrder, err := GetOrderedAppScreenshotIDs(uploadCtx, client, artifact.SetID)
+		if err != nil {
+			uploadErr = err
+		} else if desiredIDs := orderScreenshotIDsForLocalFiles(currentOrder, artifact.Files, skippedResults, uploadedResults); len(desiredIDs) > 0 && !sameScreenshotIDOrder(currentOrder, desiredIDs) {
 			if err := SetOrderedAppScreenshots(uploadCtx, client, artifact.SetID, desiredIDs); err != nil {
 				progress.OrderedIDs = desiredIDs
 				uploadErr = err

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -232,8 +232,12 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 
 	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, cfg.Client, prepared.Set.ID, prepared.OrderedIDs, prepared.Files, false)
 	if uploadErr == nil && cfg.SkipExisting && len(prepared.SkippedResults) > 0 {
+		desiredIDs := orderScreenshotIDsForLocalFiles(prepared.OrderedIDs, cfg.Files, prepared.SkippedResults, progress.Results)
 		if err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, prepared.Set.ID, cfg.Files, prepared.SkippedResults, progress.Results); err != nil {
-			return asc.AppScreenshotUploadResult{}, err
+			if len(desiredIDs) > 0 {
+				progress.OrderedIDs = desiredIDs
+			}
+			uploadErr = err
 		}
 	}
 

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -249,6 +249,14 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	result.Total = len(result.Results) + result.Pending
 	finalizeAppScreenshotUploadResult(&result)
 
+	orderedIDs := append([]string(nil), progress.OrderedIDs...)
+	if cfg.SkipExisting && len(prepared.SkippedResults) > 0 {
+		desiredIDs := orderScreenshotIDsForLocalFiles(prepared.OrderedIDs, cfg.Files, prepared.SkippedResults, progress.Results)
+		if len(desiredIDs) > 0 {
+			orderedIDs = desiredIDs
+		}
+	}
+
 	artifact := screenshotUploadFailureArtifact{
 		VersionLocalizationID: cfg.LocalizationID,
 		Path:                  artifactPath,
@@ -257,7 +265,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 		SkipExisting:          cfg.SkipExisting,
 		Replace:               cfg.Replace,
 		SetID:                 prepared.Set.ID,
-		OrderedIDs:            append([]string(nil), progress.OrderedIDs...),
+		OrderedIDs:            orderedIDs,
 		PendingFiles:          append([]string(nil), progress.PendingFiles...),
 		Results:               append([]asc.AssetUploadResultItem(nil), result.Results...),
 		Failures:              append([]asc.AssetUploadFailureItem(nil), result.Failures...),

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -21,6 +21,7 @@ type screenshotUploadFailureArtifact struct {
 	SkipExisting          bool                         `json:"skipExisting,omitempty"`
 	Replace               bool                         `json:"replace,omitempty"`
 	SetID                 string                       `json:"setId,omitempty"`
+	Files                 []string                     `json:"files,omitempty"`
 	OrderedIDs            []string                     `json:"orderedIds,omitempty"`
 	PendingFiles          []string                     `json:"pendingFiles,omitempty"`
 	Results               []asc.AssetUploadResultItem  `json:"results,omitempty"`
@@ -269,6 +270,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 		SkipExisting:          cfg.SkipExisting,
 		Replace:               cfg.Replace,
 		SetID:                 prepared.Set.ID,
+		Files:                 append([]string(nil), cfg.Files...),
 		OrderedIDs:            orderedIDs,
 		PendingFiles:          append([]string(nil), progress.PendingFiles...),
 		Results:               append([]asc.AssetUploadResultItem(nil), result.Results...),
@@ -313,6 +315,19 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 		Results:               append(append([]asc.AssetUploadResultItem(nil), artifact.Results...), progress.Results...),
 	}
 
+	if uploadErr == nil && artifact.SkipExisting && len(artifact.Files) > 0 {
+		skippedResults, uploadedResults := splitSkippedScreenshotResults(result.Results)
+		desiredIDs := orderScreenshotIDsForLocalFiles(progress.OrderedIDs, artifact.Files, skippedResults, uploadedResults)
+		if len(desiredIDs) > 0 && !sameScreenshotIDOrder(progress.OrderedIDs, desiredIDs) {
+			if err := SetOrderedAppScreenshots(uploadCtx, client, artifact.SetID, desiredIDs); err != nil {
+				progress.OrderedIDs = desiredIDs
+				uploadErr = err
+			} else {
+				progress.OrderedIDs = desiredIDs
+			}
+		}
+	}
+
 	if uploadErr == nil {
 		finalizeAppScreenshotUploadResult(&result)
 		return result, nil
@@ -331,6 +346,7 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 		SkipExisting:          artifact.SkipExisting,
 		Replace:               artifact.Replace,
 		SetID:                 artifact.SetID,
+		Files:                 append([]string(nil), artifact.Files...),
 		OrderedIDs:            append([]string(nil), progress.OrderedIDs...),
 		PendingFiles:          append([]string(nil), progress.PendingFiles...),
 		Results:               append([]asc.AssetUploadResultItem(nil), result.Results...),
@@ -348,6 +364,20 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	}
 	result.FailureArtifactPath = writtenPath
 	return result, screenshotUploadRetryError(progress)
+}
+
+func splitSkippedScreenshotResults(results []asc.AssetUploadResultItem) ([]asc.AssetUploadResultItem, []asc.AssetUploadResultItem) {
+	skipped := make([]asc.AssetUploadResultItem, 0)
+	uploaded := make([]asc.AssetUploadResultItem, 0, len(results))
+	for _, item := range results {
+		state := strings.ToLower(strings.TrimSpace(item.State))
+		if item.Skipped || state == "skipped" {
+			skipped = append(skipped, item)
+			continue
+		}
+		uploaded = append(uploaded, item)
+	}
+	return skipped, uploaded
 }
 
 func defaultScreenshotUploadFailureArtifactPath() string {
@@ -371,6 +401,14 @@ func normalizeScreenshotUploadArtifactFilePath(path string) (string, error) {
 }
 
 func normalizeScreenshotUploadFailureArtifactPaths(artifact screenshotUploadFailureArtifact) (screenshotUploadFailureArtifact, error) {
+	for i := range artifact.Files {
+		normalized, err := normalizeScreenshotUploadArtifactFilePath(artifact.Files[i])
+		if err != nil {
+			return screenshotUploadFailureArtifact{}, err
+		}
+		artifact.Files[i] = normalized
+	}
+
 	for i := range artifact.PendingFiles {
 		normalized, err := normalizeScreenshotUploadArtifactFilePath(artifact.PendingFiles[i])
 		if err != nil {

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -231,6 +231,11 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	defer cancel()
 
 	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, cfg.Client, prepared.Set.ID, prepared.OrderedIDs, prepared.Files, false)
+	if uploadErr == nil && cfg.SkipExisting && len(prepared.SkippedResults) > 0 {
+		if err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, prepared.Set.ID, cfg.Files, prepared.SkippedResults, progress.Results); err != nil {
+			return asc.AppScreenshotUploadResult{}, err
+		}
+	}
 
 	results := append(append([]asc.AssetUploadResultItem{}, prepared.SkippedResults...), progress.Results...)
 	result := buildAppScreenshotUploadResult(cfg.LocalizationID, prepared.Set, false, results)

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -479,6 +479,75 @@ func TestResumeAppScreenshotUploadSkipExistingPreservesPendingLocalOrder(t *test
 	}
 }
 
+func TestResumeAppScreenshotUploadSkipExistingRetriesOrderingWithoutIDs(t *testing.T) {
+	workDir := t.TempDir()
+	existingPath := writeAssetsTestPNG(t, workDir, "01-existing.png")
+	artifactPath := filepath.Join(workDir, "failure-artifact.json")
+
+	_, err := persistScreenshotUploadFailureArtifact(artifactPath, screenshotUploadFailureArtifact{
+		VersionLocalizationID: "LOC_123",
+		Path:                  artifactPath,
+		DisplayType:           "APP_IPHONE_65",
+		SkipExisting:          true,
+		SetID:                 "set-1",
+		Files:                 []string{existingPath},
+		Results: []asc.AssetUploadResultItem{
+			{FileName: filepath.Base(existingPath), FilePath: existingPath, AssetID: "existing-1", State: "skipped", Skipped: true},
+		},
+		Error:       "relationship lookup failed",
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
+	}
+
+	relationshipPatchCalled := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"unrelated-1"},{"type":"appScreenshots","id":"existing-1"}],"links":{}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			wantIDs := []string{"existing-1", "unrelated-1"}
+			if !reflect.DeepEqual(gotIDs, wantIDs) {
+				t.Fatalf("relationship order = %v, want %v", gotIDs, wantIDs)
+			}
+			relationshipPatchCalled = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := resumeAppScreenshotUpload(context.Background(), client, artifactPath)
+	if err != nil {
+		t.Fatalf("resumeAppScreenshotUpload() error: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("expected preserved skipped result, got %#v", result.Results)
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected relationship patch during resume")
+	}
+}
+
 func TestPersistScreenshotUploadFailureArtifactNormalizesPendingPathsForResume(t *testing.T) {
 	workDir := t.TempDir()
 	otherDir := t.TempDir()

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -317,6 +317,83 @@ func TestExecuteAppScreenshotUploadSkipExistingPatchFailurePersistsLocalOrder(t 
 	}
 }
 
+func TestExecuteAppScreenshotUploadSkipExistingSyncFailurePersistsLocalOrder(t *testing.T) {
+	workDir := t.TempDir()
+	newPath := writeAssetsTestPNGWithSize(t, workDir, "01-new.png", 9, 8)
+	existingPath := writeAssetsTestPNG(t, workDir, "02-existing.png")
+	newSizeBytes := fileSize(t, newPath)
+	existingChecksum, err := computeFileChecksum(existingPath)
+	if err != nil {
+		t.Fatalf("compute existing checksum: %v", err)
+	}
+	artifactPath := filepath.Join(workDir, "failure-artifact.json")
+
+	origTransport := http.DefaultTransport
+	relationshipPatchCount := 0
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"02-existing.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, existingChecksum))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"},{"type":"appScreenshots","id":"new-1"}],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/new-1","length":%d,"offset":0}]}}}`, newSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/new-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploaded":true}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/new-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"new-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			relationshipPatchCount++
+			if relationshipPatchCount == 1 {
+				return assetsJSONResponse(http.StatusOK, `{}`)
+			}
+			return assetsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"reorder failed"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          []string{newPath, existingPath},
+		SkipExisting:   true,
+		RequestContext: contextWithAssetUploadTimeout,
+		UploadContext:  contextWithAssetUploadTimeout,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, artifactPath)
+	if err == nil {
+		t.Fatal("expected executeAppScreenshotUpload() error")
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("expected skipped and uploaded results to be preserved, got %#v", result.Results)
+	}
+	if result.FailureArtifactPath == "" {
+		t.Fatalf("expected failure artifact path, got %#v", result)
+	}
+
+	artifactData, err := loadScreenshotUploadFailureArtifact(artifactPath)
+	if err != nil {
+		t.Fatalf("loadScreenshotUploadFailureArtifact() error: %v", err)
+	}
+	if got, want := strings.Join(artifactData.OrderedIDs, ","), "new-1,existing-1"; got != want {
+		t.Fatalf("expected artifact to preserve local file order %q, got %q", want, got)
+	}
+	if len(artifactData.Failures) != 1 || artifactData.Failures[0].FileName != "screenshot ordering" {
+		t.Fatalf("expected ordering failure in artifact, got %#v", artifactData.Failures)
+	}
+}
+
 func TestPersistScreenshotUploadFailureArtifactNormalizesPendingPathsForResume(t *testing.T) {
 	workDir := t.TempDir()
 	otherDir := t.TempDir()

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-func TestExecuteAppScreenshotUploadSkipExistingDoesNotFetchOrderingWhenNoFilesRemain(t *testing.T) {
+func TestExecuteAppScreenshotUploadSkipExistingDoesNotPatchOrderingWhenAlreadyMatched(t *testing.T) {
 	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
 	checksum, err := computeFileChecksum(filePath)
 	if err != nil {
@@ -31,7 +31,9 @@ func TestExecuteAppScreenshotUploadSkipExistingDoesNotFetchOrderingWhenNoFilesRe
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
 			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"01-home.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, checksum))
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-			t.Fatalf("unexpected remote order lookup when skip-existing leaves no files to upload")
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"}],"links":{}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			t.Fatalf("unexpected remote order patch when skip-existing order already matches")
 			return nil, nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -33,7 +33,7 @@ func TestExecuteAppScreenshotUploadSkipExistingDoesNotPatchOrderingWhenAlreadyMa
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
 			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"01-home.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, checksum))
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"}],"links":{}}`)
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"},{"type":"appScreenshots","id":"unrelated-1"}],"links":{}}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			t.Fatalf("unexpected remote order patch when skip-existing order already matches")
 			return nil, nil
@@ -275,7 +275,7 @@ func TestExecuteAppScreenshotUploadSkipExistingPatchFailurePersistsLocalOrder(t 
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
 			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"02-existing.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, existingChecksum))
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"}],"links":{}}`)
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"},{"type":"appScreenshots","id":"unrelated-1"}],"links":{}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
 			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/new-1","length":%d,"offset":0}]}}}`, newSizeBytes))
 		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
@@ -314,7 +314,7 @@ func TestExecuteAppScreenshotUploadSkipExistingPatchFailurePersistsLocalOrder(t 
 	if err != nil {
 		t.Fatalf("loadScreenshotUploadFailureArtifact() error: %v", err)
 	}
-	if got, want := strings.Join(artifactData.OrderedIDs, ","), "new-1,existing-1"; got != want {
+	if got, want := strings.Join(artifactData.OrderedIDs, ","), "new-1,existing-1,unrelated-1"; got != want {
 		t.Fatalf("expected artifact to preserve local file order %q, got %q", want, got)
 	}
 }
@@ -436,6 +436,8 @@ func TestResumeAppScreenshotUploadSkipExistingPreservesPendingLocalOrder(t *test
 			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"uploaded":true}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
 			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"unrelated-1"},{"type":"appScreenshots","id":"new-1"},{"type":"appScreenshots","id":"existing-1"},{"type":"appScreenshots","id":"pending-1"}],"links":{}}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
@@ -471,7 +473,7 @@ func TestResumeAppScreenshotUploadSkipExistingPreservesPendingLocalOrder(t *test
 	if len(relationshipPatches) == 0 {
 		t.Fatal("expected relationship patch during resume")
 	}
-	wantFinalOrder := []string{"new-1", "pending-1", "existing-1"}
+	wantFinalOrder := []string{"new-1", "pending-1", "existing-1", "unrelated-1"}
 	if got := relationshipPatches[len(relationshipPatches)-1]; !reflect.DeepEqual(got, wantFinalOrder) {
 		t.Fatalf("final relationship order = %v, want %v", got, wantFinalOrder)
 	}

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -254,6 +254,69 @@ func TestExecuteAppScreenshotUploadOrderSyncFailureSurfacesOrderingError(t *test
 	}
 }
 
+func TestExecuteAppScreenshotUploadSkipExistingPatchFailurePersistsLocalOrder(t *testing.T) {
+	workDir := t.TempDir()
+	newPath := writeAssetsTestPNGWithSize(t, workDir, "01-new.png", 9, 8)
+	existingPath := writeAssetsTestPNG(t, workDir, "02-existing.png")
+	newSizeBytes := fileSize(t, newPath)
+	existingChecksum, err := computeFileChecksum(existingPath)
+	if err != nil {
+		t.Fatalf("compute existing checksum: %v", err)
+	}
+	artifactPath := filepath.Join(workDir, "failure-artifact.json")
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"02-existing.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, existingChecksum))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1"}],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/new-1","length":%d,"offset":0}]}}}`, newSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/new-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploaded":true}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/new-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"new-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"reorder failed"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	_, err = executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          []string{newPath, existingPath},
+		SkipExisting:   true,
+		RequestContext: contextWithAssetUploadTimeout,
+		UploadContext:  contextWithAssetUploadTimeout,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, artifactPath)
+	if err == nil {
+		t.Fatal("expected executeAppScreenshotUpload() error")
+	}
+
+	artifactData, err := loadScreenshotUploadFailureArtifact(artifactPath)
+	if err != nil {
+		t.Fatalf("loadScreenshotUploadFailureArtifact() error: %v", err)
+	}
+	if got, want := strings.Join(artifactData.OrderedIDs, ","), "new-1,existing-1"; got != want {
+		t.Fatalf("expected artifact to preserve local file order %q, got %q", want, got)
+	}
+}
+
 func TestPersistScreenshotUploadFailureArtifactNormalizesPendingPathsForResume(t *testing.T) {
 	workDir := t.TempDir()
 	otherDir := t.TempDir()

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -391,6 +393,87 @@ func TestExecuteAppScreenshotUploadSkipExistingSyncFailurePersistsLocalOrder(t *
 	}
 	if len(artifactData.Failures) != 1 || artifactData.Failures[0].FileName != "screenshot ordering" {
 		t.Fatalf("expected ordering failure in artifact, got %#v", artifactData.Failures)
+	}
+}
+
+func TestResumeAppScreenshotUploadSkipExistingPreservesPendingLocalOrder(t *testing.T) {
+	workDir := t.TempDir()
+	newPath := writeAssetsTestPNGWithSize(t, workDir, "01-new.png", 9, 8)
+	pendingPath := writeAssetsTestPNGWithSize(t, workDir, "02-pending.png", 10, 8)
+	existingPath := writeAssetsTestPNG(t, workDir, "03-existing.png")
+	pendingSizeBytes := fileSize(t, pendingPath)
+	artifactPath := filepath.Join(workDir, "failure-artifact.json")
+
+	_, err := persistScreenshotUploadFailureArtifact(artifactPath, screenshotUploadFailureArtifact{
+		VersionLocalizationID: "LOC_123",
+		Path:                  artifactPath,
+		DisplayType:           "APP_IPHONE_65",
+		SkipExisting:          true,
+		SetID:                 "set-1",
+		Files:                 []string{newPath, pendingPath, existingPath},
+		OrderedIDs:            []string{"new-1", "existing-1"},
+		PendingFiles:          []string{pendingPath},
+		Results: []asc.AssetUploadResultItem{
+			{FileName: filepath.Base(existingPath), FilePath: existingPath, AssetID: "existing-1", State: "skipped", Skipped: true},
+			{FileName: filepath.Base(newPath), FilePath: newPath, AssetID: "new-1", State: "COMPLETE"},
+		},
+		Error:       "screenshots upload: 1 file(s) pending retry",
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
+	}
+
+	relationshipPatches := make([][]string, 0, 2)
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/pending-1","length":%d,"offset":0}]}}}`, pendingSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/pending-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"uploaded":true}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			relationshipPatches = append(relationshipPatches, gotIDs)
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := resumeAppScreenshotUpload(context.Background(), client, artifactPath)
+	if err != nil {
+		t.Fatalf("resumeAppScreenshotUpload() error: %v", err)
+	}
+	if len(result.Results) != 3 {
+		t.Fatalf("expected previous and resumed results, got %#v", result.Results)
+	}
+	if len(relationshipPatches) == 0 {
+		t.Fatal("expected relationship patch during resume")
+	}
+	wantFinalOrder := []string{"new-1", "pending-1", "existing-1"}
+	if got := relationshipPatches[len(relationshipPatches)-1]; !reflect.DeepEqual(got, wantFinalOrder) {
+		t.Fatalf("final relationship order = %v, want %v", got, wantFinalOrder)
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -320,6 +320,94 @@ func TestUploadScreenshotsSkipExistingSyncsLocalFileOrder(t *testing.T) {
 	}
 }
 
+func TestExecuteAppScreenshotUploadSkipExistingSyncsLocalFileOrder(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeAssetsTestPNG(t, dir, "01-home.png")
+	fileB := writeAssetsTestPNG(t, dir, "02-settings.png")
+	const (
+		checksumA = "checksum-a"
+		checksumB = "checksum-b"
+	)
+	origChecksumFunc := screenshotFileChecksumFunc
+	screenshotFileChecksumFunc = func(path string) (string, error) {
+		switch path {
+		case fileA:
+			return checksumA, nil
+		case fileB:
+			return checksumB, nil
+		default:
+			return computeFileChecksum(path)
+		}
+	}
+	t.Cleanup(func() {
+		screenshotFileChecksumFunc = origChecksumFunc
+	})
+
+	relationshipPatchCalled := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-b","attributes":{"fileName":"02-settings.png","fileSize":100,"sourceFileChecksum":"%s"}},{"type":"appScreenshots","id":"existing-a","attributes":{"fileName":"01-home.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, checksumB, checksumA))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-b"},{"type":"appScreenshots","id":"existing-a"}],"links":{}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			wantIDs := []string{"existing-a", "existing-b"}
+			if !reflect.DeepEqual(gotIDs, wantIDs) {
+				t.Fatalf("relationship order = %v, want %v", gotIDs, wantIDs)
+			}
+			relationshipPatchCalled = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request in execute --skip-existing reorder: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          []string{fileA, fileB},
+		SkipExisting:   true,
+		Access:         appStoreVersionScreenshotSetAccess,
+		BuildResult: func(localizationID string, set asc.Resource[asc.AppScreenshotSetAttributes], dryRun bool, results []asc.AssetUploadResultItem) asc.AppScreenshotUploadResult {
+			return buildAppScreenshotUploadResult(localizationID, set, dryRun, results)
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("executeAppScreenshotUpload() error: %v", err)
+	}
+
+	if len(result.Results) != 2 {
+		t.Fatalf("expected 2 skipped results, got %d", len(result.Results))
+	}
+	if result.Results[0].AssetID != "existing-a" || result.Results[1].AssetID != "existing-b" {
+		t.Fatalf("expected skipped results to keep existing IDs in local order, got %#v", result.Results)
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected execute --skip-existing to sync screenshot relationship order")
+	}
+}
+
 func TestExecuteAppScreenshotUploadMaxScreenshotsAccountsForExistingRemoteScreenshots(t *testing.T) {
 	dir := t.TempDir()
 	files := make([]string, 0, appScreenshotSetMaxScreenshots)

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -2,9 +2,12 @@ package assets
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -236,6 +239,84 @@ func TestUploadScreenshotsDryRunWithSkipExistingReportsSkipped(t *testing.T) {
 	}
 	if !result.Results[0].Skipped {
 		t.Fatal("expected Skipped=true")
+	}
+}
+
+func TestUploadScreenshotsSkipExistingSyncsLocalFileOrder(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeAssetsTestPNG(t, dir, "01-home.png")
+	fileB := writeAssetsTestPNG(t, dir, "02-settings.png")
+	const (
+		checksumA = "checksum-a"
+		checksumB = "checksum-b"
+	)
+	origChecksumFunc := screenshotFileChecksumFunc
+	screenshotFileChecksumFunc = func(path string) (string, error) {
+		switch path {
+		case fileA:
+			return checksumA, nil
+		case fileB:
+			return checksumB, nil
+		default:
+			return computeFileChecksum(path)
+		}
+	}
+	t.Cleanup(func() {
+		screenshotFileChecksumFunc = origChecksumFunc
+	})
+
+	relationshipPatchCalled := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-b","attributes":{"fileName":"02-settings.png","fileSize":100,"sourceFileChecksum":"%s"}},{"type":"appScreenshots","id":"existing-a","attributes":{"fileName":"01-home.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, checksumB, checksumA))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-b"},{"type":"appScreenshots","id":"existing-a"}],"links":{}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read relationship patch body: %v", err)
+			}
+			var payload asc.RelationshipRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode relationship patch body: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, item := range payload.Data {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			wantIDs := []string{"existing-a", "existing-b"}
+			if !reflect.DeepEqual(gotIDs, wantIDs) {
+				t.Fatalf("relationship order = %v, want %v", gotIDs, wantIDs)
+			}
+			relationshipPatchCalled = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request in --skip-existing reorder: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := uploadScreenshots(context.Background(), client, "LOC_123", "APP_IPHONE_65", []string{fileA, fileB}, true, false, false)
+	if err != nil {
+		t.Fatalf("uploadScreenshots() error: %v", err)
+	}
+
+	if len(result.Results) != 2 {
+		t.Fatalf("expected 2 skipped results, got %d", len(result.Results))
+	}
+	if result.Results[0].AssetID != "existing-a" || result.Results[1].AssetID != "existing-b" {
+		t.Fatalf("expected skipped results to keep existing IDs in local order, got %#v", result.Results)
+	}
+	if !relationshipPatchCalled {
+		t.Fatal("expected --skip-existing to sync screenshot relationship order")
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -320,6 +320,62 @@ func TestUploadScreenshotsSkipExistingSyncsLocalFileOrder(t *testing.T) {
 	}
 }
 
+func TestUploadScreenshotsSkipExistingSyncFailurePreservesResults(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeAssetsTestPNG(t, dir, "01-home.png")
+	fileB := writeAssetsTestPNG(t, dir, "02-settings.png")
+	const (
+		checksumA = "checksum-a"
+		checksumB = "checksum-b"
+	)
+	origChecksumFunc := screenshotFileChecksumFunc
+	screenshotFileChecksumFunc = func(path string) (string, error) {
+		switch path {
+		case fileA:
+			return checksumA, nil
+		case fileB:
+			return checksumB, nil
+		default:
+			return computeFileChecksum(path)
+		}
+	}
+	t.Cleanup(func() {
+		screenshotFileChecksumFunc = origChecksumFunc
+	})
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"existing-b","attributes":{"fileName":"02-settings.png","fileSize":100,"sourceFileChecksum":"%s"}},{"type":"appScreenshots","id":"existing-a","attributes":{"fileName":"01-home.png","fileSize":100,"sourceFileChecksum":"%s"}}],"links":{}}`, checksumB, checksumA))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-b"},{"type":"appScreenshots","id":"existing-a"}],"links":{}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"reorder failed"}]}`)
+		default:
+			t.Fatalf("unexpected request in --skip-existing reorder failure: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := uploadScreenshots(context.Background(), client, "LOC_123", "APP_IPHONE_65", []string{fileA, fileB}, true, false, false)
+	if err == nil {
+		t.Fatal("expected uploadScreenshots() error")
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("expected skipped results to be preserved, got %#v", result.Results)
+	}
+	if result.Results[0].AssetID != "existing-a" || result.Results[1].AssetID != "existing-b" {
+		t.Fatalf("expected skipped results in local order, got %#v", result.Results)
+	}
+}
+
 func TestExecuteAppScreenshotUploadSkipExistingSyncsLocalFileOrder(t *testing.T) {
 	dir := t.TempDir()
 	fileA := writeAssetsTestPNG(t, dir, "01-home.png")


### PR DESCRIPTION
## Summary
- Keep existing screenshot IDs when `--skip-existing` filters local files by checksum.
- Sync screenshot relationship order from local file order even when files are skipped instead of uploaded.
- Add a regression for a reordered local folder whose screenshots already exist remotely.

## Validation
- `go run . screenshots upload --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets -run TestUploadScreenshotsSkipExistingSyncsLocalFileOrder`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets -run 'TestUploadScreenshots|TestExecuteAppScreenshotUpload|TestUploadScreenshotsToSet'`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screenshot upload with `--skip-existing` now synchronizes screenshot ordering to match local file order when existing screenshots are skipped.
  * Upload resume functionality preserves and correctly applies local screenshot ordering after interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->