### PR TITLE
Close App Store Connect API 4.4 coverage gaps

### DIFF
--- a/commands/performance.mdx
+++ b/commands/performance.mdx
@@ -38,6 +38,7 @@ asc performance metrics list --app "APP_ID"
   * `HANG` - UI hangs
   * `LAUNCH` - App launch time
   * `MEMORY` - Memory usage
+  * `STORAGE` - Storage footprint (data usage and binary size)
   * `TERMINATION` - App terminations
 * `--device-type` - Comma-separated device types (e.g., `iPhone15,2`)
 

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -343,6 +343,13 @@ asc subscriptions pricing price-points view \
 
 Control which territories can purchase your subscriptions.
 
+<Note>
+  The underlying Subscription availability resource is deprecated in App Store
+  Connect API 4.4 in favor of Subscription plan availability. These commands
+  keep working for now; for plan-based availability use
+  `asc subscriptions pricing monthly-commitment`.
+</Note>
+
 ### Get Availability
 
 ```bash  theme={null}

--- a/commands/users.mdx
+++ b/commands/users.mdx
@@ -240,7 +240,7 @@ Common user roles in App Store Connect:
 * `SALES` - Access to sales and trends
 * `FINANCE` - Access to financial reports
 * `CUSTOMER_SUPPORT` - Access to customer support features
-* `ACCESS_TO_REPORTS` - Read-only access to reports
+* `ACCESS_TO_REPORTS` - Read-only access to reports (deprecated in App Store Connect API 4.4; see [UserRole](https://developer.apple.com/documentation/appstoreconnectapi/userrole) for alternatives)
 
 See the [App Store Connect documentation](https://developer.apple.com/support/roles/) for role descriptions and permissions.
 

--- a/internal/asc/age_rating.go
+++ b/internal/asc/age_rating.go
@@ -51,6 +51,7 @@ type AppStoreAgeRating string
 const (
 	AppStoreAgeRatingL             AppStoreAgeRating = "L"
 	AppStoreAgeRatingAll           AppStoreAgeRating = "ALL"
+	AppStoreAgeRatingZeroZero      AppStoreAgeRating = "ZERO_ZERO"
 	AppStoreAgeRatingOnePlus       AppStoreAgeRating = "ONE_PLUS"
 	AppStoreAgeRatingTwoPlus       AppStoreAgeRating = "TWO_PLUS"
 	AppStoreAgeRatingThreePlus     AppStoreAgeRating = "THREE_PLUS"

--- a/internal/asc/client_http_background_assets_test.go
+++ b/internal/asc/client_http_background_assets_test.go
@@ -27,6 +27,9 @@ func TestGetBackgroundAssets_SendsRequest(t *testing.T) {
 		if values.Get("filter[assetPackIdentifier]") != "pack-1,pack-2" {
 			t.Fatalf("expected filter[assetPackIdentifier]=pack-1,pack-2, got %q", values.Get("filter[assetPackIdentifier]"))
 		}
+		if values.Get("filter[versions.locale]") != "en-US,ja" {
+			t.Fatalf("expected filter[versions.locale]=en-US,ja, got %q", values.Get("filter[versions.locale]"))
+		}
 		assertAuthorized(t, req)
 	}, response)
 
@@ -36,6 +39,7 @@ func TestGetBackgroundAssets_SendsRequest(t *testing.T) {
 		WithBackgroundAssetsLimit(5),
 		WithBackgroundAssetsFilterArchived([]string{"true"}),
 		WithBackgroundAssetsFilterAssetPackIdentifier([]string{"pack-1", "pack-2"}),
+		WithBackgroundAssetsFilterVersionsLocale([]string{"en-US", "ja"}),
 	)
 	if err != nil {
 		t.Fatalf("GetBackgroundAssets() error: %v", err)
@@ -145,10 +149,13 @@ func TestGetBackgroundAssetVersions_SendsRequest(t *testing.T) {
 		if values.Get("limit") != "10" {
 			t.Fatalf("expected limit=10, got %q", values.Get("limit"))
 		}
+		if values.Get("filter[locale]") != "en-US" {
+			t.Fatalf("expected filter[locale]=en-US, got %q", values.Get("filter[locale]"))
+		}
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetBackgroundAssetVersions(context.Background(), "asset-1", WithBackgroundAssetVersionsLimit(10)); err != nil {
+	if _, err := client.GetBackgroundAssetVersions(context.Background(), "asset-1", WithBackgroundAssetVersionsLimit(10), WithBackgroundAssetVersionsFilterLocale([]string{"en-US"})); err != nil {
 		t.Fatalf("GetBackgroundAssetVersions() error: %v", err)
 	}
 }

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -688,6 +688,13 @@ func WithBackgroundAssetsFilterAssetPackIdentifier(values []string) BackgroundAs
 	}
 }
 
+// WithBackgroundAssetsFilterVersionsLocale filters background assets by uploaded version locale.
+func WithBackgroundAssetsFilterVersionsLocale(values []string) BackgroundAssetsOption {
+	return func(q *backgroundAssetsQuery) {
+		q.versionsLocales = normalizeList(values)
+	}
+}
+
 // WithBackgroundAssetVersionsLimit sets the max number of background asset versions to return.
 func WithBackgroundAssetVersionsLimit(limit int) BackgroundAssetVersionsOption {
 	return func(q *backgroundAssetVersionsQuery) {
@@ -703,6 +710,13 @@ func WithBackgroundAssetVersionsNextURL(next string) BackgroundAssetVersionsOpti
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithBackgroundAssetVersionsFilterLocale filters background asset versions by locale.
+func WithBackgroundAssetVersionsFilterLocale(values []string) BackgroundAssetVersionsOption {
+	return func(q *backgroundAssetVersionsQuery) {
+		q.locales = normalizeList(values)
 	}
 }
 

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -210,10 +210,12 @@ type backgroundAssetsQuery struct {
 	listQuery
 	archived             []string
 	assetPackIdentifiers []string
+	versionsLocales      []string
 }
 
 type backgroundAssetVersionsQuery struct {
 	listQuery
+	locales []string
 }
 
 type backgroundAssetUploadFilesQuery struct {
@@ -1268,12 +1270,14 @@ func buildBackgroundAssetsQuery(query *backgroundAssetsQuery) string {
 	values := url.Values{}
 	addCSV(values, "filter[archived]", query.archived)
 	addCSV(values, "filter[assetPackIdentifier]", query.assetPackIdentifiers)
+	addCSV(values, "filter[versions.locale]", query.versionsLocales)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
 
 func buildBackgroundAssetVersionsQuery(query *backgroundAssetVersionsQuery) string {
 	values := url.Values{}
+	addCSV(values, "filter[locale]", query.locales)
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/performance.go
+++ b/internal/asc/performance.go
@@ -13,6 +13,7 @@ const (
 	PerfPowerMetricTypeMemory      PerfPowerMetricType = "MEMORY"
 	PerfPowerMetricTypeAnimation   PerfPowerMetricType = "ANIMATION"
 	PerfPowerMetricTypeTermination PerfPowerMetricType = "TERMINATION"
+	PerfPowerMetricTypeStorage     PerfPowerMetricType = "STORAGE"
 )
 
 // DiagnosticSignatureType represents a diagnostic signature category.

--- a/internal/cli/backgroundassets/background_assets.go
+++ b/internal/cli/backgroundassets/background_assets.go
@@ -60,6 +60,7 @@ func BackgroundAssetsListCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
 	archived := fs.String("archived", "", "Filter by archived state (true/false)")
 	assetPackIdentifier := fs.String("asset-pack-identifier", "", "Filter by asset pack identifier(s), comma-separated")
+	versionsLocale := fs.String("versions-locale", "", "Filter by uploaded version locale(s), comma-separated (e.g., en-US,ja)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -74,6 +75,7 @@ func BackgroundAssetsListCommand() *ffcli.Command {
 Examples:
   asc background-assets list --app "APP_ID"
   asc background-assets list --app "APP_ID" --archived false
+  asc background-assets list --app "APP_ID" --versions-locale "en-US,ja"
   asc background-assets list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -100,6 +102,7 @@ Examples:
 			}
 
 			assetPackIdentifiers := shared.SplitCSV(*assetPackIdentifier)
+			versionsLocales := shared.SplitCSV(*versionsLocale)
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -118,6 +121,9 @@ Examples:
 			}
 			if len(assetPackIdentifiers) > 0 {
 				opts = append(opts, asc.WithBackgroundAssetsFilterAssetPackIdentifier(assetPackIdentifiers))
+			}
+			if len(versionsLocales) > 0 {
+				opts = append(opts, asc.WithBackgroundAssetsFilterVersionsLocale(versionsLocales))
 			}
 
 			if *paginate {

--- a/internal/cli/backgroundassets/background_assets_versions.go
+++ b/internal/cli/backgroundassets/background_assets_versions.go
@@ -45,6 +45,7 @@ func BackgroundAssetsVersionsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	assetID := fs.String("background-asset-id", "", "Background asset ID")
+	locale := fs.String("locale", "", "Filter by locale(s), comma-separated (e.g., en-US,ja)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -58,6 +59,7 @@ func BackgroundAssetsVersionsListCommand() *ffcli.Command {
 
 Examples:
   asc background-assets versions list --background-asset-id "ASSET_ID"
+  asc background-assets versions list --background-asset-id "ASSET_ID" --locale "en-US"
   asc background-assets versions list --background-asset-id "ASSET_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -85,6 +87,9 @@ Examples:
 			opts := []asc.BackgroundAssetVersionsOption{
 				asc.WithBackgroundAssetVersionsLimit(*limit),
 				asc.WithBackgroundAssetVersionsNextURL(*next),
+			}
+			if locales := shared.SplitCSV(*locale); len(locales) > 0 {
+				opts = append(opts, asc.WithBackgroundAssetVersionsFilterLocale(locales))
 			}
 
 			if *paginate {

--- a/internal/cli/cmdtest/background_assets_locale_filter_test.go
+++ b/internal/cli/cmdtest/background_assets_locale_filter_test.go
@@ -1,0 +1,117 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runBackgroundAssetsCommandWithTransport(
+	t *testing.T,
+	args []string,
+	wantPath string,
+	wantQuery map[string]string,
+	body string,
+) (string, string, error) {
+	t.Helper()
+
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != wantPath {
+			t.Fatalf("expected path %s, got %s", wantPath, req.URL.Path)
+		}
+		values := req.URL.Query()
+		for key, want := range wantQuery {
+			if got := values.Get(key); got != want {
+				t.Fatalf("expected %s=%q, got %q", key, want, got)
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func TestBackgroundAssetsListFiltersByVersionsLocale(t *testing.T) {
+	stdout, stderr, err := runBackgroundAssetsCommandWithTransport(
+		t,
+		[]string{"background-assets", "list", "--app", "app-1", "--versions-locale", "en-US, ja"},
+		"/v1/apps/app-1/backgroundAssets",
+		map[string]string{"filter[versions.locale]": "en-US,ja"},
+		`{"data":[{"type":"backgroundAssets","id":"asset-1"}]}`,
+	)
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &payload); jsonErr != nil {
+		t.Fatalf("failed to parse stdout JSON: %v (stdout %q)", jsonErr, stdout)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].ID != "asset-1" {
+		t.Fatalf("expected asset-1 in output, got %+v", payload.Data)
+	}
+}
+
+func TestBackgroundAssetsVersionsListFiltersByLocale(t *testing.T) {
+	stdout, stderr, err := runBackgroundAssetsCommandWithTransport(
+		t,
+		[]string{"background-assets", "versions", "list", "--background-asset-id", "asset-1", "--locale", "en-US"},
+		"/v1/backgroundAssets/asset-1/versions",
+		map[string]string{"filter[locale]": "en-US"},
+		`{"data":[{"type":"backgroundAssetVersions","id":"version-1"}]}`,
+	)
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &payload); jsonErr != nil {
+		t.Fatalf("failed to parse stdout JSON: %v (stdout %q)", jsonErr, stdout)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].ID != "version-1" {
+		t.Fatalf("expected version-1 in output, got %+v", payload.Data)
+	}
+}

--- a/internal/cli/cmdtest/performance_metrics_metric_type_test.go
+++ b/internal/cli/cmdtest/performance_metrics_metric_type_test.go
@@ -1,0 +1,112 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runPerformanceMetricsListWithMetricType(t *testing.T, metricType string) (string, string, error) {
+	t.Helper()
+
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/perfPowerMetrics" {
+			t.Fatalf("expected perfPowerMetrics path, got %s", req.URL.Path)
+		}
+		if got := req.URL.Query().Get("filter[metricType]"); got != metricType {
+			t.Fatalf("expected filter[metricType]=%q, got %q", metricType, got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"productData":[],"version":"1.0"}`)),
+			Header:     http.Header{"Content-Type": []string{"application/vnd.apple.xcode-metrics+json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"performance", "metrics", "list", "--app", "app-1", "--metric-type", metricType}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func TestPerformanceMetricsListAcceptsStorageMetricType(t *testing.T) {
+	stdout, stderr, err := runPerformanceMetricsListWithMetricType(t, "STORAGE")
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"productData"`) {
+		t.Fatalf("expected metrics payload in stdout, got %q", stdout)
+	}
+}
+
+func TestPerformanceMetricsListRejectsInvalidMetricType(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"performance", "metrics", "list", "--app", "app-1", "--metric-type", "BOGUS"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	wantErr := "--metric-type must be one of: ANIMATION, BATTERY, DISK, HANG, LAUNCH, MEMORY, STORAGE, TERMINATION"
+	if !strings.Contains(runErr.Error(), wantErr) {
+		t.Fatalf("expected error %q, got %v", wantErr, runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestPerformanceMetricsViewRejectsInvalidMetricType(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"performance", "metrics", "view", "--build", "build-1", "--metric-type", "BOGUS"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	wantErr := "--metric-type must be one of: ANIMATION, BATTERY, DISK, HANG, LAUNCH, MEMORY, STORAGE, TERMINATION"
+	if !strings.Contains(runErr.Error(), wantErr) {
+		t.Fatalf("expected error %q, got %v", wantErr, runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}

--- a/internal/cli/performance/performance_metrics.go
+++ b/internal/cli/performance/performance_metrics.go
@@ -166,6 +166,7 @@ var perfPowerMetricTypes = map[string]struct{}{
 	string(asc.PerfPowerMetricTypeMemory):      {},
 	string(asc.PerfPowerMetricTypeAnimation):   {},
 	string(asc.PerfPowerMetricTypeTermination): {},
+	string(asc.PerfPowerMetricTypeStorage):     {},
 }
 
 func perfPowerMetricTypeList() []string {
@@ -176,6 +177,7 @@ func perfPowerMetricTypeList() []string {
 		string(asc.PerfPowerMetricTypeHang),
 		string(asc.PerfPowerMetricTypeLaunch),
 		string(asc.PerfPowerMetricTypeMemory),
+		string(asc.PerfPowerMetricTypeStorage),
 		string(asc.PerfPowerMetricTypeTermination),
 	}
 }

--- a/internal/cli/subscriptions/availability_deprecation_test.go
+++ b/internal/cli/subscriptions/availability_deprecation_test.go
@@ -1,0 +1,20 @@
+package subscriptions
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionsAvailabilityCommandMentionsAPIDeprecation(t *testing.T) {
+	cmd := SubscriptionsAvailabilityCommand()
+
+	if !strings.Contains(cmd.ShortHelp, "deprecated") {
+		t.Fatalf("expected ShortHelp to mention deprecation, got %q", cmd.ShortHelp)
+	}
+	if !strings.Contains(cmd.LongHelp, "Subscription plan availability") {
+		t.Fatalf("expected LongHelp to point at Subscription plan availability, got %q", cmd.LongHelp)
+	}
+	if !strings.Contains(cmd.LongHelp, "asc subscriptions pricing monthly-commitment") {
+		t.Fatalf("expected LongHelp to reference the plan-availability commands, got %q", cmd.LongHelp)
+	}
+}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1056,8 +1056,13 @@ func SubscriptionsAvailabilityCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "availability",
 		ShortUsage: "asc subscriptions availability <subcommand> [flags]",
-		ShortHelp:  "Manage subscription availability.",
+		ShortHelp:  "Manage subscription availability (deprecated by Apple).",
 		LongHelp: `Manage subscription availability.
+
+Deprecated: the underlying Subscription availability resource is deprecated in
+App Store Connect API 4.4 in favor of Subscription plan availability. These
+commands keep working for now; for plan-based availability use
+` + "`asc subscriptions pricing monthly-commitment`" + ` (enable/disable/list).
 
 Examples:
   asc subscriptions availability view --availability-id "AVAILABILITY_ID"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining CLI gaps against the App Store Connect API 4.4 release notes (the offline OpenAPI snapshot was already at 4.4):

- **`STORAGE` metric type**: `asc performance metrics list/view --metric-type STORAGE` is now accepted and forwarded as `filter[metricType]=STORAGE`. Previously the CLI validator rejected it even though the 4.4 spec enum includes it. Added `PerfPowerMetricTypeStorage` and updated the `--metric-type` allow-list (also picked up by `performance download`).
- **Background asset locale filters** (4.4 multi-locale support):
  - `asc background-assets list --versions-locale "en-US,ja"` → `filter[versions.locale]` on `GET /v1/apps/{id}/backgroundAssets`
  - `asc background-assets versions list --locale "en-US"` → `filter[locale]` on `GET /v1/backgroundAssets/{id}/versions`
  - New client options `WithBackgroundAssetsFilterVersionsLocale` and `WithBackgroundAssetVersionsFilterLocale`.
- **Subscription availability deprecation**: `asc subscriptions pricing availability` help now notes that Apple deprecated the underlying Subscription availability resource in 4.4 in favor of Subscription plan availability, pointing at `asc subscriptions pricing monthly-commitment`. Behavior is unchanged (deprecate-first lifecycle; no removal).
- **`ZERO_ZERO` age rating**: added the Vietnam 00+ `AppStoreAgeRating` constant (responses already passed through since the type is a string).
- **`ACCESS_TO_REPORTS`**: marked the user role as deprecated in `commands/users.mdx` (the CLI passes roles through without enum validation, so no behavior change).

### Design notes

- Endpoint/param names cross-checked against `docs/openapi/latest.json` (4.4): `filter[metricType]` enum includes `STORAGE`; `filter[versions.locale]` is only on the app-scoped backgroundAssets list; the version-scoped list uses `filter[locale]`.
- Locale values are intentionally not enum-validated client-side: the spec types them as free-form strings, so invalid locales surface as upstream API errors.
- The deprecated availability commands keep working with no stderr warning since there is no complete CLI replacement yet (plan availability currently surfaces as `monthly-commitment` only); per lifecycle policy this is the deprecation-notice stage.
- Removed endpoints (`GET /v1/appStoreVersions/{id}/(relationships/)ageRatingDeclaration`) needed no changes: the client already routes via the appInfo relationship.

### Tests (TDD, RED → GREEN)

- `internal/cli/cmdtest/performance_metrics_metric_type_test.go`: valid `STORAGE` path asserting the outgoing `filter[metricType]` query, plus invalid-value tests for `list` and `view` asserting the full allow-list error.
- `internal/cli/cmdtest/background_assets_locale_filter_test.go`: CLI-level tests asserting outgoing query params and parsing JSON output.
- `internal/asc/client_http_background_assets_test.go`: extended request assertions for both new options.
- `internal/cli/subscriptions/availability_deprecation_test.go`: help text mentions the deprecation and migration target.

### Exit-code scenarios validated (built binary `/tmp/asc`)

- `performance metrics list --app x --metric-type BOGUS` → exit 1, stderr `--metric-type must be one of: ANIMATION, BATTERY, DISK, HANG, LAUNCH, MEMORY, STORAGE, TERMINATION` (matches existing invalid-enum convention)
- `--help` output verified for `performance metrics list`, `background-assets list`, `background-assets versions list`, and `subscriptions pricing availability`

Live smoke testing against the throwaway `ASC Test` app was not possible: no ASC credentials are available in this environment.

## Validation

- [x] `make format`
- [x] `make check-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0db646e-685d-46b3-9c8f-8a616597e893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0db646e-685d-46b3-9c8f-8a616597e893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added STORAGE metric type option for performance metrics reporting
  * Added locale filtering capabilities for background assets list
  * Added locale filtering capabilities for background asset versions list

* **Documentation**
  * Added deprecation notice for subscriptions availability command, directing users to plan-based availability alternatives
  * Updated user role documentation with API version guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->