### PR TITLE
[codex] Exclude expired builds from latest selectors

### DIFF
--- a/internal/cli/builds/build_selector_flags.go
+++ b/internal/cli/builds/build_selector_flags.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 type buildSelectorFlags struct {
@@ -102,6 +103,14 @@ func (s buildSelectorFlags) resolveOptions() ResolveBuildOptions {
 
 func (s buildSelectorFlags) validate() error {
 	return validateResolveBuildOptions(s.resolveOptions())
+}
+
+func (s buildSelectorFlags) validateNextPageSelectorFlags() error {
+	opts := s.resolveOptions()
+	if opts.ExcludeExpired && !opts.Latest {
+		return shared.UsageError("--exclude-expired and --not-expired require --latest")
+	}
+	return nil
 }
 
 func (s buildSelectorFlags) resolveBuild(ctx context.Context, client *asc.Client) (*asc.BuildResponse, error) {

--- a/internal/cli/builds/build_selector_flags.go
+++ b/internal/cli/builds/build_selector_flags.go
@@ -9,14 +9,16 @@ import (
 )
 
 type buildSelectorFlags struct {
-	buildID       *string
-	legacyBuildID *trackedStringFlag
-	legacyID      *trackedStringFlag
-	appID         *string
-	latest        *bool
-	version       *string
-	buildNumber   *string
-	platform      *string
+	buildID        *string
+	legacyBuildID  *trackedStringFlag
+	legacyID       *trackedStringFlag
+	appID          *string
+	latest         *bool
+	version        *string
+	buildNumber    *string
+	platform       *string
+	excludeExpired *bool
+	notExpired     *bool
 }
 
 type buildSelectorFlagOptions struct {
@@ -56,13 +58,15 @@ func bindBuildSelectorFlags(fs *flag.FlagSet, opts buildSelectorFlagOptions) bui
 	}
 
 	selectors := buildSelectorFlags{
-		buildID:       fs.String("build-id", "", buildIDUsage),
-		legacyBuildID: bindHiddenStringFlag(fs, "build"),
-		appID:         fs.String("app", "", appUsage),
-		latest:        fs.Bool("latest", false, latestUsage),
-		version:       fs.String("version", "", versionUsage),
-		buildNumber:   fs.String("build-number", "", buildNumberUsage),
-		platform:      fs.String("platform", "", platformUsage),
+		buildID:        fs.String("build-id", "", buildIDUsage),
+		legacyBuildID:  bindHiddenStringFlag(fs, "build"),
+		appID:          fs.String("app", "", appUsage),
+		latest:         fs.Bool("latest", false, latestUsage),
+		version:        fs.String("version", "", versionUsage),
+		buildNumber:    fs.String("build-number", "", buildNumberUsage),
+		platform:       fs.String("platform", "", platformUsage),
+		excludeExpired: fs.Bool("exclude-expired", false, "Exclude expired builds when selecting --latest"),
+		notExpired:     fs.Bool("not-expired", false, "Alias for --exclude-expired"),
 	}
 	if opts.includeLegacyID {
 		selectors.legacyID = bindHiddenStringFlag(fs, "id")
@@ -91,6 +95,8 @@ func (s buildSelectorFlags) resolveOptions() ResolveBuildOptions {
 		BuildNumber: strings.TrimSpace(s.value(s.buildNumber)),
 		Platform:    strings.TrimSpace(s.value(s.platform)),
 		Latest:      s.latest != nil && *s.latest,
+		ExcludeExpired: (s.excludeExpired != nil && *s.excludeExpired) ||
+			(s.notExpired != nil && *s.notExpired),
 	}
 }
 

--- a/internal/cli/builds/build_selector_flags_test.go
+++ b/internal/cli/builds/build_selector_flags_test.go
@@ -1,0 +1,51 @@
+package builds
+
+import (
+	"errors"
+	"flag"
+	"testing"
+)
+
+func TestBuildSelectorFlagsResolveExcludeExpired(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "exclude-expired",
+			args: []string{"--app", "123456789", "--latest", "--exclude-expired"},
+		},
+		{
+			name: "not-expired alias",
+			args: []string{"--app", "123456789", "--latest", "--not-expired"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			selectors := bindBuildSelectorFlags(fs, buildSelectorFlagOptions{})
+			if err := fs.Parse(test.args); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+
+			opts := selectors.resolveOptions()
+			if !opts.ExcludeExpired {
+				t.Fatal("expected ExcludeExpired to be true")
+			}
+		})
+	}
+}
+
+func TestBuildSelectorFlagsRejectExcludeExpiredWithoutLatest(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	selectors := bindBuildSelectorFlags(fs, buildSelectorFlagOptions{})
+	if err := fs.Parse([]string{"--app", "123456789", "--exclude-expired"}); err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	err := selectors.validate()
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp usage error, got %v", err)
+	}
+}

