### PR TITLE
apps wall: add Game Box - Games for Watch

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -483,6 +483,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/52/0e/ed/520eed9c-d3f0-5d0e-3e68-5b6e698e5efc/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Game Box - Games for Watch",
+    "link": "https://apps.apple.com/us/app/game-box-games-for-watch/id6741334696?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/fb/f2/5e/fbf25e58-55d1-77de-a0ad-a1e8488ab7d7/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Gecko Med",
     "link": "https://apps.apple.com/us/app/gecko-med/id6737719743?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/63/4c/14/634c143e-7e6b-4afb-9748-0816af5d4544/apple-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Game Box - Games for Watch` to the Wall of Apps

## Entry

- App ID: 6741334696
- App: Game Box - Games for Watch
- Link: https://apps.apple.com/us/app/game-box-games-for-watch/id6741334696?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Game Box - Games for Watch" to the app directory with App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->