### PR TITLE
[codex] Split long bundle ID identifier filters

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6236,6 +6236,32 @@ func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
 	}
 }
 
+func TestGetBundleIDs_SplitIdentifierFilterRejectsRepeatedNextURL(t *testing.T) {
+	identifiers := make([]string, 0, 1500)
+	for range 1500 {
+		identifiers = append(identifiers, "a")
+	}
+	nextURL := "https://api.appstoreconnect.apple.com/v1/bundleIds?cursor=repeat"
+
+	requests := 0
+	client := newTestClient(
+		t, func(req *http.Request) {
+			requests++
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-1","attributes":{"identifier":"com.example.one"}}],"links":{"next":"`+nextURL+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-2","attributes":{"identifier":"com.example.two"}}],"links":{"next":"`+nextURL+`"}}`),
+	)
+
+	_, err := client.GetBundleIDs(context.Background(), WithBundleIDsFilterIdentifier(strings.Join(identifiers, ",")))
+	if !errors.Is(err, ErrRepeatedPaginationURL) {
+		t.Fatalf("expected ErrRepeatedPaginationURL, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected repeated next URL to stop after two requests, got %d", requests)
+	}
+}
+
 func TestGetInAppPurchasesV2_WithLimit(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Pro","productId":"com.example.pro","inAppPurchaseType":"CONSUMABLE"}}]}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6184,9 +6184,13 @@ func TestGetBundleIDs_WithIdentifierFilter(t *testing.T) {
 }
 
 func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
-	identifiers := make([]string, 0, 130)
-	for i := range 130 {
-		identifiers = append(identifiers, fmt.Sprintf("com.example.long.identifier.%03d.extension", i))
+	identifiers := make([]string, 0, 1500)
+	for range 1500 {
+		identifiers = append(identifiers, "a")
+	}
+	rawIdentifierFilter := strings.Join(identifiers, ",")
+	if len(rawIdentifierFilter) > bundleIDsIdentifierFilterMaxLength {
+		t.Fatalf("test setup expected raw filter length <= %d, got %d", bundleIDsIdentifierFilterMaxLength, len(rawIdentifierFilter))
 	}
 
 	requests := 0
@@ -6210,8 +6214,8 @@ func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
 			if filter == "" {
 				t.Fatal("expected filter[identifier]")
 			}
-			if len(filter) > bundleIDsIdentifierFilterMaxLength {
-				t.Fatalf("expected filter[identifier] to be chunked below %d chars, got %d", bundleIDsIdentifierFilterMaxLength, len(filter))
+			if len(req.URL.RequestURI()) > bundleIDsIdentifierFilterMaxLength {
+				t.Fatalf("expected encoded request URI to be chunked below %d chars, got %d", bundleIDsIdentifierFilterMaxLength, len(req.URL.RequestURI()))
 			}
 			assertAuthorized(t, req)
 		},
@@ -6220,7 +6224,7 @@ func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
 		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-3","attributes":{"identifier":"com.example.two"}}]}`),
 	)
 
-	resp, err := client.GetBundleIDs(context.Background(), WithBundleIDsFilterIdentifier(strings.Join(identifiers, ",")))
+	resp, err := client.GetBundleIDs(context.Background(), WithBundleIDsFilterIdentifier(rawIdentifierFilter))
 	if err != nil {
 		t.Fatalf("GetBundleIDs() error: %v", err)
 	}

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6199,6 +6199,13 @@ func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
 			if req.URL.Path != "/v1/bundleIds" {
 				t.Fatalf("expected path /v1/bundleIds, got %s", req.URL.Path)
 			}
+			if requests == 2 {
+				if req.URL.Query().Get("cursor") != "chunk-one-next" {
+					t.Fatalf("expected next page cursor, got query %q", req.URL.RawQuery)
+				}
+				assertAuthorized(t, req)
+				return
+			}
 			filter := req.URL.Query().Get("filter[identifier]")
 			if filter == "" {
 				t.Fatal("expected filter[identifier]")
@@ -6208,18 +6215,19 @@ func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
 			}
 			assertAuthorized(t, req)
 		},
-		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-1","attributes":{"identifier":"com.example.one"}}]}`),
-		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-2","attributes":{"identifier":"com.example.two"}}]}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-1","attributes":{"identifier":"com.example.one"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/bundleIds?cursor=chunk-one-next"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-2","attributes":{"identifier":"com.example.one.more"}}]}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-3","attributes":{"identifier":"com.example.two"}}]}`),
 	)
 
 	resp, err := client.GetBundleIDs(context.Background(), WithBundleIDsFilterIdentifier(strings.Join(identifiers, ",")))
 	if err != nil {
 		t.Fatalf("GetBundleIDs() error: %v", err)
 	}
