### PR TITLE
feat(telemetry): add anonymous CLI telemetry controls

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -129,6 +129,23 @@ jobs:
       - name: Run unit tests
         run: ASC_BYPASS_KEYCHAIN=1 go test -short ./...
 
+  telemetry-windows-tests:
+    needs: changes
+    if: needs.changes.outputs.wall_only != 'true'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          cache: true
+
+      - name: Run telemetry tests
+        run: go test -short ./internal/telemetry
+
   build:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,9 @@ API keys are generated at https://appstoreconnect.apple.com/access/integrations/
 | `ASC_UPLOAD_TIMEOUT_SECONDS` | Upload timeout in seconds (alternative) |
 | `ASC_DEBUG` | Enable debug logging (set to `api` for HTTP requests/responses) |
 | `ASC_DEFAULT_OUTPUT` | Default output format: `json`, `table`, `markdown`, or `md` |
+| `ASC_TELEMETRY_DISABLED` | Disable anonymous command telemetry |
+| `ASC_TELEMETRY_EPHEMERAL` | Send telemetry without a local install ID for disposable runtimes |
+| `ASC_TELEMETRY_ENDPOINT` | Override the HTTPS telemetry collector endpoint |
 
 When `ASC_DEFAULT_OUTPUT` is unset, defaults are TTY-aware (`table` in terminals, `json` for non-interactive output).
 Explicit `--output` flags always override `ASC_DEFAULT_OUTPUT` and TTY-aware defaults.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ API keys are generated at https://appstoreconnect.apple.com/access/integrations/
 | `ASC_UPLOAD_TIMEOUT_SECONDS` | Upload timeout in seconds (alternative) |
 | `ASC_DEBUG` | Enable debug logging (set to `api` for HTTP requests/responses) |
 | `ASC_DEFAULT_OUTPUT` | Default output format: `json`, `table`, `markdown`, or `md` |
-| `ASC_TELEMETRY_DISABLED` | Disable anonymous command telemetry |
+| `ASC_TELEMETRY_DISABLED` | Disable default-on anonymous command telemetry |
 | `ASC_TELEMETRY_EPHEMERAL` | Send telemetry without a local install ID for disposable runtimes |
 | `ASC_TELEMETRY_ENDPOINT` | Override the HTTPS telemetry collector endpoint |
 

--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -70,7 +70,7 @@ var rootUsageGroups = []rootCommandGroup{
 	},
 	{
 		title:    "UTILITY COMMANDS",
-		commands: []string{"diff", "capabilities", "search", "snitch", "version", "completion", "schema"},
+		commands: []string{"diff", "capabilities", "search", "snitch", "version", "completion", "schema", "telemetry"},
 	},
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -110,7 +110,7 @@ func Run(args []string, versionInfo string) int {
 			// Report write failure is a hard error - CI depends on it
 			fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", reportErr)
 			if runErr == nil {
-				emitTelemetry(args, commandName, versionInfo, elapsed, ExitError)
+				emitTelemetry(commandName, versionInfo, elapsed, ExitError)
 				return ExitError
 			}
 		}
