### PR TITLE
fix: install asc skills globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ asc install-skills
 Direct install:
 
 ```bash
-npx skills add rorkai/app-store-connect-cli-skills --global
+npx skills add rorkai/app-store-connect-cli-skills --global --agent codex
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Automate iOS, macOS, tvOS, and visionOS release workflows from your terminal, ID
 Agent Skills for automating `asc` workflows including builds, TestFlight, metadata sync, submissions, and signing:
 https://github.com/rorkai/app-store-connect-cli-skills
 
+Install them globally so they are available across projects:
+
+```bash
+asc install-skills
+```
+
+Direct install:
+
+```bash
+npx skills add rorkai/app-store-connect-cli-skills --global
+```
+
 ## Quick Start
 
 If you want to confirm the binary works before configuring authentication:

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -44,7 +44,7 @@ Commands are organized into logical families based on functionality:
 
 * `auth` - Manage authentication for the App Store Connect API
 * `doctor` - Diagnose authentication configuration issues
-* `install-skills` - Install the asc skill pack for App Store Connect workflows
+* `install-skills` - Install the asc skill pack globally for App Store Connect workflows
 * `init` - Initialize asc helper docs in the current repo
 * `docs` - Access embedded documentation guides and reference helpers
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -38,7 +38,7 @@ asc <subcommand> [flags]
 
 - `auth` - Manage authentication for the App Store Connect API.
 - `doctor` - Diagnose authentication configuration issues.
-- `install-skills` - Install the asc skill pack for App Store Connect workflows.
+- `install-skills` - Install the asc skill pack globally for App Store Connect workflows.
 - `init` - Initialize asc helper docs in the current repo.
 - `docs` - Access embedded documentation guides and reference helpers.
 

--- a/index.mdx
+++ b/index.mdx
@@ -69,6 +69,20 @@
         ```
       </Step>
 
