### PR TITLE
apps wall: add Cruisea: Real-time Tracking

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -209,6 +209,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4d/84/49/4d84498d-802a-03b0-262f-bc80aa2c0f1a/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Cruisea: Real-time Tracking",
+    "link": "https://apps.apple.com/us/app/cruisea-real-time-tracking/id6755068162?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ad/6c/03/ad6c0376-c349-cdee-bfac-c7882f57a4d7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Crunch: Compress & Convert",
     "link": "https://apps.apple.com/us/app/crunch-compress-convert/id6748700457?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/9e/88/85/9e888594-e92b-f739-c358-7fd083cae2f6/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Cruisea: Real-time Tracking` to the Wall of Apps

## Entry

- App ID: 6755068162
- App: Cruisea: Real-time Tracking
- Link: https://apps.apple.com/us/app/cruisea-real-time-tracking/id6755068162?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cruisea: Real-time Tracking app to the app catalog, complete with its Apple App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->