### PR TITLE
apps wall: add Leafty - Travel Planner

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -673,6 +673,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/91/a9/6e/91a96e06-a3de-fcc3-0719-109159431685/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Leafty - Travel Planner",
+    "link": "https://apps.apple.com/us/app/leafty-travel-planner/id6502776303?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/93/8c/82/938c8234-a602-a54a-83ea-6f3d85017add/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Lexie: Language Tamagotchi",
     "link": "https://apps.apple.com/us/app/lexie-language-tamagotchi/id6748887471?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6d/fa/a9/6dfaa937-68e3-31e5-a090-9341aa41d70f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Leafty - Travel Planner` to the Wall of Apps

## Entry

- App ID: 6502776303
- App: Leafty - Travel Planner
- Link: https://apps.apple.com/us/app/leafty-travel-planner/id6502776303?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Leafty - Travel Planner" to the application gallery with its icon and link, placed between "Layered: AI Outfit Maker" and "Lexie: Language Tamagotchi."

* **Documentation**
  * Updated the gallery listing to include the new app so it appears in the public app directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->