### PR TITLE
[codex] Polish Apple Ads command UX

### DIFF
--- a/internal/appleads/endpoints.go
+++ b/internal/appleads/endpoints.go
@@ -188,7 +188,7 @@ func EndpointSpecs() []EndpointSpec {
 	for i := range specs {
 		specs[i].RequiresConfirm = specs[i].Method == "DELETE" || strings.Contains(specs[i].Path, "/delete/bulk")
 		specs[i].SupportsPaginate = hasLimitOffset(specs[i].QueryParams)
-		specs[i].DefaultListAlias = len(specs[i].CommandPath) == 2 && specs[i].CommandPath[1] == "list"
+		specs[i].DefaultListAlias = len(specs[i].CommandPath) == 2 && (specs[i].CommandPath[1] == "list" || specs[i].Name == "get-me-details")
 		if specs[i].Name == "get-user-acl" || specs[i].Name == "get-me-details" {
 			specs[i].RequiresOrg = false
 		}

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -219,7 +219,7 @@ Examples:
 				rows = append(rows, row)
 			}
 			result := adsAuthStatusOutput{
-				Storage:          storageDescription(),
+				Storage:          storageDescription(rows),
 				Active:           active,
 				Credentials:      rows,
 				CredentialsError: credentialsError,
@@ -369,8 +369,24 @@ func isNoAdsCredentialError(err error) bool {
 	return err.Error() == "default credentials not found"
 }
 
-func storageDescription() string {
+func storageDescription(rows []adsAuthStatusRow) string {
 	if appleads.ShouldBypassKeychain() {
+		return "Config File"
+	}
+	hasConfig := false
+	hasKeychain := false
+	for _, row := range rows {
+		switch row.Source {
+		case "config":
+			hasConfig = true
+		case "keychain":
+			hasKeychain = true
+		}
+	}
+	switch {
+	case hasConfig && hasKeychain:
+		return "System Keychain + Config File"
+	case hasConfig:
 		return "Config File"
 	}
 	return "System Keychain"

--- a/internal/cli/ads/reports_preset.go
+++ b/internal/cli/ads/reports_preset.go
@@ -93,7 +93,7 @@ func ReportsPresetCommand() *ffcli.Command {
 		lastDays:        fs.Int("last-days", 0, "Use an inclusive UTC range ending today"),
 		granularity:     fs.String("granularity", "DAILY", "Report granularity: HOURLY, DAILY, WEEKLY, MONTHLY"),
 		fields:          fs.String("fields", "", "Comma-separated selector fields to request"),
-		sort:            fs.String("sort", "-impressions", "Sort by field; prefix with - for descending, e.g. -impressions"),
+		sort:            fs.String("sort", "-impressions", "Sort field; omit direction or prefix with - for descending, use field:asc for ascending"),
 		limit:           fs.Int("limit", 1000, "Report row limit (1..1000)"),
 		offset:          fs.Int("offset", 0, "Report row offset (>=0)"),
 		timeZone:        fs.String("time-zone", "UTC", "Apple Ads reporting time zone: UTC or ORTZ"),
@@ -411,10 +411,7 @@ func parseReportPresetSort(value string) (adsReportPresetSort, error) {
 		return adsReportPresetSort{}, fmt.Errorf("--sort field is required")
 	}
 	field = normalizeReportPresetField(field)
-	sortOrder := "ASCENDING"
-	if prefixedDescending {
-		sortOrder = "DESCENDING"
-	}
+	sortOrder := "DESCENDING"
 	if ok {
 		switch strings.ToLower(strings.TrimSpace(direction)) {
 		case "asc", "ascending":

--- a/internal/cli/ads/reports_preset.go
+++ b/internal/cli/ads/reports_preset.go
@@ -410,6 +410,7 @@ func parseReportPresetSort(value string) (adsReportPresetSort, error) {
 	if field == "" {
 		return adsReportPresetSort{}, fmt.Errorf("--sort field is required")
 	}
+	field = normalizeReportPresetField(field)
 	sortOrder := "ASCENDING"
 	if prefixedDescending {
 		sortOrder = "DESCENDING"
@@ -430,11 +431,16 @@ func parseReportPresetSort(value string) (adsReportPresetSort, error) {
 func normalizeReportPresetFields(value string) []string {
 	fields := shared.SplitCSV(value)
 	for index, field := range fields {
-		if field == "spend" {
-			fields[index] = "localSpend"
-		}
+		fields[index] = normalizeReportPresetField(field)
 	}
 	return fields
+}
+
+func normalizeReportPresetField(field string) string {
+	if field == "spend" {
+		return "localSpend"
+	}
+	return field
 }
 
 func sortedReportPresetLevels() []string {

--- a/internal/cli/ads/reports_preset.go
+++ b/internal/cli/ads/reports_preset.go
@@ -93,7 +93,7 @@ func ReportsPresetCommand() *ffcli.Command {
 		lastDays:        fs.Int("last-days", 0, "Use an inclusive UTC range ending today"),
 		granularity:     fs.String("granularity", "DAILY", "Report granularity: HOURLY, DAILY, WEEKLY, MONTHLY"),
 		fields:          fs.String("fields", "", "Comma-separated selector fields to request"),
-		sort:            fs.String("sort", "", "Sort field with optional direction, e.g. impressions:desc"),
+		sort:            fs.String("sort", "-impressions", "Sort by field; prefix with - for descending, e.g. -impressions"),
 		limit:           fs.Int("limit", 1000, "Report row limit (1..1000)"),
 		offset:          fs.Int("offset", 0, "Report row offset (>=0)"),
 		timeZone:        fs.String("time-zone", "UTC", "Apple Ads reporting time zone: UTC or ORTZ"),
@@ -114,15 +114,15 @@ Apple Ads accepts UTC and ORTZ (organization time zone) for --time-zone. Use
 --last-days for an inclusive UTC rolling date range; use --from and --to when
 requesting ORTZ because Apple Ads resolves the organization time zone. Use the
 raw report commands with --file when you need custom conditions or advanced
-selector JSON. Ad-level reports require --sort because Apple Ads requires
-selector.orderBy for that endpoint. HOURLY granularity is available for
+selector JSON. Report presets default to --sort -impressions because Apple Ads
+requires selector.orderBy. HOURLY granularity is available for
 	campaign, ad-group, and keyword report levels. Search-term report levels cannot
 	request row totals.
 
 Examples:
-  asc ads reports preset --level campaigns --from 2026-05-01 --to 2026-05-31 --fields campaignName,impressions,taps,spend --sort impressions:desc --org "123456"
+  asc ads reports preset --level campaigns --from 2026-05-01 --to 2026-05-31 --fields campaignName,impressions,taps,localSpend --sort -impressions --org "123456"
   asc ads reports preset --level keywords --campaign 12345 --last-days 7 --fields keyword,impressions,taps --org "123456"
-  asc ads reports preset --level ads --campaign 12345 --from 2026-05-01 --to 2026-05-31 --sort impressions:desc --org "123456"`,
+  asc ads reports preset --level ads --campaign 12345 --from 2026-05-01 --to 2026-05-31 --sort -impressions --org "123456"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -238,21 +238,22 @@ func buildReportPresetPayload(flags adsReportPresetFlags, now time.Time) (adsRep
 	if *flags.offset < 0 {
 		return adsReportPresetPayload{}, fmt.Errorf("--offset must be >= 0")
 	}
-	if level == "ads" && strings.TrimSpace(*flags.sort) == "" {
-		return adsReportPresetPayload{}, fmt.Errorf("--sort is required for --level ads")
-	}
 	if isSearchTermReportLevel(level) && *flags.returnRowTotals {
 		return adsReportPresetPayload{}, fmt.Errorf("--return-row-totals cannot be used with search-term report levels")
 	}
 
 	selector := adsReportPresetSelector{
-		Fields: shared.SplitCSV(*flags.fields),
+		Fields: normalizeReportPresetFields(*flags.fields),
 		Pagination: &adsReportPresetPagination{
 			Offset: *flags.offset,
 			Limit:  *flags.limit,
 		},
 	}
-	if sortValue := strings.TrimSpace(*flags.sort); sortValue != "" {
+	sortValue := strings.TrimSpace(*flags.sort)
+	if sortValue == "" {
+		sortValue = "-impressions"
+	}
+	if sortValue != "" {
 		sortSpec, err := parseReportPresetSort(sortValue)
 		if err != nil {
 			return adsReportPresetPayload{}, err
@@ -399,12 +400,20 @@ func parseReportPresetDate(flagName string, value string) (time.Time, error) {
 }
 
 func parseReportPresetSort(value string) (adsReportPresetSort, error) {
+	value = strings.TrimSpace(value)
 	field, direction, ok := strings.Cut(value, ":")
 	field = strings.TrimSpace(field)
+	prefixedDescending := strings.HasPrefix(field, "-")
+	if prefixedDescending {
+		field = strings.TrimSpace(strings.TrimPrefix(field, "-"))
+	}
 	if field == "" {
 		return adsReportPresetSort{}, fmt.Errorf("--sort field is required")
 	}
-	sortOrder := "DESCENDING"
+	sortOrder := "ASCENDING"
+	if prefixedDescending {
+		sortOrder = "DESCENDING"
+	}
 	if ok {
 		switch strings.ToLower(strings.TrimSpace(direction)) {
 		case "asc", "ascending":
@@ -416,6 +425,16 @@ func parseReportPresetSort(value string) (adsReportPresetSort, error) {
 		}
 	}
 	return adsReportPresetSort{Field: field, SortOrder: sortOrder}, nil
+}
+
+func normalizeReportPresetFields(value string) []string {
+	fields := shared.SplitCSV(value)
+	for index, field := range fields {
+		if field == "spend" {
+			fields[index] = "localSpend"
+		}
+	}
+	return fields
 }
 
 func sortedReportPresetLevels() []string {

--- a/internal/cli/ads/reports_preset_test.go
+++ b/internal/cli/ads/reports_preset_test.go
@@ -364,6 +364,14 @@ func TestParseReportPresetSort(t *testing.T) {
 		t.Fatalf("sort = %+v, want impressions DESCENDING", sortSpec)
 	}
 
+	sortSpec, err = parseReportPresetSort("-spend")
+	if err != nil {
+		t.Fatalf("parseReportPresetSort() error: %v", err)
+	}
+	if sortSpec.Field != "localSpend" || sortSpec.SortOrder != "DESCENDING" {
+		t.Fatalf("sort = %+v, want localSpend DESCENDING", sortSpec)
+	}
+
 	sortSpec, err = parseReportPresetSort("impressions:desc")
 	if err != nil {
 		t.Fatalf("parseReportPresetSort() error: %v", err)

--- a/internal/cli/ads/reports_preset_test.go
+++ b/internal/cli/ads/reports_preset_test.go
@@ -25,12 +25,13 @@ func TestReportsPresetCommandHelpShowsOperatorGuidance(t *testing.T) {
 		"Choose the report resource with --level.",
 		"Apple Ads accepts UTC and ORTZ",
 		"--last-days for an inclusive UTC rolling date range",
-		"Ad-level reports require --sort",
+		"Report presets default to --sort -impressions",
 		"HOURLY granularity is available for",
 		"campaign, ad-group, and keyword report levels",
 		"Search-term report levels cannot",
 		"request row totals",
-		"asc ads reports preset --level ads --campaign 12345 --from 2026-05-01 --to 2026-05-31 --sort impressions:desc",
+		"asc ads reports preset --level campaigns --from 2026-05-01 --to 2026-05-31 --fields campaignName,impressions,taps,localSpend --sort -impressions",
+		"asc ads reports preset --level ads --campaign 12345 --from 2026-05-01 --to 2026-05-31 --sort -impressions",
 	} {
 		if !strings.Contains(cmd.LongHelp, want) {
 			t.Fatalf("LongHelp missing %q\n%s", want, cmd.LongHelp)
@@ -130,8 +131,8 @@ func TestBuildReportPresetPayloadRejectsExplicitUTCForSearchTerms(t *testing.T) 
 	}
 }
 
-func TestBuildReportPresetPayloadRequiresSortForAds(t *testing.T) {
-	_, err := buildReportPresetPayload(reportPresetTestFlags(
+func TestBuildReportPresetPayloadDefaultsSort(t *testing.T) {
+	payload, err := buildReportPresetPayload(reportPresetTestFlags(
 		"ads",
 		"12345",
 		"2026-05-01",
@@ -139,8 +140,11 @@ func TestBuildReportPresetPayloadRequiresSortForAds(t *testing.T) {
 		0,
 		"UTC",
 	), time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC))
-	if err == nil || !strings.Contains(err.Error(), "--sort is required for --level ads") {
-		t.Fatalf("error = %v, want ad-level sort validation", err)
+	if err != nil {
+		t.Fatalf("buildReportPresetPayload() error: %v", err)
+	}
+	if len(payload.Selector.OrderBy) != 1 || payload.Selector.OrderBy[0].Field != "impressions" || payload.Selector.OrderBy[0].SortOrder != "DESCENDING" {
+		t.Fatalf("orderBy = %+v, want default impressions descending", payload.Selector.OrderBy)
 	}
 }
 
@@ -250,7 +254,7 @@ func TestBuildReportPresetPayloadRejectsHourlyWhereUnsupported(t *testing.T) {
 	}{
 		{level: "search-terms", timeZone: "UTC"},
 		{level: "ad-group-search-terms", timeZone: "UTC"},
-		{level: "ads", timeZone: "UTC", sort: "impressions:desc"},
+		{level: "ads", timeZone: "UTC", sort: "-impressions"},
 	} {
 		t.Run(tt.level, func(t *testing.T) {
 			flags := reportPresetTestFlags(
@@ -344,7 +348,7 @@ func reportPresetTestFlags(level, campaign, from, to string, lastDays int, timeZ
 }
 
 func TestParseReportPresetSort(t *testing.T) {
-	sortSpec, err := parseReportPresetSort("impressions:asc")
+	sortSpec, err := parseReportPresetSort("impressions")
 	if err != nil {
 		t.Fatalf("parseReportPresetSort() error: %v", err)
 	}
@@ -352,8 +356,31 @@ func TestParseReportPresetSort(t *testing.T) {
 		t.Fatalf("sort = %+v, want impressions ASCENDING", sortSpec)
 	}
 
+	sortSpec, err = parseReportPresetSort("-impressions")
+	if err != nil {
+		t.Fatalf("parseReportPresetSort() error: %v", err)
+	}
+	if sortSpec.Field != "impressions" || sortSpec.SortOrder != "DESCENDING" {
+		t.Fatalf("sort = %+v, want impressions DESCENDING", sortSpec)
+	}
+
+	sortSpec, err = parseReportPresetSort("impressions:desc")
+	if err != nil {
+		t.Fatalf("parseReportPresetSort() error: %v", err)
+	}
+	if sortSpec.Field != "impressions" || sortSpec.SortOrder != "DESCENDING" {
+		t.Fatalf("sort = %+v, want compatibility descending sort", sortSpec)
+	}
+
 	_, err = parseReportPresetSort("impressions:sideways")
 	if err == nil || !strings.Contains(err.Error(), "--sort direction must be asc or desc") {
 		t.Fatalf("error = %v, want sort direction validation", err)
+	}
+}
+
+func TestNormalizeReportPresetFields(t *testing.T) {
+	fields := normalizeReportPresetFields("campaignName,spend,localSpend,taps")
+	if strings.Join(fields, ",") != "campaignName,localSpend,localSpend,taps" {
+		t.Fatalf("fields = %v, want spend alias normalized to localSpend", fields)
 	}
 }

--- a/internal/cli/ads/reports_preset_test.go
+++ b/internal/cli/ads/reports_preset_test.go
@@ -352,8 +352,8 @@ func TestParseReportPresetSort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseReportPresetSort() error: %v", err)
 	}
-	if sortSpec.Field != "impressions" || sortSpec.SortOrder != "ASCENDING" {
-		t.Fatalf("sort = %+v, want impressions ASCENDING", sortSpec)
+	if sortSpec.Field != "impressions" || sortSpec.SortOrder != "DESCENDING" {
+		t.Fatalf("sort = %+v, want impressions DESCENDING", sortSpec)
 	}
 
 	sortSpec, err = parseReportPresetSort("-impressions")

--- a/internal/cli/cmdtest/ads_auth_eval_test.go
+++ b/internal/cli/cmdtest/ads_auth_eval_test.go
@@ -83,6 +83,52 @@ func TestAdsAuthEvalWorkflow(t *testing.T) {
 	}
 }
 
+func TestAdsAuthStatusReportsConfigStorageForConfigCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	keyPath := filepath.Join(t.TempDir(), "apple-ads-private-key.pem")
+	writeECDSAPEM(t, keyPath)
+
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+
+	_, stderr, err := runAdsEvalCommand(
+		t,
+		"ads", "auth", "login",
+		"--bypass-keychain",
+		"--name", "Marketing",
+		"--client-id", "SEARCHADS.CLIENT",
+		"--team-id", "SEARCHADS.TEAM",
+		"--key-id", "KEY_ID",
+		"--private-key", keyPath,
+		"--org", "987654",
+	)
+	if err != nil {
+		t.Fatalf("login error: %v\nstderr: %s", err, stderr)
+	}
+
+	stdout, stderr, err := runAdsEvalCommand(t, "ads", "auth", "status", "--output", "json")
+	if err != nil {
+		t.Fatalf("status error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	var status struct {
+		Storage     string `json:"storage"`
+		Credentials []struct {
+			Source string `json:"source"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if status.Storage != "Config File" {
+		t.Fatalf("storage = %q, want Config File for config credentials", status.Storage)
+	}
+	if len(status.Credentials) != 1 || status.Credentials[0].Source != "config" {
+		t.Fatalf("credentials = %+v, want config credential", status.Credentials)
+	}
+}
+
 func TestAdsAuthStatusShowsActiveEnvironmentContext(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -80,6 +80,7 @@ func TestAdsAgentReadOnlyEvalWorkflow(t *testing.T) {
 	}))
 
 	for _, args := range [][]string{
+		{"ads", "me", "--output", "json"},
 		{"ads", "me", "view", "--output", "json"},
 		{"ads", "acls", "--output", "json"},
 		{"ads", "campaigns", "--limit", "1", "--output", "json"},

--- a/internal/cli/cmdtest/ads_test.go
+++ b/internal/cli/cmdtest/ads_test.go
@@ -121,7 +121,7 @@ func TestAdsReportsPresetBuildsCampaignRequest(t *testing.T) {
 		if body.Granularity != "HOURLY" || body.TimeZone != "UTC" || !body.ReturnRowTotals {
 			t.Fatalf("report options = %+v, want hourly UTC totals", body)
 		}
-		if strings.Join(body.Selector.Fields, ",") != "campaignName,impressions,taps,spend" {
+		if strings.Join(body.Selector.Fields, ",") != "campaignName,impressions,taps,localSpend" {
 			t.Fatalf("fields = %v", body.Selector.Fields)
 		}
 		if len(body.Selector.OrderBy) != 1 || body.Selector.OrderBy[0].Field != "impressions" || body.Selector.OrderBy[0].SortOrder != "DESCENDING" {
@@ -140,7 +140,7 @@ func TestAdsReportsPresetBuildsCampaignRequest(t *testing.T) {
 		"--last-days", "7",
 		"--fields", "campaignName,impressions,taps,spend",
 		"--granularity", "hourly",
-		"--sort", "impressions:desc",
+		"--sort", "-impressions",
 		"--limit", "25",
 		"--offset", "5",
 		"--return-row-totals",
@@ -247,7 +247,7 @@ func TestAdsReportsPresetBuildsAdLevelRequestWithSort(t *testing.T) {
 		"--campaign", "12345",
 		"--from", from,
 		"--to", to,
-		"--sort", "impressions:desc",
+		"--sort", "-impressions",
 		"--output", "json",
 	}
 	if err := root.Parse(args); err != nil {
@@ -332,7 +332,7 @@ func TestAdsReportsPresetValidatesUsageBeforeNetwork(t *testing.T) {
 		},
 		{
 			name:    "hourly unsupported for ads",
-			args:    []string{"ads", "reports", "preset", "--level", "ads", "--campaign", "12345", "--from", recentFrom, "--to", recentTo, "--granularity", "HOURLY", "--sort", "impressions:desc", "--output", "json"},
+			args:    []string{"ads", "reports", "preset", "--level", "ads", "--campaign", "12345", "--from", recentFrom, "--to", recentTo, "--granularity", "HOURLY", "--sort", "-impressions", "--output", "json"},
 			wantErr: "--granularity HOURLY is only supported",
 		},
 		{
@@ -369,11 +369,6 @@ func TestAdsReportsPresetValidatesUsageBeforeNetwork(t *testing.T) {
 			name:    "last days unsupported for ORTZ",
 			args:    []string{"ads", "reports", "preset", "--level", "campaigns", "--last-days", "1", "--time-zone", "ORTZ", "--output", "json"},
 			wantErr: "--last-days is not supported for ORTZ reports; use --from and --to",
-		},
-		{
-			name:    "ad level requires sort",
-			args:    []string{"ads", "reports", "preset", "--level", "ads", "--campaign", "12345", "--from", recentFrom, "--to", recentTo, "--output", "json"},
-			wantErr: "--sort is required for --level ads",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Make `asc ads me` run the current-user endpoint directly while keeping `ads me view`.
- Make report presets match the CLI sort convention with `--sort -impressions`, keep `field:desc` compatibility, and default to Apple-required `orderBy`.
- Normalize the user-facing report field alias `spend` to Apple Ads `localSpend` and report config-backed Ads auth as `Config File`.

## Validation
- `make format`
- `make generate-command-docs`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestAdsAgentReadOnlyEvalWorkflow|TestAdsAuthStatusReportsConfigStorageForConfigCredentials|TestAdsAuthEvalWorkflow' -count=1`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n- `go build -o /tmp/asc-ads-ux .`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-ads-ux ads auth status --validate --output json`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-ads-ux ads me --output json`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-ads-ux ads reports preset --level campaigns --last-days 7 --fields campaignName,impressions,taps,spend --return-row-totals --org "21767490" --output json`\n\n## Notes\nThis keeps the previous `impressions:desc` spelling working, but the help and examples now teach the same `-field` sort style used elsewhere in the CLI. The live report smoke confirmed Apple accepts the generated `localSpend` field and default sort.