### PR TITLE
apps wall: use official App Store icon for CabinLink

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -146,8 +146,8 @@
   },
   {
     "app": "CabinLink",
-    "link": "https://apps.apple.com/app/id6761247556",
-    "icon": "https://www.vishrutjha.com/cabinlink.png"
+    "link": "https://apps.apple.com/us/app/cabinlink/id6761247556?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f8/91/a8/f891a8c5-d49e-a5bf-83f4-cbe86e0eac04/CabinLink-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
     "app": "Cal AI - Calorie Tracker",


### PR DESCRIPTION
## Summary

- Replace the temporary self-hosted CabinLink icon with the official App Store artwork, matching the other entries.

## Context

#1619 added CabinLink with a self-hosted icon because the public App Store lookup did not find the app at the time. The lookup now resolves (https://itunes.apple.com/lookup?id=6761247556), so this updates the entry to the official `mzstatic.com` 512x512 artwork and the canonical `trackViewUrl` link format used by the other apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CabinLink app entry with the current US App Store link and refreshed app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->