### PR TITLE
Add auth config export from keychain

### DIFF
--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -91,6 +91,7 @@ type MigratedCredential struct {
 	KeyID              string `json:"keyId"`
 	PrivateKeyPath     string `json:"privateKeyPath"`
 	ExportedPrivateKey bool   `json:"exportedPrivateKey,omitempty"`
+	keychainName       string
 }
 
 // MigrateKeychainToConfigResult summarizes a keychain-to-config migration.
@@ -400,7 +401,7 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 		if name == "" {
 			continue
 		}
-		privateKeyPath, exported, err := migrationPrivateKeyPath(cred, privateKeyDir)
+		privateKeyPath, exported, err := migrationPrivateKeyPath(cred, privateKeyDir, name)
 		if err != nil {
 			return result, err
 		}
@@ -417,6 +418,7 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 			KeyID:              configCred.KeyID,
 			PrivateKeyPath:     configCred.PrivateKeyPath,
 			ExportedPrivateKey: exported,
+			keychainName:       cred.Name,
 		})
 	}
 	if len(result.Migrated) == 0 {
@@ -431,7 +433,7 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 	if opts.RemoveKeychain {
 		removedAll := true
 		for _, cred := range result.Migrated {
-			if err := removeMigratedKeychainCredential(cred.Name); err != nil {
+			if err := removeMigratedKeychainCredential(cred.keychainName); err != nil {
 				removedAll = false
 				result.Warnings = append(result.Warnings, fmt.Sprintf("failed to remove keychain credential %q: %v", cred.Name, err))
 			}
@@ -445,7 +447,7 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 func resolveMigrationConfigPath(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return config.GlobalPath()
+		return config.Path()
 	}
 	abs, err := filepath.Abs(raw)
 	if err != nil {
@@ -466,7 +468,7 @@ func resolveMigrationPrivateKeyDir(raw, configPath string) (string, error) {
 	return filepath.Clean(abs), nil
 }
 
-func migrationPrivateKeyPath(cred Credential, privateKeyDir string) (string, bool, error) {
+func migrationPrivateKeyPath(cred Credential, privateKeyDir string, configName string) (string, bool, error) {
 	currentPath := strings.TrimSpace(cred.PrivateKeyPath)
 	if currentPath != "" {
 		info, err := os.Stat(currentPath)
@@ -489,14 +491,14 @@ func migrationPrivateKeyPath(cred Credential, privateKeyDir string) (string, boo
 		return "", false, fmt.Errorf("profile %q keychain private key PEM is invalid: %w", cred.Name, err)
 	}
 
-	exportPath := filepath.Join(privateKeyDir, migrationPrivateKeyFilename(cred.Name))
+	exportPath := filepath.Join(privateKeyDir, migrationPrivateKeyFilename(configName, cred.KeyID))
 	if err := writePrivateKeyPEMFile(exportPath, privateKeyPEM); err != nil {
 		return "", false, fmt.Errorf("profile %q failed to export private key: %w", cred.Name, err)
 	}
 	return exportPath, true, nil
 }
 
-func migrationPrivateKeyFilename(name string) string {
+func migrationPrivateKeyFilename(name, keyID string) string {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		name = "default"
@@ -519,6 +521,10 @@ func migrationPrivateKeyFilename(name string) string {
 	safe := strings.Trim(b.String(), "._-")
 	if safe == "" {
 		safe = "default"
+	}
+	keyID = strings.TrimSpace(keyID)
+	if keyID != "" {
+		return "AuthKey_" + safe + "_" + keyID + ".p8"
 	}
 	return "AuthKey_" + safe + ".p8"
 }

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -396,11 +396,21 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 	}
 
 	migratedConfigCreds := make([]config.Credential, 0, len(credentials))
+	seenConfigNames := make(map[string]string, len(credentials))
 	for _, cred := range credentials {
 		name := strings.TrimSpace(cred.Name)
 		if name == "" {
 			continue
 		}
+		if previousKeychainName, exists := seenConfigNames[name]; exists && previousKeychainName != cred.Name {
+			return result, fmt.Errorf(
+				"multiple keychain credentials normalize to config profile %q: %q and %q",
+				name,
+				previousKeychainName,
+				cred.Name,
+			)
+		}
+		seenConfigNames[name] = cred.Name
 		privateKeyPath, exported, err := migrationPrivateKeyPath(cred, privateKeyDir, name)
 		if err != nil {
 			return result, err

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -99,6 +99,7 @@ type MigrateKeychainToConfigResult struct {
 	PrivateKeyDir       string               `json:"privateKeyDir,omitempty"`
 	Migrated            []MigratedCredential `json:"migrated"`
 	RemovedFromKeychain bool                 `json:"removedFromKeychain"`
+	Warnings            []string             `json:"warnings,omitempty"`
 }
 
 type credentialPayload struct {
@@ -428,12 +429,14 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 	}
 
 	if opts.RemoveKeychain {
+		removedAll := true
 		for _, cred := range result.Migrated {
 			if err := removeMigratedKeychainCredential(cred.Name); err != nil {
-				return result, err
+				removedAll = false
+				result.Warnings = append(result.Warnings, fmt.Sprintf("failed to remove keychain credential %q: %v", cred.Name, err))
 			}
 		}
-		result.RemovedFromKeychain = true
+		result.RemovedFromKeychain = removedAll
 	}
 
 	return result, nil
@@ -571,7 +574,14 @@ func upsertConfigCredential(cfg *config.Config, cred config.Credential) {
 }
 
 func applyMigratedDefault(cfg *config.Config, sourceCreds []Credential, migratedCreds []config.Credential) {
-	defaultName := ""
+	destinationDefaultName := strings.TrimSpace(cfg.DefaultKeyName)
+	if destinationDefaultName != "" {
+		if alignDefaultCredentialFields(cfg, destinationDefaultName) {
+			return
+		}
+	}
+
+	defaultName := destinationDefaultName
 	for _, cred := range sourceCreds {
 		if cred.IsDefault {
 			defaultName = strings.TrimSpace(cred.Name)
@@ -582,12 +592,12 @@ func applyMigratedDefault(cfg *config.Config, sourceCreds []Credential, migrated
 		defaultName = migratedCreds[0].Name
 	}
 	if defaultName == "" {
-		defaultName = strings.TrimSpace(cfg.DefaultKeyName)
-	}
-	if defaultName == "" {
 		return
 	}
 	cfg.DefaultKeyName = defaultName
+	if alignDefaultCredentialFields(cfg, defaultName) {
+		return
+	}
 	for _, cred := range migratedCreds {
 		if cred.Name == defaultName {
 			cfg.KeyID = cred.KeyID
@@ -598,10 +608,21 @@ func applyMigratedDefault(cfg *config.Config, sourceCreds []Credential, migrated
 	}
 }
 
+func alignDefaultCredentialFields(cfg *config.Config, defaultName string) bool {
+	cred, found, complete := findConfigCredential(cfg, defaultName)
+	if !found || !complete {
+		return false
+	}
+	cfg.DefaultKeyName = strings.TrimSpace(cred.Name)
+	cfg.KeyID = cred.KeyID
+	cfg.IssuerID = cred.IssuerID
+	cfg.PrivateKeyPath = cred.PrivateKeyPath
+	return true
+}
+
 func removeMigratedKeychainCredential(name string) error {
 	if err := removeFromKeychain(name); err != nil &&
-		!errors.Is(err, keyring.ErrKeyNotFound) &&
-		!isKeyringUnavailable(err) {
+		!errors.Is(err, keyring.ErrKeyNotFound) {
 		return err
 	}
 	if err := removeFromLegacyKeychain(name); err != nil &&

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -78,6 +78,29 @@ type Credentials struct {
 	Keys       []Credential `json:"keys"`
 }
 
+// MigrateKeychainToConfigOptions controls keychain-to-config migration.
+type MigrateKeychainToConfigOptions struct {
+	ConfigPath     string
+	PrivateKeyDir  string
+	RemoveKeychain bool
+}
+
+// MigratedCredential reports one profile copied into config.json.
+type MigratedCredential struct {
+	Name               string `json:"name"`
+	KeyID              string `json:"keyId"`
+	PrivateKeyPath     string `json:"privateKeyPath"`
+	ExportedPrivateKey bool   `json:"exportedPrivateKey,omitempty"`
+}
+
+// MigrateKeychainToConfigResult summarizes a keychain-to-config migration.
+type MigrateKeychainToConfigResult struct {
+	ConfigPath          string               `json:"configPath"`
+	PrivateKeyDir       string               `json:"privateKeyDir,omitempty"`
+	Migrated            []MigratedCredential `json:"migrated"`
+	RemovedFromKeychain bool                 `json:"removedFromKeychain"`
+}
+
 type credentialPayload struct {
 	KeyID          string `json:"key_id"`
 	IssuerID       string `json:"issuer_id"`
@@ -330,6 +353,263 @@ func StoreCredentialsConfigAt(name, keyID, issuerID, keyPath, configPath string)
 		PrivateKeyPath: keyPath,
 	}
 	return storeInConfigAt(name, payload, configPath)
+}
+
+// MigrateKeychainToConfig copies keychain-backed credentials into config.json.
+//
+// If a keychain entry contains embedded PEM data and its original private key
+// path is missing, the PEM is exported to a secure .p8 file and config.json is
+// updated to reference that file.
+func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeychainToConfigResult, error) {
+	configPath, err := resolveMigrationConfigPath(opts.ConfigPath)
+	if err != nil {
+		return MigrateKeychainToConfigResult{}, err
+	}
+	privateKeyDir, err := resolveMigrationPrivateKeyDir(opts.PrivateKeyDir, configPath)
+	if err != nil {
+		return MigrateKeychainToConfigResult{}, err
+	}
+	result := MigrateKeychainToConfigResult{
+		ConfigPath:    configPath,
+		PrivateKeyDir: privateKeyDir,
+	}
+
+	credentials, err := listFromKeychain()
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return result, fmt.Errorf("keychain unavailable: %w", err)
+		}
+		return result, err
+	}
+	if len(credentials) == 0 {
+		return result, fmt.Errorf("no keychain credentials found")
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
+		return result, err
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	migratedConfigCreds := make([]config.Credential, 0, len(credentials))
+	for _, cred := range credentials {
+		name := strings.TrimSpace(cred.Name)
+		if name == "" {
+			continue
+		}
+		privateKeyPath, exported, err := migrationPrivateKeyPath(cred, privateKeyDir)
+		if err != nil {
+			return result, err
+		}
+		configCred := config.Credential{
+			Name:           name,
+			KeyID:          strings.TrimSpace(cred.KeyID),
+			IssuerID:       strings.TrimSpace(cred.IssuerID),
+			PrivateKeyPath: privateKeyPath,
+		}
+		upsertConfigCredential(cfg, configCred)
+		migratedConfigCreds = append(migratedConfigCreds, configCred)
+		result.Migrated = append(result.Migrated, MigratedCredential{
+			Name:               configCred.Name,
+			KeyID:              configCred.KeyID,
+			PrivateKeyPath:     configCred.PrivateKeyPath,
+			ExportedPrivateKey: exported,
+		})
+	}
+	if len(result.Migrated) == 0 {
+		return result, fmt.Errorf("no named keychain credentials found")
+	}
+
+	applyMigratedDefault(cfg, credentials, migratedConfigCreds)
+	if err := config.SaveAt(configPath, cfg); err != nil {
+		return result, err
+	}
+
+	if opts.RemoveKeychain {
+		for _, cred := range result.Migrated {
+			if err := removeMigratedKeychainCredential(cred.Name); err != nil {
+				return result, err
+			}
+		}
+		result.RemovedFromKeychain = true
+	}
+
+	return result, nil
+}
+
+func resolveMigrationConfigPath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return config.GlobalPath()
+	}
+	abs, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid config path: %w", err)
+	}
+	return filepath.Clean(abs), nil
+}
+
+func resolveMigrationPrivateKeyDir(raw, configPath string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = filepath.Join(filepath.Dir(configPath), "keys")
+	}
+	abs, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid private key directory: %w", err)
+	}
+	return filepath.Clean(abs), nil
+}
+
+func migrationPrivateKeyPath(cred Credential, privateKeyDir string) (string, bool, error) {
+	currentPath := strings.TrimSpace(cred.PrivateKeyPath)
+	if currentPath != "" {
+		info, err := os.Stat(currentPath)
+		if err == nil {
+			if info.IsDir() {
+				return "", false, fmt.Errorf("profile %q private key path is a directory: %s", cred.Name, currentPath)
+			}
+			return currentPath, false, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", false, fmt.Errorf("profile %q private key file could not be read: %w", cred.Name, err)
+		}
+	}
+
+	privateKeyPEM := cred.PrivateKeyPEM
+	if strings.TrimSpace(privateKeyPEM) == "" {
+		return "", false, fmt.Errorf("profile %q private key file is missing and keychain entry does not contain embedded private key PEM", cred.Name)
+	}
+	if _, err := LoadPrivateKeyFromPEM([]byte(privateKeyPEM)); err != nil {
+		return "", false, fmt.Errorf("profile %q keychain private key PEM is invalid: %w", cred.Name, err)
+	}
+
+	exportPath := filepath.Join(privateKeyDir, migrationPrivateKeyFilename(cred.Name))
+	if err := writePrivateKeyPEMFile(exportPath, privateKeyPEM); err != nil {
+		return "", false, fmt.Errorf("profile %q failed to export private key: %w", cred.Name, err)
+	}
+	return exportPath, true, nil
+}
+
+func migrationPrivateKeyFilename(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "default"
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	safe := strings.Trim(b.String(), "._-")
+	if safe == "" {
+		safe = "default"
+	}
+	return "AuthKey_" + safe + ".p8"
+}
+
+func writePrivateKeyPEMFile(path, privateKeyPEM string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("empty private key path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink: %s", path)
+		}
+		existing, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.TrimSpace(string(existing)) != strings.TrimSpace(privateKeyPEM) {
+			return fmt.Errorf("refusing to overwrite existing private key file: %s", path)
+		}
+		if filePermissionsTooPermissive(info.Mode()) {
+			if err := os.Chmod(path, 0o600); err != nil {
+				return err
+			}
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.WriteString(privateKeyPEM)
+	closeErr := file.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
+}
+
+func upsertConfigCredential(cfg *config.Config, cred config.Credential) {
+	for i := range cfg.Keys {
+		if strings.TrimSpace(cfg.Keys[i].Name) == cred.Name {
+			cfg.Keys[i] = cred
+			return
+		}
+	}
+	cfg.Keys = append(cfg.Keys, cred)
+}
+
+func applyMigratedDefault(cfg *config.Config, sourceCreds []Credential, migratedCreds []config.Credential) {
+	defaultName := ""
+	for _, cred := range sourceCreds {
+		if cred.IsDefault {
+			defaultName = strings.TrimSpace(cred.Name)
+			break
+		}
+	}
+	if defaultName == "" && len(migratedCreds) == 1 {
+		defaultName = migratedCreds[0].Name
+	}
+	if defaultName == "" {
+		defaultName = strings.TrimSpace(cfg.DefaultKeyName)
+	}
+	if defaultName == "" {
+		return
+	}
+	cfg.DefaultKeyName = defaultName
+	for _, cred := range migratedCreds {
+		if cred.Name == defaultName {
+			cfg.KeyID = cred.KeyID
+			cfg.IssuerID = cred.IssuerID
+			cfg.PrivateKeyPath = cred.PrivateKeyPath
+			return
+		}
+	}
+}
+
+func removeMigratedKeychainCredential(name string) error {
+	if err := removeFromKeychain(name); err != nil &&
+		!errors.Is(err, keyring.ErrKeyNotFound) &&
+		!isKeyringUnavailable(err) {
+		return err
+	}
+	if err := removeFromLegacyKeychain(name); err != nil &&
+		!errors.Is(err, keyring.ErrKeyNotFound) &&
+		!isKeyringUnavailable(err) {
+		return err
+	}
+	return nil
 }
 
 // clearConfigCredentials clears credentials from the config file.

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1196,6 +1196,100 @@ func TestMigrateKeychainToConfigCanRemoveMigratedKeychainEntries(t *testing.T) {
 	}
 }
 
+func TestMigrateKeychainToConfigPreservesDestinationDefault(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	activeConfigPath := os.Getenv("ASC_CONFIG_PATH")
+	if activeConfigPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+	if err := config.SaveAt(activeConfigPath, &config.Config{DefaultKeyName: "alpha"}); err != nil {
+		t.Fatalf("config.SaveAt(active) error: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "alpha", "KEY_ALPHA", "ISS_ALPHA", keyPath)
+	storeCredentialInKeyring(t, newKr, "beta", "KEY_BETA", "ISS_BETA", keyPath)
+
+	destinationPath := filepath.Join(t.TempDir(), "custom-config.json")
+	if err := config.SaveAt(destinationPath, &config.Config{DefaultKeyName: "beta"}); err != nil {
+		t.Fatalf("config.SaveAt(destination) error: %v", err)
+	}
+
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath: destinationPath,
+	})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if len(result.Migrated) != 2 {
+		t.Fatalf("expected two migrated credentials, got %#v", result.Migrated)
+	}
+
+	cfg, err := config.LoadAt(destinationPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt(destination) error: %v", err)
+	}
+	if cfg.DefaultKeyName != "beta" {
+		t.Fatalf("DefaultKeyName = %q, want beta", cfg.DefaultKeyName)
+	}
+	if cfg.KeyID != "KEY_BETA" || cfg.IssuerID != "ISS_BETA" || cfg.PrivateKeyPath != keyPath {
+		t.Fatalf("expected top-level fields to align with destination default beta, got %+v", cfg)
+	}
+}
+
+func TestMigrateKeychainToConfigWarnsWhenKeychainRemovalFails(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "0")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	previousKeyringOpener := keyringOpener
+	previousLegacyKeyringOpener := legacyKeyringOpener
+	inner := keyring.NewArrayKeyring([]keyring.Item{})
+	kr := &removeFailingKeyring{
+		inner: inner,
+		err:   errors.New("remove denied"),
+	}
+	keyringOpener = func() (keyring.Keyring, error) {
+		return kr, nil
+	}
+	legacyKeyringOpener = func() (keyring.Keyring, error) {
+		return nil, keyring.ErrNoAvailImpl
+	}
+	t.Cleanup(func() {
+		keyringOpener = previousKeyringOpener
+		legacyKeyringOpener = previousLegacyKeyringOpener
+	})
+
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	storeCredentialInKeyring(t, inner, "demo", "KEY123", "ISS456", keyPath)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath:     configPath,
+		RemoveKeychain: true,
+	})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if result.RemovedFromKeychain {
+		t.Fatalf("expected RemovedFromKeychain=false when removal fails, got %#v", result)
+	}
+	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "remove denied") {
+		t.Fatalf("expected removal warning, got %#v", result.Warnings)
+	}
+	if _, err := inner.Get(keyringKey("demo")); err != nil {
+		t.Fatalf("expected keychain entry to remain after removal failure, got %v", err)
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "demo" {
+		t.Fatalf("expected config migration to remain successful, got %#v", cfg.Keys)
+	}
+}
+
 func TestRemoveAllCredentials(t *testing.T) {
 	withArrayKeyring(t)
 
@@ -1717,6 +1811,19 @@ func (k *countingKeyring) Set(item keyring.Item) error {
 }
 func (k *countingKeyring) Remove(key string) error { return k.inner.Remove(key) }
 func (k *countingKeyring) Keys() ([]string, error) { return k.inner.Keys() }
+
+type removeFailingKeyring struct {
+	inner keyring.Keyring
+	err   error
+}
+
+func (k *removeFailingKeyring) Get(key string) (keyring.Item, error) { return k.inner.Get(key) }
+func (k *removeFailingKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	return k.inner.GetMetadata(key)
+}
+func (k *removeFailingKeyring) Set(item keyring.Item) error { return k.inner.Set(item) }
+func (k *removeFailingKeyring) Remove(string) error         { return k.err }
+func (k *removeFailingKeyring) Keys() ([]string, error)     { return k.inner.Keys() }
 
 func TestGetCredentialsWithSource_KeychainAccessDeniedReturnsSentinel(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1141,6 +1141,100 @@ func TestMigrateKeychainToConfigExportsMissingPrivateKeyPEM(t *testing.T) {
 	}
 }
 
+func TestMigrateKeychainToConfigDefaultsToActiveConfigPath(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "demo", "KEY123", "ISS456", keyPath)
+
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if result.ConfigPath != configPath {
+		t.Fatalf("ConfigPath = %q, want active config path %q", result.ConfigPath, configPath)
+	}
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt(active) error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "demo" {
+		t.Fatalf("expected migrated credential in active config, got %#v", cfg.Keys)
+	}
+}
+
+func TestMigrateKeychainToConfigExportsCollidingProfileNames(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	sourceKeyPath := filepath.Join(t.TempDir(), "AuthKey-source.p8")
+	writeECDSAPEM(t, sourceKeyPath, 0o600, true)
+	privateKeyPEM, err := os.ReadFile(sourceKeyPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error: %v", sourceKeyPath, err)
+	}
+
+	for _, profile := range []struct {
+		name  string
+		keyID string
+	}{
+		{name: "prod", keyID: "KEY123"},
+		{name: "prod.", keyID: "KEY456"},
+	} {
+		item, err := keyringItemForCredential(profile.name, credentialPayload{
+			KeyID:          profile.keyID,
+			IssuerID:       "ISS456",
+			PrivateKeyPath: filepath.Join(t.TempDir(), profile.name, "missing.p8"),
+			PrivateKeyPEM:  string(privateKeyPEM),
+		})
+		if err != nil {
+			t.Fatalf("keyringItemForCredential(%q) error: %v", profile.name, err)
+		}
+		if err := newKr.Set(item); err != nil {
+			t.Fatalf("keyring Set(%q) error: %v", profile.name, err)
+		}
+	}
+
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if len(result.Migrated) != 2 {
+		t.Fatalf("expected two migrated credentials, got %#v", result.Migrated)
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if len(cfg.Keys) != 2 {
+		t.Fatalf("expected two config credentials, got %#v", cfg.Keys)
+	}
+	seen := map[string]struct{}{}
+	for _, cred := range cfg.Keys {
+		if cred.PrivateKeyPath == "" {
+			t.Fatalf("expected exported key path for %#v", cred)
+		}
+		if _, ok := seen[cred.PrivateKeyPath]; ok {
+			t.Fatalf("expected unique exported key path, got duplicate %q", cred.PrivateKeyPath)
+		}
+		seen[cred.PrivateKeyPath] = struct{}{}
+		if _, err := os.Stat(cred.PrivateKeyPath); err != nil {
+			t.Fatalf("expected exported key %q to exist: %v", cred.PrivateKeyPath, err)
+		}
+	}
+}
+
 func TestMigrateKeychainToConfigFailsWhenKeyMaterialIsMissing(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 	configPath := os.Getenv("ASC_CONFIG_PATH")
@@ -1193,6 +1287,43 @@ func TestMigrateKeychainToConfigCanRemoveMigratedKeychainEntries(t *testing.T) {
 	}
 	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "demo" {
 		t.Fatalf("expected migrated config credential, got %#v", cfg.Keys)
+	}
+}
+
+func TestMigrateKeychainToConfigRemovesOriginalSpacedKeychainName(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, " demo ", "KEY123", "ISS456", keyPath)
+
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath:     configPath,
+		RemoveKeychain: true,
+	})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if !result.RemovedFromKeychain {
+		t.Fatalf("expected result to report keychain removal, got %#v", result)
+	}
+	if len(result.Migrated) != 1 || result.Migrated[0].Name != "demo" {
+		t.Fatalf("expected trimmed config profile name, got %#v", result.Migrated)
+	}
+	if _, err := newKr.Get(keyringKey(" demo ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("expected original spaced keychain entry to be removed, got %v", err)
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "demo" {
+		t.Fatalf("expected trimmed migrated config credential, got %#v", cfg.Keys)
 	}
 }
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1327,6 +1327,39 @@ func TestMigrateKeychainToConfigRemovesOriginalSpacedKeychainName(t *testing.T) 
 	}
 }
 
+func TestMigrateKeychainToConfigRejectsTrimmedNameCollisions(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "demo", "KEY123", "ISS456", keyPath)
+	storeCredentialInKeyring(t, newKr, " demo ", "KEY456", "ISS789", keyPath)
+
+	_, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath:     configPath,
+		RemoveKeychain: true,
+	})
+	if err == nil {
+		t.Fatal("expected trimmed name collision error")
+	}
+	if !strings.Contains(err.Error(), `normalize to config profile "demo"`) {
+		t.Fatalf("expected trimmed name collision error, got %v", err)
+	}
+	if _, err := config.LoadAt(configPath); !errors.Is(err, config.ErrNotFound) {
+		t.Fatalf("expected config to remain unwritten, got %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("demo")); err != nil {
+		t.Fatalf("expected original demo keychain entry to remain, got %v", err)
+	}
+	if _, err := newKr.Get(keyringKey(" demo ")); err != nil {
+		t.Fatalf("expected original spaced keychain entry to remain, got %v", err)
+	}
+}
+
 func TestMigrateKeychainToConfigPreservesDestinationDefault(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 	activeConfigPath := os.Getenv("ASC_CONFIG_PATH")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1066,6 +1066,136 @@ func TestGetCredentialsWithSource_BackfillsLegacyPEMOnlyOnce(t *testing.T) {
 	}
 }
 
