### PR TITLE
apps wall: add Spritz

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1252,6 +1252,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/43/63/bd/4363bd1c-3f2d-017b-f15c-d06d89736a88/AppIcon_1-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Spritz",
+    "link": "https://apps.apple.com/us/app/spritz-cocktail-recipes/id6748970457?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ff/db/6a/ffdb6a73-be0d-ce05-743b-4a6a6f05101d/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Squeaker - Dog Training Sounds",
     "link": "https://apps.apple.com/us/app/squeaker-dog-training-sounds/id6751776211?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/87/d5/10/87d51098-4022-e6e4-1c8d-7d8a8a545538/Squeaker-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Spritz` to the Wall of Apps

## Entry

- App ID: 6748970457
- App: Spritz
- Link: https://apps.apple.com/us/app/spritz-cocktail-recipes/id6748970457?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the "Spritz" app to the public app showcase, including its display entry, link and icon; positioned immediately after "Spotter - The Travel Companion".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->