### PR TITLE
Fix profiles list expired profile visibility

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -7189,6 +7189,9 @@ func TestGetProfiles_WithFilter(t *testing.T) {
 		if values.Get("filter[profileType]") != "IOS_APP_DEVELOPMENT,IOS_APP_STORE" {
 			t.Fatalf("expected filter[profileType] to be set, got %q", values.Get("filter[profileType]"))
 		}
+		if values.Get("filter[profileState]") != "ACTIVE,INVALID" {
+			t.Fatalf("expected filter[profileState] to be set, got %q", values.Get("filter[profileState]"))
+		}
 		if values.Get("limit") != "5" {
 			t.Fatalf("expected limit=5, got %q", values.Get("limit"))
 		}
@@ -7198,6 +7201,7 @@ func TestGetProfiles_WithFilter(t *testing.T) {
 	if _, err := client.GetProfiles(
 		context.Background(),
 		WithProfilesTypes([]string{"IOS_APP_DEVELOPMENT", "IOS_APP_STORE"}),
+		WithProfilesStates([]string{"ACTIVE", "INVALID"}),
 		WithProfilesLimit(5),
 	); err != nil {
 		t.Fatalf("GetProfiles() error: %v", err)

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -2552,6 +2552,13 @@ func WithProfilesTypes(types []string) ProfilesOption {
 	}
 }
 
+// WithProfilesStates filters profiles by profile state.
+func WithProfilesStates(states []string) ProfilesOption {
+	return func(q *profilesQuery) {
+		q.profileStates = normalizeUpperList(states)
+	}
+}
+
 // WithProfilesInclude sets include for profile responses.
 func WithProfilesInclude(include []string) ProfilesOption {
 	return func(q *profilesQuery) {

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -464,9 +464,10 @@ type merchantIDCertificatesQuery struct {
 
 type profilesQuery struct {
 	listQuery
-	bundleID     string
-	profileTypes []string
-	include      []string
+	bundleID      string
+	profileTypes  []string
+	profileStates []string
+	include       []string
 }
 
 type usersQuery struct {
@@ -974,6 +975,7 @@ func buildProfilesQuery(query *profilesQuery) string {
 		values.Set("filter[bundleId]", strings.TrimSpace(query.bundleID))
 	}
 	addCSV(values, "filter[profileType]", query.profileTypes)
+	addCSV(values, "filter[profileState]", query.profileStates)
 	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()

--- a/internal/asc/signing.go
+++ b/internal/asc/signing.go
@@ -173,7 +173,8 @@ type CertificateResponse = SingleResponse[CertificateAttributes]
 type ProfileState string
 
 const (
-	ProfileStateActive ProfileState = "ACTIVE"
+	ProfileStateActive  ProfileState = "ACTIVE"
+	ProfileStateInvalid ProfileState = "INVALID"
 )
 
 // ProfileAttributes describes a profile resource.

--- a/internal/cli/cmdtest/profiles_next_validation_test.go
+++ b/internal/cli/cmdtest/profiles_next_validation_test.go
@@ -2,6 +2,9 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -53,6 +56,166 @@ func TestProfilesListRejectsInvalidNextURL(t *testing.T) {
 				t.Fatalf("expected empty stderr, got %q", stderr)
 			}
 		})
+	}
+}
+
+func TestProfilesListDefaultsToActiveAndInvalidStates(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/profiles" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("filter[profileState]"); got != "ACTIVE,INVALID" {
+			t.Fatalf("expected default profileState filter ACTIVE,INVALID, got %q", got)
+		}
+		body := `{"data":[` +
+			`{"type":"profiles","id":"profile-active","attributes":{"name":"Active","profileType":"IOS_APP_STORE","profileState":"ACTIVE"}},` +
+			`{"type":"profiles","id":"profile-invalid","attributes":{"name":"Expired","profileType":"IOS_APP_ADHOC","profileState":"INVALID"}}` +
+			`]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"profiles", "list", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID         string `json:"id"`
+			Attributes struct {
+				ProfileState string `json:"profileState"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal profiles output: %v\n%s", err, stdout)
+	}
+	if len(payload.Data) != 2 {
+		t.Fatalf("expected active and invalid profiles, got %d", len(payload.Data))
+	}
+	if payload.Data[0].Attributes.ProfileState != "ACTIVE" || payload.Data[1].Attributes.ProfileState != "INVALID" {
+		t.Fatalf("unexpected profile states: %+v", payload.Data)
+	}
+}
+
+func TestProfilesListProfileStateFilter(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/profiles" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("filter[profileState]"); got != "INVALID" {
+			t.Fatalf("expected profileState filter INVALID, got %q", got)
+		}
+		body := `{"data":[{"type":"profiles","id":"profile-invalid","attributes":{"name":"Expired","profileType":"IOS_APP_ADHOC","profileState":"INVALID"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"profiles", "list", "--profile-state", "invalid", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID         string `json:"id"`
+			Attributes struct {
+				ProfileState string `json:"profileState"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal profiles output: %v\n%s", err, stdout)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].ID != "profile-invalid" || payload.Data[0].Attributes.ProfileState != "INVALID" {
+		t.Fatalf("unexpected profiles output: %+v", payload.Data)
+	}
+}
+
+func TestProfilesListProfileStateInvalidValueReturnsUsageError(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		t.Fatalf("unexpected HTTP request for invalid profile-state: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"profiles", "list", "--profile-state", "EXPIRED"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--profile-state must be one of: ACTIVE, INVALID") {
+		t.Fatalf("expected profile-state usage error, got %q", stderr)
+	}
+	if requestCount != 0 {
+		t.Fatalf("expected 0 requests, got %d", requestCount)
 	}
 }
 

