### PR TITLE
apps wall: add Numby Pro

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -863,6 +863,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/59/57/b4/5957b419-040d-763a-3c16-cf799bdaaa76/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Numby Pro",
+    "link": "https://apps.apple.com/us/app/numby-pro/id6755249901?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/82/a7/2e/82a72e8a-3dbd-7536-f153-282682b3bdc2/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "OffScreen: Screen Time Control",
     "link": "https://apps.apple.com/us/app/offscreen-screen-time-control/id1474340105?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/00/51/2900519e-a076-de61-c91c-7e0313faf41e/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Numby Pro` to the Wall of Apps

## Entry

- App ID: 6755249901
- App: Numby Pro
- Link: https://apps.apple.com/us/app/numby-pro/id6755249901?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Numby Pro to the supported apps list with its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->