### PR TITLE
Add native Apple Ads support

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,16 @@ asc xcode-cloud run --source-run-id "BUILD_RUN_ID" --clean
 asc xcode-cloud build-runs get --id "BUILD_RUN_ID"
 ```
 
+### Apple Ads campaign management
+
+Apple Ads uses separate OAuth credentials from App Store Connect:
+
+```bash
+asc ads auth login --name "Marketing" --client-id "SEARCHADS_CLIENT_ID" --team-id "SEARCHADS_TEAM_ID" --key-id "KEY_ID" --private-key ./ads-key.pem --org "123456"
+asc ads campaigns --org "123456" --limit 100 --output json
+asc ads reports campaigns --org "123456" --file reporting-request.json --output json
+```
+
 ## Commands and Reference
 
 Use built-in help as the source of truth:

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -202,6 +202,46 @@ asc --profile "WorkApp" apps list
   Use `--strict-auth` or `ASC_STRICT_AUTH=true` to fail when credentials are resolved from multiple sources (helps catch mixed-source errors).
 </Note>
 
+## Apple Ads authentication
+
+Apple Ads uses a separate OAuth client credentials flow and a separate Apple Ads
+API key. App Store Connect API keys do not work for `asc ads`.
+
+Store Apple Ads credentials with:
+
+```bash  theme={null}
+asc ads auth login \
+  --name "Marketing" \
+  --client-id "SEARCHADS_CLIENT_ID" \
+  --team-id "SEARCHADS_TEAM_ID" \
+  --key-id "KEY_ID" \
+  --private-key ./apple-ads-private-key.pem \
+  --org "123456"
+```
+
+Validate Apple Ads credentials:
+
+```bash  theme={null}
+asc ads auth status --validate
+asc ads auth doctor
+```
+
+Apple Ads credential resolution order:
+
+1. Explicit `--ads-profile "ProfileName"`
+2. `ASC_ADS_PROFILE`
+3. `ASC_ADS_ACCESS_TOKEN`
+4. Complete Apple Ads environment variables
+5. Default stored Apple Ads profile
+6. Single stored Apple Ads profile
+
+If a profile is selected with `--ads-profile` or `ASC_ADS_PROFILE`, that profile
+wins over `ASC_ADS_ACCESS_TOKEN`. Set `ASC_ADS_STRICT_AUTH=true` to fail when a
+profile and access token are both present.
+
+Most Apple Ads commands also require an organization ID. Set it with `--org`,
+store it during Ads login, or export `ASC_ADS_ORG_ID`.
+
 ## Validate credentials
 
 Test your credentials with a lightweight API request:
@@ -331,6 +371,22 @@ This removes credentials from both keychain and config files.
 | `ASC_PROFILE`          | Named profile to use          | `MyApp`                                |
 | `ASC_BYPASS_KEYCHAIN`  | Skip keychain, use config/env | `1`, `true`, `yes`, `on`               |
 | `ASC_STRICT_AUTH`      | Fail on mixed sources         | `1`, `true`, `yes`, `on`               |
+
+### Apple Ads environment variables
+
+| Variable                    | Purpose                              | Example                    |
+| --------------------------- | ------------------------------------ | -------------------------- |
+| `ASC_ADS_CLIENT_ID`         | Apple Ads OAuth client ID            | `SEARCHADS_CLIENT_ID`      |
+| `ASC_ADS_TEAM_ID`           | Apple Ads OAuth team ID              | `SEARCHADS_TEAM_ID`        |
+| `ASC_ADS_KEY_ID`            | Apple Ads API key ID                 | `KEY123`                   |
+| `ASC_ADS_PRIVATE_KEY_PATH`  | Path to Apple Ads private key        | `/path/to/ads-key.pem`     |
+| `ASC_ADS_PRIVATE_KEY`       | Raw Apple Ads private key PEM        | `-----BEGIN PRIVATE KEY-----` |
+| `ASC_ADS_PRIVATE_KEY_B64`   | Base64-encoded Apple Ads private key | `LS0tLS1CRUdJTi...`        |
+| `ASC_ADS_PROFILE`           | Named Apple Ads profile to use       | `Marketing`                |
+| `ASC_ADS_ACCESS_TOKEN`      | Pre-minted Apple Ads OAuth token     | `eyJ...`                   |
+| `ASC_ADS_ORG_ID`            | Apple Ads organization ID            | `123456`                   |
+| `ASC_ADS_BYPASS_KEYCHAIN`   | Skip keychain for Apple Ads auth     | `1`, `true`, `yes`, `on`   |
+| `ASC_ADS_STRICT_AUTH`       | Fail on mixed Apple Ads sources      | `1`, `true`, `yes`, `on`   |
 
 ## Troubleshooting
 

--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -27,7 +27,7 @@ var rootUsageGroups = []rootCommandGroup{
 	},
 	{
 		title:    "ANALYTICS & FINANCE COMMANDS",
-		commands: []string{"analytics", "insights", "finance", "performance"},
+		commands: []string{"analytics", "ads", "insights", "finance", "performance"},
 	},
 	{
 		title: "APP MANAGEMENT COMMANDS",

--- a/commands/ads.mdx
+++ b/commands/ads.mdx
@@ -1,0 +1,390 @@
+# Apple Ads
+
+> Manage Apple Ads Campaign Management API resources from asc
+
+The `ads` command group talks to the Apple Ads Campaign Management API v5. It
+uses Apple Ads OAuth credentials, not App Store Connect API keys.
+
+Use `--help` before scripting a new command. Apple Ads has many nested
+resources, and the CLI exposes the documented path parameters as flags:
+
+```bash  theme={null}
+asc ads --help
+asc ads campaigns --help
+asc ads campaigns create --help
+```
+
+## Credential Model
+
+Apple Ads credentials are separate from App Store Connect credentials.
+`asc auth login` does not configure `asc ads`.
+
+For automation, configure an Ads profile with `asc ads auth login` or provide
+Ads credentials through `ASC_ADS_*` variables. `ASC_ADS_ACCESS_TOKEN` skips
+token exchange and still needs `--org`, `ASC_ADS_ORG_ID`, or a stored default
+org.
+
+## Authenticate
+
+Create an Apple Ads API key in Apple Ads, then store it with `asc ads auth`.
+Apple Ads expects an EC P-256 private key. Keep the private key out of your
+repo.
+
+```bash  theme={null}
+openssl ecparam -genkey -name prime256v1 -noout -out ./apple-ads-private-key.pem
+openssl ec -in ./apple-ads-private-key.pem -pubout -out ./apple-ads-public-key.pem
+```
+
+Upload the public key in Apple Ads. Apple returns a `client_id`, `team_id`, and
+`key_id` for that integration.
+
+```bash  theme={null}
+asc ads auth login \
+  --name "Marketing" \
+  --client-id "SEARCHADS_CLIENT_ID" \
+  --team-id "SEARCHADS_TEAM_ID" \
+  --key-id "KEY_ID" \
+  --private-key ./apple-ads-private-key.pem \
+  --org "123456"
+```
+
+Add `--network` during login when you want `asc` to request a token and call
+`GET /v5/me` before storing the profile:
+
+```bash  theme={null}
+asc ads auth login \
+  --name "Marketing" \
+  --client-id "SEARCHADS_CLIENT_ID" \
+  --team-id "SEARCHADS_TEAM_ID" \
+  --key-id "KEY_ID" \
+  --private-key ./apple-ads-private-key.pem \
+  --org "123456" \
+  --network
+```
+
+Validate and inspect stored credentials:
+
+```bash  theme={null}
+asc ads auth status --validate
+asc ads auth doctor
+```
+
+Print a short-lived OAuth access token only when you explicitly confirm:
+
+```bash  theme={null}
+asc ads auth token --confirm --output json
+```
+
+For CI or agent runs, use environment variables instead of storing a profile:
+
+```bash  theme={null}
+export ASC_ADS_CLIENT_ID="SEARCHADS_CLIENT_ID"
+export ASC_ADS_TEAM_ID="SEARCHADS_TEAM_ID"
+export ASC_ADS_KEY_ID="KEY_ID"
+export ASC_ADS_PRIVATE_KEY_PATH="$HOME/.asc/apple-ads-private-key.pem"
+export ASC_ADS_ORG_ID="123456"
+
+asc ads campaigns --output json
+```
+
+`ASC_ADS_PRIVATE_KEY` and `ASC_ADS_PRIVATE_KEY_B64` also work when a CI system
+can store the key material as a secret value. Use `ASC_ADS_BYPASS_KEYCHAIN=1`
+when you want environment/config auth only.
+
+If another system already minted a short-lived token, pass it directly:
+
+```bash  theme={null}
+export ASC_ADS_ACCESS_TOKEN="ACCESS_TOKEN"
+export ASC_ADS_ORG_ID="123456"
+
+asc ads campaigns --limit 10 --output json
+```
+
+## Organization context
+
+Most Apple Ads endpoints require an organization context. Provide it with
+`--org`, store it during login with `--org`, or set `ASC_ADS_ORG_ID`. If you do
+not know the org ID yet, list the account ACLs first:
+
+```bash  theme={null}
+asc ads acls --output json
+```
+
+Then pass the org ID returned by Apple:
+
+```bash  theme={null}
+asc ads campaigns list --org "123456" --output json
+```
+
+These endpoints do not send the `X-AP-Context` organization header because
+Apple defines them outside an org context:
+
+```bash  theme={null}
+asc ads me view
+asc ads acls list
+```
+
+## Campaigns
+
+List campaigns. The short form aliases `list`:
+
+```bash  theme={null}
+asc ads campaigns --org "123456" --limit 100 --output table
+asc ads campaigns list --org "123456" --paginate --output json
+```
+
+Create or update resources with JSON payload files. The CLI sends the file body
+to Apple without inventing extra field mappings:
+
+```bash  theme={null}
+asc ads campaigns create --org "123456" --file campaign.json
+asc ads campaigns update --org "123456" --campaign 987654321 --file campaign-update.json
+```
+
+Delete commands always require `--confirm`:
+
+```bash  theme={null}
+asc ads campaigns delete --org "123456" --campaign 987654321 --confirm
+```
+
+## Ad Groups and Ads
+
+Ad groups sit under campaigns. Ads sit under campaign and ad group IDs:
+
+```bash  theme={null}
+asc ads ad-groups list --org "123456" --campaign 987654321 --output json
+asc ads ad-groups create --org "123456" --campaign 987654321 --file ad-group.json
+asc ads ads list --org "123456" --campaign 987654321 --ad-group 123456789 --output json
+asc ads ads create --org "123456" --campaign 987654321 --ad-group 123456789 --file ad.json
+```
+
+Find endpoints use Apple selector payloads:
+
+```bash  theme={null}
+asc ads campaigns find --org "123456" --file selector.json --output json
+asc ads ad-groups find --org "123456" --campaign 987654321 --file selector.json
+asc ads ads find-org --org "123456" --file selector.json
+```
+
+```json selector.json
+{
+  "conditions": [
+    {
+      "field": "deleted",
+      "operator": "EQUALS",
+      "values": ["false"]
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 100
+  },
+  "orderBy": [
+    {
+      "field": "id",
+      "sortOrder": "DESCENDING"
+    }
+  ]
+}
+```
+
+## Payloads
+
+Apple Ads request bodies are passed through as JSON. Object endpoints require a
+JSON object. Bulk endpoints that accept arrays require a JSON array.
+
+```json campaign.json
+{
+  "name": "Brand Campaign",
+  "budgetAmount": {
+    "amount": "1000",
+    "currency": "USD"
+  },
+  "adamId": 1234567890,
+  "countriesOrRegions": ["US"],
+  "billingEvent": "TAPS",
+  "dailyBudgetAmount": {
+    "amount": "100",
+    "currency": "USD"
+  },
+  "displayStatus": "PAUSED"
+}
+```
+
+For live test data, prefer paused campaigns with a future start date and delete
+them after verification. Do not use production campaigns for command-shape
+testing.
+
+```bash  theme={null}
+asc ads targeting-keywords create-bulk \
+  --org "123456" \
+  --campaign 987654321 \
+  --ad-group 123456789 \
+  --file keywords.json
+```
+
+```json keywords.json
+[
+  {
+    "text": "example keyword",
+    "matchType": "EXACT",
+    "bidAmount": {
+      "amount": "1.00",
+      "currency": "USD"
+    },
+    "status": "PAUSED"
+  }
+]
+```
+
+Bulk delete endpoints accept arrays of IDs:
+
+```bash  theme={null}
+asc ads targeting-keywords delete-bulk \
+  --org "123456" \
+  --campaign 987654321 \
+  --ad-group 123456789 \
+  --file keyword-ids.json \
+  --confirm
+```
+
+```json keyword-ids.json
+[111111111, 222222222]
+```
+
+## Keywords and Negative Keywords
+
+Targeting keywords belong to an ad group:
+
+```bash  theme={null}
+asc ads targeting-keywords list --org "123456" --campaign 987654321 --ad-group 123456789
+asc ads targeting-keywords create-bulk --org "123456" --campaign 987654321 --ad-group 123456789 --file keywords.json
+asc ads targeting-keywords delete --org "123456" --campaign 987654321 --ad-group 123456789 --keyword 111111111 --confirm
+```
+
+Campaign negative keywords belong to a campaign. Ad group negative keywords add
+`--ad-group`:
+
+```bash  theme={null}
+asc ads campaign-negative-keywords create-bulk --org "123456" --campaign 987654321 --file negative-keywords.json
+asc ads ad-group-negative-keywords create-bulk --org "123456" --campaign 987654321 --ad-group 123456789 --file negative-keywords.json
+```
+
+```json negative-keywords.json
+[
+  {
+    "text": "free",
+    "matchType": "BROAD",
+    "status": "ACTIVE"
+  }
+]
+```
+
+## Apps, Product Pages, Geo, and Creatives
+
+These commands help you discover valid IDs before creating campaigns or ads:
+
+```bash  theme={null}
+asc ads apps search --org "123456" --query "My App" --limit 10 --output json
+asc ads apps view --org "123456" --adam-id 1234567890 --output json
+asc ads product-pages list --org "123456" --adam-id 1234567890 --states VISIBLE
+asc ads product-pages locales list --org "123456" --adam-id 1234567890 --product-page "DEFAULT_PRODUCT_PAGE"
+asc ads geo search --org "123456" --query "San Francisco" --country-code US --limit 10
+asc ads creatives list --org "123456" --limit 100
+asc ads rejection-reasons find --org "123456" --file selector.json
+```
+
+Apple does not allow every ad or creative to be deleted directly. For example,
+Apple can reject direct deletes for default product page creative ads. In test
+runs, clean those up by deleting the parent ad group or campaign when Apple
+allows it.
+
+## Reporting
+
+Reporting endpoints accept Apple Ads `ReportingRequest` payloads:
+
+```bash  theme={null}
+asc ads reports campaigns --org "123456" --file reporting-request.json --output json
+asc ads reports keywords --org "123456" --campaign 987654321 --file reporting-request.json
+```
+
+```json reporting-request.json
+{
+  "startTime": "2026-05-01",
+  "endTime": "2026-05-31",
+  "returnRowTotals": true,
+  "returnGrandTotals": true,
+  "selector": {
+    "orderBy": [
+      {
+        "field": "impressions",
+        "sortOrder": "DESCENDING"
+      }
+    ],
+    "pagination": {
+      "offset": 0,
+      "limit": 100
+    }
+  }
+}
+```
+
+`--paginate` is only exposed on documented query-parameter pagination endpoints.
+Reporting and selector-body endpoints keep pagination inside the request body
+exactly as supplied in `--file`.
+
+## Impression Share Reports
+
+```bash  theme={null}
+asc ads impression-share-reports --org "123456" --limit 50 --output json
+asc ads impression-share-reports create --org "123456" --file custom-report-request.json
+asc ads impression-share-reports view --org "123456" --report 123456789
+```
+
+Apple Ads limits impression share report list pages to 50 rows.
+
+## Endpoint Groups
+
+`asc ads` includes commands for:
+
+* auth, access control, and user details
+* apps, app assets, product pages, locales, countries, and devices
+* budget orders, campaigns, ad groups, and ads
+* targeting keywords, campaign negative keywords, and ad group negative keywords
+* geo search and geo resolution
+* creatives and rejection reasons
+* campaign, ad group, keyword, search term, ad, and ad-group scoped reports
+* impression share reports
+
+Every generated endpoint command supports `--ads-profile`. Every org-scoped
+endpoint also supports `--org`. List-style endpoints that expose Apple
+`limit`/`offset` query parameters also support `--paginate`.
+
+## Raw API Requests
+
+Use `ads api request` when Apple adds a new field before the first-class command
+surface is updated, or when you need to debug an API response:
+
+```bash  theme={null}
+asc ads api request \
+  --method POST \
+  --path v5/campaigns/find \
+  --org "123456" \
+  --file selector.json \
+  --output json
+```
+
+The raw request command only accepts Apple Ads v5 paths or
+`https://api.searchads.apple.com/api/v5/...` URLs. `DELETE` requests require
+`--confirm`.
+
+## Agent Checklist
+
+When you automate Apple Ads with a coding agent:
+
+1. Run `asc ads <group> --help` before choosing flags.
+2. Resolve the org with `asc ads acls --output json` unless `ASC_ADS_ORG_ID` is already known.
+3. Use `--output json` for machine parsing.
+4. Put request bodies in checked-in templates or temporary JSON files, not shell-escaped inline JSON.
+5. Pass `--confirm` only after you have printed the target ID and cleanup plan.
+6. For live mutation tests, create paused, clearly named resources and delete the parent campaign at the end.

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -55,6 +55,7 @@ Commands are organized into logical families based on functionality:
 ### Analytics and Finance
 
 * `analytics` - Request and download analytics and sales reports
+* `ads` - Manage Apple Ads campaigns, ad groups, keywords, creatives, and reports
 * `insights` - Generate weekly and daily insights from App Store data sources
 * `finance` - Download payments and financial reports
 * `performance` - Access performance metrics and diagnostic logs

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -44,6 +44,62 @@ These variables configure API authentication credentials.
   Use a named authentication profile from config or keychain
 </ParamField>
 
+## Apple Ads authentication variables
+
+These variables apply only to `asc ads`. They do not replace `ASC_KEY_ID`,
+`ASC_ISSUER_ID`, or other App Store Connect API credentials.
+
+<ParamField path="ASC_ADS_ACCESS_TOKEN" type="string">
+  Short-lived Apple Ads OAuth access token
+
+  When set, `asc ads` skips token exchange and uses this bearer token. Org-scoped
+  commands still need `--org`, `ASC_ADS_ORG_ID`, or a stored profile org.
+</ParamField>
+
+<ParamField path="ASC_ADS_CLIENT_ID" type="string">
+  Apple Ads OAuth client ID
+</ParamField>
+
+<ParamField path="ASC_ADS_TEAM_ID" type="string">
+  Apple Ads team ID used as the OAuth client-secret JWT issuer
+</ParamField>
+
+<ParamField path="ASC_ADS_KEY_ID" type="string">
+  Apple Ads API key ID used in the OAuth client-secret JWT header
+</ParamField>
+
+<ParamField path="ASC_ADS_PRIVATE_KEY_PATH" type="string">
+  Path to your Apple Ads EC P-256 private key PEM file
+</ParamField>
+
+<ParamField path="ASC_ADS_PRIVATE_KEY" type="string">
+  Raw Apple Ads private key content in PEM format
+</ParamField>
+
+<ParamField path="ASC_ADS_PRIVATE_KEY_B64" type="string">
+  Base64-encoded Apple Ads private key content
+</ParamField>
+
+<ParamField path="ASC_ADS_ORG_ID" type="string">
+  Default Apple Ads organization ID for org-scoped `asc ads` commands
+</ParamField>
+
+<ParamField path="ASC_ADS_PROFILE" type="string">
+  Use a named Apple Ads authentication profile from config or keychain
+</ParamField>
+
+<ParamField path="ASC_ADS_BYPASS_KEYCHAIN" type="boolean">
+  Ignore keychain and use Apple Ads config/env auth only
+
+  Set to `true`, `1`, `yes`, `y`, or `on` to bypass keychain lookup.
+</ParamField>
+
+<ParamField path="ASC_ADS_STRICT_AUTH" type="boolean">
+  Fail when Apple Ads credentials resolve from multiple sources
+
+  Set to `true`, `1`, `yes`, `y`, or `on` to enable strict mode.
+</ParamField>
+
 ## Operational variables
 
 These variables configure default values for apps, vendors, and other resources.
@@ -142,7 +198,9 @@ Configure default output formats.
 
 ## Variable precedence
 
-Environment variables are resolved in this order:
+### App Store Connect precedence
+
+App Store Connect credentials and defaults are resolved in this order:
 
 1. **Command-line flags** (highest priority)
 2. **Environment variables**
@@ -153,6 +211,19 @@ Environment variables are resolved in this order:
 <Note>
   When `ASC_STRICT_AUTH=true`, the CLI will fail if credentials are found in multiple sources (e.g., both environment variables and keychain).
 </Note>
+
+### Apple Ads precedence
+
+Apple Ads credentials and defaults are resolved in this order:
+
+1. **Command-line flags** (`--ads-profile`, `--org`)
+2. **Environment variables** (`ASC_ADS_*`)
+3. **Apple Ads config profile** (`~/.asc/config.json` or `.asc/config.json`)
+4. **Keychain** (for Apple Ads credentials only)
+
+`ASC_ADS_ACCESS_TOKEN` counts as an Apple Ads auth source. When
+`ASC_ADS_STRICT_AUTH=true`, the CLI will fail if it sees both a profile and
+`ASC_ADS_ACCESS_TOKEN`.
 
 ## Examples
 
@@ -175,6 +246,18 @@ export ASC_PRIVATE_KEY_B64="LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t..."
 export ASC_BYPASS_KEYCHAIN="true"
 
 asc builds upload --app 123456789 --ipa MyApp.ipa
+```
+
+### Apple Ads authentication
+
+```bash  theme={null}
+export ASC_ADS_CLIENT_ID="SEARCHADS_CLIENT_ID"
+export ASC_ADS_TEAM_ID="SEARCHADS_TEAM_ID"
+export ASC_ADS_KEY_ID="KEY_ID"
+export ASC_ADS_PRIVATE_KEY_PATH="$HOME/.asc/apple-ads-private-key.pem"
+export ASC_ADS_ORG_ID="123456"
+
+asc ads campaigns --output json
 ```
 
 ### Debug HTTP requests

--- a/docs.json
+++ b/docs.json
@@ -103,6 +103,7 @@
             "group": "Monetization & Analytics",
             "pages": [
               "commands/analytics",
+              "commands/ads",
               "commands/finance",
               "commands/performance",
               "commands/iap",

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -49,6 +49,7 @@ asc <subcommand> [flags]
 ### Analytics and Finance
 
 - `analytics` - Request and download analytics and sales reports.
+- `ads` - Manage Apple Ads Campaign Management API resources.
 - `insights` - Generate weekly and daily insights from App Store data sources.
 - `finance` - Download payments and financial reports.
 - `performance` - Access performance metrics and diagnostic logs.

--- a/docs/architecture/apple-ads-api-support.md
+++ b/docs/architecture/apple-ads-api-support.md
@@ -168,7 +168,7 @@ asc ads auth status [--verbose] [--validate] [--output table|json]
 asc ads auth switch --name NAME
 asc ads auth token --confirm [--output text|json]
 asc ads auth doctor [--output text|json]
-asc ads auth logout [--all | --name NAME]
+asc ads auth logout [--all --confirm | --name NAME]
 ```
 
 Mirror the existing `asc auth` behavior:
@@ -187,7 +187,8 @@ Mirror the existing `asc auth` behavior:
 - Keychain is preferred; config fallback is allowed when bypassing keychain.
 - `auth status` supports `--verbose` and `--validate`, matching `asc auth status`.
 - `auth logout` supports `--all` and `--name`. It requires one of those flags
-  so bare `asc ads auth logout` does not clear every stored Ads profile.
+  so bare `asc ads auth logout` does not clear every stored Ads profile, and
+  `--all` requires `--confirm`.
 
 Add config fields without changing existing App Store Connect credentials:
 

--- a/docs/architecture/apple-ads-api-support.md
+++ b/docs/architecture/apple-ads-api-support.md
@@ -1,0 +1,790 @@
+# Apple Ads API Support PR Scope
+
+Status: Implemented
+Research date: May 31, 2026
+Target API: Apple Ads Campaign Management API 5.5
+Target command root: `asc ads`
+
+## Goal
+
+Add first-class Apple Ads support to `asc` for the documented Campaign
+Management API v5 surface. Users should not need a raw HTTP client for
+supported Apple Ads campaign, targeting, creative, and reporting workflows.
+
+This PR must preserve the local CLI style:
+
+- `ffcli` commands with `shared.DefaultUsageFunc`
+- explicit long flags
+- TTY-aware output defaults through `shared.BindOutputFlags`
+- non-interactive behavior only
+- `--confirm` for deletes and bulk deletes
+- `--paginate` for multi-page list/search commands
+- JSON output that preserves Apple response envelopes for agents
+- no new third-party dependencies
+
+## Source Facts
+
+Canonical Apple sources:
+
+- Apple Ads root: https://developer.apple.com/documentation/apple_ads
+- OAuth: https://developer.apple.com/documentation/apple_ads/implementing-oauth-for-the-apple-search-ads-api
+- Calling the API: https://developer.apple.com/documentation/apple_ads/calling-the-apple-search-ads-api
+- API functionality: https://developer.apple.com/documentation/apple_ads/using-apple-search-ads-api-functionality
+- API 5 changelog: https://developer.apple.com/documentation/apple_ads/apple-search-ads-campaign-management-api-5
+
+The Apple docs currently state that API 5 is the current Campaign Management
+API, API 5.5 was released in February 2026, and the Campaign Management API is
+scheduled to sunset on January 26, 2027. The unreleased/new Apple Ads Platform
+API is not part of this PR because it is not the current documented Campaign
+Management API surface.
+
+Deprecated `Creative Sets` are not included as commands because Apple's current
+documentation marks the collection as deprecated and exposes no active v5
+endpoint under that page. The `includeDeletedCreativeSetAssets` query parameter
+on `GET /v5/creatives/{creativeId}` is included.
+
+AdServices Attribution API is out of scope. It is not part of the Apple Ads
+Campaign Management API command surface and has different caller requirements.
+
+## Command Placement
+
+Add a top-level command:
+
+```text
+asc ads <subcommand> [flags]
+```
+
+Common endpoint flags:
+
+- Every Apple Ads endpoint leaf command accepts `--ads-profile NAME`.
+- Every org-scoped endpoint leaf command accepts `--org ORG_ID`.
+- `asc ads me view`, `asc ads acls list`, and `asc ads auth ...` do not require
+  `--org`.
+- Examples in the endpoint matrix omit `--org` and `--ads-profile` unless those
+  flags are materially relevant to the endpoint. The implementation still adds
+  them to the command.
+- Resource groups with a natural list endpoint execute list by default:
+  `asc ads campaigns`, `asc ads budget-orders`, `asc ads ad-groups`,
+  `asc ads creatives`, and `asc ads impression-share-reports`.
+
+Root help placement:
+
+- Add `ads` to `cmd/root_usage.go` under `ANALYTICS & FINANCE COMMANDS` after
+  `performance`. This is acquisition/marketing rather than App Store Connect
+  resource management, but this is the closest existing command group.
+- Register `ads.AdsCommand()` in `internal/cli/registry/registry.go`.
+- Add `ads` to registry/root help tests.
+
+Package layout:
+
+```text
+internal/appleads/
+  auth.go
+  auth_store.go
+  client.go
+  client_test.go
+  endpoints.go
+  endpoints_test.go
+  errors.go
+  pagination.go
+
+internal/cli/ads/
+  api.go
+  root.go
+  auth.go
+  endpoints.go
+  endpoints_test.go
+  resolve.go
+```
+
+Use `internal/appleads`, not `internal/asc`, because the base URL, auth flow,
+error envelope, and pagination model are different from App Store Connect.
+
+Do not implement this as 73 bespoke command functions and 73 bespoke client
+methods. Add one `EndpointSpec` table in `internal/appleads/endpoints.go` and
+generic command/client builders that consume it.
+
+`EndpointSpec` must include:
+
+```go
+type EndpointSpec struct {
+	Name             string
+	Method           string
+	Path             string
+	CommandPath      []string
+	BodyKind         shared.JSONPayloadKind
+	BodyType         string
+	ResponseType     string
+	RequiresOrg      bool
+	RequiresConfirm  bool
+	PathParams       []ParamSpec
+	QueryParams      []ParamSpec
+	SupportsPaginate bool
+	DefaultListAlias bool
+}
+
+type ParamSpec struct {
+	Name      string
+	Flag      string
+	Type      ParamType
+	Required  bool
+	Max       int
+	Allowed   []string
+}
+```
+
+Acceptance check: adding a newly documented Apple Ads endpoint requires one
+spec row plus docs/tests, not a new hand-written request method.
+
+## Authentication Contract
+
+Apple Ads OAuth is separate from App Store Connect JWT auth.
+
+OAuth facts from Apple:
+
+- Token URL: `https://appleid.apple.com/auth/oauth2/token`
+- Grant type: `client_credentials`
+- Scope: `searchadsorg`
+- Client secret: ES256 JWT
+- JWT header: `alg=ES256`, `kid=<key-id>`
+- JWT claims:
+  - `iss=<team-id>`
+  - `iat=<issued-at>`
+  - `exp=<expires-at>`
+  - `aud=https://appleid.apple.com`
+  - `sub=<client-id>`
+- Token response contains `access_token`, `token_type=Bearer`,
+  `expires_in=3600`, and `scope=searchadsorg`.
+- Generate the client secret on demand for each token refresh with a 10-minute
+  lifetime and 30-second refresh skew. Do not persist the client secret.
+- Send the token request as `application/x-www-form-urlencoded` form values:
+  `grant_type`, `client_id`, `client_secret`, and `scope`.
+
+Implement this command group:
+
+```text
+asc ads auth login --name NAME --client-id CLIENT_ID --team-id TEAM_ID --key-id KEY_ID --private-key PATH [--org ORG_ID] [--network] [--skip-validation] [--bypass-keychain] [--local]
+asc ads auth status [--verbose] [--validate] [--output table|json]
+asc ads auth switch --name NAME
+asc ads auth token --confirm [--output text|json]
+asc ads auth doctor [--fix --confirm] [--output text|json]
+asc ads auth logout [--all | --name NAME]
+```
+
+Mirror the existing `asc auth` behavior:
+
+- `--name`, `--key-id`, and `--private-key` use the same meaning and validation
+  style as `asc auth login`.
+- `--client-id` is Apple Ads OAuth `client_id`.
+- `--team-id` is the JWT issuer (`iss`).
+- `--org` stores a default Apple Ads org ID for API calls.
+- `--private-key` accepts the EC P-256 PEM Apple documents for Ads. Reuse the
+  existing private-key parsing helpers because they already support ES256 keys.
+- `--network` requests an access token and calls `GET /v5/me`.
+- `--skip-validation` skips JWT and network validation.
+- `--network` and `--skip-validation` are mutually exclusive.
+- `--local` requires keychain bypass, exactly like `asc auth login`.
+- Keychain is preferred; config fallback is allowed when bypassing keychain.
+- `auth status` supports `--verbose` and `--validate`, matching `asc auth status`.
+- `auth logout` supports `--all` and `--name` and does not require
+  `--confirm`, matching `asc auth logout`.
+
+Add config fields without changing existing App Store Connect credentials:
+
+```go
+type AdsCredential struct {
+	Name           string `json:"name"`
+	ClientID       string `json:"client_id"`
+	TeamID         string `json:"team_id"`
+	KeyID          string `json:"key_id"`
+	PrivateKeyPath string `json:"private_key_path"`
+	OrgID          string `json:"org_id,omitempty"`
+}
+
+type AdsKeychainMetadata struct {
+	Name       string `json:"name"`
+	ClientID   string `json:"client_id"`
+	TeamID     string `json:"team_id"`
+	KeyID      string `json:"key_id"`
+	OrgID      string `json:"org_id,omitempty"`
+	ModifiedAt string `json:"modified_at,omitempty"`
+}
+
+type AdsConfig struct {
+	DefaultKeyName   string                `json:"default_key_name,omitempty"`
+	Keys             []AdsCredential       `json:"keys,omitempty"`
+	KeychainMetadata []AdsKeychainMetadata `json:"keychain_metadata,omitempty"`
+	OrgID            string                `json:"org_id,omitempty"`
+}
+
+type Config struct {
+	// existing fields...
+	Ads AdsConfig `json:"ads,omitempty"`
+}
+```
+
+Do not reuse the existing App Store Connect keychain item prefixes. Ads storage
+uses:
+
+```text
+asc:ads-credential:<name>
+asc:ads-metadata:<name>
+```
+
+Reuse only private-key parsing/validation helpers from `internal/auth`.
+
+Environment variables:
+
+```text
+ASC_ADS_ACCESS_TOKEN
+ASC_ADS_CLIENT_ID
+ASC_ADS_TEAM_ID
+ASC_ADS_KEY_ID
+ASC_ADS_PRIVATE_KEY_PATH
+ASC_ADS_PRIVATE_KEY
+ASC_ADS_PRIVATE_KEY_B64
+ASC_ADS_ORG_ID
+ASC_ADS_PROFILE
+ASC_ADS_STRICT_AUTH
+ASC_ADS_BYPASS_KEYCHAIN
+```
+
+Resolution order:
+
+1. Explicit `--ads-profile` if present.
+2. `ASC_ADS_PROFILE` if present.
+3. `ASC_ADS_ACCESS_TOKEN` if no profile is selected; it bypasses token exchange but still needs
+   `--org`, `ASC_ADS_ORG_ID`, or stored profile org for org-scoped calls.
+4. Complete Ads env credential tuple.
+5. Default Ads keychain/config profile.
+
+If `ASC_ADS_STRICT_AUTH` is true, fail when Ads credentials are split across
+multiple sources, matching the existing strict-auth principle.
+
+If a profile is selected by `--ads-profile` or `ASC_ADS_PROFILE`, ignore
+`ASC_ADS_ACCESS_TOKEN` unless `ASC_ADS_STRICT_AUTH` is true; in strict mode,
+selected profile plus access token is a mixed-source error.
+
+Org ID resolution is independent from token resolution:
+
+1. `--org`
+2. `ASC_ADS_ORG_ID`
+3. selected Ads profile `org_id`
+4. `ads.org_id` in config
+
+Persist the org ID both on the selected credential and in `ads.org_id` when Ads
+login receives an org ID. This lets
+`ASC_ADS_ACCESS_TOKEN` users reuse a configured default org without storing Ads
+private key material in the active environment.
+
+## HTTP Client Contract
+
+Base URL:
+
+```text
+https://api.searchads.apple.com/api/
+```
+
+Headers:
+
+```text
+Authorization: Bearer <access_token>
+Accept: application/json
+Content-Type: application/json
+X-AP-Context: orgId=<org-id>
+```
+
+Do not send `X-AP-Context` for these two endpoints:
+
+- `GET /v5/acls`
+- `GET /v5/me`
+
+For all other endpoints, resolve org ID from `--org`, `ASC_ADS_ORG_ID`, the
+selected Ads profile, or `ads.org_id` in config. If it is still empty, fail
+with:
+
+```text
+Error: --org is required (or set ASC_ADS_ORG_ID or an Ads profile org_id)
+```
+
+Use `shared.ContextWithTimeout` for all Apple Ads API requests so `ASC_TIMEOUT`
+continues to apply.
+
+Use the existing retry/backoff approach for GET and HEAD requests and for 429
+responses. Redact `Authorization`, `client_secret`, private keys, and access
+tokens in `ASC_DEBUG=api` logging.
+
+Apple Ads error envelope:
+
+```json
+{
+  "error": {
+    "errors": [
+      {
+        "field": "name",
+        "message": "message",
+        "messageCode": "CODE"
+      }
+    ]
+  }
+}
+```
+
+Add `appleads.APIError` with HTTP status, field, message, and messageCode. If
+the response is not this envelope, sanitize and return the raw detail the same
+way `internal/asc` does.
+
+## Payload Contract
+
+Every Apple Ads endpoint with an HTTP body uses `--file`.
+
+Reason: Apple Ads request objects are large, nested, API-specific JSON payloads.
+Using `--file` is already established in this repo for complex JSON payloads
+such as Xcode Cloud workflows. It also preserves full API support without
+mapping every Apple Ads nested object into unstable CLI flags.
+
+Rules:
+
+- The CLI sends the file content as the HTTP body without wrapping it.
+- Object endpoints require a JSON object file.
+- Array endpoints require a JSON array file.
+- `(CustomProductPageCreative | DefaultProductPageCreative)` accepts a JSON
+  object file.
+- `[int64]` delete-bulk endpoints accept a JSON array of numbers.
+- Do not implement `--file -` in this PR.
+
+Extend `internal/cli/shared/json_payload.go`:
+
+```go
+type JSONPayloadKind string
+
+const (
+	JSONPayloadObject JSONPayloadKind = "object"
+	JSONPayloadArray  JSONPayloadKind = "array"
+	JSONPayloadAny    JSONPayloadKind = "any"
+)
+
+func ReadJSONFilePayloadKind(path string, kind JSONPayloadKind) (json.RawMessage, error)
+```
+
+Keep `ReadJSONFilePayload(path)` as the object-only compatibility wrapper.
+
+Required errors:
+
+```text
+payload path must be a file
+payload file is empty
+invalid JSON: ...
+payload must be a JSON object
+payload must be a JSON array
+```
+
+## Pagination Contract
+
+Apple Ads uses offset pagination, not App Store Connect `links.next`.
+
+List/search commands with `limit`/`offset` support:
+
+```text
+--limit INT
+--offset INT
+--paginate
+```
+
+Do not add `--next` to Apple Ads commands. Validate:
+
+- `--limit` must be `1..1000` except `GET v5/custom-reports`, where it must be
+  `1..50`.
+- `--offset` must be `>=0`.
+- `--paginate` starts at `--offset` when provided.
+- `--paginate` uses page size `--limit` when provided, otherwise `1000`
+  except `GET v5/custom-reports`, where the default page size is `50`.
+- Continue until `pagination.startIndex + pagination.itemsPerPage >= pagination.totalResults` or a page returns no data.
+
+Do not add `--paginate` to `find` or report endpoints that carry pagination
+inside a `Selector` or `ReportingRequest` JSON body. Those endpoints keep
+pagination fully manual in the payload file. The CLI must not mutate payload
+files or rewrite body JSON to advance selector pagination in this PR.
+
+The generic paginated response shape must preserve the Apple envelope:
+
+```json
+{
+  "data": [],
+  "pagination": {
+    "itemsPerPage": 1000,
+    "startIndex": 0,
+    "totalResults": 0
+  }
+}
+```
+
+## Output Contract
+
+All endpoint commands bind:
+
+```go
+output := shared.BindOutputFlags(fs)
+```
+
+Return Apple Ads response JSON exactly as Apple returns it, including `data`,
+`pagination`, and `error` envelopes. JSON is the canonical agent output.
+
+Use the existing output-registry fallback for Apple Ads raw response types:
+`table` and `markdown` print the same JSON envelope as `json` until a dedicated
+renderer is added in a later PR. Do not add custom Apple Ads table/markdown
+renderers in this PR.
+
+Represent successful Apple Ads responses as `json.RawMessage` or a dedicated
+raw envelope type that is not registered with the output registry.
+
+## Endpoint-to-Command Matrix
+
+This matrix is the required 100% current v5 coverage. Every row needs a named
+CLI command and an HTTP client method.
+
+| CLI command | HTTP endpoint | Body | Notes |
+| --- | --- | --- | --- |
+| `asc ads acls list` | `GET v5/acls` | none | No `--org` header. |
+| `asc ads me view` | `GET v5/me` | none | No `--org` header. |
+| `asc ads apps search --query QUERY [--limit N --offset N --paginate --return-owned-apps]` | `GET v5/search/apps` | none | `query` is required. |
+| `asc ads apps view --adam-id ADAM_ID` | `GET v5/apps/{adamId}` | none | `adamId` is int64. |
+| `asc ads apps localized-details --adam-id ADAM_ID` | `GET v5/apps/{adamId}/locale-details` | none |  |
+| `asc ads apps eligibility find --adam-id ADAM_ID --file selector.json` | `POST v5/apps/{adamId}/eligibilities/find` | `Selector` object |  |
+| `asc ads apps assets find --adam-id ADAM_ID --file selector.json` | `POST v5/apps/{adamId}/assets/find` | `Selector` object |  |
+| `asc ads product-pages list --adam-id ADAM_ID [--name NAME --states STATES]` | `GET v5/apps/{adamId}/product-pages` | none | Forward `states` as raw query string. |
+| `asc ads product-pages view --adam-id ADAM_ID --product-page PRODUCT_PAGE_ID` | `GET v5/apps/{adamId}/product-pages/{productPageId}` | none |  |
+| `asc ads product-pages locales list --adam-id ADAM_ID --product-page PRODUCT_PAGE_ID [--device-classes VALUE --language-codes VALUE --languages VALUE --expand]` | `GET v5/apps/{adamId}/product-pages/{productPageId}/locale-details` | none | Forward query strings exactly. |
+| `asc ads product-pages countries list [--countries-or-regions VALUE]` | `GET v5/countries-or-regions` | none |  |
+| `asc ads product-pages devices list` | `GET v5/creativeappmappings/devices` | none |  |
+| `asc ads budget-orders list [--limit N --offset N --paginate]` | `GET v5/budgetorders` | none |  |
+| `asc ads budget-orders create --file budget-order-create.json` | `POST v5/budgetorders` | `BudgetOrderCreate` object |  |
+| `asc ads budget-orders view --budget-order BUDGET_ORDER_ID` | `GET v5/budgetorders/{boId}` | none |  |
+| `asc ads budget-orders update --budget-order BUDGET_ORDER_ID --file budget-order-update.json` | `PUT v5/budgetorders/{boId}` | `BudgetOrderUpdate` object |  |
+| `asc ads campaigns list [--limit N --offset N --paginate]` | `GET v5/campaigns` | none | `asc ads campaigns` aliases list. |
+| `asc ads campaigns find --file selector.json` | `POST v5/campaigns/find` | `Selector` object |  |
+| `asc ads campaigns view --campaign CAMPAIGN_ID` | `GET v5/campaigns/{campaignId}` | none |  |
+| `asc ads campaigns create --file campaign.json` | `POST v5/campaigns` | `Campaign` object |  |
+| `asc ads campaigns update --campaign CAMPAIGN_ID --file campaign-update.json` | `PUT v5/campaigns/{campaignId}` | `UpdateCampaignRequest` object | Campaign update uses Apple's campaign envelope. |
+| `asc ads campaigns delete --campaign CAMPAIGN_ID --confirm` | `DELETE v5/campaigns/{campaignId}` | none | Require `--confirm`. |
+| `asc ads ad-groups list --campaign CAMPAIGN_ID [--limit N --offset N --paginate]` | `GET v5/campaigns/{campaignId}/adgroups` | none | `asc ads ad-groups` aliases list. |
+| `asc ads ad-groups find --campaign CAMPAIGN_ID --file selector.json` | `POST v5/campaigns/{campaignId}/adgroups/find` | `Selector` object |  |
+| `asc ads ad-groups find-org --file selector.json` | `POST v5/adgroups/find` | `Selector` object | Org-level find. |
+| `asc ads ad-groups view --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}` | none |  |
+| `asc ads ad-groups create --campaign CAMPAIGN_ID --file ad-group.json` | `POST v5/campaigns/{campaignId}/adgroups` | `AdGroup` object |  |
+| `asc ads ad-groups update --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file ad-group-update.json` | `PUT v5/campaigns/{campaignId}/adgroups/{adgroupId}` | `AdGroupUpdate` object |  |
+| `asc ads ad-groups delete --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --confirm` | `DELETE v5/campaigns/{campaignId}/adgroups/{adgroupId}` | none | Require `--confirm`. |
+| `asc ads ads list --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads` | none |  |
+| `asc ads ads find --campaign CAMPAIGN_ID --file selector.json` | `POST v5/campaigns/{campaignId}/ads/find` | `Selector` object | Campaign-level find. |
+| `asc ads ads find-org --file selector.json` | `POST v5/ads/find` | `Selector` object | Org-level find. |
+| `asc ads ads view --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --ad AD_ID` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}` | none |  |
+| `asc ads ads create --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file ad-create.json` | `POST v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads` | `AdCreate` object |  |
+| `asc ads ads update --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --ad AD_ID --file ad-update.json` | `PUT v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}` | `AdUpdate` object |  |
+| `asc ads ads delete --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --ad AD_ID --confirm` | `DELETE v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}` | none | Require `--confirm`. |
+| `asc ads targeting-keywords list --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID [--limit N --offset N --paginate]` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords` | none |  |
+| `asc ads targeting-keywords find --campaign CAMPAIGN_ID --file selector.json` | `POST v5/campaigns/{campaignId}/adgroups/targetingkeywords/find` | `Selector` object | Campaign-level find across ad groups. |
+| `asc ads targeting-keywords view --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --keyword KEYWORD_ID` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}` | none |  |
+| `asc ads targeting-keywords create-bulk --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file keywords.json` | `POST v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/bulk` | `[Keyword]` array |  |
+| `asc ads targeting-keywords update-bulk --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file keywords-update.json` | `PUT v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/bulk` | `[KeywordUpdateRequest]` array |  |
+| `asc ads targeting-keywords delete --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --keyword KEYWORD_ID --confirm` | `DELETE v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}` | none | Require `--confirm`. |
+| `asc ads targeting-keywords delete-bulk --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file keyword-ids.json --confirm` | `POST v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/delete/bulk` | `[int64]` array | Require `--confirm`. |
+| `asc ads campaign-negative-keywords list --campaign CAMPAIGN_ID [--limit N --offset N --paginate]` | `GET v5/campaigns/{campaignId}/negativekeywords` | none |  |
+| `asc ads campaign-negative-keywords find --campaign CAMPAIGN_ID --file selector.json` | `POST v5/campaigns/{campaignId}/negativekeywords/find` | `Selector` object |  |
+| `asc ads campaign-negative-keywords view --campaign CAMPAIGN_ID --keyword KEYWORD_ID` | `GET v5/campaigns/{campaignId}/negativekeywords/{keywordId}` | none |  |
+| `asc ads campaign-negative-keywords create-bulk --campaign CAMPAIGN_ID --file negative-keywords.json` | `POST v5/campaigns/{campaignId}/negativekeywords/bulk` | `[NegativeKeyword]` array |  |
+| `asc ads campaign-negative-keywords update-bulk --campaign CAMPAIGN_ID --file negative-keywords.json` | `PUT v5/campaigns/{campaignId}/negativekeywords/bulk` | `[NegativeKeyword]` array |  |
+| `asc ads campaign-negative-keywords delete-bulk --campaign CAMPAIGN_ID --file keyword-ids.json --confirm` | `POST v5/campaigns/{campaignId}/negativekeywords/delete/bulk` | `[int64]` array | Require `--confirm`. |
+| `asc ads ad-group-negative-keywords list --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID [--limit N --offset N --paginate]` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords` | none |  |
+| `asc ads ad-group-negative-keywords find --campaign CAMPAIGN_ID --file selector.json` | `POST v5/campaigns/{campaignId}/adgroups/negativekeywords/find` | `Selector` object | Campaign-level find across ad groups. |
+| `asc ads ad-group-negative-keywords view --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --keyword KEYWORD_ID` | `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/{keywordId}` | none |  |
+| `asc ads ad-group-negative-keywords create-bulk --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file negative-keywords.json` | `POST v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/bulk` | `[NegativeKeyword]` array |  |
+| `asc ads ad-group-negative-keywords update-bulk --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file negative-keywords.json` | `PUT v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/bulk` | `[NegativeKeyword]` array |  |
+| `asc ads ad-group-negative-keywords delete-bulk --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file keyword-ids.json --confirm` | `POST v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/delete/bulk` | `[int64]` array | Require `--confirm`. |
+| `asc ads geo search [--country-code CC --entity ENTITY --query QUERY --limit N --offset N --paginate]` | `GET v5/search/geo` | none | API default query is `*:*`. |
+| `asc ads geo resolve --file geo-requests.json [--limit N --offset N --paginate]` | `POST v5/search/geo` | `[GeoRequest]` array |  |
+| `asc ads creatives list [--limit N --offset N --paginate]` | `GET v5/creatives` | none |  |
+| `asc ads creatives find --file selector.json` | `POST v5/creatives/find` | `Selector` object |  |
+| `asc ads creatives view --creative CREATIVE_ID [--include-deleted-creative-set-assets]` | `GET v5/creatives/{creativeId}` | none | Include deprecated creative set assets query. |
+| `asc ads creatives create --file creative.json` | `POST v5/creatives` | `CustomProductPageCreative` or `DefaultProductPageCreative` object |  |
+| `asc ads rejection-reasons find --file selector.json` | `POST v5/product-page-reasons/find` | `Selector` object |  |
+| `asc ads rejection-reasons view --reason PRODUCT_PAGE_REASON_ID` | `GET v5/product-page-reasons/{productPageReasonId}` | none |  |
+| `asc ads reports campaigns --file reporting-request.json` | `POST v5/reports/campaigns` | `ReportingRequest` object |  |
+| `asc ads reports ad-groups --campaign CAMPAIGN_ID --file reporting-request.json` | `POST v5/reports/campaigns/{campaignId}/adgroups` | `ReportingRequest` object |  |
+| `asc ads reports keywords --campaign CAMPAIGN_ID --file reporting-request.json` | `POST v5/reports/campaigns/{campaignId}/keywords` | `ReportingRequest` object |  |
+| `asc ads reports search-terms --campaign CAMPAIGN_ID --file reporting-request.json` | `POST v5/reports/campaigns/{campaignId}/searchterms` | `ReportingRequest` object |  |
+| `asc ads reports ads --campaign CAMPAIGN_ID --file reporting-request.json` | `POST v5/reports/campaigns/{campaignId}/ads` | `ReportingRequest` object |  |
+| `asc ads reports ad-group-keywords --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file reporting-request.json` | `POST v5/reports/campaigns/{campaignId}/adgroups/{adgroupId}/keywords` | `ReportingRequest` object |  |
+| `asc ads reports ad-group-search-terms --campaign CAMPAIGN_ID --ad-group AD_GROUP_ID --file reporting-request.json` | `POST v5/reports/campaigns/{campaignId}/adgroups/{adgroupId}/searchterms` | `ReportingRequest` object |  |
+| `asc ads impression-share-reports list [--field FIELD --sort-order ORDER --limit N --offset N --paginate]` | `GET v5/custom-reports` | none |  |
+| `asc ads impression-share-reports create --file custom-report-request.json` | `POST v5/custom-reports` | `CustomReportRequest` object |  |
+| `asc ads impression-share-reports view --report REPORT_ID` | `GET v5/custom-reports/{reportId}` | none |  |
+
+The `EndpointSpec` query parameter metadata must match Apple's current docs for
+every row. Required query parameters:
+
+| HTTP endpoint | Query flags |
+| --- | --- |
+| `GET v5/search/apps` | `--query` required, `--limit`, `--offset`, `--return-owned-apps` |
+| `GET v5/search/geo` | `--country-code`, `--entity`, `--query`, `--limit`, `--offset` |
+| `POST v5/search/geo` | `--limit`, `--offset` |
+| `GET v5/campaigns` | `--limit`, `--offset` |
+| `GET v5/budgetorders` | `--limit`, `--offset` |
+| `GET v5/campaigns/{campaignId}/adgroups` | `--limit`, `--offset` |
+| `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords` | `--limit`, `--offset` |
+| `GET v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords` | `--limit`, `--offset` |
+| `GET v5/campaigns/{campaignId}/negativekeywords` | `--limit`, `--offset` |
+| `GET v5/creatives` | `--limit`, `--offset` |
+| `GET v5/custom-reports` | `--field`, `--sort-order`, `--limit`, `--offset` |
+| `GET v5/apps/{adamId}/product-pages` | `--name`, `--states` |
+| `GET v5/apps/{adamId}/product-pages/{productPageId}/locale-details` | `--device-classes`, `--expand`, `--language-codes`, `--languages` |
+| `GET v5/countries-or-regions` | `--countries-or-regions` |
+| `GET v5/creatives/{creativeId}` | `--include-deleted-creative-set-assets` |
+
+Apple's general partial-fetch `fields` query parameter is not exposed in this
+first PR because the current endpoint pages do not list endpoint-specific
+`fields[...]` query parameters. Add it only if the implementation extracts a
+documented endpoint-specific query parameter from Apple docs.
+
+Add this debug/forward-compatibility command after the named endpoints:
+
+```text
+asc ads api request --method METHOD --path v5/... [--file payload.json] [--org ORG_ID] [--confirm]
+```
+
+Rules:
+
+- `--path` accepts only relative `v5/...` paths or full URLs under
+  `https://api.searchads.apple.com/api/`.
+- Full URLs for other hosts are rejected.
+- `DELETE` requires `--confirm`.
+- This command is not a substitute for any named endpoint above; all rows above
+  must still exist.
+
+## Request Body Reference
+
+The following body types are accepted through `--file` and must be validated
+only for JSON shape, not for every semantic field. Semantic validation belongs
+to Apple Ads.
+
+| Body type | JSON shape | Required top-level fields from Apple docs |
+| --- | --- | --- |
+| `Selector` | object | none; common fields are `conditions`, `fields`, `orderBy`, `pagination` |
+| `Condition` | object | none; common fields are `field`, `operator`, `values`, `ignoreCase` |
+| `BudgetOrderCreate` | object | none documented as top-level required |
+| `BudgetOrderUpdate` | object | none documented as top-level required |
+| `Campaign` | object | `adamId`, `adChannelType`, `billingEvent`, `countriesOrRegions`, `dailyBudgetAmount`, `name`, `supplySources` |
+| `UpdateCampaignRequest` | object | none documented as top-level required; payload uses `campaign` envelope |
+| `AdGroup` | object | `defaultBidAmount`, `name`, `pricingModel`, `startTime` |
+| `AdGroupUpdate` | object | none documented as top-level required |
+| `Keyword` | object array item | `bidAmount`, `matchType`, `text` |
+| `KeywordUpdateRequest` | object array item | `matchType`, `text` |
+| `NegativeKeyword` | object array item | `matchType`, `text` |
+| `AdCreate` | object | `creativeId`, `name`, `status` |
+| `AdUpdate` | object | none documented as top-level required |
+| `CustomProductPageCreative` | object | `productPageId`, `adamId`, `name`, `type` |
+| `DefaultProductPageCreative` | object | `adamId`, `name`, `type` |
+| `ReportingRequest` | object | `startTime`, `endTime`, `selector` |
+| `CustomReportRequest` | object | `name` |
+| `GeoRequest` | object array item | `entity`, `id` |
+| `[int64]` | array | integer IDs |
+
+Payload examples:
+
+```json
+{
+  "conditions": [
+    {
+      "field": "campaignId",
+      "operator": "EQUALS",
+      "values": ["1234567890"]
+    }
+  ],
+  "pagination": {
+    "limit": 1000,
+    "offset": 0
+  }
+}
+```
+
+```json
+{
+  "adamId": 123456789,
+  "adChannelType": "SEARCH",
+  "billingEvent": "TAPS",
+  "countriesOrRegions": ["US"],
+  "dailyBudgetAmount": {
+    "amount": "25",
+    "currency": "USD"
+  },
+  "name": "US Search Campaign",
+  "status": "ENABLED",
+  "supplySources": ["APPSTORE_SEARCH_RESULTS"]
+}
+```
+
+```json
+[
+  {
+    "text": "example keyword",
+    "matchType": "BROAD",
+    "bidAmount": {
+      "amount": "1.25",
+      "currency": "USD"
+    },
+    "status": "ACTIVE"
+  }
+]
+```
+
+```json
+{
+  "startTime": "2026-05-01",
+  "endTime": "2026-05-31",
+  "granularity": "DAILY",
+  "selector": {
+    "pagination": {
+      "limit": 1000,
+      "offset": 0
+    }
+  },
+  "timeZone": "UTC"
+}
+```
+
+## Implementation Sequence
+
+The PR implemented the work in this order:
+
+1. Added `internal/appleads` auth, token, client, error, and pagination tests.
+2. Extended `shared.ReadJSONFilePayload` with array/object/any shape support
+   while preserving the existing object-only wrapper.
+3. Added `internal/cli/ads` root, auth commands, and registry/root help wiring.
+4. Added read-only endpoints first: `me`, `acls`, app search/details, product
+   pages, countries, devices, list/view commands.
+5. Added request-body commands with `--file` and shape validation.
+6. Added deletes and bulk deletes with `--confirm`.
+7. Added reports and impression-share reports.
+8. Added `ads api request`.
+9. Added command docs and generated command docs.
+
+Do not add ergonomic create/update flags in the first PR. They would duplicate
+large Apple request schemas and weaken the guarantee that every API field can be
+used by agents immediately. Ergonomic wrappers can be a later additive PR.
+
+## Test Plan
+
+Use TDD for implementation. Start with failing tests.
+
+Required unit tests:
+
+- Apple Ads client secret JWT includes `alg=ES256`, `kid`, `iss`, `iat`, `exp`,
+  `aud=https://appleid.apple.com`, and `sub=<client-id>`.
+- Token request uses `POST https://appleid.apple.com/auth/oauth2/token` with
+  `grant_type=client_credentials`, `client_id`, `client_secret`, and
+  `scope=searchadsorg`.
+- Access token cache refreshes before expiry.
+- `ASC_ADS_ACCESS_TOKEN` bypasses token exchange.
+- `X-AP-Context` is present for org-scoped endpoints and absent for `me`/`acls`.
+- Missing org fails before auth resolution.
+- Apple Ads error envelopes parse into `appleads.APIError`.
+- Offset pagination aggregates `data` and stops at `totalResults`.
+- JSON payload helper accepts object, array, and any modes; rejects wrong shapes.
+
+Required CLI tests under `internal/cli/cmdtest`:
+
+- Every command in the matrix is registered and has help output.
+- Every leaf command validates missing required flags with exit code `2` and a
+  concrete stderr message.
+- Every command with `--file` rejects missing file, empty file, invalid JSON,
+  and wrong object/array shape.
+- Every delete and bulk delete rejects missing `--confirm` with exit code `2`.
+- Every list/search command rejects invalid `--limit`, invalid `--offset`, and
+  invalid boolean flags.
+- Query parameters are encoded exactly as documented.
+- Body payloads are forwarded byte-for-byte except for JSON validation.
+- `--output json` returns parseable JSON for representative success responses.
+- `--pretty` is accepted only for JSON.
+- `--paginate` makes multiple requests with increasing `offset`.
+- `ads api request` rejects non-Apple Ads hosts and requires `--confirm` for
+  `DELETE`.
+
+Required client tests:
+
+- One table-driven test row for every `EndpointSpec` row that asserts method,
+  path, path variables, query variables, body shape, and response passthrough.
+- One generated inventory test that compares each `EndpointSpec` path, method,
+  body kind, and query parameter names against the Apple docs snapshot used in
+  the test fixture.
+- 401, 403, 404, 429, and 500 response handling.
+- Token endpoint errors do not print secrets.
+
+Black-box verification:
+
+```bash
+go build -o /tmp/asc .
+/tmp/asc ads --help
+/tmp/asc ads campaigns list --org 123 --output json
+/tmp/asc ads campaigns delete --campaign 1 --org 123
+/tmp/asc ads campaigns delete --campaign 1 --org 123 --confirm
+```
+
+Repository checks before PR:
+
+```bash
+make format
+make check-command-docs
+make lint
+ASC_BYPASS_KEYCHAIN=1 make test
+```
+
+Live Apple Ads smoke tests are not required for PR completion when Ads
+credentials are unavailable. When Ads credentials are configured locally, run
+only these read-only smoke tests:
+
+```bash
+asc ads me view --output json
+asc ads acls list --output json
+asc ads campaigns list --org "$ASC_ADS_ORG_ID" --limit 1 --output json
+```
+
+Do not create spend-bearing Apple Ads campaigns in live smoke tests unless the
+user explicitly approves the exact org and payload.
+
+## Documentation Updates
+
+Updated:
+
+- `commands/ads.mdx`
+- `authentication.mdx` with Apple Ads auth subsection
+- `configuration/environment-variables.mdx` with `ASC_ADS_*` variables
+- `docs.json` navigation for the new command page
+- `docs/COMMANDS.md` via `make generate-command-docs`
+- `README.md` feature list
+
+Docs teach `--file` payloads with copy-pasteable JSON examples and state that
+Apple Ads credentials are separate from App Store Connect API keys.
+
+### Docs placement
+
+`commands/ads.mdx` is the user guide. Keep it focused on auth, org context,
+payload files, pagination rules, endpoint groups, and raw requests.
+
+`configuration/environment-variables.mdx` owns the full `ASC_ADS_*` reference
+and credential precedence.
+
+This architecture note owns endpoint coverage, auth internals, generated
+command strategy, test requirements, and live-smoke limits.
+
+## Definition of Done
+
+- All 73 current v5 endpoints in the matrix have named commands.
+- `asc ads api request` exists for debugging and newly added Apple fields.
+- Apple Ads OAuth login/status/token/doctor/logout are implemented.
+- All org-scoped commands require/respect `--org`.
+- All body endpoints use `--file` and support the correct JSON shape.
+- Deletes and bulk deletes require `--confirm`.
+- Offset pagination works with `--paginate`.
+- JSON output preserves Apple response envelopes.
+- Generated command docs are updated.
+- `make format`, `make check-command-docs`, `make lint`, and
+  `ASC_BYPASS_KEYCHAIN=1 make test` pass.