-	if requests < 2 {
-		t.Fatalf("expected long identifier filter to be split into multiple requests, got %d", requests)
+	if requests != 3 {
+		t.Fatalf("expected split requests to paginate each chunk, got %d", requests)
 	}
-	if len(resp.Data) != 2 {
+	if len(resp.Data) != 3 {
 		t.Fatalf("expected aggregated bundle IDs from split requests, got %d", len(resp.Data))
 	}
 }

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6183,6 +6183,47 @@ func TestGetBundleIDs_WithIdentifierFilter(t *testing.T) {
 	}
 }
 
+func TestGetBundleIDs_SplitsLongIdentifierFilter(t *testing.T) {
+	identifiers := make([]string, 0, 130)
+	for i := range 130 {
+		identifiers = append(identifiers, fmt.Sprintf("com.example.long.identifier.%03d.extension", i))
+	}
+
+	requests := 0
+	client := newTestClient(
+		t, func(req *http.Request) {
+			requests++
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/bundleIds" {
+				t.Fatalf("expected path /v1/bundleIds, got %s", req.URL.Path)
+			}
+			filter := req.URL.Query().Get("filter[identifier]")
+			if filter == "" {
+				t.Fatal("expected filter[identifier]")
+			}
+			if len(filter) > bundleIDsIdentifierFilterMaxLength {
+				t.Fatalf("expected filter[identifier] to be chunked below %d chars, got %d", bundleIDsIdentifierFilterMaxLength, len(filter))
+			}
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-1","attributes":{"identifier":"com.example.one"}}]}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"bundleIds","id":"bid-2","attributes":{"identifier":"com.example.two"}}]}`),
+	)
+
+	resp, err := client.GetBundleIDs(context.Background(), WithBundleIDsFilterIdentifier(strings.Join(identifiers, ",")))
+	if err != nil {
+		t.Fatalf("GetBundleIDs() error: %v", err)
+	}
+	if requests < 2 {
+		t.Fatalf("expected long identifier filter to be split into multiple requests, got %d", requests)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected aggregated bundle IDs from split requests, got %d", len(resp.Data))
+	}
+}
+
 func TestGetInAppPurchasesV2_WithLimit(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Pro","productId":"com.example.pro","inAppPurchaseType":"CONSUMABLE"}}]}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/client_signing.go
+++ b/internal/asc/client_signing.go
@@ -7,11 +7,17 @@ import (
 	"strings"
 )
 
+const bundleIDsIdentifierFilterMaxLength = 3900
+
 // GetBundleIDs retrieves the list of bundle IDs.
 func (c *Client) GetBundleIDs(ctx context.Context, opts ...BundleIDsOption) (*BundleIDsResponse, error) {
 	query := &bundleIDsQuery{}
 	for _, opt := range opts {
 		opt(query)
+	}
+
+	if query.nextURL == "" && shouldSplitBundleIDsIdentifierFilter(query.identifier) {
+		return c.getBundleIDsWithSplitIdentifierFilter(ctx, query)
 	}
 
 	path := "/v1/bundleIds"
@@ -36,6 +42,82 @@ func (c *Client) GetBundleIDs(ctx context.Context, opts ...BundleIDsOption) (*Bu
 	}
 
 	return &response, nil
+}
+
+func shouldSplitBundleIDsIdentifierFilter(identifier string) bool {
+	return len(strings.TrimSpace(identifier)) > bundleIDsIdentifierFilterMaxLength && strings.Contains(identifier, ",")
+}
+
+func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, query *bundleIDsQuery) (*BundleIDsResponse, error) {
+	chunks := splitCSVByMaxLength(query.identifier, bundleIDsIdentifierFilterMaxLength)
+	combined := &BundleIDsResponse{}
+
+	for _, chunk := range chunks {
+		chunkQuery := *query
+		chunkQuery.identifier = strings.Join(chunk, ",")
+		resp, err := c.getBundleIDsPage(ctx, &chunkQuery)
+		if err != nil {
+			return nil, err
+		}
+		combined.Data = append(combined.Data, resp.Data...)
+	}
+
+	return combined, nil
+}
+
+func (c *Client) getBundleIDsPage(ctx context.Context, query *bundleIDsQuery) (*BundleIDsResponse, error) {
+	path := "/v1/bundleIds"
+	if queryString := buildBundleIDsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+
+	data, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BundleIDsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+func splitCSVByMaxLength(value string, maxLength int) [][]string {
+	parts := strings.Split(value, ",")
+	chunks := make([][]string, 0, 1)
+	current := make([]string, 0)
+	currentLength := 0
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		nextLength := len(part)
+		if currentLength > 0 {
+			nextLength += currentLength + 1
+		}
+		if len(current) > 0 && nextLength > maxLength {
+			chunks = append(chunks, current)
+			current = nil
+			currentLength = 0
+		}
+
+		current = append(current, part)
+		if currentLength == 0 {
+			currentLength = len(part)
+		} else {
+			currentLength += len(part) + 1
+		}
+	}
+
+	if len(current) > 0 {
+		chunks = append(chunks, current)
+	}
+	return chunks
 }
 
 // GetBundleID retrieves a single bundle ID by ID.

