### PR TITLE
Add Apple Ads operator playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ asc ads campaigns --org "123456" --limit 100 --output json
 asc ads reports campaigns --org "123456" --file reporting-request.json --output json
 ```
 
+See [guides/apple-ads-playbooks.mdx](guides/apple-ads-playbooks.mdx) for
+operator playbooks covering credential safety, org inspection, read-only smoke
+tests, reporting, raw API usage, and guarded mutations.
+
 ## Commands and Reference
 
 Use built-in help as the source of truth:
@@ -358,6 +362,7 @@ For full command families, flags, and discovery patterns, see:
 - [docs/CI_CD.md](docs/CI_CD.md) - CI/CD integration guides (GitHub Actions, GitLab, Bitrise, CircleCI)
 - [docs/COMMANDS.md](docs/COMMANDS.md) - Command families and reference navigation
 - [docs/WORKFLOWS.md](docs/WORKFLOWS.md) - Reusable workflow patterns, including local Xcode to TestFlight
+- [guides/apple-ads-playbooks.mdx](guides/apple-ads-playbooks.mdx) - Apple Ads operator playbooks
 - [docs/API_NOTES.md](docs/API_NOTES.md) - API quirks and behaviors
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) - CLI development and testing notes
 - [docs/TESTING.md](docs/TESTING.md) - Testing patterns and conventions

--- a/commands/ads.mdx
+++ b/commands/ads.mdx
@@ -14,6 +14,8 @@ asc ads campaigns --help
 asc ads campaigns create --help
 ```
 
+For operator workflows, see [Apple Ads Operator Playbooks](/guides/apple-ads-playbooks).
+
 ## Credential Model
 
 Apple Ads credentials are separate from App Store Connect credentials.

--- a/docs.json
+++ b/docs.json
@@ -39,6 +39,7 @@
               "guides/code-signing",
               "guides/metadata-management",
               "guides/analytics-reports",
+              "guides/apple-ads-playbooks",
               "guides/screenshots",
               "guides/automation"
             ]

--- a/guides/apple-ads-playbooks.mdx
+++ b/guides/apple-ads-playbooks.mdx
@@ -34,8 +34,11 @@ export ASC_ADS_PRIVATE_KEY_PATH="$HOME/.asc/apple-ads-private-key.pem"
 export ASC_ADS_ORG_ID="123456"
 export ASC_ADS_BYPASS_KEYCHAIN=1
 
-asc ads auth status --output json
+asc ads campaigns list --org "$ASC_ADS_ORG_ID" --limit 1 --output json
 ```
+
+Use a read-only API command for CI validation so the run resolves the exported
+`ASC_ADS_*` credentials and org context instead of only listing stored profiles.
 
 Use `ASC_ADS_PRIVATE_KEY_B64` when your CI secret store handles single-line
 values more reliably than PEM blocks. Keep `ASC_ADS_ACCESS_TOKEN` for cases
@@ -74,7 +77,6 @@ asc ads campaigns list \
 Use this sequence before an automation run or after rotating credentials:
 
 ```bash  theme={null}
-asc ads auth status --validate --output json
 asc ads me view --output json
 asc ads acls list --output json
 asc ads campaigns list --org "123456" --limit 1 --output json
@@ -83,6 +85,13 @@ asc ads campaigns list --org "123456" --limit 1 --output json
 Expected result: every command exits successfully, and the campaign list returns
 either a `data` array or an empty `data` array. Treat auth failures, missing org
 errors, or unexpected account names as stop conditions.
+
+When using stored Ads profiles, add profile validation before the API smoke
+test:
+
+```bash  theme={null}
+asc ads auth status --validate --output json
+```
 
 ## Campaign and Ad Group Inventory
 

--- a/guides/apple-ads-playbooks.mdx
+++ b/guides/apple-ads-playbooks.mdx
@@ -49,12 +49,11 @@ where another trusted system already minted a short-lived token.
 Start outside an org context. These commands do not require `--org`:
 
 ```bash  theme={null}
-asc ads me view --output json
 asc ads acls list --output json
 ```
 
-Use the ACL response to choose the org ID, then pin it explicitly for the rest
-of the session:
+Use the ACL response to confirm the account and choose the org ID, then pin it
+explicitly for the rest of the session:
 
 ```bash  theme={null}
 export ASC_ADS_ORG_ID="123456"
@@ -77,7 +76,6 @@ asc ads campaigns list \
 Use this sequence before an automation run or after rotating credentials:
 
 ```bash  theme={null}
