### PR TITLE
Improve Apple Ads auth UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Apple Ads uses separate OAuth credentials from App Store Connect:
 
 ```bash
 asc ads auth login --name "Marketing" --client-id "SEARCHADS_CLIENT_ID" --team-id "SEARCHADS_TEAM_ID" --key-id "KEY_ID" --private-key ./ads-key.pem --org "123456"
+asc ads auth discover --output json
 asc ads campaigns --org "123456" --limit 100 --output json
 asc ads reports campaigns --org "123456" --file reporting-request.json --output json
 ```

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -223,6 +223,7 @@ Validate Apple Ads credentials:
 
 ```bash  theme={null}
 asc ads auth status --validate
+asc ads auth discover --output json
 asc ads auth doctor
 ```
 
@@ -240,7 +241,9 @@ wins over `ASC_ADS_ACCESS_TOKEN`. Set `ASC_ADS_STRICT_AUTH=true` to fail when a
 profile and access token are both present.
 
 Most Apple Ads commands also require an organization ID. Set it with `--org`,
-store it during Ads login, or export `ASC_ADS_ORG_ID`.
+store it during Ads login, or export `ASC_ADS_ORG_ID`. If you do not know the
+right organization ID yet, run `asc ads auth discover --output json` and inspect
+the `accounts` list.
 
 ## Validate credentials
 

--- a/commands/ads.mdx
+++ b/commands/ads.mdx
@@ -66,6 +66,7 @@ Validate and inspect stored credentials:
 
 ```bash  theme={null}
 asc ads auth status --validate
+asc ads auth discover --output json
 asc ads auth doctor
 ```
 
@@ -104,13 +105,13 @@ asc ads campaigns --limit 10 --output json
 
 Most Apple Ads endpoints require an organization context. Provide it with
 `--org`, store it during login with `--org`, or set `ASC_ADS_ORG_ID`. If you do
-not know the org ID yet, list the account ACLs first:
+not know the org ID yet, discover the active Ads user and available accounts:
 
 ```bash  theme={null}
-asc ads acls --output json
+asc ads auth discover --output json
 ```
 
-Then pass the org ID returned by Apple:
+Then pass an `accounts[].org_id` returned by Apple:
 
 ```bash  theme={null}
 asc ads campaigns list --org "123456" --output json
@@ -383,7 +384,7 @@ The raw request command only accepts Apple Ads v5 paths or
 When you automate Apple Ads with a coding agent:
 
 1. Run `asc ads <group> --help` before choosing flags.
-2. Resolve the org with `asc ads acls --output json` unless `ASC_ADS_ORG_ID` is already known.
+2. Resolve the user and org with `asc ads auth discover --output json` unless `ASC_ADS_ORG_ID` is already known.
 3. Use `--output json` for machine parsing.
 4. Put request bodies in checked-in templates or temporary JSON files, not shell-escaped inline JSON.
 5. Pass `--confirm` only after you have printed the target ID and cleanup plan.

--- a/docs/architecture/apple-ads-api-support.md
+++ b/docs/architecture/apple-ads-api-support.md
@@ -165,6 +165,7 @@ Implement this command group:
 ```text
 asc ads auth login --name NAME --client-id CLIENT_ID --team-id TEAM_ID --key-id KEY_ID --private-key PATH [--org ORG_ID] [--network] [--skip-validation] [--bypass-keychain] [--local]
 asc ads auth status [--verbose] [--validate] [--output table|json]
+asc ads auth discover [--ads-profile NAME] [--org ORG_ID] [--output table|json]
 asc ads auth switch --name NAME
 asc ads auth token --confirm [--output text|json]
 asc ads auth doctor [--output text|json]
@@ -186,6 +187,8 @@ Mirror the existing `asc auth` behavior:
 - `--local` requires keychain bypass, exactly like `asc auth login`.
 - Keychain is preferred; config fallback is allowed when bypassing keychain.
 - `auth status` supports `--verbose` and `--validate`, matching `asc auth status`.
