### PR TITLE
Fix win-back offer creation by inlining price relationships

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -10550,6 +10550,25 @@ func TestCreateWinBackOffer_SendsRequest(t *testing.T) {
 		if len(payload.Data.Relationships.Prices.Data) != 1 {
 			t.Fatalf("expected 1 price relationship, got %d", len(payload.Data.Relationships.Prices.Data))
 		}
+		if payload.Data.Relationships.Prices.Data[0].ID != "${price-1}" {
+			t.Fatalf("expected temporary price id ${price-1}, got %q", payload.Data.Relationships.Prices.Data[0].ID)
+		}
+		if len(payload.Included) != 1 {
+			t.Fatalf("expected 1 included price, got %d", len(payload.Included))
+		}
+		included := payload.Included[0]
+		if included.Type != ResourceTypeWinBackOfferPrices || included.ID != "${price-1}" {
+			t.Fatalf("unexpected included item: %+v", included)
+		}
+		if included.Relationships == nil {
+			t.Fatal("expected included price relationships")
+		}
+		if included.Relationships.Territory.Data.Type != ResourceTypeTerritories || included.Relationships.Territory.Data.ID != "USA" {
+			t.Fatalf("unexpected included territory relationship: %+v", included.Relationships.Territory.Data)
+		}
+		if included.Relationships.SubscriptionPricePoint.Data.Type != ResourceTypeSubscriptionPricePoints || included.Relationships.SubscriptionPricePoint.Data.ID != "price-point-1" {
+			t.Fatalf("unexpected included subscriptionPricePoint relationship: %+v", included.Relationships.SubscriptionPricePoint.Data)
+		}
 		assertAuthorized(t, req)
 	}, response)
 
@@ -10574,8 +10593,22 @@ func TestCreateWinBackOffer_SendsRequest(t *testing.T) {
 					Data: ResourceData{Type: ResourceTypeSubscriptions, ID: "sub-1"},
 				},
 				Prices: RelationshipList{Data: []ResourceData{
-					{Type: ResourceTypeWinBackOfferPrices, ID: "price-1"},
+					{Type: ResourceTypeWinBackOfferPrices, ID: "${price-1}"},
 				}},
+			},
+		},
+		Included: []WinBackOfferPriceInlineCreate{
+			{
+				Type: ResourceTypeWinBackOfferPrices,
+				ID:   "${price-1}",
+				Relationships: &WinBackOfferPriceRelationships{
+					Territory: Relationship{
+						Data: ResourceData{Type: ResourceTypeTerritories, ID: "USA"},
+					},
+					SubscriptionPricePoint: Relationship{
+						Data: ResourceData{Type: ResourceTypeSubscriptionPricePoints, ID: "price-point-1"},
+					},
+				},
 			},
 		},
 	}

--- a/internal/asc/win_back_offers.go
+++ b/internal/asc/win_back_offers.go
@@ -154,9 +154,15 @@ type WinBackOfferPriceRelationships struct {
 }
 
 // WinBackOfferPriceInlineCreate describes inline creation data for prices.
+// Win-back offer prices do not exist before the offer is created, so the
+// create request must inline them via the JSON:API `included` array with
+// temporary `${price-N}` IDs, each carrying territory and
+// subscriptionPricePoint relationships. Without the relationships the API
+// rejects the request with "Missing subscriptionPricePoint relationship".
 type WinBackOfferPriceInlineCreate struct {
-	Type ResourceType `json:"type"`
-	ID   string       `json:"id,omitempty"`
+	Type          ResourceType                    `json:"type"`
+	ID            string                          `json:"id,omitempty"`
+	Relationships *WinBackOfferPriceRelationships `json:"relationships,omitempty"`
 }
 
 // WinBackOffersResponse is the response from list endpoints.

--- a/internal/cli/winbackoffers/win_back_offers.go
+++ b/internal/cli/winbackoffers/win_back_offers.go
@@ -2,6 +2,8 @@ package winbackoffers
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -406,11 +408,40 @@ Examples:
 				promotionIntentValue = &intent
 			}
 
+			// Each --price value is a subscriptionPricePoint ID. Win-back
+			// offer prices don't exist before the offer does, so inline-create
+			// them in `included` with temp `${price-N}` IDs and territory +
+			// subscriptionPricePoint relationships (the territory is encoded
+			// inside the price point ID itself).
 			priceData := make([]asc.ResourceData, 0, len(prices))