@@ -119,25 +119,25 @@ func Run(args []string, versionInfo string) int {
 	if runErr != nil {
 		if _, ok := errors.AsType[shared.ReportedError](runErr); ok {
 			exitCode := ExitCodeFromError(runErr)
-			emitTelemetry(args, commandName, versionInfo, elapsed, exitCode)
+			emitTelemetry(commandName, versionInfo, elapsed, exitCode)
 			return exitCode
 		}
 		if errors.Is(runErr, flag.ErrHelp) {
-			emitTelemetry(args, commandName, versionInfo, elapsed, ExitUsage)
+			emitTelemetry(commandName, versionInfo, elapsed, ExitUsage)
 			return ExitUsage
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(runErr))
 		exitCode := ExitCodeFromError(runErr)
-		emitTelemetry(args, commandName, versionInfo, elapsed, exitCode)
+		emitTelemetry(commandName, versionInfo, elapsed, exitCode)
 		return exitCode
 	}
 
-	emitTelemetry(args, commandName, versionInfo, elapsed, ExitSuccess)
+	emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess)
 	return ExitSuccess
 }
 
 func emitImmediateTelemetry(args []string, root *ffcli.Command, versionInfo string, exitCode int) {
-	emitTelemetry(args, getCommandName(root, args), versionInfo, 0, exitCode)
+	emitTelemetry(getCommandName(root, args), versionInfo, 0, exitCode)
 }
 
 func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buffer) func() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -39,18 +41,33 @@ func Run(args []string, versionInfo string) int {
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
 
-	if err := root.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			emitHelpTelemetry(args, root, versionInfo, ExitSuccess)
+	parseOutput := &bytes.Buffer{}
+	restoreFlagOutputs := prepareFlagParsing(root, args, parseOutput)
+	parseErr := root.Parse(args)
+	restoreFlagOutputs()
+	if parseErr != nil {
+		if parseOutput.Len() > 0 {
+			fmt.Fprint(os.Stderr, parseOutput.String())
+		}
+		if errors.Is(parseErr, flag.ErrHelp) {
+			emitImmediateTelemetry(args, root, versionInfo, ExitSuccess)
 			return ExitSuccess
 		}
-		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
-		return ExitCodeFromError(err)
+		if parseOutput.Len() == 0 {
+			fmt.Fprint(os.Stderr, errfmt.FormatStderr(parseErr))
+		}
+		exitCode := ExitCodeFromError(parseErr)
+		if parseOutput.Len() > 0 {
+			exitCode = ExitUsage
+		}
+		emitImmediateTelemetry(args, root, versionInfo, exitCode)
+		return exitCode
 	}
 
 	// Validate CI report flags after parsing
 	if err := shared.ValidateReportFlags(); err != nil {
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
+		emitImmediateTelemetry(args, root, versionInfo, ExitUsage)
 		return ExitUsage
 	}
 
@@ -119,8 +136,56 @@ func Run(args []string, versionInfo string) int {
 	return ExitSuccess
 }
 
-func emitHelpTelemetry(args []string, root *ffcli.Command, versionInfo string, exitCode int) {
+func emitImmediateTelemetry(args []string, root *ffcli.Command, versionInfo string, exitCode int) {
 	emitTelemetry(args, getCommandName(root, args), versionInfo, 0, exitCode)
+}
+
+func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buffer) func() {
+	type preparedFlagSet struct {
+		flagSet *flag.FlagSet
+		output  io.Writer
+	}
+	prepared := []preparedFlagSet{}
+
+	for command != nil {
+		if command.FlagSet == nil {
+			command.FlagSet = flag.NewFlagSet(command.Name, flag.ContinueOnError)
+		}
+		prepared = append(prepared, preparedFlagSet{
+			flagSet: command.FlagSet,
+			output:  command.FlagSet.Output(),
+		})
+		command.FlagSet.Init(command.FlagSet.Name(), flag.ContinueOnError)
+		command.FlagSet.SetOutput(output)
+
+		var next *ffcli.Command
+		var remaining []string
+		for i := 0; i < len(args); {
+			token := args[i]
+			if token == "" {
+				i++
+				continue
+			}
+			if sub := findDirectSubcommand(command, token); sub != nil {
+				next = sub
+				remaining = args[i+1:]
+				break
+			}
+			nextIndex, consumed := consumeFlagToken(command.FlagSet, token, args, i)
+			if consumed {
+				i = nextIndex
+				continue
+			}
+			break
+		}
+		command = next
+		args = remaining
+	}
+	return func() {
+		for _, item := range prepared {
+			item.flagSet.SetOutput(item.output)
+		}
+	}
 }
 
 func shouldCancelRunContextAfterError(err error) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,8 +18,10 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
 
-var maybeCheckForSkillUpdates = install.MaybeCheckForSkillUpdates
-var emitTelemetry = telemetry.Emit
+var (
+	maybeCheckForSkillUpdates = install.MaybeCheckForSkillUpdates
+	emitTelemetry             = telemetry.Emit
+)
 
 // Run executes the CLI using the provided args (not including argv[0]) and version string.
 // It returns the intended process exit code.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,11 +38,10 @@ func Run(args []string, versionInfo string) int {
 	root := RootCommand(versionInfo)
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
-	start := time.Now()
 
 	if err := root.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			emitHelpTelemetry(args, root, versionInfo, start, ExitSuccess)
+			emitHelpTelemetry(args, root, versionInfo, ExitSuccess)
 			return ExitSuccess
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
@@ -75,6 +74,7 @@ func Run(args []string, versionInfo string) int {
 
 	commandName := getCommandName(root, args)
 
+	start := time.Now()
 	runErr := root.Run(runCtx)
 	elapsed := time.Since(start)
 
@@ -119,8 +119,8 @@ func Run(args []string, versionInfo string) int {
 	return ExitSuccess
 }
 
-func emitHelpTelemetry(args []string, root *ffcli.Command, versionInfo string, start time.Time, exitCode int) {
-	emitTelemetry(args, getCommandName(root, args), versionInfo, time.Since(start), exitCode)
+func emitHelpTelemetry(args []string, root *ffcli.Command, versionInfo string, exitCode int) {
+	emitTelemetry(args, getCommandName(root, args), versionInfo, 0, exitCode)
 }
 
 func shouldCancelRunContextAfterError(err error) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/install"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared/errfmt"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
 
 var maybeCheckForSkillUpdates = install.MaybeCheckForSkillUpdates
@@ -88,6 +89,7 @@ func Run(args []string, versionInfo string) int {
 			// Report write failure is a hard error - CI depends on it
 			fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", reportErr)
 			if runErr == nil {
+				telemetry.Emit(args, commandName, versionInfo, elapsed, ExitError)
 				return ExitError
 			}
 		}
@@ -95,15 +97,20 @@ func Run(args []string, versionInfo string) int {
 
 	if runErr != nil {
 		if _, ok := errors.AsType[shared.ReportedError](runErr); ok {
-			return ExitCodeFromError(runErr)
+			exitCode := ExitCodeFromError(runErr)
+			telemetry.Emit(args, commandName, versionInfo, elapsed, exitCode)
+			return exitCode
 		}
 		if errors.Is(runErr, flag.ErrHelp) {
 			return ExitUsage
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(runErr))
-		return ExitCodeFromError(runErr)
+		exitCode := ExitCodeFromError(runErr)
+		telemetry.Emit(args, commandName, versionInfo, elapsed, exitCode)
+		return exitCode
 	}
 
+	telemetry.Emit(args, commandName, versionInfo, elapsed, ExitSuccess)
 	return ExitSuccess
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,6 +19,7 @@ import (
 )
 
 var maybeCheckForSkillUpdates = install.MaybeCheckForSkillUpdates
+var emitTelemetry = telemetry.Emit
 
 // Run executes the CLI using the provided args (not including argv[0]) and version string.
 // It returns the intended process exit code.
@@ -35,9 +36,11 @@ func Run(args []string, versionInfo string) int {
 	root := RootCommand(versionInfo)
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
+	start := time.Now()
 
 	if err := root.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			emitHelpTelemetry(args, root, versionInfo, start, ExitSuccess)
 			return ExitSuccess
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
@@ -70,7 +73,6 @@ func Run(args []string, versionInfo string) int {
 
 	commandName := getCommandName(root, args)
 
-	start := time.Now()
 	runErr := root.Run(runCtx)
 	elapsed := time.Since(start)
 
@@ -89,7 +91,7 @@ func Run(args []string, versionInfo string) int {
 			// Report write failure is a hard error - CI depends on it
 			fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", reportErr)
 			if runErr == nil {
-				telemetry.Emit(args, commandName, versionInfo, elapsed, ExitError)
+				emitTelemetry(args, commandName, versionInfo, elapsed, ExitError)
 				return ExitError
 			}
 		}
@@ -98,20 +100,25 @@ func Run(args []string, versionInfo string) int {
 	if runErr != nil {
 		if _, ok := errors.AsType[shared.ReportedError](runErr); ok {
 			exitCode := ExitCodeFromError(runErr)
-			telemetry.Emit(args, commandName, versionInfo, elapsed, exitCode)
+			emitTelemetry(args, commandName, versionInfo, elapsed, exitCode)
 			return exitCode
 		}
 		if errors.Is(runErr, flag.ErrHelp) {
+			emitTelemetry(args, commandName, versionInfo, elapsed, ExitUsage)
 			return ExitUsage
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(runErr))
 		exitCode := ExitCodeFromError(runErr)
-		telemetry.Emit(args, commandName, versionInfo, elapsed, exitCode)
+		emitTelemetry(args, commandName, versionInfo, elapsed, exitCode)
 		return exitCode
 	}
 
-	telemetry.Emit(args, commandName, versionInfo, elapsed, ExitSuccess)
+	emitTelemetry(args, commandName, versionInfo, elapsed, ExitSuccess)
 	return ExitSuccess
+}
+
+func emitHelpTelemetry(args []string, root *ffcli.Command, versionInfo string, start time.Time, exitCode int) {
+	emitTelemetry(args, getCommandName(root, args), versionInfo, time.Since(start), exitCode)
 }
 
 func shouldCancelRunContextAfterError(err error) bool {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -67,7 +67,7 @@ func TestRun_ReportFlagValidationErrorEmitsTelemetry(t *testing.T) {
 	var commandName string
 	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(_ []string, command, _ string, elapsed time.Duration, code int) {
+	emitTelemetry = func(command, _ string, elapsed time.Duration, code int) {
 		calls++
 		commandName = command
 		duration = elapsed
@@ -101,7 +101,7 @@ func TestRun_ParseErrorEmitsTelemetry(t *testing.T) {
 	var commandName string
 	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(_ []string, command, _ string, elapsed time.Duration, code int) {
+	emitTelemetry = func(command, _ string, elapsed time.Duration, code int) {
 		calls++
 		commandName = command
 		duration = elapsed
@@ -440,7 +440,7 @@ func TestRun_HelpEmitsTelemetry(t *testing.T) {
 	var commandName string
 	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(_ []string, command, _ string, elapsed time.Duration, code int) {
+	emitTelemetry = func(command, _ string, elapsed time.Duration, code int) {
 		commandName = command
 		duration = elapsed
 		exitCode = code

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -370,15 +370,25 @@ func TestRun_HelpEmitsTelemetry(t *testing.T) {
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
 	var commandName string
+	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(_ []string, command, _ string, _ time.Duration, code int) {
+	emitTelemetry = func(_ []string, command, _ string, elapsed time.Duration, code int) {
 		commandName = command
+		duration = elapsed
 		exitCode = code
 	}
 
-	emitHelpTelemetry([]string{"builds", "--help"}, RootCommand("1.0.0"), "1.0.0", time.Now(), ExitSuccess)
+	emitHelpTelemetry(
+		[]string{"builds", "--help"},
+		RootCommand("1.0.0"),
+		"1.0.0",
+		ExitSuccess,
+	)
 	if commandName != "asc builds" {
 		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")
+	}
+	if duration != 0 {
+		t.Fatalf("telemetry duration = %s, want 0 for help", duration)
 	}
 	if exitCode != ExitSuccess {
 		t.Fatalf("telemetry exit code = %d, want %d", exitCode, ExitSuccess)

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -58,6 +58,74 @@ func TestRun_ReportFlagValidationError(t *testing.T) {
 	}
 }
 
+func TestRun_ReportFlagValidationErrorEmitsTelemetry(t *testing.T) {
+	resetReportFlags(t)
+
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var calls int
+	var commandName string
+	var duration time.Duration
+	var exitCode int
+	emitTelemetry = func(_ []string, command, _ string, elapsed time.Duration, code int) {
+		calls++
+		commandName = command
+		duration = elapsed
+		exitCode = code
+	}
+
+	captureCommandOutput(t, func() {
+		Run([]string{"--report-file", filepath.Join(t.TempDir(), "junit.xml"), "builds", "list"}, "1.0.0")
+	})
+
+	if calls != 1 {
+		t.Fatalf("telemetry calls = %d, want 1", calls)
+	}
+	if commandName != "asc builds list" {
+		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds list")
+	}
+	if duration != 0 {
+		t.Fatalf("telemetry duration = %s, want 0", duration)
+	}
+	if exitCode != ExitUsage {
+		t.Fatalf("telemetry exit code = %d, want %d", exitCode, ExitUsage)
+	}
+}
+
+func TestRun_ParseErrorEmitsTelemetry(t *testing.T) {
+	resetReportFlags(t)
+
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var calls int
+	var commandName string
+	var duration time.Duration
+	var exitCode int
+	emitTelemetry = func(_ []string, command, _ string, elapsed time.Duration, code int) {
+		calls++
+		commandName = command
+		duration = elapsed
+		exitCode = code
+	}
+
+	captureCommandOutput(t, func() {
+		Run([]string{"builds", "--definitely-invalid"}, "1.0.0")
+	})
+
+	if calls != 1 {
+		t.Fatalf("telemetry calls = %d, want 1", calls)
+	}
+	if commandName != "asc builds" {
+		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")
+	}
+	if duration != 0 {
+		t.Fatalf("telemetry duration = %s, want 0", duration)
+	}
+	if exitCode != ExitUsage {
+		t.Fatalf("telemetry exit code = %d, want %d", exitCode, ExitUsage)
+	}
+}
+
 func TestRun_ReportWriteFailureReturnsExitError(t *testing.T) {
 	resetReportFlags(t)
 
@@ -378,7 +446,7 @@ func TestRun_HelpEmitsTelemetry(t *testing.T) {
 		exitCode = code
 	}
 
-	emitHelpTelemetry(
+	emitImmediateTelemetry(
 		[]string{"builds", "--help"},
 		RootCommand("1.0.0"),
 		"1.0.0",

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -338,6 +338,26 @@ func TestRun_HelpSkipsAuthResolution(t *testing.T) {
 	}
 }
 
+func TestRun_HelpEmitsTelemetry(t *testing.T) {
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var commandName string
+	var exitCode int
+	emitTelemetry = func(_ []string, command, _ string, _ time.Duration, code int) {
+		commandName = command
+		exitCode = code
+	}
+
+	emitHelpTelemetry([]string{"builds", "--help"}, RootCommand("1.0.0"), "1.0.0", time.Now(), ExitSuccess)
+	if commandName != "asc builds" {
+		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")
+	}
+	if exitCode != ExitSuccess {
+		t.Fatalf("telemetry exit code = %d, want %d", exitCode, ExitSuccess)
+	}
+}
+
 func TestMergeEnvOverridesReplacesExistingKeys(t *testing.T) {
 	env := mergeEnvOverrides(
 		[]string{

--- a/cmd/test_main_test.go
+++ b/cmd/test_main_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv("ASC_TELEMETRY_DISABLED", "1")
+	os.Exit(m.Run())
+}

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -147,6 +147,7 @@ Commands are organized into logical families based on functionality:
 * `completion` - Print shell completion scripts
 * `diff` - Generate deterministic non-mutating diff plans
 * `schema` - Inspect App Store Connect API endpoint schemas at runtime
+* `telemetry` - Manage anonymous CLI telemetry settings
 
 ## TTY-Aware Output Defaults
 

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -7,6 +7,11 @@ Telemetry records coarse command-level usage so maintainers can understand which
 commands are used, which versions are active, and where reliability work is
 needed.
 
+Telemetry is enabled by default for every runtime. It remains enabled in CI,
+Rork sandboxes, Rork GitHub workflows, and explicitly ephemeral environments;
+events from those disposable runtimes omit the durable local install ID. Use
+`asc telemetry disable`, `ASC_TELEMETRY_DISABLED`, or `DO_NOT_TRACK` to opt out.
+
 Telemetry does **not** collect raw arguments, Apple account identifiers, team
 IDs, issuer IDs, key IDs, app IDs, bundle IDs, usernames, hostnames, repository
 names, IP addresses, user-agent strings, or file paths.
@@ -98,8 +103,10 @@ local user account reuses the same install ID from `~/.asc/telemetry.json`.
 
 Known runtime contexts are `local`, `ephemeral`, `ci`, `rork_sandbox`, and
 `rork_github_workflow`. Known invocation sources are `terminal`, `claude_code`,
-`cursor_agent`, `codex_desktop`, `opencode`, `pi`, and `rork_agent_setup` for the
-recognized managed setup flow.
+`cursor_agent`, `codex_desktop`, `opencode`, `pi`, and `rork_agent`. Rork agent
+invocations are recognized from the production `RORK_SANDBOX_ID` marker or the
+`rorkai/user-workflows` GitHub Actions repository, not from a local auth profile
+name.
 
 The install ID represents local CLI state, not an Apple account, person, or
 hardware identifier. It is omitted for CI, Rork sandboxes, Rork GitHub

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -1,0 +1,125 @@
+# telemetry
+
+> Manage anonymous CLI telemetry settings
+
+The `telemetry` command controls anonymous product telemetry for the CLI.
+Telemetry records coarse command-level usage so maintainers can understand which
+commands are used, which versions are active, and where reliability work is
+needed.
+
+Telemetry does **not** collect raw arguments, Apple account identifiers, team
+IDs, issuer IDs, key IDs, app IDs, bundle IDs, usernames, hostnames, repository
+names, IP addresses, user-agent strings, or file paths.
+
+## Usage
+
+```bash  theme={null}
+asc telemetry <subcommand>
+```
+
+## Subcommands
+
+<ParamField path="status">
+  Show whether telemetry is enabled, the local state path, endpoint, and the
+  anonymous local install ID when one exists.
+</ParamField>
+
+<ParamField path="enable">
+  Enable anonymous telemetry in local CLI state.
+</ParamField>
+
+<ParamField path="disable">
+  Disable anonymous telemetry in local CLI state.
+</ParamField>
+
+<ParamField path="reset-id">
+  Reset the anonymous local install ID.
+</ParamField>
+
+## Examples
+
+```bash  theme={null}
+asc telemetry status
+asc telemetry status --output json
+asc telemetry disable
+asc telemetry enable
+asc telemetry reset-id
+```
+
+## Environment Controls
+
+<ParamField path="ASC_TELEMETRY_DISABLED" type="boolean">
+  Disable telemetry for the current process when set to `true`, `1`, `yes`,
+  `y`, or `on`.
+</ParamField>
+
+<ParamField path="DO_NOT_TRACK" type="boolean">
+  Disable telemetry for the current process when set to `true`, `1`, `yes`,
+  `y`, or `on`.
+</ParamField>
+
+<ParamField path="ASC_TELEMETRY_ENDPOINT" type="string">
+  Override the telemetry collector endpoint. The endpoint must be HTTPS.
+</ParamField>
+
+## Event Payload
+
+The CLI sends a single best-effort JSON event after command completion:
+
+```json
+{
+  "event_id": "2d2f86dd-6d75-4a6f-b97f-a6ce15d4bc79",
+  "schema_version": 1,
+  "asc_version": "1.13.0",
+  "os": "darwin",
+  "arch": "arm64",
+  "command_path": "asc builds list",
+  "command_family": "builds",
+  "duration_ms": 842,
+  "duration_bucket": "500ms_1s",
+  "exit_code": 0,
+  "success": true,
+  "execution_context": "local",
+  "install_id": "5fd9bf39-2e0d-45c1-8e4a-b65a58159ed7",
+  "session_id": "ac8062e3-e6d2-4301-8d08-bb444cd55004"
+}
+```
+
+The `install_id` is only sent for `local` execution context. For CI, agent, and
+sandbox contexts it is `null`, so ephemeral machines do not inflate local active
+install metrics.
+
+## Collector Contract
+
+Collectors should accept `POST /asc/v1/events`, validate the event schema, add
+server-side receive metadata, and insert accepted events into analytics storage.
+Collector credentials must never be shipped in the CLI.
+
+Recommended ClickHouse table:
+
+```sql
+CREATE TABLE asc_cli_events
+(
+  received_at DateTime64(3, 'UTC') DEFAULT now64(3),
+  event_date Date MATERIALIZED toDate(received_at),
+  event_id UUID,
+  schema_version UInt8,
+  asc_version String,
+  os LowCardinality(String),
+  arch LowCardinality(String),
+  command_path LowCardinality(String),
+  command_family LowCardinality(String),
+  duration_ms UInt32,
+  duration_bucket LowCardinality(String),
+  exit_code Int16,
+  success Bool,
+  execution_context LowCardinality(String),
+  install_id Nullable(UUID),
+  session_id UUID,
+  source LowCardinality(String),
+  collector_version LowCardinality(String)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (event_date, execution_context, command_family, asc_version);
+```

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -12,9 +12,12 @@ Rork sandboxes, Rork GitHub workflows, and explicitly ephemeral environments;
 events from those disposable runtimes omit the durable local install ID. Use
 `asc telemetry disable`, `ASC_TELEMETRY_DISABLED`, or `DO_NOT_TRACK` to opt out.
 
-Telemetry does **not** collect raw arguments, Apple account identifiers, team
-IDs, issuer IDs, key IDs, app IDs, bundle IDs, usernames, hostnames, repository
-names, IP addresses, user-agent strings, or file paths.
+The CLI payload does **not** include raw arguments, Apple account identifiers,
+team IDs, issuer IDs, key IDs, app IDs, bundle IDs, usernames, hostnames,
+repository names, IP addresses, user-agent strings, or file paths. As with any
+HTTPS service, the collector's edge provider sees the connection address; the
+Rork collector may use it transiently for abuse throttling but does not persist
+it in telemetry events or analytics storage.
 
 ## Usage
 
@@ -64,7 +67,8 @@ asc telemetry reset-id
 </ParamField>
 
 <ParamField path="ASC_TELEMETRY_ENDPOINT" type="string">
-  Override the telemetry collector endpoint. The endpoint must be HTTPS.
+  Override the telemetry collector endpoint. The endpoint must be HTTPS and
+  must not contain embedded credentials.
 </ParamField>
 
 <ParamField path="ASC_TELEMETRY_EPHEMERAL" type="boolean">
@@ -96,6 +100,11 @@ The CLI sends a single best-effort JSON event after command completion:
 }
 ```
 
+Raw command arguments never enter event construction. `command_path` comes only
+from the CLI's registered command tree, so flag values and positional values
+cannot become telemetry dimensions. `session_id` is reused only within one CLI
+process and changes the next time `asc` starts.
+
 `runtime_context` describes where the command runs, independently from
 `invocation_source`, which describes what launched it. A command launched by
 Terminal, Claude Code, Cursor Agent, Codex Desktop, OpenCode, or Pi on the same
@@ -112,6 +121,15 @@ The install ID represents local CLI state, not an Apple account, person, or
 hardware identifier. It is omitted for CI, Rork sandboxes, Rork GitHub
 workflows, and runtimes marked with `ASC_TELEMETRY_EPHEMERAL`, so known
 disposable machines do not inflate local active-install metrics.
+
+The sender accepts only an HTTPS collector endpoint without embedded
+credentials, refuses every redirect (including HTTPS redirects), and never
+attaches cookies from the CLI's other HTTP clients. Telemetry state reads are
+bounded, and delivery errors never change the command's result.
+
+The default collector uses Rork's existing API Worker route at
+`https://rork.com/cf-api/asc/v1/events`; it does not require a separate
+telemetry hostname.
 
 ## Collector Contract
 

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -62,6 +62,11 @@ asc telemetry reset-id
   Override the telemetry collector endpoint. The endpoint must be HTTPS.
 </ParamField>
 
+<ParamField path="ASC_TELEMETRY_EPHEMERAL" type="boolean">
+  Mark the current runtime as ephemeral when set to `true`, `1`, `yes`, `y`,
+  or `on`. Events are still sent, but the local install ID is omitted.
+</ParamField>
+
 ## Event Payload
 
 The CLI sends a single best-effort JSON event after command completion:
@@ -79,15 +84,27 @@ The CLI sends a single best-effort JSON event after command completion:
   "duration_bucket": "500ms_1s",
   "exit_code": 0,
   "success": true,
-  "execution_context": "local",
+  "runtime_context": "local",
+  "invocation_source": "codex_desktop",
   "install_id": "5fd9bf39-2e0d-45c1-8e4a-b65a58159ed7",
   "session_id": "ac8062e3-e6d2-4301-8d08-bb444cd55004"
 }
 ```
 
-The `install_id` is only sent for `local` execution context. For CI, agent, and
-sandbox contexts it is `null`, so ephemeral machines do not inflate local active
-install metrics.
+`runtime_context` describes where the command runs, independently from
+`invocation_source`, which describes what launched it. A command launched by
+Terminal, Claude Code, Cursor Agent, Codex Desktop, OpenCode, or Pi on the same
+local user account reuses the same install ID from `~/.asc/telemetry.json`.
+
+Known runtime contexts are `local`, `ephemeral`, `ci`, `rork_sandbox`, and
+`rork_github_workflow`. Known invocation sources are `terminal`, `claude_code`,
+`cursor_agent`, `codex_desktop`, `opencode`, `pi`, and `rork_agent_setup` for the
+recognized managed setup flow.
+
+The install ID represents local CLI state, not an Apple account, person, or
+hardware identifier. It is omitted for CI, Rork sandboxes, Rork GitHub
+workflows, and runtimes marked with `ASC_TELEMETRY_EPHEMERAL`, so known
+disposable machines do not inflate local active-install metrics.
 
 ## Collector Contract
 
@@ -113,7 +130,8 @@ CREATE TABLE asc_cli_events
   duration_bucket LowCardinality(String),
   exit_code Int16,
   success Bool,
-  execution_context LowCardinality(String),
+  runtime_context LowCardinality(String),
+  invocation_source LowCardinality(String),
   install_id Nullable(UUID),
   session_id UUID,
   source LowCardinality(String),
@@ -121,5 +139,16 @@ CREATE TABLE asc_cli_events
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(event_date)
-ORDER BY (event_date, execution_context, command_family, asc_version);
+ORDER BY (event_date, runtime_context, invocation_source, command_family, asc_version);
+```
+
+For example, local active installations can be deduplicated across manual and
+agent-assisted commands with:
+
+```sql
+SELECT uniqExact(install_id) AS local_active_installs
+FROM asc_cli_events
+WHERE event_date = today()
+  AND runtime_context = 'local'
+  AND install_id IS NOT NULL;
 ```

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -190,7 +190,10 @@ Configure default output formats.
 
 ## Telemetry variables
 
-Configure anonymous command-level CLI telemetry.
+Anonymous command-level CLI telemetry is enabled by default in local, agent,
+CI, and other ephemeral runtimes. Disposable runtimes omit the durable local
+install ID without disabling event delivery. Use these variables to opt out or
+adjust runtime handling.
 
 <ParamField path="ASC_TELEMETRY_DISABLED" type="boolean">
   Disable anonymous telemetry for the current process

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -188,6 +188,26 @@ Configure default output formats.
   Explicit `--output` flags always override this variable.
 </ParamField>
 
+## Telemetry variables
+
+Configure anonymous command-level CLI telemetry.
+
+<ParamField path="ASC_TELEMETRY_DISABLED" type="boolean">
+  Disable anonymous telemetry for the current process
+
+  Set to `true`, `1`, `yes`, `y`, or `on` to disable telemetry.
+</ParamField>
+
+<ParamField path="DO_NOT_TRACK" type="boolean">
+  Disable anonymous telemetry for the current process
+
+  Set to `true`, `1`, `yes`, `y`, or `on` to disable telemetry.
+</ParamField>
+
+<ParamField path="ASC_TELEMETRY_ENDPOINT" type="string">
+  Override the HTTPS telemetry collector endpoint.
+</ParamField>
+
 ## Configuration path
 
 <ParamField path="ASC_CONFIG_PATH" type="string">

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -208,7 +208,9 @@ adjust runtime handling.
 </ParamField>
 
 <ParamField path="ASC_TELEMETRY_ENDPOINT" type="string">
-  Override the HTTPS telemetry collector endpoint.
+  Override the HTTPS telemetry collector endpoint. Telemetry requests do not
+  follow redirects, do not attach ambient cookies, and reject endpoint URLs
+  containing embedded credentials.
 </ParamField>
 
 <ParamField path="ASC_TELEMETRY_EPHEMERAL" type="boolean">

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -208,6 +208,14 @@ Configure anonymous command-level CLI telemetry.
   Override the HTTPS telemetry collector endpoint.
 </ParamField>
 
+<ParamField path="ASC_TELEMETRY_EPHEMERAL" type="boolean">
+  Mark the current runtime as ephemeral without disabling telemetry.
+
+  Set to `true`, `1`, `yes`, `y`, or `on` to omit the local install ID from
+  emitted events. Use this for disposable cloud agents or virtual machines that
+  are not already identified as CI or a Rork sandbox.
+</ParamField>
+
 ## Configuration path
 
 <ParamField path="ASC_CONFIG_PATH" type="string">

--- a/docs.json
+++ b/docs.json
@@ -151,8 +151,8 @@
               "commands/xcode-cloud",
               "commands/notify",
               "commands/migrate",
-              "commands/telemetry",
-              "commands/completion"
+              "commands/completion",
+              "commands/telemetry"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -151,6 +151,7 @@
               "commands/xcode-cloud",
               "commands/notify",
               "commands/migrate",
+              "commands/telemetry",
               "commands/completion"
             ]
           }

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -142,6 +142,7 @@ asc <subcommand> [flags]
 - `version` - Print version information and exit.
 - `completion` - Print shell completion scripts.
 - `schema` - Inspect App Store Connect API endpoint schemas at runtime.
+- `telemetry` - Manage anonymous CLI telemetry settings.
 
 ## Scripting Tips
 

--- a/internal/cli/cmdtest/helpers_test.go
+++ b/internal/cli/cmdtest/helpers_test.go
@@ -1,6 +1,8 @@
 package cmdtest
 
 import (
+	"testing"
+
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
@@ -14,6 +16,14 @@ func resetCmdtestState() {
 	auth.ResetInvalidBypassKeychainWarningsForTest()
 	shared.ResetDefaultOutputFormat()
 	shared.ResetTierCacheForTest()
+}
+
+func setCmdtestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
 }
 
 func RootCommand(version string) *ffcli.Command {

--- a/internal/cli/cmdtest/telemetry_test.go
+++ b/internal/cli/cmdtest/telemetry_test.go
@@ -9,6 +9,32 @@ import (
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
+func TestTelemetryStatusIsEnabledByDefault(t *testing.T) {
+	setCmdtestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := rootcmd.Run([]string{"telemetry", "status", "--output", "json"}, "1.2.3"); code != 0 {
+			t.Fatalf("status exit code = %d", code)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("status stderr = %q", stderr)
+	}
+
+	var status struct {
+		Enabled bool   `json:"enabled"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status json error: %v\n%s", err, stdout)
+	}
+	if !status.Enabled || status.Reason != "" {
+		t.Fatalf("expected telemetry enabled by default, got %+v", status)
+	}
+}
+
 func TestTelemetryCommands(t *testing.T) {
 	home := setCmdtestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")

--- a/internal/cli/cmdtest/telemetry_test.go
+++ b/internal/cli/cmdtest/telemetry_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestTelemetryCommands(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := setCmdtestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
@@ -91,7 +90,7 @@ func TestTelemetryStatusUsesDefaultOutput(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
+			setCmdtestHome(t)
 			t.Setenv("ASC_DEFAULT_OUTPUT", test.defaultOutput)
 
 			stdout, stderr := captureOutput(t, func() {
@@ -117,7 +116,7 @@ func TestTelemetryStatusUsesDefaultOutput(t *testing.T) {
 }
 
 func TestTelemetryStatusRejectsInvalidOutput(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setCmdtestHome(t)
 
 	var code int
 	stdout, stderr := captureOutput(t, func() {

--- a/internal/cli/cmdtest/telemetry_test.go
+++ b/internal/cli/cmdtest/telemetry_test.go
@@ -78,3 +78,58 @@ func TestTelemetryCommands(t *testing.T) {
 		t.Fatalf("reset-id stdout = %q", stdout)
 	}
 }
+
+func TestTelemetryStatusUsesDefaultOutput(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultOutput string
+		wantJSON      bool
+	}{
+		{name: "non-interactive defaults to JSON", wantJSON: true},
+		{name: "table environment default", defaultOutput: "table"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("ASC_DEFAULT_OUTPUT", test.defaultOutput)
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run([]string{"telemetry", "status"}, "1.2.3"); code != 0 {
+					t.Fatalf("status exit code = %d", code)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("status stderr = %q", stderr)
+			}
+			if test.wantJSON {
+				var status map[string]any
+				if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+					t.Fatalf("default status output is not JSON: %v\n%s", err, stdout)
+				}
+				return
+			}
+			if !strings.Contains(stdout, "Telemetry") || !strings.Contains(stdout, "Enabled") {
+				t.Fatalf("status table output = %q", stdout)
+			}
+		})
+	}
+}
+
+func TestTelemetryStatusRejectsInvalidOutput(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"telemetry", "status", "--output", "yaml"}, "1.2.3")
+	})
+	if code != 2 {
+		t.Fatalf("status exit code = %d, want 2", code)
+	}
+	if stdout != "" {
+		t.Fatalf("status stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "unsupported format: yaml") {
+		t.Fatalf("status stderr = %q, want invalid output error", stderr)
+	}
+}

--- a/internal/cli/cmdtest/telemetry_test.go
+++ b/internal/cli/cmdtest/telemetry_test.go
@@ -1,0 +1,80 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestTelemetryCommands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{"telemetry", "disable"}, "1.2.3")
+		if code != 0 {
+			t.Fatalf("disable exit code = %d", code)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("disable stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, "Telemetry disabled") {
+		t.Fatalf("disable stdout = %q", stdout)
+	}
+
+	stdout, stderr = captureOutput(t, func() {
+		code := rootcmd.Run([]string{"telemetry", "status", "--output", "json"}, "1.2.3")
+		if code != 0 {
+			t.Fatalf("status exit code = %d", code)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("status stderr = %q", stderr)
+	}
+	var status struct {
+		Path    string `json:"path"`
+		Enabled bool   `json:"enabled"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		t.Fatalf("status json error: %v\n%s", err, stdout)
+	}
+	if status.Enabled || status.Reason != "state" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if !strings.HasPrefix(filepath.Clean(status.Path), filepath.Clean(home)) {
+		t.Fatalf("expected status path under home %q, got %q", home, status.Path)
+	}
+
+	stdout, stderr = captureOutput(t, func() {
+		code := rootcmd.Run([]string{"telemetry", "enable"}, "1.2.3")
+		if code != 0 {
+			t.Fatalf("enable exit code = %d", code)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("enable stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, "Telemetry enabled") {
+		t.Fatalf("enable stdout = %q", stdout)
+	}
+
+	stdout, stderr = captureOutput(t, func() {
+		code := rootcmd.Run([]string{"telemetry", "reset-id"}, "1.2.3")
+		if code != 0 {
+			t.Fatalf("reset-id exit code = %d", code)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("reset-id stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, "Telemetry install ID reset") {
+		t.Fatalf("reset-id stdout = %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/test_main_test.go
+++ b/internal/cli/cmdtest/test_main_test.go
@@ -17,6 +17,7 @@ func TestMain(m *testing.M) {
 
 	_ = os.Setenv("ASC_CONFIG_PATH", testConfigPath)
 	_ = os.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	_ = os.Setenv("ASC_TELEMETRY_DISABLED", "1")
 	_ = os.Setenv("HOME", tempDir)
 
 	code := m.Run()

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -198,6 +198,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `completion` - Print shell completion scripts.
 - `schema` - Inspect App Store Connect API endpoint schemas at runtime.
 - `snitch` - Report CLI friction as a GitHub issue.
+- `telemetry` - Manage anonymous CLI telemetry settings.
 
 ## Global Flags
 

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -68,6 +68,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/status"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/submit"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/subscriptions"
+	telemetrycmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/telemetry"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/testflight"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/users"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/validate"
@@ -176,6 +177,7 @@ func Subcommands(version string) []*ffcli.Command {
 		gamecenter.GameCenterCommand(),
 		capabilities.Command(),
 		schema.SchemaCommand(),
+		telemetrycmd.TelemetryCommand(),
 		searchcmd.SearchCommand(func() []*ffcli.Command { return subs }),
 		snitch.SnitchCommand(version),
 		VersionCommand(version),

--- a/internal/cli/telemetry/telemetry.go
+++ b/internal/cli/telemetry/telemetry.go
@@ -1,0 +1,145 @@
+package telemetrycmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+)
+
+func TelemetryCommand() *ffcli.Command {
+	return &ffcli.Command{
+		Name:       "telemetry",
+		ShortUsage: "asc telemetry <subcommand>",
+		ShortHelp:  "Manage anonymous CLI telemetry settings.",
+		LongHelp: `Manage anonymous CLI telemetry settings.
+
+Telemetry sends anonymous command-level usage events to help improve asc. It
+does not collect raw arguments, Apple account identifiers, app identifiers,
+bundle identifiers, usernames, hostnames, repo names, or paths.
+
+Examples:
+  asc telemetry status
+  asc telemetry disable
+  asc telemetry enable
+  asc telemetry reset-id`,
+		FlagSet:   flag.NewFlagSet("telemetry", flag.ExitOnError),
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			statusCommand(),
+			enableCommand(),
+			disableCommand(),
+			resetIDCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n\n", args[0])
+			}
+			return flag.ErrHelp
+		},
+	}
+}
+
+func statusCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("telemetry status", flag.ExitOnError)
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "table", "Output format: table, json", "table", "json")
+	return &ffcli.Command{
+		Name:       "status",
+		ShortUsage: "asc telemetry status [flags]",
+		ShortHelp:  "Show anonymous telemetry status.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return flag.ErrHelp
+			}
+			normalizedOutput, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "table", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			status, err := telemetry.ReadStatus()
+			if err != nil {
+				return err
+			}
+			if normalizedOutput == "json" {
+				return shared.PrintOutput(status, "json", *output.Pretty)
+			}
+			printStatus(status)
+			return nil
+		},
+	}
+}
+
+func enableCommand() *ffcli.Command {
+	return stateCommand("enable", "Enable anonymous telemetry.", true)
+}
+
+func disableCommand() *ffcli.Command {
+	return stateCommand("disable", "Disable anonymous telemetry.", false)
+}
+
+func stateCommand(name, help string, enabled bool) *ffcli.Command {
+	fs := flag.NewFlagSet("telemetry "+name, flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       name,
+		ShortUsage: "asc telemetry " + name,
+		ShortHelp:  help,
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return flag.ErrHelp
+			}
+			if err := telemetry.SetEnabled(enabled); err != nil {
+				return err
+			}
+			if enabled {
+				fmt.Fprintln(os.Stdout, "Telemetry enabled")
+			} else {
+				fmt.Fprintln(os.Stdout, "Telemetry disabled")
+			}
+			return nil
+		},
+	}
+}
+
+func resetIDCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("telemetry reset-id", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "reset-id",
+		ShortUsage: "asc telemetry reset-id",
+		ShortHelp:  "Reset the anonymous local install ID.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return flag.ErrHelp
+			}
+			if _, err := telemetry.ResetInstallID(); err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, "Telemetry install ID reset")
+			return nil
+		},
+	}
+}
+
+func printStatus(status telemetry.Status) {
+	enabled := "false"
+	if status.Enabled {
+		enabled = "true"
+	}
+	rows := [][]string{
+		{"Enabled", enabled},
+		{"Reason", shared.OrNA(status.Reason)},
+		{"Install ID", shared.OrNA(status.InstallID)},
+		{"Endpoint", shared.OrNA(status.Endpoint)},
+		{"Path", status.Path},
+	}
+	shared.RenderSection("Telemetry", []string{"Field", "Value"}, rows, false)
+}

--- a/internal/cli/telemetry/telemetry.go
+++ b/internal/cli/telemetry/telemetry.go
@@ -47,7 +47,7 @@ Examples:
 
 func statusCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("telemetry status", flag.ExitOnError)
-	output := shared.BindOutputFlagsWithAllowed(fs, "output", "table", "Output format: table, json", "table", "json")
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", defaultStatusOutputFormat(), "Output format: table, json", "table", "json")
 	return &ffcli.Command{
 		Name:       "status",
 		ShortUsage: "asc telemetry status [flags]",
@@ -73,6 +73,13 @@ func statusCommand() *ffcli.Command {
 			return nil
 		},
 	}
+}
+
+func defaultStatusOutputFormat() string {
+	if shared.DefaultOutputFormat() == "json" {
+		return "json"
+	}
+	return "table"
 }
 
 func enableCommand() *ffcli.Command {

--- a/internal/cli/telemetry/telemetry.go
+++ b/internal/cli/telemetry/telemetry.go
@@ -19,9 +19,10 @@ func TelemetryCommand() *ffcli.Command {
 		ShortHelp:  "Manage anonymous CLI telemetry settings.",
 		LongHelp: `Manage anonymous CLI telemetry settings.
 
-Telemetry sends anonymous command-level usage events to help improve asc. It
-does not collect raw arguments, Apple account identifiers, app identifiers,
-bundle identifiers, usernames, hostnames, repo names, or paths.
+Telemetry is enabled by default and sends anonymous command-level usage events
+to help improve asc. It does not collect raw arguments, Apple account
+identifiers, app identifiers, bundle identifiers, usernames, hostnames, repo
+names, or paths. Use "asc telemetry disable" to opt out.
 
 Examples:
   asc telemetry status

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,0 +1,101 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultEndpoint = "https://telemetry.rork.com/asc/v1/events"
+	endpointEnvVar  = "ASC_TELEMETRY_ENDPOINT"
+	sendTimeout     = 750 * time.Millisecond
+)
+
+var sendHTTP = sendHTTPEvent
+
+func Emit(args []string, commandName, version string, duration time.Duration, exitCode int) {
+	st, err := loadCurrentState()
+	if err != nil {
+		debugf("telemetry disabled: %v", err)
+		return
+	}
+	enabled, reason := enabledFromState(st)
+	if !enabled {
+		debugf("telemetry disabled by %s", reason)
+		return
+	}
+
+	ev, ok := BuildEvent(args, commandName, version, duration, exitCode)
+	if !ok {
+		return
+	}
+
+	if err := sendHTTP(ev); err != nil {
+		debugf("telemetry send failed: %v", err)
+	}
+}
+
+func loadCurrentState() (State, error) {
+	path, err := StatePath()
+	if err != nil {
+		return State{}, err
+	}
+	return loadState(path)
+}
+
+func sendHTTPEvent(ev Event) error {
+	endpoint := endpoint()
+	if endpoint == "" {
+		return nil
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("invalid telemetry endpoint")
+	}
+
+	body, err := json.Marshal(ev)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected telemetry status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func endpoint() string {
+	if raw := strings.TrimSpace(os.Getenv(endpointEnvVar)); raw != "" {
+		return raw
+	}
+	return DefaultEndpoint
+}
+
+func debugf(format string, args ...any) {
+	debug := strings.ToLower(strings.TrimSpace(os.Getenv("ASC_DEBUG")))
+	if debug == "" || debug == "0" || debug == "false" || debug == "off" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -15,14 +15,19 @@ import (
 )
 
 const (
-	DefaultEndpoint = "https://telemetry.rork.com/asc/v1/events"
+	DefaultEndpoint = "https://rork.com/cf-api/asc/v1/events"
 	endpointEnvVar  = "ASC_TELEMETRY_ENDPOINT"
 	maxSendDuration = 250 * time.Millisecond
 )
 
 var sendHTTP = sendHTTPEvent
 
-func Emit(args []string, commandName, version string, duration time.Duration, exitCode int) {
+func Emit(commandName, version string, duration time.Duration, exitCode int) {
+	commandPath := sanitizeCommandName(commandName)
+	if shouldSkipCommand(commandPath) {
+		return
+	}
+
 	if reason := environmentOptOutReason(); reason != "" {
 		debugf("telemetry disabled by %s", reason)
 		return
@@ -39,7 +44,7 @@ func Emit(args []string, commandName, version string, duration time.Duration, ex
 		return
 	}
 
-	ev, ok := BuildEvent(args, commandName, version, duration, exitCode)
+	ev, ok := BuildEvent(commandPath, version, duration, exitCode)
 	if !ok {
 		return
 	}
@@ -63,7 +68,7 @@ func sendHTTPEvent(ev Event) error {
 		return nil
 	}
 	parsed, err := url.Parse(endpoint)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil {
 		return fmt.Errorf("invalid telemetry endpoint")
 	}
 
@@ -83,19 +88,15 @@ func sendHTTPEvent(ev Event) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := *http.DefaultClient
-	checkRedirect := client.CheckRedirect
-	client.CheckRedirect = func(request *http.Request, via []*http.Request) error {
-		if request.URL.Scheme != "https" {
-			return fmt.Errorf("non-HTTPS telemetry redirect")
-		}
-		if checkRedirect != nil {
-			return checkRedirect(request, via)
-		}
-		if len(via) >= 10 {
-			return fmt.Errorf("stopped after 10 redirects")
-		}
-		return nil
+	transport := http.DefaultClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	resp, err := client.Do(req)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -23,6 +23,11 @@ const (
 var sendHTTP = sendHTTPEvent
 
 func Emit(args []string, commandName, version string, duration time.Duration, exitCode int) {
+	if reason := environmentOptOutReason(); reason != "" {
+		debugf("telemetry disabled by %s", reason)
+		return
+	}
+
 	st, err := loadCurrentState()
 	if err != nil {
 		debugf("telemetry disabled: %v", err)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 const (
 	DefaultEndpoint = "https://telemetry.rork.com/asc/v1/events"
 	endpointEnvVar  = "ASC_TELEMETRY_ENDPOINT"
-	sendTimeout     = 750 * time.Millisecond
 )
 
 var sendHTTP = sendHTTPEvent
@@ -65,7 +66,7 @@ func sendHTTPEvent(ev Event) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	ctx, cancel := shared.ContextWithTimeout(context.Background())
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -83,7 +83,22 @@ func sendHTTPEvent(ev Event) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := *http.DefaultClient
+	checkRedirect := client.CheckRedirect
+	client.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if request.URL.Scheme != "https" {
+			return fmt.Errorf("non-HTTPS telemetry redirect")
+		}
+		if checkRedirect != nil {
+			return checkRedirect(request, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -17,6 +17,7 @@ import (
 const (
 	DefaultEndpoint = "https://telemetry.rork.com/asc/v1/events"
 	endpointEnvVar  = "ASC_TELEMETRY_ENDPOINT"
+	maxSendDuration = 250 * time.Millisecond
 )
 
 var sendHTTP = sendHTTPEvent
@@ -66,7 +67,9 @@ func sendHTTPEvent(ev Event) error {
 		return err
 	}
 
-	ctx, cancel := shared.ContextWithTimeout(context.Background())
+	configuredCtx, cancelConfigured := shared.ContextWithTimeout(context.Background())
+	defer cancelConfigured()
+	ctx, cancel := context.WithTimeout(configuredCtx, maxSendDuration)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -15,7 +15,7 @@ func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error)
 	return fn(request)
 }
 
-func TestEmitSwallowsSenderErrors(t *testing.T) {
+func TestEmitIsEnabledByDefaultAndSwallowsSenderErrors(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -81,3 +81,33 @@ func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
 		t.Fatalf("sendHTTPEvent() elapsed = %s, want ASC_TIMEOUT to stop it before 200ms", elapsed)
 	}
 }
+
+func TestSendHTTPEventCapsTelemetryTimeout(t *testing.T) {
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}),
+	}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv(endpointEnvVar, "https://telemetry.example.test/events")
+	t.Setenv("ASC_TIMEOUT", "1s")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	t.Setenv("HOME", t.TempDir())
+
+	start := time.Now()
+	err := sendHTTPEvent(Event{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected request timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("sendHTTPEvent() error = %v, want context deadline exceeded", err)
+	}
+	if elapsed >= 750*time.Millisecond {
+		t.Fatalf("sendHTTPEvent() elapsed = %s, want telemetry timeout cap before 750ms", elapsed)
+	}
+}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,10 +1,18 @@
 package telemetry
 
 import (
+	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
 
 func TestEmitSwallowsSenderErrors(t *testing.T) {
 	clearContextEnv(t)
@@ -42,4 +50,34 @@ func TestEmitHonorsDisabledEnv(t *testing.T) {
 	t.Cleanup(func() { sendHTTP = original })
 
 	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+}
+
+func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}),
+	}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv(endpointEnvVar, "https://telemetry.example.test/events")
+	t.Setenv("ASC_TIMEOUT", "20ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	t.Setenv("HOME", t.TempDir())
+
+	start := time.Now()
+	err := sendHTTPEvent(Event{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected request timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("sendHTTPEvent() error = %v, want context deadline exceeded", err)
+	}
+	if elapsed >= 200*time.Millisecond {
+		t.Fatalf("sendHTTPEvent() elapsed = %s, want ASC_TIMEOUT to stop it before 200ms", elapsed)
+	}
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -13,6 +15,13 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return fn(request)
+}
+
+func TestDefaultEndpointUsesExistingRorkAPIRoute(t *testing.T) {
+	const want = "https://rork.com/cf-api/asc/v1/events"
+	if DefaultEndpoint != want {
+		t.Fatalf("DefaultEndpoint = %q, want %q", DefaultEndpoint, want)
+	}
 }
 
 func TestEmitIsEnabledByDefaultAndSwallowsSenderErrors(t *testing.T) {
@@ -32,7 +41,7 @@ func TestEmitIsEnabledByDefaultAndSwallowsSenderErrors(t *testing.T) {
 	}
 	t.Cleanup(func() { sendHTTP = original })
 
-	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
 	if !called {
 		t.Fatal("expected sender to be called")
 	}
@@ -50,7 +59,7 @@ func TestEmitHonorsDisabledEnv(t *testing.T) {
 	}
 	t.Cleanup(func() { sendHTTP = original })
 
-	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
 }
 
 func TestEmitMarksEphemeralRuntimeWithoutDisabling(t *testing.T) {
@@ -78,7 +87,7 @@ func TestEmitMarksEphemeralRuntimeWithoutDisabling(t *testing.T) {
 	}
 	t.Cleanup(func() { sendHTTP = original })
 
-	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
 	if !called {
 		t.Fatal("expected sender to be called for ephemeral runtime")
 	}
@@ -169,5 +178,89 @@ func TestSendHTTPEventRejectsPlaintextRedirect(t *testing.T) {
 	}
 	if plaintextHit {
 		t.Fatal("telemetry request followed a redirect to plaintext HTTP")
+	}
+}
+
+func TestSendHTTPEventRejectsHTTPSRedirect(t *testing.T) {
+	redirectedPathHit := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/redirected" {
+			redirectedPathHit = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Redirect(w, request, "/redirected", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(server.Close)
+
+	originalClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv(endpointEnvVar, server.URL+"/events")
+	setTelemetryTestHome(t)
+
+	if err := sendHTTPEvent(Event{}); err == nil {
+		t.Fatal("expected HTTPS redirect to be rejected")
+	}
+	if redirectedPathHit {
+		t.Fatal("telemetry request followed an HTTPS redirect")
+	}
+}
+
+func TestSendHTTPEventDoesNotSendAmbientCookies(t *testing.T) {
+	var receivedCookie string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		receivedCookie = request.Header.Get("Cookie")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New() error = %v", err)
+	}
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	jar.SetCookies(serverURL, []*http.Cookie{{Name: "session", Value: "ambient-secret"}})
+
+	originalClient := http.DefaultClient
+	client := server.Client()
+	client.Jar = jar
+	http.DefaultClient = client
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv(endpointEnvVar, server.URL+"/events")
+	setTelemetryTestHome(t)
+
+	if err := sendHTTPEvent(Event{}); err != nil {
+		t.Fatalf("sendHTTPEvent() error = %v", err)
+	}
+	if receivedCookie != "" {
+		t.Fatalf("telemetry request sent ambient cookie %q", receivedCookie)
+	}
+}
+
+func TestSendHTTPEventRejectsCredentialBearingEndpoint(t *testing.T) {
+	called := false
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}),
+	}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv(endpointEnvVar, "https://user:secret@telemetry.example.test/events")
+	setTelemetryTestHome(t)
+
+	if err := sendHTTPEvent(Event{}); err == nil {
+		t.Fatal("expected credential-bearing telemetry endpoint to be rejected")
+	}
+	if called {
+		t.Fatal("telemetry sender contacted a credential-bearing endpoint")
 	}
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -109,5 +110,33 @@ func TestSendHTTPEventCapsTelemetryTimeout(t *testing.T) {
 	}
 	if elapsed >= 750*time.Millisecond {
 		t.Fatalf("sendHTTPEvent() elapsed = %s, want telemetry timeout cap before 750ms", elapsed)
+	}
+}
+
+func TestSendHTTPEventRejectsPlaintextRedirect(t *testing.T) {
+	plaintextHit := false
+	plaintextServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		plaintextHit = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(plaintextServer.Close)
+
+	secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		http.Redirect(w, request, plaintextServer.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(secureServer.Close)
+
+	originalClient := http.DefaultClient
+	http.DefaultClient = secureServer.Client()
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv(endpointEnvVar, secureServer.URL)
+	setTelemetryTestHome(t)
+
+	if err := sendHTTPEvent(Event{}); err == nil {
+		t.Fatal("expected plaintext redirect to be rejected")
+	}
+	if plaintextHit {
+		t.Fatal("telemetry request followed a redirect to plaintext HTTP")
 	}
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,45 @@
+package telemetry
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEmitSwallowsSenderErrors(t *testing.T) {
+	clearContextEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	called := false
+	original := sendHTTP
+	sendHTTP = func(ev Event) error {
+		called = true
+		if ev.CommandPath != "asc builds list" {
+			t.Fatalf("CommandPath = %q", ev.CommandPath)
+		}
+		return errors.New("network down")
+	}
+	t.Cleanup(func() { sendHTTP = original })
+
+	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+	if !called {
+		t.Fatal("expected sender to be called")
+	}
+}
+
+func TestEmitHonorsDisabledEnv(t *testing.T) {
+	clearContextEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "1")
+
+	original := sendHTTP
+	sendHTTP = func(ev Event) error {
+		t.Fatal("sender should not be called when disabled")
+		return nil
+	}
+	t.Cleanup(func() { sendHTTP = original })
+
+	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -53,6 +53,37 @@ func TestEmitHonorsDisabledEnv(t *testing.T) {
 	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
 }
 
+func TestEmitMarksEphemeralRuntimeWithoutDisabling(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv(telemetryEphemeralEnvVar, "1")
+	t.Setenv("PI_CODING_AGENT", "true")
+
+	called := false
+	original := sendHTTP
+	sendHTTP = func(ev Event) error {
+		called = true
+		if ev.RuntimeContext != RuntimeEphemeral {
+			t.Fatalf("RuntimeContext = %q, want %q", ev.RuntimeContext, RuntimeEphemeral)
+		}
+		if ev.InvocationSource != SourcePi {
+			t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, SourcePi)
+		}
+		if ev.InstallID != nil {
+			t.Fatalf("expected nil install ID, got %q", *ev.InstallID)
+		}
+		return nil
+	}
+	t.Cleanup(func() { sendHTTP = original })
+
+	Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+	if !called {
+		t.Fatal("expected sender to be called for ephemeral runtime")
+	}
+}
+
 func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
 	originalClient := http.DefaultClient
 	http.DefaultClient = &http.Client{

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -16,7 +16,7 @@ func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error)
 
 func TestEmitSwallowsSenderErrors(t *testing.T) {
 	clearContextEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
@@ -39,7 +39,7 @@ func TestEmitSwallowsSenderErrors(t *testing.T) {
 
 func TestEmitHonorsDisabledEnv(t *testing.T) {
 	clearContextEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "1")
 
 	original := sendHTTP
@@ -65,7 +65,7 @@ func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
 	t.Setenv(endpointEnvVar, "https://telemetry.example.test/events")
 	t.Setenv("ASC_TIMEOUT", "20ms")
 	t.Setenv("ASC_TIMEOUT_SECONDS", "")
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 
 	start := time.Now()
 	err := sendHTTPEvent(Event{})
@@ -95,7 +95,7 @@ func TestSendHTTPEventCapsTelemetryTimeout(t *testing.T) {
 	t.Setenv(endpointEnvVar, "https://telemetry.example.test/events")
 	t.Setenv("ASC_TIMEOUT", "1s")
 	t.Setenv("ASC_TIMEOUT_SECONDS", "")
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 
 	start := time.Now()
 	err := sendHTTPEvent(Event{})

--- a/internal/telemetry/client_unix_test.go
+++ b/internal/telemetry/client_unix_test.go
@@ -31,7 +31,7 @@ func TestEmitHonorsEnvironmentOptOutBeforeStateRead(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+		Emit("asc builds list", "1.2.3", time.Millisecond, 0)
 	}()
 
 	select {
@@ -46,5 +46,43 @@ func TestEmitHonorsEnvironmentOptOutBeforeStateRead(t *testing.T) {
 		}
 		<-done
 		t.Fatal("Emit() read telemetry state despite the environment opt-out")
+	}
+}
+
+func TestEmitSkipsIgnoredCommandBeforeStateRead(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create state directory: %v", err)
+	}
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("create blocking state file: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Emit("asc telemetry status", "1.2.3", time.Millisecond, 0)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		writer, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open state writer to unblock Emit(): %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close state writer: %v", err)
+		}
+		<-done
+		t.Fatal("Emit() read telemetry state for an ignored command")
 	}
 }

--- a/internal/telemetry/client_unix_test.go
+++ b/internal/telemetry/client_unix_test.go
@@ -1,0 +1,50 @@
+//go:build darwin || linux
+
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestEmitHonorsEnvironmentOptOutBeforeStateRead(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "1")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create state directory: %v", err)
+	}
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("create blocking state file: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Emit([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Millisecond, 0)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		writer, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open state writer to unblock Emit(): %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close state writer: %v", err)
+		}
+		<-done
+		t.Fatal("Emit() read telemetry state despite the environment opt-out")
+	}
+}

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -1,0 +1,90 @@
+package telemetry
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+type ExecutionContext string
+
+const (
+	ContextLocal              ExecutionContext = "local"
+	ContextClaudeCode         ExecutionContext = "claude_code"
+	ContextCursorAgent        ExecutionContext = "cursor_agent"
+	ContextCodexDesktop       ExecutionContext = "codex_desktop"
+	ContextRorkAgentSetup     ExecutionContext = "rork_agent_setup"
+	ContextRorkSandbox        ExecutionContext = "rork_sandbox"
+	ContextRorkGitHubWorkflow ExecutionContext = "rork_github_workflow"
+	ContextCI                 ExecutionContext = "ci"
+)
+
+func DetectExecutionContext(commandPath string, args []string) ExecutionContext {
+	switch {
+	case os.Getenv("GITHUB_ACTIONS") == "true" && os.Getenv("GITHUB_REPOSITORY") == "rorkai/user-workflows":
+		return ContextRorkGitHubWorkflow
+	case commandPath == "asc auth login" && hasArgValue(args, "--name", "rork"):
+		return ContextRorkAgentSetup
+	case os.Getenv("RORK_SANDBOX_ID") != "":
+		return ContextRorkSandbox
+	case os.Getenv("CLAUDECODE") == "1":
+		return ContextClaudeCode
+	case os.Getenv("CURSOR_AGENT") != "":
+		return ContextCursorAgent
+	case os.Getenv("CODEX_SHELL") == "1" && os.Getenv("CODEX_THREAD_ID") != "":
+		return ContextCodexDesktop
+	case isKnownCIEnv():
+		return ContextCI
+	default:
+		return ContextLocal
+	}
+}
+
+func isKnownCIEnv() bool {
+	if envTruthy("CI") {
+		return true
+	}
+	for _, key := range []string{
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"CIRCLECI",
+		"BUILDKITE",
+		"BITRISE_IO",
+		"TF_BUILD",
+		"TEAMCITY_VERSION",
+		"JENKINS_URL",
+		"TRAVIS",
+		"APPVEYOR",
+	} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func envTruthy(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasArgValue(args []string, name, value string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == name {
+			return i+1 < len(args) && args[i+1] == value
+		}
+		if before, after, ok := strings.Cut(arg, "="); ok && before == name && after == value {
+			return true
+		}
+	}
+	return false
+}
+
+func isLocalContext(ctx ExecutionContext) bool {
+	return slices.Contains([]ExecutionContext{ContextLocal}, ctx)
+}

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -2,41 +2,64 @@ package telemetry
 
 import (
 	"os"
-	"slices"
 	"strings"
 )
 
-type ExecutionContext string
+const telemetryEphemeralEnvVar = "ASC_TELEMETRY_EPHEMERAL"
+
+type RuntimeContext string
 
 const (
-	ContextLocal              ExecutionContext = "local"
-	ContextClaudeCode         ExecutionContext = "claude_code"
-	ContextCursorAgent        ExecutionContext = "cursor_agent"
-	ContextCodexDesktop       ExecutionContext = "codex_desktop"
-	ContextRorkAgentSetup     ExecutionContext = "rork_agent_setup"
-	ContextRorkSandbox        ExecutionContext = "rork_sandbox"
-	ContextRorkGitHubWorkflow ExecutionContext = "rork_github_workflow"
-	ContextCI                 ExecutionContext = "ci"
+	RuntimeLocal              RuntimeContext = "local"
+	RuntimeEphemeral          RuntimeContext = "ephemeral"
+	RuntimeRorkSandbox        RuntimeContext = "rork_sandbox"
+	RuntimeRorkGitHubWorkflow RuntimeContext = "rork_github_workflow"
+	RuntimeCI                 RuntimeContext = "ci"
 )
 
-func DetectExecutionContext(commandPath string, args []string) ExecutionContext {
+type InvocationSource string
+
+const (
+	SourceTerminal       InvocationSource = "terminal"
+	SourceClaudeCode     InvocationSource = "claude_code"
+	SourceCursorAgent    InvocationSource = "cursor_agent"
+	SourceCodexDesktop   InvocationSource = "codex_desktop"
+	SourceOpenCode       InvocationSource = "opencode"
+	SourcePi             InvocationSource = "pi"
+	SourceRorkAgentSetup InvocationSource = "rork_agent_setup"
+)
+
+func DetectRuntimeContext() RuntimeContext {
 	switch {
 	case os.Getenv("GITHUB_ACTIONS") == "true" && os.Getenv("GITHUB_REPOSITORY") == "rorkai/user-workflows":
-		return ContextRorkGitHubWorkflow
-	case commandPath == "asc auth login" && hasArgValue(args, "--name", "rork"):
-		return ContextRorkAgentSetup
+		return RuntimeRorkGitHubWorkflow
 	case os.Getenv("RORK_SANDBOX_ID") != "":
-		return ContextRorkSandbox
-	case os.Getenv("CLAUDECODE") == "1":
-		return ContextClaudeCode
-	case os.Getenv("CURSOR_AGENT") != "":
-		return ContextCursorAgent
-	case os.Getenv("CODEX_SHELL") == "1" && os.Getenv("CODEX_THREAD_ID") != "":
-		return ContextCodexDesktop
+		return RuntimeRorkSandbox
+	case envTruthy(telemetryEphemeralEnvVar):
+		return RuntimeEphemeral
 	case isKnownCIEnv():
-		return ContextCI
+		return RuntimeCI
 	default:
-		return ContextLocal
+		return RuntimeLocal
+	}
+}
+
+func DetectInvocationSource(commandPath string, args []string) InvocationSource {
+	switch {
+	case commandPath == "asc auth login" && hasArgValue(args, "--name", "rork"):
+		return SourceRorkAgentSetup
+	case envTruthy("PI_CODING_AGENT"):
+		return SourcePi
+	case envTruthy("OPENCODE"):
+		return SourceOpenCode
+	case os.Getenv("CLAUDECODE") == "1":
+		return SourceClaudeCode
+	case os.Getenv("CURSOR_AGENT") != "":
+		return SourceCursorAgent
+	case os.Getenv("CODEX_SHELL") == "1" && os.Getenv("CODEX_THREAD_ID") != "":
+		return SourceCodexDesktop
+	default:
+		return SourceTerminal
 	}
 }
 
@@ -81,6 +104,6 @@ func hasArgValue(args []string, name, value string) bool {
 	return false
 }
 
-func isLocalContext(ctx ExecutionContext) bool {
-	return slices.Contains([]ExecutionContext{ContextLocal}, ctx)
+func shouldAttachInstallID(ctx RuntimeContext) bool {
+	return ctx == RuntimeLocal
 }

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const telemetryEphemeralEnvVar = "ASC_TELEMETRY_EPHEMERAL"
+const (
+	telemetryEphemeralEnvVar    = "ASC_TELEMETRY_EPHEMERAL"
+	rorkUserWorkflowsRepository = "rorkai/user-workflows"
+)
 
 type RuntimeContext string
 
@@ -20,20 +23,20 @@ const (
 type InvocationSource string
 
 const (
-	SourceTerminal       InvocationSource = "terminal"
-	SourceClaudeCode     InvocationSource = "claude_code"
-	SourceCursorAgent    InvocationSource = "cursor_agent"
-	SourceCodexDesktop   InvocationSource = "codex_desktop"
-	SourceOpenCode       InvocationSource = "opencode"
-	SourcePi             InvocationSource = "pi"
-	SourceRorkAgentSetup InvocationSource = "rork_agent_setup"
+	SourceTerminal     InvocationSource = "terminal"
+	SourceClaudeCode   InvocationSource = "claude_code"
+	SourceCursorAgent  InvocationSource = "cursor_agent"
+	SourceCodexDesktop InvocationSource = "codex_desktop"
+	SourceOpenCode     InvocationSource = "opencode"
+	SourcePi           InvocationSource = "pi"
+	SourceRorkAgent    InvocationSource = "rork_agent"
 )
 
 func DetectRuntimeContext() RuntimeContext {
 	switch {
-	case os.Getenv("GITHUB_ACTIONS") == "true" && os.Getenv("GITHUB_REPOSITORY") == "rorkai/user-workflows":
+	case isRorkGitHubWorkflow():
 		return RuntimeRorkGitHubWorkflow
-	case os.Getenv("RORK_SANDBOX_ID") != "":
+	case isRorkSandbox():
 		return RuntimeRorkSandbox
 	case envTruthy(telemetryEphemeralEnvVar):
 		return RuntimeEphemeral
@@ -44,10 +47,8 @@ func DetectRuntimeContext() RuntimeContext {
 	}
 }
 
-func DetectInvocationSource(commandPath string, args []string) InvocationSource {
+func DetectInvocationSource() InvocationSource {
 	switch {
-	case commandPath == "asc auth login" && hasArgValue(args, "--name", "rork"):
-		return SourceRorkAgentSetup
 	case envTruthy("PI_CODING_AGENT"):
 		return SourcePi
 	case envTruthy("OPENCODE"):
@@ -58,9 +59,22 @@ func DetectInvocationSource(commandPath string, args []string) InvocationSource 
 		return SourceCursorAgent
 	case os.Getenv("CODEX_SHELL") == "1" && os.Getenv("CODEX_THREAD_ID") != "":
 		return SourceCodexDesktop
+	case isRorkSandbox() || isRorkGitHubWorkflow():
+		return SourceRorkAgent
 	default:
 		return SourceTerminal
 	}
+}
+
+func isRorkSandbox() bool {
+	return strings.TrimSpace(os.Getenv("RORK_SANDBOX_ID")) != ""
+}
+
+func isRorkGitHubWorkflow() bool {
+	return envTruthy("GITHUB_ACTIONS") && strings.EqualFold(
+		strings.TrimSpace(os.Getenv("GITHUB_REPOSITORY")),
+		rorkUserWorkflowsRepository,
+	)
 }
 
 func isKnownCIEnv() bool {
@@ -89,19 +103,6 @@ func envTruthy(key string) bool {
 	default:
 		return false
 	}
-}
-
-func hasArgValue(args []string, name, value string) bool {
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == name {
-			return i+1 < len(args) && args[i+1] == value
-		}
-		if before, after, ok := strings.Cut(arg, "="); ok && before == name && after == value {
-			return true
-		}
-	}
-	return false
 }
 
 func shouldAttachInstallID(ctx RuntimeContext) bool {

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -41,26 +41,22 @@ func DetectExecutionContext(commandPath string, args []string) ExecutionContext 
 }
 
 func isKnownCIEnv() bool {
-	if envTruthy("CI") {
-		return true
-	}
 	for _, key := range []string{
+		"CI",
 		"GITHUB_ACTIONS",
 		"GITLAB_CI",
 		"CIRCLECI",
 		"BUILDKITE",
 		"BITRISE_IO",
 		"TF_BUILD",
-		"TEAMCITY_VERSION",
-		"JENKINS_URL",
 		"TRAVIS",
 		"APPVEYOR",
 	} {
-		if os.Getenv(key) != "" {
+		if envTruthy(key) {
 			return true
 		}
 	}
-	return false
+	return os.Getenv("TEAMCITY_VERSION") != "" || os.Getenv("JENKINS_URL") != ""
 }
 
 func envTruthy(key string) bool {

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -1,0 +1,99 @@
+package telemetry
+
+import "testing"
+
+func TestDetectExecutionContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandPath string
+		args        []string
+		env         map[string]string
+		want        ExecutionContext
+	}{
+		{
+			name:        "claude code",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CLAUDECODE": "1"},
+			want:        ContextClaudeCode,
+		},
+		{
+			name:        "cursor agent",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CURSOR_AGENT": "1"},
+			want:        ContextCursorAgent,
+		},
+		{
+			name:        "codex desktop",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CODEX_SHELL": "1", "CODEX_THREAD_ID": "thread-1"},
+			want:        ContextCodexDesktop,
+		},
+		{
+			name:        "rork setup command shape",
+			commandPath: "asc auth login",
+			args:        []string{"auth", "login", "--name", "rork", "--key-id", "secret"},
+			want:        ContextRorkAgentSetup,
+		},
+		{
+			name:        "rork sandbox",
+			commandPath: "asc apps list",
+			env:         map[string]string{"RORK_SANDBOX_ID": "sandbox-1"},
+			want:        ContextRorkSandbox,
+		},
+		{
+			name:        "rork github workflow",
+			commandPath: "asc publish appstore",
+			env:         map[string]string{"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "rorkai/user-workflows"},
+			want:        ContextRorkGitHubWorkflow,
+		},
+		{
+			name:        "generic ci",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CI": "true"},
+			want:        ContextCI,
+		},
+		{
+			name:        "local",
+			commandPath: "asc builds list",
+			want:        ContextLocal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearContextEnv(t)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			got := DetectExecutionContext(tt.commandPath, tt.args)
+			if got != tt.want {
+				t.Fatalf("DetectExecutionContext() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func clearContextEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GITHUB_ACTIONS",
+		"GITHUB_REPOSITORY",
+		"RORK_SANDBOX_ID",
+		"CLAUDECODE",
+		"CURSOR_AGENT",
+		"CODEX_SHELL",
+		"CODEX_THREAD_ID",
+		"CI",
+		"GITLAB_CI",
+		"CIRCLECI",
+		"BUILDKITE",
+		"BITRISE_IO",
+		"TF_BUILD",
+		"TEAMCITY_VERSION",
+		"JENKINS_URL",
+		"TRAVIS",
+		"APPVEYOR",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -2,66 +2,55 @@ package telemetry
 
 import "testing"
 
-func TestDetectExecutionContext(t *testing.T) {
+func TestDetectRuntimeContext(t *testing.T) {
 	tests := []struct {
-		name        string
-		commandPath string
-		args        []string
-		env         map[string]string
-		want        ExecutionContext
+		name string
+		env  map[string]string
+		want RuntimeContext
 	}{
 		{
-			name:        "claude code",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CLAUDECODE": "1"},
-			want:        ContextClaudeCode,
+			name: "local agent stays local",
+			env:  map[string]string{"CLAUDECODE": "1"},
+			want: RuntimeLocal,
 		},
 		{
-			name:        "cursor agent",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CURSOR_AGENT": "1"},
-			want:        ContextCursorAgent,
+			name: "explicit ephemeral runtime",
+			env:  map[string]string{telemetryEphemeralEnvVar: "true"},
+			want: RuntimeEphemeral,
 		},
 		{
-			name:        "codex desktop",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CODEX_SHELL": "1", "CODEX_THREAD_ID": "thread-1"},
-			want:        ContextCodexDesktop,
+			name: "rork sandbox",
+			env:  map[string]string{"RORK_SANDBOX_ID": "sandbox-1"},
+			want: RuntimeRorkSandbox,
 		},
 		{
-			name:        "rork setup command shape",
-			commandPath: "asc auth login",
-			args:        []string{"auth", "login", "--name", "rork", "--key-id", "secret"},
-			want:        ContextRorkAgentSetup,
+			name: "rork github workflow",
+			env:  map[string]string{"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "rorkai/user-workflows"},
+			want: RuntimeRorkGitHubWorkflow,
 		},
 		{
-			name:        "rork sandbox",
-			commandPath: "asc apps list",
-			env:         map[string]string{"RORK_SANDBOX_ID": "sandbox-1"},
-			want:        ContextRorkSandbox,
+			name: "generic ci",
+			env:  map[string]string{"CI": "true"},
+			want: RuntimeCI,
 		},
 		{
-			name:        "rork github workflow",
-			commandPath: "asc publish appstore",
-			env:         map[string]string{"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "rorkai/user-workflows"},
-			want:        ContextRorkGitHubWorkflow,
+			name: "ci wins independently of agent source",
+			env:  map[string]string{"CI": "true", "CLAUDECODE": "1"},
+			want: RuntimeCI,
 		},
 		{
-			name:        "generic ci",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CI": "true"},
-			want:        ContextCI,
+			name: "false ephemeral flag stays local",
+			env:  map[string]string{telemetryEphemeralEnvVar: "false"},
+			want: RuntimeLocal,
 		},
 		{
-			name:        "false ci flags stay local",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CI": "false", "GITHUB_ACTIONS": "0"},
-			want:        ContextLocal,
+			name: "false ci flags stay local",
+			env:  map[string]string{"CI": "false", "GITHUB_ACTIONS": "0"},
+			want: RuntimeLocal,
 		},
 		{
-			name:        "local",
-			commandPath: "asc builds list",
-			want:        ContextLocal,
+			name: "local",
+			want: RuntimeLocal,
 		},
 	}
 
@@ -71,9 +60,86 @@ func TestDetectExecutionContext(t *testing.T) {
 			for key, value := range tt.env {
 				t.Setenv(key, value)
 			}
-			got := DetectExecutionContext(tt.commandPath, tt.args)
+			got := DetectRuntimeContext()
 			if got != tt.want {
-				t.Fatalf("DetectExecutionContext() = %q, want %q", got, tt.want)
+				t.Fatalf("DetectRuntimeContext() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectInvocationSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandPath string
+		args        []string
+		env         map[string]string
+		want        InvocationSource
+	}{
+		{
+			name:        "rork setup command shape",
+			commandPath: "asc auth login",
+			args:        []string{"auth", "login", "--name", "rork", "--key-id", "secret"},
+			want:        SourceRorkAgentSetup,
+		},
+		{
+			name:        "pi",
+			commandPath: "asc builds list",
+			env:         map[string]string{"PI_CODING_AGENT": "true"},
+			want:        SourcePi,
+		},
+		{
+			name:        "pi config directory is not an invocation marker",
+			commandPath: "asc builds list",
+			env:         map[string]string{"PI_CODING_AGENT_DIR": "/tmp/pi"},
+			want:        SourceTerminal,
+		},
+		{
+			name:        "opencode",
+			commandPath: "asc builds list",
+			env:         map[string]string{"OPENCODE": "1", "AGENT": "1"},
+			want:        SourceOpenCode,
+		},
+		{
+			name:        "generic agent marker is not enough",
+			commandPath: "asc builds list",
+			env:         map[string]string{"AGENT": "1"},
+			want:        SourceTerminal,
+		},
+		{
+			name:        "claude code",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CLAUDECODE": "1"},
+			want:        SourceClaudeCode,
+		},
+		{
+			name:        "cursor agent",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CURSOR_AGENT": "1"},
+			want:        SourceCursorAgent,
+		},
+		{
+			name:        "codex desktop",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CODEX_SHELL": "1", "CODEX_THREAD_ID": "thread-1"},
+			want:        SourceCodexDesktop,
+		},
+		{
+			name:        "terminal",
+			commandPath: "asc builds list",
+			want:        SourceTerminal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearContextEnv(t)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			got := DetectInvocationSource(tt.commandPath, tt.args)
+			if got != tt.want {
+				t.Fatalf("DetectInvocationSource() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -82,9 +148,14 @@ func TestDetectExecutionContext(t *testing.T) {
 func clearContextEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
+		telemetryEphemeralEnvVar,
 		"GITHUB_ACTIONS",
 		"GITHUB_REPOSITORY",
 		"RORK_SANDBOX_ID",
+		"PI_CODING_AGENT",
+		"PI_CODING_AGENT_DIR",
+		"OPENCODE",
+		"AGENT",
 		"CLAUDECODE",
 		"CURSOR_AGENT",
 		"CODEX_SHELL",

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -70,64 +70,61 @@ func TestDetectRuntimeContext(t *testing.T) {
 
 func TestDetectInvocationSource(t *testing.T) {
 	tests := []struct {
-		name        string
-		commandPath string
-		args        []string
-		env         map[string]string
-		want        InvocationSource
+		name string
+		env  map[string]string
+		want InvocationSource
 	}{
 		{
-			name:        "rork setup command shape",
-			commandPath: "asc auth login",
-			args:        []string{"auth", "login", "--name", "rork", "--key-id", "secret"},
-			want:        SourceRorkAgentSetup,
+			name: "rork agent in sandbox",
+			env:  map[string]string{"RORK_SANDBOX_ID": "sandbox-1"},
+			want: SourceRorkAgent,
 		},
 		{
-			name:        "pi",
-			commandPath: "asc builds list",
-			env:         map[string]string{"PI_CODING_AGENT": "true"},
-			want:        SourcePi,
+			name: "rork agent in user workflow",
+			env: map[string]string{
+				"GITHUB_ACTIONS":    "true",
+				"GITHUB_REPOSITORY": "rorkai/user-workflows",
+			},
+			want: SourceRorkAgent,
 		},
 		{
-			name:        "pi config directory is not an invocation marker",
-			commandPath: "asc builds list",
-			env:         map[string]string{"PI_CODING_AGENT_DIR": "/tmp/pi"},
-			want:        SourceTerminal,
+			name: "pi",
+			env:  map[string]string{"PI_CODING_AGENT": "true"},
+			want: SourcePi,
 		},
 		{
-			name:        "opencode",
-			commandPath: "asc builds list",
-			env:         map[string]string{"OPENCODE": "1", "AGENT": "1"},
-			want:        SourceOpenCode,
+			name: "pi config directory is not an invocation marker",
+			env:  map[string]string{"PI_CODING_AGENT_DIR": "/tmp/pi"},
+			want: SourceTerminal,
 		},
 		{
-			name:        "generic agent marker is not enough",
-			commandPath: "asc builds list",
-			env:         map[string]string{"AGENT": "1"},
-			want:        SourceTerminal,
+			name: "opencode",
+			env:  map[string]string{"OPENCODE": "1", "AGENT": "1"},
+			want: SourceOpenCode,
 		},
 		{
-			name:        "claude code",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CLAUDECODE": "1"},
-			want:        SourceClaudeCode,
+			name: "generic agent marker is not enough",
+			env:  map[string]string{"AGENT": "1"},
+			want: SourceTerminal,
 		},
 		{
-			name:        "cursor agent",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CURSOR_AGENT": "1"},
-			want:        SourceCursorAgent,
+			name: "claude code",
+			env:  map[string]string{"CLAUDECODE": "1"},
+			want: SourceClaudeCode,
 		},
 		{
-			name:        "codex desktop",
-			commandPath: "asc builds list",
-			env:         map[string]string{"CODEX_SHELL": "1", "CODEX_THREAD_ID": "thread-1"},
-			want:        SourceCodexDesktop,
+			name: "cursor agent",
+			env:  map[string]string{"CURSOR_AGENT": "1"},
+			want: SourceCursorAgent,
 		},
 		{
-			name:        "terminal",
-			commandPath: "asc builds list",
-			want:        SourceTerminal,
+			name: "codex desktop",
+			env:  map[string]string{"CODEX_SHELL": "1", "CODEX_THREAD_ID": "thread-1"},
+			want: SourceCodexDesktop,
+		},
+		{
+			name: "terminal",
+			want: SourceTerminal,
 		},
 	}
 
@@ -137,7 +134,7 @@ func TestDetectInvocationSource(t *testing.T) {
 			for key, value := range tt.env {
 				t.Setenv(key, value)
 			}
-			got := DetectInvocationSource(tt.commandPath, tt.args)
+			got := DetectInvocationSource()
 			if got != tt.want {
 				t.Fatalf("DetectInvocationSource() = %q, want %q", got, tt.want)
 			}

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -53,6 +53,12 @@ func TestDetectExecutionContext(t *testing.T) {
 			want:        ContextCI,
 		},
 		{
+			name:        "false ci flags stay local",
+			commandPath: "asc builds list",
+			env:         map[string]string{"CI": "false", "GITHUB_ACTIONS": "0"},
+			want:        ContextLocal,
+		},
+		{
 			name:        "local",
 			commandPath: "asc builds list",
 			want:        ContextLocal,

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -101,7 +101,7 @@ func sanitizeCommandName(commandName string) string {
 
 func shouldSkipCommand(commandPath string) bool {
 	switch commandPath {
-	case "", "asc", "asc completion", "asc version", "asc telemetry status", "asc telemetry enable", "asc telemetry disable", "asc telemetry reset-id":
+	case "", "asc", "asc completion", "asc version", "asc telemetry", "asc telemetry status", "asc telemetry enable", "asc telemetry disable", "asc telemetry reset-id":
 		return true
 	default:
 		return false
@@ -129,6 +129,9 @@ func durationMillis(d time.Duration) uint32 {
 
 func durationBucket(d time.Duration) string {
 	ms := d.Milliseconds()
+	if ms < 0 {
+		ms = 0
+	}
 	switch {
 	case ms < 100:
 		return "lt_100ms"

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -38,7 +38,7 @@ func BuildEvent(args []string, commandName, version string, duration time.Durati
 	ctx := DetectExecutionContext(commandPath, args)
 	var installID *string
 	if isLocalContext(ctx) {
-		id, err := EnsureInstallID()
+		id, err := ensureInstallID(0)
 		if err == nil && id != "" {
 			installID = &id
 		}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -37,7 +37,7 @@ func BuildEvent(args []string, commandName, version string, duration time.Durati
 	}
 
 	runtimeContext := DetectRuntimeContext()
-	invocationSource := DetectInvocationSource(commandPath, args)
+	invocationSource := DetectInvocationSource()
 	var installID *string
 	if shouldAttachInstallID(runtimeContext) {
 		id, err := ensureInstallID(0)

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -21,7 +21,8 @@ type Event struct {
 	DurationBucket   string           `json:"duration_bucket"`
 	ExitCode         int              `json:"exit_code"`
 	Success          bool             `json:"success"`
-	ExecutionContext ExecutionContext `json:"execution_context"`
+	RuntimeContext   RuntimeContext   `json:"runtime_context"`
+	InvocationSource InvocationSource `json:"invocation_source"`
 	InstallID        *string          `json:"install_id"`
 	SessionID        string           `json:"session_id"`
 }
@@ -35,9 +36,10 @@ func BuildEvent(args []string, commandName, version string, duration time.Durati
 		return Event{}, false
 	}
 
-	ctx := DetectExecutionContext(commandPath, args)
+	runtimeContext := DetectRuntimeContext()
+	invocationSource := DetectInvocationSource(commandPath, args)
 	var installID *string
-	if isLocalContext(ctx) {
+	if shouldAttachInstallID(runtimeContext) {
 		id, err := ensureInstallID(0)
 		if err == nil && id != "" {
 			installID = &id
@@ -56,7 +58,8 @@ func BuildEvent(args []string, commandName, version string, duration time.Durati
 		DurationBucket:   durationBucket(duration),
 		ExitCode:         exitCode,
 		Success:          exitCode == 0,
-		ExecutionContext: ctx,
+		RuntimeContext:   runtimeContext,
+		InvocationSource: invocationSource,
 		InstallID:        installID,
 		SessionID:        uuid.NewString(),
 	}, true
@@ -156,7 +159,8 @@ func RedactedSummary(ev Event) map[string]string {
 	return map[string]string{
 		"command_path":      ev.CommandPath,
 		"command_family":    ev.CommandFamily,
-		"execution_context": string(ev.ExecutionContext),
+		"runtime_context":   string(ev.RuntimeContext),
+		"invocation_source": string(ev.InvocationSource),
 		"duration_ms":       strconv.FormatUint(uint64(ev.DurationMS), 10),
 		"install_id":        installID,
 	}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -27,10 +27,14 @@ type Event struct {
 	SessionID        string           `json:"session_id"`
 }
 
-func BuildEvent(args []string, commandName, version string, duration time.Duration, exitCode int) (Event, bool) {
+// processSessionID groups events from one CLI process without linking separate
+// invocations of the executable.
+var processSessionID = uuid.NewString()
+
+func BuildEvent(commandName, version string, duration time.Duration, exitCode int) (Event, bool) {
 	commandPath := sanitizeCommandName(commandName)
 	if commandPath == "" {
-		commandPath = SanitizeCommandPath(args)
+		return Event{}, false
 	}
 	if shouldSkipCommand(commandPath) {
 		return Event{}, false
@@ -61,34 +65,8 @@ func BuildEvent(args []string, commandName, version string, duration time.Durati
 		RuntimeContext:   runtimeContext,
 		InvocationSource: invocationSource,
 		InstallID:        installID,
-		SessionID:        uuid.NewString(),
+		SessionID:        processSessionID,
 	}, true
-}
-
-func SanitizeCommandPath(args []string) string {
-	words := []string{"asc"}
-	for _, arg := range args {
-		if arg == "" {
-			continue
-		}
-		if strings.HasPrefix(arg, "-") {
-			if arg == "--" {
-				break
-			}
-			continue
-		}
-		if len(words) == 1 && arg == "asc" {
-			continue
-		}
-		words = append(words, strings.ToLower(arg))
-		if len(words) >= 4 {
-			break
-		}
-	}
-	if len(words) == 1 {
-		return "asc"
-	}
-	return strings.Join(words, " ")
 }
 
 func sanitizeCommandName(commandName string) string {

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,0 +1,160 @@
+package telemetry
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Event struct {
+	EventID          string           `json:"event_id"`
+	SchemaVersion    uint8            `json:"schema_version"`
+	ASCVersion       string           `json:"asc_version"`
+	OS               string           `json:"os"`
+	Arch             string           `json:"arch"`
+	CommandPath      string           `json:"command_path"`
+	CommandFamily    string           `json:"command_family"`
+	DurationMS       uint32           `json:"duration_ms"`
+	DurationBucket   string           `json:"duration_bucket"`
+	ExitCode         int              `json:"exit_code"`
+	Success          bool             `json:"success"`
+	ExecutionContext ExecutionContext `json:"execution_context"`
+	InstallID        *string          `json:"install_id"`
+	SessionID        string           `json:"session_id"`
+}
+
+func BuildEvent(args []string, commandName, version string, duration time.Duration, exitCode int) (Event, bool) {
+	commandPath := sanitizeCommandName(commandName)
+	if commandPath == "" {
+		commandPath = SanitizeCommandPath(args)
+	}
+	if shouldSkipCommand(commandPath) {
+		return Event{}, false
+	}
+
+	ctx := DetectExecutionContext(commandPath, args)
+	var installID *string
+	if isLocalContext(ctx) {
+		id, err := EnsureInstallID()
+		if err == nil && id != "" {
+			installID = &id
+		}
+	}
+
+	return Event{
+		EventID:          uuid.NewString(),
+		SchemaVersion:    1,
+		ASCVersion:       strings.TrimSpace(version),
+		OS:               runtime.GOOS,
+		Arch:             runtime.GOARCH,
+		CommandPath:      commandPath,
+		CommandFamily:    commandFamily(commandPath),
+		DurationMS:       durationMillis(duration),
+		DurationBucket:   durationBucket(duration),
+		ExitCode:         exitCode,
+		Success:          exitCode == 0,
+		ExecutionContext: ctx,
+		InstallID:        installID,
+		SessionID:        uuid.NewString(),
+	}, true
+}
+
+func SanitizeCommandPath(args []string) string {
+	words := []string{"asc"}
+	for _, arg := range args {
+		if arg == "" {
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if arg == "--" {
+				break
+			}
+			continue
+		}
+		if len(words) == 1 && arg == "asc" {
+			continue
+		}
+		words = append(words, strings.ToLower(arg))
+		if len(words) >= 4 {
+			break
+		}
+	}
+	if len(words) == 1 {
+		return "asc"
+	}
+	return strings.Join(words, " ")
+}
+
+func sanitizeCommandName(commandName string) string {
+	commandName = strings.ToLower(strings.Join(strings.Fields(commandName), " "))
+	if commandName == "" {
+		return ""
+	}
+	if commandName == "asc" || strings.HasPrefix(commandName, "asc ") {
+		return commandName
+	}
+	return "asc " + commandName
+}
+
+func shouldSkipCommand(commandPath string) bool {
+	switch commandPath {
+	case "", "asc", "asc completion", "asc version", "asc telemetry status", "asc telemetry enable", "asc telemetry disable", "asc telemetry reset-id":
+		return true
+	default:
+		return false
+	}
+}
+
+func commandFamily(commandPath string) string {
+	parts := strings.Fields(commandPath)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func durationMillis(d time.Duration) uint32 {
+	if d <= 0 {
+		return 0
+	}
+	ms := d.Milliseconds()
+	if ms > int64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(ms)
+}
+
+func durationBucket(d time.Duration) string {
+	ms := d.Milliseconds()
+	switch {
+	case ms < 100:
+		return "lt_100ms"
+	case ms < 500:
+		return "100ms_500ms"
+	case ms < 1000:
+		return "500ms_1s"
+	case ms < 5000:
+		return "1s_5s"
+	case ms < 30000:
+		return "5s_30s"
+	default:
+		return "gte_30s"
+	}
+}
+
+func RedactedSummary(ev Event) map[string]string {
+	installID := ""
+	if ev.InstallID != nil {
+		installID = *ev.InstallID
+	}
+	return map[string]string{
+		"command_path":      ev.CommandPath,
+		"command_family":    ev.CommandFamily,
+		"execution_context": string(ev.ExecutionContext),
+		"duration_ms":       strconv.FormatUint(uint64(ev.DurationMS), 10),
+		"install_id":        installID,
+	}
+}

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -71,9 +70,11 @@ func TestBuildEventDoesNotWaitForInstallIDLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StatePath() error = %v", err)
 	}
-	if err := os.MkdirAll(path+".lock", 0o700); err != nil {
-		t.Fatalf("create telemetry lock: %v", err)
+	unlock, err := lockState(path, lockTimeout)
+	if err != nil {
+		t.Fatalf("lockState() error = %v", err)
 	}
+	defer unlock()
 
 	start := time.Now()
 	ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +58,35 @@ func TestBuildEventOmitsInstallIDForNonLocalContext(t *testing.T) {
 	}
 	if ev.InstallID != nil {
 		t.Fatalf("expected nil install ID for CI, got %q", *ev.InstallID)
+	}
+}
+
+func TestBuildEventDoesNotWaitForInstallIDLock(t *testing.T) {
+	clearContextEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	if err := os.MkdirAll(path+".lock", 0o700); err != nil {
+		t.Fatalf("create telemetry lock: %v", err)
+	}
+
+	start := time.Now()
+	ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.InstallID != nil {
+		t.Fatalf("expected nil install ID while state is locked, got %q", *ev.InstallID)
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("BuildEvent() elapsed = %s, want lock contention skipped before 500ms", elapsed)
 	}
 }
 

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildEventSanitizesCommand(t *testing.T) {
+	clearContextEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	ev, ok := BuildEvent(
+		[]string{"apps", "info", "edit", "--app", "123456789", "--bundle-id", "com.secret.app", "--issuer-id", "issuer-secret"},
+		"asc apps info edit",
+		"1.2.3",
+		450*time.Millisecond,
+		0,
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.CommandPath != "asc apps info edit" {
+		t.Fatalf("CommandPath = %q", ev.CommandPath)
+	}
+	if ev.CommandFamily != "apps" {
+		t.Fatalf("CommandFamily = %q", ev.CommandFamily)
+	}
+	if ev.DurationBucket != "100ms_500ms" {
+		t.Fatalf("DurationBucket = %q", ev.DurationBucket)
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	for _, forbidden := range []string{"123456789", "com.secret.app", "issuer-secret", "--bundle-id", "--issuer-id"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("event leaked %q: %s", forbidden, data)
+		}
+	}
+}
+
+func TestBuildEventOmitsInstallIDForNonLocalContext(t *testing.T) {
+	clearContextEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CI", "true")
+
+	ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 1)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.ExecutionContext != ContextCI {
+		t.Fatalf("ExecutionContext = %q", ev.ExecutionContext)
+	}
+	if ev.InstallID != nil {
+		t.Fatalf("expected nil install ID for CI, got %q", *ev.InstallID)
+	}
+}
+
+func TestBuildEventSkipsControlCommands(t *testing.T) {
+	for _, commandPath := range []string{"asc", "asc completion", "asc version", "asc telemetry status"} {
+		t.Run(commandPath, func(t *testing.T) {
+			if _, ok := BuildEvent(nil, commandPath, "1.2.3", 0, 0); ok {
+				t.Fatalf("expected %q to be skipped", commandPath)
+			}
+		})
+	}
+}

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -61,11 +61,20 @@ func TestBuildEventOmitsInstallIDForNonLocalContext(t *testing.T) {
 }
 
 func TestBuildEventSkipsControlCommands(t *testing.T) {
-	for _, commandPath := range []string{"asc", "asc completion", "asc version", "asc telemetry status"} {
+	for _, commandPath := range []string{"asc", "asc completion", "asc version", "asc telemetry", "asc telemetry status"} {
 		t.Run(commandPath, func(t *testing.T) {
 			if _, ok := BuildEvent(nil, commandPath, "1.2.3", 0, 0); ok {
 				t.Fatalf("expected %q to be skipped", commandPath)
 			}
 		})
+	}
+}
+
+func TestNegativeDurationIsClamped(t *testing.T) {
+	if got := durationMillis(-time.Second); got != 0 {
+		t.Fatalf("durationMillis() = %d, want 0", got)
+	}
+	if got := durationBucket(-time.Second); got != "lt_100ms" {
+		t.Fatalf("durationBucket() = %q, want %q", got, "lt_100ms")
 	}
 }

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBuildEventSanitizesCommand(t *testing.T) {
 	clearContextEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
@@ -45,7 +45,7 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 
 func TestBuildEventOmitsInstallIDForNonLocalContext(t *testing.T) {
 	clearContextEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("CI", "true")
 
 	ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 1)
@@ -62,7 +62,7 @@ func TestBuildEventOmitsInstallIDForNonLocalContext(t *testing.T) {
 
 func TestBuildEventDoesNotWaitForInstallIDLock(t *testing.T) {
 	clearContextEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -143,6 +143,21 @@ func TestBuildEventOmitsInstallIDForEphemeralAgentRuntime(t *testing.T) {
 			wantSource:  SourceCodexDesktop,
 		},
 		{
+			name:        "Rork agent in Rork sandbox",
+			env:         map[string]string{"RORK_SANDBOX_ID": "sandbox-1"},
+			wantRuntime: RuntimeRorkSandbox,
+			wantSource:  SourceRorkAgent,
+		},
+		{
+			name: "Rork agent in GitHub workflow",
+			env: map[string]string{
+				"GITHUB_ACTIONS":    "true",
+				"GITHUB_REPOSITORY": "rorkai/user-workflows",
+			},
+			wantRuntime: RuntimeRorkGitHubWorkflow,
+			wantSource:  SourceRorkAgent,
+		},
+		{
 			name:        "Pi in explicitly ephemeral runtime",
 			env:         map[string]string{telemetryEphemeralEnvVar: "1", "PI_CODING_AGENT": "true"},
 			wantRuntime: RuntimeEphemeral,
@@ -175,7 +190,7 @@ func TestBuildEventOmitsInstallIDForEphemeralAgentRuntime(t *testing.T) {
 	}
 }
 
-func TestBuildEventKeepsInstallIDForLocalRorkSetup(t *testing.T) {
+func TestBuildEventTreatsLocalRorkProfileAsTerminal(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
 
@@ -192,11 +207,11 @@ func TestBuildEventKeepsInstallIDForLocalRorkSetup(t *testing.T) {
 	if ev.RuntimeContext != RuntimeLocal {
 		t.Fatalf("RuntimeContext = %q, want %q", ev.RuntimeContext, RuntimeLocal)
 	}
-	if ev.InvocationSource != SourceRorkAgentSetup {
-		t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, SourceRorkAgentSetup)
+	if ev.InvocationSource != SourceTerminal {
+		t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, SourceTerminal)
 	}
 	if ev.InstallID == nil {
-		t.Fatal("expected install ID for local Rork setup")
+		t.Fatal("expected install ID for local profile usage")
 	}
 }
 

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 )
@@ -14,7 +13,6 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 	t.Setenv("DO_NOT_TRACK", "")
 
 	ev, ok := BuildEvent(
-		[]string{"apps", "info", "edit", "--app", "123456789", "--bundle-id", "com.secret.app", "--issuer-id", "issuer-secret"},
 		"asc apps info edit",
 		"1.2.3",
 		450*time.Millisecond,
@@ -36,11 +34,6 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal event: %v", err)
 	}
-	for _, forbidden := range []string{"123456789", "com.secret.app", "issuer-secret", "--bundle-id", "--issuer-id"} {
-		if strings.Contains(string(data), forbidden) {
-			t.Fatalf("event leaked %q: %s", forbidden, data)
-		}
-	}
 	var payload map[string]any
 	if err := json.Unmarshal(data, &payload); err != nil {
 		t.Fatalf("unmarshal event: %v", err)
@@ -54,6 +47,31 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 	if _, exists := payload["execution_context"]; exists {
 		t.Fatal("legacy execution_context field should not be emitted")
 	}
+	for _, forbiddenField := range []string{"args", "argv", "raw_args", "raw_argv"} {
+		if _, exists := payload[forbiddenField]; exists {
+			t.Fatalf("event contains forbidden raw-argument field %q", forbiddenField)
+		}
+	}
+}
+
+func TestBuildEventReusesProcessSessionID(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	first, ok := BuildEvent("asc builds list", "1.2.3", time.Second, 0)
+	if !ok {
+		t.Fatal("expected first event")
+	}
+	second, ok := BuildEvent("asc apps list", "1.2.3", time.Second, 0)
+	if !ok {
+		t.Fatal("expected second event")
+	}
+	if first.SessionID != second.SessionID {
+		t.Fatalf("session IDs differ within one process: %q != %q", first.SessionID, second.SessionID)
+	}
+	if first.EventID == second.EventID {
+		t.Fatalf("event IDs must remain unique, both were %q", first.EventID)
+	}
 }
 
 func TestBuildEventReusesInstallIDAcrossLocalInvocationSources(t *testing.T) {
@@ -62,7 +80,7 @@ func TestBuildEventReusesInstallIDAcrossLocalInvocationSources(t *testing.T) {
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
-	terminalEvent, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)
+	terminalEvent, ok := BuildEvent("asc builds list", "1.2.3", time.Second, 0)
 	if !ok {
 		t.Fatal("expected terminal event")
 	}
@@ -99,7 +117,7 @@ func TestBuildEventReusesInstallIDAcrossLocalInvocationSources(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
-			agentEvent, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)
+			agentEvent, ok := BuildEvent("asc builds list", "1.2.3", time.Second, 0)
 			if !ok {
 				t.Fatal("expected agent event")
 			}
@@ -173,7 +191,7 @@ func TestBuildEventOmitsInstallIDForEphemeralAgentRuntime(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
-			ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 1)
+			ev, ok := BuildEvent("asc builds list", "1.2.3", time.Second, 1)
 			if !ok {
 				t.Fatal("expected event")
 			}
@@ -195,7 +213,6 @@ func TestBuildEventTreatsLocalRorkProfileAsTerminal(t *testing.T) {
 	setTelemetryTestHome(t)
 
 	ev, ok := BuildEvent(
-		[]string{"auth", "login", "--name", "rork", "--key-id", "secret"},
 		"asc auth login",
 		"1.2.3",
 		time.Second,
@@ -232,7 +249,7 @@ func TestBuildEventDoesNotWaitForInstallIDLock(t *testing.T) {
 	defer unlock()
 
 	start := time.Now()
-	ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)
+	ev, ok := BuildEvent("asc builds list", "1.2.3", time.Second, 0)
 	elapsed := time.Since(start)
 
 	if !ok {
@@ -249,7 +266,7 @@ func TestBuildEventDoesNotWaitForInstallIDLock(t *testing.T) {
 func TestBuildEventSkipsControlCommands(t *testing.T) {
 	for _, commandPath := range []string{"asc", "asc completion", "asc version", "asc telemetry", "asc telemetry status"} {
 		t.Run(commandPath, func(t *testing.T) {
-			if _, ok := BuildEvent(nil, commandPath, "1.2.3", 0, 0); ok {
+			if _, ok := BuildEvent(commandPath, "1.2.3", 0, 0); ok {
 				t.Fatalf("expected %q to be skipped", commandPath)
 			}
 		})

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -41,22 +41,162 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 			t.Fatalf("event leaked %q: %s", forbidden, data)
 		}
 	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if payload["runtime_context"] != string(RuntimeLocal) {
+		t.Fatalf("runtime_context = %v, want %q", payload["runtime_context"], RuntimeLocal)
+	}
+	if payload["invocation_source"] != string(SourceTerminal) {
+		t.Fatalf("invocation_source = %v, want %q", payload["invocation_source"], SourceTerminal)
+	}
+	if _, exists := payload["execution_context"]; exists {
+		t.Fatal("legacy execution_context field should not be emitted")
+	}
 }
 
-func TestBuildEventOmitsInstallIDForNonLocalContext(t *testing.T) {
+func TestBuildEventReusesInstallIDAcrossLocalInvocationSources(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
-	t.Setenv("CI", "true")
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
 
-	ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 1)
+	terminalEvent, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)
+	if !ok {
+		t.Fatal("expected terminal event")
+	}
+	if terminalEvent.InstallID == nil {
+		t.Fatal("expected terminal install ID")
+	}
+	if terminalEvent.RuntimeContext != RuntimeLocal {
+		t.Fatalf("terminal RuntimeContext = %q, want %q", terminalEvent.RuntimeContext, RuntimeLocal)
+	}
+	if terminalEvent.InvocationSource != SourceTerminal {
+		t.Fatalf("terminal InvocationSource = %q, want %q", terminalEvent.InvocationSource, SourceTerminal)
+	}
+
+	tests := []struct {
+		name       string
+		env        map[string]string
+		wantSource InvocationSource
+	}{
+		{name: "Claude Code", env: map[string]string{"CLAUDECODE": "1"}, wantSource: SourceClaudeCode},
+		{name: "Cursor Agent", env: map[string]string{"CURSOR_AGENT": "1"}, wantSource: SourceCursorAgent},
+		{
+			name:       "Codex Desktop",
+			env:        map[string]string{"CODEX_SHELL": "1", "CODEX_THREAD_ID": "thread-1"},
+			wantSource: SourceCodexDesktop,
+		},
+		{name: "OpenCode", env: map[string]string{"OPENCODE": "1"}, wantSource: SourceOpenCode},
+		{name: "Pi", env: map[string]string{"PI_CODING_AGENT": "true"}, wantSource: SourcePi},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearContextEnv(t)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			agentEvent, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 0)
+			if !ok {
+				t.Fatal("expected agent event")
+			}
+			if agentEvent.InstallID == nil {
+				t.Fatal("expected local agent install ID")
+			}
+			if *agentEvent.InstallID != *terminalEvent.InstallID {
+				t.Fatalf("agent install ID = %q, want %q", *agentEvent.InstallID, *terminalEvent.InstallID)
+			}
+			if agentEvent.RuntimeContext != RuntimeLocal {
+				t.Fatalf("RuntimeContext = %q, want %q", agentEvent.RuntimeContext, RuntimeLocal)
+			}
+			if agentEvent.InvocationSource != tt.wantSource {
+				t.Fatalf("InvocationSource = %q, want %q", agentEvent.InvocationSource, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestBuildEventOmitsInstallIDForEphemeralAgentRuntime(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         map[string]string
+		wantRuntime RuntimeContext
+		wantSource  InvocationSource
+	}{
+		{
+			name:        "Claude Code in CI",
+			env:         map[string]string{"CI": "true", "CLAUDECODE": "1"},
+			wantRuntime: RuntimeCI,
+			wantSource:  SourceClaudeCode,
+		},
+		{
+			name: "Codex Desktop marker in Rork sandbox",
+			env: map[string]string{
+				"RORK_SANDBOX_ID": "sandbox-1",
+				"CODEX_SHELL":     "1",
+				"CODEX_THREAD_ID": "thread-1",
+			},
+			wantRuntime: RuntimeRorkSandbox,
+			wantSource:  SourceCodexDesktop,
+		},
+		{
+			name:        "Pi in explicitly ephemeral runtime",
+			env:         map[string]string{telemetryEphemeralEnvVar: "1", "PI_CODING_AGENT": "true"},
+			wantRuntime: RuntimeEphemeral,
+			wantSource:  SourcePi,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearContextEnv(t)
+			setTelemetryTestHome(t)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			ev, ok := BuildEvent([]string{"builds", "list"}, "asc builds list", "1.2.3", time.Second, 1)
+			if !ok {
+				t.Fatal("expected event")
+			}
+			if ev.RuntimeContext != tt.wantRuntime {
+				t.Fatalf("RuntimeContext = %q, want %q", ev.RuntimeContext, tt.wantRuntime)
+			}
+			if ev.InvocationSource != tt.wantSource {
+				t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, tt.wantSource)
+			}
+			if ev.InstallID != nil {
+				t.Fatalf("expected nil install ID for %s, got %q", tt.wantRuntime, *ev.InstallID)
+			}
+		})
+	}
+}
+
+func TestBuildEventKeepsInstallIDForLocalRorkSetup(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEvent(
+		[]string{"auth", "login", "--name", "rork", "--key-id", "secret"},
+		"asc auth login",
+		"1.2.3",
+		time.Second,
+		0,
+	)
 	if !ok {
 		t.Fatal("expected event")
 	}
-	if ev.ExecutionContext != ContextCI {
-		t.Fatalf("ExecutionContext = %q", ev.ExecutionContext)
+	if ev.RuntimeContext != RuntimeLocal {
+		t.Fatalf("RuntimeContext = %q, want %q", ev.RuntimeContext, RuntimeLocal)
 	}
-	if ev.InstallID != nil {
-		t.Fatalf("expected nil install ID for CI, got %q", *ev.InstallID)
+	if ev.InvocationSource != SourceRorkAgentSetup {
+		t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, SourceRorkAgentSetup)
+	}
+	if ev.InstallID == nil {
+		t.Fatal("expected install ID for local Rork setup")
 	}
 }
 

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -15,6 +15,7 @@ import (
 const (
 	stateDirName  = ".asc"
 	stateFileName = "telemetry.json"
+	lockTimeout   = 2 * time.Second
 )
 
 type State struct {
@@ -63,18 +64,18 @@ func EnsureInstallID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	st, err := loadState(path)
-	if err != nil {
+
+	var installID string
+	if err := updateState(path, func(st *State) error {
+		if strings.TrimSpace(st.InstallID) == "" {
+			st.InstallID = uuid.NewString()
+		}
+		installID = st.InstallID
+		return nil
+	}); err != nil {
 		return "", err
 	}
-	if strings.TrimSpace(st.InstallID) != "" {
-		return st.InstallID, nil
-	}
-	st.InstallID = uuid.NewString()
-	if err := saveState(path, st); err != nil {
-		return "", err
-	}
-	return st.InstallID, nil
+	return installID, nil
 }
 
 func SetEnabled(enabled bool) error {
@@ -82,12 +83,10 @@ func SetEnabled(enabled bool) error {
 	if err != nil {
 		return err
 	}
-	st, err := loadState(path)
-	if err != nil {
-		return err
-	}
-	st.Disabled = !enabled
-	return saveState(path, st)
+	return updateState(path, func(st *State) error {
+		st.Disabled = !enabled
+		return nil
+	})
 }
 
 func ResetInstallID() (string, error) {
@@ -95,15 +94,16 @@ func ResetInstallID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	st, err := loadState(path)
-	if err != nil {
+
+	var installID string
+	if err := updateState(path, func(st *State) error {
+		st.InstallID = uuid.NewString()
+		installID = st.InstallID
+		return nil
+	}); err != nil {
 		return "", err
 	}
-	st.InstallID = uuid.NewString()
-	if err := saveState(path, st); err != nil {
-		return "", err
-	}
-	return st.InstallID, nil
+	return installID, nil
 }
 
 func loadState(path string) (State, error) {
@@ -126,6 +126,43 @@ func loadState(path string) (State, error) {
 	return st, nil
 }
 
+func updateState(path string, mutate func(*State) error) error {
+	unlock, err := lockState(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	st, err := loadState(path)
+	if err != nil {
+		return err
+	}
+	if err := mutate(&st); err != nil {
+		return err
+	}
+	return saveState(path, st)
+}
+
+func lockState(path string) (func(), error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("telemetry: failed to create state directory: %w", err)
+	}
+	lockPath := path + ".lock"
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		if err := os.Mkdir(lockPath, 0o700); err == nil {
+			return func() { _ = os.Remove(lockPath) }, nil
+		} else if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("telemetry: failed to lock state: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("telemetry: timed out locking state")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func saveState(path string, st State) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -137,10 +174,27 @@ func saveState(path string, st State) error {
 		return fmt.Errorf("telemetry: failed to encode state: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	tmp, err := os.CreateTemp(dir, stateFileName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("telemetry: failed to create temp state: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
 		return fmt.Errorf("telemetry: failed to write state: %w", err)
 	}
-	_ = os.Chmod(path, 0o600)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("telemetry: failed to set state permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("telemetry: failed to close state: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("telemetry: failed to replace state: %w", err)
+	}
 	return nil
 }
 

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -179,7 +179,7 @@ func lockState(path string, wait time.Duration) (func(), error) {
 	for {
 		lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 		if err != nil {
-			info, statErr := os.Stat(lockPath)
+			info, statErr := statStateLock(lockPath)
 			if errors.Is(statErr, os.ErrNotExist) {
 				if !waitForStateLockRetry(wait, deadline) {
 					return nil, fmt.Errorf("telemetry: timed out locking state")
@@ -241,7 +241,7 @@ func migrateLegacyStateLockDirectory(lockPath string, expected os.FileInfo) (boo
 		if errors.Is(err, os.ErrExist) {
 			markerInfo, statErr := os.Stat(markerPath)
 			if statErr == nil && time.Since(markerInfo.ModTime()) > legacyLockStaleAge {
-				current, currentErr := os.Stat(lockPath)
+				current, currentErr := statStateLock(lockPath)
 				if currentErr != nil {
 					if errors.Is(currentErr, os.ErrNotExist) {
 						return true, nil
@@ -265,7 +265,7 @@ func migrateLegacyStateLockDirectory(lockPath string, expected os.FileInfo) (boo
 		return false, closeErr
 	}
 
-	current, err := os.Stat(lockPath)
+	current, err := statStateLock(lockPath)
 	if err != nil {
 		_ = os.Remove(markerPath)
 		if errors.Is(err, os.ErrNotExist) {
@@ -297,6 +297,15 @@ func quarantineLegacyStateLockDirectory(lockPath, markerPath string) (bool, erro
 		return false, err
 	}
 	return true, nil
+}
+
+func statStateLock(path string) (os.FileInfo, error) {
+	file, err := openStateLockForStat(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return file.Stat()
 }
 
 func waitForStateLockRetry(wait time.Duration, deadline time.Time) bool {

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -144,6 +144,7 @@ func updateState(path string, mutate func(*State) error) error {
 }
 
 func updateStateWithLockTimeout(path string, wait time.Duration, mutate func(*State) error) error {
+	deadline := time.Now().Add(wait)
 	unlock, err := lockState(path, wait)
 	if err != nil {
 		return err
@@ -161,7 +162,11 @@ func updateStateWithLockTimeout(path string, wait time.Duration, mutate func(*St
 	if st == before {
 		return nil
 	}
-	return saveState(path, st)
+	replaceWait := wait
+	if wait > 0 {
+		replaceWait = max(time.Duration(0), time.Until(deadline))
+	}
+	return saveState(path, st, replaceWait)
 }
 
 func lockState(path string, wait time.Duration) (func(), error) {
@@ -176,6 +181,9 @@ func lockState(path string, wait time.Duration) (func(), error) {
 		if err != nil {
 			info, statErr := os.Stat(lockPath)
 			if errors.Is(statErr, os.ErrNotExist) {
+				if !waitForStateLockRetry(wait, deadline) {
+					return nil, fmt.Errorf("telemetry: timed out locking state")
+				}
 				continue
 			}
 			if statErr != nil || !info.IsDir() {
@@ -233,9 +241,15 @@ func migrateLegacyStateLockDirectory(lockPath string, expected os.FileInfo) (boo
 		if errors.Is(err, os.ErrExist) {
 			markerInfo, statErr := os.Stat(markerPath)
 			if statErr == nil && time.Since(markerInfo.ModTime()) > legacyLockStaleAge {
-				if removeErr := os.Remove(markerPath); removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
-					_ = os.Chtimes(lockPath, expected.ModTime(), expected.ModTime())
-					return true, nil
+				current, currentErr := os.Stat(lockPath)
+				if currentErr != nil {
+					if errors.Is(currentErr, os.ErrNotExist) {
+						return true, nil
+					}
+					return false, currentErr
+				}
+				if os.SameFile(expected, current) {
+					return quarantineLegacyStateLockDirectory(lockPath, markerPath)
 				}
 			}
 			return false, nil
@@ -264,6 +278,10 @@ func migrateLegacyStateLockDirectory(lockPath string, expected os.FileInfo) (boo
 		return false, nil
 	}
 
+	return quarantineLegacyStateLockDirectory(lockPath, markerPath)
+}
+
+func quarantineLegacyStateLockDirectory(lockPath, markerPath string) (bool, error) {
 	quarantinePath := lockPath + ".legacy-" + uuid.NewString()
 	if err := os.Rename(lockPath, quarantinePath); err != nil {
 		_ = os.Remove(markerPath)
@@ -293,7 +311,7 @@ func waitForStateLockRetry(wait time.Duration, deadline time.Time) bool {
 	return true
 }
 
-func saveState(path string, st State) error {
+func saveState(path string, st State, wait time.Duration) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("telemetry: failed to create state directory: %w", err)
@@ -322,7 +340,7 @@ func saveState(path string, st State) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("telemetry: failed to close state: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := replaceStateFile(tmpPath, path, wait); err != nil {
 		return fmt.Errorf("telemetry: failed to replace state: %w", err)
 	}
 	return nil

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -19,6 +19,7 @@ const (
 	lockTimeout        = 2 * time.Second
 	lockPollInterval   = 10 * time.Millisecond
 	legacyLockStaleAge = 30 * time.Second
+	maxStateFileBytes  = 64 * 1024
 )
 
 type State struct {
@@ -123,9 +124,12 @@ func loadState(path string) (State, error) {
 	}
 	defer file.Close()
 
-	data, err := io.ReadAll(file)
+	data, err := io.ReadAll(io.LimitReader(file, maxStateFileBytes+1))
 	if err != nil {
 		return State{}, fmt.Errorf("telemetry: failed to read state: %w", err)
+	}
+	if len(data) > maxStateFileBytes {
+		return State{}, fmt.Errorf("telemetry: state file is too large")
 	}
 	var st State
 	if err := json.Unmarshal(data, &st); err != nil {

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -16,6 +16,7 @@ const (
 	stateDirName  = ".asc"
 	stateFileName = "telemetry.json"
 	lockTimeout   = 2 * time.Second
+	staleLockAge  = 30 * time.Second
 )
 
 type State struct {
@@ -137,8 +138,12 @@ func updateState(path string, mutate func(*State) error) error {
 	if err != nil {
 		return err
 	}
+	before := st
 	if err := mutate(&st); err != nil {
 		return err
+	}
+	if st == before {
+		return nil
 	}
 	return saveState(path, st)
 }
@@ -155,6 +160,11 @@ func lockState(path string) (func(), error) {
 			return func() { _ = os.Remove(lockPath) }, nil
 		} else if !errors.Is(err, os.ErrExist) {
 			return nil, fmt.Errorf("telemetry: failed to lock state: %w", err)
+		}
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > staleLockAge {
+			if removeErr := os.Remove(lockPath); removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
+				continue
+			}
 		}
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("telemetry: timed out locking state")

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -1,0 +1,158 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	stateDirName  = ".asc"
+	stateFileName = "telemetry.json"
+)
+
+type State struct {
+	InstallID string `json:"install_id,omitempty"`
+	Disabled  bool   `json:"disabled,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+type Status struct {
+	Path      string `json:"path"`
+	Enabled   bool   `json:"enabled"`
+	InstallID string `json:"install_id,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Endpoint  string `json:"endpoint,omitempty"`
+}
+
+func StatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("telemetry: failed to resolve home directory: %w", err)
+	}
+	return filepath.Join(home, stateDirName, stateFileName), nil
+}
+
+func ReadStatus() (Status, error) {
+	path, err := StatePath()
+	if err != nil {
+		return Status{}, err
+	}
+	st, err := loadState(path)
+	if err != nil {
+		return Status{}, err
+	}
+	enabled, reason := enabledFromState(st)
+	return Status{
+		Path:      path,
+		Enabled:   enabled,
+		InstallID: st.InstallID,
+		Reason:    reason,
+		Endpoint:  endpoint(),
+	}, nil
+}
+
+func EnsureInstallID() (string, error) {
+	path, err := StatePath()
+	if err != nil {
+		return "", err
+	}
+	st, err := loadState(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(st.InstallID) != "" {
+		return st.InstallID, nil
+	}
+	st.InstallID = uuid.NewString()
+	if err := saveState(path, st); err != nil {
+		return "", err
+	}
+	return st.InstallID, nil
+}
+
+func SetEnabled(enabled bool) error {
+	path, err := StatePath()
+	if err != nil {
+		return err
+	}
+	st, err := loadState(path)
+	if err != nil {
+		return err
+	}
+	st.Disabled = !enabled
+	return saveState(path, st)
+}
+
+func ResetInstallID() (string, error) {
+	path, err := StatePath()
+	if err != nil {
+		return "", err
+	}
+	st, err := loadState(path)
+	if err != nil {
+		return "", err
+	}
+	st.InstallID = uuid.NewString()
+	if err := saveState(path, st); err != nil {
+		return "", err
+	}
+	return st.InstallID, nil
+}
+
+func loadState(path string) (State, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return State{}, nil
+	}
+	if err != nil {
+		return State{}, fmt.Errorf("telemetry: failed to read state: %w", err)
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return State{}, fmt.Errorf("telemetry: failed to parse state: %w", err)
+	}
+	if strings.TrimSpace(st.InstallID) != "" {
+		if _, err := uuid.Parse(st.InstallID); err != nil {
+			st.InstallID = ""
+		}
+	}
+	return st, nil
+}
+
+func saveState(path string, st State) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("telemetry: failed to create state directory: %w", err)
+	}
+	st.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("telemetry: failed to encode state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("telemetry: failed to write state: %w", err)
+	}
+	_ = os.Chmod(path, 0o600)
+	return nil
+}
+
+func enabledFromState(st State) (bool, string) {
+	if envTruthy("ASC_TELEMETRY_DISABLED") {
+		return false, "ASC_TELEMETRY_DISABLED"
+	}
+	if envTruthy("DO_NOT_TRACK") {
+		return false, "DO_NOT_TRACK"
+	}
+	if st.Disabled {
+		return false, "state"
+	}
+	return true, ""
+}

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -356,14 +356,21 @@ func saveState(path string, st State, wait time.Duration) error {
 }
 
 func enabledFromState(st State) (bool, string) {
-	if envTruthy("ASC_TELEMETRY_DISABLED") {
-		return false, "ASC_TELEMETRY_DISABLED"
-	}
-	if envTruthy("DO_NOT_TRACK") {
-		return false, "DO_NOT_TRACK"
+	if reason := environmentOptOutReason(); reason != "" {
+		return false, reason
 	}
 	if st.Disabled {
 		return false, "state"
 	}
 	return true, ""
+}
+
+func environmentOptOutReason() string {
+	if envTruthy("ASC_TELEMETRY_DISABLED") {
+		return "ASC_TELEMETRY_DISABLED"
+	}
+	if envTruthy("DO_NOT_TRACK") {
+		return "DO_NOT_TRACK"
+	}
+	return ""
 }

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,10 +14,11 @@ import (
 )
 
 const (
-	stateDirName     = ".asc"
-	stateFileName    = "telemetry.json"
-	lockTimeout      = 2 * time.Second
-	lockPollInterval = 10 * time.Millisecond
+	stateDirName       = ".asc"
+	stateFileName      = "telemetry.json"
+	lockTimeout        = 2 * time.Second
+	lockPollInterval   = 10 * time.Millisecond
+	legacyLockStaleAge = 30 * time.Second
 )
 
 type State struct {
@@ -112,10 +114,16 @@ func ResetInstallID() (string, error) {
 }
 
 func loadState(path string) (State, error) {
-	data, err := os.ReadFile(path)
+	file, err := openStateFileForRead(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return State{}, nil
 	}
+	if err != nil {
+		return State{}, fmt.Errorf("telemetry: failed to read state: %w", err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return State{}, fmt.Errorf("telemetry: failed to read state: %w", err)
 	}
@@ -162,12 +170,39 @@ func lockState(path string, wait time.Duration) (func(), error) {
 		return nil, fmt.Errorf("telemetry: failed to create state directory: %w", err)
 	}
 	lockPath := path + ".lock"
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("telemetry: failed to open state lock: %w", err)
-	}
 	deadline := time.Now().Add(wait)
 	for {
+		lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			info, statErr := os.Stat(lockPath)
+			if errors.Is(statErr, os.ErrNotExist) {
+				continue
+			}
+			if statErr != nil || !info.IsDir() {
+				return nil, fmt.Errorf("telemetry: failed to open state lock: %w", err)
+			}
+			if time.Since(info.ModTime()) > legacyLockStaleAge {
+				migrated, migrateErr := migrateLegacyStateLockDirectory(lockPath, info)
+				if migrateErr != nil {
+					return nil, fmt.Errorf("telemetry: failed to migrate legacy state lock: %w", migrateErr)
+				}
+				if migrated {
+					continue
+				}
+			}
+			if wait <= 0 || time.Now().After(deadline) {
+				return nil, fmt.Errorf("telemetry: timed out locking state")
+			}
+			if !waitForStateLockRetry(wait, deadline) {
+				return nil, fmt.Errorf("telemetry: timed out locking state")
+			}
+			continue
+		}
+		if wait > 0 && time.Until(deadline) <= 0 {
+			_ = lockFile.Close()
+			return nil, fmt.Errorf("telemetry: timed out locking state")
+		}
+
 		locked, lockErr := tryLockStateFile(lockFile)
 		if lockErr != nil {
 			_ = lockFile.Close()
@@ -183,8 +218,79 @@ func lockState(path string, wait time.Duration) (func(), error) {
 			_ = lockFile.Close()
 			return nil, fmt.Errorf("telemetry: timed out locking state")
 		}
-		time.Sleep(lockPollInterval)
+		if !waitForStateLockRetry(wait, deadline) {
+			_ = lockFile.Close()
+			return nil, fmt.Errorf("telemetry: timed out locking state")
+		}
+		_ = lockFile.Close()
 	}
+}
+
+func migrateLegacyStateLockDirectory(lockPath string, expected os.FileInfo) (bool, error) {
+	markerPath := filepath.Join(lockPath, ".asc-migrating")
+	marker, err := os.OpenFile(markerPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			markerInfo, statErr := os.Stat(markerPath)
+			if statErr == nil && time.Since(markerInfo.ModTime()) > legacyLockStaleAge {
+				if removeErr := os.Remove(markerPath); removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
+					_ = os.Chtimes(lockPath, expected.ModTime(), expected.ModTime())
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+		current, statErr := os.Stat(lockPath)
+		if errors.Is(statErr, os.ErrNotExist) || statErr == nil && !current.IsDir() {
+			return true, nil
+		}
+		return false, err
+	}
+	if closeErr := marker.Close(); closeErr != nil {
+		_ = os.Remove(markerPath)
+		return false, closeErr
+	}
+
+	current, err := os.Stat(lockPath)
+	if err != nil {
+		_ = os.Remove(markerPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+	if !os.SameFile(expected, current) {
+		_ = os.Remove(markerPath)
+		return false, nil
+	}
+
+	quarantinePath := lockPath + ".legacy-" + uuid.NewString()
+	if err := os.Rename(lockPath, quarantinePath); err != nil {
+		_ = os.Remove(markerPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+	if err := os.Remove(filepath.Join(quarantinePath, filepath.Base(markerPath))); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if err := removeLegacyStateLockDirectory(quarantinePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return true, nil
+}
+
+func waitForStateLockRetry(wait time.Duration, deadline time.Time) bool {
+	if wait <= 0 {
+		return false
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	time.Sleep(min(lockPollInterval, remaining))
+	return true
 }
 
 func saveState(path string, st State) error {

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -61,13 +61,17 @@ func ReadStatus() (Status, error) {
 }
 
 func EnsureInstallID() (string, error) {
+	return ensureInstallID(lockTimeout)
+}
+
+func ensureInstallID(wait time.Duration) (string, error) {
 	path, err := StatePath()
 	if err != nil {
 		return "", err
 	}
 
 	var installID string
-	if err := updateState(path, func(st *State) error {
+	if err := updateStateWithLockTimeout(path, wait, func(st *State) error {
 		if strings.TrimSpace(st.InstallID) == "" {
 			st.InstallID = uuid.NewString()
 		}
@@ -128,7 +132,11 @@ func loadState(path string) (State, error) {
 }
 
 func updateState(path string, mutate func(*State) error) error {
-	unlock, err := lockState(path)
+	return updateStateWithLockTimeout(path, lockTimeout, mutate)
+}
+
+func updateStateWithLockTimeout(path string, wait time.Duration, mutate func(*State) error) error {
+	unlock, err := lockState(path, wait)
 	if err != nil {
 		return err
 	}
@@ -148,13 +156,13 @@ func updateState(path string, mutate func(*State) error) error {
 	return saveState(path, st)
 }
 
-func lockState(path string) (func(), error) {
+func lockState(path string, wait time.Duration) (func(), error) {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("telemetry: failed to create state directory: %w", err)
 	}
 	lockPath := path + ".lock"
-	deadline := time.Now().Add(lockTimeout)
+	deadline := time.Now().Add(wait)
 	for {
 		if err := os.Mkdir(lockPath, 0o700); err == nil {
 			return func() { _ = os.Remove(lockPath) }, nil
@@ -166,7 +174,7 @@ func lockState(path string) (func(), error) {
 				continue
 			}
 		}
-		if time.Now().After(deadline) {
+		if wait <= 0 || time.Now().After(deadline) {
 			return nil, fmt.Errorf("telemetry: timed out locking state")
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	stateDirName  = ".asc"
-	stateFileName = "telemetry.json"
-	lockTimeout   = 2 * time.Second
-	staleLockAge  = 30 * time.Second
+	stateDirName     = ".asc"
+	stateFileName    = "telemetry.json"
+	lockTimeout      = 2 * time.Second
+	lockPollInterval = 10 * time.Millisecond
 )
 
 type State struct {
@@ -162,22 +162,28 @@ func lockState(path string, wait time.Duration) (func(), error) {
 		return nil, fmt.Errorf("telemetry: failed to create state directory: %w", err)
 	}
 	lockPath := path + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: failed to open state lock: %w", err)
+	}
 	deadline := time.Now().Add(wait)
 	for {
-		if err := os.Mkdir(lockPath, 0o700); err == nil {
-			return func() { _ = os.Remove(lockPath) }, nil
-		} else if !errors.Is(err, os.ErrExist) {
-			return nil, fmt.Errorf("telemetry: failed to lock state: %w", err)
+		locked, lockErr := tryLockStateFile(lockFile)
+		if lockErr != nil {
+			_ = lockFile.Close()
+			return nil, fmt.Errorf("telemetry: failed to lock state: %w", lockErr)
 		}
-		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > staleLockAge {
-			if removeErr := os.Remove(lockPath); removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
-				continue
-			}
+		if locked {
+			return func() {
+				_ = unlockStateFile(lockFile)
+				_ = lockFile.Close()
+			}, nil
 		}
 		if wait <= 0 || time.Now().After(deadline) {
+			_ = lockFile.Close()
 			return nil, fmt.Errorf("telemetry: timed out locking state")
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(lockPollInterval)
 	}
 }
 

--- a/internal/telemetry/state_lock_unix.go
+++ b/internal/telemetry/state_lock_unix.go
@@ -5,6 +5,7 @@ package telemetry
 import (
 	"errors"
 	"os"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -26,6 +27,10 @@ func unlockStateFile(file *os.File) error {
 
 func openStateFileForRead(path string) (*os.File, error) {
 	return os.Open(path)
+}
+
+func replaceStateFile(oldPath, newPath string, _ time.Duration) error {
+	return os.Rename(oldPath, newPath)
 }
 
 func removeLegacyStateLockDirectory(path string) error {

--- a/internal/telemetry/state_lock_unix.go
+++ b/internal/telemetry/state_lock_unix.go
@@ -1,0 +1,25 @@
+//go:build darwin || linux
+
+package telemetry
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLockStateFile(file *os.File) (bool, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockStateFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}

--- a/internal/telemetry/state_lock_unix.go
+++ b/internal/telemetry/state_lock_unix.go
@@ -23,3 +23,11 @@ func tryLockStateFile(file *os.File) (bool, error) {
 func unlockStateFile(file *os.File) error {
 	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
 }
+
+func openStateFileForRead(path string) (*os.File, error) {
+	return os.Open(path)
+}
+
+func removeLegacyStateLockDirectory(path string) error {
+	return unix.Rmdir(path)
+}

--- a/internal/telemetry/state_lock_unix.go
+++ b/internal/telemetry/state_lock_unix.go
@@ -29,6 +29,10 @@ func openStateFileForRead(path string) (*os.File, error) {
 	return os.Open(path)
 }
 
+func openStateLockForStat(path string) (*os.File, error) {
+	return os.Open(path)
+}
+
 func replaceStateFile(oldPath, newPath string, _ time.Duration) error {
 	return os.Rename(oldPath, newPath)
 }

--- a/internal/telemetry/state_lock_windows.go
+++ b/internal/telemetry/state_lock_windows.go
@@ -5,6 +5,7 @@ package telemetry
 import (
 	"errors"
 	"os"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -56,6 +57,28 @@ func openStateFileForRead(path string) (*os.File, error) {
 		return nil, &os.PathError{Op: "open", Path: path, Err: windows.ERROR_INVALID_HANDLE}
 	}
 	return file, nil
+}
+
+func replaceStateFile(oldPath, newPath string, wait time.Duration) error {
+	deadline := time.Now().Add(wait)
+	for {
+		err := os.Rename(oldPath, newPath)
+		if err == nil {
+			return nil
+		}
+		if !isRetryableStateReplaceError(err) || wait <= 0 {
+			return err
+		}
+		if !waitForStateLockRetry(wait, deadline) {
+			return err
+		}
+	}
+}
+
+func isRetryableStateReplaceError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
 }
 
 func removeLegacyStateLockDirectory(path string) error {

--- a/internal/telemetry/state_lock_windows.go
+++ b/internal/telemetry/state_lock_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package telemetry
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockStateFile(file *os.File) (bool, error) {
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockStateFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/internal/telemetry/state_lock_windows.go
+++ b/internal/telemetry/state_lock_windows.go
@@ -32,3 +32,36 @@ func unlockStateFile(file *os.File) error {
 	var overlapped windows.Overlapped
 	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
 }
+
+func openStateFileForRead(path string) (*os.File, error) {
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	handle, err := windows.CreateFile(
+		pathPointer,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, &os.PathError{Op: "open", Path: path, Err: windows.ERROR_INVALID_HANDLE}
+	}
+	return file, nil
+}
+
+func removeLegacyStateLockDirectory(path string) error {
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	return windows.RemoveDirectory(pathPointer)
+}

--- a/internal/telemetry/state_lock_windows.go
+++ b/internal/telemetry/state_lock_windows.go
@@ -59,6 +59,31 @@ func openStateFileForRead(path string) (*os.File, error) {
 	return file, nil
 }
 
+func openStateLockForStat(path string) (*os.File, error) {
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	handle, err := windows.CreateFile(
+		pathPointer,
+		windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, &os.PathError{Op: "open", Path: path, Err: windows.ERROR_INVALID_HANDLE}
+	}
+	return file, nil
+}
+
 func replaceStateFile(oldPath, newPath string, wait time.Duration) error {
 	deadline := time.Now().Add(wait)
 	for {

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -81,7 +81,7 @@ func TestEnsureInstallIDDoesNotRewriteUnchangedState(t *testing.T) {
 	}
 }
 
-func TestStaleLockIsRecovered(t *testing.T) {
+func TestExistingUnlockedLockFileIsReusable(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	path, err := StatePath()
@@ -89,16 +89,41 @@ func TestStaleLockIsRecovered(t *testing.T) {
 		t.Fatalf("StatePath() error = %v", err)
 	}
 	lockPath := path + ".lock"
-	if err := os.MkdirAll(lockPath, 0o700); err != nil {
-		t.Fatalf("create stale lock: %v", err)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		t.Fatalf("create state directory: %v", err)
 	}
-	staleTime := time.Now().Add(-staleLockAge - time.Second)
-	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
-		t.Fatalf("age stale lock: %v", err)
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatalf("create unlocked lock file: %v", err)
 	}
 
 	if _, err := EnsureInstallID(); err != nil {
-		t.Fatalf("EnsureInstallID() with stale lock error = %v", err)
+		t.Fatalf("EnsureInstallID() with existing lock file error = %v", err)
+	}
+}
+
+func TestAgedLockStillPreservesMutualExclusion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	unlockFirst, err := lockState(path, lockTimeout)
+	if err != nil {
+		t.Fatalf("lockState() first error = %v", err)
+	}
+	defer unlockFirst()
+
+	lockPath := path + ".lock"
+	oldTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(lockPath, oldTime, oldTime); err != nil {
+		t.Fatalf("age held lock: %v", err)
+	}
+
+	unlockSecond, err := lockState(path, 0)
+	if err == nil {
+		unlockSecond()
+		t.Fatal("second caller acquired an aged lock while it was still held")
 	}
 }
 

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -178,8 +178,9 @@ func TestLegacyLockMigrationPreservesReplacementDirectory(t *testing.T) {
 	if err := os.Mkdir(replacementPath, 0o700); err != nil {
 		t.Fatalf("create replacement legacy lock directory: %v", err)
 	}
-	if err := os.Remove(lockPath); err != nil {
-		t.Fatalf("remove stale legacy lock directory: %v", err)
+	stalePath := lockPath + ".stale"
+	if err := os.Rename(lockPath, stalePath); err != nil {
+		t.Fatalf("preserve stale legacy lock directory: %v", err)
 	}
 	if err := os.Rename(replacementPath, lockPath); err != nil {
 		t.Fatalf("install replacement legacy lock directory: %v", err)
@@ -201,6 +202,41 @@ func TestLegacyLockMigrationPreservesReplacementDirectory(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(lockPath, ".asc-migrating")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("migration marker was not removed: %v", err)
+	}
+}
+
+func TestStaleLegacyMigrationMarkerIsRecovered(t *testing.T) {
+	setTelemetryTestHome(t)
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("create legacy lock directory: %v", err)
+	}
+	markerPath := filepath.Join(lockPath, ".asc-migrating")
+	if err := os.WriteFile(markerPath, nil, 0o600); err != nil {
+		t.Fatalf("create stale migration marker: %v", err)
+	}
+	staleTime := time.Now().Add(-legacyLockStaleAge - time.Second)
+	if err := os.Chtimes(markerPath, staleTime, staleTime); err != nil {
+		t.Fatalf("age migration marker: %v", err)
+	}
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatalf("age legacy lock directory: %v", err)
+	}
+
+	if _, err := EnsureInstallID(); err != nil {
+		t.Fatalf("EnsureInstallID() with stale migration marker error = %v", err)
+	}
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatalf("stat migrated lock: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("legacy lock directory with stale marker was not migrated")
 	}
 }
 

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -170,7 +170,7 @@ func TestLegacyLockMigrationPreservesReplacementDirectory(t *testing.T) {
 	if err := os.MkdirAll(lockPath, 0o700); err != nil {
 		t.Fatalf("create stale legacy lock directory: %v", err)
 	}
-	staleInfo, err := os.Stat(lockPath)
+	staleInfo, err := statStateLock(lockPath)
 	if err != nil {
 		t.Fatalf("stat stale legacy lock directory: %v", err)
 	}

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -77,6 +78,45 @@ func TestReadStatusHonorsOptOuts(t *testing.T) {
 	}
 	if status.Enabled || status.Reason != "DO_NOT_TRACK" {
 		t.Fatalf("expected DO_NOT_TRACK-disabled status, got %+v", status)
+	}
+}
+
+func TestConcurrentStateUpdatesPreserveOptOutAndInstallID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, err := EnsureInstallID()
+			errs <- err
+		}()
+		go func() {
+			defer wg.Done()
+			errs <- SetEnabled(false)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent state update failed: %v", err)
+		}
+	}
+
+	status, err := ReadStatus()
+	if err != nil {
+		t.Fatalf("ReadStatus() error = %v", err)
+	}
+	if status.Enabled || status.Reason != "state" {
+		t.Fatalf("expected opt-out to survive concurrent updates, got %+v", status)
+	}
+	if status.InstallID == "" {
+		t.Fatalf("expected install ID to survive concurrent updates, got %+v", status)
 	}
 }
 

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -1,0 +1,90 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallIDCreateReuseAndReset(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	first, err := EnsureInstallID()
+	if err != nil {
+		t.Fatalf("EnsureInstallID() error = %v", err)
+	}
+	if first == "" {
+		t.Fatal("expected install ID")
+	}
+
+	second, err := EnsureInstallID()
+	if err != nil {
+		t.Fatalf("EnsureInstallID() second error = %v", err)
+	}
+	if second != first {
+		t.Fatalf("expected reused install ID %q, got %q", first, second)
+	}
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat telemetry state: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file permissions = %o, want 0600", got)
+	}
+	if dirMode := statMode(t, filepath.Dir(path)); dirMode != 0o700 {
+		t.Fatalf("state dir permissions = %o, want 0700", dirMode)
+	}
+
+	reset, err := ResetInstallID()
+	if err != nil {
+		t.Fatalf("ResetInstallID() error = %v", err)
+	}
+	if reset == "" || reset == first {
+		t.Fatalf("expected new install ID, got %q after %q", reset, first)
+	}
+}
+
+func TestReadStatusHonorsOptOuts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	if err := SetEnabled(false); err != nil {
+		t.Fatalf("SetEnabled(false) error = %v", err)
+	}
+	status, err := ReadStatus()
+	if err != nil {
+		t.Fatalf("ReadStatus() error = %v", err)
+	}
+	if status.Enabled || status.Reason != "state" {
+		t.Fatalf("expected state-disabled status, got %+v", status)
+	}
+
+	if err := SetEnabled(true); err != nil {
+		t.Fatalf("SetEnabled(true) error = %v", err)
+	}
+	t.Setenv("DO_NOT_TRACK", "1")
+	status, err = ReadStatus()
+	if err != nil {
+		t.Fatalf("ReadStatus() with env error = %v", err)
+	}
+	if status.Enabled || status.Reason != "DO_NOT_TRACK" {
+		t.Fatalf("expected DO_NOT_TRACK-disabled status, got %+v", status)
+	}
+}
+
+func statMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -10,6 +10,23 @@ import (
 	"time"
 )
 
+func TestReadStatusIsEnabledByDefault(t *testing.T) {
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+
+	status, err := ReadStatus()
+	if err != nil {
+		t.Fatalf("ReadStatus() error = %v", err)
+	}
+	if !status.Enabled {
+		t.Fatalf("expected telemetry enabled by default, got %+v", status)
+	}
+	if status.Reason != "" {
+		t.Fatalf("default status reason = %q, want empty", status.Reason)
+	}
+}
+
 func TestInstallIDCreateReuseAndReset(t *testing.T) {
 	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -24,6 +25,25 @@ func TestReadStatusIsEnabledByDefault(t *testing.T) {
 	}
 	if status.Reason != "" {
 		t.Fatalf("default status reason = %q, want empty", status.Reason)
+	}
+}
+
+func TestReadStatusRejectsOversizedState(t *testing.T) {
+	setTelemetryTestHome(t)
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create state directory: %v", err)
+	}
+	data := []byte(`{"updated_at":"` + strings.Repeat("x", 70*1024) + `"}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write oversized state: %v", err)
+	}
+
+	if _, err := ReadStatus(); err == nil {
+		t.Fatal("expected oversized telemetry state to be rejected")
 	}
 }
 

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestInstallIDCreateReuseAndReset(t *testing.T) {
@@ -49,6 +50,55 @@ func TestInstallIDCreateReuseAndReset(t *testing.T) {
 	}
 	if reset == "" || reset == first {
 		t.Fatalf("expected new install ID, got %q after %q", reset, first)
+	}
+}
+
+func TestEnsureInstallIDDoesNotRewriteUnchangedState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if _, err := EnsureInstallID(); err != nil {
+		t.Fatalf("EnsureInstallID() error = %v", err)
+	}
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	firstInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat telemetry state: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	if _, err := EnsureInstallID(); err != nil {
+		t.Fatalf("EnsureInstallID() second error = %v", err)
+	}
+	secondInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat telemetry state after reuse: %v", err)
+	}
+	if !secondInfo.ModTime().Equal(firstInfo.ModTime()) {
+		t.Fatalf("state modification time changed from %v to %v", firstInfo.ModTime(), secondInfo.ModTime())
+	}
+}
+
+func TestStaleLockIsRecovered(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("create stale lock: %v", err)
+	}
+	staleTime := time.Now().Add(-staleLockAge - time.Second)
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatalf("age stale lock: %v", err)
+	}
+
+	if _, err := EnsureInstallID(); err != nil {
+		t.Fatalf("EnsureInstallID() with stale lock error = %v", err)
 	}
 }
 

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -1,15 +1,17 @@
 package telemetry
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 )
 
 func TestInstallIDCreateReuseAndReset(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
@@ -37,11 +39,13 @@ func TestInstallIDCreateReuseAndReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat telemetry state: %v", err)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("state file permissions = %o, want 0600", got)
-	}
-	if dirMode := statMode(t, filepath.Dir(path)); dirMode != 0o700 {
-		t.Fatalf("state dir permissions = %o, want 0700", dirMode)
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("state file permissions = %o, want 0600", got)
+		}
+		if dirMode := statMode(t, filepath.Dir(path)); dirMode != 0o700 {
+			t.Fatalf("state dir permissions = %o, want 0700", dirMode)
+		}
 	}
 
 	reset, err := ResetInstallID()
@@ -54,7 +58,7 @@ func TestInstallIDCreateReuseAndReset(t *testing.T) {
 }
 
 func TestEnsureInstallIDDoesNotRewriteUnchangedState(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 
 	if _, err := EnsureInstallID(); err != nil {
 		t.Fatalf("EnsureInstallID() error = %v", err)
@@ -82,7 +86,7 @@ func TestEnsureInstallIDDoesNotRewriteUnchangedState(t *testing.T) {
 }
 
 func TestExistingUnlockedLockFileIsReusable(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 
 	path, err := StatePath()
 	if err != nil {
@@ -101,8 +105,107 @@ func TestExistingUnlockedLockFileIsReusable(t *testing.T) {
 	}
 }
 
+func TestStaleLegacyLockDirectoryIsMigrated(t *testing.T) {
+	setTelemetryTestHome(t)
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("create legacy lock directory: %v", err)
+	}
+	staleTime := time.Now().Add(-legacyLockStaleAge - time.Second)
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatalf("age legacy lock directory: %v", err)
+	}
+
+	if _, err := EnsureInstallID(); err != nil {
+		t.Fatalf("EnsureInstallID() with stale legacy lock error = %v", err)
+	}
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatalf("stat migrated lock: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("legacy lock directory was not replaced with a lock file")
+	}
+}
+
+func TestRecentLegacyLockDirectoryIsPreserved(t *testing.T) {
+	setTelemetryTestHome(t)
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("create legacy lock directory: %v", err)
+	}
+
+	unlock, err := lockState(path, 0)
+	if err == nil {
+		unlock()
+		t.Fatal("acquired a recent legacy lock directory")
+	}
+	info, statErr := os.Stat(lockPath)
+	if statErr != nil {
+		t.Fatalf("stat legacy lock directory: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatal("recent legacy lock directory was replaced")
+	}
+}
+
+func TestLegacyLockMigrationPreservesReplacementDirectory(t *testing.T) {
+	setTelemetryTestHome(t)
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("create stale legacy lock directory: %v", err)
+	}
+	staleInfo, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatalf("stat stale legacy lock directory: %v", err)
+	}
+	replacementPath := lockPath + ".replacement"
+	if err := os.Mkdir(replacementPath, 0o700); err != nil {
+		t.Fatalf("create replacement legacy lock directory: %v", err)
+	}
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove stale legacy lock directory: %v", err)
+	}
+	if err := os.Rename(replacementPath, lockPath); err != nil {
+		t.Fatalf("install replacement legacy lock directory: %v", err)
+	}
+
+	migrated, err := migrateLegacyStateLockDirectory(lockPath, staleInfo)
+	if err != nil {
+		t.Fatalf("migrateLegacyStateLockDirectory() error = %v", err)
+	}
+	if migrated {
+		t.Fatal("replacement legacy lock directory was migrated")
+	}
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatalf("stat replacement legacy lock directory: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("replacement legacy lock directory was not preserved")
+	}
+	if _, err := os.Stat(filepath.Join(lockPath, ".asc-migrating")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("migration marker was not removed: %v", err)
+	}
+}
+
 func TestAgedLockStillPreservesMutualExclusion(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 
 	path, err := StatePath()
 	if err != nil {
@@ -128,7 +231,7 @@ func TestAgedLockStillPreservesMutualExclusion(t *testing.T) {
 }
 
 func TestReadStatusHonorsOptOuts(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
@@ -157,7 +260,7 @@ func TestReadStatusHonorsOptOuts(t *testing.T) {
 }
 
 func TestConcurrentStateUpdatesPreserveOptOutAndInstallID(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
@@ -193,6 +296,13 @@ func TestConcurrentStateUpdatesPreserveOptOutAndInstallID(t *testing.T) {
 	if status.InstallID == "" {
 		t.Fatalf("expected install ID to survive concurrent updates, got %+v", status)
 	}
+}
+
+func setTelemetryTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 }
 
 func statMode(t *testing.T, path string) os.FileMode {

--- a/internal/telemetry/state_windows_test.go
+++ b/internal/telemetry/state_windows_test.go
@@ -2,9 +2,16 @@
 
 package telemetry
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
 
-func TestStateMutationSucceedsWhileStateReaderIsOpen(t *testing.T) {
+	"golang.org/x/sys/windows"
+)
+
+func TestReplaceStateFileWaitsForConcurrentReader(t *testing.T) {
 	setTelemetryTestHome(t)
 
 	if _, err := EnsureInstallID(); err != nil {
@@ -14,20 +21,103 @@ func TestStateMutationSucceedsWhileStateReaderIsOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StatePath() error = %v", err)
 	}
-	reader, err := openStateFileForRead(path)
+	reader := openStateFileWithoutDeleteSharing(t, path)
+
+	replacement, err := os.CreateTemp(filepath.Dir(path), stateFileName+".*.tmp")
 	if err != nil {
-		t.Fatalf("openStateFileForRead() error = %v", err)
+		t.Fatalf("create replacement state: %v", err)
 	}
-	defer reader.Close()
+	replacementPath := replacement.Name()
+	t.Cleanup(func() { _ = os.Remove(replacementPath) })
+	want := []byte("{\"disabled\":true}\n")
+	if _, err := replacement.Write(want); err != nil {
+		t.Fatalf("write replacement state: %v", err)
+	}
+	if err := replacement.Close(); err != nil {
+		t.Fatalf("close replacement state: %v", err)
+	}
+	if err := os.Rename(replacementPath, path); !isRetryableStateReplaceError(err) {
+		t.Fatalf("rename with non-delete-sharing reader error = %v, want retryable error", err)
+	}
+
+	replaceDone := make(chan error, 1)
+	go func() {
+		replaceDone <- replaceStateFile(replacementPath, path, lockTimeout)
+	}()
+
+	select {
+	case err := <-replaceDone:
+		t.Fatalf("replaceStateFile() completed while reader was open: %v", err)
+	case <-time.After(3 * lockPollInterval):
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close state reader: %v", err)
+	}
+	select {
+	case err := <-replaceDone:
+		if err != nil {
+			t.Fatalf("replaceStateFile() after reader close error = %v", err)
+		}
+	case <-time.After(lockTimeout + time.Second):
+		t.Fatal("replaceStateFile() did not finish after reader closed")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replaced state: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("replaced state = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureInstallIDDoesNotWaitForStateReader(t *testing.T) {
+	setTelemetryTestHome(t)
 
 	if err := SetEnabled(false); err != nil {
-		t.Fatalf("SetEnabled(false) with reader open error = %v", err)
+		t.Fatalf("SetEnabled(false) error = %v", err)
 	}
-	status, err := ReadStatus()
+	path, err := StatePath()
 	if err != nil {
-		t.Fatalf("ReadStatus() error = %v", err)
+		t.Fatalf("StatePath() error = %v", err)
 	}
-	if status.Enabled || status.Reason != "state" {
-		t.Fatalf("expected persisted opt-out, got %+v", status)
+	reader := openStateFileWithoutDeleteSharing(t, path)
+
+	start := time.Now()
+	if _, err := ensureInstallID(0); err == nil {
+		t.Fatal("ensureInstallID(0) succeeded while state reader blocked replacement")
 	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("ensureInstallID(0) elapsed = %s, want replacement contention skipped before 500ms", elapsed)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close state reader: %v", err)
+	}
+}
+
+func openStateFileWithoutDeleteSharing(t *testing.T, path string) *os.File {
+	t.Helper()
+
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatalf("encode state path: %v", err)
+	}
+	handle, err := windows.CreateFile(
+		pathPointer,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("open state without delete sharing: %v", err)
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		t.Fatal("wrap state reader handle")
+	}
+	t.Cleanup(func() { _ = file.Close() })
+	return file
 }

--- a/internal/telemetry/state_windows_test.go
+++ b/internal/telemetry/state_windows_test.go
@@ -94,6 +94,36 @@ func TestEnsureInstallIDDoesNotWaitForStateReader(t *testing.T) {
 	}
 }
 
+func TestStateLockIdentityHandleAllowsRename(t *testing.T) {
+	setTelemetryTestHome(t)
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("create state lock directory: %v", err)
+	}
+	identityHandle, err := openStateLockForStat(lockPath)
+	if err != nil {
+		t.Fatalf("openStateLockForStat() error = %v", err)
+	}
+	defer identityHandle.Close()
+
+	renamedPath := lockPath + ".renamed"
+	if err := os.Rename(lockPath, renamedPath); err != nil {
+		t.Fatalf("rename state lock with identity handle open: %v", err)
+	}
+	info, err := identityHandle.Stat()
+	if err != nil {
+		t.Fatalf("stat renamed state lock through identity handle: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("identity handle no longer describes the state lock directory")
+	}
+}
+
 func openStateFileWithoutDeleteSharing(t *testing.T, path string) *os.File {
 	t.Helper()
 

--- a/internal/telemetry/state_windows_test.go
+++ b/internal/telemetry/state_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package telemetry
+
+import "testing"
+
+func TestStateMutationSucceedsWhileStateReaderIsOpen(t *testing.T) {
+	setTelemetryTestHome(t)
+
+	if _, err := EnsureInstallID(); err != nil {
+		t.Fatalf("EnsureInstallID() error = %v", err)
+	}
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	reader, err := openStateFileForRead(path)
+	if err != nil {
+		t.Fatalf("openStateFileForRead() error = %v", err)
+	}
+	defer reader.Close()
+
+	if err := SetEnabled(false); err != nil {
+		t.Fatalf("SetEnabled(false) with reader open error = %v", err)
+	}
+	status, err := ReadStatus()
+	if err != nil {
+		t.Fatalf("ReadStatus() error = %v", err)
+	}
+	if status.Enabled || status.Reason != "state" {
+		t.Fatalf("expected persisted opt-out, got %+v", status)
+	}
+}

--- a/scripts/check_website_commands.py
+++ b/scripts/check_website_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import functools
+import os
 import re
 import shlex
 import subprocess
@@ -133,6 +134,7 @@ def command_help(binary_path: Path, path: tuple[str, ...]) -> str:
         check=True,
         capture_output=True,
         text=True,
+        env=telemetry_disabled_environment(),
     )
     return proc.stderr or proc.stdout
 
@@ -144,8 +146,15 @@ def path_help(binary_path: Path, path: tuple[str, ...]) -> str:
         check=False,
         capture_output=True,
         text=True,
+        env=telemetry_disabled_environment(),
     )
     return proc.stderr or proc.stdout
+
+
+def telemetry_disabled_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["ASC_TELEMETRY_DISABLED"] = "1"
+    return environment
 
 
 def build_command_index(binary_path: Path) -> dict[tuple[str, ...], CommandSpec]:

--- a/scripts/test_check_docs.py
+++ b/scripts/test_check_docs.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import generate_winget_manifests
 import check_repo_docs
@@ -263,6 +264,18 @@ class WebsiteDocsChecksTest(unittest.TestCase):
 
 
 class WebsiteCommandChecksTest(unittest.TestCase):
+    def test_help_subprocesses_disable_telemetry(self) -> None:
+        run = mock.Mock(return_value=mock.Mock(stderr="", stdout=""))
+
+        check_website_commands.path_help.cache_clear()
+        with mock.patch.object(check_website_commands.subprocess, "run", run):
+            check_website_commands.command_help(Path("/tmp/asc-doc-check"), ("apps",))
+            check_website_commands.path_help(Path("/tmp/asc-doc-check"), ("builds",))
+
+        self.assertEqual(run.call_count, 2)
+        for call in run.call_args_list:
+            self.assertEqual(call.kwargs["env"]["ASC_TELEMETRY_DISABLED"], "1")
+
     def test_website_command_checks_accept_valid_examples(self) -> None:
         index = {
             (): check_website_commands.CommandSpec(


### PR DESCRIPTION
## Summary

- Adds default-on, command-level telemetry emitted once from the central CLI runner after command execution.
- Adds local controls for telemetry status, enable, disable, and install ID reset.
- Separates **where asc runs** (`runtime_context`) from **what launched it** (`invocation_source`) so local agent-assisted usage is deduplicated as the same installation.
- Documents the collector payload, ClickHouse table shape, environment controls, and privacy boundaries.

## Default behavior

Telemetry is enabled on a brand-new installation without requiring a state file or setup step. It remains enabled in local terminals, local coding agents, CI, Rork sandboxes, Rork GitHub workflows, and explicitly ephemeral runtimes.

Explicit opt-outs are still respected:

- `asc telemetry disable`
- `ASC_TELEMETRY_DISABLED`
- `DO_NOT_TRACK`

Disposable runtimes still emit events but omit `install_id`.

## Identity model

A random install ID is stored in `~/.asc/telemetry.json` with owner-only permissions.

Commands launched from Terminal, Claude Code, Cursor Agent, Codex Desktop, OpenCode, or Pi under the same local user home reuse that ID. This matches the intended active-install metric: changing the local invoker does not create or hide a user.

Known disposable runtimes remain unlinked:

- CI
- Rork sandboxes
- Rork GitHub workflows
- runtimes explicitly marked with `ASC_TELEMETRY_EPHEMERAL=1`

Those events are still emitted with their runtime and invocation source, but `install_id` is `null`.

## Rork agent detection

The current production workflow downloads and runs `rork-agent publish`, and the agent binary identifies itself as `rork-agent`.

The CLI therefore records `invocation_source = rork_agent` from production runtime signals:

- `RORK_SANDBOX_ID` in Rork sandboxes
- `GITHUB_ACTIONS=true` plus `GITHUB_REPOSITORY=rorkai/user-workflows` in the centralized workflow repository

A local auth profile named `rork` is no longer treated as an agent signal. It remains ordinary local/terminal usage and retains the local install ID.

When a more specific supported launcher marker exists inside a Rork runtime, such as Codex Desktop, that launcher remains the invocation source while `runtime_context` still identifies the Rork sandbox.

## Event and privacy details

Events contain sanitized command path/family, CLI version, OS/arch, duration, exit code, success, runtime context, invocation source, event ID, per-process session ID, and the optional local install ID.

The CLI payload does **not** include raw argv, Apple account identifiers, app IDs, bundle IDs, team IDs, issuer IDs, key IDs, usernames, hostnames, repository names, paths, IP addresses, user-agent strings, hardware IDs, or process IDs.

Supported controls:

- `ASC_TELEMETRY_DISABLED`
- `DO_NOT_TRACK`
- `ASC_TELEMETRY_ENDPOINT`
- `ASC_TELEMETRY_EPHEMERAL`
- `asc telemetry status|enable|disable|reset-id`

## Design choice

Runtime durability and invocation source are independent dimensions. Keeping them in one enum would make `CI + Claude` ambiguous and was the root cause of local agent usage losing its install ID.

Alternatives rejected:

- Treating every agent invocation as ephemeral, because local agents run on persistent user machines.
- Simply allowlisting agent contexts, because an agent can also run inside CI or a disposable VM.
- Inferring Rork from `asc auth login --name rork`, because that is a user-controlled profile name rather than a production agent marker.
- Hardware or host fingerprinting, because it would violate the privacy boundary.

## Backend contract

The CLI sends JSON events to the configured HTTPS collector endpoint. The default is the existing API Worker route at `https://rork.com/cf-api/asc/v1/events`.

The event schema remains version 1 because this PR has not shipped. The documented ClickHouse contract uses:

- `runtime_context LowCardinality(String)`
- `invocation_source LowCardinality(String)`
- `install_id Nullable(UUID)`

Collector implementation, persistence, and ClickHouse analytics were merged in companion PR [rorkai/rorkai#2951](https://github.com/rorkai/rorkai/pull/2951). The backend deployment completed successfully, and the live route was smoke-tested with an invalid payload that returned the expected structured validation response.

## Validation

TDD evidence:

- RED: Rork sandbox/workflow invocations were reported as `terminal`, while a local profile named `rork` was incorrectly reported as `rork_agent_setup`.
- GREEN: production Rork runtimes report `rork_agent`; a local `--name rork` profile reports `terminal` and keeps its install ID.
- A fresh untouched home reports `enabled: true`.
- Terminal, Claude Code, Cursor Agent, Codex Desktop, OpenCode, and Pi reuse the same install ID under one local home.
- CI, Rork, and explicitly ephemeral executions retain source attribution while omitting the ID.
- Raw argv never enters event construction; command paths come from the registered command tree.
- Telemetry refuses redirects, embedded endpoint credentials, and ambient cookies.
- State-file reads are bounded, and the documentation crawler explicitly disables telemetry.

Commands run on the final head:

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc-pr1609 .`
- isolated-home `/tmp/asc-pr1609 telemetry status --output json` -> exit 0, `enabled: true`
- isolated-home `ASC_TELEMETRY_DISABLED=1 /tmp/asc-pr1609 telemetry status --output json` -> exit 0, `enabled: false`
- `/tmp/asc-pr1609 telemetry status --output yaml` -> exit 2
- `/tmp/asc-pr1609 telemetry --help`
