### PR TITLE
feat(Makefile): add test-parallel target for multi-core test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,13 @@ test:
 	@echo "$(BLUE)Running tests...$(NC)"
 	ASC_BYPASS_KEYCHAIN=1 $(GO) test -v ./...
 
+# Run tests with parallel package compilation
+# Defaults to GOMAXPROCS; set PARALLEL to override (e.g. PARALLEL=4)
+.PHONY: test-parallel
+test-parallel:
+	@echo "$(BLUE)Running tests (parallel=$(or $(PARALLEL),auto))...$(NC)"
+	ASC_BYPASS_KEYCHAIN=1 $(GO) test -v -count=1 $(if $(PARALLEL),-p=$(PARALLEL)) ./...
+
 # Run tests with coverage
 .PHONY: test-coverage
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ help:
 	@echo "  build-all      Build release binaries for supported platforms"
 	@echo "  build-debug    Build with debug symbols"
 	@echo "  test           Run tests"
+	@echo "  test-parallel  Run tests with optional package parallelism (PARALLEL=<n>)"
 	@echo "  test-coverage  Run tests with coverage"
 	@echo "  test-integration  Run opt-in integration tests"
 	@echo "  lint           Lint the code"


### PR DESCRIPTION
Close #1622 

Adds `make test-parallel` target that leverages `go test -p` for parallel package compilation, significantly reducing test suite runtime on multi-core machines.

Usage:
- `make test-parallel` — uses all available CPU cores
- `make test-parallel PARALLEL=4` — limit to 4 parallel package builds

Also includes `-count=1` to disable test caching, ensuring fresh runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new Make target for running tests with parallel package compilation and an optional PARALLEL setting to control concurrency. Tests now run verbosely across the project with single-run behavior. The help output was updated to include the new test option, improving test execution and parallelization visibility for developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->