### PR TITLE
[codex] Filter expired build list results

### DIFF
--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -431,7 +431,7 @@ func TestBuildsTestNotesUpdateConflictingFlagsExitCode(t *testing.T) {
 	}
 }
 
-func TestBuildsLatestExcludeExpiredInvalidBooleanExitCode(t *testing.T) {
+func TestBuildsExpiredFlagsInvalidBooleanExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryPath := filepath.Join(tmpDir, "asc-test")
 
@@ -441,27 +441,63 @@ func TestBuildsLatestExcludeExpiredInvalidBooleanExitCode(t *testing.T) {
 		t.Fatalf("failed to build binary: %v\n%s", err, out)
 	}
 
-	runCmd := exec.Command(binaryPath, "builds", "latest", "--app", "APP_ID", "--exclude-expired=maybe")
-	runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
-	output, err := runCmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected non-zero exit for invalid boolean value, got success output: %s", output)
+	tests := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{
+			name: "latest exclude-expired",
+			args: []string{"builds", "latest", "--app", "APP_ID", "--exclude-expired=maybe"},
+			flag: "exclude-expired",
+		},
+		{
+			name: "list exclude-expired",
+			args: []string{"builds", "list", "--app", "APP_ID", "--exclude-expired=maybe"},
+			flag: "exclude-expired",
+		},
+		{
+			name: "list not-expired",
+			args: []string{"builds", "list", "--app", "APP_ID", "--not-expired=maybe"},
+			flag: "not-expired",
+		},
+		{
+			name: "count exclude-expired",
+			args: []string{"builds", "count", "--app", "APP_ID", "--exclude-expired=maybe"},
+			flag: "exclude-expired",
+		},
+		{
+			name: "count not-expired",
+			args: []string{"builds", "count", "--app", "APP_ID", "--not-expired=maybe"},
+			flag: "not-expired",
+		},
 	}
 
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
-	}
-	if exitErr.ExitCode() != ExitUsage {
-		t.Fatalf("expected exit code %d, got %d (output: %s)", ExitUsage, exitErr.ExitCode(), output)
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runCmd := exec.Command(binaryPath, test.args...)
+			runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
+			output, err := runCmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected non-zero exit for invalid boolean value, got success output: %s", output)
+			}
 
