### PR TITLE
apps wall: add VVTerm: Native SSH Client

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1491,6 +1491,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/dd/b5/26/ddb52642-a03e-5ff7-ad0c-d973c80726c6/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "VVTerm: Native SSH Client",
+    "link": "https://apps.apple.com/us/app/vvterm-native-ssh-client/id6757482822?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/df/80/ae/df80aeb3-38cc-afe1-e15c-e0b27e957f66/AppIcon-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Wat Kham",
     "link": "https://apps.apple.com/us/app/wat-kham/id6760705576?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/86/4a/45/864a4587-87e9-4a25-e53e-2e9e025800e0/AppIcon-1x_U007emarketing-0-8-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `VVTerm: Native SSH Client` to the Wall of Apps

## Entry

- App ID: 6757482822
- App: VVTerm: Native SSH Client
- Link: https://apps.apple.com/us/app/vvterm-native-ssh-client/id6757482822?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added VVTerm: Native SSH Client to the application directory, making this native SSH client tool discoverable alongside other available applications in the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->