### PR TITLE
apps wall: add VivyShot

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1476,8 +1476,8 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e4/3d/81/e43d810c-3bf3-ea24-9aa6-1ced116d0f1d/AppIcon3-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
-    "app": "VivyShot",
-    "link": "https://apps.apple.com/us/app/id6760658121?mt=12&uo=4",
+    "app": "VivyShot: Screen Studio",
+    "link": "https://apps.apple.com/us/app/vivyshot-screen-studio/id6760658121?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cb/3a/3d/cb3a3d36-ba8b-6e36-a332-5a51209a2a86/AppIcon-85-220-0-5-0-0-2x-0-0.png/512x512bb.png"
   },
   {

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1476,6 +1476,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e4/3d/81/e43d810c-3bf3-ea24-9aa6-1ced116d0f1d/AppIcon3-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "VivyShot",
+    "link": "https://apps.apple.com/us/app/id6760658121?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cb/3a/3d/cb3a3d36-ba8b-6e36-a332-5a51209a2a86/AppIcon-85-220-0-5-0-0-2x-0-0.png/512x512bb.png"
+  },
+  {
     "app": "Voice Do",
     "link": "https://apps.apple.com/us/app/voice-do-task-manager/id6746357453",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/27/ed/a2/27eda257-5dd2-5150-7b0e-977f35636552/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `VivyShot` to the Wall of Apps

## Entry

- App ID: 6760658121
- App: VivyShot
- Link: https://apps.apple.com/us/app/id6760658121?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "VivyShot: Screen Studio" to the featured applications list, including its listing details (link and icon), inserted into the apps lineup immediately after "VivaDicta - Speech to Text" and before "Voice Do".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->