--- a/docs/architecture/apple-ads-api-support.md
+++ b/docs/architecture/apple-ads-api-support.md
@@ -167,7 +167,7 @@ asc ads auth login --name NAME --client-id CLIENT_ID --team-id TEAM_ID --key-id 
 asc ads auth status [--verbose] [--validate] [--output table|json]
 asc ads auth switch --name NAME
 asc ads auth token --confirm [--output text|json]
-asc ads auth doctor [--fix --confirm] [--output text|json]
+asc ads auth doctor [--output text|json]
 asc ads auth logout [--all | --name NAME]
 ```
 
@@ -186,8 +186,8 @@ Mirror the existing `asc auth` behavior:
 - `--local` requires keychain bypass, exactly like `asc auth login`.
 - Keychain is preferred; config fallback is allowed when bypassing keychain.
 - `auth status` supports `--verbose` and `--validate`, matching `asc auth status`.
-- `auth logout` supports `--all` and `--name` and does not require
-  `--confirm`, matching `asc auth logout`.
+- `auth logout` supports `--all` and `--name`. It requires one of those flags
+  so bare `asc ads auth logout` does not clear every stored Ads profile.
 
 Add config fields without changing existing App Store Connect credentials:
 

--- a/internal/appleads/auth.go
+++ b/internal/appleads/auth.go
@@ -1,0 +1,177 @@
+package appleads
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
+)
+
+const (
+	tokenURL         = "https://appleid.apple.com/auth/oauth2/token"
+	tokenScope       = "searchadsorg"
+	clientSecretTTL  = 10 * time.Minute
+	tokenRefreshSkew = 30 * time.Second
+	clientSecretAud  = "https://appleid.apple.com"
+	grantClientCreds = "client_credentials"
+)
+
+// Credentials contains resolved Apple Ads authentication inputs.
+type Credentials struct {
+	ClientID       string
+	TeamID         string
+	KeyID          string
+	PrivateKeyPath string
+	PrivateKeyPEM  string
+	AccessToken    string
+	OrgID          string
+	Profile        string
+}
+
+type tokenCache struct {
+	accessToken string
+	expiresAt   time.Time
+}
+
+func (c *Client) bearerToken(ctx context.Context) (string, error) {
+	if strings.TrimSpace(c.credentials.AccessToken) != "" {
+		return strings.TrimSpace(c.credentials.AccessToken), nil
+	}
+
+	now := c.now()
+	c.tokenMu.Lock()
+	if c.token.accessToken != "" && now.Before(c.token.expiresAt.Add(-tokenRefreshSkew)) {
+		token := c.token.accessToken
+		c.tokenMu.Unlock()
+		return token, nil
+	}
+	c.tokenMu.Unlock()
+
+	privateKey, err := c.privateKey()
+	if err != nil {
+		return "", err
+	}
+	clientSecret, err := GenerateClientSecret(c.credentials.KeyID, c.credentials.TeamID, c.credentials.ClientID, privateKey, now, clientSecretTTL)
+	if err != nil {
+		return "", err
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", grantClientCreds)
+	form.Set("client_id", c.credentials.ClientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("scope", tokenScope)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", parseError(body, resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+		Scope       string `json:"scope"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if strings.TrimSpace(tokenResp.AccessToken) == "" {
+		return "", fmt.Errorf("token response missing access_token")
+	}
+	if !strings.EqualFold(tokenResp.TokenType, "Bearer") {
+		return "", fmt.Errorf("token response has unsupported token_type %q", tokenResp.TokenType)
+	}
+	expiresIn := tokenResp.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 3600
+	}
+
+	c.tokenMu.Lock()
+	c.token = tokenCache{
+		accessToken: tokenResp.AccessToken,
+		expiresAt:   now.Add(time.Duration(expiresIn) * time.Second),
+	}
+	c.tokenMu.Unlock()
+
+	return tokenResp.AccessToken, nil
+}
+
+// AccessToken returns a bearer token for diagnostics and auth token commands.
+func (c *Client) AccessToken(ctx context.Context) (string, error) {
+	return c.bearerToken(ctx)
+}
+
+func (c *Client) privateKey() (*ecdsa.PrivateKey, error) {
+	c.privateKeyMu.Lock()
+	defer c.privateKeyMu.Unlock()
+
+	if c.privateKeyValue != nil {
+		return c.privateKeyValue, nil
+	}
+
+	var (
+		key *ecdsa.PrivateKey
+		err error
+	)
+	if strings.TrimSpace(c.credentials.PrivateKeyPEM) != "" {
+		key, err = auth.LoadPrivateKeyFromPEM([]byte(c.credentials.PrivateKeyPEM))
+	} else {
+		key, err = auth.LoadPrivateKey(c.credentials.PrivateKeyPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key: %w", err)
+	}
+	c.privateKeyValue = key
+	return key, nil
+}
+
+// GenerateClientSecret creates an Apple Ads OAuth client secret JWT.
+func GenerateClientSecret(keyID, teamID, clientID string, privateKey *ecdsa.PrivateKey, now time.Time, lifetime time.Duration) (string, error) {
+	if lifetime <= 0 {
+		lifetime = clientSecretTTL
+	}
+	if lifetime > 180*24*time.Hour {
+		return "", fmt.Errorf("client secret lifetime must be <= 180 days")
+	}
+	claims := jwt.MapClaims{
+		"iss": teamID,
+		"iat": jwt.NewNumericDate(now),
+		"exp": jwt.NewNumericDate(now.Add(lifetime)),
+		"aud": clientSecretAud,
+		"sub": clientID,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = keyID
+
+	signed, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("sign client secret: %w", err)
+	}
+	return signed, nil
+}

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -128,6 +128,9 @@ func GetCredentialsWithSource(profile string) (Credentials, string, error) {
 				}
 				return Credentials{}, "", fmt.Errorf("credentials not found for profile %q", profile)
 			}