--- a/internal/cli/builds/build_test_notes.go
+++ b/internal/cli/builds/build_test_notes.go
@@ -104,6 +104,8 @@ Examples:
 				if err := validateResolveBuildOptions(selectors.resolveOptions()); err != nil {
 					return fmt.Errorf("builds test-notes list: %w", err)
 				}
+			} else if err := selectors.validateNextPageSelectorFlags(); err != nil {
+				return fmt.Errorf("builds test-notes list: %w", err)
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
@@ -167,6 +168,29 @@ func TestBuildsUpdateCommand_Shape(t *testing.T) {
 	encFlag := cmd.FlagSet.Lookup("uses-non-exempt-encryption")
 	if encFlag == nil {
 		t.Fatal("expected --uses-non-exempt-encryption flag to be defined")
+	}
+}
+
+func TestBuildSelectorCommandsExposeExcludeExpiredFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  func() *ffcli.Command
+	}{
+		{name: "add-groups", cmd: BuildsAddGroupsCommand},
+		{name: "dsyms", cmd: BuildsDsymsCommand},
+		{name: "update", cmd: BuildsUpdateCommand},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flags := test.cmd().FlagSet
+			if flags.Lookup("exclude-expired") == nil {
+				t.Fatal("expected --exclude-expired flag to be defined")
+			}
+			if flags.Lookup("not-expired") == nil {
+				t.Fatal("expected --not-expired flag to be defined")
+			}
+		})
 	}
 }
 

--- a/internal/cli/builds/builds_dsyms.go
+++ b/internal/cli/builds/builds_dsyms.go
@@ -54,6 +54,8 @@ func BuildsDsymsCommand() *ffcli.Command {
 	buildNumber := fs.String("build-number", "", "Build number (CFBundleVersion)")
 	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	latest := fs.Bool("latest", false, "Download dSYMs for the latest build")
+	excludeExpired := fs.Bool("exclude-expired", false, "Exclude expired builds when selecting --latest")
+	notExpired := fs.Bool("not-expired", false, "Alias for --exclude-expired")
 	outputDir := fs.String("output-dir", ".", "Output directory for dSYM files")
 	output := shared.BindOutputFlags(fs)
 
@@ -89,12 +91,13 @@ Examples:
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			appInput := strings.TrimSpace(*appID)
 			resolveOpts := ResolveBuildOptions{
-				BuildID:     trimmedBuildID,
-				AppID:       appInput,
-				Version:     strings.TrimSpace(*version),
-				BuildNumber: strings.TrimSpace(*buildNumber),
-				Platform:    strings.TrimSpace(*platform),
-				Latest:      *latest,
+				BuildID:        trimmedBuildID,
+				AppID:          appInput,
+				Version:        strings.TrimSpace(*version),
+				BuildNumber:    strings.TrimSpace(*buildNumber),
+				Platform:       strings.TrimSpace(*platform),
+				Latest:         *latest,
+				ExcludeExpired: *excludeExpired || *notExpired,
 			}
 			if err := validateResolveBuildOptions(resolveOpts); err != nil {
 				return fmt.Errorf("builds dsyms: %w", err)

--- a/internal/cli/builds/builds_individual_testers.go
+++ b/internal/cli/builds/builds_individual_testers.go
@@ -80,6 +80,8 @@ Examples:
 				if err := selectors.validate(); err != nil {
 					return err
 				}
+			} else if err := selectors.validateNextPageSelectorFlags(); err != nil {
+				return fmt.Errorf("builds individual-testers list: %w", err)
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_metrics.go
+++ b/internal/cli/builds/builds_metrics.go
@@ -75,6 +75,8 @@ Examples:
 				if err := selectors.validate(); err != nil {
 					return err
 				}
+			} else if err := selectors.validateNextPageSelectorFlags(); err != nil {
+				return fmt.Errorf("builds metrics beta-usages: %w", err)
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_related.go
+++ b/internal/cli/builds/builds_related.go
@@ -235,6 +235,8 @@ Examples:
 				if err := selectors.validate(); err != nil {
 					return err
 				}
+			} else if err := selectors.validateNextPageSelectorFlags(); err != nil {
+				return fmt.Errorf("builds icons list: %w", err)
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_relationships.go
+++ b/internal/cli/builds/builds_relationships.go
@@ -108,6 +108,8 @@ Examples:
 				if err := selectors.validate(); err != nil {
 					return err
 				}
+			} else if err := selectors.validateNextPageSelectorFlags(); err != nil {
+				return fmt.Errorf("builds links view: %w", err)
 			}
 
 			if kind == relationshipSingle && (nextValue != "" || *paginate || *limit != 0) {

--- a/internal/cli/cmdtest/builds_next_validation_phase48_test.go
+++ b/internal/cli/cmdtest/builds_next_validation_phase48_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -189,11 +191,63 @@ func runBuildsFetchFromNext(
 	}
 }
 
+func runBuildsRejectExpiredFilterFromNext(
+	t *testing.T,
+	argsPrefix []string,
+	nextURL string,
+) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{name: "exclude-expired", flag: "--exclude-expired"},
+		{name: "not-expired", flag: "--not-expired"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := append(append([]string{}, argsPrefix...), "--next", nextURL, test.flag)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+			}
+			wantErr := "--exclude-expired and --not-expired require --latest"
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "Error: "+wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", "Error: "+wantErr, stderr)
+			}
+		})
+	}
+}
+
 func TestBuildsIconsListRejectsInvalidNextURL(t *testing.T) {
 	runBuildsInvalidNextURLCases(
 		t,
 		[]string{"builds", "icons", "list"},
 		"builds icons list: --next",
+	)
+}
+
+func TestBuildsIconsListRejectsExpiredFilterFromNextWithoutLatest(t *testing.T) {
+	runBuildsRejectExpiredFilterFromNext(
+		t,
+		[]string{"builds", "icons", "list"},
+		"https://api.appstoreconnect.apple.com/v1/builds/build-1/icons?cursor=AQ",
 	)
 }
 
