### PR TITLE
[codex] Preserve screenshot download order

### DIFF
--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -1391,16 +1391,13 @@ Examples:
 						return fmt.Errorf("screenshots download: failed to fetch screenshots for set %s: %w", set.ID, err)
 					}
 
-					shots := make([]asc.Resource[asc.AppScreenshotAttributes], 0, len(shotsResp.Data))
-					shots = append(shots, shotsResp.Data...)
-					sort.Slice(shots, func(i, j int) bool {
-						fi := strings.ToLower(strings.TrimSpace(shots[i].Attributes.FileName))
-						fj := strings.ToLower(strings.TrimSpace(shots[j].Attributes.FileName))
-						if fi == fj {
-							return shots[i].ID < shots[j].ID
-						}
-						return fi < fj
-					})
+					requestCtx, cancel = shared.ContextWithTimeout(ctx)
+					orderedIDs, err := GetOrderedAppScreenshotIDs(requestCtx, client, set.ID)
+					cancel()
+					if err != nil {
+						return fmt.Errorf("screenshots download: failed to fetch screenshot order for set %s: %w", set.ID, err)
+					}
+					shots := orderScreenshotsForDownload(shotsResp.Data, orderedIDs)
 
 					for idx, shot := range shots {
 						base := sanitizeBaseFileName(shot.Attributes.FileName)
@@ -1498,6 +1495,43 @@ Examples:
 			return nil
 		},
 	}
+}
+
+func orderScreenshotsForDownload(shots []asc.Resource[asc.AppScreenshotAttributes], orderedIDs []string) []asc.Resource[asc.AppScreenshotAttributes] {
+	ordered := append([]asc.Resource[asc.AppScreenshotAttributes](nil), shots...)
+	orderByID := make(map[string]int, len(orderedIDs))
+	for idx, id := range orderedIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := orderByID[id]; exists {
+			continue
+		}
+		orderByID[id] = idx
+	}
+
+	sort.SliceStable(ordered, func(i, j int) bool {
+		iOrder, iOK := orderByID[strings.TrimSpace(ordered[i].ID)]
+		jOrder, jOK := orderByID[strings.TrimSpace(ordered[j].ID)]
+		switch {
+		case iOK && jOK:
+			return iOrder < jOrder
+		case iOK:
+			return true
+		case jOK:
+			return false
+		}
+
+		fi := strings.ToLower(strings.TrimSpace(ordered[i].Attributes.FileName))
+		fj := strings.ToLower(strings.TrimSpace(ordered[j].Attributes.FileName))
+		if fi == fj {
+			return ordered[i].ID < ordered[j].ID
+		}
+		return fi < fj
+	})
+
+	return ordered
 }
 
 func renderScreenshotDownloadResult(result *screenshotDownloadResult, markdown bool) error {

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -48,6 +48,25 @@ func TestAssetsScreenshotsSizesCommandDefaultFocused(t *testing.T) {
 	}
 }
 
+func TestOrderScreenshotsForDownloadUsesRelationshipOrder(t *testing.T) {
+	shots := []asc.Resource[asc.AppScreenshotAttributes]{
+		{ID: "shot-b", Attributes: asc.AppScreenshotAttributes{FileName: "01-home.png"}},
+		{ID: "shot-c", Attributes: asc.AppScreenshotAttributes{FileName: "02-settings.png"}},
+		{ID: "shot-a", Attributes: asc.AppScreenshotAttributes{FileName: "03-paywall.png"}},
+	}
+
+	ordered := orderScreenshotsForDownload(shots, []string{"shot-a", "shot-b"})
+
+	gotIDs := make([]string, 0, len(ordered))
+	for _, shot := range ordered {
+		gotIDs = append(gotIDs, shot.ID)
+	}
+	wantIDs := []string{"shot-a", "shot-b", "shot-c"}
+	if strings.Join(gotIDs, ",") != strings.Join(wantIDs, ",") {
+		t.Fatalf("ordered IDs = %v, want %v", gotIDs, wantIDs)
+	}
+}
+
 func TestAssetsScreenshotsSizesCommandFilter(t *testing.T) {
 	cmd := AssetsScreenshotsSizesCommand()
 	cmd.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/assets_download_media_test.go
+++ b/internal/cli/cmdtest/assets_download_media_test.go
@@ -144,6 +144,13 @@ func TestScreenshotsDownload_ByLocalization_WritesFiles(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader(body)),
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
 				}, nil
+			case "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+				body := `{"data":[{"type":"appScreenshots","id":"shot-1"}],"links":{}}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+				}, nil
 			default:
 				t.Fatalf("unexpected API path: %s", req.URL.Path)
 				return nil, nil
@@ -233,6 +240,13 @@ func TestScreenshotsDownload_ByLocalization_RetriesTransientForbidden(t *testing
 				}, nil
 			case "/v1/appScreenshotSets/set-1/appScreenshots":
 				body := `{"data":[{"type":"appScreenshots","id":"shot-1","attributes":{"fileName":"screen.png","fileSize":7,"imageAsset":{"templateUrl":"https://example.com/screen_{w}x{h}.{f}","width":100,"height":200}}}]}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+				}, nil
+			case "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+				body := `{"data":[{"type":"appScreenshots","id":"shot-1"}],"links":{}}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),