-	stderr := string(output)
-	if !strings.Contains(stderr, "invalid boolean value") {
-		t.Fatalf("expected stderr to contain invalid boolean message, got %q", stderr)
-	}
-	if !strings.Contains(stderr, "exclude-expired") {
-		t.Fatalf("expected stderr to mention exclude-expired flag, got %q", stderr)
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
+			}
+			if exitErr.ExitCode() != ExitUsage {
+				t.Fatalf("expected exit code %d, got %d (output: %s)", ExitUsage, exitErr.ExitCode(), output)
+			}
+
+			stderr := string(output)
+			if !strings.Contains(stderr, "invalid boolean value") {
+				t.Fatalf("expected stderr to contain invalid boolean message, got %q", stderr)
+			}
+			if !strings.Contains(stderr, test.flag) {
+				t.Fatalf("expected stderr to mention %s flag, got %q", test.flag, stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -414,6 +414,8 @@ func BuildsListCommand() *ffcli.Command {
 	buildNumber := fs.String("build-number", "", "Filter by build number (CFBundleVersion)")
 	platform := fs.String("platform", "", "Filter by platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	processingState := fs.String("processing-state", "", "Filter by processing state: VALID, PROCESSING, FAILED, INVALID, or all")
+	excludeExpired := fs.Bool("exclude-expired", false, "Exclude expired builds")
+	notExpired := fs.Bool("not-expired", false, "Alias for --exclude-expired")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -435,6 +437,7 @@ Examples:
   asc builds list --app "123456789" --platform IOS --version "1.2.3"
   asc builds list --app "123456789" --processing-state "PROCESSING"
   asc builds list --app "123456789" --processing-state "all"
+  asc builds list --app "123456789" --exclude-expired
   asc builds list --app "123456789" --version "1.2.3" --build-number "123"
   asc builds list --app "123456789" --limit 10
   asc builds list --app "123456789" --paginate`,
@@ -516,6 +519,9 @@ Examples:
 			}
 			if len(processingStateValues) > 0 {
 				opts = append(opts, asc.WithBuildsProcessingStates(processingStateValues))
+			}
+			if *excludeExpired || *notExpired {
+				opts = append(opts, asc.WithBuildsExpired(false))
 			}
 			if len(preReleaseVersionIDs) > 0 {
 				opts = append(opts, asc.WithBuildsPreReleaseVersions(preReleaseVersionIDs))

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -53,6 +53,25 @@ func TestBuildsListCommand_ProcessingStateFlagDescription(t *testing.T) {
 	}
 }
 
+func TestBuildsListCommand_ExcludeExpiredFlagsExist(t *testing.T) {
+	cmd := BuildsListCommand()
+
+	excludeExpiredFlag := cmd.FlagSet.Lookup("exclude-expired")
+	if excludeExpiredFlag == nil {
+		t.Fatal("expected --exclude-expired flag to be defined")
+	}
+	if !strings.Contains(excludeExpiredFlag.Usage, "expired") {
+		t.Fatalf("expected --exclude-expired usage to mention expired builds, got %q", excludeExpiredFlag.Usage)
+	}
+
+	if cmd.FlagSet.Lookup("not-expired") == nil {
+		t.Fatal("expected --not-expired alias to be defined")
+	}
+	if !strings.Contains(cmd.LongHelp, "--exclude-expired") {
+		t.Fatalf("expected long help to include --exclude-expired example, got %q", cmd.LongHelp)
+	}
+}
+
 func TestNormalizeBuildProcessingStateFilter(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/builds/builds_count.go
+++ b/internal/cli/builds/builds_count.go
@@ -22,6 +22,8 @@ func BuildsCountCommand() *ffcli.Command {
 	buildNumber := fs.String("build-number", "", "Filter by build number (CFBundleVersion)")
 	platform := fs.String("platform", "", "Filter by platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	processingState := fs.String("processing-state", "", "Filter by processing state: VALID, PROCESSING, FAILED, INVALID, or all")
+	excludeExpired := fs.Bool("exclude-expired", false, "Exclude expired builds")
+	notExpired := fs.Bool("not-expired", false, "Alias for --exclude-expired")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -44,6 +46,7 @@ Examples:
   asc builds count --app "123456789" --platform IOS
   asc builds count --app "123456789" --processing-state VALID
   asc builds count --app "123456789" --processing-state all
+  asc builds count --app "123456789" --exclude-expired
   asc builds count --app "123456789" --version "2.1.0" --platform IOS --output json`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -106,6 +109,9 @@ Examples:
 			}
 			if len(processingStateValues) > 0 {
 				filterOpts = append(filterOpts, asc.WithBuildsProcessingStates(processingStateValues))
+			}
+			if *excludeExpired || *notExpired {
+				filterOpts = append(filterOpts, asc.WithBuildsExpired(false))
 			}
 			if len(preReleaseVersionIDs) > 0 {
 				filterOpts = append(filterOpts, asc.WithBuildsPreReleaseVersions(preReleaseVersionIDs))

--- a/internal/cli/builds/builds_count_test.go
+++ b/internal/cli/builds/builds_count_test.go
@@ -81,7 +81,7 @@ func TestBuildsCountCommand_UsesAppIDEnv(t *testing.T) {
 func TestBuildsCountCommand_FlagsExist(t *testing.T) {
 	cmd := BuildsCountCommand()
 
-	required := []string{"app", "version", "build-number", "platform", "processing-state", "output"}
+	required := []string{"app", "version", "build-number", "platform", "processing-state", "exclude-expired", "not-expired", "output"}
 	for _, name := range required {
 		if cmd.FlagSet.Lookup(name) == nil {
 			t.Errorf("expected --%s flag to be defined", name)

--- a/internal/cli/cmdtest/builds_processing_state_test.go
+++ b/internal/cli/cmdtest/builds_processing_state_test.go
@@ -119,6 +119,106 @@ func TestBuildsListProcessingStateAllExpandsToAllStates(t *testing.T) {
 	}
 }
 
+func TestBuildsListExcludeExpiredSendsExpiredFilter(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/builds" {
+			t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+		}
+		if got := req.URL.Query().Get("filter[expired]"); got != "false" {
+			t.Fatalf("expected filter[expired]=false, got %q", got)
+		}
+		body := `{"data":[{"type":"builds","id":"build-active","attributes":{"expired":false,"version":"42"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "list", "--app", "123456789", "--exclude-expired"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"build-active"`) {
+		t.Fatalf("expected build output, got %q", stdout)
+	}
+}
+
+func TestBuildsCountNotExpiredSendsExpiredFilter(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/builds" {
+			t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if got := query.Get("filter[expired]"); got != "false" {
+			t.Fatalf("expected filter[expired]=false, got %q", got)
+		}
+		if got := query.Get("limit"); got != "1" {
+			t.Fatalf("expected limit=1 probe request, got %q", got)
+		}
+		body := `{"data":[],"meta":{"paging":{"total":7,"limit":1}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "count", "--app", "123456789", "--not-expired"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"total":7`) {
+		t.Fatalf("expected total output, got %q", stdout)
+	}
+}
+
 func TestBuildsListProcessingStateInvalidValueReturnsUsageError(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))


### PR DESCRIPTION
## Summary
- Add `--exclude-expired` and `--not-expired` to `asc builds list`.
- Add the same expired-build filter aliases to `asc builds count`.
- Cover both commands with request-level regression tests that assert `filter[expired]=false`.

## Validation
- `go run . builds list --help`
- `go run . builds count --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/builds ./internal/cli/cmdtest -run 'TestBuildsListCommand_ExcludeExpiredFlagsExist|TestBuildsCountCommand_FlagsExist|TestBuildsListExcludeExpiredSendsExpiredFilter|TestBuildsCountNotExpiredSendsExpiredFilter'`\n- `make generate-command-docs`\n- `make format`\n- `make check-command-docs`\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n- `go build -o /tmp/asc .`\n- `/tmp/asc builds list --help 2>&1 | rg -- '--exclude-expired|--not-expired'`\n- `/tmp/asc builds count --help 2>&1 | rg -- '--exclude-expired|--not-expired'`