### PR TITLE
apps wall: add Alune: Planner & Assistant

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -45,6 +45,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6f/d5/6b/6fd56b58-41da-7aa7-4737-04bee755418d/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Alune: Planner & Assistant",
+    "link": "https://apps.apple.com/us/app/alune-planner-assistant/id6761420047?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/00/14/93/0014939d-ce61-2386-0bf3-b79c4dd678c4/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Appboard: Find Apps · Rankings",
     "link": "https://apps.apple.com/us/app/appboard-find-apps-rankings/id1667492380?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b8/86/4e/b8864eea-7c79-4b57-dc58-4a208fc28863/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Alune: Planner & Assistant` to the Wall of Apps

## Entry

- App ID: 6761420047
- App: Alune: Planner & Assistant
- Link: https://apps.apple.com/us/app/alune-planner-assistant/id6761420047?uo=4

## Notes

- Submitted via `asc apps wall submit` dry-run, completed manually because the CLI still checks the pre-rename upstream owner (`rudrankriyam`) while GitHub reports the canonical parent as `rorkai`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Alune: Planner & Assistant" app entry to the public app directory, including its App Store link and icon URL.
  * Change is a data-only addition; no other directory entries were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->