### PR TITLE
[codex] Reuse registered device UDIDs

### DIFF
--- a/internal/cli/cmdtest/devices_register_existing_test.go
+++ b/internal/cli/cmdtest/devices_register_existing_test.go
@@ -2,6 +2,7 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -62,5 +63,101 @@ func TestDevicesRegisterReusesExistingDeviceWithNormalizedUDID(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"device-existing"`) {
 		t.Fatalf("expected existing device output, got %q", stdout)
+	}
+}
+
+func TestDevicesRegisterCreatesDeviceWhenNoExistingUDIDMatches(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET before create, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/devices" {
+				t.Fatalf("expected devices list path, got %s", req.URL.Path)
+			}
+			if got := req.URL.Query().Get("filter[platform]"); got != "IOS" {
+				t.Fatalf("expected filter[platform]=IOS, got %q", got)
+			}
+			body := `{"data":[],"links":{"next":""}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodPost {
+				t.Fatalf("expected POST after no existing match, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/devices" {
+				t.Fatalf("expected create path, got %s", req.URL.Path)
+			}
+			var payload struct {
+				Data struct {
+					Type       string `json:"type"`
+					Attributes struct {
+						Name     string `json:"name"`
+						UDID     string `json:"udid"`
+						Platform string `json:"platform"`
+					} `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode create payload: %v", err)
+			}
+			if payload.Data.Type != "devices" {
+				t.Fatalf("expected type devices, got %q", payload.Data.Type)
+			}
+			if payload.Data.Attributes.Name != "New iPhone" {
+				t.Fatalf("expected name New iPhone, got %q", payload.Data.Attributes.Name)
+			}
+			if payload.Data.Attributes.UDID != "NEW-UDID" {
+				t.Fatalf("expected UDID NEW-UDID, got %q", payload.Data.Attributes.UDID)
+			}
+			if payload.Data.Attributes.Platform != "IOS" {
+				t.Fatalf("expected platform IOS, got %q", payload.Data.Attributes.Platform)
+			}
+			body := `{"data":{"type":"devices","id":"device-new","attributes":{"name":"New iPhone","platform":"IOS","udid":"NEW-UDID","status":"ENABLED"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"devices", "register", "--name", "New iPhone", "--udid", "NEW-UDID", "--platform", "IOS"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"device-new"`) {
+		t.Fatalf("expected created device output, got %q", stdout)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected GET and POST requests, got %d", requestCount)
 	}
 }

--- a/internal/cli/cmdtest/devices_register_existing_test.go
+++ b/internal/cli/cmdtest/devices_register_existing_test.go
@@ -66,6 +66,61 @@ func TestDevicesRegisterReusesExistingDeviceWithNormalizedUDID(t *testing.T) {
 	}
 }
 
+func TestDevicesRegisterStopsScanningAfterExistingUDIDMatch(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET before create, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/devices" {
+				t.Fatalf("expected devices list path, got %s", req.URL.Path)
+			}
+			body := `{"data":[{"type":"devices","id":"device-existing","attributes":{"name":"Existing iPhone","platform":"IOS","udid":"ABC-123-DEF","status":"ENABLED"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/devices?cursor=next"}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("expected register to stop after first matching page, got request %d: %s %s", requestCount, req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"devices", "register", "--name", "Existing iPhone", "--udid", "ABC123DEF", "--platform", "IOS"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"device-existing"`) {
+		t.Fatalf("expected existing device output, got %q", stdout)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected one preflight request, got %d", requestCount)
+	}
+}
+
 func TestDevicesRegisterCreatesDeviceWhenNoExistingUDIDMatches(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/devices_register_existing_test.go
+++ b/internal/cli/cmdtest/devices_register_existing_test.go
@@ -1,0 +1,66 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDevicesRegisterReusesExistingDeviceWithNormalizedUDID(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET before create, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/devices" {
+				t.Fatalf("expected devices list path, got %s", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if got := query.Get("filter[platform]"); got != "IOS" {
+				t.Fatalf("expected filter[platform]=IOS, got %q", got)
+			}
+			body := `{"data":[{"type":"devices","id":"device-existing","attributes":{"name":"Existing iPhone","platform":"IOS","udid":"ABC-123-DEF","status":"ENABLED"}}],"links":{"next":""}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("expected register to reuse existing device without POST, got request %d: %s %s", requestCount, req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"devices", "register", "--name", "Existing iPhone", "--udid", "ABC123DEF", "--platform", "IOS"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"device-existing"`) {
+		t.Fatalf("expected existing device output, got %q", stdout)
+	}
+}

--- a/internal/cli/devices/devices.go
+++ b/internal/cli/devices/devices.go
@@ -324,6 +324,14 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
+			existingDevice, err := findExistingDeviceByNormalizedUDID(requestCtx, client, udidValue, platformValue)
+			if err != nil {
+				return fmt.Errorf("devices register: failed to check existing devices: %w", err)
+			}
+			if existingDevice != nil {
+				return shared.PrintOutput(existingDevice, *output.Output, *output.Pretty)
+			}
+
 			attrs := asc.DeviceCreateAttributes{
 				Name:     nameValue,
 				UDID:     udidValue,
@@ -338,6 +346,48 @@ Examples:
 			return shared.PrintOutput(device, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func findExistingDeviceByNormalizedUDID(ctx context.Context, client *asc.Client, udidValue, platformValue string) (*asc.DeviceResponse, error) {
+	targetUDID := normalizeDeviceUDIDForComparison(udidValue)
+	if targetUDID == "" {
+		return nil, nil
+	}
+
+	firstPage, err := client.GetDevices(
+		ctx,
+		asc.WithDevicesPlatforms([]string{platformValue}),
+		asc.WithDevicesFields([]string{"name", "udid", "platform", "status"}),
+		asc.WithDevicesLimit(200),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetDevices(ctx, asc.WithDevicesNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	devices, ok := pages.(*asc.DevicesResponse)
+	if !ok || devices == nil {
+		return nil, nil
+	}
+	for _, device := range devices.Data {
+		if normalizeDeviceUDIDForComparison(device.Attributes.UDID) == targetUDID {
+			return &asc.DeviceResponse{Data: device}, nil
+		}
+	}
+	return nil, nil
+}
+
+func normalizeDeviceUDIDForComparison(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "-", "")
+	value = strings.ReplaceAll(value, ":", "")
+	return strings.ToUpper(value)
 }
 
 // DevicesUpdateCommand returns the devices update subcommand.

--- a/internal/cli/devices/devices.go
+++ b/internal/cli/devices/devices.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -18,6 +19,8 @@ import (
 )
 
 const defaultLocalUDIDCommandTimeout = 10 * time.Second
+
+var errExistingDeviceFound = errors.New("existing device found")
 
 var (
 	localUDIDGOOS           = runtime.GOOS
@@ -364,23 +367,26 @@ func findExistingDeviceByNormalizedUDID(ctx context.Context, client *asc.Client,
 		return nil, err
 	}
 
-	pages, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+	var found *asc.DeviceResponse
+	err = asc.PaginateEach(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
 		return client.GetDevices(ctx, asc.WithDevicesNextURL(nextURL))
+	}, func(page asc.PaginatedResponse) error {
+		devices, ok := page.(*asc.DevicesResponse)
+		if !ok || devices == nil {
+			return nil
+		}
+		for _, device := range devices.Data {
+			if normalizeDeviceUDIDForComparison(device.Attributes.UDID) == targetUDID {
+				found = &asc.DeviceResponse{Data: device}
+				return errExistingDeviceFound
+			}
+		}
+		return nil
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, errExistingDeviceFound) {
 		return nil, err
 	}
-
-	devices, ok := pages.(*asc.DevicesResponse)
-	if !ok || devices == nil {
-		return nil, nil
-	}
-	for _, device := range devices.Data {
-		if normalizeDeviceUDIDForComparison(device.Attributes.UDID) == targetUDID {
-			return &asc.DeviceResponse{Data: device}, nil
-		}
-	}
-	return nil, nil
+	return found, nil
 }
 
 func normalizeDeviceUDIDForComparison(value string) string {


### PR DESCRIPTION
## Summary
- Check existing devices on the requested platform before `asc devices register` creates a new device.
- Compare UDIDs after trimming, uppercasing, and removing hyphens/colons so formatted and unformatted values match.
- Return the existing device response instead of posting a duplicate registration.

## Validation
- `go run . devices register --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestDevicesRegisterReusesExistingDeviceWithNormalizedUDID`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/devices`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `/tmp/asc devices register --help 2>&1 | rg -- '--udid|--platform'`