### PR TITLE
apps wall: add CabinLink

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -145,6 +145,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/80/f5/84/80f584d0-6956-72b2-1294-8a5157c450b9/AppIcon-0-0-1x_U007emarketing-0-7-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "CabinLink",
+    "link": "https://apps.apple.com/app/id6761247556",
+    "icon": "https://www.vishrutjha.com/cabinlink.png"
+  },
+  {
     "app": "Cal AI - Calorie Tracker",
     "link": "https://apps.apple.com/us/app/cal-ai-calorie-tracker/id6480417616?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5e/5d/e9/5e5de9bc-18ef-3c07-79f0-e0a9e3009629/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add CabinLink to the Wall of Apps

## Entry

- App: CabinLink
- Link: https://apps.apple.com/app/id6761247556

## Notes

- Submitted for the CabinLink app after the public App Store lookup path did not find the app yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CabinLink has been added to the available apps directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->