### PR TITLE
apps wall: add Cinefuse: AI Movie Maker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -170,6 +170,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fe/da/29/feda29cd-84dc-ad22-66f4-a276004811fc/appicon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Cinefuse: AI Movie Maker",
+    "link": "https://apps.apple.com/us/app/cinefuse-ai-movie-maker/id6758482061?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/98/b8/9f/98b89fce-4ee9-3a15-45d5-4def0e3808e0/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Clean Links: URL Privacy",
     "link": "https://apps.apple.com/us/app/clean-links-url-privacy/id6747395062?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/06/bd/0d/06bd0de6-4342-ed6d-357d-6178b1ebce6c/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Cinefuse: AI Movie Maker` to the Wall of Apps

## Entry

- App ID: 6758482061
- App: Cinefuse: AI Movie Maker
- Link: https://apps.apple.com/us/app/cinefuse-ai-movie-maker/id6758482061?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Cinefuse: AI Movie Maker" app entry with App Store link and icon to the app directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->