--- a/internal/asc/client_signing.go
+++ b/internal/asc/client_signing.go
@@ -16,19 +16,17 @@ func (c *Client) GetBundleIDs(ctx context.Context, opts ...BundleIDsOption) (*Bu
 		opt(query)
 	}
 
-	if query.nextURL == "" && shouldSplitBundleIDsIdentifierFilter(query.identifier) {
+	if query.nextURL == "" && shouldSplitBundleIDsIdentifierFilter(query) {
 		return c.getBundleIDsWithSplitIdentifierFilter(ctx, query)
 	}
 
-	path := "/v1/bundleIds"
+	path := bundleIDsRequestPath(query)
 	if query.nextURL != "" {
 		// Validate nextURL to prevent credential exfiltration
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("bundleIds: %w", err)
 		}
 		path = query.nextURL
-	} else if queryString := buildBundleIDsQuery(query); queryString != "" {
-		path += "?" + queryString
 	}
 
 	data, err := c.do(ctx, "GET", path, nil)
@@ -44,12 +42,13 @@ func (c *Client) GetBundleIDs(ctx context.Context, opts ...BundleIDsOption) (*Bu
 	return &response, nil
 }
 
-func shouldSplitBundleIDsIdentifierFilter(identifier string) bool {
-	return len(strings.TrimSpace(identifier)) > bundleIDsIdentifierFilterMaxLength && strings.Contains(identifier, ",")
+func shouldSplitBundleIDsIdentifierFilter(query *bundleIDsQuery) bool {
+	identifier := strings.TrimSpace(query.identifier)
+	return strings.Contains(identifier, ",") && len(bundleIDsRequestPath(query)) > bundleIDsIdentifierFilterMaxLength
 }
 
 func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, query *bundleIDsQuery) (*BundleIDsResponse, error) {
-	chunks := splitCSVByMaxLength(query.identifier, bundleIDsIdentifierFilterMaxLength)
+	chunks := splitBundleIDsIdentifierFilter(query, bundleIDsIdentifierFilterMaxLength)
 	combined := &BundleIDsResponse{}
 
 	for _, chunk := range chunks {
@@ -73,14 +72,12 @@ func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, quer
 }
 
 func (c *Client) getBundleIDsPage(ctx context.Context, query *bundleIDsQuery) (*BundleIDsResponse, error) {
-	path := "/v1/bundleIds"
+	path := bundleIDsRequestPath(query)
 	if strings.TrimSpace(query.nextURL) != "" {
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("bundleIds: %w", err)
 		}
 		path = query.nextURL
-	} else if queryString := buildBundleIDsQuery(query); queryString != "" {
-		path += "?" + queryString
 	}
 
 	data, err := c.do(ctx, "GET", path, nil)
@@ -96,11 +93,18 @@ func (c *Client) getBundleIDsPage(ctx context.Context, query *bundleIDsQuery) (*
 	return &response, nil
 }
 
-func splitCSVByMaxLength(value string, maxLength int) [][]string {
-	parts := strings.Split(value, ",")
+func bundleIDsRequestPath(query *bundleIDsQuery) string {
+	path := "/v1/bundleIds"
+	if queryString := buildBundleIDsQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
+	return path
+}
+
+func splitBundleIDsIdentifierFilter(query *bundleIDsQuery, maxLength int) [][]string {
+	parts := strings.Split(query.identifier, ",")
 	chunks := make([][]string, 0, 1)
 	current := make([]string, 0)
-	currentLength := 0
 
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
@@ -108,22 +112,16 @@ func splitCSVByMaxLength(value string, maxLength int) [][]string {
 			continue
 		}
 
-		nextLength := len(part)
-		if currentLength > 0 {
-			nextLength += currentLength + 1
-		}
-		if len(current) > 0 && nextLength > maxLength {
+		candidate := append(append([]string{}, current...), part)
+		candidateQuery := *query
+		candidateQuery.identifier = strings.Join(candidate, ",")
+		if len(current) > 0 && len(bundleIDsRequestPath(&candidateQuery)) > maxLength {
 			chunks = append(chunks, current)
-			current = nil
-			currentLength = 0
+			current = []string{part}
+			continue
 		}
 
-		current = append(current, part)
-		if currentLength == 0 {
-			currentLength = len(part)
-		} else {
-			currentLength += len(part) + 1
-		}
+		current = candidate
 	}
 
 	if len(current) > 0 {

--- a/internal/asc/client_signing.go
+++ b/internal/asc/client_signing.go
@@ -54,6 +54,8 @@ func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, quer
 	for _, chunk := range chunks {
 		chunkQuery := *query
 		chunkQuery.identifier = strings.Join(chunk, ",")
+		page := 1
+		seenNext := make(map[string]struct{})
 
 		for {
 			resp, err := c.getBundleIDsPage(ctx, &chunkQuery)
@@ -61,10 +63,16 @@ func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, quer
 				return nil, err
 			}
 			combined.Data = append(combined.Data, resp.Data...)
-			if strings.TrimSpace(resp.Links.Next) == "" {
+			next := strings.TrimSpace(resp.Links.Next)
+			if next == "" {
 				break
 			}
-			chunkQuery = bundleIDsQuery{listQuery: listQuery{nextURL: resp.Links.Next}}
+			if _, ok := seenNext[next]; ok {
+				return nil, fmt.Errorf("page %d: %w", page+1, ErrRepeatedPaginationURL)
+			}
+			seenNext[next] = struct{}{}
+			page++
+			chunkQuery = bundleIDsQuery{listQuery: listQuery{nextURL: next}}
 		}
 	}
 

--- a/internal/asc/client_signing.go
+++ b/internal/asc/client_signing.go
@@ -55,11 +55,18 @@ func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, quer
 	for _, chunk := range chunks {
 		chunkQuery := *query
 		chunkQuery.identifier = strings.Join(chunk, ",")
-		resp, err := c.getBundleIDsPage(ctx, &chunkQuery)
-		if err != nil {
-			return nil, err
+
+		for {
+			resp, err := c.getBundleIDsPage(ctx, &chunkQuery)
+			if err != nil {
+				return nil, err
+			}
+			combined.Data = append(combined.Data, resp.Data...)
+			if strings.TrimSpace(resp.Links.Next) == "" {
+				break
+			}
+			chunkQuery = bundleIDsQuery{listQuery: listQuery{nextURL: resp.Links.Next}}
 		}
-		combined.Data = append(combined.Data, resp.Data...)
 	}
 
 	return combined, nil
@@ -67,7 +74,12 @@ func (c *Client) getBundleIDsWithSplitIdentifierFilter(ctx context.Context, quer
 
 func (c *Client) getBundleIDsPage(ctx context.Context, query *bundleIDsQuery) (*BundleIDsResponse, error) {
 	path := "/v1/bundleIds"
-	if queryString := buildBundleIDsQuery(query); queryString != "" {
+	if strings.TrimSpace(query.nextURL) != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("bundleIds: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildBundleIDsQuery(query); queryString != "" {
 		path += "?" + queryString
 	}
 


### PR DESCRIPTION
## Summary
- Split oversized `filter[identifier]` CSV lookups for bundle IDs into multiple requests.
- Keep each identifier filter below the App Store Connect URL-length danger zone.
- Aggregate split responses so signing lookups can handle large bundle ID sets.

## Validation
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run 'TestGetBundleIDs_WithIdentifierFilter|TestGetBundleIDs_SplitsLongIdentifierFilter'`\n- `make format`\n- `make check-command-docs`\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 go test ./apps/studio -run TestCheckAuthStatusTreatsEmptyStoredCredentialsAsUnauthenticated -count=1 -v`\n- `ASC_BYPASS_KEYCHAIN=1 go test ./apps/studio -count=1`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n- `go build -o /tmp/asc .`\n- `/tmp/asc bundle-ids list --help 2>&1 | rg -- 'bundle-ids list|--paginate|--limit'`\n\nNote: the first full gate run hit a transient `apps/studio` auth-status assertion; the exact test, package rerun, and full `make test` rerun all passed cleanly.