+func TestMigrateKeychainToConfigExportsMissingPrivateKeyPEM(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	sourceKeyPath := filepath.Join(t.TempDir(), "AuthKey-source.p8")
+	writeECDSAPEM(t, sourceKeyPath, 0o600, true)
+	privateKeyPEM, err := os.ReadFile(sourceKeyPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error: %v", sourceKeyPath, err)
+	}
+
+	missingKeyPath := filepath.Join(t.TempDir(), "missing", "AuthKey.p8")
+	payload := credentialPayload{
+		KeyID:          "KEY123",
+		IssuerID:       "ISS456",
+		PrivateKeyPath: missingKeyPath,
+		PrivateKeyPEM:  string(privateKeyPEM),
+	}
+	item, err := keyringItemForCredential("demo profile", payload)
+	if err != nil {
+		t.Fatalf("keyringItemForCredential() error: %v", err)
+	}
+	if err := newKr.Set(item); err != nil {
+		t.Fatalf("keyring Set() error: %v", err)
+	}
+
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if result.ConfigPath != configPath {
+		t.Fatalf("ConfigPath = %q, want %q", result.ConfigPath, configPath)
+	}
+	if len(result.Migrated) != 1 {
+		t.Fatalf("expected one migrated credential, got %#v", result.Migrated)
+	}
+	if !result.Migrated[0].ExportedPrivateKey {
+		t.Fatalf("expected exported private key flag, got %#v", result.Migrated[0])
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if cfg.DefaultKeyName != "demo profile" {
+		t.Fatalf("DefaultKeyName = %q, want demo profile", cfg.DefaultKeyName)
+	}
+	if len(cfg.Keys) != 1 {
+		t.Fatalf("expected one config credential, got %#v", cfg.Keys)
+	}
+	exportedPath := cfg.Keys[0].PrivateKeyPath
+	if exportedPath == "" || exportedPath == missingKeyPath {
+		t.Fatalf("expected migrated config to point at exported key, got %q", exportedPath)
+	}
+	exportedPEM, err := os.ReadFile(exportedPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(exported key) error: %v", err)
+	}
+	if string(exportedPEM) != string(privateKeyPEM) {
+		t.Fatal("exported private key PEM did not match keychain PEM")
+	}
+	info, err := os.Stat(exportedPath)
+	if err != nil {
+		t.Fatalf("os.Stat(exported key) error: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected exported key permissions 0600, got %#o", got)
+	}
+}
+
+func TestMigrateKeychainToConfigFailsWhenKeyMaterialIsMissing(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	missingKeyPath := filepath.Join(t.TempDir(), "missing", "AuthKey.p8")
+	storeCredentialInKeyring(t, newKr, "demo", "KEY123", "ISS456", missingKeyPath)
+
+	_, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("expected missing key material error")
+	}
+	if !strings.Contains(err.Error(), "private key file is missing") {
+		t.Fatalf("expected missing private key error, got %v", err)
+	}
+}
+
+func TestMigrateKeychainToConfigCanRemoveMigratedKeychainEntries(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	configPath := os.Getenv("ASC_CONFIG_PATH")
+	if configPath == "" {
+		t.Fatal("expected ASC_CONFIG_PATH to be set")
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "demo", "KEY123", "ISS456", keyPath)
+
+	result, err := MigrateKeychainToConfig(MigrateKeychainToConfigOptions{
+		ConfigPath:     configPath,
+		RemoveKeychain: true,
+	})
+	if err != nil {
+		t.Fatalf("MigrateKeychainToConfig() error: %v", err)
+	}
+	if !result.RemovedFromKeychain {
+		t.Fatalf("expected result to report keychain removal, got %#v", result)
+	}
+	if _, err := newKr.Get(keyringKey("demo")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("expected migrated keychain entry to be removed, got %v", err)
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "demo" {
+		t.Fatalf("expected migrated config credential, got %#v", cfg.Keys)
+	}
+}
+
 func TestRemoveAllCredentials(t *testing.T) {
 	withArrayKeyring(t)
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -25,6 +26,7 @@ var (
 	statusValidateCredential = validateStoredCredential
 	listStoredCredentials    = authsvc.ListCredentials
 	listCredentialSummaries  = authsvc.ListCredentialSummaries
+	migrateKeychainToConfig  = authsvc.MigrateKeychainToConfig
 )
 
 // Auth command factory
@@ -55,12 +57,14 @@ Use "asc auth status" to see which credentials/profile are currently active.
 Examples:
   asc auth status
   asc auth status --verbose
-  asc auth switch --name work`,
+  asc auth switch --name work
+  asc auth migrate-to-config --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			AuthInitCommand(),
 			AuthLoginCommand(),
+			AuthMigrateToConfigCommand(),
 			AuthSwitchCommand(),
 			AuthLogoutCommand(),
 			AuthDoctorCommand(),
@@ -526,6 +530,132 @@ so commands continue to work even if the original .p8 file is removed.`,
 			return nil
 		},
 	}