--- a/internal/cli/cmdtest/assets_download_media_test.go
+++ b/internal/cli/cmdtest/assets_download_media_test.go
@@ -138,14 +138,14 @@ func TestScreenshotsDownload_ByLocalization_WritesFiles(t *testing.T) {
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
 				}, nil
 			case "/v1/appScreenshotSets/set-1/appScreenshots":
-				body := `{"data":[{"type":"appScreenshots","id":"shot-1","attributes":{"fileName":"screen.png","fileSize":7,"imageAsset":{"templateUrl":"https://example.com/screen_{w}x{h}.{f}","width":100,"height":200}}}]}`
+				body := `{"data":[{"type":"appScreenshots","id":"shot-b","attributes":{"fileName":"01-home.png","fileSize":7,"imageAsset":{"templateUrl":"https://example.com/shot-b_{w}x{h}.{f}","width":100,"height":200}}},{"type":"appScreenshots","id":"shot-a","attributes":{"fileName":"02-paywall.png","fileSize":7,"imageAsset":{"templateUrl":"https://example.com/shot-a_{w}x{h}.{f}","width":100,"height":200}}}]}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
 				}, nil
 			case "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-				body := `{"data":[{"type":"appScreenshots","id":"shot-1"}],"links":{}}`
+				body := `{"data":[{"type":"appScreenshots","id":"shot-a"},{"type":"appScreenshots","id":"shot-b"}],"links":{}}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),
@@ -159,12 +159,12 @@ func TestScreenshotsDownload_ByLocalization_WritesFiles(t *testing.T) {
 			if req.Method != http.MethodGet {
 				t.Fatalf("expected GET, got %s", req.Method)
 			}
-			if req.URL.Path != "/screen_100x200.png" {
+			if req.URL.Path != "/shot-a_100x200.png" && req.URL.Path != "/shot-b_100x200.png" {
 				t.Fatalf("unexpected asset path: %s", req.URL.Path)
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("PNGDATA")),
+				Body:       io.NopCloser(strings.NewReader("PNGDATA:" + req.URL.Path)),
 				Header:     http.Header{"Content-Type": []string{"image/png"}},
 			}, nil
 		default:
@@ -182,6 +182,10 @@ func TestScreenshotsDownload_ByLocalization_WritesFiles(t *testing.T) {
 		Total      int `json:"total"`
 		Downloaded int `json:"downloaded"`
 		Failed     int `json:"failed"`
+		Items      []struct {
+			ID         string `json:"id"`
+			OutputPath string `json:"outputPath"`
+		} `json:"items"`
 	}
 
 	stdout, stderr := captureOutput(t, func() {
@@ -201,16 +205,37 @@ func TestScreenshotsDownload_ByLocalization_WritesFiles(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
 		t.Fatalf("decode stdout JSON: %v (stdout=%q)", err, stdout)
 	}
-	if got.Total != 1 || got.Downloaded != 1 || got.Failed != 0 {
+	if got.Total != 2 || got.Downloaded != 2 || got.Failed != 0 {
 		t.Fatalf("unexpected result: %+v", got)
 	}
+	if len(got.Items) != 2 {
+		t.Fatalf("expected 2 result items, got %d", len(got.Items))
+	}
+	if got.Items[0].ID != "shot-a" || got.Items[1].ID != "shot-b" {
+		t.Fatalf("expected relationship-ordered item IDs [shot-a shot-b], got [%s %s]", got.Items[0].ID, got.Items[1].ID)
+	}
 
-	wantPath := filepath.Join(outDir, "APP_IPHONE_65", "01_shot-1_screen.png")
-	data, err := os.ReadFile(wantPath)
+	wantFirstPath := filepath.Join(outDir, "APP_IPHONE_65", "01_shot-a_02-paywall.png")
+	wantSecondPath := filepath.Join(outDir, "APP_IPHONE_65", "02_shot-b_01-home.png")
+	if filepath.Clean(got.Items[0].OutputPath) != filepath.Clean(wantFirstPath) {
+		t.Fatalf("expected first outputPath %q, got %q", wantFirstPath, got.Items[0].OutputPath)
+	}
+	if filepath.Clean(got.Items[1].OutputPath) != filepath.Clean(wantSecondPath) {
+		t.Fatalf("expected second outputPath %q, got %q", wantSecondPath, got.Items[1].OutputPath)
+	}
+
+	data, err := os.ReadFile(wantFirstPath)
 	if err != nil {
 		t.Fatalf("ReadFile() error: %v", err)
 	}
-	if string(data) != "PNGDATA" {
+	if string(data) != "PNGDATA:/shot-a_100x200.png" {
+		t.Fatalf("unexpected file contents: %q", string(data))
+	}
+	data, err = os.ReadFile(wantSecondPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "PNGDATA:/shot-b_100x200.png" {
 		t.Fatalf("unexpected file contents: %q", string(data))
 	}
 }


### PR DESCRIPTION
## Summary
- Download localization screenshots in the screenshot-set relationship order instead of filename order.
- Keep deterministic filename/ID fallback for screenshots not present in the relationship response.
- Add unit and black-box coverage for relationship-order-aware screenshot downloads.

## Validation
- `go run . screenshots download --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets -run TestOrderScreenshotsForDownloadUsesRelationshipOrder`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestScreenshotsDownload_ByLocalization|TestOrderScreenshotsForDownloadUsesRelationshipOrder'`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`