### PR TITLE
Support individual App Store Connect API keys

### DIFF
--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -71,10 +71,14 @@ func (c *Client) generateJWT() (string, error) {
 func GenerateJWT(keyID, issuerID string, privateKey *ecdsa.PrivateKey) (string, error) {
 	now := time.Now()
 	claims := jwt.RegisteredClaims{
-		Issuer:    issuerID,
 		Audience:  jwt.ClaimStrings{"appstoreconnect-v1"},
 		IssuedAt:  jwt.NewNumericDate(now),
 		ExpiresAt: jwt.NewNumericDate(now.Add(tokenLifetime)),
+	}
+	if strings.TrimSpace(issuerID) == "" {
+		claims.Subject = "user"
+	} else {
+		claims.Issuer = issuerID
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)

--- a/internal/asc/client_http_jwt_test.go
+++ b/internal/asc/client_http_jwt_test.go
@@ -1,0 +1,82 @@
+package asc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestGenerateJWT_TeamKeyUsesIssuerClaim(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	tokenString, err := GenerateJWT("KEY123", "ISS456", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateJWT() error: %v", err)
+	}
+
+	claims := parseJWTClaims(t, tokenString, privateKey)
+	if claims.Issuer != "ISS456" {
+		t.Fatalf("issuer claim = %q, want ISS456", claims.Issuer)
+	}
+	if claims.Subject != "" {
+		t.Fatalf("subject claim = %q, want empty", claims.Subject)
+	}
+}
+
+func TestGenerateJWT_IndividualKeyUsesUserSubjectClaim(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	tokenString, err := GenerateJWT("KEY123", "", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateJWT() error: %v", err)
+	}
+
+	claims := parseJWTClaims(t, tokenString, privateKey)
+	if claims.Issuer != "" {
+		t.Fatalf("issuer claim = %q, want empty", claims.Issuer)
+	}
+	if claims.Subject != "user" {
+		t.Fatalf("subject claim = %q, want user", claims.Subject)
+	}
+	if !jwtAudienceContains(claims.Audience, "appstoreconnect-v1") {
+		t.Fatalf("audience claim = %v, want appstoreconnect-v1", claims.Audience)
+	}
+}
+
+func testJWTPrivateKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error: %v", err)
+	}
+	return key
+}
+
+func parseJWTClaims(t *testing.T, tokenString string, privateKey *ecdsa.PrivateKey) jwt.RegisteredClaims {
+	t.Helper()
+
+	claims := jwt.RegisteredClaims{}
+	token, err := jwt.ParseWithClaims(tokenString, &claims, func(token *jwt.Token) (any, error) {
+		return &privateKey.PublicKey, nil
+	}, jwt.WithAudience("appstoreconnect-v1"))
+	if err != nil {
+		t.Fatalf("ParseWithClaims() error: %v", err)
+	}
+	if !token.Valid {
+		t.Fatal("expected token to be valid")
+	}
+	return claims
+}
+
+func jwtAudienceContains(audience jwt.ClaimStrings, value string) bool {
+	for _, item := range audience {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/doctor.go
+++ b/internal/auth/doctor.go
@@ -388,13 +388,23 @@ func inspectEnvironment() DoctorSection {
 
 	keyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
 	issuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
-	keyType := config.NormalizeCredentialKeyType(os.Getenv("ASC_KEY_TYPE"))
+	keyTypeRaw := strings.TrimSpace(os.Getenv("ASC_KEY_TYPE"))
+	keyType := config.NormalizeCredentialKeyType(keyTypeRaw)
+	keyTypeValid := keyTypeRaw == "" || config.IsValidCredentialKeyType(keyType)
 	hasKeyPath := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
 		strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY")) != "" ||
 		strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_B64")) != ""
-	envProvided := keyID != "" || issuerID != "" || hasKeyPath || strings.TrimSpace(os.Getenv("ASC_KEY_TYPE")) != ""
+	envProvided := keyID != "" || issuerID != "" || hasKeyPath || keyTypeRaw != ""
 	envComplete := keyID != "" && hasKeyPath &&
+		keyTypeValid &&
 		(issuerID != "" || config.IsIndividualCredentialKeyType(keyType))
+	if keyTypeRaw != "" && !keyTypeValid {
+		checks = append(checks, DoctorCheck{
+			Status:         DoctorWarn,
+			Message:        "ASC_KEY_TYPE is invalid (expected team or individual)",
+			Recommendation: "Set ASC_KEY_TYPE to team or individual, or clear it",
+		})
+	}
 	if envProvided && !envComplete {
 		checks = append(checks, DoctorCheck{
 			Status:         DoctorWarn,

--- a/internal/auth/doctor.go
+++ b/internal/auth/doctor.go
@@ -221,7 +221,7 @@ func inspectProfiles() DoctorSection {
 		if !isCompleteConfigCredential(cred) {
 			checks = append(checks, DoctorCheck{
 				Status:         DoctorWarn,
-				Message:        fmt.Sprintf("%s - incomplete (missing key ID, issuer ID, or private key path)", name),
+				Message:        fmt.Sprintf("%s - incomplete (missing key ID, issuer ID for team keys, or private key path)", name),
 				Recommendation: fmt.Sprintf("Re-run auth login for %q", name),
 			})
 		}
@@ -371,6 +371,7 @@ func inspectEnvironment() DoctorSection {
 		"ASC_PROFILE",
 		"ASC_BYPASS_KEYCHAIN",
 		"ASC_STRICT_AUTH",
+		"ASC_KEY_TYPE",
 	}
 	for _, name := range envVars {
 		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
@@ -387,15 +388,17 @@ func inspectEnvironment() DoctorSection {
 
 	keyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
 	issuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
+	keyType := config.NormalizeCredentialKeyType(os.Getenv("ASC_KEY_TYPE"))
 	hasKeyPath := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
 		strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY")) != "" ||
 		strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_B64")) != ""
-	envProvided := keyID != "" || issuerID != "" || hasKeyPath
-	envComplete := keyID != "" && issuerID != "" && hasKeyPath
+	envProvided := keyID != "" || issuerID != "" || hasKeyPath || strings.TrimSpace(os.Getenv("ASC_KEY_TYPE")) != ""
+	envComplete := keyID != "" && hasKeyPath &&
+		(issuerID != "" || config.IsIndividualCredentialKeyType(keyType))
 	if envProvided && !envComplete {
 		checks = append(checks, DoctorCheck{
 			Status:         DoctorWarn,
-			Message:        "Environment credentials are incomplete (set ASC_KEY_ID, ASC_ISSUER_ID, and a private key)",
+			Message:        "Environment credentials are incomplete (set ASC_KEY_ID, ASC_ISSUER_ID unless ASC_KEY_TYPE=individual, and a private key)",
 			Recommendation: "Set missing ASC_* variables or clear partial values",
 		})
 	}

--- a/internal/auth/doctor_test.go
+++ b/internal/auth/doctor_test.go
@@ -80,6 +80,24 @@ func TestDoctorEnvironmentRedactsCredentialIdentifiers(t *testing.T) {
 	}
 }
 
+func TestDoctorEnvironmentWarnsForInvalidKeyType(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_KEY_TYPE", "personal")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+
+	report := Doctor(DoctorOptions{})
+	section := findDoctorSection(t, report, "Environment")
+	if !sectionHasStatus(section, DoctorWarn, "ASC_KEY_TYPE is invalid") {
+		t.Fatalf("expected invalid ASC_KEY_TYPE warning, got %#v", section.Checks)
+	}
+	if !sectionHasStatus(section, DoctorWarn, "Environment credentials are incomplete") {
+		t.Fatalf("expected incomplete environment warning, got %#v", section.Checks)
+	}
+}
+
 func TestDoctorTempFilesWarns(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -51,6 +51,7 @@ type Credential struct {
 	IssuerID              string    `json:"issuer_id"`
 	PrivateKeyPath        string    `json:"private_key_path"`
 	PrivateKeyPEM         string    `json:"-"`
+	KeyType               string    `json:"key_type,omitempty"`
 	IsDefault             bool      `json:"is_default"`
 	Source                string    `json:"source,omitempty"`
 	SourcePath            string    `json:"source_path,omitempty"`
@@ -108,11 +109,13 @@ type credentialPayload struct {
 	IssuerID       string `json:"issuer_id"`
 	PrivateKeyPath string `json:"private_key_path"`
 	PrivateKeyPEM  string `json:"private_key_pem,omitempty"`
+	KeyType        string `json:"key_type,omitempty"`
 }
 
 type credentialMetadata struct {
 	KeyID    string `json:"key_id,omitempty"`
 	IssuerID string `json:"issuer_id,omitempty"`
+	KeyType  string `json:"key_type,omitempty"`
 }
 
 func keyringConfig(keychainName string) keyring.Config {
@@ -298,10 +301,16 @@ func LoadPrivateKeyFromPEM(data []byte) (*ecdsa.PrivateKey, error) {
 
 // StoreCredentials stores credentials in the keychain when available.
 func StoreCredentials(name, keyID, issuerID, keyPath string) error {
+	return StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, config.CredentialKeyTypeTeam)
+}
+
+// StoreCredentialsWithKeyType stores credentials with an explicit App Store Connect key type.
+func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string) error {
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,
 		PrivateKeyPath: keyPath,
+		KeyType:        normalizedStoredKeyType(keyType),
 	}
 	if privateKeyPEM, err := loadPrivateKeyPEMForStorage(keyPath); err == nil && strings.TrimSpace(privateKeyPEM) != "" {
 		payload.PrivateKeyPEM = privateKeyPEM
@@ -335,10 +344,16 @@ func loadPrivateKeyPEMForStorage(path string) (string, error) {
 
 // StoreCredentialsConfig stores credentials in the config file only.
 func StoreCredentialsConfig(name, keyID, issuerID, keyPath string) error {
+	return StoreCredentialsConfigWithKeyType(name, keyID, issuerID, keyPath, config.CredentialKeyTypeTeam)
+}
+
+// StoreCredentialsConfigWithKeyType stores credentials in the config file only with an explicit key type.
+func StoreCredentialsConfigWithKeyType(name, keyID, issuerID, keyPath, keyType string) error {
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,
 		PrivateKeyPath: keyPath,
+		KeyType:        normalizedStoredKeyType(keyType),
 	}
 	path, err := config.GlobalPath()
 	if err != nil {
@@ -349,12 +364,26 @@ func StoreCredentialsConfig(name, keyID, issuerID, keyPath string) error {
 
 // StoreCredentialsConfigAt stores credentials in the specified config file.
 func StoreCredentialsConfigAt(name, keyID, issuerID, keyPath, configPath string) error {
+	return StoreCredentialsConfigAtWithKeyType(name, keyID, issuerID, keyPath, configPath, config.CredentialKeyTypeTeam)
+}
+
+// StoreCredentialsConfigAtWithKeyType stores credentials in the specified config file with an explicit key type.
+func StoreCredentialsConfigAtWithKeyType(name, keyID, issuerID, keyPath, configPath, keyType string) error {
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,
 		PrivateKeyPath: keyPath,
+		KeyType:        normalizedStoredKeyType(keyType),
 	}
 	return storeInConfigAt(name, payload, configPath)
+}
+
+func normalizedStoredKeyType(keyType string) string {
+	normalized := config.NormalizeCredentialKeyType(keyType)
+	if normalized == config.CredentialKeyTypeTeam {
+		return ""
+	}
+	return normalized
 }
 
 // MigrateKeychainToConfig copies keychain-backed credentials into config.json.
@@ -420,6 +449,7 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 			KeyID:          strings.TrimSpace(cred.KeyID),
 			IssuerID:       strings.TrimSpace(cred.IssuerID),
 			PrivateKeyPath: privateKeyPath,
+			KeyType:        normalizedStoredKeyType(cred.KeyType),
 		}
 		upsertConfigCredential(cfg, configCred)
 		migratedConfigCreds = append(migratedConfigCreds, configCred)
@@ -619,6 +649,7 @@ func applyMigratedDefault(cfg *config.Config, sourceCreds []Credential, migrated
 			cfg.KeyID = cred.KeyID
 			cfg.IssuerID = cred.IssuerID
 			cfg.PrivateKeyPath = cred.PrivateKeyPath
+			cfg.KeyType = normalizedStoredKeyType(cred.KeyType)
 			return
 		}
 	}
@@ -633,6 +664,7 @@ func alignDefaultCredentialFields(cfg *config.Config, defaultName string) bool {
 	cfg.KeyID = cred.KeyID
 	cfg.IssuerID = cred.IssuerID
 	cfg.PrivateKeyPath = cred.PrivateKeyPath
+	cfg.KeyType = normalizedStoredKeyType(cred.KeyType)
 	return true
 }
 
@@ -672,6 +704,7 @@ func clearConfigCredentialsAt(path string) error {
 	cfg.KeyID = ""
 	cfg.IssuerID = ""
 	cfg.PrivateKeyPath = ""
+	cfg.KeyType = ""
 	cfg.DefaultKeyName = ""
 	cfg.Keys = nil
 	cfg.KeychainMetadata = nil
@@ -1013,6 +1046,7 @@ func configFromCredential(cred Credential) *config.Config {
 		IssuerID:       cred.IssuerID,
 		PrivateKeyPath: cred.PrivateKeyPath,
 		PrivateKeyPEM:  cred.PrivateKeyPEM,
+		KeyType:        normalizedStoredKeyType(cred.KeyType),
 		DefaultKeyName: cred.Name,
 	}
 }
@@ -1065,6 +1099,7 @@ func credentialMetadataDescription(payload credentialPayload) string {
 	data, err := json.Marshal(credentialMetadata{
 		KeyID:    strings.TrimSpace(payload.KeyID),
 		IssuerID: strings.TrimSpace(payload.IssuerID),
+		KeyType:  normalizedStoredKeyType(payload.KeyType),
 	})
 	if err != nil {
 		return ""
@@ -1086,7 +1121,9 @@ func parseCredentialMetadataDescription(description string) credentialMetadata {
 }
 
 func hasCredentialMetadata(metadata credentialMetadata) bool {
-	return strings.TrimSpace(metadata.KeyID) != "" || strings.TrimSpace(metadata.IssuerID) != ""
+	return strings.TrimSpace(metadata.KeyID) != "" ||
+		strings.TrimSpace(metadata.IssuerID) != "" ||
+		strings.TrimSpace(metadata.KeyType) != ""
 }
 
 func metadataModifiedAtString(value time.Time) string {
@@ -1098,13 +1135,15 @@ func metadataModifiedAtString(value time.Time) string {
 
 func credentialMetadataMatchesPayload(metadata credentialMetadata, payload credentialPayload) bool {
 	return strings.TrimSpace(metadata.KeyID) == strings.TrimSpace(payload.KeyID) &&
-		strings.TrimSpace(metadata.IssuerID) == strings.TrimSpace(payload.IssuerID)
+		strings.TrimSpace(metadata.IssuerID) == strings.TrimSpace(payload.IssuerID) &&
+		config.NormalizeCredentialKeyType(metadata.KeyType) == config.NormalizeCredentialKeyType(payload.KeyType)
 }
 
 func storedKeychainMetadataSummary(entry config.KeychainMetadata) credentialMetadata {
 	return credentialMetadata{
 		KeyID:    strings.TrimSpace(entry.KeyID),
 		IssuerID: strings.TrimSpace(entry.IssuerID),
+		KeyType:  normalizedStoredKeyType(entry.KeyType),
 	}
 }
 
@@ -1133,6 +1172,7 @@ func loadStoredKeychainMetadata() map[string]config.KeychainMetadata {
 		entry.Name = name
 		entry.KeyID = strings.TrimSpace(entry.KeyID)
 		entry.IssuerID = strings.TrimSpace(entry.IssuerID)
+		entry.KeyType = normalizedStoredKeyType(entry.KeyType)
 		entry.ModifiedAt = strings.TrimSpace(entry.ModifiedAt)
 		stored[name] = entry
 	}
@@ -1159,9 +1199,10 @@ func persistKeychainMetadata(cred Credential) {
 		Name:       name,
 		KeyID:      strings.TrimSpace(cred.KeyID),
 		IssuerID:   strings.TrimSpace(cred.IssuerID),
+		KeyType:    normalizedStoredKeyType(cred.KeyType),
 		ModifiedAt: metadataModifiedAtString(cred.MetadataModifiedAt),
 	}
-	if (metadata.KeyID == "" && metadata.IssuerID == "") || metadata.ModifiedAt == "" {
+	if (metadata.KeyID == "" && metadata.IssuerID == "" && metadata.KeyType == "") || metadata.ModifiedAt == "" {
 		return
 	}
 	updated := false
@@ -1330,6 +1371,7 @@ func listCredentialSummariesFromKeyring(kr keyring.Keyring) ([]Credential, error
 			Name:      name,
 			KeyID:     summary.KeyID,
 			IssuerID:  summary.IssuerID,
+			KeyType:   normalizedStoredKeyType(summary.KeyType),
 			IsDefault: name == defaultName,
 			Source:    "keychain",
 		})
@@ -1396,6 +1438,7 @@ func listFromKeyring(kr keyring.Keyring) ([]Credential, error) {
 			IssuerID:              payload.IssuerID,
 			PrivateKeyPath:        payload.PrivateKeyPath,
 			PrivateKeyPEM:         payload.PrivateKeyPEM,
+			KeyType:               normalizedStoredKeyType(payload.KeyType),
 			IsDefault:             name == defaultName,
 			Source:                "keychain",
 			MetadataNeedsBackfill: metadataNeedsBackfill,
@@ -1413,6 +1456,7 @@ func migrateLegacyCredentials(credentials []Credential) {
 			IssuerID:       cred.IssuerID,
 			PrivateKeyPath: cred.PrivateKeyPath,
 			PrivateKeyPEM:  cred.PrivateKeyPEM,
+			KeyType:        normalizedStoredKeyType(cred.KeyType),
 		}
 		if err := storeInKeychain(cred.Name, payload); err != nil {
 			continue
@@ -1531,6 +1575,7 @@ func storeInConfigAt(name string, payload credentialPayload, configPath string) 
 			cfg.Keys[i].KeyID = payload.KeyID
 			cfg.Keys[i].IssuerID = payload.IssuerID
 			cfg.Keys[i].PrivateKeyPath = payload.PrivateKeyPath
+			cfg.Keys[i].KeyType = normalizedStoredKeyType(payload.KeyType)
 			updated = true
 			break
 		}
@@ -1541,12 +1586,14 @@ func storeInConfigAt(name string, payload credentialPayload, configPath string) 
 			KeyID:          payload.KeyID,
 			IssuerID:       payload.IssuerID,
 			PrivateKeyPath: payload.PrivateKeyPath,
+			KeyType:        normalizedStoredKeyType(payload.KeyType),
 		})
 	}
 
 	cfg.KeyID = payload.KeyID
 	cfg.IssuerID = payload.IssuerID
 	cfg.PrivateKeyPath = payload.PrivateKeyPath
+	cfg.KeyType = normalizedStoredKeyType(payload.KeyType)
 	cfg.DefaultKeyName = name
 	return config.SaveAt(configPath, cfg)
 }
@@ -1561,14 +1608,16 @@ func hasAnyCredentials(cfg *config.Config) bool {
 	}
 	if strings.TrimSpace(cfg.KeyID) != "" ||
 		strings.TrimSpace(cfg.IssuerID) != "" ||
-		strings.TrimSpace(cfg.PrivateKeyPath) != "" {
+		strings.TrimSpace(cfg.PrivateKeyPath) != "" ||
+		strings.TrimSpace(cfg.KeyType) != "" {
 		return true
 	}
 	for _, cred := range cfg.Keys {
 		if strings.TrimSpace(cred.Name) != "" ||
 			strings.TrimSpace(cred.KeyID) != "" ||
 			strings.TrimSpace(cred.IssuerID) != "" ||
-			strings.TrimSpace(cred.PrivateKeyPath) != "" {
+			strings.TrimSpace(cred.PrivateKeyPath) != "" ||
+			strings.TrimSpace(cred.KeyType) != "" {
 			return true
 		}
 	}
@@ -1576,15 +1625,17 @@ func hasAnyCredentials(cfg *config.Config) bool {
 }
 
 func isCompleteConfigCredential(cred config.Credential) bool {
+	hasIssuer := strings.TrimSpace(cred.IssuerID) != "" ||
+		config.IsIndividualCredentialKeyType(cred.KeyType)
 	return strings.TrimSpace(cred.KeyID) != "" &&
-		strings.TrimSpace(cred.IssuerID) != "" &&
+		hasIssuer &&
 		strings.TrimSpace(cred.PrivateKeyPath) != ""
 }
 
 func hasLegacyCredentials(cfg *config.Config) bool {
 	return cfg != nil &&
 		strings.TrimSpace(cfg.KeyID) != "" &&
-		strings.TrimSpace(cfg.IssuerID) != "" &&
+		(strings.TrimSpace(cfg.IssuerID) != "" || config.IsIndividualCredentialKeyType(cfg.KeyType)) &&
 		strings.TrimSpace(cfg.PrivateKeyPath) != ""
 }
 
@@ -1618,6 +1669,7 @@ func configCredentialList(cfg *config.Config) []config.Credential {
 				KeyID:          cfg.KeyID,
 				IssuerID:       cfg.IssuerID,
 				PrivateKeyPath: cfg.PrivateKeyPath,
+				KeyType:        normalizedStoredKeyType(cfg.KeyType),
 			})
 		}
 	}
@@ -1646,12 +1698,14 @@ func findConfigCredential(cfg *config.Config, name string) (config.Credential, b
 	}
 	if name == legacyName && (strings.TrimSpace(cfg.KeyID) != "" ||
 		strings.TrimSpace(cfg.IssuerID) != "" ||
-		strings.TrimSpace(cfg.PrivateKeyPath) != "") {
+		strings.TrimSpace(cfg.PrivateKeyPath) != "" ||
+		strings.TrimSpace(cfg.KeyType) != "") {
 		cred := config.Credential{
 			Name:           legacyName,
 			KeyID:          cfg.KeyID,
 			IssuerID:       cfg.IssuerID,
 			PrivateKeyPath: cfg.PrivateKeyPath,
+			KeyType:        normalizedStoredKeyType(cfg.KeyType),
 		}
 		return cred, true, isCompleteConfigCredential(cred)
 	}
@@ -1664,6 +1718,7 @@ func applyConfigCredential(cfg *config.Config, cred config.Credential) *config.C
 			KeyID:          cred.KeyID,
 			IssuerID:       cred.IssuerID,
 			PrivateKeyPath: cred.PrivateKeyPath,
+			KeyType:        normalizedStoredKeyType(cred.KeyType),
 			DefaultKeyName: strings.TrimSpace(cred.Name),
 		}
 	}
@@ -1671,6 +1726,7 @@ func applyConfigCredential(cfg *config.Config, cred config.Credential) *config.C
 	copied.KeyID = cred.KeyID
 	copied.IssuerID = cred.IssuerID
 	copied.PrivateKeyPath = cred.PrivateKeyPath
+	copied.KeyType = normalizedStoredKeyType(cred.KeyType)
 	if strings.TrimSpace(cred.Name) != "" {
 		copied.DefaultKeyName = strings.TrimSpace(cred.Name)
 	}
@@ -1775,6 +1831,7 @@ func listFromConfig() ([]Credential, error) {
 			KeyID:          cred.KeyID,
 			IssuerID:       cred.IssuerID,
 			PrivateKeyPath: cred.PrivateKeyPath,
+			KeyType:        normalizedStoredKeyType(cred.KeyType),
 			IsDefault:      cred.Name == defaultName,
 			Source:         "config",
 			SourcePath:     path,
@@ -1807,6 +1864,7 @@ func saveDefaultName(name string) error {
 				cfg.KeyID = cred.KeyID
 				cfg.IssuerID = cred.IssuerID
 				cfg.PrivateKeyPath = cred.PrivateKeyPath
+				cfg.KeyType = normalizedStoredKeyType(cred.KeyType)
 				return config.Save(cfg)
 			}
 		}
@@ -1850,6 +1908,7 @@ func removeFromConfigAt(name, path string) error {
 		cfg.KeyID = ""
 		cfg.IssuerID = ""
 		cfg.PrivateKeyPath = ""
+		cfg.KeyType = ""
 		cfg.DefaultKeyName = ""
 		cfg.Keys = nil
 		cfg.KeychainMetadata = nil
@@ -1884,6 +1943,7 @@ func removeFromConfigAt(name, path string) error {
 		cfg.KeyID = ""
 		cfg.IssuerID = ""
 		cfg.PrivateKeyPath = ""
+		cfg.KeyType = ""
 		cfg.DefaultKeyName = ""
 		removed = true
 	}

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -436,6 +436,7 @@ func AuthLoginCommand() *ffcli.Command {
 	name := fs.String("name", "", "Friendly name for this key")
 	keyID := fs.String("key-id", "", "App Store Connect API Key ID")
 	issuerID := fs.String("issuer-id", "", "App Store Connect Issuer ID")
+	keyType := fs.String("key-type", config.CredentialKeyTypeTeam, "App Store Connect API key type: team or individual")
 	keyPath := fs.String("private-key", "", "Path to private key (.p8) file")
 	bypassKeychain := fs.Bool("bypass-keychain", false, "Store credentials in config.json instead of keychain")
 	local := fs.Bool("local", false, "When bypassing keychain, write to ./.asc/config.json")
@@ -455,6 +456,7 @@ Add --local to write ./.asc/config.json for the current repo.
 
 Examples:
   asc auth login --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
+  asc auth login --name "MyIndividualKey" --key-id "ABC123" --key-type individual --private-key /path/to/AuthKey.p8
   asc auth login --bypass-keychain --local --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
   asc auth login --network --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
   asc auth login --skip-validation --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
@@ -476,9 +478,16 @@ so commands continue to work even if the original .p8 file is removed.`,
 				fmt.Fprintln(os.Stderr, "Error: --key-id is required")
 				return flag.ErrHelp
 			}
-			if *issuerID == "" {
+			normalizedKeyType := config.NormalizeCredentialKeyType(*keyType)
+			if !config.IsValidCredentialKeyType(normalizedKeyType) {
+				return shared.UsageError("--key-type must be one of: team, individual")
+			}
+			if normalizedKeyType == config.CredentialKeyTypeTeam && *issuerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --issuer-id is required")
 				return flag.ErrHelp
+			}
+			if normalizedKeyType == config.CredentialKeyTypeIndividual && strings.TrimSpace(*issuerID) != "" {
+				return shared.UsageError("--issuer-id must be omitted when --key-type individual")
 			}
 			if *keyPath == "" {
 				fmt.Fprintln(os.Stderr, "Error: --private-key is required")
@@ -512,16 +521,16 @@ so commands continue to work even if the original .p8 file is removed.`,
 					if err != nil {
 						return fmt.Errorf("auth login: %w", err)
 					}
-					if err := authsvc.StoreCredentialsConfigAt(*name, *keyID, *issuerID, *keyPath, path); err != nil {
+					if err := authsvc.StoreCredentialsConfigAtWithKeyType(*name, *keyID, *issuerID, *keyPath, path, normalizedKeyType); err != nil {
 						return fmt.Errorf("auth login: failed to store credentials: %w", err)
 					}
 				} else {
-					if err := authsvc.StoreCredentialsConfig(*name, *keyID, *issuerID, *keyPath); err != nil {
+					if err := authsvc.StoreCredentialsConfigWithKeyType(*name, *keyID, *issuerID, *keyPath, normalizedKeyType); err != nil {
 						return fmt.Errorf("auth login: failed to store credentials: %w", err)
 					}
 				}
 			} else {
-				if err := authsvc.StoreCredentials(*name, *keyID, *issuerID, *keyPath); err != nil {
+				if err := authsvc.StoreCredentialsWithKeyType(*name, *keyID, *issuerID, *keyPath, normalizedKeyType); err != nil {
 					return fmt.Errorf("auth login: failed to store credentials: %w", err)
 				}
 			}
@@ -920,11 +929,13 @@ Examples:
 			profile := shared.ResolveProfileName()
 			envKeyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
 			envIssuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
+			envKeyType := config.NormalizeCredentialKeyType(os.Getenv("ASC_KEY_TYPE"))
 			hasKeyEnv := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
 				strings.TrimSpace(os.Getenv(shared.PrivateKeyEnvVar)) != "" ||
 				strings.TrimSpace(os.Getenv(shared.PrivateKeyBase64EnvVar)) != ""
-			envProvided := envKeyID != "" || envIssuerID != "" || hasKeyEnv
-			envComplete := envKeyID != "" && envIssuerID != "" && hasKeyEnv
+			envProvided := envKeyID != "" || envIssuerID != "" || hasKeyEnv || strings.TrimSpace(os.Getenv("ASC_KEY_TYPE")) != ""
+			envComplete := envKeyID != "" && hasKeyEnv &&
+				(envIssuerID != "" || config.IsIndividualCredentialKeyType(envKeyType))
 
 			environmentNote := authStatusEnvironmentNote(profile, bypassKeychain, envProvided, envComplete)
 			if normalizedOutput == "table" && environmentNote != "" {
@@ -1032,7 +1043,7 @@ func authStatusEnvironmentNote(profile string, bypassKeychain, envProvided, envC
 		return ""
 	}
 	if !envComplete {
-		return "Environment credentials are incomplete. Set ASC_KEY_ID, ASC_ISSUER_ID, and one of ASC_PRIVATE_KEY_PATH/ASC_PRIVATE_KEY/ASC_PRIVATE_KEY_B64."
+		return "Environment credentials are incomplete. Set ASC_KEY_ID, ASC_ISSUER_ID (unless ASC_KEY_TYPE=individual), and one of ASC_PRIVATE_KEY_PATH/ASC_PRIVATE_KEY/ASC_PRIVATE_KEY_B64."
 	}
 	return "Environment credentials detected (ASC_KEY_ID present). In bypass mode, stored config credentials are preferred; environment credentials are only used when no stored config credential is selected."
 }

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -340,12 +340,13 @@ func validateStoredCredential(ctx context.Context, cred authsvc.Credential) erro
 		client     *asc.Client
 		err        error
 	)
+	signingIssuerID := credentialSigningIssuerID(cred)
 	if pemValue := strings.TrimSpace(cred.PrivateKeyPEM); pemValue != "" {
 		privateKey, err = authsvc.LoadPrivateKeyFromPEM([]byte(pemValue))
 		if err != nil {
 			return fmt.Errorf("invalid private key: %w", err)
 		}
-		client, err = asc.NewClientFromPEM(cred.KeyID, cred.IssuerID, pemValue)
+		client, err = asc.NewClientFromPEM(cred.KeyID, signingIssuerID, pemValue)
 		if err != nil {
 			return err
 		}
@@ -357,12 +358,12 @@ func validateStoredCredential(ctx context.Context, cred authsvc.Credential) erro
 		if err != nil {
 			return fmt.Errorf("failed to load private key: %w", err)
 		}
-		client, err = asc.NewClient(cred.KeyID, cred.IssuerID, cred.PrivateKeyPath)
+		client, err = asc.NewClient(cred.KeyID, signingIssuerID, cred.PrivateKeyPath)
 		if err != nil {
 			return err
 		}
 	}
-	if _, err := asc.GenerateJWT(cred.KeyID, cred.IssuerID, privateKey); err != nil {
+	if _, err := asc.GenerateJWT(cred.KeyID, signingIssuerID, privateKey); err != nil {
 		return fmt.Errorf("failed to generate JWT: %w", err)
 	}
 	if _, err := client.GetApps(ctx, asc.WithAppsLimit(1)); err != nil {
@@ -372,6 +373,13 @@ func validateStoredCredential(ctx context.Context, cred authsvc.Credential) erro
 		return err
 	}
 	return nil
+}
+
+func credentialSigningIssuerID(cred authsvc.Credential) string {
+	if config.IsIndividualCredentialKeyType(cred.KeyType) {
+		return ""
+	}
+	return cred.IssuerID
 }
 
 func validateLoginCredentials(ctx context.Context, keyID, issuerID, keyPath string, network bool) error {
@@ -929,15 +937,18 @@ Examples:
 			profile := shared.ResolveProfileName()
 			envKeyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
 			envIssuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
-			envKeyType := config.NormalizeCredentialKeyType(os.Getenv("ASC_KEY_TYPE"))
+			envKeyTypeRaw := strings.TrimSpace(os.Getenv("ASC_KEY_TYPE"))
+			envKeyType := config.NormalizeCredentialKeyType(envKeyTypeRaw)
+			envKeyTypeValid := envKeyTypeRaw == "" || config.IsValidCredentialKeyType(envKeyType)
 			hasKeyEnv := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
 				strings.TrimSpace(os.Getenv(shared.PrivateKeyEnvVar)) != "" ||
 				strings.TrimSpace(os.Getenv(shared.PrivateKeyBase64EnvVar)) != ""
-			envProvided := envKeyID != "" || envIssuerID != "" || hasKeyEnv || strings.TrimSpace(os.Getenv("ASC_KEY_TYPE")) != ""
+			envProvided := envKeyID != "" || envIssuerID != "" || hasKeyEnv || envKeyTypeRaw != ""
 			envComplete := envKeyID != "" && hasKeyEnv &&
+				envKeyTypeValid &&
 				(envIssuerID != "" || config.IsIndividualCredentialKeyType(envKeyType))
 
-			environmentNote := authStatusEnvironmentNote(profile, bypassKeychain, envProvided, envComplete)
+			environmentNote := authStatusEnvironmentNote(profile, bypassKeychain, envProvided, envComplete, envKeyTypeValid)
 			if normalizedOutput == "table" && environmentNote != "" {
 				fmt.Println(environmentNote)
 			}
@@ -1035,12 +1046,15 @@ func defaultAuthStatusOutputFormat() string {
 	return "table"
 }
 
-func authStatusEnvironmentNote(profile string, bypassKeychain, envProvided, envComplete bool) string {
+func authStatusEnvironmentNote(profile string, bypassKeychain, envProvided, envComplete, envKeyTypeValid bool) string {
 	if profile != "" && envProvided {
 		return fmt.Sprintf("Profile %q selected; environment credentials will be ignored.", profile)
 	}
 	if !bypassKeychain || !envProvided {
 		return ""
+	}
+	if !envKeyTypeValid {
+		return "Environment credentials are incomplete. ASC_KEY_TYPE must be one of: team, individual."
 	}
 	if !envComplete {
 		return "Environment credentials are incomplete. Set ASC_KEY_ID, ASC_ISSUER_ID (unless ASC_KEY_TYPE=individual), and one of ASC_PRIVATE_KEY_PATH/ASC_PRIVATE_KEY/ASC_PRIVATE_KEY_B64."

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -250,6 +250,25 @@ func TestValidateStoredCredential_UsesPEMWhenPathMissing(t *testing.T) {
 	}
 }
 
+func TestCredentialSigningIssuerIDClearsIndividualIssuer(t *testing.T) {
+	team := authsvc.Credential{
+		KeyID:    "KEY",
+		IssuerID: "ISS",
+	}
+	if got := credentialSigningIssuerID(team); got != "ISS" {
+		t.Fatalf("team signing issuer = %q, want ISS", got)
+	}
+
+	individual := authsvc.Credential{
+		KeyID:    "KEY",
+		IssuerID: "STRAYISS",
+		KeyType:  config.CredentialKeyTypeIndividual,
+	}
+	if got := credentialSigningIssuerID(individual); got != "" {
+		t.Fatalf("individual signing issuer = %q, want empty", got)
+	}
+}
+
 func TestValidateLoginCredentials(t *testing.T) {
 	keyPath := writeTempECDSAKeyFile(t)
 

--- a/internal/cli/cmdtest/auth_status_output_test.go
+++ b/internal/cli/cmdtest/auth_status_output_test.go
@@ -204,6 +204,43 @@ func TestAuthStatusOutputInvalidReturnsExitUsage(t *testing.T) {
 	}
 }
 
+func TestAuthStatusInvalidEnvKeyTypeMarksEnvironmentIncomplete(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_KEY_TYPE", "personal")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = cmd.Run([]string{"auth", "status", "--output", "json"}, "1.0.0")
+	})
+	if code != cmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, cmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		EnvironmentCredentialsComplete bool   `json:"environmentCredentialsComplete"`
+		EnvironmentNote                string `json:"environmentNote"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to unmarshal auth status json: %v; stdout=%q", err, stdout)
+	}
+	if payload.EnvironmentCredentialsComplete {
+		t.Fatalf("expected environmentCredentialsComplete=false, got true; stdout=%q", stdout)
+	}
+	if !strings.Contains(payload.EnvironmentNote, "ASC_KEY_TYPE must be one of: team, individual") {
+		t.Fatalf("expected invalid key type environment note, got %q", payload.EnvironmentNote)
+	}
+}
+
 func TestAuthStatusInvalidBypassWarningPrintedOnce(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -5369,6 +5370,97 @@ func TestAuthLoginSkipValidationBypassesJWT(t *testing.T) {
 	configPath := filepath.Join(workDir, ".asc", "config.json")
 	if _, err := os.Stat(configPath); err != nil {
 		t.Fatalf("expected config to be written, got %v", err)
+	}
+}
+
+func TestAuthLoginIndividualKeyAllowsMissingIssuer(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+
+	workDir := t.TempDir()
+	previousDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("Chdir() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(previousDir)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"auth", "login",
+			"--bypass-keychain",
+			"--local",
+			"--skip-validation",
+			"--key-type", "individual",
+			"--name", "IndividualKey",
+			"--key-id", "KEY123",
+			"--private-key", keyPath,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	configPath := filepath.Join(workDir, ".asc", "config.json")
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("LoadAt() error: %v", err)
+	}
+	if len(cfg.Keys) != 1 {
+		t.Fatalf("expected one stored key, got %d", len(cfg.Keys))
+	}
+	if cfg.Keys[0].IssuerID != "" {
+		t.Fatalf("issuer ID = %q, want empty", cfg.Keys[0].IssuerID)
+	}
+	if cfg.Keys[0].KeyType != config.CredentialKeyTypeIndividual {
+		t.Fatalf("key type = %q, want %q", cfg.Keys[0].KeyType, config.CredentialKeyTypeIndividual)
+	}
+	if cfg.KeyType != config.CredentialKeyTypeIndividual {
+		t.Fatalf("default key type = %q, want %q", cfg.KeyType, config.CredentialKeyTypeIndividual)
+	}
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+
+	var statusCode int
+	statusStdout, statusStderr := captureOutput(t, func() {
+		statusCode = rootcmd.Run([]string{"auth", "status", "--output", "json"}, "1.2.3")
+	})
+	if statusCode != rootcmd.ExitSuccess {
+		t.Fatalf("auth status exit code = %d, want %d; stderr=%q", statusCode, rootcmd.ExitSuccess, statusStderr)
+	}
+	if statusStderr != "" {
+		t.Fatalf("expected auth status stderr to be empty, got %q", statusStderr)
+	}
+	var statusPayload struct {
+		Credentials []struct {
+			Name  string `json:"name"`
+			KeyID string `json:"keyId"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal([]byte(statusStdout), &statusPayload); err != nil {
+		t.Fatalf("failed to unmarshal auth status output: %v; stdout=%q", err, statusStdout)
+	}
+	if len(statusPayload.Credentials) != 1 || statusPayload.Credentials[0].Name != "IndividualKey" {
+		t.Fatalf("unexpected auth status credentials: %+v", statusPayload.Credentials)
 	}
 }
 

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -296,6 +296,17 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			wantErr: "--skip-validation and --network are mutually exclusive",
 		},
 		{
+			name: "auth login invalid key type",
+			args: []string{
+				"auth", "login",
+				"--name", "demo",
+				"--key-id", "KEY",
+				"--key-type", "personal",
+				"--private-key", "/tmp/AuthKey.p8",
+			},
+			wantErr: "--key-type must be one of: team, individual",
+		},
+		{
 			name:    "apps info view conflicting version flags",
 			args:    []string{"apps", "info", "view", "--app", "APP_ID", "--version", "1.0.0", "--version-id", "VERSION_ID"},
 			wantErr: "--version and --version-id are mutually exclusive",

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -486,6 +486,10 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 		}
 		return resolvedCredentials{}, missingAuthError{msg: "missing authentication. Run 'asc auth login' or 'asc auth init'"}
 	}
+	if config.IsIndividualCredentialKeyType(actualKeyType) {
+		actualIssuerID = ""
+		sources.issuerID = ""
+	}
 	if err := checkMixedCredentialSources(sources); err != nil {
 		return resolvedCredentials{}, err
 	}

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -34,6 +34,7 @@ var (
 const (
 	privateKeyEnvVar       = "ASC_PRIVATE_KEY"
 	privateKeyBase64EnvVar = "ASC_PRIVATE_KEY_B64"
+	keyTypeEnvVar          = "ASC_KEY_TYPE"
 	profileEnvVar          = "ASC_PROFILE"
 	strictAuthEnvVar       = "ASC_STRICT_AUTH"
 	defaultOutputEnvVar    = "ASC_DEFAULT_OUTPUT"
@@ -301,6 +302,7 @@ type envCredentials struct {
 	keyID    string
 	issuerID string
 	keyPath  string
+	keyType  string
 	complete bool
 }
 
@@ -357,6 +359,7 @@ type ResolvedAuthCredentials struct {
 	IssuerID string
 	KeyPath  string
 	KeyPEM   string
+	KeyType  string
 	Profile  string
 }
 
@@ -365,6 +368,7 @@ type resolvedCredentials struct {
 	issuerID string
 	keyPath  string
 	keyPEM   string
+	keyType  string
 	profile  string
 }
 
@@ -377,12 +381,16 @@ type credentialSource struct {
 func resolveEnvCredentials() (envCredentials, error) {
 	keyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
 	issuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
+	keyType := config.NormalizeCredentialKeyType(os.Getenv(keyTypeEnvVar))
 	hasKeyPathEnv := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
 		strings.TrimSpace(os.Getenv(privateKeyEnvVar)) != "" ||
 		strings.TrimSpace(os.Getenv(privateKeyBase64EnvVar)) != ""
 
-	if keyID == "" && issuerID == "" && !hasKeyPathEnv {
+	if keyID == "" && issuerID == "" && !hasKeyPathEnv && strings.TrimSpace(os.Getenv(keyTypeEnvVar)) == "" {
 		return envCredentials{}, nil
+	}
+	if !config.IsValidCredentialKeyType(keyType) {
+		return envCredentials{}, fmt.Errorf("%s must be one of: team, individual", keyTypeEnvVar)
 	}
 
 	keyPath, err := resolvePrivateKeyPath()
@@ -394,8 +402,11 @@ func resolveEnvCredentials() (envCredentials, error) {
 		keyID:    keyID,
 		issuerID: issuerID,
 		keyPath:  keyPath,
+		keyType:  normalizedResolvedKeyType(keyType),
 	}
-	creds.complete = keyID != "" && issuerID != "" && keyPath != ""
+	creds.complete = keyID != "" &&
+		keyPath != "" &&
+		(issuerID != "" || config.IsIndividualCredentialKeyType(keyType))
 	return creds, nil
 }
 
@@ -404,7 +415,7 @@ func resolveCredentials() (resolvedCredentials, error) {
 }
 
 func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, error) {
-	var actualKeyID, actualIssuerID, actualKeyPath, actualKeyPEM string
+	var actualKeyID, actualIssuerID, actualKeyPath, actualKeyPEM, actualKeyType string
 	actualProfile := ""
 	profile := strings.TrimSpace(profileOverride)
 	if profile == "" {
@@ -432,6 +443,7 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 		actualIssuerID = cfg.IssuerID
 		actualKeyPath = cfg.PrivateKeyPath
 		actualKeyPEM = strings.TrimSpace(cfg.PrivateKeyPEM)
+		actualKeyType = normalizedResolvedKeyType(cfg.KeyType)
 		actualProfile = strings.TrimSpace(cfg.DefaultKeyName)
 		sources.keyID = storedSource
 		sources.issuerID = storedSource
@@ -441,7 +453,9 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 	}
 
 	// Priority 2: Environment variables (fallback for CI/CD or when keychain unavailable)
-	if actualKeyID == "" || actualIssuerID == "" || (actualKeyPath == "" && actualKeyPEM == "") {
+	if actualKeyID == "" ||
+		(actualIssuerID == "" && !config.IsIndividualCredentialKeyType(actualKeyType)) ||
+		(actualKeyPath == "" && actualKeyPEM == "") {
 		resolved, err := resolveEnvCredentials()
 		if err != nil {
 			return resolvedCredentials{}, fmt.Errorf("invalid private key environment: %w", err)
@@ -455,13 +469,18 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 			actualIssuerID = envCreds.issuerID
 			sources.issuerID = "env"
 		}
+		if actualKeyType == "" && envCreds.keyType != "" {
+			actualKeyType = envCreds.keyType
+		}
 		if actualKeyPath == "" && actualKeyPEM == "" && envCreds.keyPath != "" {
 			actualKeyPath = envCreds.keyPath
 			sources.keyMaterial = "env"
 		}
 	}
 
-	if actualKeyID == "" || actualIssuerID == "" || (actualKeyPath == "" && actualKeyPEM == "") {
+	if actualKeyID == "" ||
+		(actualIssuerID == "" && !config.IsIndividualCredentialKeyType(actualKeyType)) ||
+		(actualKeyPath == "" && actualKeyPEM == "") {
 		if path, err := config.Path(); err == nil {
 			return resolvedCredentials{}, missingAuthError{msg: fmt.Sprintf("missing authentication. Run 'asc auth login' or create %s (see 'asc auth init')", path)}
 		}
@@ -476,14 +495,24 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 		issuerID: actualIssuerID,
 		keyPath:  actualKeyPath,
 		keyPEM:   actualKeyPEM,
+		keyType:  normalizedResolvedKeyType(actualKeyType),
 		profile:  actualProfile,
 	}, nil
+}
+
+func normalizedResolvedKeyType(keyType string) string {
+	normalized := config.NormalizeCredentialKeyType(keyType)
+	if normalized == config.CredentialKeyTypeTeam {
+		return ""
+	}
+	return normalized
 }
 
 type credentialMetadataSummary struct {
 	name     string
 	keyID    string
 	issuerID string
+	keyType  string
 }
 
 func resolveCredentialsMetadataForProfile(profileOverride string) (ResolvedAuthCredentials, error) {
@@ -543,6 +572,7 @@ func resolveStoredCredentialsMetadataFallback(profile string) (ResolvedAuthCrede
 	return ResolvedAuthCredentials{
 		KeyID:    keyID,
 		IssuerID: issuerID,
+		KeyType:  normalizedResolvedKeyType(cred.KeyType),
 		Profile:  strings.TrimSpace(cred.Name),
 	}, nil
 }
@@ -582,6 +612,7 @@ func resolveStoredCredentialMetadata(profile string) (ResolvedAuthCredentials, e
 	return ResolvedAuthCredentials{
 		KeyID:    summary.keyID,
 		IssuerID: summary.issuerID,
+		KeyType:  normalizedResolvedKeyType(summary.keyType),
 		Profile:  summary.name,
 	}, nil
 }
@@ -630,7 +661,9 @@ func hasConfigCredentialSelection(cfg *config.Config) bool {
 	if strings.TrimSpace(cfg.DefaultKeyName) != "" {
 		return true
 	}
-	if strings.TrimSpace(cfg.KeyID) != "" || strings.TrimSpace(cfg.IssuerID) != "" {
+	if strings.TrimSpace(cfg.KeyID) != "" ||
+		strings.TrimSpace(cfg.IssuerID) != "" ||
+		strings.TrimSpace(cfg.KeyType) != "" {
 		return true
 	}
 	if strings.TrimSpace(cfg.PrivateKeyPath) != "" || strings.TrimSpace(cfg.PrivateKeyPEM) != "" {
@@ -661,6 +694,7 @@ func configCredentialMetadataSummaries(cfg *config.Config) []credentialMetadataS
 			name:     name,
 			keyID:    keyID,
 			issuerID: strings.TrimSpace(entry.IssuerID),
+			keyType:  normalizedResolvedKeyType(entry.KeyType),
 		})
 	}
 
@@ -678,6 +712,7 @@ func configCredentialMetadataSummaries(cfg *config.Config) []credentialMetadataS
 			name:     name,
 			keyID:    keyID,
 			issuerID: strings.TrimSpace(cred.IssuerID),
+			keyType:  normalizedResolvedKeyType(cred.KeyType),
 		})
 	}
 
@@ -692,6 +727,7 @@ func configCredentialMetadataSummaries(cfg *config.Config) []credentialMetadataS
 				name:     name,
 				keyID:    legacyKeyID,
 				issuerID: strings.TrimSpace(cfg.IssuerID),
+				keyType:  normalizedResolvedKeyType(cfg.KeyType),
 			})
 		}
 	}
@@ -1528,6 +1564,7 @@ func ResolveAuthCredentials(profile string) (ResolvedAuthCredentials, error) {
 		IssuerID: resolved.issuerID,
 		KeyPath:  resolved.keyPath,
 		KeyPEM:   resolved.keyPEM,
+		KeyType:  resolved.keyType,
 		Profile:  resolved.profile,
 	}, nil
 }

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -490,7 +490,7 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 		actualIssuerID = ""
 		sources.issuerID = ""
 	}
-	if err := checkMixedCredentialSources(sources); err != nil {
+	if err := checkMixedCredentialSourcesForKeyType(sources, actualKeyType); err != nil {
 		return resolvedCredentials{}, err
 	}
 
@@ -843,13 +843,34 @@ func ApplyRootLoggingOverrides() {
 }
 
 func checkMixedCredentialSources(sources credentialSource) error {
+	return checkMixedCredentialSourcesForKeyType(sources, config.CredentialKeyTypeTeam)
+}
+
+func checkMixedCredentialSourcesForKeyType(sources credentialSource, keyType string) error {
 	keyIDSource := strings.TrimSpace(sources.keyID)
 	issuerSource := strings.TrimSpace(sources.issuerID)
 	keyMaterialSource := strings.TrimSpace(sources.keyMaterial)
-	if keyIDSource == "" || issuerSource == "" || keyMaterialSource == "" {
+	if keyIDSource == "" || keyMaterialSource == "" {
 		return nil
 	}
-	if keyIDSource == issuerSource && issuerSource == keyMaterialSource {
+	if config.IsIndividualCredentialKeyType(keyType) {
+		if keyIDSource == keyMaterialSource {
+			return nil
+		}
+
+		message := fmt.Sprintf(
+			"Warning: credentials loaded from multiple sources:\n  Key ID: %s\n  Private Key: %s\n",
+			keyIDSource,
+			keyMaterialSource,
+		)
+		if strictAuthEnabled() {
+			return fmt.Errorf("mixed authentication sources detected:\n  Key ID: %s\n  Private Key: %s", keyIDSource, keyMaterialSource)
+		}
+		fmt.Fprint(os.Stderr, message)
+		return nil
+	}
+
+	if issuerSource == "" || keyIDSource == issuerSource && issuerSource == keyMaterialSource {
 		return nil
 	}
 

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -1140,6 +1140,93 @@ func TestResolveCredentials_BypassKeychainFallsBackToEnvWhenConfigMissing(t *tes
 	}
 }
 
+func TestResolveCredentials_IndividualEnvIgnoresIssuerID(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	envKeyPath := filepath.Join(tempDir, "AuthKey-Env.p8")
+	writeECDSAPEM(t, envKeyPath)
+
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(tempDir, "missing.json"))
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "STRAYISS")
+	t.Setenv("ASC_KEY_TYPE", config.CredentialKeyTypeIndividual)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", envKeyPath)
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() {
+		selectedProfile = previousProfile
+	})
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if creds.keyID != "ENVKEY" || creds.keyType != config.CredentialKeyTypeIndividual || creds.keyPath != envKeyPath {
+		t.Fatalf("expected individual env credentials, got %+v", creds)
+	}
+	if creds.issuerID != "" {
+		t.Fatalf("expected individual credentials to ignore issuer ID, got %q", creds.issuerID)
+	}
+}
+
+func TestResolveCredentials_IndividualStoredCredentialIgnoresIssuerID(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+
+	cfg := &config.Config{
+		DefaultKeyName: "individual",
+		Keys: []config.Credential{
+			{
+				Name:           "individual",
+				KeyID:          "CFGKEY",
+				IssuerID:       "STRAYISS",
+				PrivateKeyPath: keyPath,
+				KeyType:        config.CredentialKeyTypeIndividual,
+			},
+		},
+	}
+	if err := config.SaveAt(configPath, cfg); err != nil {
+		t.Fatalf("SaveAt() error: %v", err)
+	}
+
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() {
+		selectedProfile = previousProfile
+	})
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if creds.keyID != "CFGKEY" || creds.keyType != config.CredentialKeyTypeIndividual || creds.keyPath != keyPath {
+		t.Fatalf("expected individual stored credentials, got %+v", creds)
+	}
+	if creds.issuerID != "" {
+		t.Fatalf("expected individual credentials to ignore issuer ID, got %q", creds.issuerID)
+	}
+}
+
 func TestResolveCredentials_DefaultSelectionErrorFallsBackToEnv(t *testing.T) {
 	resetPrivateKeyTemp(t)
 

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -940,6 +940,31 @@ func TestCheckMixedCredentialSourcesStrictAuthEnvErrors(t *testing.T) {
 	}
 }
 
+func TestCheckMixedCredentialSourcesIndividualStrictErrors(t *testing.T) {
+	previousStrict := strictAuth
+	strictAuth = true
+	t.Cleanup(func() {
+		strictAuth = previousStrict
+	})
+	t.Setenv(strictAuthEnvVar, "")
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := checkMixedCredentialSourcesForKeyType(credentialSource{
+			keyID:       "config",
+			keyMaterial: "env",
+		}, config.CredentialKeyTypeIndividual); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
 func TestStrictAuthEnabled_EnvTruthyValues(t *testing.T) {
 	previousStrict := strictAuth
 	strictAuth = false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,37 @@ const (
 	maxConfigRetries = 30
 )
 
+const (
+	// CredentialKeyTypeTeam is the default App Store Connect API key type.
+	CredentialKeyTypeTeam = "team"
+	// CredentialKeyTypeIndividual signs JWTs with sub:"user" and no issuer.
+	CredentialKeyTypeIndividual = "individual"
+)
+
+// NormalizeCredentialKeyType returns the canonical credential key type.
+func NormalizeCredentialKeyType(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return CredentialKeyTypeTeam
+	}
+	return value
+}
+
+// IsValidCredentialKeyType reports whether value names a supported key type.
+func IsValidCredentialKeyType(value string) bool {
+	switch NormalizeCredentialKeyType(value) {
+	case CredentialKeyTypeTeam, CredentialKeyTypeIndividual:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsIndividualCredentialKeyType reports whether value names an individual key.
+func IsIndividualCredentialKeyType(value string) bool {
+	return NormalizeCredentialKeyType(value) == CredentialKeyTypeIndividual
+}
+
 // DurationValue stores a duration with its raw string representation.
 // It marshals to/from JSON as a string to preserve config compatibility.
 type DurationValue struct {
@@ -115,6 +146,7 @@ type Credential struct {
 	KeyID          string `json:"key_id"`
 	IssuerID       string `json:"issuer_id"`
 	PrivateKeyPath string `json:"private_key_path"`
+	KeyType        string `json:"key_type,omitempty"`
 }
 
 // AdsCredential stores a named Apple Ads API credential in config.json.
@@ -132,6 +164,7 @@ type KeychainMetadata struct {
 	Name       string `json:"name"`
 	KeyID      string `json:"key_id"`
 	IssuerID   string `json:"issuer_id"`
+	KeyType    string `json:"key_type,omitempty"`
 	ModifiedAt string `json:"modified_at,omitempty"`
 }
 
@@ -159,6 +192,7 @@ type Config struct {
 	IssuerID         string             `json:"issuer_id"`
 	PrivateKeyPath   string             `json:"private_key_path"`
 	PrivateKeyPEM    string             `json:"-"`
+	KeyType          string             `json:"key_type,omitempty"`
 	DefaultKeyName   string             `json:"default_key_name"`
 	Keys             []Credential       `json:"keys,omitempty"`
 	KeychainMetadata []KeychainMetadata `json:"keychain_metadata,omitempty"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add explicit `auth login --key-type team|individual` support, allowing individual keys to omit `--issuer-id`.
- Persist `key_type` through config/keychain metadata and treat issuer-less credentials as complete only when marked `individual`.
- Generate individual-key JWTs with `sub:"user"` and no `iss` claim.
- Addressed PR feedback by ignoring stray issuer IDs whenever resolved credentials are marked `individual`, including env/config edge cases.
- Addressed follow-up comments by:
  - making `auth status --validate` sign individual credentials without stale issuer IDs,
  - reporting invalid `ASC_KEY_TYPE` as incomplete in `auth status` and `auth doctor`,
  - preserving mixed-source warnings/errors for individual keys using key ID + private key sources.

## Validation

- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

Key exit-code / smoke scenarios validated:
- Built `/tmp/asc` and checked `asc auth login --help` includes `--key-type` and the individual-key example.
- `/tmp/asc auth login --key-type personal ...` returns usage exit code 2 with `--key-type must be one of: team, individual`.
- `/tmp/asc auth login --skip-validation --key-type individual --key-id KEY123 --private-key AuthKey.p8` succeeds without `--issuer-id` using config storage.
- `/tmp/asc auth status --output json` sees the saved individual profile.
- `/tmp/asc auth token --confirm --output json` for that profile emits a JWT payload with `sub:"user"` and no `iss` claim.
- `ASC_KEY_TYPE=individual ASC_ISSUER_ID=STRAYISS /tmp/asc auth token --confirm --output json` emits `sub:"user"` and no `iss` claim.
- `ASC_KEY_TYPE=personal /tmp/asc auth status --output json` reports `environmentCredentialsComplete=false` and an `ASC_KEY_TYPE must be one of: team, individual` note.

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I used `asc apps wall submit --app "1234567890" --confirm` (or made the equivalent single-file update manually)
- [ ] This PR only updates `docs/wall-of-apps.json`
- [ ] I ran `make check-wall-of-apps`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24a8d8a6-d140-43f1-9c78-72f52f1cd6a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24a8d8a6-d140-43f1-9c78-72f52f1cd6a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for App Store Connect individual API keys alongside existing team key support
  * Introduced `--key-type` flag to `auth login` command for specifying key type (defaults to team)
  * Added `ASC_KEY_TYPE` environment variable for configuring key type

* **Improvements**
  * Enhanced validation messaging for key type configuration
  * Individual keys no longer require issuer ID; issuer ID is now required only for team keys

<!-- end of auto-generated comment: release notes by coderabbit.ai -->