+      <Step title="Install the agent skills globally">
+        Make the asc workflow skills available across your projects:
+
+        ```bash  theme={null}
+        asc install-skills
+        ```
+
+        Direct install:
+
+        ```bash  theme={null}
+        npx skills add rorkai/app-store-connect-cli-skills --global
+        ```
+      </Step>
+
       <Step title="Authenticate with your API key">
         Generate an API key from [App Store Connect](https://appstoreconnect.apple.com/access/integrations/api) and authenticate:
 

--- a/index.mdx
+++ b/index.mdx
@@ -79,7 +79,7 @@
         Direct install:
 
         ```bash  theme={null}
-        npx skills add rorkai/app-store-connect-cli-skills --global
+        npx skills add rorkai/app-store-connect-cli-skills --global --agent codex
         ```
       </Step>
 

--- a/installation.mdx
+++ b/installation.mdx
@@ -191,7 +191,7 @@ asc install-skills
 Direct install:
 
 ```bash  theme={null}
-npx skills add rorkai/app-store-connect-cli-skills --global
+npx skills add rorkai/app-store-connect-cli-skills --global --agent codex
 ```
 
 ## Shell completion

--- a/installation.mdx
+++ b/installation.mdx
@@ -180,6 +180,20 @@ ASC_BYPASS_KEYCHAIN=1 make test
   Always use `ASC_BYPASS_KEYCHAIN=1` when running tests to avoid macOS keychain prompts and environment bleed-through.
 </Warning>
 
+## Agent skills
+
+`asc` can install the App Store Connect workflow skills globally so your agent can use them across projects:
+
+```bash  theme={null}
+asc install-skills
+```
+
+Direct install:
+
+```bash  theme={null}
+npx skills add rorkai/app-store-connect-cli-skills --global
+```
+
 ## Shell completion
 
 `asc` supports shell completion for bash, zsh, and fish.

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -126,7 +126,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `doctor` - Diagnose authentication configuration issues.
 - `web` - `[experimental]` Unofficial Apple web-session `/iris` workflows (discouraged; not part of the official API). Uses low-rate calls, user-owned Apple ID sessions, and signed-URL redaction by default. Use `asc web apps create` as the canonical app-creation path in this family.
 - `account` - Inspect account-level health and access signals.
-- `install-skills` - Install the asc skill pack for App Store Connect workflows.
+- `install-skills` - Install the asc skill pack globally for App Store Connect workflows.
 - `init` - Initialize asc helper docs in the current repo.
 - `docs` - Generate asc cli reference docs for a repo.
 - `diff` - Generate deterministic non-mutating diff plans.

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -51,7 +51,7 @@ func installSkills(ctx context.Context) error {
 	}
 
 	// `npx add-skill` is deprecated upstream; use the new subcommand style.
-	return runCommand(ctx, path, "--yes", "skills", "add", defaultSkillsPackage, "--global", "--yes")
+	return runCommand(ctx, path, "--yes", "skills", "add", defaultSkillsPackage, "--global", "--agent", "codex", "--yes")
 }
 
 func defaultRunCommand(ctx context.Context, name string, args ...string) error {

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -28,8 +28,8 @@ func InstallSkillsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "install-skills",
 		ShortUsage: "asc install-skills",
-		ShortHelp:  "Install the asc skill pack for App Store Connect workflows.",
-		LongHelp: `Install the asc skill pack for App Store Connect workflows.
+		ShortHelp:  "Install the asc skill pack globally for App Store Connect workflows.",
+		LongHelp: `Install the asc skill pack globally for App Store Connect workflows.
 
 Examples:
   asc install-skills`,
@@ -51,7 +51,7 @@ func installSkills(ctx context.Context) error {
 	}
 
 	// `npx add-skill` is deprecated upstream; use the new subcommand style.
-	return runCommand(ctx, path, "--yes", "skills", "add", defaultSkillsPackage)
+	return runCommand(ctx, path, "--yes", "skills", "add", defaultSkillsPackage, "--global", "--yes")
 }
 
 func defaultRunCommand(ctx context.Context, name string, args ...string) error {

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-const defaultSkillsPackage = "rudrankriyam/asc-skills"
+const defaultSkillsPackage = "rorkai/app-store-connect-cli-skills"
 
 var (
 	lookupNpx      = exec.LookPath

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -41,7 +41,7 @@ func TestInstallSkillsRunsNpxSkillsAdd(t *testing.T) {
 	if gotName != "/bin/npx" {
 		t.Fatalf("expected npx path /bin/npx, got %q", gotName)
 	}
-	expected := []string{"--yes", "skills", "add", defaultSkillsPackage}
+	expected := []string{"--yes", "skills", "add", defaultSkillsPackage, "--global", "--yes"}
 	if !reflect.DeepEqual(gotArgs, expected) {
 		t.Fatalf("expected args %v, got %v", expected, gotArgs)
 	}

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -41,7 +41,7 @@ func TestInstallSkillsRunsNpxSkillsAdd(t *testing.T) {
 	if gotName != "/bin/npx" {
 		t.Fatalf("expected npx path /bin/npx, got %q", gotName)
 	}
-	expected := []string{"--yes", "skills", "add", defaultSkillsPackage, "--global", "--yes"}
+	expected := []string{"--yes", "skills", "add", defaultSkillsPackage, "--global", "--agent", "codex", "--yes"}
 	if !reflect.DeepEqual(gotArgs, expected) {
 		t.Fatalf("expected args %v, got %v", expected, gotArgs)
 	}


### PR DESCRIPTION
## Summary
- make `asc install-skills` install the asc skill pack in global scope
- keep the built-in installer non-interactive by passing the skills CLI `--yes` flag
- update README, installation docs, command overview, and generated command docs to describe global skill installation

## Validation
- `make generate-command-docs`
- `make check-command-docs`
- `PATH="/Users/iPrado/go/bin:$PATH" make format`
- `PATH="/Users/iPrado/go/bin:$PATH" make lint` (passed via Makefile go vet fallback; `golangci-lint` was not installed locally)
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/install ./cmd -run 'TestInstallSkills|TestShouldRunSkillsUpdateCheck|TestRootCommand_UsageGroupsSubcommands|TestRun_UnknownCommandReturnsUsage'`\n- `ASC_BYPASS_KEYCHAIN=1 make test`\n\n## Notes\n- `make tools` was attempted to install `gofumpt`/`golangci-lint`, but the `golangci-lint` install failed on a Go module proxy connection reset. `gofumpt` is available under `/Users/iPrado/go/bin`, so formatting was run with that directory added to PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added agent skills installation instructions to quickstart, installation guides, and command docs, including a direct npx global-install example.
  * Clarified command descriptions to state the skill pack is installed globally.

* **Improvements**
  * install-skills now performs a global installation of the agent skill pack for App Store Connect workflows by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->