+}
+
+// AuthMigrateToConfigCommand copies keychain-backed credentials to config.json.
+func AuthMigrateToConfigCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("auth migrate-to-config", flag.ExitOnError)
+
+	confirm := fs.Bool("confirm", false, "Confirm writing keychain credentials to config.json")
+	local := fs.Bool("local", false, "Write credentials to ./.asc/config.json in the current repo")
+	configPath := fs.String("config", "", "Write credentials to this config.json path")
+	privateKeyDir := fs.String("private-key-dir", "", "Directory for exported .p8 files when original key files are missing")
+	removeKeychain := fs.Bool("remove-keychain", false, "Remove migrated credentials from keychain after config.json is written")
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "table", "Output format: table, json", "table", "json")
+
+	return &ffcli.Command{
+		Name:       "migrate-to-config",
+		ShortUsage: "asc auth migrate-to-config --confirm [flags]",
+		ShortHelp:  "Copy keychain credentials into config.json.",
+		LongHelp: `Copy keychain credentials into config.json.
+
+This helps move from system keychain storage to JSON config storage. Credentials
+are written to ~/.asc/config.json by default, or to ./.asc/config.json with
+--local. If a keychain entry has embedded private key material and the original
+.p8 file is missing, the key is exported as a secure .p8 file and config.json
+references that exported file.
+
+Use --remove-keychain to delete migrated keychain entries after config.json is
+written successfully. Otherwise keychain entries are left in place.
+
+Examples:
+  asc auth migrate-to-config --confirm
+  asc auth migrate-to-config --confirm --local
+  asc auth migrate-to-config --confirm --private-key-dir ~/.asc/keys
+  asc auth migrate-to-config --confirm --remove-keychain
+  asc auth migrate-to-config --confirm --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			normalizedOutput, err := shared.ValidateOutputFormatAllowed(*output.Output, *output.Pretty, "table", "json")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if !*confirm {
+				return shared.UsageError("--confirm is required")
+			}
+			if strings.TrimSpace(*privateKeyDir) == "" && *privateKeyDir != "" {
+				return shared.UsageError("--private-key-dir cannot be blank")
+			}
+			if strings.TrimSpace(*configPath) == "" && *configPath != "" {
+				return shared.UsageError("--config cannot be blank")
+			}
+			if *local && strings.TrimSpace(*configPath) != "" {
+				return shared.UsageError("--local and --config are mutually exclusive")
+			}
+
+			targetConfigPath := strings.TrimSpace(*configPath)
+			if targetConfigPath == "" {
+				if *local {
+					targetConfigPath, err = config.LocalPath()
+				} else {
+					targetConfigPath, err = config.GlobalPath()
+				}
+				if err != nil {
+					return fmt.Errorf("auth migrate-to-config: %w", err)
+				}
+			} else {
+				targetConfigPath, err = filepath.Abs(targetConfigPath)
+				if err != nil {
+					return fmt.Errorf("auth migrate-to-config: invalid --config: %w", err)
+				}
+			}
+
+			result, err := migrateKeychainToConfig(authsvc.MigrateKeychainToConfigOptions{
+				ConfigPath:     targetConfigPath,
+				PrivateKeyDir:  strings.TrimSpace(*privateKeyDir),
+				RemoveKeychain: *removeKeychain,
+			})
+			if err != nil {
+				return fmt.Errorf("auth migrate-to-config: %w", err)
+			}
+
+			if normalizedOutput == "json" {
+				return shared.PrintOutput(result, "json", *output.Pretty)
+			}
+			printMigrateToConfigResult(result)
+			return nil
+		},
+	}
+}
+
+func printMigrateToConfigResult(result authsvc.MigrateKeychainToConfigResult) {
+	fmt.Printf("Migrated %d credential(s) to %s\n", len(result.Migrated), result.ConfigPath)
+	if strings.TrimSpace(result.PrivateKeyDir) != "" {
+		fmt.Printf("Private key directory: %s\n", result.PrivateKeyDir)
+	}
+	if len(result.Migrated) > 0 {
+		fmt.Println()
+		asc.RenderTable(
+			[]string{"Name", "Key ID", "Private Key", "Exported"},
+			buildMigrateToConfigRows(result.Migrated),
+		)
+	}
+	if result.RemovedFromKeychain {
+		fmt.Println("\nRemoved migrated credentials from keychain.")
+	} else {
+		fmt.Println("\nKeychain entries were left unchanged. Set ASC_BYPASS_KEYCHAIN=1 to prefer config.json.")
+	}
+}
+
+func buildMigrateToConfigRows(credentials []authsvc.MigratedCredential) [][]string {
+	rows := make([][]string, 0, len(credentials))
+	for _, cred := range credentials {
+		exported := "no"
+		if cred.ExportedPrivateKey {
+			exported = "yes"
+		}
+		rows = append(rows, []string{
+			cred.Name,
+			cred.KeyID,
+			cred.PrivateKeyPath,
+			exported,
+		})
+	}
+	return rows
 }
 
 // AuthSwitch command factory

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -58,13 +58,13 @@ Examples:
   asc auth status
   asc auth status --verbose
   asc auth switch --name work
-  asc auth migrate-to-config --confirm`,
+  asc auth export-to-config --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			AuthInitCommand(),
 			AuthLoginCommand(),
-			AuthMigrateToConfigCommand(),
+			AuthExportToConfigCommand(),
 			AuthSwitchCommand(),
 			AuthLogoutCommand(),
 			AuthDoctorCommand(),
@@ -532,9 +532,9 @@ so commands continue to work even if the original .p8 file is removed.`,
 	}
 }
 
-// AuthMigrateToConfigCommand copies keychain-backed credentials to config.json.
-func AuthMigrateToConfigCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("auth migrate-to-config", flag.ExitOnError)
+// AuthExportToConfigCommand copies keychain-backed credentials to config.json.
+func AuthExportToConfigCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("auth export-to-config", flag.ExitOnError)
 
 	confirm := fs.Bool("confirm", false, "Confirm writing keychain credentials to config.json")
 	local := fs.Bool("local", false, "Write credentials to ./.asc/config.json in the current repo")
@@ -544,8 +544,8 @@ func AuthMigrateToConfigCommand() *ffcli.Command {
 	output := shared.BindOutputFlagsWithAllowed(fs, "output", "table", "Output format: table, json", "table", "json")
 
 	return &ffcli.Command{
-		Name:       "migrate-to-config",
-		ShortUsage: "asc auth migrate-to-config --confirm [flags]",
+		Name:       "export-to-config",
+		ShortUsage: "asc auth export-to-config --confirm [flags]",
 		ShortHelp:  "Copy keychain credentials into config.json.",
 		LongHelp: `Copy keychain credentials into config.json.
 
@@ -559,11 +559,11 @@ Use --remove-keychain to delete migrated keychain entries after config.json is
 written successfully. Otherwise keychain entries are left in place.
 
 Examples:
-  asc auth migrate-to-config --confirm
-  asc auth migrate-to-config --confirm --local
-  asc auth migrate-to-config --confirm --private-key-dir ~/.asc/keys
-  asc auth migrate-to-config --confirm --remove-keychain
-  asc auth migrate-to-config --confirm --output json`,
+  asc auth export-to-config --confirm
+  asc auth export-to-config --confirm --local
+  asc auth export-to-config --confirm --private-key-dir ~/.asc/keys
+  asc auth export-to-config --confirm --remove-keychain
+  asc auth export-to-config --confirm --output json`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -592,15 +592,15 @@ Examples:
 				if *local {
 					targetConfigPath, err = config.LocalPath()
 				} else {
-					targetConfigPath, err = config.GlobalPath()
+					targetConfigPath, err = config.Path()
 				}
 				if err != nil {
-					return fmt.Errorf("auth migrate-to-config: %w", err)
+					return fmt.Errorf("auth export-to-config: %w", err)
 				}
 			} else {
 				targetConfigPath, err = filepath.Abs(targetConfigPath)
 				if err != nil {
-					return fmt.Errorf("auth migrate-to-config: invalid --config: %w", err)
+					return fmt.Errorf("auth export-to-config: invalid --config: %w", err)
 				}
 			}
 
