### PR TITLE
apps wall: add journeybot: trip packing list

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -603,6 +603,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6c/ce/46/6cce46eb-8613-c97d-8913-6888c3d4f1d2/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "journeybot: trip packing list",
+    "link": "https://apps.apple.com/us/app/journeybot-trip-packing-list/id6756543673?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8a/c2/bc/8ac2bcd8-9ddc-da52-cf6a-14990c6e107f/AppIcon-0-1x_U007epad-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Jurni: Trip Planner",
     "link": "https://apps.apple.com/us/app/jurni-trip-planner/id6759559463?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/67/19/a1/6719a179-73ef-1266-5682-bf1c944f98b9/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `journeybot: trip packing list` to the Wall of Apps

## Entry

- App ID: 6756543673
- App: journeybot: trip packing list
- Link: https://apps.apple.com/us/app/journeybot-trip-packing-list/id6756543673?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added journeybot: trip packing list to the app directory with App Store link and icon information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->