-			for _, priceID := range prices {
+			includedPrices := make([]asc.WinBackOfferPriceInlineCreate, 0, len(prices))
+			for i, priceID := range prices {
+				territory, err := territoryFromPricePointID(priceID)
+				if err != nil {
+					return fmt.Errorf("win-back-offers create: %w", err)
+				}
+				tempID := fmt.Sprintf("${price-%d}", i+1)
 				priceData = append(priceData, asc.ResourceData{
 					Type: asc.ResourceTypeWinBackOfferPrices,
-					ID:   priceID,
+					ID:   tempID,
+				})
+				includedPrices = append(includedPrices, asc.WinBackOfferPriceInlineCreate{
+					Type: asc.ResourceTypeWinBackOfferPrices,
+					ID:   tempID,
+					Relationships: &asc.WinBackOfferPriceRelationships{
+						Territory: asc.Relationship{
+							Data: asc.ResourceData{
+								Type: asc.ResourceTypeTerritories,
+								ID:   territory,
+							},
+						},
+						SubscriptionPricePoint: asc.Relationship{
+							Data: asc.ResourceData{
+								Type: asc.ResourceTypeSubscriptionPricePoints,
+								ID:   priceID,
+							},
+						},
+					},
 				})
 			}
 
@@ -470,6 +501,7 @@ Examples:
 						Prices: asc.RelationshipList{Data: priceData},
 					},
 				},
+				Included: includedPrices,
 			}
 
 			resp, err := client.CreateWinBackOffer(requestCtx, req)
@@ -1024,4 +1056,22 @@ func winBackOfferSubscriptionPricePointFieldsList() []string {
 
 func winBackOfferPriceIncludeList() []string {
 	return []string{"territory", "subscriptionPricePoint"}
+}
+
+// territoryFromPricePointID extracts the territory code embedded in a
+// subscriptionPricePoint ID. Price point IDs are unpadded base64 of
+// {"s":"<subscriptionID>","t":"<territory>","p":"<pricePoint>"}.
+func territoryFromPricePointID(id string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(id), "=")
+	decoded, err := base64.RawStdEncoding.DecodeString(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("--price %q is not a subscription price point ID: %w", id, err)
+	}
+	var payload struct {
+		Territory string `json:"t"`
+	}
+	if err := json.Unmarshal(decoded, &payload); err != nil || payload.Territory == "" {
+		return "", fmt.Errorf("--price %q does not decode to a subscription price point ID", id)
+	}
+	return payload.Territory, nil
 }

--- a/internal/cli/winbackoffers/win_back_offers_test.go
+++ b/internal/cli/winbackoffers/win_back_offers_test.go
@@ -25,3 +25,58 @@ func TestWinBackOffersCommandConstructors(t *testing.T) {
 		t.Fatal("expected relationships command")
 	}
 }
+
+func TestTerritoryFromPricePointID(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		want    string
+		wantErr bool
+	}{
+		{
+			// base64 of {"s":"6755496237","t":"USA","p":"10101"}
+			name: "valid price point ID",
+			id:   "eyJzIjoiNjc1NTQ5NjIzNyIsInQiOiJVU0EiLCJwIjoiMTAxMDEifQ",
+			want: "USA",
+		},
+		{
+			name: "valid price point ID with padding",
+			id:   "eyJzIjoiNjc1NTQ5NjIzNyIsInQiOiJVU0EiLCJwIjoiMTAxMDEifQ==",
+			want: "USA",
+		},
+		{
+			name:    "not base64",
+			id:      "not-a-price-point!!",
+			wantErr: true,
+		},
+		{
+			name:    "base64 of non-JSON",
+			id:      "aGVsbG8",
+			wantErr: true,
+		},
+		{
+			// base64 of {"s":"1"} — decodes but lacks a territory
+			name:    "missing territory field",
+			id:      "eyJzIjoiMSJ9",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := territoryFromPricePointID(test.id)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got territory %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("expected territory %q, got %q", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

I've struggled with automatic win-back offers creation - seems like doing them inline solves it but there is a chance I am missing something and there is a better way.

- `subscriptions offers win-back create` failed on every request with `Missing subscriptionPricePoint relationship for resource.`
- The App Store Connect API requires win-back offer prices to be created inline through the `included` array, with `territory` and `subscriptionPricePoint` relationships on each entry. The command was sending bare `winBackOfferPrices` ID references in `relationships.prices` and no `included` array.
- Each `--price` value is now treated as a subscriptionPricePoint ID and referenced through a temporary `${price-N}` id, following the inline pattern `subscriptions pricing prices set` already uses. The territory for each entry is decoded from the price point ID payload, so no extra flag is needed.
- Verified against the live API: created one `PAY_AS_YOU_GO` and one `PAY_UP_FRONT` offer successfully, and `win-back prices --id` shows the expected price record.

## Validation

- [x] `make format`
- [x] `make check-docs`
- [ ] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `win-back-offers create` command now automatically derives territory information from subscription price point IDs, streamlining the creation process.
  * Enhanced support for inline creation of win-back offer prices with proper relationship handling.

* **Tests**
  * Added test coverage for territory derivation from subscription price point identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->