+- `auth discover` calls `/v5/me` and `/v5/acls` to show the active Ads user and
+  available organizations without printing access tokens.
 - `auth logout` supports `--all` and `--name`. It requires one of those flags
   so bare `asc ads auth logout` does not clear every stored Ads profile, and
   `--all` requires `--confirm`.

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -2,6 +2,7 @@ package ads
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -35,6 +36,7 @@ Examples:
 		Subcommands: []*ffcli.Command{
 			AuthLoginCommand(),
 			AuthStatusCommand(),
+			AuthDiscoverCommand(),
 			AuthSwitchCommand(),
 			AuthTokenCommand(),
 			AuthDoctorCommand(),
@@ -214,6 +216,7 @@ Examples:
 			}
 			result := adsAuthStatusOutput{
 				Storage:     storageDescription(),
+				Active:      statusActiveContext(),
 				Credentials: rows,
 			}
 			if normalized == "json" {
@@ -233,7 +236,16 @@ Examples:
 
 type adsAuthStatusOutput struct {
 	Storage     string             `json:"storage"`
+	Active      adsAuthContext     `json:"active"`
 	Credentials []adsAuthStatusRow `json:"credentials"`
+}
+
+type adsAuthContext struct {
+	Profile     string `json:"profile,omitempty"`
+	Source      string `json:"source,omitempty"`
+	OrgID       string `json:"org_id,omitempty"`
+	OrgIDSource string `json:"org_id_source,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 type adsAuthStatusRow struct {
@@ -251,6 +263,8 @@ type adsAuthStatusRow struct {
 
 func printStatusTable(result adsAuthStatusOutput) {
 	fmt.Printf("Credential storage: %s\n\n", result.Storage)
+	printActiveContext(result.Active)
+	fmt.Println()
 	if len(result.Credentials) == 0 {
 		fmt.Println("No Apple Ads credentials stored. Run 'asc ads auth login' to get started.")
 		return
@@ -279,11 +293,254 @@ func printStatusTable(result adsAuthStatusOutput) {
 	}
 }
 
+func printActiveContext(active adsAuthContext) {
+	if active.Error != "" {
+		fmt.Printf("Active auth: unavailable (%s)\n", active.Error)
+		return
+	}
+	if active.Source == "" {
+		fmt.Println("Active auth: none")
+		return
+	}
+	fmt.Printf("Active auth: %s\n", active.Source)
+	if active.Profile != "" {
+		fmt.Printf("  Profile: %s\n", active.Profile)
+	}
+	if active.OrgID != "" {
+		if active.OrgIDSource != "" {
+			fmt.Printf("  Org ID: %s (%s)\n", active.OrgID, active.OrgIDSource)
+		} else {
+			fmt.Printf("  Org ID: %s\n", active.OrgID)
+		}
+	} else {
+		fmt.Println("  Org ID: not selected")
+	}
+}
+
+func statusActiveContext() adsAuthContext {
+	credentials, source, err := resolveCredentialsWithSource(commonFlags{})
+	if err != nil {
+		if isNoAdsCredentialError(err) {
+			return adsAuthContext{}
+		}
+		return adsAuthContext{Error: err.Error()}
+	}
+	orgID, orgSource, err := resolveOrgIDWithSource(commonFlags{}, credentials)
+	if err != nil {
+		return adsAuthContext{Error: err.Error()}
+	}
+	return adsAuthContext{
+		Profile:     credentials.Profile,
+		Source:      source,
+		OrgID:       orgID,
+		OrgIDSource: orgSource,
+	}
+}
+
+func isNoAdsCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "default credentials not found") ||
+		strings.Contains(message, "credentials not found")
+}
+
 func storageDescription() string {
 	if appleads.ShouldBypassKeychain() {
 		return "Config File"
 	}
 	return "System Keychain"
+}
+
+func AuthDiscoverCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("ads auth discover", flag.ExitOnError)
+	common := commonFlags{
+		AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile"),
+		Org:        fs.String("org", "", "Apple Ads organization ID to mark active"),
+	}
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "table", "Output format: table, json", "table", "json")
+	return &ffcli.Command{
+		Name:       "discover",
+		ShortUsage: "asc ads auth discover [flags]",
+		ShortHelp:  "Discover Apple Ads user and organization access.",
+		LongHelp: `Discover Apple Ads user and organization access.
+
+This read-only command calls GET v5/me and GET v5/acls. It does not print access tokens.
+
+Examples:
+  asc ads auth discover
+  asc ads auth discover --output json
+  asc ads auth discover --ads-profile "Ads"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
+			normalized, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "table", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			credentials, source, err := resolveCredentialsWithSource(common)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: %w", err)
+			}
+			orgID, orgSource, err := resolveOrgIDWithSource(common, credentials)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: %w", err)
+			}
+			client, err := appleads.NewClient(credentials)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: %w", err)
+			}
+			requestCtx, cancel := requestContext(ctx)
+			defer cancel()
+
+			meSpec, _ := appleads.EndpointByCommandPath("me", "view")
+			meRaw, err := client.Do(requestCtx, meSpec, nil, nil, nil)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: me lookup failed: %w", err)
+			}
+			aclsSpec, _ := appleads.EndpointByCommandPath("acls", "list")
+			aclsRaw, err := client.Do(requestCtx, aclsSpec, nil, nil, nil)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: acl lookup failed: %w", err)
+			}
+
+			result := adsAuthDiscoveryOutput{
+				AuthSource:  source,
+				Profile:     credentials.Profile,
+				OrgID:       orgID,
+				OrgIDSource: orgSource,
+				Me:          envelopeData(meRaw),
+				Accounts:    summarizeACLAccounts(aclsRaw, orgID),
+			}
+			if normalized == "json" {
+				return shared.PrintOutput(result, "json", *output.Pretty)
+			}
+			printDiscoveryTable(result)
+			return nil
+		},
+	}
+}
+
+type adsAuthDiscoveryOutput struct {
+	AuthSource  string                  `json:"auth_source"`
+	Profile     string                  `json:"profile,omitempty"`
+	OrgID       string                  `json:"org_id,omitempty"`
+	OrgIDSource string                  `json:"org_id_source,omitempty"`
+	Me          json.RawMessage         `json:"me"`
+	Accounts    []adsAuthAccountSummary `json:"accounts"`
+}
+
+type adsAuthAccountSummary struct {
+	OrgID  string   `json:"org_id,omitempty"`
+	Name   string   `json:"name,omitempty"`
+	Roles  []string `json:"roles,omitempty"`
+	Active bool     `json:"active"`
+}
+
+func printDiscoveryTable(result adsAuthDiscoveryOutput) {
+	fmt.Printf("Auth source: %s\n", result.AuthSource)
+	if result.Profile != "" {
+		fmt.Printf("Profile: %s\n", result.Profile)
+	}
+	if result.OrgID != "" {
+		if result.OrgIDSource != "" {
+			fmt.Printf("Selected org: %s (%s)\n", result.OrgID, result.OrgIDSource)
+		} else {
+			fmt.Printf("Selected org: %s\n", result.OrgID)
+		}
+	} else {
+		fmt.Println("Selected org: none")
+	}
+	if len(result.Accounts) == 0 {
+		fmt.Println("Accounts: none returned")
+		return
+	}
+	fmt.Println("Accounts:")
+	for _, account := range result.Accounts {
+		marker := ""
+		if account.Active {
+			marker = " (active)"
+		}
+		label := account.OrgID
+		if account.Name != "" {
+			label += " - " + account.Name
+		}
+		fmt.Printf("  %s%s\n", label, marker)
+		if len(account.Roles) > 0 {
+			fmt.Printf("    Roles: %s\n", strings.Join(account.Roles, ", "))
+		}
+	}
+}
+
+func envelopeData(raw appleads.RawResponse) json.RawMessage {
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil || len(envelope.Data) == 0 {
+		return json.RawMessage("null")
+	}
+	return envelope.Data
+}
+
+func summarizeACLAccounts(raw appleads.RawResponse, activeOrgID string) []adsAuthAccountSummary {
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil
+	}
+	accounts := make([]adsAuthAccountSummary, 0, len(envelope.Data))
+	for _, item := range envelope.Data {
+		orgID := jsonScalarString(firstMapValue(item, "orgId", "orgID", "organizationId", "id"))
+		account := adsAuthAccountSummary{
+			OrgID:  orgID,
+			Name:   jsonScalarString(firstMapValue(item, "orgName", "organizationName", "name")),
+			Roles:  jsonStringList(firstMapValue(item, "roleNames", "roles")),
+			Active: orgID != "" && activeOrgID != "" && orgID == activeOrgID,
+		}
+		accounts = append(accounts, account)
+	}
+	return accounts
+}
+
+func firstMapValue(item map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := item[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func jsonScalarString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case float64:
+		return strings.TrimSuffix(strings.TrimSuffix(fmt.Sprintf("%.0f", typed), ".0"), ".")
+	case json.Number:
+		return typed.String()
+	default:
+		return ""
+	}
+}
+
+func jsonStringList(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if text := jsonScalarString(item); text != "" {
+			result = append(result, text)
+		}
+	}
+	return result
 }
 
 func AuthSwitchCommand() *ffcli.Command {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -1,6 +1,7 @@
 package ads
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -177,9 +178,11 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
+			active := statusActiveContext()
 			credentials, err := appleads.ListCredentials()
+			credentialsError := ""
 			if err != nil {
-				return fmt.Errorf("ads auth status: %w", err)
+				credentialsError = err.Error()
 			}
 			rows := make([]adsAuthStatusRow, 0, len(credentials))
 			failures := 0
@@ -216,9 +219,10 @@ Examples:
 				rows = append(rows, row)
 			}
 			result := adsAuthStatusOutput{
-				Storage:     storageDescription(),
-				Active:      statusActiveContext(),
-				Credentials: rows,
+				Storage:          storageDescription(),
+				Active:           active,
+				Credentials:      rows,
+				CredentialsError: credentialsError,
 			}
 			if normalized == "json" {
 				if err := shared.PrintOutput(result, "json", *output.Pretty); err != nil {
@@ -236,9 +240,10 @@ Examples:
 }
 
 type adsAuthStatusOutput struct {
-	Storage     string             `json:"storage"`
-	Active      adsAuthContext     `json:"active"`
-	Credentials []adsAuthStatusRow `json:"credentials"`
+	Storage          string             `json:"storage"`
+	Active           adsAuthContext     `json:"active"`
+	Credentials      []adsAuthStatusRow `json:"credentials"`
+	CredentialsError string             `json:"credentials_error,omitempty"`
 }
 
 type adsAuthContext struct {
@@ -266,6 +271,10 @@ func printStatusTable(result adsAuthStatusOutput) {
 	fmt.Printf("Credential storage: %s\n\n", result.Storage)
 	printActiveContext(result.Active)
 	fmt.Println()
+	if result.CredentialsError != "" {
+		fmt.Printf("Stored credentials: unavailable (%s)\n", result.CredentialsError)
+		return
+	}
 	if len(result.Credentials) == 0 {
 		fmt.Println("No Apple Ads credentials stored. Run 'asc ads auth login' to get started.")
 		return
@@ -296,7 +305,15 @@ func printStatusTable(result adsAuthStatusOutput) {
 
 func printActiveContext(active adsAuthContext) {
 	if active.Error != "" {
-		fmt.Printf("Active auth: unavailable (%s)\n", active.Error)
+		if active.Source == "" {
+			fmt.Printf("Active auth: unavailable (%s)\n", active.Error)
+			return
+		}
+		fmt.Printf("Active auth: %s\n", active.Source)
+		if active.Profile != "" {
+			fmt.Printf("  Profile: %s\n", active.Profile)
+		}
+		fmt.Printf("  Org ID: unavailable (%s)\n", active.Error)
 		return
 	}
 	if active.Source == "" {
@@ -328,7 +345,11 @@ func statusActiveContext() adsAuthContext {
 	}
 	orgID, orgSource, err := resolveOrgIDWithSource(commonFlags{}, credentials)
 	if err != nil {
-		return adsAuthContext{Error: err.Error()}
+		return adsAuthContext{
+			Profile: credentials.Profile,
+			Source:  source,
+			Error:   err.Error(),
+		}
 	}
 	return adsAuthContext{
 		Profile:     credentials.Profile,
@@ -493,23 +514,24 @@ func printDiscoveryTable(result adsAuthDiscoveryOutput) {
 }
 
 func discoveryUserSummary(me json.RawMessage) string {
-	var user struct {
-		ID    string `json:"id"`
-		Name  string `json:"name"`
-		Email string `json:"email"`
-	}
+	var user map[string]any
 	if err := json.Unmarshal(me, &user); err != nil {
 		return ""
 	}
+	id := jsonScalarString(firstMapValue(user, "userId", "id"))
+	name := jsonScalarString(firstMapValue(user, "name"))
+	email := jsonScalarString(firstMapValue(user, "email"))
 	switch {
-	case strings.TrimSpace(user.Name) != "" && strings.TrimSpace(user.ID) != "":
-		return strings.TrimSpace(user.Name) + " (" + strings.TrimSpace(user.ID) + ")"
-	case strings.TrimSpace(user.Name) != "":
-		return strings.TrimSpace(user.Name)
-	case strings.TrimSpace(user.Email) != "":
-		return strings.TrimSpace(user.Email)
+	case name != "" && id != "":
+		return name + " (" + id + ")"
+	case name != "":
+		return name
+	case email != "":
+		return email
+	case id != "":
+		return id
 	default:
-		return strings.TrimSpace(user.ID)
+		return jsonScalarString(firstMapValue(user, "parentOrgId"))
 	}
 }
 
@@ -528,13 +550,17 @@ func envelopeData(raw appleads.RawResponse) (json.RawMessage, error) {
 
 func summarizeACLAccounts(raw appleads.RawResponse, activeOrgID string) ([]adsAuthAccountSummary, error) {
 	var envelope struct {
-		Data []map[string]any `json:"data"`
+		Data json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return nil, err
 	}
-	accounts := make([]adsAuthAccountSummary, 0, len(envelope.Data))
-	for _, item := range envelope.Data {
+	items, err := aclDataItems(envelope.Data)
+	if err != nil {
+		return nil, err
+	}
+	accounts := make([]adsAuthAccountSummary, 0, len(items))
+	for _, item := range items {
 		orgID := jsonScalarString(firstMapValue(item, "orgId", "orgID", "organizationId", "id"))
 		account := adsAuthAccountSummary{
 			OrgID:  orgID,
@@ -545,6 +571,25 @@ func summarizeACLAccounts(raw appleads.RawResponse, activeOrgID string) ([]adsAu
 		accounts = append(accounts, account)
 	}
 	return accounts, nil
+}
+
+func aclDataItems(data json.RawMessage) ([]map[string]any, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	if trimmed[0] == '[' {
+		var items []map[string]any
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return nil, err
+		}
+		return items, nil
+	}
+	var item map[string]any
+	if err := json.Unmarshal(trimmed, &item); err != nil {
+		return nil, err
+	}
+	return []map[string]any{item}, nil
 }
 
 func firstMapValue(item map[string]any, keys ...string) any {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -30,6 +30,7 @@ Apple Ads uses OAuth client credentials and separate Apple Ads API keys.
 Examples:
   asc ads auth login --name "Ads" --client-id "SEARCHADS..." --team-id "SEARCHADS..." --key-id "KEY_ID" --private-key ./private-key.pem
   asc ads auth status
+  asc ads auth discover --output json
   asc ads auth token --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -341,9 +342,7 @@ func isNoAdsCredentialError(err error) bool {
 	if err == nil {
 		return false
 	}
-	message := err.Error()
-	return strings.Contains(message, "default credentials not found") ||
-		strings.Contains(message, "credentials not found")
+	return err.Error() == "default credentials not found"
 }
 
 func storageDescription() string {
@@ -408,13 +407,22 @@ Examples:
 				return fmt.Errorf("ads auth discover: acl lookup failed: %w", err)
 			}
 
+			me, err := envelopeData(meRaw)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: me response parse failed: %w", err)
+			}
+			accounts, err := summarizeACLAccounts(aclsRaw, orgID)
+			if err != nil {
+				return fmt.Errorf("ads auth discover: acl response parse failed: %w", err)
+			}
+
 			result := adsAuthDiscoveryOutput{
 				AuthSource:  source,
 				Profile:     credentials.Profile,
 				OrgID:       orgID,
 				OrgIDSource: orgSource,
-				Me:          envelopeData(meRaw),
-				Accounts:    summarizeACLAccounts(aclsRaw, orgID),
+				Me:          me,
+				Accounts:    accounts,
 			}
 			if normalized == "json" {
 				return shared.PrintOutput(result, "json", *output.Pretty)
@@ -446,6 +454,9 @@ func printDiscoveryTable(result adsAuthDiscoveryOutput) {
 	if result.Profile != "" {
 		fmt.Printf("Profile: %s\n", result.Profile)
 	}
+	if user := discoveryUserSummary(result.Me); user != "" {
+		fmt.Printf("User: %s\n", user)
+	}
 	if result.OrgID != "" {
 		if result.OrgIDSource != "" {
 			fmt.Printf("Selected org: %s (%s)\n", result.OrgID, result.OrgIDSource)
@@ -476,22 +487,46 @@ func printDiscoveryTable(result adsAuthDiscoveryOutput) {
 	}
 }
 
-func envelopeData(raw appleads.RawResponse) json.RawMessage {
+func discoveryUserSummary(me json.RawMessage) string {
+	var user struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(me, &user); err != nil {
+		return ""
+	}
+	switch {
+	case strings.TrimSpace(user.Name) != "" && strings.TrimSpace(user.ID) != "":
+		return strings.TrimSpace(user.Name) + " (" + strings.TrimSpace(user.ID) + ")"
+	case strings.TrimSpace(user.Name) != "":
+		return strings.TrimSpace(user.Name)
+	case strings.TrimSpace(user.Email) != "":
+		return strings.TrimSpace(user.Email)
+	default:
+		return strings.TrimSpace(user.ID)
+	}
+}
+
+func envelopeData(raw appleads.RawResponse) (json.RawMessage, error) {
 	var envelope struct {
 		Data json.RawMessage `json:"data"`
 	}
-	if err := json.Unmarshal(raw, &envelope); err != nil || len(envelope.Data) == 0 {
-		return json.RawMessage("null")
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, err
 	}
-	return envelope.Data
+	if len(envelope.Data) == 0 {
+		return json.RawMessage("null"), nil
+	}
+	return envelope.Data, nil
 }
 
-func summarizeACLAccounts(raw appleads.RawResponse, activeOrgID string) []adsAuthAccountSummary {
+func summarizeACLAccounts(raw appleads.RawResponse, activeOrgID string) ([]adsAuthAccountSummary, error) {
 	var envelope struct {
 		Data []map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return nil
+		return nil, err
 	}
 	accounts := make([]adsAuthAccountSummary, 0, len(envelope.Data))
 	for _, item := range envelope.Data {
@@ -504,7 +539,7 @@ func summarizeACLAccounts(raw appleads.RawResponse, activeOrgID string) []adsAut
 		}
 		accounts = append(accounts, account)
 	}
-	return accounts
+	return accounts, nil
 }
 
 func firstMapValue(item map[string]any, keys ...string) any {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -385,10 +385,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("ads auth discover: %w", err)
 			}
-			orgID, orgSource, err := resolveOrgIDWithSource(common, credentials)
-			if err != nil {
-				return fmt.Errorf("ads auth discover: %w", err)
-			}
+			orgID, orgSource := discoverOrgIDWithSource(common, credentials)
 			client, err := appleads.NewClient(credentials)
 			if err != nil {
 				return fmt.Errorf("ads auth discover: %w", err)
@@ -431,6 +428,14 @@ Examples:
 			return nil
 		},
 	}
+}
+
+func discoverOrgIDWithSource(flags commonFlags, credentials appleads.Credentials) (string, string) {
+	orgID, orgSource, err := resolveOrgIDWithSource(flags, credentials)
+	if err != nil {
+		return "", ""
+	}
+	return orgID, orgSource
 }
 
 type adsAuthDiscoveryOutput struct {

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -231,6 +231,9 @@ Examples:
 			} else {
 				printStatusTable(result)
 			}
+			if *validate && credentialsError != "" {
+				return shared.NewReportedError(fmt.Errorf("ads auth status: validation skipped because credentials could not be listed: %s", credentialsError))
+			}
 			if failures > 0 {
 				return shared.NewReportedError(fmt.Errorf("ads auth status: validation failed for %d credential(s)", failures))
 			}

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -118,14 +118,14 @@ func sortedChildNames(node *commandNode) []string {
 
 func endpointShortHelp(node *commandNode) string {
 	if node.spec == nil {
-		return "Manage Apple Ads " + strings.ReplaceAll(node.name, "-", " ") + "."
+		return endpointGroupHelp(node.name)
 	}
 	return sentenceFromEndpointName(node.spec.Name)
 }
 
 func endpointLongHelp(node *commandNode, path []string) string {
 	if node.spec == nil {
-		return fmt.Sprintf("Manage Apple Ads %s.\n\nExamples:\n  asc ads %s --help", strings.ReplaceAll(node.name, "-", " "), strings.Join(path, " "))
+		return fmt.Sprintf("%s\n\nExamples:\n  asc ads %s --help", endpointGroupHelp(node.name), strings.Join(path, " "))
 	}
 	examples := []string{"  asc ads " + strings.Join(path, " ")}
 	for _, param := range node.spec.PathParams {
@@ -143,7 +143,24 @@ func endpointLongHelp(node *commandNode, path []string) string {
 	return fmt.Sprintf("%s\n\nEndpoint: %s %s\n\nExamples:\n%s", endpointShortHelp(node), node.spec.Method, node.spec.Path, strings.Join(examples, "\n"))
 }
 
+func endpointGroupHelp(name string) string {
+	switch name {
+	case "me":
+		return "View the current Apple Ads user."
+	case "geo":
+		return "Manage Apple Ads geographic targeting resources."
+	default:
+		return "Manage Apple Ads " + strings.ReplaceAll(name, "-", " ") + "."
+	}
+}
+
 func sentenceFromEndpointName(name string) string {
+	switch name {
+	case "get-me-details":
+		return "View the current Apple Ads user."
+	case "get-user-acl":
+		return "List Apple Ads account ACLs."
+	}
 	text := strings.ReplaceAll(strings.TrimSpace(name), "-", " ")
 	replacements := []struct {
 		old string

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -258,6 +258,28 @@ func TestCollectQueryIncludesAllowedValidValues(t *testing.T) {
 	}
 }
 
+func TestEndpointHelpUsesOperatorFriendlyAuthDiscoveryNames(t *testing.T) {
+	root := AdsCommand()
+	tests := []struct {
+		path []string
+		want string
+	}{
+		{path: []string{"me"}, want: "View the current Apple Ads user."},
+		{path: []string{"me", "view"}, want: "View the current Apple Ads user."},
+		{path: []string{"acls"}, want: "List Apple Ads account ACLs."},
+		{path: []string{"acls", "list"}, want: "List Apple Ads account ACLs."},
+	}
+	for _, test := range tests {
+		cmd := findCommand(root, test.path...)
+		if cmd == nil {
+			t.Fatalf("missing command asc ads %s", strings.Join(test.path, " "))
+		}
+		if cmd.ShortHelp != test.want {
+			t.Fatalf("asc ads %s ShortHelp = %q, want %q", strings.Join(test.path, " "), cmd.ShortHelp, test.want)
+		}
+	}
+}
+
 func findCommand(root *ffcli.Command, path ...string) *ffcli.Command {
 	current := root
 	for _, part := range path {

--- a/internal/cli/ads/resolve.go
+++ b/internal/cli/ads/resolve.go
@@ -38,53 +38,60 @@ func resolveClient(ctx context.Context, flags commonFlags, requiresOrg bool) (*a
 }
 
 func resolveCredentials(flags commonFlags) (appleads.Credentials, error) {
+	credentials, _, err := resolveCredentialsWithSource(flags)
+	return credentials, err
+}
+
+func resolveCredentialsWithSource(flags commonFlags) (appleads.Credentials, string, error) {
 	profile := strings.TrimSpace(value(flags.AdsProfile))
+	profileSource := "--ads-profile"
 	if profile == "" {
 		profile = strings.TrimSpace(os.Getenv("ASC_ADS_PROFILE"))
+		profileSource = "ASC_ADS_PROFILE"
 	}
 	accessToken := strings.TrimSpace(os.Getenv("ASC_ADS_ACCESS_TOKEN"))
 	strict := parseBoolEnv("ASC_ADS_STRICT_AUTH")
 	if profile != "" {
 		if strict && accessToken != "" {
-			return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_ACCESS_TOKEN")
+			return appleads.Credentials{}, "", fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_ACCESS_TOKEN")
 		}
 		if strict {
 			if _, ok, err := envCredentials(); err != nil {
-				return appleads.Credentials{}, err
+				return appleads.Credentials{}, "", err
 			} else if ok {
-				return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_* key credentials")
+				return appleads.Credentials{}, "", fmt.Errorf("mixed Apple Ads authentication sources detected: profile and ASC_ADS_* key credentials")
 			}
 		}
 		credentials, _, err := appleads.GetCredentialsWithSource(profile)
 		if err != nil {
-			return appleads.Credentials{}, err
+			return appleads.Credentials{}, "", err
 		}
-		return credentials, nil
+		return credentials, profileSource, nil
 	}
 	if accessToken != "" {
 		if strict {
 			if _, ok, err := envCredentials(); err != nil {
-				return appleads.Credentials{}, err
+				return appleads.Credentials{}, "", err
 			} else if ok {
-				return appleads.Credentials{}, fmt.Errorf("mixed Apple Ads authentication sources detected: ASC_ADS_ACCESS_TOKEN and ASC_ADS_* key credentials")
+				return appleads.Credentials{}, "", fmt.Errorf("mixed Apple Ads authentication sources detected: ASC_ADS_ACCESS_TOKEN and ASC_ADS_* key credentials")
 			}
 		}
-		return appleads.Credentials{AccessToken: accessToken}, nil
+		return appleads.Credentials{AccessToken: accessToken}, "ASC_ADS_ACCESS_TOKEN", nil
 	}
 
 	env, ok, err := envCredentials()
 	if err != nil {
-		return appleads.Credentials{}, err
+		return appleads.Credentials{}, "", err
 	}
 	if ok {
-		return env, nil
+		return env, "ASC_ADS_* key credentials", nil
 	}
 
 	credentials, _, err := appleads.GetCredentialsWithSource("")
 	if err != nil {
-		return appleads.Credentials{}, err
+		return appleads.Credentials{}, "", err
 	}
-	return credentials, nil
+	return credentials, "default Ads profile", nil
 }
 
 func envCredentials() (appleads.Credentials, bool, error) {
@@ -122,17 +129,31 @@ func envCredentials() (appleads.Credentials, bool, error) {
 }
 
 func resolveOrgID(flags commonFlags, credentials appleads.Credentials) (string, error) {
-	if orgID := firstNonEmpty(value(flags.Org), os.Getenv("ASC_ADS_ORG_ID"), credentials.OrgID); orgID != "" {
-		return orgID, nil
+	orgID, _, err := resolveOrgIDWithSource(flags, credentials)
+	return orgID, err
+}
+
+func resolveOrgIDWithSource(flags commonFlags, credentials appleads.Credentials) (string, string, error) {
+	if orgID := value(flags.Org); orgID != "" {
+		return orgID, "--org", nil
+	}
+	if orgID := strings.TrimSpace(os.Getenv("ASC_ADS_ORG_ID")); orgID != "" {
+		return orgID, "ASC_ADS_ORG_ID", nil
+	}
+	if orgID := strings.TrimSpace(credentials.OrgID); orgID != "" {
+		if strings.TrimSpace(credentials.Profile) != "" {
+			return orgID, "Ads profile org_id", nil
+		}
+		return orgID, "credential org_id", nil
 	}
 	cfg, err := config.Load()
 	if err != nil {
 		if errors.Is(err, config.ErrNotFound) {
-			return "", nil
+			return "", "", nil
 		}
-		return "", err
+		return "", "", err
 	}
-	return strings.TrimSpace(cfg.Ads.OrgID), nil
+	return strings.TrimSpace(cfg.Ads.OrgID), "ads.org_id", nil
 }
 
 func requestContext(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -153,13 +174,4 @@ func value(ptr *string) string {
 		return ""
 	}
 	return strings.TrimSpace(*ptr)
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, item := range values {
-		if strings.TrimSpace(item) != "" {
-			return strings.TrimSpace(item)
-		}
-	}
-	return ""
 }

--- a/internal/cli/ads/resolve.go
+++ b/internal/cli/ads/resolve.go
@@ -153,7 +153,11 @@ func resolveOrgIDWithSource(flags commonFlags, credentials appleads.Credentials)
 		}
 		return "", "", err
 	}
-	return strings.TrimSpace(cfg.Ads.OrgID), "ads.org_id", nil
+	orgID := strings.TrimSpace(cfg.Ads.OrgID)
+	if orgID == "" {
+		return "", "", nil
+	}
+	return orgID, "ads.org_id", nil
 }
 
 func requestContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/cli/ads/root.go
+++ b/internal/cli/ads/root.go
@@ -22,7 +22,7 @@ Apple Ads credentials are separate from App Store Connect API credentials.
 
 Examples:
   asc ads auth login --name "Ads" --client-id "SEARCHADS..." --team-id "SEARCHADS..." --key-id "KEY_ID" --private-key ./private-key.pem --org "123456"
-  asc ads me view --output json
+  asc ads auth discover --output json
   asc ads campaigns list --org "123456" --limit 10
   asc ads reports campaigns --org "123456" --file report.json`,
 		FlagSet:   fs,

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -253,6 +253,20 @@ func TestAdsAuthStatusKeepsAuthSourceWhenOptionalOrgConfigIsInvalid(t *testing.T
 			t.Fatalf("table status = %q, missing %q", stdout, want)
 		}
 	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status", "--validate", "--output", "json")
+	if _, ok := errors.AsType[ReportedError](err); !ok {
+		t.Fatalf("validate status error = %T %v, want ReportedError", err, err)
+	}
+	if !strings.Contains(err.Error(), "validation skipped because credentials could not be listed") {
+		t.Fatalf("validate status error = %v, want validation skipped error", err)
+	}
+	if stderr != "" {
+		t.Fatalf("validate status stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"source":"ASC_ADS_ACCESS_TOKEN"`) || !strings.Contains(stdout, `"credentials_error"`) {
+		t.Fatalf("validate status stdout = %q, want active source and credentials_error", stdout)
+	}
 }
 
 func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -203,6 +203,58 @@ func TestAdsAuthStatusOmitsBlankConfigOrgSource(t *testing.T) {
 	}
 }
 
+func TestAdsAuthStatusKeepsAuthSourceWhenOptionalOrgConfigIsInvalid(t *testing.T) {
+	configPath := writeAdsEvalPayload(t, "config.json", `{"ads":`)
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json")
+	if err != nil {
+		t.Fatalf("status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	var status struct {
+		Active struct {
+			Source string `json:"source"`
+			Error  string `json:"error"`
+		} `json:"active"`
+		CredentialsError string `json:"credentials_error"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if status.Active.Source != "ASC_ADS_ACCESS_TOKEN" {
+		t.Fatalf("active.source = %q, want ASC_ADS_ACCESS_TOKEN", status.Active.Source)
+	}
+	if status.Active.Error == "" || !strings.Contains(status.Active.Error, "failed to parse config") {
+		t.Fatalf("active.error = %q, want config parse error", status.Active.Error)
+	}
+	if status.CredentialsError == "" || !strings.Contains(status.CredentialsError, "failed to parse config") {
+		t.Fatalf("credentials_error = %q, want config parse error", status.CredentialsError)
+	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status")
+	if err != nil {
+		t.Fatalf("table status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("table status stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"Active auth: ASC_ADS_ACCESS_TOKEN",
+		"Org ID: unavailable (",
+		"Stored credentials: unavailable (",
+		"failed to parse config",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("table status = %q, missing %q", stdout, want)
+		}
+	}
+}
+
 func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -83,6 +83,58 @@ func TestAdsAuthEvalWorkflow(t *testing.T) {
 	}
 }
 
+func TestAdsAuthStatusShowsActiveEnvironmentContext(t *testing.T) {
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json")
+	if err != nil {
+		t.Fatalf("status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, `"ACCESS"`) {
+		t.Fatalf("status leaked access token: %s", stdout)
+	}
+	var status struct {
+		Active struct {
+			Source      string `json:"source"`
+			OrgID       string `json:"org_id"`
+			OrgIDSource string `json:"org_id_source"`
+		} `json:"active"`
+		Credentials []struct {
+			Name string `json:"name"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if status.Active.Source != "ASC_ADS_ACCESS_TOKEN" || status.Active.OrgID != "987654" || status.Active.OrgIDSource != "ASC_ADS_ORG_ID" {
+		t.Fatalf("active = %+v, want env access token and org source", status.Active)
+	}
+	if len(status.Credentials) != 0 {
+		t.Fatalf("credentials = %+v, want no stored credentials", status.Credentials)
+	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status")
+	if err != nil {
+		t.Fatalf("table status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("table status stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"Active auth: ASC_ADS_ACCESS_TOKEN",
+		"Org ID: 987654 (ASC_ADS_ORG_ID)",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("table status = %q, missing %q", stdout, want)
+		}
+	}
+}
+
 func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -135,6 +135,74 @@ func TestAdsAuthStatusShowsActiveEnvironmentContext(t *testing.T) {
 	}
 }
 
+func TestAdsAuthStatusSurfacesMissingNamedProfile(t *testing.T) {
+	configPath := writeAdsEvalPayload(t, "config.json", `{"ads":{"keys":[]}}`)
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_ADS_PROFILE", "Missing")
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json")
+	if err != nil {
+		t.Fatalf("status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	var status struct {
+		Active struct {
+			Error string `json:"error"`
+		} `json:"active"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(status.Active.Error, `credentials not found for profile "Missing"`) {
+		t.Fatalf("active.error = %q, want missing named profile", status.Active.Error)
+	}
+
+	stdout, stderr, err = runAdsEvalCommand(t, "ads", "auth", "status")
+	if err != nil {
+		t.Fatalf("table status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("table status stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `Active auth: unavailable (credentials not found for profile "Missing")`) {
+		t.Fatalf("table status = %q, want missing named profile surfaced", stdout)
+	}
+}
+
+func TestAdsAuthStatusOmitsBlankConfigOrgSource(t *testing.T) {
+	configPath := writeAdsEvalPayload(t, "config.json", `{"ads":{"org_id":"   "}}`)
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json")
+	if err != nil {
+		t.Fatalf("status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	var status struct {
+		Active struct {
+			Source      string `json:"source"`
+			OrgID       string `json:"org_id"`
+			OrgIDSource string `json:"org_id_source"`
+		} `json:"active"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if status.Active.Source != "ASC_ADS_ACCESS_TOKEN" {
+		t.Fatalf("active.source = %q, want ASC_ADS_ACCESS_TOKEN", status.Active.Source)
+	}
+	if status.Active.OrgID != "" || status.Active.OrgIDSource != "" {
+		t.Fatalf("active org = %+v, want no org ID or source", status.Active)
+	}
+}
+
 func TestAdsAuthEvalValidatesUsageErrors(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -230,6 +230,45 @@ func TestAdsAuthDiscoverTableShowsUserAndAccounts(t *testing.T) {
 	}
 }
 
+func TestAdsAuthDiscoverAcceptsRealMeFieldsAndSingletonACL(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		assertAdsEvalNoOrg(t, req)
+		assertAdsEvalNoBody(t, req)
+
+		switch req.URL.Path {
+		case "/api/v5/me":
+			return adsJSONResponse(200, `{"data":{"userId":"user-1","parentOrgId":987654}}`), nil
+		case "/api/v5/acls":
+			return adsJSONResponse(200, `{"data":{"orgId":987654,"orgName":"Example Org","roleNames":["Admin"]}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "discover")
+	if err != nil {
+		t.Fatalf("discover table error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("discover table stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"User: user-1",
+		"987654 - Example Org (active)",
+		"Roles: Admin",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("discover table stdout = %q, missing %q", stdout, want)
+		}
+	}
+}
+
 func TestAdsAuthDiscoverRejectsInvalidOutput(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -110,6 +110,78 @@ func TestAdsAgentReadOnlyEvalWorkflow(t *testing.T) {
 	}
 }
 
+func TestAdsAuthDiscoverSummarizesMeAndAcls(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	log := newRequestLog(2)
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		assertAdsEvalNoOrg(t, req)
+		assertAdsEvalNoBody(t, req)
+		log.Add(req.Method + " " + req.URL.RequestURI())
+
+		switch req.URL.Path {
+		case "/api/v5/me":
+			return adsJSONResponse(200, `{"data":{"id":"user-1","name":"Ada Example"}}`), nil
+		case "/api/v5/acls":
+			return adsJSONResponse(200, `{"data":[{"orgId":987654,"orgName":"Example Org","roleNames":["Admin"]},{"orgId":123456,"name":"Other Org","roles":["ReadOnly"]}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "discover", "--output", "json")
+	if err != nil {
+		t.Fatalf("discover error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("discover stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, `"ACCESS"`) {
+		t.Fatalf("discover leaked access token: %s", stdout)
+	}
+
+	var result struct {
+		AuthSource  string `json:"auth_source"`
+		OrgID       string `json:"org_id"`
+		OrgIDSource string `json:"org_id_source"`
+		Me          struct {
+			ID string `json:"id"`
+		} `json:"me"`
+		Accounts []struct {
+			OrgID  string   `json:"org_id"`
+			Name   string   `json:"name"`
+			Roles  []string `json:"roles"`
+			Active bool     `json:"active"`
+		} `json:"accounts"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("discover stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if result.AuthSource != "ASC_ADS_ACCESS_TOKEN" || result.OrgID != "987654" || result.OrgIDSource != "ASC_ADS_ORG_ID" {
+		t.Fatalf("discovery context = %+v, want env token/org", result)
+	}
+	if result.Me.ID != "user-1" {
+		t.Fatalf("me.id = %q, want user-1", result.Me.ID)
+	}
+	if len(result.Accounts) != 2 || result.Accounts[0].OrgID != "987654" || result.Accounts[0].Name != "Example Org" || !result.Accounts[0].Active {
+		t.Fatalf("accounts = %+v, want active Example Org first", result.Accounts)
+	}
+	if got := strings.Join(result.Accounts[0].Roles, ","); got != "Admin" {
+		t.Fatalf("roles = %q, want Admin", got)
+	}
+
+	requests := strings.Join(log.Snapshot(), "\n")
+	for _, want := range []string{"GET /api/v5/me", "GET /api/v5/acls"} {
+		if !strings.Contains(requests, want) {
+			t.Fatalf("requests = %q, missing %q", requests, want)
+		}
+	}
+}
+
 func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_ADS_ORG_ID", "987654")

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestAdsAgentReadOnlyEvalWorkflow(t *testing.T) {
@@ -179,6 +181,124 @@ func TestAdsAuthDiscoverSummarizesMeAndAcls(t *testing.T) {
 		if !strings.Contains(requests, want) {
 			t.Fatalf("requests = %q, missing %q", requests, want)
 		}
+	}
+}
+
+func TestAdsAuthDiscoverTableShowsUserAndAccounts(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	log := newRequestLog(2)
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		assertAdsEvalNoOrg(t, req)
+		assertAdsEvalNoBody(t, req)
+		log.Add(req.Method + " " + req.URL.RequestURI())
+
+		switch req.URL.Path {
+		case "/api/v5/me":
+			return adsJSONResponse(200, `{"data":{"id":"user-1","name":"Ada Example"}}`), nil
+		case "/api/v5/acls":
+			return adsJSONResponse(200, `{"data":[{"orgId":987654,"orgName":"Example Org","roleNames":["Admin"]}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "discover")
+	if err != nil {
+		t.Fatalf("discover table error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("discover table stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"Auth source: ASC_ADS_ACCESS_TOKEN",
+		"User: Ada Example (user-1)",
+		"Selected org: 987654 (ASC_ADS_ORG_ID)",
+		"987654 - Example Org (active)",
+		"Roles: Admin",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("discover table stdout = %q, missing %q", stdout, want)
+		}
+	}
+	if requests := strings.Join(log.Snapshot(), "\n"); !strings.Contains(requests, "GET /api/v5/me") || !strings.Contains(requests, "GET /api/v5/acls") {
+		t.Fatalf("requests = %q, want me and acls lookups", requests)
+	}
+}
+
+func TestAdsAuthDiscoverRejectsInvalidOutput(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "discover", "--output", "invalid")
+	if rootcmd.ExitCodeFromError(err) != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d (err=%v)", rootcmd.ExitCodeFromError(err), rootcmd.ExitUsage, err)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "unsupported format: invalid") {
+		t.Fatalf("stderr = %q, want invalid --output usage error", stderr)
+	}
+}
+
+func TestAdsAuthDiscoverRejectsMalformedDiscoveryResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		meBody  string
+		aclBody string
+		wantErr string
+	}{
+		{
+			name:    "me",
+			meBody:  `{"data":`,
+			aclBody: `{"data":[]}`,
+			wantErr: "me response parse failed",
+		},
+		{
+			name:    "acls",
+			meBody:  `{"data":{"id":"user-1"}}`,
+			aclBody: `{"data":`,
+			wantErr: "acl response parse failed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+			installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				assertAdsEvalBearer(t, req)
+				assertAdsEvalNoOrg(t, req)
+				assertAdsEvalNoBody(t, req)
+
+				switch req.URL.Path {
+				case "/api/v5/me":
+					return adsJSONResponse(200, test.meBody), nil
+				case "/api/v5/acls":
+					return adsJSONResponse(200, test.aclBody), nil
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			}))
+
+			stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "discover", "--output", "json")
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error = %v, want %q", err, test.wantErr)
+			}
+			if stdout != "" || stderr != "" {
+				t.Fatalf("stdout = %q stderr = %q, want empty output on parse failure", stdout, stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -302,6 +302,52 @@ func TestAdsAuthDiscoverRejectsMalformedDiscoveryResponses(t *testing.T) {
 	}
 }
 
+func TestAdsAuthDiscoverContinuesWhenOptionalOrgConfigIsInvalid(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	configPath := writeAdsEvalPayload(t, "config.json", `{"ads":`)
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assertAdsEvalBearer(t, req)
+		assertAdsEvalNoOrg(t, req)
+		assertAdsEvalNoBody(t, req)
+
+		switch req.URL.Path {
+		case "/api/v5/me":
+			return adsJSONResponse(200, `{"data":{"id":"user-1","name":"Ada Example"}}`), nil
+		case "/api/v5/acls":
+			return adsJSONResponse(200, `{"data":[{"orgId":987654,"orgName":"Example Org"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "discover", "--output", "json")
+	if err != nil {
+		t.Fatalf("discover error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("discover stderr = %q, want empty", stderr)
+	}
+	var result struct {
+		OrgID       string `json:"org_id"`
+		OrgIDSource string `json:"org_id_source"`
+		Accounts    []struct {
+			OrgID string `json:"org_id"`
+		} `json:"accounts"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("discover stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if result.OrgID != "" || result.OrgIDSource != "" {
+		t.Fatalf("org context = %+v, want no selected org from invalid config", result)
+	}
+	if len(result.Accounts) != 1 || result.Accounts[0].OrgID != "987654" {
+		t.Fatalf("accounts = %+v, want discovered account despite invalid config", result.Accounts)
+	}
+}
+
 func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_ADS_ORG_ID", "987654")


### PR DESCRIPTION
## Summary
- add `asc ads auth discover` for read-only Apple Ads user/org discovery via existing `GET v5/me` and `GET v5/acls`
- enhance `asc ads auth status` JSON/table output with active auth source and selected org source without printing tokens
- share source-aware Ads credential/org resolution so env token, env key credentials, selected profiles, and default profiles report consistently

## Why
Apple Ads org context is separate from App Store Connect auth, and the first support PR left users needing to infer which Ads profile/org was active. This keeps the follow-up focused on discovery and status clarity, with no workflow mutation or reporting preset changes.

## UX examples
```bash
asc ads auth status --output json
asc ads auth discover --output json
asc ads auth discover --ads-profile "Ads"
```

## Alternatives considered
- Reusing raw `asc ads me view` and `asc ads acls list`: kept those intact, but added `auth discover` because users need one safe command that summarizes the active org alongside ACL accounts.
- Adding org discovery under top-level `ads accounts`: deferred to avoid broad taxonomy changes; this PR keeps discovery in the auth/account-selection flow.

## Validation
- `go run . ads auth --help`
- `go run . ads auth discover --help`
- `go build -o /tmp/asc-ads-auth-ux .`
- `ASC_ADS_ACCESS_TOKEN=ACCESS ASC_ADS_ORG_ID=987654 ASC_CONFIG_PATH=$(mktemp -u) /tmp/asc-ads-auth-ux ads auth status --output json`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestAds'`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/ads ./internal/appleads`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

`make lint` passed with 0 issues; it also printed a stale golangci warning for an old missing worktree path outside this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `ads auth discover` subcommand that retrieves and displays active organization, user context, and associated accounts from Apple Ads in table or JSON format.
* Enhanced `ads auth status` to display active authentication context, including source and organization ID information.

## Tests

* Added tests to verify authentication discovery and status output behavior with environment variable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->