@@ -243,6 +297,14 @@ func TestBuildsIndividualTestersListRejectsInvalidNextURL(t *testing.T) {
 	)
 }
 
+func TestBuildsIndividualTestersListRejectsExpiredFilterFromNextWithoutLatest(t *testing.T) {
+	runBuildsRejectExpiredFilterFromNext(
+		t,
+		[]string{"builds", "individual-testers", "list"},
+		"https://api.appstoreconnect.apple.com/v1/builds/build-1/individualTesters?cursor=AQ",
+	)
+}
+
 func TestBuildsIndividualTestersListPaginateFromNext(t *testing.T) {
 	const firstURL = "https://api.appstoreconnect.apple.com/v1/builds/build-1/individualTesters?cursor=AQ&limit=200"
 	const secondURL = "https://api.appstoreconnect.apple.com/v1/builds/build-1/individualTesters?cursor=BQ&limit=200"
@@ -286,6 +348,14 @@ func TestBuildsMetricsBetaUsagesRejectsInvalidNextURL(t *testing.T) {
 		t,
 		[]string{"builds", "metrics", "beta-usages"},
 		"builds metrics beta-usages: --next",
+	)
+}
+
+func TestBuildsMetricsBetaUsagesRejectsExpiredFilterFromNextWithoutLatest(t *testing.T) {
+	runBuildsRejectExpiredFilterFromNext(
+		t,
+		[]string{"builds", "metrics", "beta-usages"},
+		"https://api.appstoreconnect.apple.com/v1/builds/build-1/metrics/betaBuildUsages?cursor=AQ",
 	)
 }
 

--- a/internal/cli/cmdtest/builds_selector_exclude_expired_test.go
+++ b/internal/cli/cmdtest/builds_selector_exclude_expired_test.go
@@ -1,0 +1,89 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildSelectorLatestExcludeExpiredFiltersResolvedBuild(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/builds" {
+				t.Fatalf("expected builds lookup, got %s", req.URL.Path)
+			}
+			query := req.URL.Query()
+			if got := query.Get("filter[app]"); got != "123456789" {
+				t.Fatalf("expected app filter 123456789, got %q", got)
+			}
+			if got := query.Get("filter[expired]"); got != "false" {
+				t.Fatalf("expected expired=false filter, got %q", got)
+			}
+			if got := query.Get("sort"); got != "-uploadedDate" {
+				t.Fatalf("expected sort=-uploadedDate, got %q", got)
+			}
+			body := `{"data":[{"type":"builds","id":"build-active","attributes":{"version":"42","uploadedDate":"2026-05-31T00:00:00Z"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/builds/build-active/app" {
+				t.Fatalf("expected build app lookup, got %s", req.URL.Path)
+			}
+			body := `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Example"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "app", "view", "--app", "123456789", "--latest", "--exclude-expired"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"123456789"`) {
+		t.Fatalf("expected app output, got %q", stdout)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected 2 requests, got %d", requestCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--exclude-expired` and `--not-expired` to shared build `--app --latest` selectors.
- Wire the same filtering into `builds dsyms`, which owns its selector flags directly.
- Preserve the existing validation rule that expired-build filtering only applies with `--latest`.

## Validation
- `go run . builds dsyms --help`
- `go run . builds add-groups --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/builds ./internal/cli/cmdtest -run 'TestBuildSelectorFlagsResolveExcludeExpired|TestBuildSelectorFlagsRejectExcludeExpiredWithoutLatest|TestBuildSelectorCommandsExposeExcludeExpiredFlags|TestBuildSelectorLatestExcludeExpiredFiltersResolvedBuild'`\n- `make generate-command-docs`\n- `make format`\n- `make check-command-docs`\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n- `go build -o /tmp/asc .`\n- `/tmp/asc builds dsyms --help 2>&1 | rg -- '--exclude-expired|--not-expired'`\n- `/tmp/asc builds add-groups --help 2>&1 | rg -- '--exclude-expired|--not-expired'`