### PR TITLE
[codex] Cover internal TestFlight group payload

### DIFF
--- a/internal/cli/cmdtest/beta_groups_create_test.go
+++ b/internal/cli/cmdtest/beta_groups_create_test.go
@@ -40,6 +40,11 @@ func TestBetaGroupsCreateInternalSetsAttributeOnCreate(t *testing.T) {
 			if !strings.Contains(string(payload), `"isInternalGroup":true`) {
 				t.Fatalf("expected isInternalGroup=true in body, got %s", string(payload))
 			}
+			for _, field := range []string{"publicLinkEnabled", "publicLinkLimitEnabled", "publicLinkLimit"} {
+				if strings.Contains(string(payload), field) {
+					t.Fatalf("did not expect internal group create payload to include %s, got %s", field, string(payload))
+				}
+			}
 			if !strings.Contains(string(payload), `"type":"apps"`) || !strings.Contains(string(payload), `"id":"app-1"`) {
 				t.Fatalf("expected app relationship in body, got %s", string(payload))
 			}


### PR DESCRIPTION
## Summary
- Adds command-level regression coverage for internal TestFlight group creation.
- Verifies internal group create payloads send `isInternalGroup` and omit public-link attributes that are invalid for internal groups.

## Validation
- `go run . testflight groups create --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestBetaGroupsCreateInternalSetsAttributeOnCreate -count=1`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `/tmp/asc testflight groups create --help`
