### PR TITLE
apps wall: add Lurker Reader

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -713,6 +713,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/05/6a/92/056a928c-8748-1457-e513-43e96ce8a97e/Lumical-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Lurker Reader",
+    "link": "https://apps.apple.com/us/app/lurker-reader/id6762110921?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ef/35/a7/ef35a766-7031-dbd3-d9b5-8b1c88a77fc6/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Magic Sticker Printer",
     "link": "https://apps.apple.com/app/id6759186064",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/70/6a/e1/706ae16e-f081-eef4-6970-9d6896c4dbf4/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Lurker Reader` to the Wall of Apps

## Entry

- App ID: 6762110921
- App: Lurker Reader
- Link: https://apps.apple.com/us/app/lurker-reader/id6762110921?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Lurker Reader to the featured applications list with App Store link and icon information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->