@@ -610,7 +610,7 @@ Examples:
 				RemoveKeychain: *removeKeychain,
 			})
 			if err != nil {
-				return fmt.Errorf("auth migrate-to-config: %w", err)
+				return fmt.Errorf("auth export-to-config: %w", err)
 			}
 
 			if normalizedOutput == "json" {

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -636,8 +636,13 @@ func printMigrateToConfigResult(result authsvc.MigrateKeychainToConfigResult) {
 	}
 	if result.RemovedFromKeychain {
 		fmt.Println("\nRemoved migrated credentials from keychain.")
+	} else if len(result.Warnings) > 0 {
+		fmt.Println("\nKeychain cleanup incomplete; inspect warnings below.")
 	} else {
 		fmt.Println("\nKeychain entries were left unchanged. Set ASC_BYPASS_KEYCHAIN=1 to prefer config.json.")
+	}
+	for _, warning := range result.Warnings {
+		fmt.Printf("Warning: %s\n", warning)
 	}
 }
 

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -658,9 +658,9 @@ func TestAuthLogoutCommand(t *testing.T) {
 	})
 }
 
-func TestAuthMigrateToConfigCommand(t *testing.T) {
+func TestAuthExportToConfigCommand(t *testing.T) {
 	t.Run("requires confirm", func(t *testing.T) {
-		cmd := AuthMigrateToConfigCommand()
+		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
@@ -676,7 +676,7 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 	})
 
 	t.Run("invalid output format", func(t *testing.T) {
-		cmd := AuthMigrateToConfigCommand()
+		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{"--confirm", "--output", "yaml"}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
@@ -692,7 +692,7 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 	})
 
 	t.Run("blank private key dir", func(t *testing.T) {
-		cmd := AuthMigrateToConfigCommand()
+		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{"--confirm", "--private-key-dir", "   "}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
@@ -708,7 +708,7 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 	})
 
 	t.Run("blank config path", func(t *testing.T) {
-		cmd := AuthMigrateToConfigCommand()
+		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{"--confirm", "--config", "   "}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
@@ -724,7 +724,7 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 	})
 
 	t.Run("local and config are mutually exclusive", func(t *testing.T) {
-		cmd := AuthMigrateToConfigCommand()
+		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{"--confirm", "--local", "--config", filepath.Join(t.TempDir(), "config.json")}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
@@ -753,7 +753,7 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 			})
 			t.Cleanup(restore)
 
-			cmd := AuthMigrateToConfigCommand()
+			cmd := AuthExportToConfigCommand()
 			if err := cmd.FlagSet.Parse([]string{"--confirm", "--local"}); err != nil {
 				t.Fatalf("Parse() error: %v", err)
 			}
@@ -769,6 +769,33 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 				t.Fatalf("captured ConfigPath = %q, want %q", captured.ConfigPath, expected)
 			}
 		})