--- a/internal/cli/profiles/profiles.go
+++ b/internal/cli/profiles/profiles.go
@@ -59,6 +59,7 @@ func ProfilesListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	profileType := fs.String("profile-type", "", "Filter by profile type(s), comma-separated")
+	profileState := fs.String("profile-state", "", "Filter by profile state(s): ACTIVE, INVALID (default: ACTIVE,INVALID)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -73,6 +74,7 @@ func ProfilesListCommand() *ffcli.Command {
 Examples:
   asc profiles list
   asc profiles list --profile-type IOS_APP_DEVELOPMENT
+  asc profiles list --profile-state INVALID
   asc profiles list --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -85,6 +87,10 @@ Examples:
 			}
 
 			profileTypes := shared.SplitCSVUpper(*profileType)
+			profileStates, err := normalizeProfileStates(*profileState)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -97,6 +103,7 @@ Examples:
 			opts := []asc.ProfilesOption{
 				asc.WithProfilesLimit(*limit),
 				asc.WithProfilesNextURL(*next),
+				asc.WithProfilesStates(profileStates),
 			}
 			if len(profileTypes) > 0 {
 				opts = append(opts, asc.WithProfilesTypes(profileTypes))
@@ -401,4 +408,29 @@ func normalizeProfileInclude(value string) ([]string, error) {
 
 func profileIncludeList() []string {
 	return []string{"bundleId", "certificates", "devices"}
+}
+
+func normalizeProfileStates(value string) ([]string, error) {
+	states := shared.SplitCSVUpper(value)
+	if len(states) == 0 {
+		return defaultProfileStates(), nil
+	}
+	allowed := map[string]struct{}{}
+	for _, item := range profileStateList() {
+		allowed[item] = struct{}{}
+	}
+	for _, item := range states {
+		if _, ok := allowed[item]; !ok {
+			return nil, fmt.Errorf("--profile-state must be one of: %s", strings.Join(profileStateList(), ", "))
+		}
+	}
+	return states, nil
+}
+
+func defaultProfileStates() []string {
+	return []string{string(asc.ProfileStateActive), string(asc.ProfileStateInvalid)}
+}
+
+func profileStateList() []string {
+	return []string{string(asc.ProfileStateActive), string(asc.ProfileStateInvalid)}
 }


### PR DESCRIPTION
## Summary
- Default `asc profiles list` to request both documented profile states: `ACTIVE,INVALID`, so expired profiles classified by App Store Connect as `INVALID` are not hidden.
- Add `--profile-state ACTIVE|INVALID` for explicit active-only or invalid-only listing.
- Wire `filter[profileState]` through the ASC client query layer and add focused regression coverage.

Fixes #1606

## Why this approach
The `/v1/profiles` OpenAPI snapshot documents `filter[profileState]` with `ACTIVE` and `INVALID`. The issue report shows Apple’s web UI including expired profiles, while the CLI had no state control. Making the default request explicit keeps `profiles list` aligned with the web UI and gives scripts an opt-in way to narrow back to `ACTIVE`.

Alternatives considered:
- Add only `--include-invalid`: lower behavior change, but leaves the default command silently mismatched with the web UI.
- Add only `--profile-state` without changing defaults: useful, but only fixes the “no option” half of the bug.

## Invocation examples
```bash
asc profiles list
asc profiles list --profile-state ACTIVE
asc profiles list --profile-state INVALID
asc profiles list --profile-state ACTIVE,INVALID --paginate
```

Invalid values fail before auth/network with usage exit code 2:
```bash
asc profiles list --profile-state EXPIRED
# Error: --profile-state must be one of: ACTIVE, INVALID
```

## Validation
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestProfilesList(Default|ProfileState)'`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestProfiles'`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run TestGetProfiles_WithFilter`
- `make generate-command-docs`
- `make format`
- `make check-command-docs`
- `make lint` (0 issues; emitted a stale generated-file warning for a removed sibling worktree path)
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `/tmp/asc profiles list --profile-state EXPIRED` => exit code 2
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc profiles list --limit 1 --output json` => succeeded; response links included `filter[profileState]=ACTIVE,INVALID`; no live resources mutated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--profile-state` flag to the `profiles list` command, enabling filtering provisioning profiles by their state (ACTIVE or INVALID).
  * Default filtering now includes both ACTIVE and INVALID profile states.
  * Implemented validation for the `--profile-state` flag with helpful error messages for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->