### PR TITLE
Update monthly commitment API notes

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -74,8 +74,8 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
   - https://developer.apple.com/news/?id=agq42lxe
   - https://developer.apple.com/help/app-store-connect/manage-subscriptions/set-availability-for-an-auto-renewable-subscription/
 - The App Store Connect help docs describe this as a billing option on a regular 1-year subscription, with separate `1 Year Upfront` and `Monthly with 12-Month Commitment` availability sections for the same product.
-- The public App Store Connect OpenAPI snapshot currently exposes `subscriptionAvailabilities` and `subscriptionPrices` without a billing-mode discriminator or a separate monthly-commitment resource. The CLI therefore exposes an experimental guarded `asc subscriptions pricing monthly-commitment` surface that validates period, territory exclusions, and the 1.5x price rule, then returns a "not yet supported by Apple's public App Store Connect API" error before attempting mutation.
-- The experimental web-session client can observe internal `subscriptionPlanAvailabilities` with a `planType` attribute, but that surface is private and should not be wired into the canonical JWT-backed subscription pricing commands until Apple documents a stable API.
+- App Store Connect API 4.4 exposes `subscriptionPlanAvailabilities` with a `planType` attribute and `/v1/subscriptions/{id}/planAvailabilities` for reading the upfront/monthly plan availability set. Use `planType=MONTHLY` for Monthly with 12-Month Commitment, and keep `subscriptionAvailability` for the default/upfront availability.
+- Monthly commitment remains unavailable in the United States and Singapore; the CLI removes `USA` and `SGP` from requested monthly-commitment territories before writing plan availability.
 
 ## Pass Type IDs
 


### PR DESCRIPTION
## Summary
- update `docs/API_NOTES.md` now that App Store Connect API 4.4 exposes `subscriptionPlanAvailabilities` publicly
- clarify that default/upfront availability still uses `subscriptionAvailability` and monthly commitment uses `planType=MONTHLY`
- keep the USA/Singapore exclusion note documented

## Verification
- `make check-command-docs`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestSubscriptionsPricingMonthlyCommitment|TestSubscriptionsPricingAvailabilityEdit|TestSubscriptionsSetup'`\n\n## Note\nPR #1632 already merged the implementation; this only fixes the stale API note that still described monthly commitment as private/unavailable.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated App Store Connect API documentation with current behavior for monthly subscriptions featuring 12-month commitment support
  * Documented plan availability exposure through API endpoints and territory handling in the CLI tool
  * Removed experimental feature guidance and warnings about internal API data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->