+	})
+
+	t.Run("default resolves active config path", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "active-config.json")
+		t.Setenv("ASC_CONFIG_PATH", configPath)
+		var captured authsvc.MigrateKeychainToConfigOptions
+		restore := SetMigrateKeychainToConfig(func(opts authsvc.MigrateKeychainToConfigOptions) (authsvc.MigrateKeychainToConfigResult, error) {
+			captured = opts
+			return authsvc.MigrateKeychainToConfigResult{
+				ConfigPath: opts.ConfigPath,
+				Migrated: []authsvc.MigratedCredential{
+					{Name: "demo", KeyID: "KEY123", PrivateKeyPath: "/tmp/AuthKey.p8"},
+				},
+			}, nil
+		})
+		t.Cleanup(restore)
+
+		cmd := AuthExportToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{"--confirm"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		if err := cmd.Exec(context.Background(), []string{}); err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+		if captured.ConfigPath != configPath {
+			t.Fatalf("captured ConfigPath = %q, want active config path %q", captured.ConfigPath, configPath)
+		}
 	})
 
 	t.Run("json success", func(t *testing.T) {
@@ -792,7 +819,7 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 		})
 		t.Cleanup(restore)
 
-		cmd := AuthMigrateToConfigCommand()
+		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{
 			"--confirm",
 			"--output", "json",

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -760,7 +760,11 @@ func TestAuthMigrateToConfigCommand(t *testing.T) {
 			if err := cmd.Exec(context.Background(), []string{}); err != nil {
 				t.Fatalf("Exec() error: %v", err)
 			}
-			expected := filepath.Join(repo, ".asc", "config.json")
+			expectedRepo := repo
+			if resolvedRepo, err := filepath.EvalSymlinks(repo); err == nil {
+				expectedRepo = resolvedRepo
+			}
+			expected := filepath.Join(expectedRepo, ".asc", "config.json")
 			if captured.ConfigPath != expected {
 				t.Fatalf("captured ConfigPath = %q, want %q", captured.ConfigPath, expected)
 			}

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -658,6 +658,185 @@ func TestAuthLogoutCommand(t *testing.T) {
 	})
 }
 
