### PR TITLE
Add subscription plan availability support

### DIFF
--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -99,6 +99,7 @@ func init() {
 	registerRowsErr(subscriptionPricesRows)
 	registerRows(subscriptionPriceRows)
 	registerRows(subscriptionAvailabilityRows)
+	registerRowsWithSingleResourceAdapter(subscriptionPlanAvailabilitiesRows)
 	registerRows(subscriptionGracePeriodRows)
 	registerRowsWithSingleResourceAdapter(territoriesRows)
 	registerRowsErr(territoryAgeRatingsRows)

--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -1,0 +1,178 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const ResourceTypeSubscriptionPlanAvailabilities ResourceType = "subscriptionPlanAvailabilities"
+
+// SubscriptionPlanType identifies a subscription billing plan.
+type SubscriptionPlanType string
+
+const (
+	SubscriptionPlanTypeMonthly SubscriptionPlanType = "MONTHLY"
+	SubscriptionPlanTypeUpfront SubscriptionPlanType = "UPFRONT"
+)
+
+// SubscriptionPlanAvailabilityAttributes describes a subscription plan availability.
+type SubscriptionPlanAvailabilityAttributes struct {
+	AvailableInNewTerritories *bool                `json:"availableInNewTerritories,omitempty"`
+	PlanType                  SubscriptionPlanType `json:"planType,omitempty"`
+}
+
+// SubscriptionPlanAvailabilityRelationships describes relationships for plan availability.
+type SubscriptionPlanAvailabilityRelationships struct {
+	Subscription         *Relationship     `json:"subscription,omitempty"`
+	AvailableTerritories *RelationshipList `json:"availableTerritories,omitempty"`
+}
+
+// SubscriptionPlanAvailabilityCreateData is the data portion of plan availability create requests.
+type SubscriptionPlanAvailabilityCreateData struct {
+	Type          ResourceType                               `json:"type"`
+	Attributes    SubscriptionPlanAvailabilityAttributes     `json:"attributes"`
+	Relationships *SubscriptionPlanAvailabilityRelationships `json:"relationships"`
+}
+
+// SubscriptionPlanAvailabilityCreateRequest is a request to create plan availability.
+type SubscriptionPlanAvailabilityCreateRequest struct {
+	Data SubscriptionPlanAvailabilityCreateData `json:"data"`
+}
+
+// SubscriptionPlanAvailabilityUpdateData is the data portion of plan availability update requests.
+type SubscriptionPlanAvailabilityUpdateData struct {
+	Type          ResourceType                               `json:"type"`
+	ID            string                                     `json:"id"`
+	Attributes    *SubscriptionPlanAvailabilityAttributes    `json:"attributes,omitempty"`
+	Relationships *SubscriptionPlanAvailabilityRelationships `json:"relationships,omitempty"`
+}
+
+// SubscriptionPlanAvailabilityUpdateRequest is a request to update plan availability.
+type SubscriptionPlanAvailabilityUpdateRequest struct {
+	Data SubscriptionPlanAvailabilityUpdateData `json:"data"`
+}
+
+// SubscriptionPlanAvailabilityResponse is the response from plan availability endpoints.
+type SubscriptionPlanAvailabilityResponse = SingleResponse[SubscriptionPlanAvailabilityAttributes]
+
+// SubscriptionPlanAvailabilitiesResponse is the response from plan availability list endpoints.
+type SubscriptionPlanAvailabilitiesResponse = Response[SubscriptionPlanAvailabilityAttributes]
+
+// CreateSubscriptionPlanAvailability sets subscription plan availability in territories.
+func (c *Client) CreateSubscriptionPlanAvailability(ctx context.Context, subID string, territoryIDs []string, attrs SubscriptionPlanAvailabilityAttributes) (*SubscriptionPlanAvailabilityResponse, error) {
+	subID = strings.TrimSpace(subID)
+	territoryIDs = normalizeList(territoryIDs)
+	if subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+	if len(territoryIDs) == 0 {
+		return nil, fmt.Errorf("territory IDs are required")
+	}
+	if attrs.PlanType == "" {
+		return nil, fmt.Errorf("plan type is required")
+	}
+
+	relData := make([]ResourceData, 0, len(territoryIDs))
+	for _, territoryID := range territoryIDs {
+		relData = append(relData, ResourceData{Type: ResourceTypeTerritories, ID: territoryID})
+	}
+
+	payload := SubscriptionPlanAvailabilityCreateRequest{
+		Data: SubscriptionPlanAvailabilityCreateData{
+			Type:       ResourceTypeSubscriptionPlanAvailabilities,
+			Attributes: attrs,
+			Relationships: &SubscriptionPlanAvailabilityRelationships{
+				Subscription: &Relationship{
+					Data: ResourceData{Type: ResourceTypeSubscriptions, ID: subID},
+				},
+				AvailableTerritories: &RelationshipList{Data: relData},
+			},
+		},
+	}
+
+	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
+		body, err := BuildRequestBody(payload)
+		if err != nil {
+			return nil, err
+		}
+		return c.do(ctx, http.MethodPost, "/v1/subscriptionPlanAvailabilities", body)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionPlanAvailabilityResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// UpdateSubscriptionPlanAvailability updates subscription plan availability in territories.
+func (c *Client) UpdateSubscriptionPlanAvailability(ctx context.Context, planAvailabilityID string, territoryIDs []string, attrs *SubscriptionPlanAvailabilityAttributes) (*SubscriptionPlanAvailabilityResponse, error) {
+	planAvailabilityID = strings.TrimSpace(planAvailabilityID)
+	territoryIDs = normalizeList(territoryIDs)
+	if planAvailabilityID == "" {
+		return nil, fmt.Errorf("plan availability ID is required")
+	}
+
+	relData := make([]ResourceData, 0, len(territoryIDs))
+	for _, territoryID := range territoryIDs {
+		relData = append(relData, ResourceData{Type: ResourceTypeTerritories, ID: territoryID})
+	}
+
+	payload := SubscriptionPlanAvailabilityUpdateRequest{
+		Data: SubscriptionPlanAvailabilityUpdateData{
+			Type:       ResourceTypeSubscriptionPlanAvailabilities,
+			ID:         planAvailabilityID,
+			Attributes: attrs,
+			Relationships: &SubscriptionPlanAvailabilityRelationships{
+				AvailableTerritories: &RelationshipList{Data: relData},
+			},
+		},
+	}
+
+	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
+		body, err := BuildRequestBody(payload)
+		if err != nil {
+			return nil, err
+		}
+		path := fmt.Sprintf("/v1/subscriptionPlanAvailabilities/%s", planAvailabilityID)
+		return c.do(ctx, http.MethodPatch, path, body)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionPlanAvailabilityResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetSubscriptionPlanAvailabilitiesForSubscription retrieves plan availabilities for a subscription.
+func (c *Client) GetSubscriptionPlanAvailabilitiesForSubscription(ctx context.Context, subID string) (*SubscriptionPlanAvailabilitiesResponse, error) {
+	subID = strings.TrimSpace(subID)
+	if subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	path := fmt.Sprintf("/v1/subscriptions/%s/planAvailabilities", subID)
+	data, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubscriptionPlanAvailabilitiesResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}

--- a/internal/asc/subscription_plan_availability_output.go
+++ b/internal/asc/subscription_plan_availability_output.go
@@ -1,0 +1,23 @@
+package asc
+
+import "fmt"
+
+func subscriptionPlanAvailabilitiesRows(resp *SubscriptionPlanAvailabilitiesResponse) ([]string, [][]string) {
+	headers := []string{"ID", "Plan Type", "Available In New Territories"}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		rows = append(rows, []string{
+			item.ID,
+			string(item.Attributes.PlanType),
+			formatOptionalSubscriptionBool(item.Attributes.AvailableInNewTerritories),
+		})
+	}
+	return headers, rows
+}
+
+func formatOptionalSubscriptionBool(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%t", *value)
+}

--- a/internal/asc/subscription_plan_availability_test.go
+++ b/internal/asc/subscription_plan_availability_test.go
@@ -1,0 +1,80 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestCreateSubscriptionPlanAvailability(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptionPlanAvailabilities" {
+			t.Fatalf("expected path /v1/subscriptionPlanAvailabilities, got %s", req.URL.Path)
+		}
+		var payload SubscriptionPlanAvailabilityCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if payload.Data.Type != ResourceTypeSubscriptionPlanAvailabilities {
+			t.Fatalf("expected type subscriptionPlanAvailabilities, got %q", payload.Data.Type)
+		}
+		if payload.Data.Attributes.PlanType != SubscriptionPlanTypeMonthly {
+			t.Fatalf("expected MONTHLY plan type, got %q", payload.Data.Attributes.PlanType)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.Subscription == nil || payload.Data.Relationships.AvailableTerritories == nil {
+			t.Fatalf("expected subscription and territory relationships")
+		}
+		if payload.Data.Relationships.Subscription.Data.ID != "sub-1" {
+			t.Fatalf("unexpected subscription relationship: %+v", payload.Data.Relationships.Subscription.Data)
+		}
+		got := payload.Data.Relationships.AvailableTerritories.Data
+		if len(got) != 2 || got[0].ID != "NOR" || got[1].ID != "DEU" {
+			t.Fatalf("expected NOR,DEU territories, got %#v", got)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	availableInNew := true
+	attrs := SubscriptionPlanAvailabilityAttributes{
+		AvailableInNewTerritories: &availableInNew,
+		PlanType:                  SubscriptionPlanTypeMonthly,
+	}
+	if _, err := client.CreateSubscriptionPlanAvailability(context.Background(), "sub-1", []string{"NOR", "DEU"}, attrs); err != nil {
+		t.Fatalf("CreateSubscriptionPlanAvailability() error: %v", err)
+	}
+}
+
+func TestUpdateSubscriptionPlanAvailability(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptionPlanAvailabilities/plan-1" {
+			t.Fatalf("expected path /v1/subscriptionPlanAvailabilities/plan-1, got %s", req.URL.Path)
+		}
+		var payload SubscriptionPlanAvailabilityUpdateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if payload.Data.ID != "plan-1" || payload.Data.Type != ResourceTypeSubscriptionPlanAvailabilities {
+			t.Fatalf("unexpected update data: %+v", payload.Data)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.AvailableTerritories == nil {
+			t.Fatalf("expected availableTerritories relationship")
+		}
+		if len(payload.Data.Relationships.AvailableTerritories.Data) != 0 {
+			t.Fatalf("expected empty territory list, got %#v", payload.Data.Relationships.AvailableTerritories.Data)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.UpdateSubscriptionPlanAvailability(context.Background(), "plan-1", nil, nil); err != nil {
+		t.Fatalf("UpdateSubscriptionPlanAvailability() error: %v", err)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestSubscriptionsPricingMonthlyCommitmentHelp(t *testing.T) {
@@ -31,8 +34,8 @@ func TestSubscriptionsPricingMonthlyCommitmentHelp(t *testing.T) {
 		return
 	}
 	monthlyUsage := monthlyCmd.UsageFunc(monthlyCmd)
-	if !strings.Contains(monthlyUsage, "April 27, 2026") {
-		t.Fatalf("expected monthly-commitment help to mention Apple announcement date, got %q", monthlyUsage)
+	if !strings.Contains(monthlyUsage, "App Store Connect API 4.4") {
+		t.Fatalf("expected monthly-commitment help to mention App Store Connect API 4.4, got %q", monthlyUsage)
 	}
 }
 
@@ -159,25 +162,47 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 }
 
 func TestSubscriptionsPricingMonthlyCommitmentDisableFiltersExcludedTerritories(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1" && req.Method == http.MethodPatch:
+			var payload asc.SubscriptionPlanAvailabilityUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if len(payload.Data.Relationships.AvailableTerritories.Data) != 0 {
+				t.Fatalf("expected empty territory list, got %#v", payload.Data.Relationships.AvailableTerritories.Data)
+			}
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
+	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"subscriptions", "pricing", "monthly-commitment", "disable",
-			"--subscription-id", "sub-1",
+			"--subscription-id", "8000000001",
 			"--territories", "United States,Norway,Singapore",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
-		err := root.Run(context.Background())
-		if err == nil || !strings.Contains(err.Error(), "not yet supported by Apple's public App Store Connect API") {
-			t.Fatalf("expected upstream API unsupported error, got %v", err)
-		}
+		runErr = root.Run(context.Background())
 	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
 
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
+	if !strings.Contains(stdout, `"id":"plan-1"`) {
+		t.Fatalf("expected plan availability response, got %q", stdout)
 	}
 	if !strings.Contains(stderr, "Warning: monthly-commitment billing is unavailable in USA,SGP") {
 		t.Fatalf("expected excluded territory warning, got %q", stderr)

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -2,7 +2,6 @@ package subscriptions
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"math/big"
@@ -23,8 +22,6 @@ const (
 	subscriptionBillingModeMonthlyCommitment subscriptionBillingMode = "monthly-commitment"
 )
 
-var errMonthlyCommitmentPublicAPINotAvailable = errors.New("monthly subscriptions with a 12-month commitment are not yet supported by Apple's public App Store Connect API; Apple documents the App Store Connect web UI flow, but the public OpenAPI schema currently has no billing-mode field or resource for subscriptionAvailabilities or subscriptionPrices")
-
 var monthlyCommitmentExcludedTerritories = map[string]struct{}{
 	"USA": {},
 	"SGP": {},
@@ -37,13 +34,12 @@ func SubscriptionsPricingMonthlyCommitmentCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "monthly-commitment",
 		ShortUsage: "asc subscriptions pricing monthly-commitment <subcommand> [flags]",
-		ShortHelp:  "[experimental] Prepare Monthly with 12-Month Commitment subscription billing.",
-		LongHelp: `[experimental] Prepare Monthly with 12-Month Commitment subscription billing.
+		ShortHelp:  "Manage Monthly with 12-Month Commitment subscription availability.",
+		LongHelp: `Manage Monthly with 12-Month Commitment subscription availability.
 
-Apple announced Monthly Subscriptions with a 12-Month Commitment on April 27, 2026.
-The public App Store Connect API currently exposes standard subscription
-availability and prices only; these commands validate the supported inputs and
-return a clear upstream-API error until Apple publishes the billing-mode fields.
+App Store Connect API 4.4 exposes subscriptionPlanAvailabilities for configuring
+monthly subscriptions with a 12-month commitment. The subscription must use
+subscriptionPeriod ONE_YEAR. USA and Singapore are excluded by Apple.
 
 Examples:
   asc subscriptions pricing monthly-commitment enable --subscription-id "SUB_ID" --price "9.99" --price-territory "Norway" --territories "Norway,Germany,France"
@@ -62,7 +58,7 @@ Examples:
 	}
 }
 
-// SubscriptionsPricingMonthlyCommitmentEnableCommand validates enabling monthly commitment billing.
+// SubscriptionsPricingMonthlyCommitmentEnableCommand enables monthly commitment billing.
 func SubscriptionsPricingMonthlyCommitmentEnableCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("pricing monthly-commitment enable", flag.ExitOnError)
 
@@ -71,13 +67,14 @@ func SubscriptionsPricingMonthlyCommitmentEnableCommand() *ffcli.Command {
 	price := fs.String("price", "", "Monthly customer price; total commitment is price x 12")
 	priceTerritory := fs.String("price-territory", "", "Territory used to compare the upfront annual price")
 	territories := fs.String("territories", "", "Territories to enable, comma-separated; USA and Singapore are excluded")
-	availableInNew := fs.Bool("available-in-new-territories", false, "Include new eligible territories automatically when Apple exposes a public API")
+	availableInNew := fs.Bool("available-in-new-territories", false, "Include new eligible territories automatically")
+	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "enable",
 		ShortUsage: "asc subscriptions pricing monthly-commitment enable [flags]",
-		ShortHelp:  "[experimental] Validate monthly-commitment enable inputs.",
-		LongHelp: `[experimental] Validate Monthly with 12-Month Commitment enable inputs.
+		ShortHelp:  "Enable monthly-commitment availability.",
+		LongHelp: `Enable Monthly with 12-Month Commitment availability.
 
 The subscription must use subscriptionPeriod ONE_YEAR. USA and Singapore are
 removed from --territories because Apple excludes those storefronts. The CLI
@@ -161,23 +158,48 @@ Examples:
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
 
-			return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", errMonthlyCommitmentPublicAPINotAvailable)
+			availableInNewValue := *availableInNew
+			attrs := asc.SubscriptionPlanAvailabilityAttributes{
+				AvailableInNewTerritories: &availableInNewValue,
+				PlanType:                  asc.SubscriptionPlanTypeMonthly,
+			}
+
+			existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch plan availabilities: %w", err)
+			}
+
+			if monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing); ok {
+				resp, err := client.UpdateSubscriptionPlanAvailability(requestCtx, monthlyPlan.ID, territoryIDs, &attrs)
+				if err != nil {
+					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to update plan availability: %w", err)
+				}
+				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			}
+
+			resp, err := client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, attrs)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to create plan availability: %w", err)
+			}
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
 }
 
-// SubscriptionsPricingMonthlyCommitmentDisableCommand validates disabling monthly commitment billing.
+// SubscriptionsPricingMonthlyCommitmentDisableCommand disables monthly commitment billing.
 func SubscriptionsPricingMonthlyCommitmentDisableCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("pricing monthly-commitment disable", flag.ExitOnError)
 
 	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	appID := addSubscriptionLookupAppFlag(fs)
 	territories := fs.String("territories", "", "Territories to disable, comma-separated; USA and Singapore are excluded")
+	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "disable",
 		ShortUsage: "asc subscriptions pricing monthly-commitment disable [flags]",
-		ShortHelp:  "[experimental] Validate monthly-commitment disable inputs.",
-		LongHelp: `[experimental] Validate Monthly with 12-Month Commitment disable inputs.
+		ShortHelp:  "Disable monthly-commitment availability.",
+		LongHelp: `Disable Monthly with 12-Month Commitment availability.
 
 Examples:
   asc subscriptions pricing monthly-commitment disable --subscription-id "SUB_ID" --territories "Norway"`,
@@ -187,7 +209,8 @@ Examples:
 			if len(args) > 0 {
 				return shared.UsageError("subscriptions pricing monthly-commitment disable does not accept positional arguments")
 			}
-			if strings.TrimSpace(*subscriptionID) == "" {
+			id := strings.TrimSpace(*subscriptionID)
+			if id == "" {
 				return shared.UsageError("--subscription-id is required")
 			}
 			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
@@ -202,22 +225,50 @@ Examples:
 			if len(territoryIDs) == 0 {
 				return shared.UsageError("no eligible monthly-commitment territories remain after excluding USA and Singapore")
 			}
-			return fmt.Errorf("subscriptions pricing monthly-commitment disable: %w", errMonthlyCommitmentPublicAPINotAvailable)
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment disable: %w", err)
+			}
+			id, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, id)
+			if err != nil {
+				return err
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment disable: failed to fetch plan availabilities: %w", err)
+			}
+			monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing)
+			if !ok {
+				return fmt.Errorf("subscriptions pricing monthly-commitment disable: no monthly-commitment plan availability found for subscription %q", id)
+			}
+
+			resp, err := client.UpdateSubscriptionPlanAvailability(requestCtx, monthlyPlan.ID, nil, nil)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment disable: failed to update plan availability: %w", err)
+			}
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
 }
 
-// SubscriptionsPricingMonthlyCommitmentListCommand reports upstream support status.
+// SubscriptionsPricingMonthlyCommitmentListCommand lists monthly commitment billing.
 func SubscriptionsPricingMonthlyCommitmentListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("pricing monthly-commitment list", flag.ExitOnError)
 
 	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	appID := addSubscriptionLookupAppFlag(fs)
+	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc subscriptions pricing monthly-commitment list --subscription-id \"SUB_ID\"",
-		ShortHelp:  "[experimental] List monthly-commitment billing configuration when Apple exposes a public API.",
-		LongHelp: `[experimental] List Monthly with 12-Month Commitment billing configuration.
+		ShortHelp:  "List monthly-commitment plan availability.",
+		LongHelp: `List Monthly with 12-Month Commitment plan availability.
 
 Examples:
   asc subscriptions pricing monthly-commitment list --subscription-id "SUB_ID"`,
@@ -227,12 +278,41 @@ Examples:
 			if len(args) > 0 {
 				return shared.UsageError("subscriptions pricing monthly-commitment list does not accept positional arguments")
 			}
-			if strings.TrimSpace(*subscriptionID) == "" {
+			id := strings.TrimSpace(*subscriptionID)
+			if id == "" {
 				return shared.UsageError("--subscription-id is required")
 			}
-			return fmt.Errorf("subscriptions pricing monthly-commitment list: %w", errMonthlyCommitmentPublicAPINotAvailable)
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment list: %w", err)
+			}
+			id, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, id)
+			if err != nil {
+				return err
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			resp, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment list: failed to fetch: %w", err)
+			}
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func findMonthlySubscriptionPlanAvailability(resp *asc.SubscriptionPlanAvailabilitiesResponse) (asc.Resource[asc.SubscriptionPlanAvailabilityAttributes], bool) {
+	if resp == nil {
+		return asc.Resource[asc.SubscriptionPlanAvailabilityAttributes]{}, false
+	}
+	for _, item := range resp.Data {
+		if item.Attributes.PlanType == asc.SubscriptionPlanTypeMonthly {
+			return item, true
+		}
+	}
+	return asc.Resource[asc.SubscriptionPlanAvailabilityAttributes]{}, false
 }
 
 func normalizeSubscriptionBillingMode(value string) (subscriptionBillingMode, error) {

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -133,7 +133,7 @@ func SubscriptionsSetupCommand() *ffcli.Command {
 
 	territories := fs.String("territories", "", "Availability territories to enable after creation (comma-separated; accepts alpha-2, alpha-3, or exact English country names)")
 	availableInNewTerritories := fs.Bool("available-in-new-territories", false, "Include new territories automatically when creating availability")
-	enableMonthlyCommitment := fs.Bool("enable-monthly-commitment", false, "[experimental] Also configure Monthly with 12-Month Commitment availability for ONE_YEAR subscriptions when Apple exposes a public API")
+	enableMonthlyCommitment := fs.Bool("enable-monthly-commitment", false, "Also configure Monthly with 12-Month Commitment availability for ONE_YEAR subscriptions")
 	noVerify := fs.Bool("no-verify", false, "Skip post-create readback verification for faster execution")
 	output := shared.BindOutputFlags(fs)
 
@@ -241,7 +241,7 @@ Examples:
 				return shared.UsageError("--enable-monthly-commitment requires --subscription-period ONE_YEAR")
 			}
 			if opts.EnableMonthlyCommitment {
-				return fmt.Errorf("subscriptions setup: %w", errMonthlyCommitmentPublicAPINotAvailable)
+				return shared.UsageError("--enable-monthly-commitment is not supported by setup yet; create the ONE_YEAR subscription first, then run `asc subscriptions pricing monthly-commitment enable`")
 			}
 
 			if opts.hasLocalization() {

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1268,7 +1268,6 @@ Examples:
 				if len(territoryIDs) == 0 {
 					return shared.UsageError("no eligible monthly-commitment territories remain after excluding USA and Singapore")
 				}
-				return fmt.Errorf("subscriptions availability edit: %w", errMonthlyCommitmentPublicAPINotAvailable)
 			}
 
 			client, err := shared.GetASCClient()
@@ -1283,6 +1282,18 @@ Examples:
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
+
+			if normalizedBillingMode == subscriptionBillingModeMonthlyCommitment {
+				availableInNewValue := *availableInNew
+				resp, err := client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, asc.SubscriptionPlanAvailabilityAttributes{
+					AvailableInNewTerritories: &availableInNewValue,
+					PlanType:                  asc.SubscriptionPlanTypeMonthly,
+				})
+				if err != nil {
+					return fmt.Errorf("subscriptions availability edit: failed to set monthly-commitment plan availability: %w", err)
+				}
+				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			}
 
 			attrs := asc.SubscriptionAvailabilityAttributes{
 				AvailableInNewTerritories: *availableInNew,


### PR DESCRIPTION
## Summary
- add App Store Connect API 4.4 `subscriptionPlanAvailabilities` client models, output rendering, and request tests
- wire monthly-commitment list/enable/disable to the public plan availability endpoints
- route `subscriptions pricing availability edit --billing-mode monthly-commitment` through `subscriptionPlanAvailabilities` and keep setup from silently no-oping

## Verification
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc ./internal/cli/subscriptions`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestSubscriptionsPricingMonthlyCommitment|TestSubscriptionsPricingAvailabilityEdit|TestSubscriptionsSetup'`\n- `go build -o /tmp/asc .`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc subscriptions pricing monthly-commitment list --subscription-id 6759789022 --output json --pretty`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc subscriptions create --group-id 21952969 --reference-name "Monthly Commitment Probe 1780963230" --product-id "com.rudrank.asc.monthlycommitment.1780963230" --subscription-period ONE_YEAR --output json --pretty`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc subscriptions pricing availability edit --subscription-id 6778208353 --territories Norway,Germany --available-in-new-territories true --output json --pretty`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc subscriptions pricing availability edit --subscription-id 6778208353 --billing-mode monthly-commitment --territories Norway,Germany --available-in-new-territories true --output json --pretty`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc subscriptions pricing monthly-commitment list --subscription-id 6778208353 --output json --pretty`\n- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc subscriptions delete --id 6778208353 --confirm --output json --pretty`\n\n## Live ASC notes\n- Throwaway app: `ASC Test 20260216074703` (`6759231657`)\n- Read path confirmed: `subscriptionPlanAvailabilities` returned for subscription `6759789022`.\n- Created and deleted disposable one-year subscription `6778208353`.\n- Default availability succeeded for the disposable subscription.\n- Monthly plan availability POST reached Apple’s API 4.4 endpoint, then Apple rejected that disposable subscription as ineligible: `The provided value is not supported for your subscription and planType.`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Monthly commitment subscription pricing is now fully functional and no longer experimental
* Users can enable, disable, and list monthly commitment options for subscriptions
* Added support for creating and updating subscription plan availabilities with territory management
* Removed experimental designation from monthly commitment CLI commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->