### PR TITLE
Add app availability content statuses

### DIFF
--- a/docs/openapi/latest.json
+++ b/docs/openapi/latest.json
@@ -214329,6 +214329,7 @@
                     "MISSING_RATING",
                     "CANNOT_SELL_RESTRICTED_RATING",
                     "BRAZIL_REQUIRED_TAX_ID",
+                    "BRAZIL_GAMBLING_NOT_VERIFIED",
                     "MISSING_GRN",
                     "UNVERIFIED_GRN",
                     "ICP_NUMBER_INVALID",

--- a/internal/asc/client_pricing.go
+++ b/internal/asc/client_pricing.go
@@ -525,7 +525,7 @@ func (c *Client) GetTerritoryAvailabilities(ctx context.Context, availabilityID 
 		path = query.nextURL
 	} else {
 		values := url.Values{}
-		values.Set("fields[territoryAvailabilities]", "available,releaseDate,preOrderEnabled,territory")
+		values.Set("fields[territoryAvailabilities]", "available,releaseDate,preOrderEnabled,contentStatuses,territory")
 		values.Set("include", "territory")
 		addLimit(values, query.limit)
 		path += "?" + values.Encode()

--- a/internal/asc/pricing.go
+++ b/internal/asc/pricing.go
@@ -30,9 +30,10 @@ type AppAvailabilityV2Attributes struct {
 
 // TerritoryAvailabilityAttributes describes availability for a territory.
 type TerritoryAvailabilityAttributes struct {
-	Available       bool   `json:"available"`
-	ReleaseDate     string `json:"releaseDate,omitempty"`
-	PreOrderEnabled bool   `json:"preOrderEnabled,omitempty"`
+	Available       bool     `json:"available"`
+	ReleaseDate     string   `json:"releaseDate,omitempty"`
+	PreOrderEnabled bool     `json:"preOrderEnabled,omitempty"`
+	ContentStatuses []string `json:"contentStatuses,omitempty"`
 }
 
 // Response types

--- a/internal/asc/pricing_output.go
+++ b/internal/asc/pricing_output.go
@@ -1,6 +1,9 @@
 package asc
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func territoriesRows(resp *TerritoriesResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Currency"}
@@ -51,7 +54,7 @@ func appAvailabilityRows(resp *AppAvailabilityV2Response) ([]string, [][]string)
 }
 
 func territoryAvailabilitiesRows(resp *TerritoryAvailabilitiesResponse) ([]string, [][]string) {
-	headers := []string{"ID", "Available", "Release Date", "Preorder Enabled"}
+	headers := []string{"ID", "Available", "Release Date", "Preorder Enabled", "Content Statuses"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{
@@ -59,6 +62,7 @@ func territoryAvailabilitiesRows(resp *TerritoryAvailabilitiesResponse) ([]strin
 			fmt.Sprintf("%t", item.Attributes.Available),
 			compactWhitespace(item.Attributes.ReleaseDate),
 			fmt.Sprintf("%t", item.Attributes.PreOrderEnabled),
+			compactWhitespace(strings.Join(item.Attributes.ContentStatuses, ", ")),
 		})
 	}
 	return headers, rows

--- a/internal/asc/pricing_output_test.go
+++ b/internal/asc/pricing_output_test.go
@@ -1,0 +1,40 @@
+package asc
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+)
+
+func TestTerritoryAvailabilitiesRowsIncludesContentStatuses(t *testing.T) {
+	body := []byte(`{
+		"data": [{
+			"type": "territoryAvailabilities",
+			"id": "ta-bra",
+			"attributes": {
+				"available": false,
+				"contentStatuses": ["BRAZIL_GAMBLING_NOT_VERIFIED"]
+			}
+		}]
+	}`)
+
+	var resp TerritoryAvailabilitiesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("failed to decode territory availabilities: %v", err)
+	}
+
+	if got := resp.Data[0].Attributes.ContentStatuses; !slices.Contains(got, "BRAZIL_GAMBLING_NOT_VERIFIED") {
+		t.Fatalf("expected decoded Brazil gambling status, got %v", got)
+	}
+
+	headers, rows := territoryAvailabilitiesRows(&resp)
+	if !slices.Contains(headers, "Content Statuses") {
+		t.Fatalf("expected Content Statuses header, got %v", headers)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if got := rows[0][4]; got != "BRAZIL_GAMBLING_NOT_VERIFIED" {
+		t.Fatalf("expected Brazil gambling status in output, got %q", got)
+	}
+}

--- a/internal/asc/pricing_test.go
+++ b/internal/asc/pricing_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -545,7 +546,13 @@ func TestGetAppAvailabilityV2ByID_RequiresID(t *testing.T) {
 func TestGetTerritoryAvailabilities(t *testing.T) {
 	resp := TerritoryAvailabilitiesResponse{
 		Data: []Resource[TerritoryAvailabilityAttributes]{
-			{Type: ResourceTypeTerritoryAvailabilities, ID: "ta-1"},
+			{
+				Type: ResourceTypeTerritoryAvailabilities,
+				ID:   "ta-1",
+				Attributes: TerritoryAvailabilityAttributes{
+					ContentStatuses: []string{"BRAZIL_GAMBLING_NOT_VERIFIED"},
+				},
+			},
 		},
 	}
 	body, _ := json.Marshal(resp)
@@ -559,13 +566,17 @@ func TestGetTerritoryAvailabilities(t *testing.T) {
 		if query.Get("include") != "territory" {
 			t.Fatalf("expected include=territory, got %q", query.Get("include"))
 		}
-		if query.Get("fields[territoryAvailabilities]") != "available,releaseDate,preOrderEnabled,territory" {
+		if query.Get("fields[territoryAvailabilities]") != "available,releaseDate,preOrderEnabled,contentStatuses,territory" {
 			t.Fatalf("expected territory availability fields, got %q", query.Get("fields[territoryAvailabilities]"))
 		}
 	}, jsonResponse(http.StatusOK, string(body)))
 
-	if _, err := client.GetTerritoryAvailabilities(context.Background(), "availability-1"); err != nil {
+	got, err := client.GetTerritoryAvailabilities(context.Background(), "availability-1")
+	if err != nil {
 		t.Fatalf("GetTerritoryAvailabilities() error: %v", err)
+	}
+	if len(got.Data) != 1 || !slices.Contains(got.Data[0].Attributes.ContentStatuses, "BRAZIL_GAMBLING_NOT_VERIFIED") {
+		t.Fatalf("expected Brazil gambling status in response, got %#v", got.Data)
 	}
 }
 

--- a/internal/cli/cmdtest/pre_orders_list_pagination_test.go
+++ b/internal/cli/cmdtest/pre_orders_list_pagination_test.go
@@ -13,8 +13,8 @@ import (
 func TestPreOrdersListPaginate(t *testing.T) {
 	setupAuth(t)
 
-	const firstURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2Cterritory&include=territory&limit=200"
-	const secondURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2Cterritory&include=territory&cursor=Mg"
+	const firstURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2CcontentStatuses%2Cterritory&include=territory&limit=200"
+	const secondURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2CcontentStatuses%2Cterritory&include=territory&cursor=Mg"
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -125,7 +125,7 @@ func TestPreOrdersListLimit(t *testing.T) {
 func TestPreOrdersListNext(t *testing.T) {
 	setupAuth(t)
 
-	const nextURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2Cterritory&include=territory&cursor=Mg"
+	const nextURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2CcontentStatuses%2Cterritory&include=territory&cursor=Mg"
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {

--- a/internal/cli/cmdtest/pricing_availability_territory_availabilities_test.go
+++ b/internal/cli/cmdtest/pricing_availability_territory_availabilities_test.go
@@ -13,8 +13,8 @@ import (
 func TestPricingAvailabilityTerritoryAvailabilitiesPaginate(t *testing.T) {
 	setupAuth(t)
 
-	const firstURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2Cterritory&include=territory&limit=200"
-	const secondURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2Cterritory&include=territory&cursor=Mg"
+	const firstURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2CcontentStatuses%2Cterritory&include=territory&limit=200"
+	const secondURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2CcontentStatuses%2Cterritory&include=territory&cursor=Mg"
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -125,7 +125,7 @@ func TestPricingAvailabilityTerritoryAvailabilitiesLimit(t *testing.T) {
 func TestPricingAvailabilityTerritoryAvailabilitiesNext(t *testing.T) {
 	setupAuth(t)
 
-	const nextURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2Cterritory&include=territory&cursor=Mg"
+	const nextURL = "https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?fields%5BterritoryAvailabilities%5D=available%2CreleaseDate%2CpreOrderEnabled%2CcontentStatuses%2Cterritory&include=territory&cursor=Mg"
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- add contentStatuses to territory availability API attributes and table output
- add BRAZIL_GAMBLING_NOT_VERIFIED to the checked-in OpenAPI enum snapshot
- cover decoding/output for the Brazil gambling status with a focused internal/asc test

## Test
- go test ./internal/asc