+func TestAuthMigrateToConfigCommand(t *testing.T) {
+	t.Run("requires confirm", func(t *testing.T) {
+		cmd := AuthMigrateToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "--confirm is required") {
+			t.Fatalf("expected confirm error in stderr, got %q", stderr)
+		}
+	})
+
+	t.Run("invalid output format", func(t *testing.T) {
+		cmd := AuthMigrateToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{"--confirm", "--output", "yaml"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "unsupported format: yaml") {
+			t.Fatalf("expected unsupported format error, got %q", stderr)
+		}
+	})
+
+	t.Run("blank private key dir", func(t *testing.T) {
+		cmd := AuthMigrateToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{"--confirm", "--private-key-dir", "   "}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "--private-key-dir cannot be blank") {
+			t.Fatalf("expected blank private-key-dir error, got %q", stderr)
+		}
+	})
+
+	t.Run("blank config path", func(t *testing.T) {
+		cmd := AuthMigrateToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{"--confirm", "--config", "   "}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "--config cannot be blank") {
+			t.Fatalf("expected blank config error, got %q", stderr)
+		}
+	})
+
+	t.Run("local and config are mutually exclusive", func(t *testing.T) {
+		cmd := AuthMigrateToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{"--confirm", "--local", "--config", filepath.Join(t.TempDir(), "config.json")}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "--local and --config are mutually exclusive") {
+			t.Fatalf("expected local/config error, got %q", stderr)
+		}
+	})
+
+	t.Run("local resolves repo config path", func(t *testing.T) {
+		withTempRepo(t, func(repo string) {
+			var captured authsvc.MigrateKeychainToConfigOptions
+			restore := SetMigrateKeychainToConfig(func(opts authsvc.MigrateKeychainToConfigOptions) (authsvc.MigrateKeychainToConfigResult, error) {
+				captured = opts
+				return authsvc.MigrateKeychainToConfigResult{
+					ConfigPath: opts.ConfigPath,
+					Migrated: []authsvc.MigratedCredential{
+						{Name: "demo", KeyID: "KEY123", PrivateKeyPath: "/tmp/AuthKey.p8"},
+					},
+				}, nil
+			})
+			t.Cleanup(restore)
+
+			cmd := AuthMigrateToConfigCommand()
+			if err := cmd.FlagSet.Parse([]string{"--confirm", "--local"}); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+			expected := filepath.Join(repo, ".asc", "config.json")
+			if captured.ConfigPath != expected {
+				t.Fatalf("captured ConfigPath = %q, want %q", captured.ConfigPath, expected)
+			}
+		})
+	})
+
+	t.Run("json success", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.json")
+		privateKeyDir := filepath.Join(t.TempDir(), "keys")
+		var captured authsvc.MigrateKeychainToConfigOptions
+		restore := SetMigrateKeychainToConfig(func(opts authsvc.MigrateKeychainToConfigOptions) (authsvc.MigrateKeychainToConfigResult, error) {
+			captured = opts
+			return authsvc.MigrateKeychainToConfigResult{
+				ConfigPath:          opts.ConfigPath,
+				PrivateKeyDir:       opts.PrivateKeyDir,
+				RemovedFromKeychain: opts.RemoveKeychain,
+				Migrated: []authsvc.MigratedCredential{
+					{
+						Name:           "demo",
+						KeyID:          "KEY123",
+						PrivateKeyPath: filepath.Join(privateKeyDir, "AuthKey_demo.p8"),
+					},
+				},
+			}, nil
+		})
+		t.Cleanup(restore)
+
+		cmd := AuthMigrateToConfigCommand()
+		if err := cmd.FlagSet.Parse([]string{
+			"--confirm",
+			"--output", "json",
+			"--config", configPath,
+			"--private-key-dir", privateKeyDir,
+			"--remove-keychain",
+		}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		stdout, stderr := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("expected empty stderr, got %q", stderr)
+		}
+		if captured.ConfigPath != configPath {
+			t.Fatalf("captured ConfigPath = %q, want %q", captured.ConfigPath, configPath)
+		}
+		if captured.PrivateKeyDir != privateKeyDir {
+			t.Fatalf("captured PrivateKeyDir = %q, want %q", captured.PrivateKeyDir, privateKeyDir)
+		}
+		if !captured.RemoveKeychain {
+			t.Fatal("expected RemoveKeychain option to be true")
+		}
+
+		var payload struct {
+			ConfigPath          string `json:"configPath"`
+			PrivateKeyDir       string `json:"privateKeyDir"`
+			RemovedFromKeychain bool   `json:"removedFromKeychain"`
+			Migrated            []struct {
+				Name  string `json:"name"`
+				KeyID string `json:"keyId"`
+			} `json:"migrated"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("failed to unmarshal migration json: %v; stdout=%q", err, stdout)
+		}
+		if payload.ConfigPath != configPath || payload.PrivateKeyDir != privateKeyDir || !payload.RemovedFromKeychain {
+			t.Fatalf("unexpected migration payload: %+v", payload)
+		}
+		if len(payload.Migrated) != 1 || payload.Migrated[0].Name != "demo" || payload.Migrated[0].KeyID != "KEY123" {
+			t.Fatalf("unexpected migrated credentials payload: %+v", payload.Migrated)
+		}
+	})
+}
+
 func TestAuthStatusCommand(t *testing.T) {
 	t.Run("no credentials", func(t *testing.T) {
 		cfgPath := filepath.Join(t.TempDir(), "config.json")

--- a/internal/cli/auth/test_hooks.go
+++ b/internal/cli/auth/test_hooks.go
@@ -50,6 +50,20 @@ func SetListCredentialSummaries(fn func() ([]authsvc.Credential, error)) func() 
 	}
 }
 
+// SetMigrateKeychainToConfig replaces the keychain-to-config migration hook for tests.
+// It returns a restore function to reset the previous handler.
+func SetMigrateKeychainToConfig(fn func(authsvc.MigrateKeychainToConfigOptions) (authsvc.MigrateKeychainToConfigResult, error)) func() {
+	previous := migrateKeychainToConfig
+	if fn == nil {
+		migrateKeychainToConfig = authsvc.MigrateKeychainToConfig
+	} else {
+		migrateKeychainToConfig = fn
+	}
+	return func() {
+		migrateKeychainToConfig = previous
+	}
+}
+
 // NewPermissionWarning builds a permission warning error for tests.
 func NewPermissionWarning(err error) error {
 	if err == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `asc auth export-to-config` to copy keychain-backed App Store Connect API credentials into JSON config storage.
- Export embedded keychain PEM material to secure `.p8` files when the original private key path is missing.
- Support `--local`, `--config`, `--private-key-dir`, `--remove-keychain`, and JSON/table output for auditable migration workflows.
- Harden migration edge cases found during PR audit: active config path resolution, destination default preservation, keychain cleanup reporting, original keychain-name removal, private-key export filename collisions, and ambiguous trimmed profile-name collisions.

## Validation

- [x] `asc auth export-to-config --help`
- [x] `asc auth export-to-config` exits 2 when `--confirm` is missing
- [x] `asc auth export-to-config --confirm --output yaml` exits 2 for unsupported output
- [x] `asc auth export-to-config --confirm --local --config /tmp/asc-config.json` exits 2 for mutually exclusive config targets
- [x] Built `/tmp/asc-pr-1615` and ran a live local migration drill:
  - Seeded keychain from the existing `/Users/rudrank/.asc/config.json` credential data
  - Temporarily moved the config aside
  - Ran `/tmp/asc-pr-1615 auth export-to-config --confirm --output json`
  - Verified `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-pr-1615 auth status --output json` reads the migrated config credential
  - Restored the original config file and its `uchg` flag
- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] Cursor Bugbot review threads resolved

## Notes

The command was renamed from `migrate-to-config` to `export-to-config` during audit because the default behavior copies credentials to config while leaving keychain entries in place. Destructive cleanup remains explicit behind `--remove-keychain`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-626efee8-dfcc-4be0-9165-92142cb8825f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-626efee8-dfcc-4be0-9165-92142cb8825f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