+			if cfgCred, err := getCredentialFromConfig(""); err == nil {
+				return cfgCred.Credentials, "config", nil
+			}
 			if len(credentials) > 0 {
 				return Credentials{}, "", fmt.Errorf("default credentials not found")
 			}

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -42,7 +42,7 @@ type credentialPayload struct {
 func ShouldBypassKeychain() bool {
 	value := strings.ToLower(strings.TrimSpace(os.Getenv(adsBypassKeychainEnvVar)))
 	switch value {
-	case "1", "true", "yes", "on":
+	case "1", "true", "yes", "y", "on":
 		return true
 	default:
 		return false

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -66,9 +66,9 @@ func StoreCredentials(name string, credentials Credentials) error {
 	return StoreCredentialsConfig(name, credentials)
 }
 
-// StoreCredentialsConfig stores Apple Ads credentials in the global config file.
+// StoreCredentialsConfig stores Apple Ads credentials in the active config file.
 func StoreCredentialsConfig(name string, credentials Credentials) error {
-	path, err := config.GlobalPath()
+	path, err := config.Path()
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,10 @@ func RemoveCredentials(name string) error {
 	if name == "" {
 		return fmt.Errorf("credential name is required")
 	}
-	keychainErr := removeFromKeychain(name)
+	var keychainErr error
+	if !ShouldBypassKeychain() {
+		keychainErr = removeFromKeychain(name)
+	}
 	configErr := removeFromConfigIfPresent(name)
 	if keychainErr != nil && !isKeyringUnavailable(keychainErr) && !errors.Is(keychainErr, keyring.ErrKeyNotFound) {
 		return keychainErr
@@ -203,6 +206,9 @@ func SetDefaultCredentials(name string) error {
 // RemoveAllCredentials removes all Apple Ads credentials.
 func RemoveAllCredentials() error {
 	configErr := clearConfigCredentials()
+	if ShouldBypassKeychain() {
+		return configErr
+	}
 	keychainErr := removeAllFromKeychain()
 	if keychainErr != nil && !isKeyringUnavailable(keychainErr) {
 		return keychainErr
@@ -226,7 +232,7 @@ func keyringConfig() keyring.Config {
 	}
 }
 
-func openKeyring() (keyring.Keyring, error) {
+var openKeyring = func() (keyring.Keyring, error) {
 	return keyring.Open(keyringConfig())
 }
 
@@ -489,9 +495,15 @@ func loadConfigWithPath() (*config.Config, string, error) {
 	if !errors.Is(err, config.ErrNotFound) {
 		return nil, "", err
 	}
+	if strings.TrimSpace(os.Getenv("ASC_CONFIG_PATH")) != "" {
+		return nil, "", err
+	}
 	global, globalErr := config.GlobalPath()
 	if globalErr != nil {
 		return nil, "", globalErr
+	}
+	if global == path {
+		return nil, "", err
 	}
 	cfg, err = config.LoadAt(global)
 	if err != nil {

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -122,6 +122,10 @@ func GetCredentialsWithSource(profile string) (Credentials, string, error) {
 		} else if ok {
 			return selected.Credentials, "config", nil
 		}
+	} else if selected, ok, err := findDefaultCredentialInActiveConfig(); err != nil {
+		return Credentials{}, "", err
+	} else if ok {
+		return selected.Credentials, "config", nil
 	}
 	if !ShouldBypassKeychain() {
 		credentials, err := listFromKeychain()
@@ -491,6 +495,26 @@ func findCredentialInActiveConfig(profile string) (StoredCredential, bool, error
 		return StoredCredential{}, false, err
 	}
 	selected, ok := selectCredential(profile, storedCredentialsFromConfig(cfg, path))
+	return selected, ok, nil
+}
+
+func findDefaultCredentialInActiveConfig() (StoredCredential, bool, error) {
+	path, err := config.Path()
+	if err != nil {
+		return StoredCredential{}, false, err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return StoredCredential{}, false, nil
+		}
+		return StoredCredential{}, false, err
+	}
+	defaultName := strings.TrimSpace(cfg.Ads.DefaultKeyName)
+	if defaultName == "" {
+		return StoredCredential{}, false, nil
+	}
+	selected, ok := selectCredential(defaultName, storedCredentialsFromConfig(cfg, path))
 	return selected, ok, nil
 }
 

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -1,0 +1,587 @@
+package appleads
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/99designs/keyring"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+const (
+	adsKeyringService       = "asc"
+	adsKeyringItemPrefix    = "asc:ads-credential:"
+	adsKeyringMetadataID    = "asc:ads-metadata:"
+	adsBypassKeychainEnvVar = "ASC_ADS_BYPASS_KEYCHAIN"
+)
+
+// StoredCredential is an Apple Ads credential with storage metadata.
+type StoredCredential struct {
+	Credentials
+	Name       string
+	IsDefault  bool
+	Source     string
+	SourcePath string
+}
+
+type credentialPayload struct {
+	ClientID       string `json:"client_id"`
+	TeamID         string `json:"team_id"`
+	KeyID          string `json:"key_id"`
+	PrivateKeyPath string `json:"private_key_path"`
+	PrivateKeyPEM  string `json:"private_key_pem,omitempty"`
+	OrgID          string `json:"org_id,omitempty"`
+}
+
+// ShouldBypassKeychain reports whether Apple Ads keychain usage is disabled.
+func ShouldBypassKeychain() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(adsBypassKeychainEnvVar)))
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// StoreCredentials stores Apple Ads credentials in keychain when available.
+func StoreCredentials(name string, credentials Credentials) error {
+	payload, err := payloadFromCredentials(credentials, true)
+	if err != nil {
+		return err
+	}
+	if !ShouldBypassKeychain() {
+		if err := storeInKeychain(name, payload); err == nil {
+			_ = removeFromConfigIfPresent(name)
+			return saveDefaultName(name, payload.OrgID)
+		} else if !isKeyringUnavailable(err) {
+			return err
+		}
+	}
+	return StoreCredentialsConfig(name, credentials)
+}
+
+// StoreCredentialsConfig stores Apple Ads credentials in the global config file.
+func StoreCredentialsConfig(name string, credentials Credentials) error {
+	path, err := config.GlobalPath()
+	if err != nil {
+		return err
+	}
+	return StoreCredentialsConfigAt(name, credentials, path)
+}
+
+// StoreCredentialsConfigAt stores Apple Ads credentials in a specific config file.
+func StoreCredentialsConfigAt(name string, credentials Credentials, path string) error {
+	payload, err := payloadFromCredentials(credentials, false)
+	if err != nil {
+		return err
+	}
+	return storeInConfigAt(name, payload, path)
+}
+
+func payloadFromCredentials(credentials Credentials, includePEM bool) (credentialPayload, error) {
+	payload := credentialPayload{
+		ClientID:       strings.TrimSpace(credentials.ClientID),
+		TeamID:         strings.TrimSpace(credentials.TeamID),
+		KeyID:          strings.TrimSpace(credentials.KeyID),
+		PrivateKeyPath: strings.TrimSpace(credentials.PrivateKeyPath),
+		OrgID:          strings.TrimSpace(credentials.OrgID),
+	}
+	if includePEM && strings.TrimSpace(credentials.PrivateKeyPEM) != "" {
+		payload.PrivateKeyPEM = strings.TrimSpace(credentials.PrivateKeyPEM)
+	} else if includePEM && payload.PrivateKeyPath != "" {
+		if data, err := os.ReadFile(payload.PrivateKeyPath); err == nil {
+			payload.PrivateKeyPEM = string(data)
+		}
+	}
+	if payload.ClientID == "" {
+		return payload, fmt.Errorf("client ID is required")
+	}
+	if payload.TeamID == "" {
+		return payload, fmt.Errorf("team ID is required")
+	}
+	if payload.KeyID == "" {
+		return payload, fmt.Errorf("key ID is required")
+	}
+	if payload.PrivateKeyPath == "" && payload.PrivateKeyPEM == "" {
+		return payload, fmt.Errorf("private key is required")
+	}
+	return payload, nil
+}
+
+// GetCredentialsWithSource resolves Apple Ads credentials by profile.
+func GetCredentialsWithSource(profile string) (Credentials, string, error) {
+	if !ShouldBypassKeychain() {
+		credentials, err := listFromKeychain()
+		if err == nil {
+			if selected, ok := selectCredential(profile, credentials); ok {
+				return selected.Credentials, "keychain", nil
+			}
+			if strings.TrimSpace(profile) != "" {
+				if cfgCred, err := getCredentialFromConfig(profile); err == nil {
+					return cfgCred.Credentials, "config", nil
+				}
+				return Credentials{}, "", fmt.Errorf("credentials not found for profile %q", profile)
+			}
+			if len(credentials) > 0 {
+				return Credentials{}, "", fmt.Errorf("default credentials not found")
+			}
+		} else if !isKeyringUnavailable(err) {
+			return Credentials{}, "", err
+		}
+	}
+	selected, err := getCredentialFromConfig(profile)
+	if err != nil {
+		return Credentials{}, "", err
+	}
+	return selected.Credentials, "config", nil
+}
+
+// ListCredentials lists Apple Ads credentials.
+func ListCredentials() ([]StoredCredential, error) {
+	var keychainCreds []StoredCredential
+	var keychainErr error
+	if !ShouldBypassKeychain() {
+		keychainCreds, keychainErr = listFromKeychain()
+		if keychainErr != nil && !isKeyringUnavailable(keychainErr) {
+			return nil, keychainErr
+		}
+	}
+	configCreds, configErr := listFromConfig()
+	if configErr != nil && !errors.Is(configErr, config.ErrNotFound) {
+		if len(keychainCreds) > 0 {
+			return normalizeDefaults(keychainCreds), nil
+		}
+		return nil, configErr
+	}
+	if keychainErr != nil || ShouldBypassKeychain() {
+		return normalizeDefaults(configCreds), nil
+	}
+	return normalizeDefaults(mergeCredentials(keychainCreds, configCreds)), nil
+}
+
+// RemoveCredentials removes one Apple Ads credential.
+func RemoveCredentials(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
+	keychainErr := removeFromKeychain(name)
+	configErr := removeFromConfigIfPresent(name)
+	if keychainErr != nil && !isKeyringUnavailable(keychainErr) && !errors.Is(keychainErr, keyring.ErrKeyNotFound) {
+		return keychainErr
+	}
+	if configErr != nil && !errors.Is(configErr, config.ErrNotFound) && !errors.Is(configErr, keyring.ErrKeyNotFound) {
+		return configErr
+	}
+	return clearDefaultNameIf(name)
+}
+
+// SetDefaultCredentials switches the default Apple Ads profile.
+func SetDefaultCredentials(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
+	credentials, err := ListCredentials()
+	if err != nil {
+		return err
+	}
+	for _, cred := range credentials {
+		if cred.Name == name {
+			return saveDefaultName(name, cred.OrgID)
+		}
+	}
+	return fmt.Errorf("credentials not found for profile %q", name)
+}
+
+// RemoveAllCredentials removes all Apple Ads credentials.
+func RemoveAllCredentials() error {
+	configErr := clearConfigCredentials()
+	keychainErr := removeAllFromKeychain()
+	if keychainErr != nil && !isKeyringUnavailable(keychainErr) {
+		return keychainErr
+	}
+	return configErr
+}
+
+func keyringConfig() keyring.Config {
+	return keyring.Config{
+		ServiceName:                    adsKeyringService,
+		KeychainTrustApplication:       true,
+		KeychainSynchronizable:         false,
+		KeychainAccessibleWhenUnlocked: true,
+		AllowedBackends: []keyring.BackendType{
+			keyring.KeychainBackend,
+			keyring.WinCredBackend,
+			keyring.SecretServiceBackend,
+			keyring.KWalletBackend,
+			keyring.KeyCtlBackend,
+		},
+	}
+}
+
+func openKeyring() (keyring.Keyring, error) {
+	return keyring.Open(keyringConfig())
+}
+
+func storeInKeychain(name string, payload credentialPayload) error {
+	kr, err := openKeyring()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return kr.Set(keyring.Item{
+		Key:         keyringKey(name),
+		Data:        data,
+		Label:       "ASC Apple Ads API Key (" + name + ")",
+		Description: metadataDescription(payload),
+	})
+}
+
+func listFromKeychain() ([]StoredCredential, error) {
+	kr, err := openKeyring()
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		return nil, err
+	}
+	credentials := []StoredCredential{}
+	for _, key := range keys {
+		if !strings.HasPrefix(key, adsKeyringItemPrefix) {
+			continue
+		}
+		item, err := kr.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		var payload credentialPayload
+		if err := json.Unmarshal(item.Data, &payload); err != nil {
+			return nil, fmt.Errorf("invalid keychain entry %q: %w", key, err)
+		}
+		name := strings.TrimPrefix(key, adsKeyringItemPrefix)
+		credentials = append(credentials, storedFromPayload(name, payload, "keychain", "system keychain"))
+	}
+	return credentials, nil
+}
+
+func removeFromKeychain(name string) error {
+	kr, err := openKeyring()
+	if err != nil {
+		return err
+	}
+	return kr.Remove(keyringKey(name))
+}
+
+func removeAllFromKeychain() error {
+	kr, err := openKeyring()
+	if err != nil {
+		return err
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if strings.HasPrefix(key, adsKeyringItemPrefix) {
+			if err := kr.Remove(key); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func keyringKey(name string) string {
+	return adsKeyringItemPrefix + strings.TrimSpace(name)
+}
+
+func metadataDescription(payload credentialPayload) string {
+	data, err := json.Marshal(config.AdsKeychainMetadata{
+		ClientID:   strings.TrimSpace(payload.ClientID),
+		TeamID:     strings.TrimSpace(payload.TeamID),
+		KeyID:      strings.TrimSpace(payload.KeyID),
+		OrgID:      strings.TrimSpace(payload.OrgID),
+		ModifiedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return ""
+	}
+	return adsKeyringMetadataID + string(data)
+}
+
+func isKeyringUnavailable(err error) bool {
+	return errors.Is(err, keyring.ErrNoAvailImpl)
+}
+
+func storeInConfigAt(name string, payload credentialPayload, path string) error {
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if !errors.Is(err, config.ErrNotFound) {
+			return err
+		}
+		cfg = &config.Config{}
+	}
+	name = strings.TrimSpace(name)
+	replacement := config.AdsCredential{
+		Name:           name,
+		ClientID:       payload.ClientID,
+		TeamID:         payload.TeamID,
+		KeyID:          payload.KeyID,
+		PrivateKeyPath: payload.PrivateKeyPath,
+		OrgID:          payload.OrgID,
+	}
+	replaced := false
+	for i := range cfg.Ads.Keys {
+		if cfg.Ads.Keys[i].Name == name {
+			cfg.Ads.Keys[i] = replacement
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		cfg.Ads.Keys = append(cfg.Ads.Keys, replacement)
+	}
+	cfg.Ads.DefaultKeyName = name
+	if payload.OrgID != "" {
+		cfg.Ads.OrgID = payload.OrgID
+	}
+	return config.SaveAt(path, cfg)
+}
+
+func removeFromConfigIfPresent(name string) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		return err
+	}
+	filtered := cfg.Ads.Keys[:0]
+	removed := false
+	for _, cred := range cfg.Ads.Keys {
+		if cred.Name == name {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, cred)
+	}
+	if !removed {
+		return keyring.ErrKeyNotFound
+	}
+	cfg.Ads.Keys = filtered
+	if cfg.Ads.DefaultKeyName == name {
+		cfg.Ads.DefaultKeyName = ""
+	}
+	return config.SaveAt(path, cfg)
+}
+
+func clearConfigCredentials() error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	cfg.Ads.DefaultKeyName = ""
+	cfg.Ads.Keys = nil
+	cfg.Ads.KeychainMetadata = nil
+	cfg.Ads.OrgID = ""
+	return config.SaveAt(path, cfg)
+}
+
+func saveDefaultName(name, orgID string) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if !errors.Is(err, config.ErrNotFound) {
+			return err
+		}
+		cfg = &config.Config{}
+	}
+	cfg.Ads.DefaultKeyName = strings.TrimSpace(name)
+	if strings.TrimSpace(orgID) != "" {
+		cfg.Ads.OrgID = strings.TrimSpace(orgID)
+	}
+	return config.SaveAt(path, cfg)
+}
+
+func clearDefaultNameIf(name string) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if cfg.Ads.DefaultKeyName == name {
+		cfg.Ads.DefaultKeyName = ""
+		return config.SaveAt(path, cfg)
+	}
+	return nil
+}
+
+func listFromConfig() ([]StoredCredential, error) {
+	cfg, path, err := loadConfigWithPath()
+	if err != nil {
+		return nil, err
+	}
+	credentials := make([]StoredCredential, 0, len(cfg.Ads.Keys))
+	for _, cred := range cfg.Ads.Keys {
+		payload := credentialPayload{
+			ClientID:       cred.ClientID,
+			TeamID:         cred.TeamID,
+			KeyID:          cred.KeyID,
+			PrivateKeyPath: cred.PrivateKeyPath,
+			OrgID:          firstNonEmpty(cred.OrgID, cfg.Ads.OrgID),
+		}
+		credentials = append(credentials, storedFromPayload(cred.Name, payload, "config", path))
+	}
+	return credentials, nil
+}
+
+func getCredentialFromConfig(profile string) (StoredCredential, error) {
+	credentials, err := listFromConfig()
+	if err != nil {
+		return StoredCredential{}, err
+	}
+	if selected, ok := selectCredential(profile, credentials); ok {
+		return selected, nil
+	}
+	if strings.TrimSpace(profile) != "" {
+		return StoredCredential{}, fmt.Errorf("credentials not found for profile %q", profile)
+	}
+	return StoredCredential{}, fmt.Errorf("default credentials not found")
+}
+
+func loadConfigWithPath() (*config.Config, string, error) {
+	path, err := config.Path()
+	if err != nil {
+		return nil, "", err
+	}
+	cfg, err := config.LoadAt(path)
+	if err == nil {
+		return cfg, path, nil
+	}
+	if !errors.Is(err, config.ErrNotFound) {
+		return nil, "", err
+	}
+	global, globalErr := config.GlobalPath()
+	if globalErr != nil {
+		return nil, "", globalErr
+	}
+	cfg, err = config.LoadAt(global)
+	if err != nil {
+		return nil, "", err
+	}
+	return cfg, global, nil
+}
+
+func selectCredential(profile string, credentials []StoredCredential) (StoredCredential, bool) {
+	profile = strings.TrimSpace(profile)
+	if profile != "" {
+		for _, cred := range credentials {
+			if cred.Name == profile {
+				return cred, true
+			}
+		}
+		return StoredCredential{}, false
+	}
+	for _, cred := range normalizeDefaults(credentials) {
+		if cred.IsDefault {
+			return cred, true
+		}
+	}
+	return StoredCredential{}, false
+}
+
+func storedFromPayload(name string, payload credentialPayload, source, sourcePath string) StoredCredential {
+	credentials := Credentials{
+		ClientID:       payload.ClientID,
+		TeamID:         payload.TeamID,
+		KeyID:          payload.KeyID,
+		PrivateKeyPath: payload.PrivateKeyPath,
+		PrivateKeyPEM:  payload.PrivateKeyPEM,
+		OrgID:          payload.OrgID,
+		Profile:        name,
+	}
+	return StoredCredential{
+		Credentials: credentials,
+		Name:        name,
+		Source:      source,
+		SourcePath:  sourcePath,
+	}
+}
+
+func normalizeDefaults(credentials []StoredCredential) []StoredCredential {
+	if len(credentials) == 0 {
+		return credentials
+	}
+	cfg, _, err := loadConfigWithPath()
+	defaultName := ""
+	if err == nil {
+		defaultName = strings.TrimSpace(cfg.Ads.DefaultKeyName)
+	}
+	for i := range credentials {
+		credentials[i].IsDefault = false
+	}
+	if defaultName != "" {
+		for i := range credentials {
+			if credentials[i].Name == defaultName {
+				credentials[i].IsDefault = true
+				return credentials
+			}
+		}
+	}
+	if len(credentials) == 1 {
+		credentials[0].IsDefault = true
+	}
+	return credentials
+}
+
+func mergeCredentials(primary, secondary []StoredCredential) []StoredCredential {
+	seen := map[string]struct{}{}
+	merged := make([]StoredCredential, 0, len(primary)+len(secondary))
+	for _, cred := range primary {
+		seen[cred.Name] = struct{}{}
+		merged = append(merged, cred)
+	}
+	for _, cred := range secondary {
+		if _, ok := seen[cred.Name]; !ok {
+			merged = append(merged, cred)
+		}
+	}
+	return merged
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -116,6 +116,13 @@ func payloadFromCredentials(credentials Credentials, includePEM bool) (credentia
 
 // GetCredentialsWithSource resolves Apple Ads credentials by profile.
 func GetCredentialsWithSource(profile string) (Credentials, string, error) {
+	if strings.TrimSpace(profile) != "" {
+		if selected, ok, err := findCredentialInActiveConfig(profile); err != nil {
+			return Credentials{}, "", err
+		} else if ok {
+			return selected.Credentials, "config", nil
+		}
+	}
 	if !ShouldBypassKeychain() {
 		credentials, err := listFromKeychain()
 		if err == nil {
@@ -458,6 +465,26 @@ func listFromConfig() ([]StoredCredential, error) {
 	if err != nil {
 		return nil, err
 	}
+	return storedCredentialsFromConfig(cfg, path), nil
+}
+
+func findCredentialInActiveConfig(profile string) (StoredCredential, bool, error) {
+	path, err := config.Path()
+	if err != nil {
+		return StoredCredential{}, false, err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return StoredCredential{}, false, nil
+		}
+		return StoredCredential{}, false, err
+	}
+	selected, ok := selectCredential(profile, storedCredentialsFromConfig(cfg, path))
+	return selected, ok, nil
+}
+
+func storedCredentialsFromConfig(cfg *config.Config, path string) []StoredCredential {
 	credentials := make([]StoredCredential, 0, len(cfg.Ads.Keys))
 	for _, cred := range cfg.Ads.Keys {
 		payload := credentialPayload{
@@ -469,7 +496,7 @@ func listFromConfig() ([]StoredCredential, error) {
 		}
 		credentials = append(credentials, storedFromPayload(cred.Name, payload, "config", path))
 	}
-	return credentials, nil
+	return credentials
 }
 
 func getCredentialFromConfig(profile string) (StoredCredential, error) {

--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -181,16 +181,26 @@ func RemoveCredentials(name string) error {
 	if name == "" {
 		return fmt.Errorf("credential name is required")
 	}
+	removed := false
 	var keychainErr error
 	if !ShouldBypassKeychain() {
 		keychainErr = removeFromKeychain(name)
+		if keychainErr == nil {
+			removed = true
+		}
 	}
 	configErr := removeFromConfigIfPresent(name)
+	if configErr == nil {
+		removed = true
+	}
 	if keychainErr != nil && !isKeyringUnavailable(keychainErr) && !errors.Is(keychainErr, keyring.ErrKeyNotFound) {
 		return keychainErr
 	}
 	if configErr != nil && !errors.Is(configErr, config.ErrNotFound) && !errors.Is(configErr, keyring.ErrKeyNotFound) {
 		return configErr
+	}
+	if !removed {
+		return keyring.ErrKeyNotFound
 	}
 	return clearDefaultNameIf(name)
 }

--- a/internal/appleads/auth_store_test.go
+++ b/internal/appleads/auth_store_test.go
@@ -92,6 +92,48 @@ func TestGetCredentialsFallsBackToConfigDefaultWhenKeychainHasNoDefault(t *testi
 	}
 }
 
+func TestGetCredentialsPrefersConfigDefaultOverSingleKeychainFallback(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	configCreds := testAdsCredentials()
+	configCreds.ClientID = "CONFIG_CLIENT"
+	if err := StoreCredentialsConfigAt("config-default", configCreds, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	keychainPayload, err := json.Marshal(credentialPayload{
+		ClientID:       "KEYCHAIN_CLIENT",
+		TeamID:         "KEYCHAIN_TEAM",
+		KeyID:          "KEYCHAIN_KEY",
+		PrivateKeyPath: "keychain-private-key.pem",
+		OrgID:          "999999",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	original := openKeyring
+	openKeyring = func() (keyring.Keyring, error) {
+		return fakeAdsKeyring{
+			items: map[string]keyring.Item{
+				keyringKey("keychain-only"): {
+					Key:  keyringKey("keychain-only"),
+					Data: keychainPayload,
+				},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { openKeyring = original })
+
+	credentials, source, err := GetCredentialsWithSource("")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource() error: %v", err)
+	}
+	if source != "config" || credentials.Profile != "config-default" || credentials.ClientID != "CONFIG_CLIENT" {
+		t.Fatalf("credentials = %+v source = %q, want config default over keychain fallback", credentials, source)
+	}
+}
+
 func TestGetCredentialsPrefersActiveConfigProfileOverSameNamedKeychainProfile(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)
@@ -155,6 +197,14 @@ func TestBypassKeychainRemovalSkipsKeychain(t *testing.T) {
 	}
 	if called {
 		t.Fatal("RemoveCredentials opened keychain despite ASC_ADS_BYPASS_KEYCHAIN")
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("LoadAt() error: %v", err)
+	}
+	if len(cfg.Ads.Keys) != 0 {
+		t.Fatalf("ads config after removal = %+v, want no keys", cfg.Ads.Keys)
 	}
 }
 

--- a/internal/appleads/auth_store_test.go
+++ b/internal/appleads/auth_store_test.go
@@ -92,6 +92,48 @@ func TestGetCredentialsFallsBackToConfigDefaultWhenKeychainHasNoDefault(t *testi
 	}
 }
 
+func TestGetCredentialsPrefersActiveConfigProfileOverSameNamedKeychainProfile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	configCreds := testAdsCredentials()
+	configCreds.ClientID = "CONFIG_CLIENT"
+	configCreds.OrgID = "CONFIG_ORG"
+	if err := StoreCredentialsConfigAt("shared", configCreds, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	keychainPayload, err := json.Marshal(credentialPayload{
+		ClientID:       "KEYCHAIN_CLIENT",
+		TeamID:         "KEYCHAIN_TEAM",
+		KeyID:          "KEYCHAIN_KEY",
+		PrivateKeyPath: "keychain-private-key.pem",
+		OrgID:          "KEYCHAIN_ORG",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	original := openKeyring
+	openKeyring = func() (keyring.Keyring, error) {
+		return fakeAdsKeyring{
+			items: map[string]keyring.Item{
+				keyringKey("shared"): {
+					Key:  keyringKey("shared"),
+					Data: keychainPayload,
+				},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { openKeyring = original })
+
+	credentials, source, err := GetCredentialsWithSource("shared")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource() error: %v", err)
+	}
+	if source != "config" || credentials.ClientID != "CONFIG_CLIENT" || credentials.OrgID != "CONFIG_ORG" {
+		t.Fatalf("credentials = %+v source = %q, want active config profile", credentials, source)
+	}
+}
+
 func TestBypassKeychainRemovalSkipsKeychain(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)

--- a/internal/appleads/auth_store_test.go
+++ b/internal/appleads/auth_store_test.go
@@ -1,0 +1,114 @@
+package appleads
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/99designs/keyring"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+func TestStoreCredentialsConfigUsesActiveConfigPath(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "active-config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+
+	if err := StoreCredentialsConfig("ads", testAdsCredentials()); err != nil {
+		t.Fatalf("StoreCredentialsConfig() error: %v", err)
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("LoadAt(active) error: %v", err)
+	}
+	if len(cfg.Ads.Keys) != 1 || cfg.Ads.Keys[0].Name != "ads" {
+		t.Fatalf("active config ads keys = %+v, want ads profile", cfg.Ads.Keys)
+	}
+}
+
+func TestLoadConfigWithPathDoesNotFallbackToGlobalWhenASCConfigPathSet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatalf("GlobalPath() error: %v", err)
+	}
+	if err := StoreCredentialsConfigAt("global", testAdsCredentials(), globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(global) error: %v", err)
+	}
+
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	_, _, err = loadConfigWithPath()
+	if !errors.Is(err, config.ErrNotFound) {
+		t.Fatalf("loadConfigWithPath() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestBypassKeychainRemovalSkipsKeychain(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	if err := StoreCredentialsConfigAt("ads", testAdsCredentials(), configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	called := false
+	original := openKeyring
+	openKeyring = func() (keyring.Keyring, error) {
+		called = true
+		return nil, errors.New("keychain should be bypassed")
+	}
+	t.Cleanup(func() { openKeyring = original })
+
+	if err := RemoveCredentials("ads"); err != nil {
+		t.Fatalf("RemoveCredentials() error: %v", err)
+	}
+	if called {
+		t.Fatal("RemoveCredentials opened keychain despite ASC_ADS_BYPASS_KEYCHAIN")
+	}
+}
+
+func TestBypassKeychainRemoveAllSkipsKeychain(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	if err := StoreCredentialsConfigAt("ads", testAdsCredentials(), configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	called := false
+	original := openKeyring
+	openKeyring = func() (keyring.Keyring, error) {
+		called = true
+		return nil, errors.New("keychain should be bypassed")
+	}
+	t.Cleanup(func() { openKeyring = original })
+
+	if err := RemoveAllCredentials(); err != nil {
+		t.Fatalf("RemoveAllCredentials() error: %v", err)
+	}
+	if called {
+		t.Fatal("RemoveAllCredentials opened keychain despite ASC_ADS_BYPASS_KEYCHAIN")
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("LoadAt() error: %v", err)
+	}
+	if len(cfg.Ads.Keys) != 0 || strings.TrimSpace(cfg.Ads.DefaultKeyName) != "" {
+		t.Fatalf("ads config after clear = %+v, want empty credentials", cfg.Ads)
+	}
+}
+
+func testAdsCredentials() Credentials {
+	return Credentials{
+		ClientID:       "CLIENT",
+		TeamID:         "TEAM",
+		KeyID:          "KEY",
+		PrivateKeyPath: "private-key.pem",
+		OrgID:          "123456",
+	}
+}

--- a/internal/appleads/auth_store_test.go
+++ b/internal/appleads/auth_store_test.go
@@ -158,6 +158,20 @@ func TestBypassKeychainRemovalSkipsKeychain(t *testing.T) {
 	}
 }
 
+func TestRemoveCredentialsReturnsNotFoundWhenProfileMissing(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	if err := StoreCredentialsConfigAt("ads", testAdsCredentials(), configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	err := RemoveCredentials("missing")
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("RemoveCredentials() error = %v, want key not found", err)
+	}
+}
+
 func TestBypassKeychainRemoveAllSkipsKeychain(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)

--- a/internal/appleads/auth_store_test.go
+++ b/internal/appleads/auth_store_test.go
@@ -1,6 +1,7 @@
 package appleads
 
 import (
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,50 @@ func TestLoadConfigWithPathDoesNotFallbackToGlobalWhenASCConfigPathSet(t *testin
 	_, _, err = loadConfigWithPath()
 	if !errors.Is(err, config.ErrNotFound) {
 		t.Fatalf("loadConfigWithPath() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetCredentialsFallsBackToConfigDefaultWhenKeychainHasNoDefault(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	if err := StoreCredentialsConfigAt("config-default", testAdsCredentials(), configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	keychainPayload, err := json.Marshal(credentialPayload{
+		ClientID:       "KEYCHAIN_CLIENT",
+		TeamID:         "KEYCHAIN_TEAM",
+		KeyID:          "KEYCHAIN_KEY",
+		PrivateKeyPath: "keychain-private-key.pem",
+		OrgID:          "999999",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	original := openKeyring
+	openKeyring = func() (keyring.Keyring, error) {
+		return fakeAdsKeyring{
+			items: map[string]keyring.Item{
+				keyringKey("keychain-only"): {
+					Key:  keyringKey("keychain-only"),
+					Data: keychainPayload,
+				},
+				keyringKey("keychain-other"): {
+					Key:  keyringKey("keychain-other"),
+					Data: keychainPayload,
+				},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { openKeyring = original })
+
+	credentials, source, err := GetCredentialsWithSource("")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource() error: %v", err)
+	}
+	if source != "config" || credentials.Profile != "config-default" || credentials.ClientID != "CLIENT" {
+		t.Fatalf("credentials = %+v source = %q, want config default profile", credentials, source)
 	}
 }
 
@@ -101,6 +146,53 @@ func TestBypassKeychainRemoveAllSkipsKeychain(t *testing.T) {
 	if len(cfg.Ads.Keys) != 0 || strings.TrimSpace(cfg.Ads.DefaultKeyName) != "" {
 		t.Fatalf("ads config after clear = %+v, want empty credentials", cfg.Ads)
 	}
+}
+
+type fakeAdsKeyring struct {
+	items map[string]keyring.Item
+}
+
+func (f fakeAdsKeyring) Get(key string) (keyring.Item, error) {
+	item, ok := f.items[key]
+	if !ok {
+		return keyring.Item{}, keyring.ErrKeyNotFound
+	}
+	return item, nil
+}
+
+func (f fakeAdsKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	item, ok := f.items[key]
+	if !ok {
+		return keyring.Metadata{}, keyring.ErrKeyNotFound
+	}
+	return keyring.Metadata{
+		Item: &keyring.Item{
+			Key:         item.Key,
+			Label:       item.Label,
+			Description: item.Description,
+		},
+	}, nil
+}
+
+func (f fakeAdsKeyring) Set(item keyring.Item) error {
+	f.items[item.Key] = item
+	return nil
+}
+
+func (f fakeAdsKeyring) Remove(key string) error {
+	if _, ok := f.items[key]; !ok {
+		return keyring.ErrKeyNotFound
+	}
+	delete(f.items, key)
+	return nil
+}
+
+func (f fakeAdsKeyring) Keys() ([]string, error) {
+	keys := make([]string, 0, len(f.items))
+	for key := range f.items {
+		keys = append(keys, key)
+	}
+	return keys, nil
 }
 
 func testAdsCredentials() Credentials {

--- a/internal/appleads/auth_store_test.go
+++ b/internal/appleads/auth_store_test.go
@@ -208,6 +208,17 @@ func TestBypassKeychainRemovalSkipsKeychain(t *testing.T) {
 	}
 }
 
+func TestShouldBypassKeychainAcceptsDocumentedTruthyValues(t *testing.T) {
+	for _, value := range []string{"1", "true", "yes", "y", "on"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", value)
+			if !ShouldBypassKeychain() {
+				t.Fatalf("ShouldBypassKeychain() = false for %q, want true", value)
+			}
+		})
+	}
+}
+
 func TestRemoveCredentialsReturnsNotFoundWhenProfileMissing(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)

--- a/internal/appleads/client.go
+++ b/internal/appleads/client.go
@@ -1,0 +1,266 @@
+package appleads
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+const BaseURL = "https://api.searchads.apple.com/api/"
+
+// RawResponse preserves the Apple Ads response envelope.
+type RawResponse json.RawMessage
+
+// MarshalJSON implements json.Marshaler.
+func (r RawResponse) MarshalJSON() ([]byte, error) {
+	if len(r) == 0 {
+		return []byte("null"), nil
+	}
+	return json.RawMessage(r).MarshalJSON()
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// Client is an Apple Ads Campaign Management API client.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	tokenURL   string
+	now        func() time.Time
+
+	credentials Credentials
+
+	tokenMu         sync.Mutex
+	token           tokenCache
+	privateKeyMu    sync.Mutex
+	privateKeyValue *ecdsa.PrivateKey
+}
+
+// NewClient constructs an Apple Ads API client.
+func NewClient(credentials Credentials, opts ...ClientOption) (*Client, error) {
+	client := &Client{
+		httpClient:  &http.Client{Timeout: asc.ResolveTimeout()},
+		baseURL:     BaseURL,
+		tokenURL:    tokenURL,
+		now:         time.Now,
+		credentials: normalizeCredentials(credentials),
+	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{Timeout: asc.ResolveTimeout()}
+	}
+	if strings.TrimSpace(client.baseURL) == "" {
+		client.baseURL = BaseURL
+	}
+	if strings.TrimSpace(client.tokenURL) == "" {
+		client.tokenURL = tokenURL
+	}
+	if client.now == nil {
+		client.now = time.Now
+	}
+	if err := validateCredentials(client.credentials); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func normalizeCredentials(credentials Credentials) Credentials {
+	credentials.ClientID = strings.TrimSpace(credentials.ClientID)
+	credentials.TeamID = strings.TrimSpace(credentials.TeamID)
+	credentials.KeyID = strings.TrimSpace(credentials.KeyID)
+	credentials.PrivateKeyPath = strings.TrimSpace(credentials.PrivateKeyPath)
+	credentials.PrivateKeyPEM = strings.TrimSpace(credentials.PrivateKeyPEM)
+	credentials.AccessToken = strings.TrimSpace(credentials.AccessToken)
+	credentials.OrgID = strings.TrimSpace(credentials.OrgID)
+	credentials.Profile = strings.TrimSpace(credentials.Profile)
+	return credentials
+}
+
+func validateCredentials(credentials Credentials) error {
+	if credentials.AccessToken != "" {
+		return nil
+	}
+	if credentials.ClientID == "" {
+		return fmt.Errorf("client ID is required")
+	}
+	if credentials.TeamID == "" {
+		return fmt.Errorf("team ID is required")
+	}
+	if credentials.KeyID == "" {
+		return fmt.Errorf("key ID is required")
+	}
+	if credentials.PrivateKeyPath == "" && credentials.PrivateKeyPEM == "" {
+		return fmt.Errorf("private key is required")
+	}
+	return nil
+}
+
+// WithHTTPClient configures the HTTP client.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(client *Client) {
+		client.httpClient = httpClient
+	}
+}
+
+// WithBaseURL configures the Apple Ads API base URL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(client *Client) {
+		client.baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/"
+	}
+}
+
+// WithTokenURL configures the OAuth token URL.
+func WithTokenURL(tokenURL string) ClientOption {
+	return func(client *Client) {
+		client.tokenURL = strings.TrimSpace(tokenURL)
+	}
+}
+
+// WithNow configures the clock used by token caching.
+func WithNow(now func() time.Time) ClientOption {
+	return func(client *Client) {
+		client.now = now
+	}
+}
+
+// Do executes a documented Apple Ads endpoint.
+func (c *Client) Do(ctx context.Context, spec EndpointSpec, pathParams map[string]string, query url.Values, body json.RawMessage) (RawResponse, error) {
+	path, err := expandPath(spec.Path, pathParams)
+	if err != nil {
+		return nil, err
+	}
+	return c.Request(ctx, spec.Method, path, query, body, spec.RequiresOrg)
+}
+
+// Request executes an Apple Ads API request for a relative v5 path.
+func (c *Client) Request(ctx context.Context, method, path string, query url.Values, body json.RawMessage, requiresOrg bool) (RawResponse, error) {
+	token, err := c.bearerToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL, err := c.requestURL(path, query)
+	if err != nil {
+		return nil, err
+	}
+
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if requiresOrg {
+		orgID := strings.TrimSpace(c.credentials.OrgID)
+		if orgID == "" {
+			return nil, fmt.Errorf("org ID is required")
+		}
+		req.Header.Set("X-AP-Context", "orgId="+orgID)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, parseError(respBody, resp.StatusCode)
+	}
+	if len(strings.TrimSpace(string(respBody))) == 0 {
+		return RawResponse(`{"data":null}`), nil
+	}
+	return RawResponse(respBody), nil
+}
+
+func (c *Client) requestURL(path string, query url.Values) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	if parsed.IsAbs() {
+		base, err := url.Parse(c.baseURL)
+		if err != nil {
+			return "", err
+		}
+		if parsed.Scheme != "https" || parsed.Host != base.Host || !strings.HasPrefix(parsed.Path, base.Path+"v5/") {
+			return "", fmt.Errorf("--path must be an Apple Ads v5 URL")
+		}
+		if len(query) > 0 {
+			values := parsed.Query()
+			for key, items := range query {
+				for _, item := range items {
+					values.Add(key, item)
+				}
+			}
+			parsed.RawQuery = values.Encode()
+		}
+		return parsed.String(), nil
+	}
+	clean := strings.TrimPrefix(path, "/")
+	if !strings.HasPrefix(clean, "v5/") {
+		return "", fmt.Errorf("--path must start with v5/")
+	}
+	rel, err := url.Parse(clean)
+	if err != nil {
+		return "", err
+	}
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", err
+	}
+	resolved := base.ResolveReference(rel)
+	if len(query) > 0 {
+		values := resolved.Query()
+		for key, items := range query {
+			for _, item := range items {
+				values.Add(key, item)
+			}
+		}
+		resolved.RawQuery = values.Encode()
+	}
+	return resolved.String(), nil
+}
+
+func expandPath(path string, params map[string]string) (string, error) {
+	result := path
+	for key, value := range params {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", fmt.Errorf("%s is required", key)
+		}
+		result = strings.ReplaceAll(result, "{"+key+"}", url.PathEscape(value))
+	}
+	if strings.Contains(result, "{") || strings.Contains(result, "}") {
+		return "", fmt.Errorf("missing path parameter for %s", path)
+	}
+	return result, nil
+}

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -152,9 +152,9 @@ func TestRequestSetsBearerAndOrganizationContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient() error: %v", err)
 	}
-	me, ok := EndpointByCommandPath("me", "get")
+	me, ok := EndpointByCommandPath("me", "view")
 	if !ok {
-		t.Fatal("missing me get endpoint")
+		t.Fatal("missing me view endpoint")
 	}
 	if _, err := client.Do(context.Background(), me, nil, nil, nil); err != nil {
 		t.Fatalf("me Do() error: %v", err)

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -1,0 +1,248 @@
+package appleads
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func testPrivateKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	return key
+}
+
+func marshalECPrivateKeyPEM(t *testing.T, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey() error: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+}
+
+func TestGenerateClientSecretClaims(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	tokenString, err := GenerateClientSecret("KEY123", "TEAM123", "CLIENT123", testPrivateKey(t), now, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateClientSecret() error: %v", err)
+	}
+
+	claims := jwt.MapClaims{}
+	token, _, err := jwt.NewParser().ParseUnverified(tokenString, claims)
+	if err != nil {
+		t.Fatalf("ParseUnverified() error: %v", err)
+	}
+	if got := token.Header["kid"]; got != "KEY123" {
+		t.Fatalf("kid = %v, want KEY123", got)
+	}
+	if got := token.Method.Alg(); got != "ES256" {
+		t.Fatalf("alg = %q, want ES256", got)
+	}
+	assertClaim(t, claims, "iss", "TEAM123")
+	assertClaim(t, claims, "aud", "https://appleid.apple.com")
+	assertClaim(t, claims, "sub", "CLIENT123")
+	if got, want := int64(claims["exp"].(float64)-claims["iat"].(float64)), int64((10 * time.Minute).Seconds()); got != want {
+		t.Fatalf("exp-iat = %d, want %d", got, want)
+	}
+}
+
+func TestAccessTokenUsesAppleOAuthClientCredentialsRequest(t *testing.T) {
+	requests := 0
+	client, err := NewClient(Credentials{
+		ClientID:      "CLIENT123",
+		TeamID:        "TEAM123",
+		KeyID:         "KEY123",
+		PrivateKeyPEM: marshalECPrivateKeyPEM(t, testPrivateKey(t)),
+	}, WithTokenURL("https://appleid.test/auth/oauth2/token"), WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			if req.Method != http.MethodPost {
+				t.Fatalf("token method = %s, want POST", req.Method)
+			}
+			if got := req.URL.String(); got != "https://appleid.test/auth/oauth2/token" {
+				t.Fatalf("token URL = %s", got)
+			}
+			if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+				t.Fatalf("Content-Type = %q, want form encoded", got)
+			}
+			data, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(body) error: %v", err)
+			}
+			form, err := url.ParseQuery(string(data))
+			if err != nil {
+				t.Fatalf("ParseQuery() error: %v", err)
+			}
+			if form.Get("grant_type") != "client_credentials" {
+				t.Fatalf("grant_type = %q", form.Get("grant_type"))
+			}
+			if form.Get("client_id") != "CLIENT123" {
+				t.Fatalf("client_id = %q", form.Get("client_id"))
+			}
+			if form.Get("scope") != "searchadsorg" {
+				t.Fatalf("scope = %q", form.Get("scope"))
+			}
+			if form.Get("client_secret") == "" {
+				t.Fatal("client_secret is empty")
+			}
+			return jsonResponse(200, `{"access_token":"ACCESS","token_type":"Bearer","expires_in":3600}`), nil
+		}),
+	}))
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+
+	token, err := client.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("AccessToken() error: %v", err)
+	}
+	if token != "ACCESS" {
+		t.Fatalf("token = %q, want ACCESS", token)
+	}
+	token, err = client.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("second AccessToken() error: %v", err)
+	}
+	if token != "ACCESS" || requests != 1 {
+		t.Fatalf("token cache got token %q requests %d, want ACCESS requests 1", token, requests)
+	}
+}
+
+func TestRequestSetsBearerAndOrganizationContext(t *testing.T) {
+	seen := []string{}
+	client, err := NewClient(Credentials{AccessToken: "ACCESS", OrgID: "123456"}, WithBaseURL("https://api.searchads.apple.com/api/"), WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			seen = append(seen, req.Method+" "+req.URL.Path+" "+req.Header.Get("X-AP-Context"))
+			if got := req.Header.Get("Authorization"); got != "Bearer ACCESS" {
+				t.Fatalf("Authorization = %q, want bearer token", got)
+			}
+			return jsonResponse(200, `{"data":[]}`), nil
+		}),
+	}))
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	me, ok := EndpointByCommandPath("me", "get")
+	if !ok {
+		t.Fatal("missing me get endpoint")
+	}
+	if _, err := client.Do(context.Background(), me, nil, nil, nil); err != nil {
+		t.Fatalf("me Do() error: %v", err)
+	}
+	campaigns, ok := EndpointByCommandPath("campaigns", "list")
+	if !ok {
+		t.Fatal("missing campaigns list endpoint")
+	}
+	if _, err := client.Do(context.Background(), campaigns, nil, url.Values{"limit": {"1"}}, nil); err != nil {
+		t.Fatalf("campaigns Do() error: %v", err)
+	}
+	want := []string{
+		"GET /api/v5/me ",
+		"GET /api/v5/campaigns orgId=123456",
+	}
+	if strings.Join(seen, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("requests:\n%s\nwant:\n%s", strings.Join(seen, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestRequestParsesAppleAdsErrorEnvelope(t *testing.T) {
+	client, err := NewClient(Credentials{AccessToken: "ACCESS", OrgID: "123456"}, WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(400, `{"error":{"errors":[{"field":"campaignId","message":"Invalid campaign","messageCode":"INVALID_INPUT"}]}}`), nil
+		}),
+	}))
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	campaigns, ok := EndpointByCommandPath("campaigns", "get")
+	if !ok {
+		t.Fatal("missing campaigns get endpoint")
+	}
+	_, err = client.Do(context.Background(), campaigns, map[string]string{"campaignId": "1"}, nil, nil)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if got := err.Error(); !strings.Contains(got, "HTTP 400: INVALID_INPUT: campaignId: Invalid campaign") {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestPaginateAllAggregatesOffsetPages(t *testing.T) {
+	requestOffsets := []string{}
+	client, err := NewClient(Credentials{AccessToken: "ACCESS", OrgID: "123456"}, WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			offset := req.URL.Query().Get("offset")
+			requestOffsets = append(requestOffsets, offset)
+			switch offset {
+			case "0":
+				return jsonResponse(200, `{"data":[{"id":1},{"id":2}],"pagination":{"itemsPerPage":2,"startIndex":0,"totalResults":3}}`), nil
+			case "2":
+				return jsonResponse(200, `{"data":[{"id":3}],"pagination":{"itemsPerPage":2,"startIndex":2,"totalResults":3}}`), nil
+			default:
+				t.Fatalf("unexpected offset %q", offset)
+				return nil, nil
+			}
+		}),
+	}))
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	campaigns, ok := EndpointByCommandPath("campaigns", "list")
+	if !ok {
+		t.Fatal("missing campaigns list endpoint")
+	}
+	raw, err := client.PaginateAll(context.Background(), campaigns, nil, nil, 0, 2, nil)
+	if err != nil {
+		t.Fatalf("PaginateAll() error: %v", err)
+	}
+	var parsed struct {
+		Data       []map[string]int `json:"data"`
+		Pagination PageDetail       `json:"pagination"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	if len(parsed.Data) != 3 || parsed.Data[2]["id"] != 3 {
+		t.Fatalf("aggregated data = %+v, want 3 rows ending with id=3", parsed.Data)
+	}
+	if got := strings.Join(requestOffsets, ","); got != "0,2" {
+		t.Fatalf("offsets = %q, want 0,2", got)
+	}
+}
+
+func assertClaim(t *testing.T, claims jwt.MapClaims, name, want string) {
+	t.Helper()
+	if got := claims[name]; got != want {
+		t.Fatalf("%s = %v, want %s", name, got, want)
+	}
+}

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -184,9 +184,9 @@ func TestRequestParsesAppleAdsErrorEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient() error: %v", err)
 	}
-	campaigns, ok := EndpointByCommandPath("campaigns", "get")
+	campaigns, ok := EndpointByCommandPath("campaigns", "view")
 	if !ok {
-		t.Fatal("missing campaigns get endpoint")
+		t.Fatal("missing campaigns view endpoint")
 	}
 	_, err = client.Do(context.Background(), campaigns, map[string]string{"campaignId": "1"}, nil, nil)
 	if err == nil {

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -240,6 +240,37 @@ func TestPaginateAllAggregatesOffsetPages(t *testing.T) {
 	}
 }
 
+func TestPaginateAllReportsClampedStartOffset(t *testing.T) {
+	client, err := NewClient(Credentials{AccessToken: "ACCESS", OrgID: "123456"}, WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.URL.Query().Get("offset"); got != "0" {
+				t.Fatalf("offset = %q, want 0", got)
+			}
+			return jsonResponse(200, `{"data":[{"id":1}],"pagination":{"itemsPerPage":1,"startIndex":0,"totalResults":1}}`), nil
+		}),
+	}))
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	campaigns, ok := EndpointByCommandPath("campaigns", "list")
+	if !ok {
+		t.Fatal("missing campaigns list endpoint")
+	}
+	raw, err := client.PaginateAll(context.Background(), campaigns, nil, nil, -10, 1, nil)
+	if err != nil {
+		t.Fatalf("PaginateAll() error: %v", err)
+	}
+	var parsed struct {
+		Pagination PageDetail `json:"pagination"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	if parsed.Pagination.StartIndex != 0 {
+		t.Fatalf("StartIndex = %d, want 0", parsed.Pagination.StartIndex)
+	}
+}
+
 func assertClaim(t *testing.T, claims jwt.MapClaims, name, want string) {
 	t.Helper()
 	if got := claims[name]; got != want {

--- a/internal/appleads/endpoints.go
+++ b/internal/appleads/endpoints.go
@@ -100,27 +100,27 @@ func EndpointSpecs() []EndpointSpec {
 		endpoint("get-me-details", "GET", "v5/me", []string{"me", "view"}, BodyNone, "", "MeDetailResponse", nil, nil),
 
 		endpoint("search-for-ios-apps", "GET", "v5/search/apps", []string{"apps", "search"}, BodyNone, "", "AppInfoListResponse", nil, []ParamSpec{limitParam, offsetParam, q("query", "query", ParamString, true), q("returnOwnedApps", "return-owned-apps", ParamBool, false)}),
-		endpoint("get-app-details", "GET", "v5/apps/{adamId}", []string{"apps", "get"}, BodyNone, "", "MediaDetailResponse", []ParamSpec{adamIDParam}, nil),
+		endpoint("get-app-details", "GET", "v5/apps/{adamId}", []string{"apps", "view"}, BodyNone, "", "MediaDetailResponse", []ParamSpec{adamIDParam}, nil),
 		endpoint("get-localized-app-details", "GET", "v5/apps/{adamId}/locale-details", []string{"apps", "localized-details"}, BodyNone, "", "MediaLocaleDetailResponse", []ParamSpec{adamIDParam}, nil),
 		endpoint("find-app-eligibility-records", "POST", "v5/apps/{adamId}/eligibilities/find", []string{"apps", "eligibility", "find"}, BodyObject, "Selector", "EligibilityRecordListResponse", []ParamSpec{adamIDParam}, nil),
 		endpoint("find-app-assets", "POST", "v5/apps/{adamId}/assets/find", []string{"apps", "assets", "find"}, BodyObject, "Selector", "AppAssetListResponse", []ParamSpec{adamIDParam}, nil),
 
 		endpoint("get-product-pages", "GET", "v5/apps/{adamId}/product-pages", []string{"product-pages", "list"}, BodyNone, "", "ProductPageDetailListResponse", []ParamSpec{adamIDParam}, []ParamSpec{q("name", "name", ParamString, false), qAllowed("states", "states", "HIDDEN", "VISIBLE")}),
-		endpoint("get-product-pages-by-identifier", "GET", "v5/apps/{adamId}/product-pages/{productPageId}", []string{"product-pages", "get"}, BodyNone, "", "ProductPageDetailResponse", []ParamSpec{adamIDParam, productPageParam}, nil),
+		endpoint("get-product-pages-by-identifier", "GET", "v5/apps/{adamId}/product-pages/{productPageId}", []string{"product-pages", "view"}, BodyNone, "", "ProductPageDetailResponse", []ParamSpec{adamIDParam, productPageParam}, nil),
 		endpoint("get-product-page-locales", "GET", "v5/apps/{adamId}/product-pages/{productPageId}/locale-details", []string{"product-pages", "locales", "list"}, BodyNone, "", "ProductPageLocaleDetailListResponse", []ParamSpec{adamIDParam, productPageParam}, []ParamSpec{qAllowed("deviceClasses", "device-classes", "IPAD", "IPHONE"), q("expand", "expand", ParamBool, false), q("languageCodes", "language-codes", ParamString, false), q("languages", "languages", ParamString, false)}),
 		endpoint("get-supported-countries-or-regions", "GET", "v5/countries-or-regions", []string{"product-pages", "countries", "list"}, BodyNone, "", "CountriesOrRegionsListResponse", nil, []ParamSpec{q("countriesOrRegions", "countries-or-regions", ParamString, false)}),
 		endpoint("get-app-preview-device-sizes", "GET", "v5/creativeappmappings/devices", []string{"product-pages", "devices", "list"}, BodyNone, "", "AppPreviewDevicesMappingResponse", nil, nil),
 
 		endpoint("get-all-budget-orders", "GET", "v5/budgetorders", []string{"budget-orders", "list"}, BodyNone, "", "BudgetOrderInfoListResponse", nil, qLimitOffset()),
 		endpoint("create-a-budget-order", "POST", "v5/budgetorders", []string{"budget-orders", "create"}, BodyObject, "BudgetOrderCreate", "BudgetOrderInfoResponse", nil, nil),
-		endpoint("get-a-budget-order", "GET", "v5/budgetorders/{boId}", []string{"budget-orders", "get"}, BodyNone, "", "BudgetOrderInfoResponse", []ParamSpec{budgetOrderParam}, nil),
+		endpoint("get-a-budget-order", "GET", "v5/budgetorders/{boId}", []string{"budget-orders", "view"}, BodyNone, "", "BudgetOrderInfoResponse", []ParamSpec{budgetOrderParam}, nil),
 		endpoint("update-a-budget-order", "PUT", "v5/budgetorders/{boId}", []string{"budget-orders", "update"}, BodyObject, "BudgetOrderUpdate", "BudgetOrderInfoResponse", []ParamSpec{budgetOrderParam}, nil),
 
 		endpoint("get-all-campaigns", "GET", "v5/campaigns", []string{"campaigns", "list"}, BodyNone, "", "CampaignListResponse", nil, qLimitOffset()),
 		endpoint("create-a-campaign", "POST", "v5/campaigns", []string{"campaigns", "create"}, BodyObject, "Campaign", "CampaignResponse", nil, nil),
 		endpoint("find-campaigns", "POST", "v5/campaigns/find", []string{"campaigns", "find"}, BodyObject, "Selector", "CampaignListResponse", nil, nil),
 		endpoint("delete-a-campaign", "DELETE", "v5/campaigns/{campaignId}", []string{"campaigns", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam}, nil),
-		endpoint("get-a-campaign", "GET", "v5/campaigns/{campaignId}", []string{"campaigns", "get"}, BodyNone, "", "CampaignResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("get-a-campaign", "GET", "v5/campaigns/{campaignId}", []string{"campaigns", "view"}, BodyNone, "", "CampaignResponse", []ParamSpec{campaignParam}, nil),
 		endpoint("update-a-campaign", "PUT", "v5/campaigns/{campaignId}", []string{"campaigns", "update"}, BodyObject, "UpdateCampaignRequest", "CampaignResponse", []ParamSpec{campaignParam}, nil),
 
 		endpoint("get-all-ad-groups", "GET", "v5/campaigns/{campaignId}/adgroups", []string{"ad-groups", "list"}, BodyNone, "", "AdGroupListResponse", []ParamSpec{campaignParam}, qLimitOffset()),
@@ -128,20 +128,20 @@ func EndpointSpecs() []EndpointSpec {
 		endpoint("find-ad-groups", "POST", "v5/campaigns/{campaignId}/adgroups/find", []string{"ad-groups", "find"}, BodyObject, "Selector", "AdGroupListResponse", []ParamSpec{campaignParam}, nil),
 		endpoint("find-ad-groups-org", "POST", "v5/adgroups/find", []string{"ad-groups", "find-org"}, BodyObject, "Selector", "AdGroupListResponse", nil, nil),
 		endpoint("delete-an-ad-group", "DELETE", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
-		endpoint("get-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "get"}, BodyNone, "", "AdGroupResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("get-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "view"}, BodyNone, "", "AdGroupResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("update-an-ad-group", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "update"}, BodyObject, "AdGroupUpdate", "AdGroupResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 
 		endpoint("get-all-ads", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads", []string{"ads", "list"}, BodyNone, "", "AdListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("create-an-ad", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads", []string{"ads", "create"}, BodyObject, "AdCreate", "AdResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("delete-an-ad", "DELETE", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
-		endpoint("get-an-ad", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "get"}, BodyNone, "", "AdResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
+		endpoint("get-an-ad", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "view"}, BodyNone, "", "AdResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
 		endpoint("update-an-ad", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "update"}, BodyObject, "AdUpdate", "AdResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
 		endpoint("find-ads", "POST", "v5/campaigns/{campaignId}/ads/find", []string{"ads", "find"}, BodyObject, "Selector", "AdListResponse", []ParamSpec{campaignParam}, nil),
 		endpoint("find-ads-org", "POST", "v5/ads/find", []string{"ads", "find-org"}, BodyObject, "Selector", "AdListResponse", nil, nil),
 
 		endpoint("get-all-targeting-keywords-in-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords", []string{"targeting-keywords", "list"}, BodyNone, "", "KeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, qLimitOffset()),
 		endpoint("find-targeting-keywords-in-a-campaign", "POST", "v5/campaigns/{campaignId}/adgroups/targetingkeywords/find", []string{"targeting-keywords", "find"}, BodyObject, "Selector", "KeywordListResponse", []ParamSpec{campaignParam}, nil),
-		endpoint("get-a-targeting-keyword-in-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}", []string{"targeting-keywords", "get"}, BodyNone, "", "KeywordResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
+		endpoint("get-a-targeting-keyword-in-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}", []string{"targeting-keywords", "view"}, BodyNone, "", "KeywordResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
 		endpoint("create-targeting-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/bulk", []string{"targeting-keywords", "create-bulk"}, BodyArray, "[Keyword]", "KeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("update-targeting-keywords", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/bulk", []string{"targeting-keywords", "update-bulk"}, BodyArray, "[KeywordUpdateRequest]", "KeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("delete-a-targeting-keyword", "DELETE", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}", []string{"targeting-keywords", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
@@ -149,14 +149,14 @@ func EndpointSpecs() []EndpointSpec {
 
 		endpoint("get-all-campaign-negative-keywords", "GET", "v5/campaigns/{campaignId}/negativekeywords", []string{"campaign-negative-keywords", "list"}, BodyNone, "", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, qLimitOffset()),
 		endpoint("find-campaign-negative-keywords", "POST", "v5/campaigns/{campaignId}/negativekeywords/find", []string{"campaign-negative-keywords", "find"}, BodyObject, "Selector", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
-		endpoint("get-a-campaign-negative-keyword", "GET", "v5/campaigns/{campaignId}/negativekeywords/{keywordId}", []string{"campaign-negative-keywords", "get"}, BodyNone, "", "NegativeKeywordResponse", []ParamSpec{campaignParam, keywordParam}, nil),
+		endpoint("get-a-campaign-negative-keyword", "GET", "v5/campaigns/{campaignId}/negativekeywords/{keywordId}", []string{"campaign-negative-keywords", "view"}, BodyNone, "", "NegativeKeywordResponse", []ParamSpec{campaignParam, keywordParam}, nil),
 		endpoint("create-campaign-negative-keywords", "POST", "v5/campaigns/{campaignId}/negativekeywords/bulk", []string{"campaign-negative-keywords", "create-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
 		endpoint("update-campaign-negative-keywords", "PUT", "v5/campaigns/{campaignId}/negativekeywords/bulk", []string{"campaign-negative-keywords", "update-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
 		endpoint("delete-campaign-negative-keywords", "POST", "v5/campaigns/{campaignId}/negativekeywords/delete/bulk", []string{"campaign-negative-keywords", "delete-bulk"}, BodyArray, "[int64]", "IntegerResponse", []ParamSpec{campaignParam}, nil),
 
 		endpoint("get-all-ad-group-negative-keywords", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords", []string{"ad-group-negative-keywords", "list"}, BodyNone, "", "NegativeKeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, qLimitOffset()),
 		endpoint("find-ad-group-negative-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/negativekeywords/find", []string{"ad-group-negative-keywords", "find"}, BodyObject, "Selector", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
-		endpoint("get-an-ad-group-negative-keyword", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/{keywordId}", []string{"ad-group-negative-keywords", "get"}, BodyNone, "", "NegativeKeywordResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
+		endpoint("get-an-ad-group-negative-keyword", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/{keywordId}", []string{"ad-group-negative-keywords", "view"}, BodyNone, "", "NegativeKeywordResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
 		endpoint("create-ad-group-negative-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/bulk", []string{"ad-group-negative-keywords", "create-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("update-ad-group-negative-keywords", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/bulk", []string{"ad-group-negative-keywords", "update-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
 		endpoint("delete-ad-group-negative-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/delete/bulk", []string{"ad-group-negative-keywords", "delete-bulk"}, BodyArray, "[int64]", "IntegerResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
@@ -167,10 +167,10 @@ func EndpointSpecs() []EndpointSpec {
 		endpoint("get-all-creatives", "GET", "v5/creatives", []string{"creatives", "list"}, BodyNone, "", "CreativeListResponse", nil, qLimitOffset()),
 		endpoint("create-a-creative", "POST", "v5/creatives", []string{"creatives", "create"}, BodyObject, "(CustomProductPageCreative | DefaultProductPageCreative)", "CreativeResponse", nil, nil),
 		endpoint("find-creatives", "POST", "v5/creatives/find", []string{"creatives", "find"}, BodyObject, "Selector", "CreativeListResponse", nil, nil),
-		endpoint("get-a-creative", "GET", "v5/creatives/{creativeId}", []string{"creatives", "get"}, BodyNone, "", "CreativeResponse", []ParamSpec{creativeParam}, []ParamSpec{q("includeDeletedCreativeSetAssets", "include-deleted-creative-set-assets", ParamBool, false)}),
+		endpoint("get-a-creative", "GET", "v5/creatives/{creativeId}", []string{"creatives", "view"}, BodyNone, "", "CreativeResponse", []ParamSpec{creativeParam}, []ParamSpec{q("includeDeletedCreativeSetAssets", "include-deleted-creative-set-assets", ParamBool, false)}),
 
 		endpoint("find-ad-creative-rejection-reasons", "POST", "v5/product-page-reasons/find", []string{"rejection-reasons", "find"}, BodyObject, "Selector", "ProductPageReasonListResponse", nil, nil),
-		endpoint("gets-a-product-page-reason", "GET", "v5/product-page-reasons/{productPageReasonId}", []string{"rejection-reasons", "get"}, BodyNone, "", "ProductPageReasonResponse", []ParamSpec{reasonParam}, nil),
+		endpoint("gets-a-product-page-reason", "GET", "v5/product-page-reasons/{productPageReasonId}", []string{"rejection-reasons", "view"}, BodyNone, "", "ProductPageReasonResponse", []ParamSpec{reasonParam}, nil),
 
 		endpoint("get-campaign-level-reports", "POST", "v5/reports/campaigns", []string{"reports", "campaigns"}, BodyObject, "ReportingRequest", "ReportingResponseBody", nil, nil),
 		endpoint("get-ad-group-level-reports", "POST", "v5/reports/campaigns/{campaignId}/adgroups", []string{"reports", "ad-groups"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam}, nil),
@@ -182,7 +182,7 @@ func EndpointSpecs() []EndpointSpec {
 
 		endpoint("get-all-impression-share-reports", "GET", "v5/custom-reports", []string{"impression-share-reports", "list"}, BodyNone, "", "CustomReportResponseBody", nil, []ParamSpec{q("field", "field", ParamString, false), {Name: "limit", Flag: "limit", Type: ParamInt, Max: 50}, offsetParam, q("sortOrder", "sort-order", ParamString, false)}),
 		endpoint("impression-share-report", "POST", "v5/custom-reports", []string{"impression-share-reports", "create"}, BodyObject, "CustomReportRequest", "CustomReportResponseBody", nil, nil),
-		endpoint("get-a-single-impression-share-report", "GET", "v5/custom-reports/{reportId}", []string{"impression-share-reports", "get"}, BodyNone, "", "CustomReportResponseBody", []ParamSpec{reportParam}, nil),
+		endpoint("get-a-single-impression-share-report", "GET", "v5/custom-reports/{reportId}", []string{"impression-share-reports", "view"}, BodyNone, "", "CustomReportResponseBody", []ParamSpec{reportParam}, nil),
 	}
 
 	for i := range specs {

--- a/internal/appleads/endpoints.go
+++ b/internal/appleads/endpoints.go
@@ -97,7 +97,7 @@ func endpoint(name, method, path string, commandPath []string, bodyKind BodyKind
 func EndpointSpecs() []EndpointSpec {
 	specs := []EndpointSpec{
 		endpoint("get-user-acl", "GET", "v5/acls", []string{"acls", "list"}, BodyNone, "", "UserAclListResponse", nil, nil),
-		endpoint("get-me-details", "GET", "v5/me", []string{"me", "get"}, BodyNone, "", "MeDetailResponse", nil, nil),
+		endpoint("get-me-details", "GET", "v5/me", []string{"me", "view"}, BodyNone, "", "MeDetailResponse", nil, nil),
 
 		endpoint("search-for-ios-apps", "GET", "v5/search/apps", []string{"apps", "search"}, BodyNone, "", "AppInfoListResponse", nil, []ParamSpec{limitParam, offsetParam, q("query", "query", ParamString, true), q("returnOwnedApps", "return-owned-apps", ParamBool, false)}),
 		endpoint("get-app-details", "GET", "v5/apps/{adamId}", []string{"apps", "get"}, BodyNone, "", "MediaDetailResponse", []ParamSpec{adamIDParam}, nil),

--- a/internal/appleads/endpoints.go
+++ b/internal/appleads/endpoints.go
@@ -1,0 +1,222 @@
+package appleads
+
+import "strings"
+
+// BodyKind describes the JSON body shape accepted by an Apple Ads endpoint.
+type BodyKind string
+
+const (
+	BodyNone   BodyKind = ""
+	BodyObject BodyKind = "object"
+	BodyArray  BodyKind = "array"
+)
+
+// ParamType describes the primitive type of a path or query parameter.
+type ParamType string
+
+const (
+	ParamString ParamType = "string"
+	ParamInt    ParamType = "int"
+	ParamBool   ParamType = "bool"
+)
+
+// ParamSpec describes a documented Apple Ads path or query parameter.
+type ParamSpec struct {
+	Name     string
+	Flag     string
+	Type     ParamType
+	Required bool
+	Max      int
+	Allowed  []string
+}
+
+// EndpointSpec is the single source of truth for the Apple Ads command and
+// client surface.
+type EndpointSpec struct {
+	Name             string
+	Method           string
+	Path             string
+	CommandPath      []string
+	BodyKind         BodyKind
+	BodyType         string
+	ResponseType     string
+	RequiresOrg      bool
+	RequiresConfirm  bool
+	PathParams       []ParamSpec
+	QueryParams      []ParamSpec
+	SupportsPaginate bool
+	DefaultListAlias bool
+}
+
+const maxAppleAdsPageLimit = 1000
+
+var (
+	adamIDParam      = ParamSpec{Name: "adamId", Flag: "adam-id", Type: ParamInt, Required: true}
+	adGroupParam     = ParamSpec{Name: "adgroupId", Flag: "ad-group", Type: ParamInt, Required: true}
+	adParam          = ParamSpec{Name: "adId", Flag: "ad", Type: ParamInt, Required: true}
+	budgetOrderParam = ParamSpec{Name: "boId", Flag: "budget-order", Type: ParamInt, Required: true}
+	campaignParam    = ParamSpec{Name: "campaignId", Flag: "campaign", Type: ParamInt, Required: true}
+	creativeParam    = ParamSpec{Name: "creativeId", Flag: "creative", Type: ParamInt, Required: true}
+	keywordParam     = ParamSpec{Name: "keywordId", Flag: "keyword", Type: ParamInt, Required: true}
+	productPageParam = ParamSpec{Name: "productPageId", Flag: "product-page", Type: ParamString, Required: true}
+	reasonParam      = ParamSpec{Name: "productPageReasonId", Flag: "reason", Type: ParamInt, Required: true}
+	reportParam      = ParamSpec{Name: "reportId", Flag: "report", Type: ParamInt, Required: true}
+
+	limitParam  = ParamSpec{Name: "limit", Flag: "limit", Type: ParamInt, Max: maxAppleAdsPageLimit}
+	offsetParam = ParamSpec{Name: "offset", Flag: "offset", Type: ParamInt}
+)
+
+func q(name, flag string, typ ParamType, required bool) ParamSpec {
+	return ParamSpec{Name: name, Flag: flag, Type: typ, Required: required}
+}
+
+func qAllowed(name, flag string, allowed ...string) ParamSpec {
+	return ParamSpec{Name: name, Flag: flag, Type: ParamString, Allowed: append([]string(nil), allowed...)}
+}
+
+func qLimitOffset() []ParamSpec {
+	return []ParamSpec{limitParam, offsetParam}
+}
+
+func endpoint(name, method, path string, commandPath []string, bodyKind BodyKind, bodyType, responseType string, pathParams []ParamSpec, queryParams []ParamSpec) EndpointSpec {
+	return EndpointSpec{
+		Name:         name,
+		Method:       method,
+		Path:         path,
+		CommandPath:  append([]string(nil), commandPath...),
+		BodyKind:     bodyKind,
+		BodyType:     bodyType,
+		ResponseType: responseType,
+		RequiresOrg:  true,
+		PathParams:   append([]ParamSpec(nil), pathParams...),
+		QueryParams:  append([]ParamSpec(nil), queryParams...),
+	}
+}
+
+// EndpointSpecs returns the current Apple Ads Campaign Management API v5 surface.
+func EndpointSpecs() []EndpointSpec {
+	specs := []EndpointSpec{
+		endpoint("get-user-acl", "GET", "v5/acls", []string{"acls", "list"}, BodyNone, "", "UserAclListResponse", nil, nil),
+		endpoint("get-me-details", "GET", "v5/me", []string{"me", "get"}, BodyNone, "", "MeDetailResponse", nil, nil),
+
+		endpoint("search-for-ios-apps", "GET", "v5/search/apps", []string{"apps", "search"}, BodyNone, "", "AppInfoListResponse", nil, []ParamSpec{limitParam, offsetParam, q("query", "query", ParamString, true), q("returnOwnedApps", "return-owned-apps", ParamBool, false)}),
+		endpoint("get-app-details", "GET", "v5/apps/{adamId}", []string{"apps", "get"}, BodyNone, "", "MediaDetailResponse", []ParamSpec{adamIDParam}, nil),
+		endpoint("get-localized-app-details", "GET", "v5/apps/{adamId}/locale-details", []string{"apps", "localized-details"}, BodyNone, "", "MediaLocaleDetailResponse", []ParamSpec{adamIDParam}, nil),
+		endpoint("find-app-eligibility-records", "POST", "v5/apps/{adamId}/eligibilities/find", []string{"apps", "eligibility", "find"}, BodyObject, "Selector", "EligibilityRecordListResponse", []ParamSpec{adamIDParam}, nil),
+		endpoint("find-app-assets", "POST", "v5/apps/{adamId}/assets/find", []string{"apps", "assets", "find"}, BodyObject, "Selector", "AppAssetListResponse", []ParamSpec{adamIDParam}, nil),
+
+		endpoint("get-product-pages", "GET", "v5/apps/{adamId}/product-pages", []string{"product-pages", "list"}, BodyNone, "", "ProductPageDetailListResponse", []ParamSpec{adamIDParam}, []ParamSpec{q("name", "name", ParamString, false), qAllowed("states", "states", "HIDDEN", "VISIBLE")}),
+		endpoint("get-product-pages-by-identifier", "GET", "v5/apps/{adamId}/product-pages/{productPageId}", []string{"product-pages", "get"}, BodyNone, "", "ProductPageDetailResponse", []ParamSpec{adamIDParam, productPageParam}, nil),
+		endpoint("get-product-page-locales", "GET", "v5/apps/{adamId}/product-pages/{productPageId}/locale-details", []string{"product-pages", "locales", "list"}, BodyNone, "", "ProductPageLocaleDetailListResponse", []ParamSpec{adamIDParam, productPageParam}, []ParamSpec{qAllowed("deviceClasses", "device-classes", "IPAD", "IPHONE"), q("expand", "expand", ParamBool, false), q("languageCodes", "language-codes", ParamString, false), q("languages", "languages", ParamString, false)}),
+		endpoint("get-supported-countries-or-regions", "GET", "v5/countries-or-regions", []string{"product-pages", "countries", "list"}, BodyNone, "", "CountriesOrRegionsListResponse", nil, []ParamSpec{q("countriesOrRegions", "countries-or-regions", ParamString, false)}),
+		endpoint("get-app-preview-device-sizes", "GET", "v5/creativeappmappings/devices", []string{"product-pages", "devices", "list"}, BodyNone, "", "AppPreviewDevicesMappingResponse", nil, nil),
+
+		endpoint("get-all-budget-orders", "GET", "v5/budgetorders", []string{"budget-orders", "list"}, BodyNone, "", "BudgetOrderInfoListResponse", nil, qLimitOffset()),
+		endpoint("create-a-budget-order", "POST", "v5/budgetorders", []string{"budget-orders", "create"}, BodyObject, "BudgetOrderCreate", "BudgetOrderInfoResponse", nil, nil),
+		endpoint("get-a-budget-order", "GET", "v5/budgetorders/{boId}", []string{"budget-orders", "get"}, BodyNone, "", "BudgetOrderInfoResponse", []ParamSpec{budgetOrderParam}, nil),
+		endpoint("update-a-budget-order", "PUT", "v5/budgetorders/{boId}", []string{"budget-orders", "update"}, BodyObject, "BudgetOrderUpdate", "BudgetOrderInfoResponse", []ParamSpec{budgetOrderParam}, nil),
+
+		endpoint("get-all-campaigns", "GET", "v5/campaigns", []string{"campaigns", "list"}, BodyNone, "", "CampaignListResponse", nil, qLimitOffset()),
+		endpoint("create-a-campaign", "POST", "v5/campaigns", []string{"campaigns", "create"}, BodyObject, "Campaign", "CampaignResponse", nil, nil),
+		endpoint("find-campaigns", "POST", "v5/campaigns/find", []string{"campaigns", "find"}, BodyObject, "Selector", "CampaignListResponse", nil, nil),
+		endpoint("delete-a-campaign", "DELETE", "v5/campaigns/{campaignId}", []string{"campaigns", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("get-a-campaign", "GET", "v5/campaigns/{campaignId}", []string{"campaigns", "get"}, BodyNone, "", "CampaignResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("update-a-campaign", "PUT", "v5/campaigns/{campaignId}", []string{"campaigns", "update"}, BodyObject, "UpdateCampaignRequest", "CampaignResponse", []ParamSpec{campaignParam}, nil),
+
+		endpoint("get-all-ad-groups", "GET", "v5/campaigns/{campaignId}/adgroups", []string{"ad-groups", "list"}, BodyNone, "", "AdGroupListResponse", []ParamSpec{campaignParam}, qLimitOffset()),
+		endpoint("create-an-ad-group", "POST", "v5/campaigns/{campaignId}/adgroups", []string{"ad-groups", "create"}, BodyObject, "AdGroup", "AdGroupResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("find-ad-groups", "POST", "v5/campaigns/{campaignId}/adgroups/find", []string{"ad-groups", "find"}, BodyObject, "Selector", "AdGroupListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("find-ad-groups-org", "POST", "v5/adgroups/find", []string{"ad-groups", "find-org"}, BodyObject, "Selector", "AdGroupListResponse", nil, nil),
+		endpoint("delete-an-ad-group", "DELETE", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("get-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "get"}, BodyNone, "", "AdGroupResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("update-an-ad-group", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}", []string{"ad-groups", "update"}, BodyObject, "AdGroupUpdate", "AdGroupResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+
+		endpoint("get-all-ads", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads", []string{"ads", "list"}, BodyNone, "", "AdListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("create-an-ad", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads", []string{"ads", "create"}, BodyObject, "AdCreate", "AdResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("delete-an-ad", "DELETE", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
+		endpoint("get-an-ad", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "get"}, BodyNone, "", "AdResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
+		endpoint("update-an-ad", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/ads/{adId}", []string{"ads", "update"}, BodyObject, "AdUpdate", "AdResponse", []ParamSpec{campaignParam, adGroupParam, adParam}, nil),
+		endpoint("find-ads", "POST", "v5/campaigns/{campaignId}/ads/find", []string{"ads", "find"}, BodyObject, "Selector", "AdListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("find-ads-org", "POST", "v5/ads/find", []string{"ads", "find-org"}, BodyObject, "Selector", "AdListResponse", nil, nil),
+
+		endpoint("get-all-targeting-keywords-in-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords", []string{"targeting-keywords", "list"}, BodyNone, "", "KeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, qLimitOffset()),
+		endpoint("find-targeting-keywords-in-a-campaign", "POST", "v5/campaigns/{campaignId}/adgroups/targetingkeywords/find", []string{"targeting-keywords", "find"}, BodyObject, "Selector", "KeywordListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("get-a-targeting-keyword-in-an-ad-group", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}", []string{"targeting-keywords", "get"}, BodyNone, "", "KeywordResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
+		endpoint("create-targeting-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/bulk", []string{"targeting-keywords", "create-bulk"}, BodyArray, "[Keyword]", "KeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("update-targeting-keywords", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/bulk", []string{"targeting-keywords", "update-bulk"}, BodyArray, "[KeywordUpdateRequest]", "KeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("delete-a-targeting-keyword", "DELETE", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/{keywordId}", []string{"targeting-keywords", "delete"}, BodyNone, "", "VoidResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
+		endpoint("delete-targeting-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/targetingkeywords/delete/bulk", []string{"targeting-keywords", "delete-bulk"}, BodyArray, "[int64]", "IntegerResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+
+		endpoint("get-all-campaign-negative-keywords", "GET", "v5/campaigns/{campaignId}/negativekeywords", []string{"campaign-negative-keywords", "list"}, BodyNone, "", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, qLimitOffset()),
+		endpoint("find-campaign-negative-keywords", "POST", "v5/campaigns/{campaignId}/negativekeywords/find", []string{"campaign-negative-keywords", "find"}, BodyObject, "Selector", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("get-a-campaign-negative-keyword", "GET", "v5/campaigns/{campaignId}/negativekeywords/{keywordId}", []string{"campaign-negative-keywords", "get"}, BodyNone, "", "NegativeKeywordResponse", []ParamSpec{campaignParam, keywordParam}, nil),
+		endpoint("create-campaign-negative-keywords", "POST", "v5/campaigns/{campaignId}/negativekeywords/bulk", []string{"campaign-negative-keywords", "create-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("update-campaign-negative-keywords", "PUT", "v5/campaigns/{campaignId}/negativekeywords/bulk", []string{"campaign-negative-keywords", "update-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("delete-campaign-negative-keywords", "POST", "v5/campaigns/{campaignId}/negativekeywords/delete/bulk", []string{"campaign-negative-keywords", "delete-bulk"}, BodyArray, "[int64]", "IntegerResponse", []ParamSpec{campaignParam}, nil),
+
+		endpoint("get-all-ad-group-negative-keywords", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords", []string{"ad-group-negative-keywords", "list"}, BodyNone, "", "NegativeKeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, qLimitOffset()),
+		endpoint("find-ad-group-negative-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/negativekeywords/find", []string{"ad-group-negative-keywords", "find"}, BodyObject, "Selector", "NegativeKeywordListResponse", []ParamSpec{campaignParam}, nil),
+		endpoint("get-an-ad-group-negative-keyword", "GET", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/{keywordId}", []string{"ad-group-negative-keywords", "get"}, BodyNone, "", "NegativeKeywordResponse", []ParamSpec{campaignParam, adGroupParam, keywordParam}, nil),
+		endpoint("create-ad-group-negative-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/bulk", []string{"ad-group-negative-keywords", "create-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("update-ad-group-negative-keywords", "PUT", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/bulk", []string{"ad-group-negative-keywords", "update-bulk"}, BodyArray, "[NegativeKeyword]", "NegativeKeywordListResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("delete-ad-group-negative-keywords", "POST", "v5/campaigns/{campaignId}/adgroups/{adgroupId}/negativekeywords/delete/bulk", []string{"ad-group-negative-keywords", "delete-bulk"}, BodyArray, "[int64]", "IntegerResponse", []ParamSpec{campaignParam, adGroupParam}, nil),
+
+		endpoint("search-for-geolocations", "GET", "v5/search/geo", []string{"geo", "search"}, BodyNone, "", "SearchEntityListResponse", nil, []ParamSpec{q("countrycode", "country-code", ParamString, false), q("entity", "entity", ParamString, false), limitParam, offsetParam, q("query", "query", ParamString, false)}),
+		endpoint("get-a-list-of-geo-locations", "POST", "v5/search/geo", []string{"geo", "resolve"}, BodyArray, "[GeoRequest]", "SearchEntityListResponse", nil, qLimitOffset()),
+
+		endpoint("get-all-creatives", "GET", "v5/creatives", []string{"creatives", "list"}, BodyNone, "", "CreativeListResponse", nil, qLimitOffset()),
+		endpoint("create-a-creative", "POST", "v5/creatives", []string{"creatives", "create"}, BodyObject, "(CustomProductPageCreative | DefaultProductPageCreative)", "CreativeResponse", nil, nil),
+		endpoint("find-creatives", "POST", "v5/creatives/find", []string{"creatives", "find"}, BodyObject, "Selector", "CreativeListResponse", nil, nil),
+		endpoint("get-a-creative", "GET", "v5/creatives/{creativeId}", []string{"creatives", "get"}, BodyNone, "", "CreativeResponse", []ParamSpec{creativeParam}, []ParamSpec{q("includeDeletedCreativeSetAssets", "include-deleted-creative-set-assets", ParamBool, false)}),
+
+		endpoint("find-ad-creative-rejection-reasons", "POST", "v5/product-page-reasons/find", []string{"rejection-reasons", "find"}, BodyObject, "Selector", "ProductPageReasonListResponse", nil, nil),
+		endpoint("gets-a-product-page-reason", "GET", "v5/product-page-reasons/{productPageReasonId}", []string{"rejection-reasons", "get"}, BodyNone, "", "ProductPageReasonResponse", []ParamSpec{reasonParam}, nil),
+
+		endpoint("get-campaign-level-reports", "POST", "v5/reports/campaigns", []string{"reports", "campaigns"}, BodyObject, "ReportingRequest", "ReportingResponseBody", nil, nil),
+		endpoint("get-ad-group-level-reports", "POST", "v5/reports/campaigns/{campaignId}/adgroups", []string{"reports", "ad-groups"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam}, nil),
+		endpoint("get-keyword-level-reports", "POST", "v5/reports/campaigns/{campaignId}/keywords", []string{"reports", "keywords"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam}, nil),
+		endpoint("get-search-term-level-reports", "POST", "v5/reports/campaigns/{campaignId}/searchterms", []string{"reports", "search-terms"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam}, nil),
+		endpoint("get-ad-level-reports", "POST", "v5/reports/campaigns/{campaignId}/ads", []string{"reports", "ads"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam}, nil),
+		endpoint("get-keyword-level-within-ad-group-reports", "POST", "v5/reports/campaigns/{campaignId}/adgroups/{adgroupId}/keywords", []string{"reports", "ad-group-keywords"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam, adGroupParam}, nil),
+		endpoint("get-search-term-level-within-ad-group-reports", "POST", "v5/reports/campaigns/{campaignId}/adgroups/{adgroupId}/searchterms", []string{"reports", "ad-group-search-terms"}, BodyObject, "ReportingRequest", "ReportingResponseBody", []ParamSpec{campaignParam, adGroupParam}, nil),
+
+		endpoint("get-all-impression-share-reports", "GET", "v5/custom-reports", []string{"impression-share-reports", "list"}, BodyNone, "", "CustomReportResponseBody", nil, []ParamSpec{q("field", "field", ParamString, false), {Name: "limit", Flag: "limit", Type: ParamInt, Max: 50}, offsetParam, q("sortOrder", "sort-order", ParamString, false)}),
+		endpoint("impression-share-report", "POST", "v5/custom-reports", []string{"impression-share-reports", "create"}, BodyObject, "CustomReportRequest", "CustomReportResponseBody", nil, nil),
+		endpoint("get-a-single-impression-share-report", "GET", "v5/custom-reports/{reportId}", []string{"impression-share-reports", "get"}, BodyNone, "", "CustomReportResponseBody", []ParamSpec{reportParam}, nil),
+	}
+
+	for i := range specs {
+		specs[i].RequiresConfirm = specs[i].Method == "DELETE" || strings.Contains(specs[i].Path, "/delete/bulk")
+		specs[i].SupportsPaginate = hasLimitOffset(specs[i].QueryParams)
+		specs[i].DefaultListAlias = len(specs[i].CommandPath) == 2 && specs[i].CommandPath[1] == "list"
+		if specs[i].Name == "get-user-acl" || specs[i].Name == "get-me-details" {
+			specs[i].RequiresOrg = false
+		}
+	}
+	return specs
+}
+
+func hasLimitOffset(params []ParamSpec) bool {
+	hasLimit := false
+	hasOffset := false
+	for _, param := range params {
+		switch param.Name {
+		case "limit":
+			hasLimit = true
+		case "offset":
+			hasOffset = true
+		}
+	}
+	return hasLimit && hasOffset
+}
+
+// EndpointByCommandPath returns a spec by command path.
+func EndpointByCommandPath(path ...string) (EndpointSpec, bool) {
+	joined := strings.Join(path, " ")
+	for _, spec := range EndpointSpecs() {
+		if strings.Join(spec.CommandPath, " ") == joined {
+			return spec, true
+		}
+	}
+	return EndpointSpec{}, false
+}

--- a/internal/appleads/endpoints_test.go
+++ b/internal/appleads/endpoints_test.go
@@ -43,6 +43,7 @@ func TestEndpointSpecsCoverCampaignManagementAPI5Surface(t *testing.T) {
 	}
 
 	for _, path := range []string{
+		"me view",
 		"campaigns list",
 		"ad-groups find-org",
 		"targeting-keywords delete-bulk",
@@ -57,7 +58,7 @@ func TestEndpointSpecsCoverCampaignManagementAPI5Surface(t *testing.T) {
 }
 
 func TestEndpointSpecsAuthenticationAndPaginationMetadata(t *testing.T) {
-	for _, path := range [][]string{{"me", "get"}, {"acls", "list"}} {
+	for _, path := range [][]string{{"me", "view"}, {"acls", "list"}} {
 		spec, ok := EndpointByCommandPath(path...)
 		if !ok {
 			t.Fatalf("missing endpoint %q", strings.Join(path, " "))

--- a/internal/appleads/endpoints_test.go
+++ b/internal/appleads/endpoints_test.go
@@ -1,0 +1,125 @@
+package appleads
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEndpointSpecsCoverCampaignManagementAPI5Surface(t *testing.T) {
+	specs := EndpointSpecs()
+	if got, want := len(specs), 73; got != want {
+		t.Fatalf("EndpointSpecs() count = %d, want %d", got, want)
+	}
+
+	names := map[string]struct{}{}
+	commandPaths := map[string]struct{}{}
+	for _, spec := range specs {
+		if strings.TrimSpace(spec.Name) == "" {
+			t.Fatalf("empty endpoint name in %+v", spec)
+		}
+		if strings.TrimSpace(spec.Method) == "" || strings.TrimSpace(spec.Path) == "" {
+			t.Fatalf("endpoint %q is missing method or path", spec.Name)
+		}
+		if len(spec.CommandPath) == 0 {
+			t.Fatalf("endpoint %q is missing command path", spec.Name)
+		}
+		if _, ok := names[spec.Name]; ok {
+			t.Fatalf("duplicate endpoint name %q", spec.Name)
+		}
+		names[spec.Name] = struct{}{}
+
+		commandPath := strings.Join(spec.CommandPath, " ")
+		if _, ok := commandPaths[commandPath]; ok {
+			t.Fatalf("duplicate command path %q", commandPath)
+		}
+		commandPaths[commandPath] = struct{}{}
+
+		if (spec.Method == "DELETE" || strings.Contains(spec.Path, "/delete/bulk")) && !spec.RequiresConfirm {
+			t.Fatalf("%s %s should require --confirm", spec.Method, spec.Path)
+		}
+		if spec.SupportsPaginate && !hasLimitOffset(spec.QueryParams) {
+			t.Fatalf("%q supports paginate without limit+offset params", spec.Name)
+		}
+	}
+
+	for _, path := range []string{
+		"campaigns list",
+		"ad-groups find-org",
+		"targeting-keywords delete-bulk",
+		"geo resolve",
+		"reports ad-group-search-terms",
+		"impression-share-reports list",
+	} {
+		if _, ok := commandPaths[path]; !ok {
+			t.Fatalf("expected command path %q", path)
+		}
+	}
+}
+
+func TestEndpointSpecsAuthenticationAndPaginationMetadata(t *testing.T) {
+	for _, path := range [][]string{{"me", "get"}, {"acls", "list"}} {
+		spec, ok := EndpointByCommandPath(path...)
+		if !ok {
+			t.Fatalf("missing endpoint %q", strings.Join(path, " "))
+		}
+		if spec.RequiresOrg {
+			t.Fatalf("%q must not require X-AP-Context", strings.Join(path, " "))
+		}
+	}
+
+	campaigns, ok := EndpointByCommandPath("campaigns", "list")
+	if !ok {
+		t.Fatal("missing campaigns list endpoint")
+	}
+	if !campaigns.RequiresOrg {
+		t.Fatal("campaigns list should require org context")
+	}
+	if !campaigns.SupportsPaginate || MaxPageLimit(campaigns) != 1000 {
+		t.Fatalf("campaigns list pagination metadata = supports %t max %d, want true max 1000", campaigns.SupportsPaginate, MaxPageLimit(campaigns))
+	}
+
+	customReports, ok := EndpointByCommandPath("impression-share-reports", "list")
+	if !ok {
+		t.Fatal("missing impression-share-reports list endpoint")
+	}
+	if !customReports.SupportsPaginate || MaxPageLimit(customReports) != 50 {
+		t.Fatalf("custom reports pagination metadata = supports %t max %d, want true max 50", customReports.SupportsPaginate, MaxPageLimit(customReports))
+	}
+
+	reports, ok := EndpointByCommandPath("reports", "campaigns")
+	if !ok {
+		t.Fatal("missing reports campaigns endpoint")
+	}
+	if reports.SupportsPaginate {
+		t.Fatal("reporting request body endpoints must not expose automatic query pagination")
+	}
+}
+
+func TestEndpointSpecsValidatedCSVQueryParameters(t *testing.T) {
+	productPages, ok := EndpointByCommandPath("product-pages", "list")
+	if !ok {
+		t.Fatal("missing product-pages list endpoint")
+	}
+	states := findQueryParam(productPages, "states")
+	if got, want := strings.Join(states.Allowed, ","), "HIDDEN,VISIBLE"; got != want {
+		t.Fatalf("states allowed values = %q, want %q", got, want)
+	}
+
+	locales, ok := EndpointByCommandPath("product-pages", "locales", "list")
+	if !ok {
+		t.Fatal("missing product-pages locales list endpoint")
+	}
+	deviceClasses := findQueryParam(locales, "deviceClasses")
+	if got, want := strings.Join(deviceClasses.Allowed, ","), "IPAD,IPHONE"; got != want {
+		t.Fatalf("deviceClasses allowed values = %q, want %q", got, want)
+	}
+}
+
+func findQueryParam(spec EndpointSpec, name string) ParamSpec {
+	for _, param := range spec.QueryParams {
+		if param.Name == name {
+			return param
+		}
+	}
+	return ParamSpec{}
+}

--- a/internal/appleads/errors.go
+++ b/internal/appleads/errors.go
@@ -1,0 +1,88 @@
+package appleads
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// APIError describes an Apple Ads API error response.
+type APIError struct {
+	StatusCode  int
+	Field       string
+	Message     string
+	MessageCode string
+	Detail      string
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := []string{}
+	if e.StatusCode > 0 {
+		parts = append(parts, fmt.Sprintf("HTTP %d", e.StatusCode))
+	}
+	if strings.TrimSpace(e.MessageCode) != "" {
+		parts = append(parts, e.MessageCode)
+	}
+	if strings.TrimSpace(e.Field) != "" {
+		parts = append(parts, e.Field)
+	}
+	message := strings.TrimSpace(e.Message)
+	if message == "" {
+		message = strings.TrimSpace(e.Detail)
+	}
+	if message == "" {
+		message = http.StatusText(e.StatusCode)
+	}
+	if message != "" {
+		parts = append(parts, message)
+	}
+	if len(parts) == 0 {
+		return "Apple Ads API request failed"
+	}
+	return strings.Join(parts, ": ")
+}
+
+func parseError(body []byte, statusCode int) error {
+	var errResp struct {
+		Error struct {
+			Errors []struct {
+				Field       string `json:"field"`
+				Message     string `json:"message"`
+				MessageCode string `json:"messageCode"`
+			} `json:"errors"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errResp); err == nil && len(errResp.Error.Errors) > 0 {
+		item := errResp.Error.Errors[0]
+		return &APIError{
+			StatusCode:  statusCode,
+			Field:       item.Field,
+			Message:     item.Message,
+			MessageCode: item.MessageCode,
+		}
+	}
+
+	detail := sanitizeErrorBody(body)
+	if detail == "" {
+		detail = http.StatusText(statusCode)
+	}
+	return &APIError{
+		StatusCode: statusCode,
+		Detail:     detail,
+	}
+}
+
+func sanitizeErrorBody(body []byte) string {
+	sanitized := strings.TrimSpace(string(body))
+	if sanitized == "" {
+		return ""
+	}
+	if len(sanitized) > 4096 {
+		sanitized = sanitized[:4096]
+	}
+	return sanitized
+}

--- a/internal/appleads/pagination.go
+++ b/internal/appleads/pagination.go
@@ -71,7 +71,7 @@ func (c *Client) PaginateAll(ctx context.Context, spec EndpointSpec, pathParams 
 		Data: aggregated,
 		Pagination: PageDetail{
 			ItemsPerPage: pageSize,
-			StartIndex:   startOffset,
+			StartIndex:   max(0, startOffset),
 			TotalResults: total,
 		},
 	}

--- a/internal/appleads/pagination.go
+++ b/internal/appleads/pagination.go
@@ -1,0 +1,105 @@
+package appleads
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// PageDetail is the Apple Ads offset pagination envelope.
+type PageDetail struct {
+	ItemsPerPage int `json:"itemsPerPage"`
+	StartIndex   int `json:"startIndex"`
+	TotalResults int `json:"totalResults"`
+}
+
+type paginatedEnvelope struct {
+	Data       []json.RawMessage `json:"data"`
+	Pagination PageDetail        `json:"pagination"`
+}
+
+// PaginateAll fetches all pages for an offset-paginated endpoint.
+func (c *Client) PaginateAll(ctx context.Context, spec EndpointSpec, pathParams map[string]string, query url.Values, startOffset, pageSize int, body json.RawMessage) (RawResponse, error) {
+	maxLimit := MaxPageLimit(spec)
+	if pageSize <= 0 {
+		pageSize = maxLimit
+	}
+	if pageSize > maxLimit {
+		pageSize = maxLimit
+	}
+
+	offset := startOffset
+	if offset < 0 {
+		offset = 0
+	}
+	var aggregated []json.RawMessage
+	total := -1
+	for {
+		pageQuery := cloneValues(query)
+		pageQuery.Set("limit", strconv.Itoa(pageSize))
+		pageQuery.Set("offset", strconv.Itoa(offset))
+		raw, err := c.Do(ctx, spec, pathParams, pageQuery, body)
+		if err != nil {
+			return nil, err
+		}
+		var page paginatedEnvelope
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return nil, fmt.Errorf("parse paginated response: %w", err)
+		}
+		aggregated = append(aggregated, page.Data...)
+		itemsPerPage := page.Pagination.ItemsPerPage
+		if itemsPerPage <= 0 {
+			itemsPerPage = len(page.Data)
+		}
+		total = page.Pagination.TotalResults
+		if len(page.Data) == 0 {
+			break
+		}
+		nextOffset := page.Pagination.StartIndex + itemsPerPage
+		if total >= 0 && nextOffset >= total {
+			break
+		}
+		if nextOffset <= offset {
+			nextOffset = offset + len(page.Data)
+		}
+		offset = nextOffset
+	}
+
+	out := paginatedEnvelope{
+		Data: aggregated,
+		Pagination: PageDetail{
+			ItemsPerPage: pageSize,
+			StartIndex:   startOffset,
+			TotalResults: total,
+		},
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return RawResponse(data), nil
+}
+
+// MaxPageLimit returns the endpoint-specific maximum page size.
+func MaxPageLimit(spec EndpointSpec) int {
+	maxLimit := maxAppleAdsPageLimit
+	for _, param := range spec.QueryParams {
+		if param.Name == "limit" && param.Max > 0 {
+			maxLimit = param.Max
+			break
+		}
+	}
+	return maxLimit
+}
+
+func cloneValues(values url.Values) url.Values {
+	cloned := url.Values{}
+	for key, items := range values {
+		for _, item := range items {
+			cloned.Add(key, item)
+		}
+	}
+	return cloned
+}

--- a/internal/cli/ads/api.go
+++ b/internal/cli/ads/api.go
@@ -60,6 +60,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			methodValue := strings.ToUpper(strings.TrimSpace(*method))
 			switch methodValue {
 			case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete:

--- a/internal/cli/ads/api.go
+++ b/internal/cli/ads/api.go
@@ -106,13 +106,21 @@ func rawRequestRequiresOrg(pathValue string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("--path must be a valid URL or v5 path: %w", err)
 	}
-	pathOnly := strings.TrimPrefix(trimmed, "/")
 	if parsed.IsAbs() {
 		if parsed.Scheme != "https" || parsed.Host != "api.searchads.apple.com" || !strings.HasPrefix(parsed.Path, "/api/v5/") {
 			return false, fmt.Errorf("--path must be an Apple Ads v5 URL")
 		}
-		pathOnly = strings.TrimPrefix(parsed.Path, "/api/")
+		pathOnly := strings.TrimPrefix(parsed.Path, "/api/")
+		return rawPathRequiresOrg(pathOnly)
 	}
+	pathOnly := strings.TrimPrefix(parsed.Path, "/")
+	if pathOnly == "" {
+		pathOnly = strings.TrimPrefix(trimmed, "/")
+	}
+	return rawPathRequiresOrg(pathOnly)
+}
+
+func rawPathRequiresOrg(pathOnly string) (bool, error) {
 	if !strings.HasPrefix(pathOnly, "v5/") {
 		return false, fmt.Errorf("--path must start with v5/")
 	}

--- a/internal/cli/ads/api.go
+++ b/internal/cli/ads/api.go
@@ -1,0 +1,123 @@
+package ads
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// APICommand returns the raw Apple Ads API request command.
+func APICommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads api", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "api",
+		ShortUsage: "asc ads api <subcommand> [flags]",
+		ShortHelp:  "Make raw Apple Ads API requests.",
+		LongHelp: `Make raw Apple Ads API requests.
+
+Examples:
+  asc ads api request --method GET --path v5/campaigns --org "123456"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			APIRequestCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func APIRequestCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads api request", flag.ExitOnError)
+	method := fs.String("method", "GET", "HTTP method: GET, POST, PUT, DELETE")
+	path := fs.String("path", "", "Relative v5 path or Apple Ads API URL")
+	file := fs.String("file", "", "Path to JSON request payload")
+	confirm := fs.Bool("confirm", false, "Confirm destructive DELETE requests")
+	common := commonFlags{
+		AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile"),
+		Org:        fs.String("org", "", "Apple Ads organization ID (or ASC_ADS_ORG_ID env)"),
+	}
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "request",
+		ShortUsage: "asc ads api request --method METHOD --path v5/... [flags]",
+		ShortHelp:  "Make a raw Apple Ads API request.",
+		LongHelp: `Make a raw Apple Ads API request.
+
+Examples:
+  asc ads api request --method GET --path v5/campaigns --org "123456"
+  asc ads api request --method POST --path v5/campaigns/find --file selector.json --org "123456"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			methodValue := strings.ToUpper(strings.TrimSpace(*method))
+			switch methodValue {
+			case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete:
+			default:
+				return shared.UsageError("--method must be one of: GET, POST, PUT, DELETE")
+			}
+			pathValue := strings.TrimSpace(*path)
+			if pathValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --path is required")
+				return flag.ErrHelp
+			}
+			if methodValue == http.MethodDelete && !*confirm {
+				return shared.UsageError("--confirm is required")
+			}
+			requiresOrg, err := rawRequestRequiresOrg(pathValue)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			var payload json.RawMessage
+			if strings.TrimSpace(*file) != "" {
+				payload, err = shared.ReadJSONFilePayloadKind(*file, shared.JSONPayloadAny)
+				if err != nil {
+					return fmt.Errorf("ads api request: %w", err)
+				}
+			}
+			client, err := resolveClient(ctx, common, requiresOrg)
+			if err != nil {
+				return fmt.Errorf("ads api request: %w", err)
+			}
+			requestCtx, cancel := requestContext(ctx)
+			defer cancel()
+			resp, err := client.Request(requestCtx, methodValue, pathValue, nil, payload, requiresOrg)
+			if err != nil {
+				return fmt.Errorf("ads api request: %w", err)
+			}
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func rawRequestRequiresOrg(pathValue string) (bool, error) {
+	trimmed := strings.TrimSpace(pathValue)
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return false, fmt.Errorf("--path must be a valid URL or v5 path: %w", err)
+	}
+	pathOnly := strings.TrimPrefix(trimmed, "/")
+	if parsed.IsAbs() {
+		if parsed.Scheme != "https" || parsed.Host != "api.searchads.apple.com" || !strings.HasPrefix(parsed.Path, "/api/v5/") {
+			return false, fmt.Errorf("--path must be an Apple Ads v5 URL")
+		}
+		pathOnly = strings.TrimPrefix(parsed.Path, "/api/")
+	}
+	if !strings.HasPrefix(pathOnly, "v5/") {
+		return false, fmt.Errorf("--path must start with v5/")
+	}
+	if strings.Contains(pathOnly, "..") {
+		return false, fmt.Errorf("--path must not contain path traversal")
+	}
+	return pathOnly != "v5/me" && pathOnly != "v5/acls", nil
+}

--- a/internal/cli/ads/args.go
+++ b/internal/cli/ads/args.go
@@ -1,0 +1,14 @@
+package ads
+
+import (
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func rejectUnexpectedArgs(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+}

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -98,7 +98,7 @@ Examples:
 				return shared.UsageError("--skip-validation and --network are mutually exclusive")
 			}
 			if *local && !*bypassKeychain && !appleads.ShouldBypassKeychain() {
-				return shared.UsageError("--local requires --bypass-keychain or ASC_ADS_BYPASS_KEYCHAIN set to 1/true/yes/on")
+				return shared.UsageError("--local requires --bypass-keychain or ASC_ADS_BYPASS_KEYCHAIN set to 1/true/yes/y/on")
 			}
 			if !*skipValidation {
 				if err := authsvc.ValidateKeyFile(*privateKey); err != nil {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -359,8 +359,6 @@ Examples:
 func AuthDoctorCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("ads auth doctor", flag.ExitOnError)
 	output := shared.BindOutputFlagsWithAllowed(fs, "output", "text", "Output format: text, json", "text", "json")
-	fix := fs.Bool("fix", false, "Attempt to fix issues where possible")
-	confirm := fs.Bool("confirm", false, "Confirm applying fixes")
 	return &ffcli.Command{
 		Name:       "doctor",
 		ShortUsage: "asc ads auth doctor [flags]",
@@ -373,9 +371,6 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if *fix && !*confirm {
-				return shared.UsageError("--fix requires --confirm")
-			}
 			credentials, err := appleads.ListCredentials()
 			checks := []doctorCheck{}
 			if err != nil {
@@ -416,7 +411,7 @@ type doctorCheck struct {
 
 func AuthLogoutCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("ads auth logout", flag.ExitOnError)
-	all := fs.Bool("all", false, "Remove all stored Apple Ads credentials (default)")
+	all := fs.Bool("all", false, "Remove all stored Apple Ads credentials")
 	name := fs.String("name", "", "Remove a named Apple Ads credential")
 	return &ffcli.Command{
 		Name:       "logout",
@@ -425,7 +420,6 @@ func AuthLogoutCommand() *ffcli.Command {
 		LongHelp: `Remove stored Apple Ads credentials.
 
 Examples:
-  asc ads auth logout
   asc ads auth logout --all
   asc ads auth logout --name "Ads"`,
 		FlagSet:   fs,
@@ -437,6 +431,9 @@ Examples:
 			}
 			if trimmedName != "" && *all {
 				return shared.UsageError("--all and --name are mutually exclusive")
+			}
+			if trimmedName == "" && !*all {
+				return shared.UsageError("provide --name or --all")
 			}
 			if trimmedName != "" {
 				if err := appleads.RemoveCredentials(trimmedName); err != nil {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -117,7 +117,7 @@ Examples:
 				}
 				requestCtx, cancel := requestContext(ctx)
 				defer cancel()
-				spec, _ := appleads.EndpointByCommandPath("me", "get")
+				spec, _ := appleads.EndpointByCommandPath("me", "view")
 				if _, err := client.Do(requestCtx, spec, nil, nil, nil); err != nil {
 					return fmt.Errorf("ads auth login: network validation failed: %w", err)
 				}
@@ -192,7 +192,7 @@ Examples:
 					client, err := appleads.NewClient(cred.Credentials)
 					if err == nil {
 						requestCtx, cancel := requestContext(ctx)
-						spec, _ := appleads.EndpointByCommandPath("me", "get")
+						spec, _ := appleads.EndpointByCommandPath("me", "view")
 						_, err = client.Do(requestCtx, spec, nil, nil, nil)
 						cancel()
 					}

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -412,6 +412,7 @@ type doctorCheck struct {
 func AuthLogoutCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("ads auth logout", flag.ExitOnError)
 	all := fs.Bool("all", false, "Remove all stored Apple Ads credentials")
+	confirm := fs.Bool("confirm", false, "Confirm removal of all Apple Ads credentials")
 	name := fs.String("name", "", "Remove a named Apple Ads credential")
 	return &ffcli.Command{
 		Name:       "logout",
@@ -420,7 +421,7 @@ func AuthLogoutCommand() *ffcli.Command {
 		LongHelp: `Remove stored Apple Ads credentials.
 
 Examples:
-  asc ads auth logout --all
+  asc ads auth logout --all --confirm
   asc ads auth logout --name "Ads"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -434,6 +435,9 @@ Examples:
 			}
 			if trimmedName == "" && !*all {
 				return shared.UsageError("provide --name or --all")
+			}
+			if *all && !*confirm {
+				return shared.UsageError("--all requires --confirm")
 			}
 			if trimmedName != "" {
 				if err := appleads.RemoveCredentials(trimmedName); err != nil {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -1,0 +1,455 @@
+package ads
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	authsvc "github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+// AuthCommand returns the Apple Ads auth command group.
+func AuthCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "auth",
+		ShortUsage: "asc ads auth <subcommand> [flags]",
+		ShortHelp:  "Manage Apple Ads API credentials.",
+		LongHelp: `Manage Apple Ads API credentials.
+
+Apple Ads uses OAuth client credentials and separate Apple Ads API keys.
+
+Examples:
+  asc ads auth login --name "Ads" --client-id "SEARCHADS..." --team-id "SEARCHADS..." --key-id "KEY_ID" --private-key ./private-key.pem
+  asc ads auth status
+  asc ads auth token --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AuthLoginCommand(),
+			AuthStatusCommand(),
+			AuthSwitchCommand(),
+			AuthTokenCommand(),
+			AuthDoctorCommand(),
+			AuthLogoutCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func AuthLoginCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth login", flag.ExitOnError)
+	name := fs.String("name", "", "Friendly name for this Apple Ads key")
+	clientID := fs.String("client-id", "", "Apple Ads OAuth client ID")
+	teamID := fs.String("team-id", "", "Apple Ads OAuth team ID")
+	keyID := fs.String("key-id", "", "Apple Ads API key ID")
+	privateKey := fs.String("private-key", "", "Path to Apple Ads EC private key PEM")
+	org := fs.String("org", "", "Default Apple Ads organization ID")
+	bypassKeychain := fs.Bool("bypass-keychain", false, "Store credentials in config.json instead of keychain")
+	local := fs.Bool("local", false, "When bypassing keychain, write to ./.asc/config.json")
+	network := fs.Bool("network", false, "Validate credentials with Apple Ads API")
+	skipValidation := fs.Bool("skip-validation", false, "Skip private key and network validation checks")
+
+	return &ffcli.Command{
+		Name:       "login",
+		ShortUsage: "asc ads auth login [flags]",
+		ShortHelp:  "Register and store Apple Ads API credentials.",
+		LongHelp: `Register and store Apple Ads API credentials.
+
+Examples:
+  asc ads auth login --name "Ads" --client-id "SEARCHADS..." --team-id "SEARCHADS..." --key-id "KEY_ID" --private-key ./private-key.pem --org "123456"
+  asc ads auth login --bypass-keychain --local --name "Ads" --client-id "SEARCHADS..." --team-id "SEARCHADS..." --key-id "KEY_ID" --private-key ./private-key.pem`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*name) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --name is required")
+				return flag.ErrHelp
+			}
+			if strings.TrimSpace(*clientID) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --client-id is required")
+				return flag.ErrHelp
+			}
+			if strings.TrimSpace(*teamID) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --team-id is required")
+				return flag.ErrHelp
+			}
+			if strings.TrimSpace(*keyID) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --key-id is required")
+				return flag.ErrHelp
+			}
+			if strings.TrimSpace(*privateKey) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --private-key is required")
+				return flag.ErrHelp
+			}
+			if *skipValidation && *network {
+				return shared.UsageError("--skip-validation and --network are mutually exclusive")
+			}
+			if *local && !*bypassKeychain && !appleads.ShouldBypassKeychain() {
+				return shared.UsageError("--local requires --bypass-keychain or ASC_ADS_BYPASS_KEYCHAIN set to 1/true/yes/on")
+			}
+			if !*skipValidation {
+				if err := authsvc.ValidateKeyFile(*privateKey); err != nil {
+					return fmt.Errorf("ads auth login: invalid private key: %w", err)
+				}
+			}
+
+			credentials := appleads.Credentials{
+				ClientID:       *clientID,
+				TeamID:         *teamID,
+				KeyID:          *keyID,
+				PrivateKeyPath: *privateKey,
+				OrgID:          *org,
+			}
+			if *network {
+				client, err := appleads.NewClient(credentials)
+				if err != nil {
+					return fmt.Errorf("ads auth login: %w", err)
+				}
+				requestCtx, cancel := requestContext(ctx)
+				defer cancel()
+				spec, _ := appleads.EndpointByCommandPath("me", "get")
+				if _, err := client.Do(requestCtx, spec, nil, nil, nil); err != nil {
+					return fmt.Errorf("ads auth login: network validation failed: %w", err)
+				}
+			}
+
+			if *bypassKeychain || appleads.ShouldBypassKeychain() {
+				if *local {
+					path, err := config.LocalPath()
+					if err != nil {
+						return fmt.Errorf("ads auth login: %w", err)
+					}
+					if err := appleads.StoreCredentialsConfigAt(*name, credentials, path); err != nil {
+						return fmt.Errorf("ads auth login: failed to store credentials: %w", err)
+					}
+				} else if err := appleads.StoreCredentialsConfig(*name, credentials); err != nil {
+					return fmt.Errorf("ads auth login: failed to store credentials: %w", err)
+				}
+			} else if err := appleads.StoreCredentials(*name, credentials); err != nil {
+				return fmt.Errorf("ads auth login: failed to store credentials: %w", err)
+			}
+			fmt.Printf("Successfully registered Apple Ads API key '%s'\n", strings.TrimSpace(*name))
+			return nil
+		},
+	}
+}
+
+func AuthStatusCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth status", flag.ExitOnError)
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "table", "Output format: table, json", "table", "json")
+	verbose := fs.Bool("verbose", false, "Show detailed storage information")
+	validate := fs.Bool("validate", false, "Validate stored credentials via network")
+
+	return &ffcli.Command{
+		Name:       "status",
+		ShortUsage: "asc ads auth status [flags]",
+		ShortHelp:  "Show Apple Ads authentication status.",
+		LongHelp: `Show Apple Ads authentication status.
+
+Examples:
+  asc ads auth status
+  asc ads auth status --output json
+  asc ads auth status --verbose
+  asc ads auth status --validate`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			normalized, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "table", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			credentials, err := appleads.ListCredentials()
+			if err != nil {
+				return fmt.Errorf("ads auth status: %w", err)
+			}
+			rows := make([]adsAuthStatusRow, 0, len(credentials))
+			failures := 0
+			for _, cred := range credentials {
+				row := adsAuthStatusRow{
+					Name:      cred.Name,
+					ClientID:  cred.ClientID,
+					TeamID:    cred.TeamID,
+					KeyID:     cred.KeyID,
+					OrgID:     cred.OrgID,
+					Default:   cred.IsDefault,
+					Source:    cred.Source,
+					Validated: !*validate,
+				}
+				if *verbose {
+					row.SourcePath = cred.SourcePath
+				}
+				if *validate {
+					client, err := appleads.NewClient(cred.Credentials)
+					if err == nil {
+						requestCtx, cancel := requestContext(ctx)
+						spec, _ := appleads.EndpointByCommandPath("me", "get")
+						_, err = client.Do(requestCtx, spec, nil, nil, nil)
+						cancel()
+					}
+					if err != nil {
+						failures++
+						row.Validated = false
+						row.Error = err.Error()
+					} else {
+						row.Validated = true
+					}
+				}
+				rows = append(rows, row)
+			}
+			result := adsAuthStatusOutput{
+				Storage:     storageDescription(),
+				Credentials: rows,
+			}
+			if normalized == "json" {
+				if err := shared.PrintOutput(result, "json", *output.Pretty); err != nil {
+					return err
+				}
+			} else {
+				printStatusTable(result)
+			}
+			if failures > 0 {
+				return shared.NewReportedError(fmt.Errorf("ads auth status: validation failed for %d credential(s)", failures))
+			}
+			return nil
+		},
+	}
+}
+
+type adsAuthStatusOutput struct {
+	Storage     string             `json:"storage"`
+	Credentials []adsAuthStatusRow `json:"credentials"`
+}
+
+type adsAuthStatusRow struct {
+	Name       string `json:"name"`
+	ClientID   string `json:"client_id"`
+	TeamID     string `json:"team_id"`
+	KeyID      string `json:"key_id"`
+	OrgID      string `json:"org_id,omitempty"`
+	Default    bool   `json:"default"`
+	Source     string `json:"source"`
+	SourcePath string `json:"source_path,omitempty"`
+	Validated  bool   `json:"validated"`
+	Error      string `json:"error,omitempty"`
+}
+
+func printStatusTable(result adsAuthStatusOutput) {
+	fmt.Printf("Credential storage: %s\n\n", result.Storage)
+	if len(result.Credentials) == 0 {
+		fmt.Println("No Apple Ads credentials stored. Run 'asc ads auth login' to get started.")
+		return
+	}
+	for _, cred := range result.Credentials {
+		defaultMarker := ""
+		if cred.Default {
+			defaultMarker = " (default)"
+		}
+		fmt.Printf("%s%s\n", cred.Name, defaultMarker)
+		fmt.Printf("  Client ID: %s\n", cred.ClientID)
+		fmt.Printf("  Team ID: %s\n", cred.TeamID)
+		fmt.Printf("  Key ID: %s\n", cred.KeyID)
+		if cred.OrgID != "" {
+			fmt.Printf("  Org ID: %s\n", cred.OrgID)
+		}
+		fmt.Printf("  Source: %s\n", cred.Source)
+		if cred.SourcePath != "" {
+			fmt.Printf("  Source path: %s\n", cred.SourcePath)
+		}
+		if cred.Error != "" {
+			fmt.Printf("  Validation: failed: %s\n", cred.Error)
+		} else if cred.Validated {
+			fmt.Println("  Validation: ok")
+		}
+	}
+}
+
+func storageDescription() string {
+	if appleads.ShouldBypassKeychain() {
+		return "Config File"
+	}
+	return "System Keychain"
+}
+
+func AuthSwitchCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth switch", flag.ExitOnError)
+	name := fs.String("name", "", "Apple Ads profile name")
+	return &ffcli.Command{
+		Name:       "switch",
+		ShortUsage: "asc ads auth switch --name NAME",
+		ShortHelp:  "Switch the default Apple Ads profile.",
+		LongHelp: `Switch the default Apple Ads profile.
+
+Examples:
+  asc ads auth switch --name "Ads"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*name) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --name is required")
+				return flag.ErrHelp
+			}
+			if err := appleads.SetDefaultCredentials(*name); err != nil {
+				return fmt.Errorf("ads auth switch: %w", err)
+			}
+			fmt.Printf("Default Apple Ads profile set to '%s'\n", strings.TrimSpace(*name))
+			return nil
+		},
+	}
+}
+
+func AuthTokenCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth token", flag.ExitOnError)
+	common := commonFlags{AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile")}
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "text", "Output format: text, json", "text", "json")
+	confirm := fs.Bool("confirm", false, "Confirm printing a sensitive access token")
+	return &ffcli.Command{
+		Name:       "token",
+		ShortUsage: "asc ads auth token --confirm [flags]",
+		ShortHelp:  "Print an Apple Ads access token.",
+		LongHelp: `Print an Apple Ads access token.
+
+Examples:
+  asc ads auth token --confirm
+  asc ads auth token --confirm --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if !*confirm {
+				return shared.UsageError("--confirm is required")
+			}
+			credentials, err := resolveCredentials(common)
+			if err != nil {
+				return fmt.Errorf("ads auth token: %w", err)
+			}
+			client, err := appleads.NewClient(credentials)
+			if err != nil {
+				return fmt.Errorf("ads auth token: %w", err)
+			}
+			requestCtx, cancel := requestContext(ctx)
+			defer cancel()
+			token, err := client.AccessToken(requestCtx)
+			if err != nil {
+				return fmt.Errorf("ads auth token: %w", err)
+			}
+			normalized, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "text", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if normalized == "json" {
+				return shared.PrintOutput(struct {
+					AccessToken string `json:"access_token"`
+				}{AccessToken: token}, "json", *output.Pretty)
+			}
+			fmt.Println(token)
+			return nil
+		},
+	}
+}
+
+func AuthDoctorCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth doctor", flag.ExitOnError)
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "text", "Output format: text, json", "text", "json")
+	fix := fs.Bool("fix", false, "Attempt to fix issues where possible")
+	confirm := fs.Bool("confirm", false, "Confirm applying fixes")
+	return &ffcli.Command{
+		Name:       "doctor",
+		ShortUsage: "asc ads auth doctor [flags]",
+		ShortHelp:  "Diagnose Apple Ads authentication configuration.",
+		LongHelp: `Diagnose Apple Ads authentication configuration.
+
+Examples:
+  asc ads auth doctor
+  asc ads auth doctor --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if *fix && !*confirm {
+				return shared.UsageError("--fix requires --confirm")
+			}
+			credentials, err := appleads.ListCredentials()
+			checks := []doctorCheck{}
+			if err != nil {
+				checks = append(checks, doctorCheck{Status: "fail", Message: err.Error()})
+			} else if len(credentials) == 0 {
+				checks = append(checks, doctorCheck{Status: "warn", Message: "No Apple Ads credentials stored"})
+			} else {
+				checks = append(checks, doctorCheck{Status: "ok", Message: fmt.Sprintf("%d Apple Ads credential(s) found", len(credentials))})
+			}
+			if os.Getenv("ASC_ADS_ACCESS_TOKEN") != "" {
+				checks = append(checks, doctorCheck{Status: "info", Message: "ASC_ADS_ACCESS_TOKEN is set"})
+			}
+			result := doctorReport{Checks: checks}
+			normalized, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "text", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if normalized == "json" {
+				return shared.PrintOutput(result, "json", *output.Pretty)
+			}
+			fmt.Println("Apple Ads Auth Doctor")
+			for _, check := range checks {
+				fmt.Printf("  [%s] %s\n", strings.ToUpper(check.Status), check.Message)
+			}
+			return nil
+		},
+	}
+}
+
+type doctorReport struct {
+	Checks []doctorCheck `json:"checks"`
+}
+
+type doctorCheck struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+func AuthLogoutCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth logout", flag.ExitOnError)
+	all := fs.Bool("all", false, "Remove all stored Apple Ads credentials (default)")
+	name := fs.String("name", "", "Remove a named Apple Ads credential")
+	return &ffcli.Command{
+		Name:       "logout",
+		ShortUsage: "asc ads auth logout [flags]",
+		ShortHelp:  "Remove stored Apple Ads credentials.",
+		LongHelp: `Remove stored Apple Ads credentials.
+
+Examples:
+  asc ads auth logout
+  asc ads auth logout --all
+  asc ads auth logout --name "Ads"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			trimmedName := strings.TrimSpace(*name)
+			if trimmedName == "" && *name != "" {
+				return shared.UsageError("--name cannot be blank")
+			}
+			if trimmedName != "" && *all {
+				return shared.UsageError("--all and --name are mutually exclusive")
+			}
+			if trimmedName != "" {
+				if err := appleads.RemoveCredentials(trimmedName); err != nil {
+					return fmt.Errorf("ads auth logout: %w", err)
+				}
+				fmt.Printf("Successfully removed Apple Ads credential '%s'\n", trimmedName)
+				return nil
+			}
+			if err := appleads.RemoveAllCredentials(); err != nil {
+				return fmt.Errorf("ads auth logout: %w", err)
+			}
+			fmt.Println("Successfully removed Apple Ads credentials")
+			return nil
+		},
+	}
+}

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -71,6 +71,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if strings.TrimSpace(*name) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
 				return flag.ErrHelp
@@ -164,6 +167,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			normalized, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "table", "json")
 			if err != nil {
 				return shared.UsageError(err.Error())
@@ -294,6 +300,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if strings.TrimSpace(*name) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
 				return flag.ErrHelp
@@ -324,6 +333,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if !*confirm {
 				return shared.UsageError("--confirm is required")
 			}
@@ -371,6 +383,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			credentials, err := appleads.ListCredentials()
 			checks := []doctorCheck{}
 			if err != nil {
@@ -426,6 +441,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			trimmedName := strings.TrimSpace(*name)
 			if trimmedName == "" && *name != "" {
 				return shared.UsageError("--name cannot be blank")

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -18,8 +18,9 @@ import (
 )
 
 type endpointFlagValues struct {
-	common commonFlags
-	output shared.OutputFlags
+	common  commonFlags
+	output  shared.OutputFlags
+	flagSet *flag.FlagSet
 
 	file     *string
 	confirm  *bool
@@ -185,6 +186,7 @@ func bindEndpointFlags(spec appleads.EndpointSpec, flagSetName string) (*flag.Fl
 			AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile"),
 		},
 		output:       shared.BindOutputFlags(fs),
+		flagSet:      fs,
 		pathStrings:  map[string]*string{},
 		queryStrings: map[string]*string{},
 		queryInts:    map[string]*int{},
@@ -297,9 +299,13 @@ func collectQuery(spec appleads.EndpointSpec, flags endpointFlagValues) (url.Val
 		switch param.Type {
 		case appleads.ParamInt:
 			raw := intValue(flags.queryInts[param.Name])
+			provided := flagProvided(flags.flagSet, param.Flag)
 			if raw == 0 {
 				if param.Required {
 					return nil, fmt.Errorf("--%s is required", param.Flag)
+				}
+				if provided && param.Name == "limit" {
+					return nil, fmt.Errorf("--limit must be between 1 and %d", appleads.MaxPageLimit(spec))
 				}
 				continue
 			}
@@ -332,6 +338,19 @@ func collectQuery(spec appleads.EndpointSpec, flags endpointFlagValues) (url.Val
 		}
 	}
 	return query, nil
+}
+
+func flagProvided(fs *flag.FlagSet, name string) bool {
+	if fs == nil {
+		return false
+	}
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			provided = true
+		}
+	})
+	return provided
 }
 
 func validateAllowed(param appleads.ParamSpec, raw string) error {

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -276,6 +276,13 @@ func collectPathParams(spec appleads.EndpointSpec, flags endpointFlagValues) (ma
 		if param.Required && value == "" {
 			return nil, fmt.Errorf("--%s is required", param.Flag)
 		}
+		if value != "" && param.Type == appleads.ParamInt {
+			if parsed, err := strconv.ParseInt(value, 10, 64); err != nil {
+				return nil, fmt.Errorf("--%s must be an integer", param.Flag)
+			} else if parsed < 0 {
+				return nil, fmt.Errorf("--%s must be >= 0", param.Flag)
+			}
+		}
 		params[param.Name] = value
 	}
 	return params, nil

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -1,0 +1,369 @@
+package ads
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type endpointFlagValues struct {
+	common commonFlags
+	output shared.OutputFlags
+
+	file     *string
+	confirm  *bool
+	paginate *bool
+
+	pathStrings  map[string]*string
+	queryStrings map[string]*string
+	queryInts    map[string]*int
+	queryBools   map[string]*bool
+}
+
+type commandNode struct {
+	name     string
+	children map[string]*commandNode
+	spec     *appleads.EndpointSpec
+}
+
+func endpointCommands() []*ffcli.Command {
+	root := &commandNode{children: map[string]*commandNode{}}
+	for _, spec := range appleads.EndpointSpecs() {
+		addSpec(root, spec)
+	}
+	commands := make([]*ffcli.Command, 0, len(root.children))
+	for _, name := range sortedChildNames(root) {
+		commands = append(commands, buildNodeCommand(root.children[name], nil))
+	}
+	return commands
+}
+
+func addSpec(root *commandNode, spec appleads.EndpointSpec) {
+	current := root
+	for index, part := range spec.CommandPath {
+		if current.children == nil {
+			current.children = map[string]*commandNode{}
+		}
+		child := current.children[part]
+		if child == nil {
+			child = &commandNode{name: part, children: map[string]*commandNode{}}
+			current.children[part] = child
+		}
+		current = child
+		if spec.DefaultListAlias && index == 0 {
+			specCopy := spec
+			current.spec = &specCopy
+		}
+	}
+	specCopy := spec
+	current.spec = &specCopy
+}
+
+func buildNodeCommand(node *commandNode, parentPath []string) *ffcli.Command {
+	path := append(append([]string(nil), parentPath...), node.name)
+	var flags endpointFlagValues
+	var fs *flag.FlagSet
+	if node.spec != nil {
+		fs, flags = bindEndpointFlags(*node.spec, strings.Join(path, " "))
+	} else {
+		fs = flag.NewFlagSet(strings.Join(path, " "), flag.ExitOnError)
+	}
+
+	subcommands := []*ffcli.Command{}
+	for _, name := range sortedChildNames(node) {
+		subcommands = append(subcommands, buildNodeCommand(node.children[name], path))
+	}
+
+	command := &ffcli.Command{
+		Name:        node.name,
+		ShortUsage:  "asc ads " + strings.Join(path, " ") + " [flags]",
+		ShortHelp:   endpointShortHelp(node),
+		LongHelp:    endpointLongHelp(node, path),
+		FlagSet:     fs,
+		UsageFunc:   shared.DefaultUsageFunc,
+		Subcommands: subcommands,
+	}
+	if node.spec != nil {
+		spec := *node.spec
+		command.Exec = func(ctx context.Context, args []string) error {
+			return executeEndpoint(ctx, spec, flags)
+		}
+	}
+	return command
+}
+
+func sortedChildNames(node *commandNode) []string {
+	names := make([]string, 0, len(node.children))
+	for name := range node.children {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func endpointShortHelp(node *commandNode) string {
+	if node.spec == nil {
+		return "Manage Apple Ads " + strings.ReplaceAll(node.name, "-", " ") + "."
+	}
+	return sentenceFromEndpointName(node.spec.Name)
+}
+
+func endpointLongHelp(node *commandNode, path []string) string {
+	if node.spec == nil {
+		return fmt.Sprintf("Manage Apple Ads %s.\n\nExamples:\n  asc ads %s --help", strings.ReplaceAll(node.name, "-", " "), strings.Join(path, " "))
+	}
+	examples := []string{"  asc ads " + strings.Join(path, " ")}
+	for _, param := range node.spec.PathParams {
+		examples[0] += fmt.Sprintf(" --%s %s", param.Flag, strings.ToUpper(param.Flag))
+	}
+	if node.spec.BodyKind != appleads.BodyNone {
+		examples[0] += " --file payload.json"
+	}
+	if node.spec.RequiresConfirm {
+		examples[0] += " --confirm"
+	}
+	if node.spec.RequiresOrg {
+		examples[0] += " --org ORG_ID"
+	}
+	return fmt.Sprintf("%s\n\nEndpoint: %s %s\n\nExamples:\n%s", endpointShortHelp(node), node.spec.Method, node.spec.Path, strings.Join(examples, "\n"))
+}
+
+func sentenceFromEndpointName(name string) string {
+	text := strings.ReplaceAll(strings.TrimSpace(name), "-", " ")
+	replacements := []struct {
+		old string
+		new string
+	}{
+		{"get all ", "List all "},
+		{"get a ", "View a "},
+		{"get an ", "View an "},
+		{"get ", "View "},
+		{"gets a ", "View a "},
+		{"search for ", "Search for "},
+		{"find ", "Find "},
+		{"create a ", "Create a "},
+		{"create an ", "Create an "},
+		{"create ", "Create "},
+		{"update a ", "Update a "},
+		{"update an ", "Update an "},
+		{"update ", "Update "},
+		{"delete a ", "Delete a "},
+		{"delete an ", "Delete an "},
+		{"delete ", "Delete "},
+		{"impression share report", "Create impression share report"},
+	}
+	for _, replacement := range replacements {
+		if strings.HasPrefix(text, replacement.old) {
+			text = replacement.new + strings.TrimPrefix(text, replacement.old)
+			break
+		}
+	}
+	if text == "" {
+		text = name
+	}
+	return strings.TrimSuffix(text, ".") + "."
+}
+
+func bindEndpointFlags(spec appleads.EndpointSpec, flagSetName string) (*flag.FlagSet, endpointFlagValues) {
+	fs := flag.NewFlagSet(flagSetName, flag.ExitOnError)
+	values := endpointFlagValues{
+		common: commonFlags{
+			AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile"),
+		},
+		output:       shared.BindOutputFlags(fs),
+		pathStrings:  map[string]*string{},
+		queryStrings: map[string]*string{},
+		queryInts:    map[string]*int{},
+		queryBools:   map[string]*bool{},
+	}
+	if spec.RequiresOrg {
+		values.common.Org = fs.String("org", "", "Apple Ads organization ID (or ASC_ADS_ORG_ID env)")
+	}
+	for _, param := range spec.PathParams {
+		values.pathStrings[param.Name] = fs.String(param.Flag, "", flagUsage(param))
+	}
+	for _, param := range spec.QueryParams {
+		switch param.Type {
+		case appleads.ParamInt:
+			values.queryInts[param.Name] = fs.Int(param.Flag, 0, flagUsage(param))
+		case appleads.ParamBool:
+			values.queryBools[param.Name] = fs.Bool(param.Flag, false, flagUsage(param))
+		default:
+			values.queryStrings[param.Name] = fs.String(param.Flag, "", flagUsage(param))
+		}
+	}
+	if spec.BodyKind != appleads.BodyNone {
+		values.file = fs.String("file", "", "Path to Apple Ads JSON payload")
+	}
+	if spec.RequiresConfirm {
+		values.confirm = fs.Bool("confirm", false, "Confirm this destructive Apple Ads operation")
+	}
+	if spec.SupportsPaginate {
+		values.paginate = fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	}
+	return fs, values
+}
+
+func flagUsage(param appleads.ParamSpec) string {
+	usage := strings.ReplaceAll(param.Name, "-", " ")
+	if param.Required {
+		usage += " (required)"
+	}
+	if param.Max > 0 {
+		usage += fmt.Sprintf(" (max %d)", param.Max)
+	}
+	if len(param.Allowed) > 0 {
+		usage += " (" + strings.Join(param.Allowed, ", ") + ")"
+	}
+	return usage
+}
+
+func executeEndpoint(ctx context.Context, spec appleads.EndpointSpec, flags endpointFlagValues) error {
+	if flags.confirm != nil && !*flags.confirm {
+		return shared.UsageError("--confirm is required")
+	}
+	pathParams, err := collectPathParams(spec, flags)
+	if err != nil {
+		return shared.UsageError(err.Error())
+	}
+	query, err := collectQuery(spec, flags)
+	if err != nil {
+		return shared.UsageError(err.Error())
+	}
+	body, err := readBody(spec, flags)
+	if err != nil {
+		return err
+	}
+
+	client, err := resolveClient(ctx, flags.common, spec.RequiresOrg)
+	if err != nil {
+		return fmt.Errorf("ads: %w", err)
+	}
+
+	requestCtx, cancel := requestContext(ctx)
+	defer cancel()
+
+	var result appleads.RawResponse
+	if flags.paginate != nil && *flags.paginate {
+		startOffset := intValue(flags.queryInts["offset"])
+		pageSize := intValue(flags.queryInts["limit"])
+		result, err = client.PaginateAll(requestCtx, spec, pathParams, query, startOffset, pageSize, body)
+	} else {
+		result, err = client.Do(requestCtx, spec, pathParams, query, body)
+	}
+	if err != nil {
+		return fmt.Errorf("ads %s: %w", strings.Join(spec.CommandPath, " "), err)
+	}
+	return shared.PrintOutput(result, *flags.output.Output, *flags.output.Pretty)
+}
+
+func collectPathParams(spec appleads.EndpointSpec, flags endpointFlagValues) (map[string]string, error) {
+	params := map[string]string{}
+	for _, param := range spec.PathParams {
+		ptr := flags.pathStrings[param.Name]
+		value := value(ptr)
+		if param.Required && value == "" {
+			return nil, fmt.Errorf("--%s is required", param.Flag)
+		}
+		params[param.Name] = value
+	}
+	return params, nil
+}
+
+func collectQuery(spec appleads.EndpointSpec, flags endpointFlagValues) (url.Values, error) {
+	query := url.Values{}
+	for _, param := range spec.QueryParams {
+		switch param.Type {
+		case appleads.ParamInt:
+			raw := intValue(flags.queryInts[param.Name])
+			if raw == 0 {
+				if param.Required {
+					return nil, fmt.Errorf("--%s is required", param.Flag)
+				}
+				continue
+			}
+			if raw < 0 {
+				return nil, fmt.Errorf("--%s must be >= 0", param.Flag)
+			}
+			if param.Name == "limit" {
+				maxLimit := appleads.MaxPageLimit(spec)
+				if raw < 1 || raw > maxLimit {
+					return nil, fmt.Errorf("--limit must be between 1 and %d", maxLimit)
+				}
+			}
+			query.Set(param.Name, strconv.Itoa(raw))
+		case appleads.ParamBool:
+			if ptr := flags.queryBools[param.Name]; ptr != nil && *ptr {
+				query.Set(param.Name, "true")
+			}
+		default:
+			raw := value(flags.queryStrings[param.Name])
+			if raw == "" {
+				if param.Required {
+					return nil, fmt.Errorf("--%s is required", param.Flag)
+				}
+				continue
+			}
+			if err := validateAllowed(param, raw); err != nil {
+				return nil, err
+			}
+			query.Set(param.Name, raw)
+		}
+	}
+	return query, nil
+}
+
+func validateAllowed(param appleads.ParamSpec, raw string) error {
+	if len(param.Allowed) == 0 {
+		return nil
+	}
+	allowed := map[string]struct{}{}
+	for _, item := range param.Allowed {
+		allowed[item] = struct{}{}
+	}
+	for _, part := range strings.Split(raw, ",") {
+		value := strings.TrimSpace(part)
+		if _, ok := allowed[value]; !ok {
+			return fmt.Errorf("--%s must be one of: %s", param.Flag, strings.Join(param.Allowed, ", "))
+		}
+	}
+	return nil
+}
+
+func readBody(spec appleads.EndpointSpec, flags endpointFlagValues) (json.RawMessage, error) {
+	if spec.BodyKind == appleads.BodyNone {
+		return nil, nil
+	}
+	fileValue := value(flags.file)
+	if fileValue == "" {
+		fmt.Fprintln(os.Stderr, "Error: --file is required")
+		return nil, flag.ErrHelp
+	}
+	kind := shared.JSONPayloadObject
+	if spec.BodyKind == appleads.BodyArray {
+		kind = shared.JSONPayloadArray
+	}
+	payload, err := shared.ReadJSONFilePayloadKind(fileValue, kind)
+	if err != nil {
+		return nil, fmt.Errorf("ads %s: %w", strings.Join(spec.CommandPath, " "), err)
+	}
+	return payload, nil
+}
+
+func intValue(ptr *int) int {
+	if ptr == nil {
+		return 0
+	}
+	return *ptr
+}

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -97,6 +97,9 @@ func buildNodeCommand(node *commandNode, parentPath []string) *ffcli.Command {
 	if node.spec != nil {
 		spec := *node.spec
 		command.Exec = func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			return executeEndpoint(ctx, spec, flags)
 		}
 	}

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -1,0 +1,257 @@
+package ads
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+func TestAdsCommandRegistersEveryEndpointSpec(t *testing.T) {
+	root := AdsCommand()
+	for _, spec := range appleads.EndpointSpecs() {
+		cmd := findCommand(root, spec.CommandPath...)
+		if cmd == nil {
+			t.Fatalf("missing command asc ads %s", strings.Join(spec.CommandPath, " "))
+		}
+		if cmd.Exec == nil {
+			t.Fatalf("command asc ads %s has no Exec", strings.Join(spec.CommandPath, " "))
+		}
+		assertSpecFlags(t, cmd, spec)
+
+		if spec.DefaultListAlias {
+			alias := findCommand(root, spec.CommandPath[0])
+			if alias == nil {
+				t.Fatalf("missing default list alias asc ads %s", spec.CommandPath[0])
+			}
+			if alias.Exec == nil {
+				t.Fatalf("default list alias asc ads %s has no Exec", spec.CommandPath[0])
+			}
+			assertSpecFlags(t, alias, spec)
+		}
+	}
+}
+
+func TestCollectQueryValidatesEndpointSpecificLimitsAndEnums(t *testing.T) {
+	customReports, _ := appleads.EndpointByCommandPath("impression-share-reports", "list")
+	_, flags := bindEndpointFlags(customReports, "test")
+	*flags.queryInts["limit"] = 51
+	if _, err := collectQuery(customReports, flags); err == nil || !strings.Contains(err.Error(), "--limit must be between 1 and 50") {
+		t.Fatalf("custom reports limit error = %v, want max 50 error", err)
+	}
+
+	productPages, _ := appleads.EndpointByCommandPath("product-pages", "list")
+	_, flags = bindEndpointFlags(productPages, "test")
+	*flags.pathStrings["adamId"] = "123456789"
+	*flags.queryStrings["states"] = "VISIBLE,PAUSED"
+	if _, err := collectQuery(productPages, flags); err == nil || !strings.Contains(err.Error(), "--states must be one of: HIDDEN, VISIBLE") {
+		t.Fatalf("states error = %v, want enum validation", err)
+	}
+}
+
+func TestCollectPathParamsRequiresDocumentedIdentifiers(t *testing.T) {
+	campaign, _ := appleads.EndpointByCommandPath("campaigns", "get")
+	_, flags := bindEndpointFlags(campaign, "test")
+	if _, err := collectPathParams(campaign, flags); err == nil || !strings.Contains(err.Error(), "--campaign is required") {
+		t.Fatalf("path error = %v, want campaign required", err)
+	}
+
+	*flags.pathStrings["campaignId"] = "123"
+	params, err := collectPathParams(campaign, flags)
+	if err != nil {
+		t.Fatalf("collectPathParams() error: %v", err)
+	}
+	if params["campaignId"] != "123" {
+		t.Fatalf("campaignId = %q, want 123", params["campaignId"])
+	}
+}
+
+func TestRawRequestRequiresOrgGuardrails(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		requiresOrg bool
+		wantErr     string
+	}{
+		{name: "me does not need org", path: "v5/me", requiresOrg: false},
+		{name: "acls does not need org", path: "https://api.searchads.apple.com/api/v5/acls", requiresOrg: false},
+		{name: "campaigns needs org", path: "v5/campaigns", requiresOrg: true},
+		{name: "reject non apple host", path: "https://example.com/api/v5/campaigns", wantErr: "Apple Ads v5 URL"},
+		{name: "reject path traversal", path: "v5/../campaigns", wantErr: "path traversal"},
+		{name: "reject wrong version", path: "v4/campaigns", wantErr: "start with v5/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requiresOrg, err := rawRequestRequiresOrg(tt.path)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want contains %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("rawRequestRequiresOrg() error: %v", err)
+			}
+			if requiresOrg != tt.requiresOrg {
+				t.Fatalf("requiresOrg = %t, want %t", requiresOrg, tt.requiresOrg)
+			}
+		})
+	}
+}
+
+func TestResolveCredentialsPrefersExplicitProfileAndStrictRejectsMixedSources(t *testing.T) {
+	asc.ResetConfigCacheForTest()
+	t.Cleanup(asc.ResetConfigCacheForTest)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	if err := appleads.StoreCredentialsConfigAt("profile-a", appleads.Credentials{
+		ClientID:       "CLIENT",
+		TeamID:         "TEAM",
+		KeyID:          "KEY",
+		PrivateKeyPath: "private-key.pem",
+		OrgID:          "ORG",
+	}, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	profileName := "profile-a"
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	credentials, err := resolveCredentials(commonFlags{AdsProfile: &profileName})
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if credentials.Profile != "profile-a" || credentials.AccessToken != "" || credentials.ClientID != "CLIENT" {
+		t.Fatalf("credentials = %+v, want stored profile over access token", credentials)
+	}
+
+	t.Setenv("ASC_ADS_STRICT_AUTH", "1")
+	_, err = resolveCredentials(commonFlags{AdsProfile: &profileName})
+	if err == nil || !strings.Contains(err.Error(), "mixed Apple Ads authentication sources") {
+		t.Fatalf("strict mixed source error = %v", err)
+	}
+}
+
+func TestResolveClientRequiresOrgForOrgScopedEndpoints(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	_, err := resolveClient(context.Background(), commonFlags{}, true)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("resolveClient() error = %v, want usage error", err)
+	}
+
+	org := "123456"
+	client, err := resolveClient(context.Background(), commonFlags{Org: &org}, true)
+	if err != nil {
+		t.Fatalf("resolveClient() with org error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+}
+
+func TestResolveClientUsesStoredAdsOrgWithAccessToken(t *testing.T) {
+	asc.ResetConfigCacheForTest()
+	t.Cleanup(asc.ResetConfigCacheForTest)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	if err := config.SaveAt(configPath, &config.Config{
+		Ads: config.AdsConfig{OrgID: "CONFIG_ORG"},
+	}); err != nil {
+		t.Fatalf("SaveAt() error: %v", err)
+	}
+
+	client, err := resolveClient(context.Background(), commonFlags{}, true)
+	if err != nil {
+		t.Fatalf("resolveClient() error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+}
+
+func TestEnvCredentialsRejectsInvalidPrivateKeyBase64(t *testing.T) {
+	t.Setenv("ASC_ADS_CLIENT_ID", "CLIENT")
+	t.Setenv("ASC_ADS_TEAM_ID", "TEAM")
+	t.Setenv("ASC_ADS_KEY_ID", "KEY")
+	t.Setenv("ASC_ADS_PRIVATE_KEY_B64", "not-base64")
+
+	_, _, err := envCredentials()
+	if err == nil || !strings.Contains(err.Error(), "ASC_ADS_PRIVATE_KEY_B64 is not valid base64") {
+		t.Fatalf("envCredentials() error = %v, want invalid base64 error", err)
+	}
+}
+
+func TestCollectQueryIncludesAllowedValidValues(t *testing.T) {
+	productPages, _ := appleads.EndpointByCommandPath("product-pages", "list")
+	_, flags := bindEndpointFlags(productPages, "test")
+	*flags.queryStrings["states"] = "HIDDEN,VISIBLE"
+	query, err := collectQuery(productPages, flags)
+	if err != nil {
+		t.Fatalf("collectQuery() error: %v", err)
+	}
+	want := url.Values{"states": {"HIDDEN,VISIBLE"}}
+	if query.Encode() != want.Encode() {
+		t.Fatalf("query = %s, want %s", query.Encode(), want.Encode())
+	}
+}
+
+func findCommand(root *ffcli.Command, path ...string) *ffcli.Command {
+	current := root
+	for _, part := range path {
+		var next *ffcli.Command
+		for _, sub := range current.Subcommands {
+			if sub.Name == part {
+				next = sub
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		current = next
+	}
+	return current
+}
+
+func assertSpecFlags(t *testing.T, cmd *ffcli.Command, spec appleads.EndpointSpec) {
+	t.Helper()
+	for _, name := range []string{"ads-profile", "output"} {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Fatalf("asc ads %s missing --%s", strings.Join(spec.CommandPath, " "), name)
+		}
+	}
+	if spec.RequiresOrg && cmd.FlagSet.Lookup("org") == nil {
+		t.Fatalf("asc ads %s missing --org", strings.Join(spec.CommandPath, " "))
+	}
+	for _, param := range spec.PathParams {
+		if cmd.FlagSet.Lookup(param.Flag) == nil {
+			t.Fatalf("asc ads %s missing --%s", strings.Join(spec.CommandPath, " "), param.Flag)
+		}
+	}
+	for _, param := range spec.QueryParams {
+		if cmd.FlagSet.Lookup(param.Flag) == nil {
+			t.Fatalf("asc ads %s missing --%s", strings.Join(spec.CommandPath, " "), param.Flag)
+		}
+	}
+	if spec.BodyKind != appleads.BodyNone && cmd.FlagSet.Lookup("file") == nil {
+		t.Fatalf("asc ads %s missing --file", strings.Join(spec.CommandPath, " "))
+	}
+	if spec.RequiresConfirm && cmd.FlagSet.Lookup("confirm") == nil {
+		t.Fatalf("asc ads %s missing --confirm", strings.Join(spec.CommandPath, " "))
+	}
+	if spec.SupportsPaginate && cmd.FlagSet.Lookup("paginate") == nil {
+		t.Fatalf("asc ads %s missing --paginate", strings.Join(spec.CommandPath, " "))
+	}
+}

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -73,6 +73,11 @@ func TestCollectPathParamsRequiresDocumentedIdentifiers(t *testing.T) {
 	if params["campaignId"] != "123" {
 		t.Fatalf("campaignId = %q, want 123", params["campaignId"])
 	}
+
+	*flags.pathStrings["campaignId"] = "not-a-number"
+	if _, err := collectPathParams(campaign, flags); err == nil || !strings.Contains(err.Error(), "--campaign must be an integer") {
+		t.Fatalf("path error = %v, want integer validation", err)
+	}
 }
 
 func TestRawRequestRequiresOrgGuardrails(t *testing.T) {

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -83,7 +83,9 @@ func TestRawRequestRequiresOrgGuardrails(t *testing.T) {
 		wantErr     string
 	}{
 		{name: "me does not need org", path: "v5/me", requiresOrg: false},
+		{name: "me with query does not need org", path: "v5/me?fields=id", requiresOrg: false},
 		{name: "acls does not need org", path: "https://api.searchads.apple.com/api/v5/acls", requiresOrg: false},
+		{name: "absolute me with query does not need org", path: "https://api.searchads.apple.com/api/v5/me?fields=id", requiresOrg: false},
 		{name: "campaigns needs org", path: "v5/campaigns", requiresOrg: true},
 		{name: "reject non apple host", path: "https://example.com/api/v5/campaigns", wantErr: "Apple Ads v5 URL"},
 		{name: "reject path traversal", path: "v5/../campaigns", wantErr: "path traversal"},
@@ -143,6 +145,7 @@ func TestResolveCredentialsPrefersExplicitProfileAndStrictRejectsMixedSources(t 
 }
 
 func TestResolveClientRequiresOrgForOrgScopedEndpoints(t *testing.T) {
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	_, err := resolveClient(context.Background(), commonFlags{}, true)
 	if !errors.Is(err, flag.ErrHelp) {
@@ -190,6 +193,41 @@ func TestEnvCredentialsRejectsInvalidPrivateKeyBase64(t *testing.T) {
 	_, _, err := envCredentials()
 	if err == nil || !strings.Contains(err.Error(), "ASC_ADS_PRIVATE_KEY_B64 is not valid base64") {
 		t.Fatalf("envCredentials() error = %v, want invalid base64 error", err)
+	}
+}
+
+func TestResolveCredentialsStrictRejectsAccessTokenAndKeyEnv(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_STRICT_AUTH", "1")
+	t.Setenv("ASC_ADS_CLIENT_ID", "CLIENT")
+	t.Setenv("ASC_ADS_TEAM_ID", "TEAM")
+	t.Setenv("ASC_ADS_KEY_ID", "KEY")
+	t.Setenv("ASC_ADS_PRIVATE_KEY_PATH", "private-key.pem")
+
+	_, err := resolveCredentials(commonFlags{})
+	if err == nil || !strings.Contains(err.Error(), "mixed Apple Ads authentication sources") {
+		t.Fatalf("resolveCredentials() error = %v, want mixed source error", err)
+	}
+}
+
+func TestResolveCredentialsRejectsPartialEnvBeforeStoredFallback(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_ADS_CLIENT_ID", "CLIENT")
+	if err := appleads.StoreCredentialsConfigAt("profile-a", appleads.Credentials{
+		ClientID:       "STORED_CLIENT",
+		TeamID:         "STORED_TEAM",
+		KeyID:          "STORED_KEY",
+		PrivateKeyPath: "stored-private-key.pem",
+		OrgID:          "ORG",
+	}, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
+	}
+
+	_, err := resolveCredentials(commonFlags{})
+	if err == nil || !strings.Contains(err.Error(), "incomplete Apple Ads environment credentials") {
+		t.Fatalf("resolveCredentials() error = %v, want incomplete env error", err)
 	}
 }
 

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -59,7 +59,7 @@ func TestCollectQueryValidatesEndpointSpecificLimitsAndEnums(t *testing.T) {
 }
 
 func TestCollectPathParamsRequiresDocumentedIdentifiers(t *testing.T) {
-	campaign, _ := appleads.EndpointByCommandPath("campaigns", "get")
+	campaign, _ := appleads.EndpointByCommandPath("campaigns", "view")
 	_, flags := bindEndpointFlags(campaign, "test")
 	if _, err := collectPathParams(campaign, flags); err == nil || !strings.Contains(err.Error(), "--campaign is required") {
 		t.Fatalf("path error = %v, want campaign required", err)

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -43,7 +43,15 @@ func TestAdsCommandRegistersEveryEndpointSpec(t *testing.T) {
 
 func TestCollectQueryValidatesEndpointSpecificLimitsAndEnums(t *testing.T) {
 	customReports, _ := appleads.EndpointByCommandPath("impression-share-reports", "list")
-	_, flags := bindEndpointFlags(customReports, "test")
+	fs, flags := bindEndpointFlags(customReports, "test")
+	if err := fs.Parse([]string{"--limit", "0"}); err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	if _, err := collectQuery(customReports, flags); err == nil || !strings.Contains(err.Error(), "--limit must be between 1 and 50") {
+		t.Fatalf("custom reports explicit zero limit error = %v, want min 1 error", err)
+	}
+
+	_, flags = bindEndpointFlags(customReports, "test")
 	*flags.queryInts["limit"] = 51
 	if _, err := collectQuery(customReports, flags); err == nil || !strings.Contains(err.Error(), "--limit must be between 1 and 50") {
 		t.Fatalf("custom reports limit error = %v, want max 50 error", err)

--- a/internal/cli/ads/resolve.go
+++ b/internal/cli/ads/resolve.go
@@ -48,6 +48,13 @@ func resolveCredentials(flags commonFlags) (appleads.Credentials, error) {
 		if strict && accessToken != "" {
 			return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_ACCESS_TOKEN")
 		}
+		if strict {
+			if _, ok, err := envCredentials(); err != nil {
+				return appleads.Credentials{}, err
+			} else if ok {
+				return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_* key credentials")
+			}
+		}
 		credentials, _, err := appleads.GetCredentialsWithSource(profile)
 		if err != nil {
 			return appleads.Credentials{}, err
@@ -55,6 +62,13 @@ func resolveCredentials(flags commonFlags) (appleads.Credentials, error) {
 		return credentials, nil
 	}
 	if accessToken != "" {
+		if strict {
+			if _, ok, err := envCredentials(); err != nil {
+				return appleads.Credentials{}, err
+			} else if ok {
+				return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: ASC_ADS_ACCESS_TOKEN and ASC_ADS_* key credentials")
+			}
+		}
 		return appleads.Credentials{AccessToken: accessToken}, nil
 	}
 
@@ -82,8 +96,9 @@ func envCredentials() (appleads.Credentials, bool, error) {
 		PrivateKeyPEM:  strings.TrimSpace(os.Getenv("ASC_ADS_PRIVATE_KEY")),
 		OrgID:          strings.TrimSpace(os.Getenv("ASC_ADS_ORG_ID")),
 	}
-	if b64 := strings.TrimSpace(os.Getenv("ASC_ADS_PRIVATE_KEY_B64")); b64 != "" {
-		decoded, err := base64.StdEncoding.DecodeString(b64)
+	privateKeyB64 := strings.TrimSpace(os.Getenv("ASC_ADS_PRIVATE_KEY_B64"))
+	if privateKeyB64 != "" {
+		decoded, err := base64.StdEncoding.DecodeString(privateKeyB64)
 		if err != nil {
 			return appleads.Credentials{}, false, fmt.Errorf("ASC_ADS_PRIVATE_KEY_B64 is not valid base64: %w", err)
 		}
@@ -95,6 +110,14 @@ func envCredentials() (appleads.Credentials, bool, error) {
 		credentials.TeamID != "" &&
 		credentials.KeyID != "" &&
 		(credentials.PrivateKeyPath != "" || credentials.PrivateKeyPEM != "")
+	keyEnvSet := credentials.ClientID != "" ||
+		credentials.TeamID != "" ||
+		credentials.KeyID != "" ||
+		credentials.PrivateKeyPath != "" ||
+		credentials.PrivateKeyPEM != ""
+	if !complete && keyEnvSet {
+		return appleads.Credentials{}, false, fmt.Errorf("incomplete Apple Ads environment credentials: set ASC_ADS_CLIENT_ID, ASC_ADS_TEAM_ID, ASC_ADS_KEY_ID, and one of ASC_ADS_PRIVATE_KEY_PATH, ASC_ADS_PRIVATE_KEY, or ASC_ADS_PRIVATE_KEY_B64")
+	}
 	return credentials, complete, nil
 }
 

--- a/internal/cli/ads/resolve.go
+++ b/internal/cli/ads/resolve.go
@@ -1,0 +1,142 @@
+package ads
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+type commonFlags struct {
+	AdsProfile *string
+	Org        *string
+}
+
+func resolveClient(ctx context.Context, flags commonFlags, requiresOrg bool) (*appleads.Client, error) {
+	credentials, err := resolveCredentials(flags)
+	if err != nil {
+		return nil, err
+	}
+	if requiresOrg {
+		orgID, err := resolveOrgID(flags, credentials)
+		if err != nil {
+			return nil, err
+		}
+		if orgID == "" {
+			return nil, shared.UsageError("--org is required (or set ASC_ADS_ORG_ID or an Ads profile org_id)")
+		}
+		credentials.OrgID = orgID
+	}
+	_ = ctx
+	return appleads.NewClient(credentials)
+}
+
+func resolveCredentials(flags commonFlags) (appleads.Credentials, error) {
+	profile := strings.TrimSpace(value(flags.AdsProfile))
+	if profile == "" {
+		profile = strings.TrimSpace(os.Getenv("ASC_ADS_PROFILE"))
+	}
+	accessToken := strings.TrimSpace(os.Getenv("ASC_ADS_ACCESS_TOKEN"))
+	strict := parseBoolEnv("ASC_ADS_STRICT_AUTH")
+	if profile != "" {
+		if strict && accessToken != "" {
+			return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_ACCESS_TOKEN")
+		}
+		credentials, _, err := appleads.GetCredentialsWithSource(profile)
+		if err != nil {
+			return appleads.Credentials{}, err
+		}
+		return credentials, nil
+	}
+	if accessToken != "" {
+		return appleads.Credentials{AccessToken: accessToken}, nil
+	}
+
+	env, ok, err := envCredentials()
+	if err != nil {
+		return appleads.Credentials{}, err
+	}
+	if ok {
+		return env, nil
+	}
+
+	credentials, _, err := appleads.GetCredentialsWithSource("")
+	if err != nil {
+		return appleads.Credentials{}, err
+	}
+	return credentials, nil
+}
+
+func envCredentials() (appleads.Credentials, bool, error) {
+	credentials := appleads.Credentials{
+		ClientID:       strings.TrimSpace(os.Getenv("ASC_ADS_CLIENT_ID")),
+		TeamID:         strings.TrimSpace(os.Getenv("ASC_ADS_TEAM_ID")),
+		KeyID:          strings.TrimSpace(os.Getenv("ASC_ADS_KEY_ID")),
+		PrivateKeyPath: strings.TrimSpace(os.Getenv("ASC_ADS_PRIVATE_KEY_PATH")),
+		PrivateKeyPEM:  strings.TrimSpace(os.Getenv("ASC_ADS_PRIVATE_KEY")),
+		OrgID:          strings.TrimSpace(os.Getenv("ASC_ADS_ORG_ID")),
+	}
+	if b64 := strings.TrimSpace(os.Getenv("ASC_ADS_PRIVATE_KEY_B64")); b64 != "" {
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return appleads.Credentials{}, false, fmt.Errorf("ASC_ADS_PRIVATE_KEY_B64 is not valid base64: %w", err)
+		}
+		if credentials.PrivateKeyPEM == "" {
+			credentials.PrivateKeyPEM = string(decoded)
+		}
+	}
+	complete := credentials.ClientID != "" &&
+		credentials.TeamID != "" &&
+		credentials.KeyID != "" &&
+		(credentials.PrivateKeyPath != "" || credentials.PrivateKeyPEM != "")
+	return credentials, complete, nil
+}
+
+func resolveOrgID(flags commonFlags, credentials appleads.Credentials) (string, error) {
+	if orgID := firstNonEmpty(value(flags.Org), os.Getenv("ASC_ADS_ORG_ID"), credentials.OrgID); orgID != "" {
+		return orgID, nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(cfg.Ads.OrgID), nil
+}
+
+func requestContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return shared.ContextWithTimeout(ctx)
+}
+
+func parseBoolEnv(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func value(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+	return strings.TrimSpace(*ptr)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, item := range values {
+		if strings.TrimSpace(item) != "" {
+			return strings.TrimSpace(item)
+		}
+	}
+	return ""
+}

--- a/internal/cli/ads/root.go
+++ b/internal/cli/ads/root.go
@@ -1,0 +1,38 @@
+package ads
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// AdsCommand returns the Apple Ads root command.
+func AdsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "ads",
+		ShortUsage: "asc ads <subcommand> [flags]",
+		ShortHelp:  "Manage Apple Ads Campaign Management API resources.",
+		LongHelp: `Manage Apple Ads Campaign Management API resources.
+
+Apple Ads credentials are separate from App Store Connect API credentials.
+
+Examples:
+  asc ads auth login --name "Ads" --client-id "SEARCHADS..." --team-id "SEARCHADS..." --key-id "KEY_ID" --private-key ./private-key.pem --org "123456"
+  asc ads me view --output json
+  asc ads campaigns list --org "123456" --limit 10
+  asc ads reports campaigns --org "123456" --file report.json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: append([]*ffcli.Command{
+			AuthCommand(),
+			APICommand(),
+		}, endpointCommands()...),
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -1,0 +1,136 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAdsAuthEvalWorkflow(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	keyPath := filepath.Join(t.TempDir(), "apple-ads-private-key.pem")
+	writeECDSAPEM(t, keyPath)
+
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+
+	stdout, stderr, err := runAdsEvalCommand(
+		t,
+		"ads", "auth", "login",
+		"--bypass-keychain",
+		"--name", "Marketing",
+		"--client-id", "SEARCHADS.CLIENT",
+		"--team-id", "SEARCHADS.TEAM",
+		"--key-id", "KEY_ID",
+		"--private-key", keyPath,
+		"--org", "987654",
+	)
+	if err != nil {
+		t.Fatalf("login error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("login stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "Successfully registered Apple Ads API key 'Marketing'") {
+		t.Fatalf("login stdout = %q", stdout)
+	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json")
+	if err != nil {
+		t.Fatalf("status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	var status struct {
+		Storage     string `json:"storage"`
+		Credentials []struct {
+			Name     string `json:"name"`
+			ClientID string `json:"client_id"`
+			OrgID    string `json:"org_id"`
+			Default  bool   `json:"default"`
+			Source   string `json:"source"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if status.Storage != "Config File" || len(status.Credentials) != 1 {
+		t.Fatalf("status = %+v, want one config credential", status)
+	}
+	got := status.Credentials[0]
+	if got.Name != "Marketing" || got.ClientID != "SEARCHADS.CLIENT" || got.OrgID != "987654" || !got.Default || got.Source != "config" {
+		t.Fatalf("credential = %+v, want stored Marketing profile", got)
+	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "switch", "--name", "Marketing")
+	if err != nil {
+		t.Fatalf("switch error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" || !strings.Contains(stdout, "Default Apple Ads profile set to 'Marketing'") {
+		t.Fatalf("switch stdout = %q stderr = %q", stdout, stderr)
+	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "logout", "--name", "Marketing")
+	if err != nil {
+		t.Fatalf("logout error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" || !strings.Contains(stdout, "Successfully removed Apple Ads credential 'Marketing'") {
+		t.Fatalf("logout stdout = %q stderr = %q", stdout, stderr)
+	}
+}
+
+func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+
+	_, stderr, err := runAdsEvalCommand(t, "ads", "auth", "login")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--name is required") {
+		t.Fatalf("login error = %v stderr = %q, want missing name usage error", err, stderr)
+	}
+
+	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "login", "--local", "--name", "Marketing")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--client-id is required") {
+		t.Fatalf("login partial error = %v stderr = %q, want missing client ID usage error", err, stderr)
+	}
+
+	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status", "--output", "markdown")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "unsupported format: markdown") {
+		t.Fatalf("status error = %v stderr = %q, want invalid output usage error", err, stderr)
+	}
+
+	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "logout", "--all", "--name", "Marketing")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--all and --name are mutually exclusive") {
+		t.Fatalf("logout error = %v stderr = %q, want mutually exclusive usage error", err, stderr)
+	}
+}
+
+func TestAdsAuthTokenEvalRequiresConfirm(t *testing.T) {
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+
+	_, stderr, err := runAdsEvalCommand(t, "ads", "auth", "token", "--output", "json")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("token error = %v stderr = %q, want confirm usage error", err, stderr)
+	}
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "token", "--confirm", "--output", "json")
+	if err != nil {
+		t.Fatalf("token error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("token stderr = %q, want empty", stderr)
+	}
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("token stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if parsed.AccessToken != "ACCESS" {
+		t.Fatalf("access_token = %q, want ACCESS", parsed.AccessToken)
+	}
+}

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -102,6 +102,11 @@ func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
 		t.Fatalf("status error = %v stderr = %q, want invalid output usage error", err, stderr)
 	}
 
+	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json", "unexpected")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "unexpected argument(s): unexpected") {
+		t.Fatalf("status args error = %v stderr = %q, want unexpected argument usage error", err, stderr)
+	}
+
 	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "logout", "--all", "--name", "Marketing")
 	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--all and --name are mutually exclusive") {
 		t.Fatalf("logout error = %v stderr = %q, want mutually exclusive usage error", err, stderr)

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -106,6 +106,11 @@ func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
 	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--all and --name are mutually exclusive") {
 		t.Fatalf("logout error = %v stderr = %q, want mutually exclusive usage error", err, stderr)
 	}
+
+	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "logout")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "provide --name or --all") {
+		t.Fatalf("logout error = %v stderr = %q, want explicit target usage error", err, stderr)
+	}
 }
 
 func TestAdsAuthTokenEvalRequiresConfirm(t *testing.T) {

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -107,6 +107,11 @@ func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
 		t.Fatalf("logout error = %v stderr = %q, want mutually exclusive usage error", err, stderr)
 	}
 
+	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "logout", "--all")
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--all requires --confirm") {
+		t.Fatalf("logout error = %v stderr = %q, want confirm usage error", err, stderr)
+	}
+
 	_, stderr, err = runAdsEvalCommand(t, "ads", "auth", "logout")
 	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "provide --name or --all") {
 		t.Fatalf("logout error = %v stderr = %q, want explicit target usage error", err, stderr)

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -1,0 +1,377 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAdsAgentReadOnlyEvalWorkflow(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	reportPayload := writeAdsEvalPayload(t, "report.json", `{
+		"startTime": "2026-05-01",
+		"endTime": "2026-05-31",
+		"returnRowTotals": true,
+		"selector": {
+			"orderBy": [
+				{"field": "impressions", "sortOrder": "DESCENDING"}
+			],
+			"pagination": {"offset": 0, "limit": 100}
+		}
+	}`)
+
+	log := newRequestLog(5)
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		log.Add(req.Method + " " + req.URL.RequestURI())
+
+		switch req.URL.Path {
+		case "/api/v5/me":
+			assertAdsEvalNoOrg(t, req)
+			assertAdsEvalNoBody(t, req)
+			return adsJSONResponse(200, `{"data":{"id":"user-1"}}`), nil
+		case "/api/v5/acls":
+			assertAdsEvalNoOrg(t, req)
+			assertAdsEvalNoBody(t, req)
+			return adsJSONResponse(200, `{"data":[{"orgId":987654}]}`), nil
+		case "/api/v5/campaigns":
+			assertAdsEvalOrg(t, req)
+			if req.Method != http.MethodGet {
+				t.Fatalf("campaigns method = %s, want GET", req.Method)
+			}
+			if got := req.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("campaigns limit = %q, want 1", got)
+			}
+			assertAdsEvalNoBody(t, req)
+			return adsJSONResponse(200, `{"data":[{"id":12345}],"pagination":{"itemsPerPage":1,"startIndex":0,"totalResults":1}}`), nil
+		case "/api/v5/reports/campaigns":
+			assertAdsEvalOrg(t, req)
+			if req.Method != http.MethodPost {
+				t.Fatalf("reports method = %s, want POST", req.Method)
+			}
+			if got := req.Header.Get("Content-Type"); got != "application/json" {
+				t.Fatalf("Content-Type = %q, want application/json", got)
+			}
+			body := readAdsEvalJSONBody(t, req)
+			selector, ok := body["selector"].(map[string]any)
+			if !ok {
+				t.Fatalf("report body selector = %#v, want object", body["selector"])
+			}
+			if _, ok := selector["orderBy"].([]any); !ok {
+				t.Fatalf("report body selector.orderBy = %#v, want array", selector["orderBy"])
+			}
+			return adsJSONResponse(200, `{"data":{"reportingDataResponse":{"row":[{"metadata":{"campaignId":12345}}]}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	for _, args := range [][]string{
+		{"ads", "me", "view", "--output", "json"},
+		{"ads", "acls", "--output", "json"},
+		{"ads", "campaigns", "--limit", "1", "--output", "json"},
+		{"ads", "reports", "campaigns", "--file", reportPayload, "--output", "json"},
+		{"ads", "api", "request", "--method", "GET", "--path", "v5/me", "--output", "json"},
+	} {
+		stdout, stderr, err := runAdsEvalCommand(t, args...)
+		if err != nil {
+			t.Fatalf("asc %s error: %v\nstderr: %s", strings.Join(args, " "), err, stderr)
+		}
+		if stderr != "" {
+			t.Fatalf("asc %s stderr = %q, want empty", strings.Join(args, " "), stderr)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+			t.Fatalf("asc %s stdout is not JSON: %v\n%s", strings.Join(args, " "), err, stdout)
+		}
+	}
+
+	joined := strings.Join(log.Snapshot(), "\n")
+	for _, want := range []string{
+		"GET /api/v5/me",
+		"GET /api/v5/acls",
+		"GET /api/v5/campaigns?limit=1",
+		"POST /api/v5/reports/campaigns",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("requests = %q, missing %q", joined, want)
+		}
+	}
+}
+
+func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	campaignCreate := writeAdsEvalPayload(t, "campaign-create.json", `{"name":"ASC CLI Eval Campaign","status":"PAUSED"}`)
+	campaignUpdate := writeAdsEvalPayload(t, "campaign-update.json", `{"status":"PAUSED"}`)
+	keywords := writeAdsEvalPayload(t, "keywords.json", `[{"text":"example keyword","matchType":"EXACT","status":"PAUSED"}]`)
+	keywordIDs := writeAdsEvalPayload(t, "keyword-ids.json", `[111111111]`)
+
+	log := newRequestLog(4)
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		assertAdsEvalOrg(t, req)
+		log.Add(req.Method + " " + req.URL.RequestURI())
+
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/api/v5/campaigns":
+			body := readAdsEvalJSONBody(t, req)
+			if got := body["name"]; got != "ASC CLI Eval Campaign" {
+				t.Fatalf("campaign create name = %#v, want ASC CLI Eval Campaign", got)
+			}
+			return adsJSONResponse(200, `{"data":{"id":1001}}`), nil
+		case req.Method == http.MethodPut && req.URL.Path == "/api/v5/campaigns/1001":
+			body := readAdsEvalJSONBody(t, req)
+			if got := body["status"]; got != "PAUSED" {
+				t.Fatalf("campaign update status = %#v, want PAUSED", got)
+			}
+			return adsJSONResponse(200, `{"data":{"id":1001,"status":"PAUSED"}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/api/v5/campaigns/1001/adgroups/2002/targetingkeywords/bulk":
+			items := readAdsEvalJSONArrayBody(t, req)
+			if len(items) != 1 {
+				t.Fatalf("keyword create body length = %d, want 1", len(items))
+			}
+			return adsJSONResponse(200, `{"data":[{"id":111111111}]}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/api/v5/campaigns/1001/adgroups/2002/targetingkeywords/delete/bulk":
+			items := readAdsEvalJSONArrayBody(t, req)
+			if len(items) != 1 || items[0] != float64(111111111) {
+				t.Fatalf("keyword delete body = %#v, want [111111111]", items)
+			}
+			return adsJSONResponse(200, `{"data":[111111111]}`), nil
+		case req.Method == http.MethodDelete && req.URL.Path == "/api/v5/campaigns/1001":
+			assertAdsEvalNoBody(t, req)
+			return adsJSONResponse(204, ``), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	for _, args := range [][]string{
+		{"ads", "campaigns", "create", "--file", campaignCreate, "--output", "json"},
+		{"ads", "campaigns", "update", "--campaign", "1001", "--file", campaignUpdate, "--output", "json"},
+		{"ads", "targeting-keywords", "create-bulk", "--campaign", "1001", "--ad-group", "2002", "--file", keywords, "--output", "json"},
+		{"ads", "targeting-keywords", "delete-bulk", "--campaign", "1001", "--ad-group", "2002", "--file", keywordIDs, "--confirm", "--output", "json"},
+		{"ads", "campaigns", "delete", "--campaign", "1001", "--confirm", "--output", "json"},
+	} {
+		stdout, stderr, err := runAdsEvalCommand(t, args...)
+		if err != nil {
+			t.Fatalf("asc %s error: %v\nstderr: %s", strings.Join(args, " "), err, stderr)
+		}
+		if stderr != "" {
+			t.Fatalf("asc %s stderr = %q, want empty", strings.Join(args, " "), stderr)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+			t.Fatalf("asc %s stdout is not JSON: %v\n%s", strings.Join(args, " "), err, stdout)
+		}
+	}
+
+	joined := strings.Join(log.Snapshot(), "\n")
+	for _, want := range []string{
+		"POST /api/v5/campaigns",
+		"PUT /api/v5/campaigns/1001",
+		"POST /api/v5/campaigns/1001/adgroups/2002/targetingkeywords/bulk",
+		"POST /api/v5/campaigns/1001/adgroups/2002/targetingkeywords/delete/bulk",
+		"DELETE /api/v5/campaigns/1001",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("requests = %q, missing %q", joined, want)
+		}
+	}
+}
+
+func TestAdsAgentEvalRejectsArrayPayloadMistakesBeforeNetwork(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	objectPayload := writeAdsEvalPayload(t, "keyword-object.json", `{"text":"not an array"}`)
+	_, _, err := runAdsEvalCommand(
+		t,
+		"ads", "targeting-keywords", "create-bulk",
+		"--campaign", "1001",
+		"--ad-group", "2002",
+		"--file", objectPayload,
+		"--output", "json",
+	)
+	if err == nil || !strings.Contains(err.Error(), "payload must be a JSON array") {
+		t.Fatalf("error = %v, want JSON array validation", err)
+	}
+}
+
+func TestAdsAgentRawAPIEvalRequiresConfirmAndAcceptsAppleURL(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	log := newRequestLog(1)
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		assertAdsEvalOrg(t, req)
+		log.Add(req.Method + " " + req.URL.RequestURI())
+		if req.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", req.Method)
+		}
+		if got := req.URL.RawQuery; got != "audit=true" {
+			t.Fatalf("query = %q, want audit=true", got)
+		}
+		assertAdsEvalNoBody(t, req)
+		return adsJSONResponse(204, ``), nil
+	}))
+
+	_, stderr, err := runAdsEvalCommand(
+		t,
+		"ads", "api", "request",
+		"--method", "DELETE",
+		"--path", "https://api.searchads.apple.com/api/v5/campaigns/1001?audit=true",
+		"--output", "json",
+	)
+	if !errors.Is(err, flag.ErrHelp) || !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("error = %v stderr = %q, want confirm usage error", err, stderr)
+	}
+	if got := len(log.Snapshot()); got != 0 {
+		t.Fatalf("requests before confirm = %d, want 0", got)
+	}
+
+	stdout, stderr, err := runAdsEvalCommand(
+		t,
+		"ads", "api", "request",
+		"--method", "DELETE",
+		"--path", "https://api.searchads.apple.com/api/v5/campaigns/1001?audit=true",
+		"--confirm",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("confirmed raw delete error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	var parsed struct {
+		Data any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if parsed.Data != nil {
+		t.Fatalf("data = %#v, want nil", parsed.Data)
+	}
+	requests := log.Snapshot()
+	if len(requests) != 1 || requests[0] != "DELETE /api/v5/campaigns/1001?audit=true" {
+		t.Fatalf("requests = %#v", requests)
+	}
+}
+
+func runAdsEvalCommand(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		root := RootCommand("dev")
+		if err := root.Parse(args); err != nil {
+			runErr = err
+			return
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func writeAdsEvalPayload(t *testing.T, name string, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	return path
+}
+
+func assertAdsEvalBearer(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	if got := req.Header.Get("Authorization"); got != "Bearer ACCESS" {
+		t.Fatalf("Authorization = %q, want Bearer ACCESS", got)
+	}
+}
+
+func assertAdsEvalOrg(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	want := "orgId=987654"
+	if got := req.Header.Get("X-AP-Context"); got != want {
+		t.Fatalf("X-AP-Context = %q, want %s", got, want)
+	}
+}
+
+func assertAdsEvalNoOrg(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	if got := req.Header.Get("X-AP-Context"); got != "" {
+		t.Fatalf("X-AP-Context = %q, want empty", got)
+	}
+}
+
+func assertAdsEvalNoBody(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	if req.Body == nil {
+		return
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if strings.TrimSpace(string(body)) != "" {
+		t.Fatalf("body = %q, want empty", string(body))
+	}
+	if got := req.Header.Get("Content-Type"); got != "" {
+		t.Fatalf("Content-Type = %q, want empty", got)
+	}
+}
+
+func readAdsEvalJSONBody(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("body is not a JSON object: %v\n%s", err, body)
+	}
+	return parsed
+}
+
+func readAdsEvalJSONArrayBody(t *testing.T, req *http.Request) []any {
+	t.Helper()
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var parsed []any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("body is not a JSON array: %v\n%s", err, body)
+	}
+	return parsed
+}

--- a/internal/cli/cmdtest/ads_test.go
+++ b/internal/cli/cmdtest/ads_test.go
@@ -91,6 +91,28 @@ func TestAdsImpressionShareReportsLimitValidation(t *testing.T) {
 	}
 }
 
+func TestAdsLimitZeroValidation(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "campaigns", "--limit", "0", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "--limit must be between 1 and 1000") {
+		t.Fatalf("run error = %v stderr = %q, want zero limit validation", runErr, stderr)
+	}
+}
+
 func TestAdsDeleteRequiresConfirmBeforeNetwork(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_ADS_ORG_ID", "123456")

--- a/internal/cli/cmdtest/ads_test.go
+++ b/internal/cli/cmdtest/ads_test.go
@@ -1,0 +1,140 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type adsRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f adsRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestAdsCampaignsAliasPaginatesWithOrgContext(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	log := newRequestLog(2)
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "api.searchads.apple.com" {
+			t.Fatalf("unexpected host %s", req.URL.Host)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer ACCESS" {
+			t.Fatalf("Authorization = %q, want Bearer ACCESS", got)
+		}
+		if got := req.Header.Get("X-AP-Context"); got != "orgId=123456" {
+			t.Fatalf("X-AP-Context = %q, want orgId=123456", got)
+		}
+		log.Add(req.URL.Path + "?" + req.URL.RawQuery)
+		switch req.URL.Query().Get("offset") {
+		case "0":
+			return adsJSONResponse(200, `{"data":[{"id":1},{"id":2}],"pagination":{"itemsPerPage":2,"startIndex":0,"totalResults":3}}`), nil
+		case "2":
+			return adsJSONResponse(200, `{"data":[{"id":3}],"pagination":{"itemsPerPage":2,"startIndex":2,"totalResults":3}}`), nil
+		default:
+			t.Fatalf("unexpected offset %q", req.URL.Query().Get("offset"))
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("dev")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"ads", "campaigns", "--limit", "2", "--paginate", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	var parsed struct {
+		Data []map[string]int `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if len(parsed.Data) != 3 || parsed.Data[2]["id"] != 3 {
+		t.Fatalf("data = %+v, want three aggregated campaign rows", parsed.Data)
+	}
+	requests := strings.Join(log.Snapshot(), "\n")
+	if !strings.Contains(requests, "/api/v5/campaigns?limit=2&offset=0") || !strings.Contains(requests, "/api/v5/campaigns?limit=2&offset=2") {
+		t.Fatalf("requests = %q, want both paginated offsets", requests)
+	}
+}
+
+func TestAdsImpressionShareReportsLimitValidation(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "123456")
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "impression-share-reports", "--limit", "51", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "--limit must be between 1 and 50") {
+		t.Fatalf("run error = %v stderr = %q, want custom reports limit validation", runErr, stderr)
+	}
+}
+
+func TestAdsDeleteRequiresConfirmBeforeNetwork(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "campaigns", "delete", "--campaign", "123"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("run error = %v stderr = %q, want confirm validation", runErr, stderr)
+	}
+}
+
+func TestAdsAPIRequestRejectsNonAppleURLsBeforeNetwork(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "api", "request", "--path", "https://example.com/api/v5/campaigns"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "Apple Ads v5 URL") {
+		t.Fatalf("run error = %v stderr = %q, want Apple host guardrail", runErr, stderr)
+	}
+}
+
+func adsJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/cli/cmdtest/ads_test.go
+++ b/internal/cli/cmdtest/ads_test.go
@@ -111,6 +111,28 @@ func TestAdsDeleteRequiresConfirmBeforeNetwork(t *testing.T) {
 	}
 }
 
+func TestAdsEndpointRejectsUnexpectedArgsBeforeNetwork(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "campaigns", "--output", "json", "unexpected"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "unexpected argument(s): unexpected") {
+		t.Fatalf("run error = %v stderr = %q, want unexpected argument usage error", runErr, stderr)
+	}
+}
+
 func TestAdsAPIRequestRejectsNonAppleURLsBeforeNetwork(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -128,6 +150,28 @@ func TestAdsAPIRequestRejectsNonAppleURLsBeforeNetwork(t *testing.T) {
 	})
 	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "Apple Ads v5 URL") {
 		t.Fatalf("run error = %v stderr = %q, want Apple host guardrail", runErr, stderr)
+	}
+}
+
+func TestAdsAPIRequestRejectsUnexpectedArgsBeforeNetwork(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "api", "request", "--path", "v5/campaigns", "--output", "json", "unexpected"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "unexpected argument(s): unexpected") {
+		t.Fatalf("run error = %v stderr = %q, want unexpected argument usage error", runErr, stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/ads_test.go
+++ b/internal/cli/cmdtest/ads_test.go
@@ -76,6 +76,7 @@ func TestAdsCampaignsAliasPaginatesWithOrgContext(t *testing.T) {
 func TestAdsImpressionShareReportsLimitValidation(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
 
 	root := RootCommand("dev")
 	if err := root.Parse([]string{"ads", "impression-share-reports", "--limit", "51", "--output", "json"}); err != nil {
@@ -93,6 +94,7 @@ func TestAdsImpressionShareReportsLimitValidation(t *testing.T) {
 func TestAdsDeleteRequiresConfirmBeforeNetwork(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_ADS_ORG_ID", "123456")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
 	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
 		return nil, nil
@@ -135,6 +137,7 @@ func TestAdsEndpointRejectsUnexpectedArgsBeforeNetwork(t *testing.T) {
 
 func TestAdsAPIRequestRejectsNonAppleURLsBeforeNetwork(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
 	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
 		return nil, nil

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -138,6 +138,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `reviews` - List and manage App Store customer reviews.
 - `review` - Manage App Store review details, attachments, and submissions.
 - `analytics` - Request and download analytics and sales reports.
+- `ads` - Manage Apple Ads Campaign Management API resources.
 - `performance` - Access performance metrics and diagnostic logs.
 - `finance` - Download payments and financial reports.
 - `apps` - List and manage apps in App Store Connect. App creation moved out of `asc apps`; use `asc web apps create` for the unofficial web-session path.

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/accessibility"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/account"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/actors"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/ads"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/agerating"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/agreements"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/alternativedistribution"
@@ -118,6 +119,7 @@ func Subcommands(version string) []*ffcli.Command {
 		reviews.ReviewsCommand(),
 		reviews.ReviewCommand(),
 		analytics.AnalyticsCommand(),
+		ads.AdsCommand(),
 		performance.PerformanceCommand(),
 		finance.FinanceCommand(),
 		apps.AppsCommand(),

--- a/internal/cli/registry/registry_test.go
+++ b/internal/cli/registry/registry_test.go
@@ -39,7 +39,7 @@ func TestSubcommandsIncludesCoreEntries(t *testing.T) {
 		names[name] = struct{}{}
 	}
 
-	required := []string{"auth", "doctor", "account", "insights", "builds", "reviews", "version", "completion"}
+	required := []string{"auth", "doctor", "account", "ads", "insights", "builds", "reviews", "version", "completion"}
 	for _, name := range required {
 		if _, ok := names[name]; !ok {
 			t.Fatalf("expected root subcommands to include %q", name)

--- a/internal/cli/shared/json_payload.go
+++ b/internal/cli/shared/json_payload.go
@@ -9,9 +9,24 @@ import (
 	"strings"
 )
 
+// JSONPayloadKind describes the top-level JSON shape a raw payload command accepts.
+type JSONPayloadKind string
+
+const (
+	JSONPayloadObject JSONPayloadKind = "object"
+	JSONPayloadArray  JSONPayloadKind = "array"
+	JSONPayloadAny    JSONPayloadKind = "any"
+)
+
 // ReadJSONFilePayload loads a JSON object from a file path for commands that
 // accept raw payload documents.
 func ReadJSONFilePayload(path string) (json.RawMessage, error) {
+	return ReadJSONFilePayloadKind(path, JSONPayloadObject)
+}
+
+// ReadJSONFilePayloadKind loads a JSON payload from a file path and validates
+// the requested top-level JSON shape.
+func ReadJSONFilePayloadKind(path string, kind JSONPayloadKind) (json.RawMessage, error) {
 	file, err := openJSONPayloadFile(path)
 	if err != nil {
 		return nil, err
@@ -34,9 +49,23 @@ func ReadJSONFilePayload(path string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("payload file is empty")
 	}
 
-	var payload map[string]any
+	var payload any
 	if err := json.Unmarshal(data, &payload); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	switch kind {
+	case JSONPayloadObject:
+		if _, ok := payload.(map[string]any); !ok {
+			return nil, fmt.Errorf("payload must be a JSON object")
+		}
+	case JSONPayloadArray:
+		if _, ok := payload.([]any); !ok {
+			return nil, fmt.Errorf("payload must be a JSON array")
+		}
+	case JSONPayloadAny, "":
+	default:
+		return nil, fmt.Errorf("unsupported JSON payload kind: %s", kind)
 	}
 
 	return json.RawMessage(data), nil

--- a/internal/cli/shared/json_payload_test.go
+++ b/internal/cli/shared/json_payload_test.go
@@ -152,4 +152,20 @@ func TestReadJSONFilePayloadKind(t *testing.T) {
 			t.Fatalf("unexpected payload: %q", string(payload))
 		}
 	})
+
+	t.Run("unsupported kind", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "payload.json")
+		if err := os.WriteFile(path, []byte(`{"name":"demo"}`), 0o600); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+
+		_, err := ReadJSONFilePayloadKind(path, JSONPayloadKind("document"))
+		if err == nil {
+			t.Fatal("expected unsupported kind error")
+		}
+		if !strings.Contains(err.Error(), "unsupported JSON payload kind: document") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/internal/cli/shared/json_payload_test.go
+++ b/internal/cli/shared/json_payload_test.go
@@ -86,4 +86,70 @@ func TestReadJSONFilePayload(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("object helper rejects array", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "array.json")
+		if err := os.WriteFile(path, []byte(`[1,2,3]`), 0o600); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+
+		_, err := ReadJSONFilePayload(path)
+		if err == nil {
+			t.Fatal("expected object payload error")
+		}
+		if !strings.Contains(err.Error(), "payload must be a JSON object") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestReadJSONFilePayloadKind(t *testing.T) {
+	t.Run("array payload", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "array.json")
+		if err := os.WriteFile(path, []byte(`[{"name":"demo"}]`), 0o600); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+
+		payload, err := ReadJSONFilePayloadKind(path, JSONPayloadArray)
+		if err != nil {
+			t.Fatalf("ReadJSONFilePayloadKind unexpected error: %v", err)
+		}
+		if string(payload) != `[{"name":"demo"}]` {
+			t.Fatalf("unexpected payload: %q", string(payload))
+		}
+	})
+
+	t.Run("array mode rejects object", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "object.json")
+		if err := os.WriteFile(path, []byte(`{"name":"demo"}`), 0o600); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+
+		_, err := ReadJSONFilePayloadKind(path, JSONPayloadArray)
+		if err == nil {
+			t.Fatal("expected array payload error")
+		}
+		if !strings.Contains(err.Error(), "payload must be a JSON array") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("any payload accepts scalar", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "scalar.json")
+		if err := os.WriteFile(path, []byte(`true`), 0o600); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+
+		payload, err := ReadJSONFilePayloadKind(path, JSONPayloadAny)
+		if err != nil {
+			t.Fatalf("ReadJSONFilePayloadKind unexpected error: %v", err)
+		}
+		if string(payload) != `true` {
+			t.Fatalf("unexpected payload: %q", string(payload))
+		}
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,12 +117,40 @@ type Credential struct {
 	PrivateKeyPath string `json:"private_key_path"`
 }
 
+// AdsCredential stores a named Apple Ads API credential in config.json.
+type AdsCredential struct {
+	Name           string `json:"name"`
+	ClientID       string `json:"client_id"`
+	TeamID         string `json:"team_id"`
+	KeyID          string `json:"key_id"`
+	PrivateKeyPath string `json:"private_key_path"`
+	OrgID          string `json:"org_id,omitempty"`
+}
+
 // KeychainMetadata stores non-secret metadata for keychain-backed credentials.
 type KeychainMetadata struct {
 	Name       string `json:"name"`
 	KeyID      string `json:"key_id"`
 	IssuerID   string `json:"issuer_id"`
 	ModifiedAt string `json:"modified_at,omitempty"`
+}
+
+// AdsKeychainMetadata stores non-secret metadata for keychain-backed Apple Ads credentials.
+type AdsKeychainMetadata struct {
+	Name       string `json:"name"`
+	ClientID   string `json:"client_id"`
+	TeamID     string `json:"team_id"`
+	KeyID      string `json:"key_id"`
+	OrgID      string `json:"org_id,omitempty"`
+	ModifiedAt string `json:"modified_at,omitempty"`
+}
+
+// AdsConfig stores Apple Ads-specific auth configuration.
+type AdsConfig struct {
+	DefaultKeyName   string                `json:"default_key_name,omitempty"`
+	Keys             []AdsCredential       `json:"keys,omitempty"`
+	KeychainMetadata []AdsKeychainMetadata `json:"keychain_metadata,omitempty"`
+	OrgID            string                `json:"org_id,omitempty"`
 }
 
 // Config holds the application configuration
@@ -149,6 +177,8 @@ type Config struct {
 	MaxDelay             string        `json:"max_delay"`
 	RetryLog             string        `json:"retry_log"`
 	Debug                string        `json:"debug"`
+
+	Ads AdsConfig `json:"ads,omitempty"`
 }
 
 // ErrNotFound is returned when the config file doesn't exist


### PR DESCRIPTION
## Summary

- Add native Apple Ads Campaign Management API support under `asc ads`.
- Add Apple Ads OAuth, keychain/config/env auth, org resolution, pagination, raw v5 requests, and generated endpoint commands.
- Add command docs, environment variable docs, architecture notes, mocked eval tests, and generated command docs.

## Author note

I really like asccli and use it daily in my projects. I needed a way to manipulate ads and didn't want a separate project for it so extended asccli with a native support for apple ads. I tried to stay as true as possible to the style and way of repo and retain as much of the logic and overall approach. I do hope I have achieved that. I have tested the code extensively both on dummy and live account data and everything seems to be working correctly.

## Verification

- `make format`
- `make check-command-docs`
- `make lint`
- `python3 scripts/check_website_docs.py --website-root .`
- `python3 scripts/check_website_commands.py --website-root .`
- `go build -o /tmp/asc .`
- `/tmp/asc ads --help`
- `/tmp/asc ads campaigns view --help`
- `/tmp/asc ads targeting-keywords create-bulk --campaign 11 --ad-group 22 --org 123 --output json` returned exit code 2 for missing `--file`
- `/tmp/asc ads campaigns delete --campaign 1 --org 123 --output json` returned exit code 2 for missing `--confirm`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `hasp check-repo --project-root . --json`

## Live Apple Ads validation

- Read-only suite: 46 passed, 2 skipped because the account had no optional matching data, 0 failed.
- Mutating suite: Search Results campaign, ad group, keyword, and negative keyword create/update/delete paths passed.
- Search Tab ad create/update passed with an existing default product page creative.
- Direct default product page ad delete returned Apple's `CAN_NOT_DELETE_DPP_CREATIVE_AD`; parent campaign cleanup removed the test resources.
- Final cleanup query found no remaining `ASC CLI Live Test` campaigns.

## Notes

Budget order, creative, and custom report live creates were not run because they can leave account artifacts without a clean delete path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asc ads command group for managing Apple Ads (campaigns, ad groups, keywords, creatives, reports) and raw API requests.
  * Auth UX: login/status/token/switch/doctor/logout with credential profiles, keychain vs config storage, strict/bypass auth, org handling, and token output.
  * Per-endpoint --confirm for destructive actions, --paginate aggregation, and top-level JSON payload shape validation.

* **Documentation**
  * New, comprehensive Apple Ads docs: auth, env vars & precedence, CLI usage, examples, and command reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->