### PR TITLE
Add web auth provider selection

### DIFF
--- a/apps/studio/app_auth_test.go
+++ b/apps/studio/app_auth_test.go
@@ -4,51 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/rudrankriyam/App-Store-Connect-CLI/apps/studio/internal/studio/settings"
 )
-
-func TestCheckAuthStatusTreatsEmptyStoredCredentialsAsUnauthenticated(t *testing.T) {
-	app := newCheckAuthStatusTestApp(t, `{
-		"storageBackend":"System Keychain",
-		"storageLocation":"system keychain",
-		"profile":"",
-		"environmentCredentialsComplete":false,
-		"credentials":[]
-	}`)
-
-	status, err := app.CheckAuthStatus()
-	if err != nil {
-		t.Fatalf("CheckAuthStatus() error = %v", err)
-	}
-	if status.Authenticated {
-		t.Fatal("status.Authenticated = true, want false when no stored or environment credentials exist")
-	}
-	if status.Storage != "System Keychain" {
-		t.Fatalf("status.Storage = %q, want System Keychain", status.Storage)
-	}
-}
-
-func TestCheckAuthStatusTreatsCompleteEnvironmentCredentialsAsAuthenticated(t *testing.T) {
-	app := newCheckAuthStatusTestApp(t, `{
-		"storageBackend":"Config File",
-		"storageLocation":"/tmp/config.json",
-		"profile":"",
-		"environmentCredentialsComplete":true,
-		"credentials":[]
-	}`)
-
-	status, err := app.CheckAuthStatus()
-	if err != nil {
-		t.Fatalf("CheckAuthStatus() error = %v", err)
-	}
-	if !status.Authenticated {
-		t.Fatal("status.Authenticated = false, want true when complete environment credentials are available")
-	}
-	if status.Storage != "Config File" {
-		t.Fatalf("status.Storage = %q, want Config File", status.Storage)
-	}
-}
 
 func TestCacheAuthFromConfigUsesActiveConfigPath(t *testing.T) {
 	tmp := t.TempDir()
@@ -73,31 +29,5 @@ func TestCacheAuthFromConfigUsesActiveConfigPath(t *testing.T) {
 	}
 	if app.cachedPrivateKeyPath != "/tmp/custom.p8" {
 		t.Fatalf("cachedPrivateKeyPath = %q, want /tmp/custom.p8", app.cachedPrivateKeyPath)
-	}
-}
-
-func newCheckAuthStatusTestApp(t *testing.T, output string) *App {
-	t.Helper()
-
-	rootDir := t.TempDir()
-	t.Setenv("HOME", rootDir)
-
-	ascPath := filepath.Join(rootDir, "asc")
-	script := "#!/bin/sh\ncat <<'EOF'\n" + output + "\nEOF\n"
-	if err := os.WriteFile(ascPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	settingsStore := settings.NewStore(rootDir)
-	if err := settingsStore.Save(settings.StudioSettings{
-		SystemASCPath:    ascPath,
-		PreferBundledASC: false,
-	}); err != nil {
-		t.Fatalf("Save() error = %v", err)
-	}
-
-	return &App{
-		rootDir:  rootDir,
-		settings: settingsStore,
 	}
 }

--- a/internal/cli/web/test_hooks.go
+++ b/internal/cli/web/test_hooks.go
@@ -25,9 +25,12 @@ func SetResolveWebSession(fn any) func() {
 		panic(fmt.Sprintf("unsupported resolve session hook type %T", fn))
 	}
 	prev := resolveSessionFn
+	prevNoPersist := resolveSessionWithoutPersistFn
 	resolveSessionFn = fn
+	resolveSessionWithoutPersistFn = fn
 	return func() {
 		resolveSessionFn = prev
+		resolveSessionWithoutPersistFn = prevNoPersist
 	}
 }
 

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -56,6 +56,7 @@ var (
 	loadCachedSessionFn                      = webcore.LoadCachedSession
 	loadLastCachedSessionFn                  = webcore.LoadLastCachedSession
 	webLoginWithClientFn                     = webcore.LoginWithClient
+	selectWebProviderFn                      = webcore.SelectProvider
 	resolveSessionFn               any       = resolveSession
 	twoFactorStatusWriter          io.Writer = os.Stderr
 	sessionExpiredWriter           io.Writer = os.Stderr
@@ -87,11 +88,12 @@ func openTTY() (*os.File, error) {
 }
 
 type webAuthStatus struct {
-	Authenticated bool   `json:"authenticated"`
-	Source        string `json:"source,omitempty"`
-	AppleID       string `json:"appleId,omitempty"`
-	TeamID        string `json:"teamId,omitempty"`
-	ProviderID    int64  `json:"providerId,omitempty"`
+	Authenticated    bool   `json:"authenticated"`
+	Source           string `json:"source,omitempty"`
+	AppleID          string `json:"appleId,omitempty"`
+	TeamID           string `json:"teamId,omitempty"`
+	ProviderID       int64  `json:"providerId,omitempty"`
+	PublicProviderID string `json:"publicProviderId,omitempty"`
 }
 
 func signalProcessInterrupt() error {
@@ -626,6 +628,19 @@ func persistFreshResolvedSession(session *webcore.AuthSession) error {
 	return nil
 }
 
+func selectResolvedWebSessionProvider(ctx context.Context, session *webcore.AuthSession, selection webcore.ProviderSelection) error {
+	if selection.ProviderID == 0 && strings.TrimSpace(selection.PublicProviderID) == "" {
+		return nil
+	}
+	if err := selectWebProviderFn(ctx, session, selection); err != nil {
+		return fmt.Errorf("web provider selection failed: %w", err)
+	}
+	if err := persistWebSessionFn(session); err != nil {
+		return fmt.Errorf("web provider selection succeeded but failed to cache session: %w", err)
+	}
+	return nil
+}
+
 func resolveSession(ctx context.Context, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, string, error) {
 	command := ""
 	if len(twoFactorCodeCommand) > 0 {
@@ -673,11 +688,13 @@ func WebAuthLoginCommand() *ffcli.Command {
 	appleID := fs.String("apple-id", "", "Apple Account email")
 	twoFactorCode := bindDeprecatedTwoFactorCodeFlag(fs)
 	twoFactorCodeCommand := fs.String("two-factor-code-command", "", "Shell command that prints the 2FA code to stdout if verification is required")
+	providerID := fs.Int64("provider-id", 0, "Numeric App Store Connect provider ID to select for this web session")
+	publicProviderID := fs.String("public-provider-id", "", "Public App Store Connect provider/team ID to select for this web session")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "login",
-		ShortUsage: "asc web auth login --apple-id EMAIL [--two-factor-code-command CMD]",
+		ShortUsage: "asc web auth login --apple-id EMAIL [--public-provider-id TEAM_ID]",
 		ShortHelp:  "[experimental] Authenticate unofficial Apple web session.",
 		LongHelp: fmt.Sprintf(
 			`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
@@ -694,10 +711,15 @@ Two-factor input options:
   - %s environment variable (recommended for automation)
   - --two-factor-code (deprecated compatibility alias when the code is already known)
 
+Provider selection:
+  - --public-provider-id selects the public App Store Connect provider/team ID
+  - --provider-id selects Apple's numeric App Store Connect provider ID
+
 `+webWarningText+`
 
 Examples:
   asc web auth login --apple-id "user@example.com"
+  asc web auth login --apple-id "user@example.com" --public-provider-id "Z4N6A5FQKW"
   %s asc web auth login --apple-id "user@example.com"
   %s='osascript /path/to/get-apple-2fa-code.scpt' asc web auth login --apple-id "user@example.com"`,
 			webPasswordEnvDisplay(),
@@ -716,13 +738,21 @@ Examples:
 			if err != nil {
 				return err
 			}
+			selection := webcore.ProviderSelection{
+				ProviderID:       *providerID,
+				PublicProviderID: *publicProviderID,
+			}
+			if err := selectResolvedWebSessionProvider(requestCtx, session, selection); err != nil {
+				return err
+			}
 
 			status := webAuthStatus{
-				Authenticated: true,
-				Source:        source,
-				AppleID:       session.UserEmail,
-				TeamID:        session.TeamID,
-				ProviderID:    session.ProviderID,
+				Authenticated:    true,
+				Source:           source,
+				AppleID:          session.UserEmail,
+				TeamID:           session.TeamID,
+				ProviderID:       session.ProviderID,
+				PublicProviderID: session.PublicProviderID,
 			}
 			return shared.PrintOutput(status, *output.Output, *output.Pretty)
 		},
@@ -774,11 +804,12 @@ If --apple-id is not provided, this checks the last cached session.
 				return shared.PrintOutput(webAuthStatus{Authenticated: false}, *output.Output, *output.Pretty)
 			}
 			return shared.PrintOutput(webAuthStatus{
-				Authenticated: true,
-				Source:        "cache",
-				AppleID:       session.UserEmail,
-				TeamID:        session.TeamID,
-				ProviderID:    session.ProviderID,
+				Authenticated:    true,
+				Source:           "cache",
+				AppleID:          session.UserEmail,
+				TeamID:           session.TeamID,
+				ProviderID:       session.ProviderID,
+				PublicProviderID: session.PublicProviderID,
 			}, *output.Output, *output.Pretty)
 		},
 	}

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -58,6 +58,7 @@ var (
 	webLoginWithClientFn                     = webcore.LoginWithClient
 	selectWebProviderFn                      = webcore.SelectProvider
 	resolveSessionFn               any       = resolveSession
+	resolveSessionWithoutPersistFn any       = resolveSessionWithoutPersist
 	twoFactorStatusWriter          io.Writer = os.Stderr
 	sessionExpiredWriter           io.Writer = os.Stderr
 	sessionCacheWarningWriter      io.Writer = os.Stderr
@@ -470,7 +471,6 @@ func tryAutoReauthWebSession(ctx context.Context, appleID, password string) (*we
 		// best-effort and may not preserve enough cookie metadata for relogin.
 		return nil, "", false, nil
 	}
-	_ = persistWebSessionFn(session)
 	return session, "auto-reauth", true, nil
 }
 
@@ -504,6 +504,7 @@ type webSessionResolveOptions struct {
 	promptAppleID        func(*string) error
 	resolvePassword      func(context.Context, string) (string, error)
 	persistFresh         func(*webcore.AuthSession) error
+	persistAutoReauth    func(*webcore.AuthSession)
 	twoFactorCodeCommand string
 }
 
@@ -549,6 +550,9 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 			}
 			return nil, "", false, fmt.Errorf("web auth auto-reauth failed: %w", err)
 		} else if ok {
+			if opts.persistAutoReauth != nil {
+				opts.persistAutoReauth(session)
+			}
 			return session, source, true, nil
 		}
 		if !expiredNoticePrinted {
@@ -628,6 +632,10 @@ func persistFreshResolvedSession(session *webcore.AuthSession) error {
 	return nil
 }
 
+func persistAutoReauthResolvedSession(session *webcore.AuthSession) {
+	_ = persistWebSessionFn(session)
+}
+
 func selectResolvedWebSessionProvider(ctx context.Context, session *webcore.AuthSession, selection webcore.ProviderSelection) error {
 	if selection.ProviderID == 0 && strings.TrimSpace(selection.PublicProviderID) == "" {
 		return nil
@@ -649,8 +657,31 @@ func resolveSession(ctx context.Context, appleID, password, twoFactorCode string
 	return resolveWebSession(ctx, appleID, password, twoFactorCode, webSessionResolveOptions{
 		resolvePassword:      resolveSessionPassword,
 		persistFresh:         persistFreshResolvedSession,
+		persistAutoReauth:    persistAutoReauthResolvedSession,
 		twoFactorCodeCommand: command,
 	})
+}
+
+func resolveSessionWithoutPersist(ctx context.Context, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, string, error) {
+	command := ""
+	if len(twoFactorCodeCommand) > 0 {
+		command = twoFactorCodeCommand[0]
+	}
+	return resolveWebSession(ctx, appleID, password, twoFactorCode, webSessionResolveOptions{
+		resolvePassword:      resolveSessionPassword,
+		twoFactorCodeCommand: command,
+	})
+}
+
+func hasProviderSelection(selection webcore.ProviderSelection) bool {
+	return selection.ProviderID != 0 || strings.TrimSpace(selection.PublicProviderID) != ""
+}
+
+func callResolveSessionForProviderSelection(ctx context.Context, appleID, password, twoFactorCode, twoFactorCodeCommand string, selection webcore.ProviderSelection) (*webcore.AuthSession, string, error) {
+	if !hasProviderSelection(selection) {
+		return callResolveSessionFn(ctx, appleID, password, twoFactorCode, twoFactorCodeCommand)
+	}
+	return callSessionResolverHook(ctx, resolveSessionWithoutPersistFn, "resolveSessionWithoutPersistFn", appleID, password, twoFactorCode, twoFactorCodeCommand)
 }
 
 // WebAuthCommand returns the detached web auth command group.
@@ -734,13 +765,13 @@ Examples:
 			defer cancel()
 
 			warnDeprecatedTwoFactorCodeFlag(*twoFactorCode)
-			session, source, err := callResolveSessionFn(requestCtx, *appleID, "", *twoFactorCode, *twoFactorCodeCommand)
-			if err != nil {
-				return err
-			}
 			selection := webcore.ProviderSelection{
 				ProviderID:       *providerID,
 				PublicProviderID: *publicProviderID,
+			}
+			session, source, err := callResolveSessionForProviderSelection(requestCtx, *appleID, "", *twoFactorCode, *twoFactorCodeCommand, selection)
+			if err != nil {
+				return err
 			}
 			if err := selectResolvedWebSessionProvider(requestCtx, session, selection); err != nil {
 				return err

--- a/internal/cli/web/web_session_flags.go
+++ b/internal/cli/web/web_session_flags.go
@@ -44,17 +44,19 @@ func warnDeprecatedTwoFactorCodeFlag(twoFactorCode string) {
 
 func resolveWebSessionForCommand(ctx context.Context, flags webSessionFlags) (*webcore.AuthSession, error) {
 	warnDeprecatedTwoFactorCodeFlag(*flags.twoFactorCode)
-	session, _, err := callResolveSessionFn(
+	selection := providerSelectionFromFlags(flags)
+	session, _, err := callResolveSessionForProviderSelection(
 		ctx,
 		*flags.appleID,
 		"",
 		*flags.twoFactorCode,
 		*flags.twoFactorCodeCommand,
+		selection,
 	)
 	if err != nil {
 		return nil, err
 	}
-	if err := selectResolvedWebSessionProvider(ctx, session, providerSelectionFromFlags(flags)); err != nil {
+	if err := selectResolvedWebSessionProvider(ctx, session, selection); err != nil {
 		return nil, err
 	}
 	return session, nil

--- a/internal/cli/web/web_session_flags.go
+++ b/internal/cli/web/web_session_flags.go
@@ -15,6 +15,8 @@ type webSessionFlags struct {
 	appleID              *string
 	twoFactorCode        *string
 	twoFactorCodeCommand *string
+	providerID           *int64
+	publicProviderID     *string
 }
 
 const deprecatedTwoFactorCodeFlagName = "two-factor-code"
@@ -28,6 +30,8 @@ func bindWebSessionFlags(fs *flag.FlagSet) webSessionFlags {
 		appleID:              fs.String("apple-id", "", "Apple Account email used to scope a user-owned session cache (optional when a cached session exists)"),
 		twoFactorCode:        bindDeprecatedTwoFactorCodeFlag(fs),
 		twoFactorCodeCommand: fs.String("two-factor-code-command", "", "Shell command that prints the 2FA code to stdout if verification is required"),
+		providerID:           fs.Int64("provider-id", 0, "Numeric App Store Connect provider ID to select for this web session"),
+		publicProviderID:     fs.String("public-provider-id", "", "Public App Store Connect provider/team ID to select for this web session"),
 	}
 }
 
@@ -50,7 +54,25 @@ func resolveWebSessionForCommand(ctx context.Context, flags webSessionFlags) (*w
 	if err != nil {
 		return nil, err
 	}
+	if err := selectResolvedWebSessionProvider(ctx, session, providerSelectionFromFlags(flags)); err != nil {
+		return nil, err
+	}
 	return session, nil
+}
+
+func providerSelectionFromFlags(flags webSessionFlags) webcore.ProviderSelection {
+	var providerID int64
+	if flags.providerID != nil {
+		providerID = *flags.providerID
+	}
+	var publicProviderID string
+	if flags.publicProviderID != nil {
+		publicProviderID = *flags.publicProviderID
+	}
+	return webcore.ProviderSelection{
+		ProviderID:       providerID,
+		PublicProviderID: publicProviderID,
+	}
 }
 
 func withWebAuthHint(err error, operation string) error {

--- a/internal/cli/web/web_session_flags_test.go
+++ b/internal/cli/web/web_session_flags_test.go
@@ -29,6 +29,12 @@ func TestBindWebSessionFlagsIncludesDeprecatedTwoFactorAlias(t *testing.T) {
 	if fs.Lookup("two-factor-code-command") == nil {
 		t.Fatal("expected --two-factor-code-command to remain registered")
 	}
+	if fs.Lookup("provider-id") == nil {
+		t.Fatal("expected --provider-id to be registered")
+	}
+	if fs.Lookup("public-provider-id") == nil {
+		t.Fatal("expected --public-provider-id to be registered")
+	}
 }
 
 func TestResolveWebSessionForCommandPassesTwoFactorCodeCommand(t *testing.T) {
@@ -58,6 +64,69 @@ func TestResolveWebSessionForCommandPassesTwoFactorCodeCommand(t *testing.T) {
 	}
 	if session == nil {
 		t.Fatal("expected session")
+	}
+}
+
+func TestResolveWebSessionForCommandSelectsProvider(t *testing.T) {
+	expected := &webcore.AuthSession{UserEmail: "user@example.com"}
+	restoreResolve := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode, twoFactorCodeCommand string) (*webcore.AuthSession, string, error) {
+		return expected, "cache", nil
+	})
+	t.Cleanup(restoreResolve)
+
+	origSelectProvider := selectWebProviderFn
+	origPersist := persistWebSessionFn
+	t.Cleanup(func() {
+		selectWebProviderFn = origSelectProvider
+		persistWebSessionFn = origPersist
+	})
+
+	selected := false
+	selectWebProviderFn = func(ctx context.Context, session *webcore.AuthSession, selection webcore.ProviderSelection) error {
+		selected = true
+		if session != expected {
+			t.Fatal("expected resolved session to be selected")
+		}
+		if selection.ProviderID != 123456 {
+			t.Fatalf("ProviderID = %d, want 123456", selection.ProviderID)
+		}
+		if selection.PublicProviderID != "TEAM123" {
+			t.Fatalf("PublicProviderID = %q, want TEAM123", selection.PublicProviderID)
+		}
+		session.ProviderID = selection.ProviderID
+		session.PublicProviderID = selection.PublicProviderID
+		return nil
+	}
+	persisted := false
+	persistWebSessionFn = func(session *webcore.AuthSession) error {
+		persisted = true
+		if session != expected {
+			t.Fatal("expected selected session to be persisted")
+		}
+		return nil
+	}
+
+	providerID := int64(123456)
+	flags := webSessionFlags{
+		appleID:              ptrTo("user@example.com"),
+		twoFactorCode:        ptrTo(""),
+		twoFactorCodeCommand: ptrTo(""),
+		providerID:           &providerID,
+		publicProviderID:     ptrTo("TEAM123"),
+	}
+
+	session, err := resolveWebSessionForCommand(context.Background(), flags)
+	if err != nil {
+		t.Fatalf("resolveWebSessionForCommand() error = %v", err)
+	}
+	if session != expected {
+		t.Fatal("expected selected session")
+	}
+	if !selected {
+		t.Fatal("expected provider selection")
+	}
+	if !persisted {
+		t.Fatal("expected selected provider session to be persisted")
 	}
 }
 

--- a/internal/cli/web/web_session_flags_test.go
+++ b/internal/cli/web/web_session_flags_test.go
@@ -2,7 +2,9 @@ package web
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -128,6 +130,97 @@ func TestResolveWebSessionForCommandSelectsProvider(t *testing.T) {
 	if !persisted {
 		t.Fatal("expected selected provider session to be persisted")
 	}
+}
+
+func TestResolveWebSessionForCommandDoesNotPersistBeforeProviderSelection(t *testing.T) {
+	origTryResume := tryResumeSessionFn
+	origTryResumeLast := tryResumeLastFn
+	origLoadCachedSession := loadCachedSessionFn
+	origLoadLastCachedSession := loadLastCachedSessionFn
+	origWebLogin := webLoginFn
+	origWebLoginWithClient := webLoginWithClientFn
+	origSelectProvider := selectWebProviderFn
+	origPersist := persistWebSessionFn
+	t.Cleanup(func() {
+		tryResumeSessionFn = origTryResume
+		tryResumeLastFn = origTryResumeLast
+		loadCachedSessionFn = origLoadCachedSession
+		loadLastCachedSessionFn = origLoadLastCachedSession
+		webLoginFn = origWebLogin
+		webLoginWithClientFn = origWebLoginWithClient
+		selectWebProviderFn = origSelectProvider
+		persistWebSessionFn = origPersist
+	})
+
+	t.Setenv(webPasswordEnv, "secret")
+
+	providerID := int64(123456)
+	flags := webSessionFlags{
+		appleID:              ptrTo("user@example.com"),
+		twoFactorCode:        ptrTo(""),
+		twoFactorCodeCommand: ptrTo(""),
+		providerID:           &providerID,
+		publicProviderID:     ptrTo("TEAM123"),
+	}
+
+	selectErr := errors.New("provider unavailable")
+	selectWebProviderFn = func(ctx context.Context, session *webcore.AuthSession, selection webcore.ProviderSelection) error {
+		return selectErr
+	}
+	persistWebSessionFn = func(session *webcore.AuthSession) error {
+		t.Fatal("did not expect session cache persistence before provider selection succeeds")
+		return nil
+	}
+
+	t.Run("fresh login", func(t *testing.T) {
+		tryResumeSessionFn = func(ctx context.Context, username string) (*webcore.AuthSession, bool, error) {
+			return nil, false, nil
+		}
+		tryResumeLastFn = func(ctx context.Context) (*webcore.AuthSession, bool, error) {
+			t.Fatal("did not expect last-session cache lookup when apple-id is provided")
+			return nil, false, nil
+		}
+		webLoginFn = func(ctx context.Context, creds webcore.LoginCredentials) (*webcore.AuthSession, error) {
+			if creds.Username != "user@example.com" {
+				t.Fatalf("Username = %q, want user@example.com", creds.Username)
+			}
+			return &webcore.AuthSession{UserEmail: creds.Username}, nil
+		}
+
+		_, err := resolveWebSessionForCommand(context.Background(), flags)
+		if !errors.Is(err, selectErr) {
+			t.Fatalf("expected provider selection error, got %v", err)
+		}
+	})
+
+	t.Run("auto reauth", func(t *testing.T) {
+		cachedClient := &http.Client{}
+		tryResumeSessionFn = func(ctx context.Context, username string) (*webcore.AuthSession, bool, error) {
+			return nil, false, webcore.ErrCachedSessionExpired
+		}
+		tryResumeLastFn = func(ctx context.Context) (*webcore.AuthSession, bool, error) {
+			t.Fatal("did not expect last-session cache lookup when apple-id is provided")
+			return nil, false, nil
+		}
+		loadCachedSessionFn = func(username string) (*webcore.AuthSession, bool, error) {
+			return &webcore.AuthSession{Client: cachedClient, UserEmail: username}, true, nil
+		}
+		loadLastCachedSessionFn = func() (*webcore.AuthSession, bool, error) {
+			t.Fatal("did not expect last cached-session load when apple-id is provided")
+			return nil, false, nil
+		}
+		webLoginWithClientFn = func(ctx context.Context, client *http.Client, creds webcore.LoginCredentials) (*webcore.AuthSession, error) {
+			if client != cachedClient {
+				t.Fatal("expected cached client to be reused")
+			}
+			return &webcore.AuthSession{Client: client, UserEmail: creds.Username}, nil
+		}
+
+		_, err := resolveWebSessionForCommand(context.Background(), flags)
+		if !errors.Is(err, selectErr) {
+			t.Fatalf("expected provider selection error, got %v", err)
+		}
+	})
 }
 
 func ptrTo(value string) *string {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -114,6 +114,18 @@ type AuthSession struct {
 	twoFactorCodeRequested bool
 }
 
+// ProviderSelection identifies the App Store Connect provider/team a web
+// session should use. ProviderID is Apple's numeric provider id; PublicProviderID
+// is the public team/provider id users usually recognize.
+type ProviderSelection struct {
+	ProviderID       int64
+	PublicProviderID string
+}
+
+func (s ProviderSelection) empty() bool {
+	return s.ProviderID == 0 && strings.TrimSpace(s.PublicProviderID) == ""
+}
+
 // LoginCredentials holds Apple ID credentials.
 type LoginCredentials struct {
 	Username string
@@ -243,13 +255,16 @@ type signinInitResponse struct {
 	Challenge  json.RawMessage `json:"c"`
 }
 
+type sessionProviderInfo struct {
+	ProviderID       int64  `json:"providerId"`
+	PublicProviderID string `json:"publicProviderId"`
+	Name             string `json:"name"`
+}
+
 type sessionInfo struct {
-	Provider struct {
-		ProviderID       int64  `json:"providerId"`
-		PublicProviderID string `json:"publicProviderId"`
-		Name             string `json:"name"`
-	} `json:"provider"`
-	User struct {
+	Provider           sessionProviderInfo   `json:"provider"`
+	AvailableProviders []sessionProviderInfo `json:"availableProviders"`
+	User               struct {
 		EmailAddress string `json:"emailAddress"`
 	} `json:"user"`
 }
@@ -427,6 +442,16 @@ func LoginWithClient(ctx context.Context, client *http.Client, creds LoginCreden
 	return loginWithHTTPClient(ctx, client, creds)
 }
 
+func applySessionInfo(session *AuthSession, info *sessionInfo) {
+	if session == nil || info == nil {
+		return
+	}
+	session.ProviderID = info.Provider.ProviderID
+	session.PublicProviderID = strings.TrimSpace(info.Provider.PublicProviderID)
+	session.TeamID = fmt.Sprintf("%d", info.Provider.ProviderID)
+	session.UserEmail = strings.TrimSpace(info.User.EmailAddress)
+}
+
 func loginWithHTTPClient(ctx context.Context, client *http.Client, creds LoginCredentials) (*AuthSession, error) {
 	if strings.TrimSpace(creds.Username) == "" {
 		return nil, fmt.Errorf("apple id is required")
@@ -460,14 +485,12 @@ func loginWithHTTPClient(ctx context.Context, client *http.Client, creds LoginCr
 		return nil, fmt.Errorf("failed to get session info: %w", err)
 	}
 
-	return &AuthSession{
-		Client:           client,
-		ProviderID:       info.Provider.ProviderID,
-		PublicProviderID: strings.TrimSpace(info.Provider.PublicProviderID),
-		TeamID:           fmt.Sprintf("%d", info.Provider.ProviderID),
-		UserEmail:        strings.TrimSpace(info.User.EmailAddress),
-		ServiceKey:       serviceKey,
-	}, nil
+	session := &AuthSession{
+		Client:     client,
+		ServiceKey: serviceKey,
+	}
+	applySessionInfo(session, info)
+	return session, nil
 }
 
 func getAuthServiceKey(ctx context.Context, client *http.Client) (string, error) {
@@ -973,6 +996,147 @@ func getSessionInfo(ctx context.Context, client *http.Client) (*sessionInfo, err
 	return &result, nil
 }
 
+func providerSelectionDescription(selection ProviderSelection) string {
+	parts := make([]string, 0, 2)
+	if selection.ProviderID != 0 {
+		parts = append(parts, fmt.Sprintf("provider-id=%d", selection.ProviderID))
+	}
+	if publicID := strings.TrimSpace(selection.PublicProviderID); publicID != "" {
+		parts = append(parts, fmt.Sprintf("public-provider-id=%s", publicID))
+	}
+	return strings.Join(parts, " ")
+}
+
+func providerSummary(provider sessionProviderInfo) string {
+	name := strings.TrimSpace(provider.Name)
+	publicID := strings.TrimSpace(provider.PublicProviderID)
+	parts := []string{fmt.Sprintf("%d", provider.ProviderID)}
+	if publicID != "" {
+		parts = append(parts, publicID)
+	}
+	if name != "" {
+		parts = append(parts, name)
+	}
+	return strings.Join(parts, " / ")
+}
+
+func availableProviderSummaries(info *sessionInfo) string {
+	if info == nil {
+		return ""
+	}
+	providers := info.AvailableProviders
+	if len(providers) == 0 && info.Provider.ProviderID != 0 {
+		providers = []sessionProviderInfo{info.Provider}
+	}
+	summaries := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		summaries = append(summaries, providerSummary(provider))
+	}
+	return strings.Join(summaries, ", ")
+}
+
+func resolveProviderSelection(info *sessionInfo, selection ProviderSelection) (sessionProviderInfo, error) {
+	if info == nil {
+		return sessionProviderInfo{}, fmt.Errorf("session info is required")
+	}
+	publicID := strings.TrimSpace(selection.PublicProviderID)
+	providers := info.AvailableProviders
+	if len(providers) == 0 && info.Provider.ProviderID != 0 {
+		providers = []sessionProviderInfo{info.Provider}
+	}
+
+	var matched *sessionProviderInfo
+	for i := range providers {
+		provider := providers[i]
+		idMatches := selection.ProviderID != 0 && provider.ProviderID == selection.ProviderID
+		publicMatches := publicID != "" && strings.EqualFold(strings.TrimSpace(provider.PublicProviderID), publicID)
+		switch {
+		case idMatches && publicID != "" && !publicMatches:
+			return sessionProviderInfo{}, fmt.Errorf("provider selection mismatch: provider-id %d is %q, not %q", selection.ProviderID, strings.TrimSpace(provider.PublicProviderID), publicID)
+		case idMatches || publicMatches:
+			matched = &provider
+		}
+	}
+	if matched == nil {
+		available := availableProviderSummaries(info)
+		if available == "" {
+			return sessionProviderInfo{}, fmt.Errorf("provider selection %s did not match any available providers", providerSelectionDescription(selection))
+		}
+		return sessionProviderInfo{}, fmt.Errorf("provider selection %s did not match any available providers (available: %s)", providerSelectionDescription(selection), available)
+	}
+	return *matched, nil
+}
+
+// SelectProvider switches an authenticated web session to a specific App Store
+// Connect provider/team using Apple's private olympus session endpoint.
+func SelectProvider(ctx context.Context, session *AuthSession, selection ProviderSelection) error {
+	if selection.empty() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if session == nil || session.Client == nil {
+		return fmt.Errorf("web session is required")
+	}
+
+	info, err := getSessionInfo(ctx, session.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get session info: %w", err)
+	}
+	selected, err := resolveProviderSelection(info, selection)
+	if err != nil {
+		return err
+	}
+	if info.Provider.ProviderID == selected.ProviderID {
+		applySessionInfo(session, info)
+		return nil
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"provider": map[string]int64{
+			"providerId": selected.ProviderID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build provider selection payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, olympusSessionURL, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "olympus-ui")
+	setModifiedCookieHeader(session.Client, req)
+
+	resp, err := session.Client.Do(req)
+	if err != nil {
+		logWebAuthHTTP("select_provider", req, nil, nil, err)
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logWebAuthHTTP("select_provider", req, resp, nil, err)
+		return fmt.Errorf("failed to read provider selection response: %w", err)
+	}
+	logWebAuthHTTP("select_provider", req, resp, body, nil)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("failed to select provider %s with status %d", providerSummary(selected), resp.StatusCode)
+	}
+
+	refreshed, err := getSessionInfo(ctx, session.Client)
+	if err != nil {
+		return fmt.Errorf("failed to refresh session info after provider selection: %w", err)
+	}
+	if refreshed.Provider.ProviderID != selected.ProviderID {
+		return fmt.Errorf("provider selection did not take effect: selected %d but session reports %d", selected.ProviderID, refreshed.Provider.ProviderID)
+	}
+	applySessionInfo(session, refreshed)
+	return nil
+}
+
 func isSessionInfoAuthExpired(err error) bool {
 	var statusErr *sessionInfoStatusError
 	if !errors.As(err, &statusErr) {
@@ -1200,10 +1364,7 @@ func finalizeTwoFactor(ctx context.Context, session *AuthSession) error {
 	if err != nil {
 		return err
 	}
-	session.ProviderID = info.Provider.ProviderID
-	session.PublicProviderID = strings.TrimSpace(info.Provider.PublicProviderID)
-	session.TeamID = fmt.Sprintf("%d", info.Provider.ProviderID)
-	session.UserEmail = strings.TrimSpace(info.User.EmailAddress)
+	applySessionInfo(session, info)
 	return nil
 }
 

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1050,6 +1050,17 @@ func resolveProviderSelection(info *sessionInfo, selection ProviderSelection) (s
 		provider := providers[i]
 		idMatches := selection.ProviderID != 0 && provider.ProviderID == selection.ProviderID
 		publicMatches := publicID != "" && strings.EqualFold(strings.TrimSpace(provider.PublicProviderID), publicID)
+		if selection.ProviderID != 0 && publicID != "" {
+			switch {
+			case idMatches && publicMatches:
+				matched = &provider
+			case idMatches:
+				return sessionProviderInfo{}, fmt.Errorf("provider selection mismatch: provider-id %d is %q, not %q", selection.ProviderID, strings.TrimSpace(provider.PublicProviderID), publicID)
+			case publicMatches:
+				return sessionProviderInfo{}, fmt.Errorf("provider selection mismatch: public-provider-id %q is provider-id %d, not %d", publicID, provider.ProviderID, selection.ProviderID)
+			}
+			continue
+		}
 		switch {
 		case idMatches && publicID != "" && !publicMatches:
 			return sessionProviderInfo{}, fmt.Errorf("provider selection mismatch: provider-id %d is %q, not %q", selection.ProviderID, strings.TrimSpace(provider.PublicProviderID), publicID)

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -719,6 +719,124 @@ func TestSubmitTwoFactorCodeRequestsPhoneDeliveryBeforeVerification(t *testing.T
 	}
 }
 
+func TestSelectProviderByPublicProviderID(t *testing.T) {
+	requests := 0
+	session := &AuthSession{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				switch requests {
+				case 1:
+					if req.Method != http.MethodGet || req.URL.String() != olympusSessionURL {
+						t.Fatalf("unexpected initial request %s %s", req.Method, req.URL.String())
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body: io.NopCloser(strings.NewReader(`{
+							"provider": {"providerId": 111, "publicProviderId": "TEAM111", "name": "Old Team"},
+							"availableProviders": [
+								{"providerId": 111, "publicProviderId": "TEAM111", "name": "Old Team"},
+								{"providerId": 222, "publicProviderId": "TEAM222", "name": "New Team"}
+							],
+							"user": {"emailAddress": "user@example.com"}
+						}`)),
+					}, nil
+				case 2:
+					if req.Method != http.MethodPost || req.URL.String() != olympusSessionURL {
+						t.Fatalf("unexpected provider selection request %s %s", req.Method, req.URL.String())
+					}
+					if got := req.Header.Get("X-Requested-With"); got != "olympus-ui" {
+						t.Fatalf("expected X-Requested-With olympus-ui, got %q", got)
+					}
+					var payload struct {
+						Provider struct {
+							ProviderID int64 `json:"providerId"`
+						} `json:"provider"`
+					}
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode provider selection payload: %v", err)
+					}
+					if payload.Provider.ProviderID != 222 {
+						t.Fatalf("expected providerId 222, got %d", payload.Provider.ProviderID)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(`{}`)),
+					}, nil
+				case 3:
+					if req.Method != http.MethodGet || req.URL.String() != olympusSessionURL {
+						t.Fatalf("unexpected refresh request %s %s", req.Method, req.URL.String())
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body: io.NopCloser(strings.NewReader(`{
+							"provider": {"providerId": 222, "publicProviderId": "TEAM222", "name": "New Team"},
+							"user": {"emailAddress": "user@example.com"}
+						}`)),
+					}, nil
+				default:
+					t.Fatalf("unexpected extra request %d: %s %s", requests, req.Method, req.URL.String())
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	err := SelectProvider(context.Background(), session, ProviderSelection{PublicProviderID: "team222"})
+	if err != nil {
+		t.Fatalf("SelectProvider returned error: %v", err)
+	}
+	if session.ProviderID != 222 {
+		t.Fatalf("expected provider id 222, got %d", session.ProviderID)
+	}
+	if session.PublicProviderID != "TEAM222" {
+		t.Fatalf("expected public provider id TEAM222, got %q", session.PublicProviderID)
+	}
+	if session.TeamID != "222" {
+		t.Fatalf("expected team id 222, got %q", session.TeamID)
+	}
+	if session.UserEmail != "user@example.com" {
+		t.Fatalf("expected user email user@example.com, got %q", session.UserEmail)
+	}
+	if requests != 3 {
+		t.Fatalf("expected 3 requests, got %d", requests)
+	}
+}
+
+func TestSelectProviderRejectsUnknownPublicProviderID(t *testing.T) {
+	session := &AuthSession{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodGet || req.URL.String() != olympusSessionURL {
+					t.Fatalf("unexpected request %s %s", req.Method, req.URL.String())
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(`{
+						"provider": {"providerId": 111, "publicProviderId": "TEAM111", "name": "Old Team"},
+						"availableProviders": [
+							{"providerId": 111, "publicProviderId": "TEAM111", "name": "Old Team"}
+						],
+						"user": {"emailAddress": "user@example.com"}
+					}`)),
+				}, nil
+			}),
+		},
+	}
+
+	err := SelectProvider(context.Background(), session, ProviderSelection{PublicProviderID: "TEAM404"})
+	if err == nil {
+		t.Fatal("expected unknown provider error")
+	}
+	if !strings.Contains(err.Error(), "TEAM404") || !strings.Contains(err.Error(), "TEAM111") {
+		t.Fatalf("expected error to include requested and available providers, got %v", err)
+	}
+}
+
 func TestPreparePasswordForProtocol(t *testing.T) {
 	t.Run("s2k", func(t *testing.T) {
 		prepared, err := preparePasswordForProtocol("example", "s2k")

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -837,6 +837,43 @@ func TestSelectProviderRejectsUnknownPublicProviderID(t *testing.T) {
 	}
 }
 
+func TestSelectProviderRejectsMismatchedProviderIDs(t *testing.T) {
+	requests := 0
+	session := &AuthSession{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				if req.Method != http.MethodGet || req.URL.String() != olympusSessionURL {
+					t.Fatalf("unexpected request %s %s", req.Method, req.URL.String())
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(`{
+						"provider": {"providerId": 111, "publicProviderId": "TEAM111", "name": "Old Team"},
+						"availableProviders": [
+							{"providerId": 111, "publicProviderId": "TEAM111", "name": "Old Team"},
+							{"providerId": 222, "publicProviderId": "TEAM222", "name": "New Team"}
+						],
+						"user": {"emailAddress": "user@example.com"}
+					}`)),
+				}, nil
+			}),
+		},
+	}
+
+	err := SelectProvider(context.Background(), session, ProviderSelection{ProviderID: 999, PublicProviderID: "TEAM222"})
+	if err == nil {
+		t.Fatal("expected provider mismatch error")
+	}
+	if !strings.Contains(err.Error(), "TEAM222") || !strings.Contains(err.Error(), "999") || !strings.Contains(err.Error(), "222") {
+		t.Fatalf("expected error to include mismatched provider ids, got %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected mismatch to stop before provider selection POST, got %d requests", requests)
+	}
+}
+
 func TestPreparePasswordForProtocol(t *testing.T) {
 	t.Run("s2k", func(t *testing.T) {
 		prepared, err := preparePasswordForProtocol("example", "s2k")

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -1047,13 +1047,9 @@ func resumeFromPersistedSession(ctx context.Context, sess persistedSession) (*Au
 		}
 		return nil, false, nil
 	}
-	return &AuthSession{
-		Client:           client,
-		ProviderID:       info.Provider.ProviderID,
-		PublicProviderID: strings.TrimSpace(info.Provider.PublicProviderID),
-		TeamID:           fmt.Sprintf("%d", info.Provider.ProviderID),
-		UserEmail:        strings.TrimSpace(info.User.EmailAddress),
-	}, true, nil
+	session := &AuthSession{Client: client}
+	applySessionInfo(session, info)
+	return session, true, nil
 }
 
 func loadSessionFromPersistedSession(sess persistedSession) (*AuthSession, bool, error) {


### PR DESCRIPTION
## Summary

Fixes #1538.

Adds provider/team selection for private App Store Connect web sessions so multi-team Apple Accounts can select the intended provider before cached/private web commands run.

## What changed

- Added `web.ProviderSelection` and `web.SelectProvider`, backed by the private Olympus session endpoint used by App Store Connect web sessions.
- Supports selecting by numeric `--provider-id` or public `--public-provider-id`.
- Applies selection during `asc web auth login` and every shared web-session command resolver, including Xcode Cloud/private web flows.
- Persists the selected session after switching provider so later commands reuse the intended team.
- Exposes `publicProviderId` in web auth login/status output.
- Adds regression tests for provider switching, unknown provider errors, flag registration, and command session-provider persistence.

## Debugging notes

Fastlane's Spaceship client handles this by posting `{"provider":{"providerId": ...}}` to `https://appstoreconnect.apple.com/olympus/v1/session` with `X-Requested-With: olympus-ui`. This PR mirrors that flow and refreshes `/olympus/v1/session` afterward to verify the provider switch took effect.

Fastlane reference: https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/client.rb

## Validation

Passed:

- `go run . web auth login --help`
- `go run . web xcode-cloud products --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/web ./internal/cli/web -run 'TestSelectProvider|TestResolveWebSessionForCommand|TestBindWebSessionFlags|TestSubmitTwoFactorCode'`
- `make generate-command-docs`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test -v ./apps/studio -run TestCheckAuthStatusTreatsCompleteEnvironmentCredentialsAsAuthenticated`

Full-suite note:

- `ASC_BYPASS_KEYCHAIN=1 make test` was rerun and failed in `apps/studio`, outside this PR's changed packages:
  - First run: `TestCheckAuthStatusTreatsCompleteEnvironmentCredentialsAsAuthenticated` reported `status.Authenticated = false, want true when complete environment credentials are available`.
  - Standalone rerun of that exact test passed.
  - Second full-suite run failed at `TestCheckAuthStatusTreatsEmptyStoredCredentialsAsUnauthenticated` with `status.Storage = "", want System Keychain`.
