### PR TITLE
Add App Clip parent bundle web capability sync

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -117,6 +117,30 @@ func TestRun_RemovedTopLevelCommandsReturnUnknown(t *testing.T) {
 	}
 }
 
+func TestRun_WebBundleIDSyncAppClipInvalidSettingsJSONReturnsUsage(t *testing.T) {
+	resetReportFlags(t)
+
+	_, stderr := captureCommandOutput(t, func() {
+		code := Run([]string{
+			"web", "bundle-ids", "capabilities", "sync-app-clip",
+			"--bundle-id", "clip-1",
+			"--parent-bundle-id", "parent-1",
+			"--capability", "PUSH_NOTIFICATIONS",
+			"--settings-json", "null",
+		}, "1.0.0")
+		if code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if !strings.Contains(stderr, "--settings-json must be a JSON array") {
+		t.Fatalf("expected settings-json usage error, got %q", stderr)
+	}
+	if strings.Contains(stderr, "--apple-id is required") {
+		t.Fatalf("expected settings-json validation before auth resolution, got %q", stderr)
+	}
+}
+
 func TestRun_NoArgsShowsHelpReturnsSuccess(t *testing.T) {
 	resetReportFlags(t)
 

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -51,6 +51,13 @@ func TestWebAppsMedicalDeviceSetSubcommandIsRegistered(t *testing.T) {
 	}
 }
 
+func TestWebBundleIDCapabilitiesSyncAppClipSubcommandIsRegistered(t *testing.T) {
+	root := RootCommand("1.2.3")
+	if sub := findSubcommand(root, "web", "bundle-ids", "capabilities", "sync-app-clip"); sub == nil {
+		t.Fatalf("expected web bundle-ids capabilities sync-app-clip to be registered")
+	}
+}
+
 func TestWebSandboxCreateSubcommandIsRegistered(t *testing.T) {
 	root := RootCommand("1.2.3")
 	if sub := findSubcommand(root, "web", "sandbox", "create"); sub == nil {

--- a/internal/cli/web/test_hooks.go
+++ b/internal/cli/web/test_hooks.go
@@ -49,3 +49,11 @@ func SetLookupWebAuthKey(fn func(context.Context, *webcore.Client, string) (*web
 		lookupWebAuthKeyFn = prev
 	}
 }
+
+func SetSyncAppClipBundleIDCapability(fn func(context.Context, *webcore.Client, webcore.AppClipBundleIDCapabilitySyncRequest) (*webcore.AppClipBundleIDCapabilitySyncResult, error)) func() {
+	prev := syncAppClipBundleIDCapabilityFn
+	syncAppClipBundleIDCapabilityFn = fn
+	return func() {
+		syncAppClipBundleIDCapabilityFn = prev
+	}
+}

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -47,6 +47,7 @@ Examples:
 			WebAuthCommand(),
 			WebSandboxCommand(),
 			WebAppsCommand(),
+			WebBundleIDsCommand(),
 			WebPrivacyCommand(),
 			WebReviewCommand(),
 			WebSubscriptionsCommand(),

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+var syncAppClipBundleIDCapabilityFn = func(ctx context.Context, client *webcore.Client, req webcore.AppClipBundleIDCapabilitySyncRequest) (*webcore.AppClipBundleIDCapabilitySyncResult, error) {
+	return client.SyncAppClipBundleIDCapability(ctx, req)
+}
+
+// WebBundleIDsCommand returns the private Bundle ID command group.
+func WebBundleIDsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web bundle-ids", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "bundle-ids",
+		ShortUsage: "asc web bundle-ids <subcommand> [flags]",
+		ShortHelp:  "[experimental] Manage Bundle IDs via private web-session endpoints.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Manage Bundle ID operations that are only available through Apple's private
+web-session endpoints.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebBundleIDCapabilitiesCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebBundleIDCapabilitiesCommand returns the private Bundle ID capabilities group.
+func WebBundleIDCapabilitiesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web bundle-ids capabilities", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "capabilities",
+		ShortUsage: "asc web bundle-ids capabilities <subcommand> [flags]",
+		ShortHelp:  "[experimental] Sync Bundle ID capabilities via web sessions.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Sync Bundle ID capabilities through Apple's private Bundle ID patch endpoint.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebBundleIDCapabilitiesSyncAppClipCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebBundleIDCapabilitiesSyncAppClipCommand syncs one App Clip capability relationship.
+func WebBundleIDCapabilitiesSyncAppClipCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web bundle-ids capabilities sync-app-clip", flag.ExitOnError)
+
+	bundleID := fs.String("bundle-id", "", "Opaque App Clip Bundle ID resource ID")
+	parentBundleID := fs.String("parent-bundle-id", "", "Opaque parent app Bundle ID resource ID")
+	capability := fs.String("capability", "", "Capability ID (for example: PUSH_NOTIFICATIONS)")
+	settingsJSON := fs.String("settings-json", "", "Optional JSON array of capability settings")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "sync-app-clip",
+		ShortUsage: "asc web bundle-ids capabilities sync-app-clip --bundle-id BUNDLE_ID --parent-bundle-id PARENT_BUNDLE_ID --capability CAPABILITY [flags]",
+		ShortHelp:  "[experimental] Sync an App Clip capability with parentBundleId.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Patch an App Clip Bundle ID capability through Apple's private Bundle ID update
+payload and include the parentBundleId relationship required for App Clip
+targets. This mirrors the App Store Connect web-session shape used for App Clip
+Bundle IDs, not the public API-key capability endpoint.
+
+Examples:
+  asc web bundle-ids capabilities sync-app-clip --bundle-id "CLIP_BUNDLE_ID" --parent-bundle-id "PARENT_BUNDLE_ID" --capability "PUSH_NOTIFICATIONS"
+  asc web bundle-ids capabilities sync-app-clip --bundle-id "CLIP_BUNDLE_ID" --parent-bundle-id "PARENT_BUNDLE_ID" --capability "PUSH_NOTIFICATIONS" --settings-json '[{"key":"PUSH_NOTIFICATION_FEATURES","options":[{"key":"PUSH_NOTIFICATION_FEATURE_BROADCAST","enabled":true}]}]'
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web bundle-ids capabilities sync-app-clip does not accept positional arguments")
+			}
+
+			resolvedBundleID := strings.TrimSpace(*bundleID)
+			resolvedParentBundleID := strings.TrimSpace(*parentBundleID)
+			resolvedCapability := strings.ToUpper(strings.TrimSpace(*capability))
+			if resolvedBundleID == "" {
+				return shared.UsageError("--bundle-id is required")
+			}
+			if resolvedParentBundleID == "" {
+				return shared.UsageError("--parent-bundle-id is required")
+			}
+			if resolvedCapability == "" {
+				return shared.UsageError("--capability is required")
+			}
+
+			settings, err := parseWebBundleIDCapabilitySettings(*settingsJSON)
+			if err != nil {
+				return shared.UsageErrorf("--settings-json must be a JSON array of capability settings: %v", err)
+			}
+
+			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			if err != nil {
+				return err
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			client := newWebClientFn(session)
+			var result *webcore.AppClipBundleIDCapabilitySyncResult
+			err = withWebSpinner("Syncing App Clip Bundle ID capability", func() error {
+				var err error
+				result, err = syncAppClipBundleIDCapabilityFn(requestCtx, client, webcore.AppClipBundleIDCapabilitySyncRequest{
+					BundleID:       resolvedBundleID,
+					ParentBundleID: resolvedParentBundleID,
+					Capability:     resolvedCapability,
+					Enabled:        true,
+					Settings:       settings,
+				})
+				return err
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web bundle-ids capabilities sync-app-clip")
+			}
+			if result == nil {
+				return fmt.Errorf("web bundle-ids capabilities sync-app-clip failed: missing sync result")
+			}
+
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderWebBundleIDCapabilitySyncTable(result) },
+				func() error { return renderWebBundleIDCapabilitySyncMarkdown(result) },
+			)
+		},
+	}
+}
+
+func parseWebBundleIDCapabilitySettings(value string) ([]webcore.BundleIDCapabilitySetting, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return []webcore.BundleIDCapabilitySetting{}, nil
+	}
+	var settings []webcore.BundleIDCapabilitySetting
+	decoder := json.NewDecoder(strings.NewReader(value))
+	if err := decoder.Decode(&settings); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("multiple JSON values are not supported")
+	}
+	return settings, nil
+}
+
+func renderWebBundleIDCapabilitySyncTable(result *webcore.AppClipBundleIDCapabilitySyncResult) error {
+	asc.RenderTable(
+		[]string{"Bundle ID", "Parent Bundle ID", "Capability", "Enabled"},
+		[][]string{{
+			result.BundleID,
+			result.ParentBundleID,
+			result.Capability,
+			fmt.Sprintf("%t", result.Enabled),
+		}},
+	)
+	return nil
+}
+
+func renderWebBundleIDCapabilitySyncMarkdown(result *webcore.AppClipBundleIDCapabilitySyncResult) error {
+	asc.RenderMarkdown(
+		[]string{"Bundle ID", "Parent Bundle ID", "Capability", "Enabled"},
+		[][]string{{
+			result.BundleID,
+			result.ParentBundleID,
+			result.Capability,
+			fmt.Sprintf("%t", result.Enabled),
+		}},
+	)
+	return nil
+}

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -169,6 +169,9 @@ func parseWebBundleIDCapabilitySettings(value string) ([]webcore.BundleIDCapabil
 	if err := decoder.Decode(&settings); err != nil {
 		return nil, err
 	}
+	if settings == nil {
+		return nil, fmt.Errorf("expected JSON array, got null")
+	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		return nil, fmt.Errorf("multiple JSON values are not supported")

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -132,11 +132,12 @@ Examples:
 			err = withWebSpinner("Syncing App Clip Bundle ID capability", func() error {
 				var err error
 				result, err = syncAppClipBundleIDCapabilityFn(requestCtx, client, webcore.AppClipBundleIDCapabilitySyncRequest{
-					BundleID:       resolvedBundleID,
-					ParentBundleID: resolvedParentBundleID,
-					Capability:     resolvedCapability,
-					Enabled:        true,
-					Settings:       settings,
+					BundleID:         resolvedBundleID,
+					ParentBundleID:   resolvedParentBundleID,
+					Capability:       resolvedCapability,
+					Enabled:          true,
+					Settings:         settings,
+					SettingsProvided: strings.TrimSpace(*settingsJSON) != "",
 				})
 				return err
 			})

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -97,6 +97,9 @@ func TestWebBundleIDCapabilitiesSyncAppClipCallsPrivateSync(t *testing.T) {
 	if gotReq.BundleID != "clip-1" || gotReq.ParentBundleID != "parent-1" || gotReq.Capability != "PUSH_NOTIFICATIONS" {
 		t.Fatalf("unexpected sync request: %+v", gotReq)
 	}
+	if !gotReq.SettingsProvided {
+		t.Fatal("expected settings to be marked as explicitly provided")
+	}
 	if len(gotReq.Settings) != 1 || gotReq.Settings[0].Key != "PUSH_NOTIFICATION_FEATURES" {
 		t.Fatalf("expected parsed settings, got %+v", gotReq.Settings)
 	}

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -20,6 +20,8 @@ func TestWebBundleIDCapabilitiesSyncAppClipValidationErrors(t *testing.T) {
 		{name: "missing parent bundle id", args: []string{"--bundle-id", "clip-1", "--capability", "PUSH_NOTIFICATIONS"}, wantErr: "--parent-bundle-id is required"},
 		{name: "missing capability", args: []string{"--bundle-id", "clip-1", "--parent-bundle-id", "parent-1"}, wantErr: "--capability is required"},
 		{name: "invalid settings json", args: []string{"--bundle-id", "clip-1", "--parent-bundle-id", "parent-1", "--capability", "PUSH_NOTIFICATIONS", "--settings-json", `{"key":"BAD"}`}, wantErr: "--settings-json must be a JSON array"},
+		{name: "null settings json", args: []string{"--bundle-id", "clip-1", "--parent-bundle-id", "parent-1", "--capability", "PUSH_NOTIFICATIONS", "--settings-json", `null`}, wantErr: "--settings-json must be a JSON array"},
+		{name: "multiple settings json values", args: []string{"--bundle-id", "clip-1", "--parent-bundle-id", "parent-1", "--capability", "PUSH_NOTIFICATIONS", "--settings-json", `[] []`}, wantErr: "--settings-json must be a JSON array"},
 	}
 
 	for _, tc := range tests {

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -1,0 +1,103 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebBundleIDCapabilitiesSyncAppClipValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing bundle id", args: []string{"--parent-bundle-id", "parent-1", "--capability", "PUSH_NOTIFICATIONS"}, wantErr: "--bundle-id is required"},
+		{name: "missing parent bundle id", args: []string{"--bundle-id", "clip-1", "--capability", "PUSH_NOTIFICATIONS"}, wantErr: "--parent-bundle-id is required"},
+		{name: "missing capability", args: []string{"--bundle-id", "clip-1", "--parent-bundle-id", "parent-1"}, wantErr: "--capability is required"},
+		{name: "invalid settings json", args: []string{"--bundle-id", "clip-1", "--parent-bundle-id", "parent-1", "--capability", "PUSH_NOTIFICATIONS", "--settings-json", `{"key":"BAD"}`}, wantErr: "--settings-json must be a JSON array"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := WebBundleIDCapabilitiesSyncAppClipCommand()
+			if err := cmd.FlagSet.Parse(tc.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			stdout, stderr := captureWebCommandOutput(t, func() {
+				err := cmd.Exec(context.Background(), nil)
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected flag.ErrHelp, got %v", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, tc.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", tc.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestWebBundleIDCapabilitiesSyncAppClipCallsPrivateSync(t *testing.T) {
+	origResolveSession := resolveSessionFn
+	origNewWebClient := newWebClientFn
+	origSync := syncAppClipBundleIDCapabilityFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+		newWebClientFn = origNewWebClient
+		syncAppClipBundleIDCapabilityFn = origSync
+	})
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	}
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+
+	var gotReq webcore.AppClipBundleIDCapabilitySyncRequest
+	syncAppClipBundleIDCapabilityFn = func(ctx context.Context, client *webcore.Client, req webcore.AppClipBundleIDCapabilitySyncRequest) (*webcore.AppClipBundleIDCapabilitySyncResult, error) {
+		gotReq = req
+		return &webcore.AppClipBundleIDCapabilitySyncResult{
+			BundleID:       req.BundleID,
+			ParentBundleID: req.ParentBundleID,
+			Capability:     req.Capability,
+			Enabled:        req.Enabled,
+		}, nil
+	}
+
+	cmd := WebBundleIDCapabilitiesSyncAppClipCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--bundle-id", "clip-1",
+		"--parent-bundle-id", "parent-1",
+		"--capability", "push_notifications",
+		"--settings-json", `[{"key":"PUSH_NOTIFICATION_FEATURES","options":[{"key":"PUSH_NOTIFICATION_FEATURE_BROADCAST","enabled":true}]}]`,
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"parentBundleId":"parent-1"`) || !strings.Contains(stdout, `"capability":"PUSH_NOTIFICATIONS"`) {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+	if gotReq.BundleID != "clip-1" || gotReq.ParentBundleID != "parent-1" || gotReq.Capability != "PUSH_NOTIFICATIONS" {
+		t.Fatalf("unexpected sync request: %+v", gotReq)
+	}
+	if len(gotReq.Settings) != 1 || gotReq.Settings[0].Key != "PUSH_NOTIFICATION_FEATURES" {
+		t.Fatalf("expected parsed settings, got %+v", gotReq.Settings)
+	}
+}

--- a/internal/web/bundle_ids.go
+++ b/internal/web/bundle_ids.go
@@ -33,11 +33,12 @@ type BundleIDCapabilitySetting struct {
 // AppClipBundleIDCapabilitySyncRequest updates an App Clip Bundle ID capability set
 // through Apple's web-session bundleIds patch payload.
 type AppClipBundleIDCapabilitySyncRequest struct {
-	BundleID       string
-	ParentBundleID string
-	Capability     string
-	Enabled        bool
-	Settings       []BundleIDCapabilitySetting
+	BundleID         string
+	ParentBundleID   string
+	Capability       string
+	Enabled          bool
+	Settings         []BundleIDCapabilitySetting
+	SettingsProvided bool
 }
 
 // AppClipBundleIDCapabilitySyncResult summarizes the private capability sync.
@@ -159,12 +160,9 @@ func buildAppClipBundleIDCapabilityPatchRequest(current webBundleIDResponse, req
 
 	capability := webBundleIDCapabilityRelationship{
 		Type: "bundleIdCapabilities",
-		Attributes: struct {
-			Enabled  bool                        `json:"enabled"`
-			Settings []BundleIDCapabilitySetting `json:"settings"`
-		}{
-			Enabled:  req.Enabled,
-			Settings: req.Settings,
+		Attributes: map[string]any{
+			"enabled":  req.Enabled,
+			"settings": req.Settings,
 		},
 		Relationships: map[string]webBundleIDRelationshipData{
 			"capability": {
@@ -175,7 +173,7 @@ func buildAppClipBundleIDCapabilityPatchRequest(current webBundleIDResponse, req
 			},
 		},
 	}
-	payload.Data.Relationships.BundleIDCapabilities.Data = appendPreservedBundleIDCapabilities(currentBundleIDCapabilities(current), capability)
+	payload.Data.Relationships.BundleIDCapabilities.Data = appendPreservedBundleIDCapabilities(currentBundleIDCapabilities(current), capability, req.SettingsProvided)
 	return payload
 }
 
@@ -206,7 +204,7 @@ func currentBundleIDCapabilities(current webBundleIDResponse) []webBundleIDCapab
 	return capabilities
 }
 
-func appendPreservedBundleIDCapabilities(existing []webBundleIDCapabilityRelationship, synced webBundleIDCapabilityRelationship) []webBundleIDCapabilityRelationship {
+func appendPreservedBundleIDCapabilities(existing []webBundleIDCapabilityRelationship, synced webBundleIDCapabilityRelationship, settingsProvided bool) []webBundleIDCapabilityRelationship {
 	capabilityID := synced.capabilityID()
 	capabilities := make([]webBundleIDCapabilityRelationship, 0, len(existing)+1)
 	for _, capability := range existing {
@@ -214,9 +212,28 @@ func appendPreservedBundleIDCapabilities(existing []webBundleIDCapabilityRelatio
 			if synced.ID == "" {
 				synced.ID = capability.ID
 			}
+			if !settingsProvided {
+				preserveBundleIDCapabilitySettings(capability, &synced)
+			}
 			continue
 		}
 		capabilities = append(capabilities, capability)
 	}
 	return append(capabilities, synced)
+}
+
+func preserveBundleIDCapabilitySettings(existing webBundleIDCapabilityRelationship, synced *webBundleIDCapabilityRelationship) {
+	existingAttributes, ok := existing.Attributes.(map[string]any)
+	if !ok {
+		return
+	}
+	existingSettings, ok := existingAttributes["settings"]
+	if !ok {
+		return
+	}
+	syncedAttributes, ok := synced.Attributes.(map[string]any)
+	if !ok {
+		return
+	}
+	syncedAttributes["settings"] = existingSettings
 }

--- a/internal/web/bundle_ids.go
+++ b/internal/web/bundle_ids.go
@@ -1,0 +1,163 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// BundleIDCapabilityOption describes one option inside a capability setting.
+type BundleIDCapabilityOption struct {
+	Key              string `json:"key"`
+	Name             string `json:"name,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Enabled          *bool  `json:"enabled,omitempty"`
+	EnabledByDefault *bool  `json:"enabledByDefault,omitempty"`
+	SupportsWildcard *bool  `json:"supportsWildcard,omitempty"`
+}
+
+// BundleIDCapabilitySetting describes an App Store Connect bundle ID capability setting.
+type BundleIDCapabilitySetting struct {
+	Key              string                     `json:"key"`
+	Name             string                     `json:"name,omitempty"`
+	Description      string                     `json:"description,omitempty"`
+	EnabledByDefault *bool                      `json:"enabledByDefault,omitempty"`
+	Visible          *bool                      `json:"visible,omitempty"`
+	AllowedInstances string                     `json:"allowedInstances,omitempty"`
+	MinInstances     *int                       `json:"minInstances,omitempty"`
+	Options          []BundleIDCapabilityOption `json:"options,omitempty"`
+}
+
+// AppClipBundleIDCapabilitySyncRequest updates an App Clip Bundle ID capability set
+// through Apple's web-session bundleIds patch payload.
+type AppClipBundleIDCapabilitySyncRequest struct {
+	BundleID       string
+	ParentBundleID string
+	Capability     string
+	Enabled        bool
+	Settings       []BundleIDCapabilitySetting
+}
+
+// AppClipBundleIDCapabilitySyncResult summarizes the private capability sync.
+type AppClipBundleIDCapabilitySyncResult struct {
+	BundleID       string `json:"bundleId"`
+	ParentBundleID string `json:"parentBundleId"`
+	Capability     string `json:"capability"`
+	Enabled        bool   `json:"enabled"`
+}
+
+type webBundleIDResponse struct {
+	Data struct {
+		ID         string `json:"id"`
+		Type       string `json:"type"`
+		Attributes struct {
+			Name       string `json:"name"`
+			Identifier string `json:"identifier"`
+			SeedID     string `json:"seedId,omitempty"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+type webBundleIDPatchRequest struct {
+	Data struct {
+		ID            string `json:"id"`
+		Type          string `json:"type"`
+		Attributes    any    `json:"attributes"`
+		Relationships struct {
+			BundleIDCapabilities struct {
+				Data []webBundleIDCapabilityRelationship `json:"data"`
+			} `json:"bundleIdCapabilities"`
+		} `json:"relationships"`
+	} `json:"data"`
+}
+
+type webBundleIDCapabilityRelationship struct {
+	Type          string `json:"type"`
+	Attributes    any    `json:"attributes"`
+	Relationships struct {
+		Capability struct {
+			Data relationshipData `json:"data"`
+		} `json:"capability"`
+		ParentBundleID struct {
+			Data relationshipData `json:"data"`
+		} `json:"parentBundleId"`
+	} `json:"relationships"`
+}
+
+func normalizeAppClipBundleIDCapabilitySyncRequest(req AppClipBundleIDCapabilitySyncRequest) (AppClipBundleIDCapabilitySyncRequest, error) {
+	req.BundleID = strings.TrimSpace(req.BundleID)
+	req.ParentBundleID = strings.TrimSpace(req.ParentBundleID)
+	req.Capability = strings.ToUpper(strings.TrimSpace(req.Capability))
+	if req.BundleID == "" {
+		return req, fmt.Errorf("bundle id is required")
+	}
+	if req.ParentBundleID == "" {
+		return req, fmt.Errorf("parent bundle id is required")
+	}
+	if req.Capability == "" {
+		return req, fmt.Errorf("capability is required")
+	}
+	return req, nil
+}
+
+// SyncAppClipBundleIDCapability patches a bundle ID capability relationship with
+// the parentBundleId relationship required by App Clip targets.
+func (c *Client) SyncAppClipBundleIDCapability(ctx context.Context, req AppClipBundleIDCapabilitySyncRequest) (*AppClipBundleIDCapabilitySyncResult, error) {
+	req, err := normalizeAppClipBundleIDCapabilitySyncRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doIrisV1Request(ctx, http.MethodGet, fmt.Sprintf("/bundleIds/%s?include=bundleIdCapabilities", req.BundleID), nil)
+	if err != nil {
+		return nil, err
+	}
+	var current webBundleIDResponse
+	if err := json.Unmarshal(body, &current); err != nil {
+		return nil, fmt.Errorf("failed to parse bundle id response: %w", err)
+	}
+
+	payload := buildAppClipBundleIDCapabilityPatchRequest(current, req)
+	if _, err := c.doIrisV1Request(ctx, http.MethodPatch, fmt.Sprintf("/bundleIds/%s", req.BundleID), payload); err != nil {
+		return nil, err
+	}
+
+	return &AppClipBundleIDCapabilitySyncResult{
+		BundleID:       req.BundleID,
+		ParentBundleID: req.ParentBundleID,
+		Capability:     req.Capability,
+		Enabled:        req.Enabled,
+	}, nil
+}
+
+func buildAppClipBundleIDCapabilityPatchRequest(current webBundleIDResponse, req AppClipBundleIDCapabilitySyncRequest) webBundleIDPatchRequest {
+	var payload webBundleIDPatchRequest
+	payload.Data.ID = req.BundleID
+	payload.Data.Type = "bundleIds"
+	payload.Data.Attributes = struct {
+		Name       string `json:"name"`
+		Identifier string `json:"identifier"`
+		SeedID     string `json:"seedId,omitempty"`
+	}{
+		Name:       current.Data.Attributes.Name,
+		Identifier: current.Data.Attributes.Identifier,
+		SeedID:     current.Data.Attributes.SeedID,
+	}
+
+	capability := webBundleIDCapabilityRelationship{
+		Type: "bundleIdCapabilities",
+		Attributes: struct {
+			Enabled  bool                        `json:"enabled"`
+			Settings []BundleIDCapabilitySetting `json:"settings"`
+		}{
+			Enabled:  req.Enabled,
+			Settings: req.Settings,
+		},
+	}
+	capability.Relationships.Capability.Data = relationshipData{Type: "capabilities", ID: req.Capability}
+	capability.Relationships.ParentBundleID.Data = relationshipData{Type: "bundleIds", ID: req.ParentBundleID}
+	payload.Data.Relationships.BundleIDCapabilities.Data = []webBundleIDCapabilityRelationship{capability}
+	return payload
+}

--- a/internal/web/bundle_ids.go
+++ b/internal/web/bundle_ids.go
@@ -57,7 +57,13 @@ type webBundleIDResponse struct {
 			Identifier string `json:"identifier"`
 			SeedID     string `json:"seedId,omitempty"`
 		} `json:"attributes"`
+		Relationships struct {
+			BundleIDCapabilities struct {
+				Data []webBundleIDCapabilityRelationship `json:"data"`
+			} `json:"bundleIdCapabilities"`
+		} `json:"relationships"`
 	} `json:"data"`
+	Included []webBundleIDCapabilityRelationship `json:"included,omitempty"`
 }
 
 type webBundleIDPatchRequest struct {
@@ -74,16 +80,21 @@ type webBundleIDPatchRequest struct {
 }
 
 type webBundleIDCapabilityRelationship struct {
-	Type          string `json:"type"`
-	Attributes    any    `json:"attributes"`
-	Relationships struct {
-		Capability struct {
-			Data relationshipData `json:"data"`
-		} `json:"capability"`
-		ParentBundleID struct {
-			Data relationshipData `json:"data"`
-		} `json:"parentBundleId"`
-	} `json:"relationships"`
+	ID            string                                 `json:"id,omitempty"`
+	Type          string                                 `json:"type"`
+	Attributes    any                                    `json:"attributes,omitempty"`
+	Relationships map[string]webBundleIDRelationshipData `json:"relationships,omitempty"`
+}
+
+type webBundleIDRelationshipData struct {
+	Data relationshipData `json:"data"`
+}
+
+func (r webBundleIDCapabilityRelationship) capabilityID() string {
+	if r.Relationships == nil {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(r.Relationships["capability"].Data.ID))
 }
 
 func normalizeAppClipBundleIDCapabilitySyncRequest(req AppClipBundleIDCapabilitySyncRequest) (AppClipBundleIDCapabilitySyncRequest, error) {
@@ -155,9 +166,57 @@ func buildAppClipBundleIDCapabilityPatchRequest(current webBundleIDResponse, req
 			Enabled:  req.Enabled,
 			Settings: req.Settings,
 		},
+		Relationships: map[string]webBundleIDRelationshipData{
+			"capability": {
+				Data: relationshipData{Type: "capabilities", ID: req.Capability},
+			},
+			"parentBundleId": {
+				Data: relationshipData{Type: "bundleIds", ID: req.ParentBundleID},
+			},
+		},
 	}
-	capability.Relationships.Capability.Data = relationshipData{Type: "capabilities", ID: req.Capability}
-	capability.Relationships.ParentBundleID.Data = relationshipData{Type: "bundleIds", ID: req.ParentBundleID}
-	payload.Data.Relationships.BundleIDCapabilities.Data = []webBundleIDCapabilityRelationship{capability}
+	payload.Data.Relationships.BundleIDCapabilities.Data = appendPreservedBundleIDCapabilities(currentBundleIDCapabilities(current), capability)
 	return payload
+}
+
+func currentBundleIDCapabilities(current webBundleIDResponse) []webBundleIDCapabilityRelationship {
+	capabilities := make([]webBundleIDCapabilityRelationship, 0, len(current.Included)+len(current.Data.Relationships.BundleIDCapabilities.Data))
+	seen := make(map[string]struct{})
+	for _, capability := range current.Included {
+		if capability.Type != "bundleIdCapabilities" {
+			continue
+		}
+		capabilities = append(capabilities, capability)
+		if capability.ID != "" {
+			seen[capability.ID] = struct{}{}
+		}
+	}
+	for _, capability := range current.Data.Relationships.BundleIDCapabilities.Data {
+		if capability.Type != "bundleIdCapabilities" {
+			continue
+		}
+		if capability.ID != "" {
+			if _, ok := seen[capability.ID]; ok {
+				continue
+			}
+			seen[capability.ID] = struct{}{}
+		}
+		capabilities = append(capabilities, capability)
+	}
+	return capabilities
+}
+
+func appendPreservedBundleIDCapabilities(existing []webBundleIDCapabilityRelationship, synced webBundleIDCapabilityRelationship) []webBundleIDCapabilityRelationship {
+	capabilityID := synced.capabilityID()
+	capabilities := make([]webBundleIDCapabilityRelationship, 0, len(existing)+1)
+	for _, capability := range existing {
+		if capability.capabilityID() == capabilityID {
+			if synced.ID == "" {
+				synced.ID = capability.ID
+			}
+			continue
+		}
+		capabilities = append(capabilities, capability)
+	}
+	return append(capabilities, synced)
 }

--- a/internal/web/bundle_ids_test.go
+++ b/internal/web/bundle_ids_test.go
@@ -95,12 +95,8 @@ func TestSyncAppClipBundleIDCapabilityAddsParentBundleRelationship(t *testing.T)
 							} `json:"settings"`
 						} `json:"attributes"`
 						Relationships struct {
-							Capability struct {
-								Data relationshipData `json:"data"`
-							} `json:"capability"`
-							ParentBundleID struct {
-								Data relationshipData `json:"data"`
-							} `json:"parentBundleId"`
+							Capability     webBundleIDRelationshipData `json:"capability"`
+							ParentBundleID webBundleIDRelationshipData `json:"parentBundleId"`
 						} `json:"relationships"`
 					} `json:"data"`
 				} `json:"bundleIdCapabilities"`
@@ -128,5 +124,105 @@ func TestSyncAppClipBundleIDCapabilityAddsParentBundleRelationship(t *testing.T)
 	}
 	if len(caps[0].Attributes.Settings) != 1 || caps[0].Attributes.Settings[0].Key != "PUSH_NOTIFICATION_FEATURES" {
 		t.Fatalf("expected settings to be preserved, got %+v", caps[0].Attributes.Settings)
+	}
+}
+
+func TestSyncAppClipBundleIDCapabilityPreservesExistingCapabilities(t *testing.T) {
+	var patchBody []byte
+	client := &Client{
+		httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/iris/v1/bundleIds/clip-bundle":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(bytes.NewBufferString(`{
+						"data":{
+							"id":"clip-bundle",
+							"type":"bundleIds",
+							"attributes":{
+								"name":"Example Clip",
+								"identifier":"com.example.app.Clip"
+							},
+							"relationships":{
+								"bundleIdCapabilities":{
+									"data":[
+										{"id":"existing-icloud","type":"bundleIdCapabilities"},
+										{"id":"existing-push","type":"bundleIdCapabilities"}
+									]
+								}
+							}
+						},
+						"included":[
+							{
+								"id":"existing-icloud",
+								"type":"bundleIdCapabilities",
+								"attributes":{"enabled":true,"settings":[]},
+								"relationships":{
+									"capability":{"data":{"type":"capabilities","id":"ICLOUD"}}
+								}
+							},
+							{
+								"id":"existing-push",
+								"type":"bundleIdCapabilities",
+								"attributes":{"enabled":false,"settings":[]},
+								"relationships":{
+									"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}
+								}
+							}
+						]
+					}`)),
+				}, nil
+			case r.Method == http.MethodPatch && r.URL.Path == "/iris/v1/bundleIds/clip-bundle":
+				var err error
+				patchBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("ReadAll patch body error: %v", err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"id":"clip-bundle","type":"bundleIds"}}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+				return nil, nil
+			}
+		})},
+	}
+
+	if _, err := client.SyncAppClipBundleIDCapability(context.Background(), AppClipBundleIDCapabilitySyncRequest{
+		BundleID:       "clip-bundle",
+		ParentBundleID: "parent-bundle",
+		Capability:     "PUSH_NOTIFICATIONS",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("SyncAppClipBundleIDCapability error: %v", err)
+	}
+
+	var payload struct {
+		Data struct {
+			Relationships struct {
+				BundleIDCapabilities struct {
+					Data []webBundleIDCapabilityRelationship `json:"data"`
+				} `json:"bundleIdCapabilities"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(patchBody, &payload); err != nil {
+		t.Fatalf("json.Unmarshal patch body error: %v; body=%s", err, patchBody)
+	}
+	caps := payload.Data.Relationships.BundleIDCapabilities.Data
+	if len(caps) != 2 {
+		t.Fatalf("expected existing ICLOUD plus synced PUSH_NOTIFICATIONS, got %d: %+v", len(caps), caps)
+	}
+	if caps[0].ID != "existing-icloud" || caps[0].capabilityID() != "ICLOUD" {
+		t.Fatalf("expected existing ICLOUD capability to be preserved first, got %+v", caps[0])
+	}
+	if caps[1].ID != "existing-push" || caps[1].capabilityID() != "PUSH_NOTIFICATIONS" {
+		t.Fatalf("expected synced PUSH_NOTIFICATIONS capability to replace existing entry, got %+v", caps[1])
+	}
+	if caps[1].Relationships["parentBundleId"].Data != (relationshipData{Type: "bundleIds", ID: "parent-bundle"}) {
+		t.Fatalf("unexpected synced parentBundleId relationship: %+v", caps[1].Relationships["parentBundleId"].Data)
 	}
 }

--- a/internal/web/bundle_ids_test.go
+++ b/internal/web/bundle_ids_test.go
@@ -1,0 +1,132 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestSyncAppClipBundleIDCapabilityAddsParentBundleRelationship(t *testing.T) {
+	var patchBody []byte
+	client := &Client{
+		httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/iris/v1/bundleIds/clip-bundle":
+				if r.URL.Query().Get("include") != "bundleIdCapabilities" {
+					t.Fatalf("expected include=bundleIdCapabilities, got %q", r.URL.RawQuery)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(bytes.NewBufferString(`{
+						"data":{
+							"id":"clip-bundle",
+							"type":"bundleIds",
+							"attributes":{
+								"name":"Example Clip",
+								"identifier":"com.example.app.Clip",
+								"seedId":"TEAMID"
+							}
+						}
+					}`)),
+				}, nil
+			case r.Method == http.MethodPatch && r.URL.Path == "/iris/v1/bundleIds/clip-bundle":
+				var err error
+				patchBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("ReadAll patch body error: %v", err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"id":"clip-bundle","type":"bundleIds"}}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+				return nil, nil
+			}
+		})},
+	}
+
+	enabled := true
+	result, err := client.SyncAppClipBundleIDCapability(context.Background(), AppClipBundleIDCapabilitySyncRequest{
+		BundleID:       "clip-bundle",
+		ParentBundleID: "parent-bundle",
+		Capability:     "PUSH_NOTIFICATIONS",
+		Enabled:        true,
+		Settings: []BundleIDCapabilitySetting{{
+			Key: "PUSH_NOTIFICATION_FEATURES",
+			Options: []BundleIDCapabilityOption{{
+				Key:     "PUSH_NOTIFICATION_FEATURE_BROADCAST",
+				Enabled: &enabled,
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SyncAppClipBundleIDCapability error: %v", err)
+	}
+	if result.ParentBundleID != "parent-bundle" || result.Capability != "PUSH_NOTIFICATIONS" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(patchBody) == 0 {
+		t.Fatal("expected patch body")
+	}
+
+	var payload struct {
+		Data struct {
+			Type       string `json:"type"`
+			ID         string `json:"id"`
+			Attributes struct {
+				Name       string `json:"name"`
+				Identifier string `json:"identifier"`
+				SeedID     string `json:"seedId"`
+			} `json:"attributes"`
+			Relationships struct {
+				BundleIDCapabilities struct {
+					Data []struct {
+						Type       string `json:"type"`
+						Attributes struct {
+							Enabled  bool `json:"enabled"`
+							Settings []struct {
+								Key string `json:"key"`
+							} `json:"settings"`
+						} `json:"attributes"`
+						Relationships struct {
+							Capability struct {
+								Data relationshipData `json:"data"`
+							} `json:"capability"`
+							ParentBundleID struct {
+								Data relationshipData `json:"data"`
+							} `json:"parentBundleId"`
+						} `json:"relationships"`
+					} `json:"data"`
+				} `json:"bundleIdCapabilities"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(patchBody, &payload); err != nil {
+		t.Fatalf("json.Unmarshal patch body error: %v; body=%s", err, patchBody)
+	}
+	if payload.Data.Type != "bundleIds" || payload.Data.ID != "clip-bundle" {
+		t.Fatalf("unexpected bundle data: %+v", payload.Data)
+	}
+	if payload.Data.Attributes.Identifier != "com.example.app.Clip" || payload.Data.Attributes.SeedID != "TEAMID" {
+		t.Fatalf("expected current bundle attributes in patch, got %+v", payload.Data.Attributes)
+	}
+	caps := payload.Data.Relationships.BundleIDCapabilities.Data
+	if len(caps) != 1 {
+		t.Fatalf("expected one capability relationship, got %d", len(caps))
+	}
+	if caps[0].Relationships.Capability.Data != (relationshipData{Type: "capabilities", ID: "PUSH_NOTIFICATIONS"}) {
+		t.Fatalf("unexpected capability relationship: %+v", caps[0].Relationships.Capability.Data)
+	}
+	if caps[0].Relationships.ParentBundleID.Data != (relationshipData{Type: "bundleIds", ID: "parent-bundle"}) {
+		t.Fatalf("unexpected parentBundleId relationship: %+v", caps[0].Relationships.ParentBundleID.Data)
+	}
+	if len(caps[0].Attributes.Settings) != 1 || caps[0].Attributes.Settings[0].Key != "PUSH_NOTIFICATION_FEATURES" {
+		t.Fatalf("expected settings to be preserved, got %+v", caps[0].Attributes.Settings)
+	}
+}

--- a/internal/web/bundle_ids_test.go
+++ b/internal/web/bundle_ids_test.go
@@ -165,7 +165,7 @@ func TestSyncAppClipBundleIDCapabilityPreservesExistingCapabilities(t *testing.T
 							{
 								"id":"existing-push",
 								"type":"bundleIdCapabilities",
-								"attributes":{"enabled":false,"settings":[]},
+								"attributes":{"enabled":false,"settings":[{"key":"PUSH_NOTIFICATION_FEATURES"}]},
 								"relationships":{
 									"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}
 								}
@@ -224,5 +224,17 @@ func TestSyncAppClipBundleIDCapabilityPreservesExistingCapabilities(t *testing.T
 	}
 	if caps[1].Relationships["parentBundleId"].Data != (relationshipData{Type: "bundleIds", ID: "parent-bundle"}) {
 		t.Fatalf("unexpected synced parentBundleId relationship: %+v", caps[1].Relationships["parentBundleId"].Data)
+	}
+	attributes, ok := caps[1].Attributes.(map[string]any)
+	if !ok {
+		t.Fatalf("expected synced attributes map, got %T", caps[1].Attributes)
+	}
+	settings, ok := attributes["settings"].([]any)
+	if !ok || len(settings) != 1 {
+		t.Fatalf("expected existing settings to be preserved, got %+v", attributes["settings"])
+	}
+	setting, ok := settings[0].(map[string]any)
+	if !ok || setting["key"] != "PUSH_NOTIFICATION_FEATURES" {
+		t.Fatalf("expected existing PUSH_NOTIFICATION_FEATURES setting, got %+v", settings[0])
 	}
 }


### PR DESCRIPTION
## Summary
- add a private `asc web bundle-ids capabilities sync-app-clip` command for App Clip capability syncs that require `parentBundleId`
- patch Bundle IDs through the private `/iris/v1/bundleIds/{id}` shape used by Apple web-session flows instead of the public API-key capability endpoint
- add regression coverage for the parent Bundle ID relationship payload, command registration, validation, and JSON settings parsing

## Context
Covers the App Clip credential regression reported in expo/eas-cli#2056, where Apple rejects App Clip capability updates with:

> The relationship 'parentBundleId' is required but was not provided with this request.

The public OpenAPI snapshot does not expose `parentBundleId` for public Bundle ID capability updates, but Expo's Apple utility package shows the App Clip web-session shape nests `bundleIdCapabilities` with `relationships.parentBundleId`. This keeps the fix in the existing experimental/private `web` command family.

## Validation
- `go run . web bundle-ids capabilities sync-app-clip --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/web ./internal/cli/web ./internal/cli/cmdtest -run 'TestSyncAppClipBundleIDCapability|TestWebBundleIDCapabilitiesSyncAppClip|TestWebBundleIDCapabilitiesSyncAppClipSubcommandIsRegistered'`
- `make generate-command-docs`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