-asc ads me view --output json
 asc ads acls list --output json
 asc ads campaigns list --org "123456" --limit 1 --output json
 ```
@@ -195,8 +193,9 @@ the exact target path you intend to delete.
 Before running create, update, delete, or bulk commands:
 
 1. Run the matching `--help` command and confirm required flags.
-2. Resolve the active account with `asc ads me view --output json`.
-3. Resolve org access with `asc ads acls list --output json`.
+2. Resolve account and org access with `asc ads acls list --output json`.
+3. Run a read-only resource check:
+   `asc ads campaigns list --org "123456" --limit 1 --output json`.
 4. Pass `--ads-profile` and `--org` explicitly when more than one account or org is possible.
 5. Store request bodies in reviewed JSON files; avoid shell-escaped inline JSON.
 6. Create paused or clearly named test resources when validating workflow shape.

--- a/guides/apple-ads-playbooks.mdx
+++ b/guides/apple-ads-playbooks.mdx
@@ -1,0 +1,222 @@
+# Apple Ads Operator Playbooks
+
+> Practical Apple Ads workflows for safe setup, read-only checks, reporting, and guarded mutations
+
+Use these playbooks when you are operating Apple Ads from `asc` in a terminal,
+CI job, or agent run. The goal is to start read-only, confirm the org context,
+and only mutate resources after the target IDs and payload files are reviewed.
+
+## Setup and Credential Safety
+
+Apple Ads credentials are separate from App Store Connect API credentials.
+`asc auth login` does not configure `asc ads`.
+
+Create a named Apple Ads profile and store the default org when you know it:
+
+```bash  theme={null}
+asc ads auth login \
+  --name "Marketing" \
+  --client-id "SEARCHADS_CLIENT_ID" \
+  --team-id "SEARCHADS_TEAM_ID" \
+  --key-id "KEY_ID" \
+  --private-key "$HOME/.asc/apple-ads-private-key.pem" \
+  --org "123456" \
+  --network
+```
+
+For CI, prefer secrets and environment variables over checked-in config:
+
+```bash  theme={null}
+export ASC_ADS_CLIENT_ID="SEARCHADS_CLIENT_ID"
+export ASC_ADS_TEAM_ID="SEARCHADS_TEAM_ID"
+export ASC_ADS_KEY_ID="KEY_ID"
+export ASC_ADS_PRIVATE_KEY_PATH="$HOME/.asc/apple-ads-private-key.pem"
+export ASC_ADS_ORG_ID="123456"
+export ASC_ADS_BYPASS_KEYCHAIN=1
+
+asc ads auth status --output json
+```
+
+Use `ASC_ADS_PRIVATE_KEY_B64` when your CI secret store handles single-line
+values more reliably than PEM blocks. Keep `ASC_ADS_ACCESS_TOKEN` for cases
+where another trusted system already minted a short-lived token.
+
+## Org Access Inspection
+
+Start outside an org context. These commands do not require `--org`:
+
+```bash  theme={null}
+asc ads me view --output json
+asc ads acls list --output json
+```
+
+Use the ACL response to choose the org ID, then pin it explicitly for the rest
+of the session:
+
+```bash  theme={null}
+export ASC_ADS_ORG_ID="123456"
+asc ads campaigns list --org "$ASC_ADS_ORG_ID" --limit 1 --output json
+```
+
+When operating multiple Apple Ads accounts, avoid relying on the ambient
+default. Pass both profile and org:
+
+```bash  theme={null}
+asc ads campaigns list \
+  --ads-profile "Marketing" \
+  --org "123456" \
+  --limit 10 \
+  --output table
+```
+
+## Safe Read-Only Smoke Test
+
+Use this sequence before an automation run or after rotating credentials:
+
+```bash  theme={null}
+asc ads auth status --validate --output json
+asc ads me view --output json
+asc ads acls list --output json
+asc ads campaigns list --org "123456" --limit 1 --output json
+```
+
+Expected result: every command exits successfully, and the campaign list returns
+either a `data` array or an empty `data` array. Treat auth failures, missing org
+errors, or unexpected account names as stop conditions.
+
+## Campaign and Ad Group Inventory
+
+List campaigns first, then inspect ad groups under one confirmed campaign ID:
+
+```bash  theme={null}
+asc ads campaigns list \
+  --org "123456" \
+  --limit 100 \
+  --output table
+
+asc ads ad-groups list \
+  --org "123456" \
+  --campaign 987654321 \
+  --limit 100 \
+  --output json
+```
+
+For full exports from query-parameter list endpoints, use pagination:
+
+```bash  theme={null}
+asc ads campaigns list --org "123456" --paginate --output json
+asc ads ad-groups list --org "123456" --campaign 987654321 --paginate --output json
+```
+
+Do not use report payloads as inventory replacements. Reports answer
+performance questions; list and find endpoints answer "what exists right now?"
+questions.
+
+## Report Workflow
+
+Keep reporting requests in files so they can be reviewed and reused:
+
+```json reporting-request.json
+{
+  "startTime": "2026-05-01",
+  "endTime": "2026-05-31",
+  "returnRowTotals": true,
+  "returnGrandTotals": true,
+  "selector": {
+    "pagination": {
+      "offset": 0,
+      "limit": 100
+    },
+    "orderBy": [
+      {
+        "field": "impressions",
+        "sortOrder": "DESCENDING"
+      }
+    ]
+  }
+}
+```
+
+Run the campaign report with an explicit org and output format:
+
+```bash  theme={null}
+asc ads reports campaigns \
+  --org "123456" \
+  --file reporting-request.json \
+  --output json
+```
+
+For ad-group, keyword, search-term, or ad-level reports, first verify the parent
+campaign ID with `asc ads campaigns list`. Report pagination lives inside the
+Apple Ads request body, so update the file's selector pagination rather than
+adding `--paginate`.
+
+## Raw API Safety
+
+Use `asc ads api request` for debugging, newly added Apple fields, or support
+captures. Prefer first-class commands for routine work.
+
+Read-only raw request:
+
+```bash  theme={null}
+asc ads api request \
+  --method GET \
+  --path v5/campaigns \
+  --org "123456" \
+  --output json
+```
+
+Selector request with a reviewed JSON file:
+
+```bash  theme={null}
+asc ads api request \
+  --method POST \
+  --path v5/campaigns/find \
+  --org "123456" \
+  --file selector.json \
+  --output json
+```
+
+Raw requests only accept Apple Ads v5 paths or Apple Ads API URLs. `DELETE`
+requests require `--confirm`; do not pass it until the command line includes
+the exact target path you intend to delete.
+
+## Mutation Safety Checklist
+
+Before running create, update, delete, or bulk commands:
+
+1. Run the matching `--help` command and confirm required flags.
+2. Resolve the active account with `asc ads me view --output json`.
+3. Resolve org access with `asc ads acls list --output json`.
+4. Pass `--ads-profile` and `--org` explicitly when more than one account or org is possible.
+5. Store request bodies in reviewed JSON files; avoid shell-escaped inline JSON.
+6. Create paused or clearly named test resources when validating workflow shape.
+7. Print or log the target IDs before using `--confirm`.
+8. Prefer deleting temporary parent campaigns only after confirming Apple allows the cleanup.
+
+Example guarded delete:
+
+```bash  theme={null}
+asc ads campaigns view --org "123456" --campaign 987654321 --output json
+asc ads campaigns delete --org "123456" --campaign 987654321 --confirm
+```
+
+## Troubleshooting Auth and Source Precedence
+
+Use the auth doctor first:
+
+```bash  theme={null}
+asc ads auth doctor --output json
+asc ads auth status --verbose --output json
+```
+
+Common fixes:
+
+* Missing org: pass `--org`, export `ASC_ADS_ORG_ID`, or store `--org` during login.
+* Wrong profile: pass `--ads-profile "Marketing"` or export `ASC_ADS_PROFILE`.
+* Keychain prompts in CI: export `ASC_ADS_BYPASS_KEYCHAIN=1`.
+* Mixed sources: set `ASC_ADS_STRICT_AUTH=1` to fail when both profile and env token/key sources are present.
+* Token-only runs: `ASC_ADS_ACCESS_TOKEN` still needs `--org`, `ASC_ADS_ORG_ID`, or a stored profile org.
+
+When debugging API responses, use an explicit output format and redact tokens,
+client IDs, team IDs, key IDs, org IDs, and account names before sharing logs.


### PR DESCRIPTION
## Summary
- add a guide-style Apple Ads operator playbook for credential safety, org inspection, read-only smoke tests, campaign/ad group inventory, reports, raw API safety, mutation guardrails, and auth troubleshooting
- wire the playbook into Mintlify navigation, README docs, and the existing Apple Ads command guide
- keep examples scoped to commands verified from current `./asc ads --help` output on `origin/main`

## Validation
- `./asc ads --help`
- `./asc ads auth --help`
- `./asc ads auth login --help`
- `./asc ads auth status --help`
- `./asc ads auth doctor --help`
- `./asc ads me view --help`
- `./asc ads acls list --help`
- `./asc ads campaigns --help`
- `./asc ads campaigns view --help`
- `./asc ads campaigns delete --help`
- `./asc ads ad-groups list --help`
- `./asc ads reports campaigns --help`
- `./asc ads api request --help`
- `make check-command-docs`
- `make check-repo-docs`
- `make check-website-docs`
- `make format`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Notes
- Docs-only PR; no live Apple Ads API calls were made.
- `make lint` passed with 0 issues, but golangci-lint printed a stale generated-file-filter warning for a deleted sibling worktree path outside this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Apple Ads operator playbook covering credential safety, org/account selection, CI-friendly secret handling, read-only smoke tests, reporting, raw API safety, mutation safety checklist, and troubleshooting/auth-source guidance.
  * Linked the new playbook from relevant command docs to guide operator workflows.
  * Updated site navigation and documentation index to include the new guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->