### PR TITLE
docs: add agent iOS release guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -36,6 +36,7 @@
             "pages": [
               "guides/testflight",
               "guides/app-store-submission",
+              "guides/agent-ios-release",
               "guides/code-signing",
               "guides/metadata-management",
               "guides/analytics-reports",

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -154,7 +154,39 @@ asc validate \
   --output table
 ```
 
-For apps with digital goods, gate those products too:
+For apps with digital goods, inspect product readiness before using the strict
+gate:
+
+```bash  theme={null}
+asc validate iap --app "$ASC_APP_ID" --output json
+asc validate subscriptions --app "$ASC_APP_ID" --output json
+```
+
+Resolve the exact `resourceId` for every product included in this release.
+`READY_TO_SUBMIT` is an action item, not a passing state. Submit each affected
+product, then re-read its state:
+
+```bash  theme={null}
+asc iap submit \
+  --app "$ASC_APP_ID" \
+  --iap-id "IAP_ID" \
+  --confirm \
+  --output json
+
+asc subscriptions review submit \
+  --app "$ASC_APP_ID" \
+  --subscription-id "SUBSCRIPTION_ID" \
+  --confirm \
+  --output json
+```
+
+These product submission commands do not support `--dry-run`; use the
+validation report and exact resource IDs as the pre-mutation check. First-time
+subscriptions may need to be submitted with the app version in App Store
+Connect instead of through the public API. If that limitation applies, stop and
+complete or hand off the UI step with the exact subscription and version IDs.
+
+After product submission, rerun the applicable validators in strict mode:
 
 ```bash  theme={null}
 asc validate iap --app "$ASC_APP_ID" --strict --output table

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -86,6 +86,7 @@ asc release stage \
   --app "$ASC_APP_ID" \
   --version "$VERSION" \
   --build "$ASC_BUILD_ID" \
+  --platform IOS \
   --copy-metadata-from "1.2.2" \
   --dry-run \
   --output table
@@ -104,6 +105,7 @@ asc release stage \
   --app "$ASC_APP_ID" \
   --version "$VERSION" \
   --build "$ASC_BUILD_ID" \
+  --platform IOS \
   --copy-metadata-from "1.2.2" \
   --confirm \
   --output table
@@ -118,6 +120,7 @@ asc publish appstore \
   --app "$ASC_APP_ID" \
   --ipa "./build/ios/ipa/MyApp.ipa" \
   --version "$VERSION" \
+  --platform IOS \
   --wait \
   --dry-run \
   --output table
@@ -131,6 +134,7 @@ asc publish appstore \
   --app "$ASC_APP_ID" \
   --ipa "./build/ios/ipa/MyApp.ipa" \
   --version "$VERSION" \
+  --platform IOS \
   --wait \
   --output json
 ```
@@ -221,6 +225,7 @@ asc review submit \
   --app "$ASC_APP_ID" \
   --version "$VERSION" \
   --build "$ASC_BUILD_ID" \
+  --platform IOS \
   --dry-run \
   --output table
 ```
@@ -235,6 +240,7 @@ Re-read App Store Connect and include the attached build and submission:
 ```bash  theme={null}
 asc status \
   --app "$ASC_APP_ID" \
+  --platform IOS \
   --include builds,appstore,submission,review \
   --output json
 

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -45,6 +45,7 @@ asc builds info \
   --latest \
   --version "$VERSION" \
   --platform IOS \
+  --processing-state VALID \
   --output json
 ```
 

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -1,199 +1,156 @@
-# Agent iOS Release
+# Agent iOS Release Checklist
 
-> Use `asc` for App Store submission before falling back to App Store Connect web UI
+> Use this checklist as an agent release gate. See
+> [App Store Submission](/guides/app-store-submission) for the full workflow and
+> troubleshooting guide.
 
-This guide is for agents and release scripts that need to ship an iOS app
-without clicking through App Store Connect by hand. The goal is not just to run a
-command, but to prove the exact app version and build reached a real review
-state.
+This page adds the agent-specific contract: resolve exact resources, use strict
+validation, preview one mutation path, and prove the final App Store Connect
+state before reporting success.
 
-## When to use this flow
+## Operating rules
 
-Use this flow when you need to:
+* Run `--help` for every command before using it.
+* Resolve the app ID, version ID, and build ID before changing anything.
+* Use public App Store Connect API commands before experimental web commands.
+* Preview mutations with `--dry-run`, then use `--confirm` only after checking
+  the resolved version and build.
+* Never print credentials or personal identity values in logs or handoffs.
+* A successful mutation response is not proof that the version entered review.
 
-* upload an IPA and submit it for App Review
-* attach an already processed build to a new App Store version
-* copy or apply metadata before review
-* verify whether the submission is really `WAITING_FOR_REVIEW`
+## 1. Validate authentication and resolve the target
 
-Use the web UI only for Apple ID two-factor authentication, legal agreements,
-payment/account issues, CAPTCHA, government filing, or any App Store Connect
-surface that is not covered by public API or an explicit `asc web` command.
+Validate the stored credentials against App Store Connect:
 
-## Safety rules for agents
+```bash  theme={null}
+asc auth status --validate
+```
 
-* Resolve IDs before mutating anything: app ID, version ID, build ID, and
-  submission ID when applicable.
-* Run `--help` for the command you plan to use; command surfaces can evolve.
-* Prefer `--dry-run` before `--confirm` where supported.
-* Never print API keys, private keys, passwords, phone numbers, or personal
-  identity values in logs or handoffs.
-* Do not report "submitted" until the CLI or App Store Connect shows a hard
-  review state for the exact version/build.
+Resolve the app, version, and processed build:
 
-## Resolve the target app, version, and build
+```bash  theme={null}
+asc apps list --bundle-id "com.example.app" --output table
 
-<Steps>
-  <Step title="Check authentication">
-    ```bash  theme={null}
-    asc auth status
-    ```
-  </Step>
+export ASC_APP_ID="1234567890"
+export VERSION="1.2.3"
 
-  <Step title="Resolve the app ID">
-    ```bash  theme={null}
-    asc apps list --bundle-id "com.example.app" --output table
-    ```
+asc versions list \
+  --app "$ASC_APP_ID" \
+  --version "$VERSION" \
+  --platform IOS \
+  --output json
 
-    Or use `ASC_APP_ID` when the repository has a stable app target:
+asc builds info \
+  --app "$ASC_APP_ID" \
+  --latest \
+  --version "$VERSION" \
+  --platform IOS \
+  --output json
+```
 
-    ```bash  theme={null}
-    export ASC_APP_ID="1234567890"
-    ```
-  </Step>
+Create the version only when the list result confirms it does not exist:
 
-  <Step title="Find or create the version">
-    ```bash  theme={null}
-    asc versions list --app "$ASC_APP_ID" --platform IOS --output json
-    asc versions create --app "$ASC_APP_ID" --version "1.2.3" --platform IOS
-    ```
-  </Step>
+```bash  theme={null}
+asc versions create \
+  --app "$ASC_APP_ID" \
+  --version "$VERSION" \
+  --platform IOS
+```
 
-  <Step title="Resolve the build">
-    ```bash  theme={null}
-    asc builds info \
-      --app "$ASC_APP_ID" \
-      --latest \
-      --version "1.2.3" \
-      --platform IOS \
-      --output json
-    ```
-  </Step>
-</Steps>
+## 2. Gate release readiness
 
-## Validate before submission
-
-Run the release readiness check before staging or submitting:
+Use strict validation so readiness warnings return a non-zero exit code:
 
 ```bash  theme={null}
 asc validate \
   --app "$ASC_APP_ID" \
-  --version "1.2.3" \
+  --version "$VERSION" \
   --platform IOS \
+  --strict \
   --output table
 ```
 
-For apps with digital goods, also validate product readiness:
+For apps with digital goods, gate those products too:
 
 ```bash  theme={null}
-asc validate iap --app "$ASC_APP_ID" --output table
-asc validate subscriptions --app "$ASC_APP_ID" --output table
+asc validate iap --app "$ASC_APP_ID" --strict --output table
+asc validate subscriptions --app "$ASC_APP_ID" --strict --output table
 ```
 
-Treat validation failures as blockers. Fix metadata, screenshots, review
-details, build processing, IAP, subscription, Game Center, or privacy issues
-before submission.
+Do not continue while a required metadata, build, product, privacy, or review
+check is failing.
 
-## Stage metadata and build attachment
+## 3. Choose exactly one mutation path
 
-Use `release stage` when you need to prepare the version but stop before review
-submission:
+Preview the path that matches the release:
+
+### Stage an existing build without submitting
 
 ```bash  theme={null}
 asc release stage \
   --app "$ASC_APP_ID" \
-  --version "1.2.3" \
-  --build "BUILD_ID" \
-  --metadata-dir "./metadata/version/1.2.3" \
-  --dry-run \
-  --output table
-```
-
-Apply the plan only after it names the intended version and build:
-
-```bash  theme={null}
-asc release stage \
-  --app "$ASC_APP_ID" \
-  --version "1.2.3" \
-  --build "BUILD_ID" \
-  --metadata-dir "./metadata/version/1.2.3" \
-  --confirm
-```
-
-When carrying an existing listing forward, copy from the live version instead of
-rebuilding metadata by hand:
-
-```bash  theme={null}
-asc release stage \
-  --app "$ASC_APP_ID" \
-  --version "1.2.3" \
+  --version "$VERSION" \
   --build "BUILD_ID" \
   --copy-metadata-from "1.2.2" \
-  --confirm
+  --dry-run \
+  --output table
 ```
 
-## Submit for review
-
-Submit an already prepared version:
+### Submit an already prepared version
 
 ```bash  theme={null}
 asc review submit \
   --app "$ASC_APP_ID" \
-  --version "1.2.3" \
+  --version "$VERSION" \
   --build "BUILD_ID" \
   --dry-run \
   --output table
 ```
 
-```bash  theme={null}
-asc review submit \
-  --app "$ASC_APP_ID" \
-  --version "1.2.3" \
-  --build "BUILD_ID" \
-  --confirm
-```
-
-If the IPA is local and the user wants a single upload-and-submit flow:
+### Upload a local IPA and submit it
 
 ```bash  theme={null}
 asc publish appstore \
   --app "$ASC_APP_ID" \
   --ipa "./build/ios/ipa/MyApp.ipa" \
-  --version "1.2.3" \
+  --version "$VERSION" \
   --wait \
   --submit \
   --dry-run \
   --output table
 ```
 
+After inspecting the preview, repeat that same command with `--confirm` instead
+of `--dry-run`.
+
+## 4. Prove the final state
+
+Re-read App Store Connect and include the attached build and submission:
+
 ```bash  theme={null}
-asc publish appstore \
+asc status \
   --app "$ASC_APP_ID" \
-  --ipa "./build/ios/ipa/MyApp.ipa" \
-  --version "1.2.3" \
-  --wait \
-  --submit \
-  --confirm
+  --include builds,appstore,submission,review \
+  --output json
+
+asc versions view \
+  --version-id "VERSION_ID" \
+  --include-build \
+  --include-submission \
+  --output json
+
+asc submit status --version-id "VERSION_ID" --output json
 ```
 
-## Verify the final state
+The handoff must name the app ID or bundle ID, version string, version ID, build
+number or build ID, submission ID when available, and the observed state. Report
+a draft as a draft. Only claim submission after the exact version and build show
+a review state such as `WAITING_FOR_REVIEW`, `IN_REVIEW`, or
+`PENDING_DEVELOPER_RELEASE`.
 
-Do not stop at a successful mutation response. Re-read the version or submission
-state:
+## Web fallback
 
-```bash  theme={null}
-asc submit status --version-id "VERSION_ID" --output table
-asc versions view --version-id "VERSION_ID" --output json
-```
-
-Successful handoffs should name:
-
-* app ID or bundle ID
-* version string
-* build number or build ID
-* submission ID when available
-* observed state such as `WAITING_FOR_REVIEW`, `IN_REVIEW`, or
-  `PENDING_DEVELOPER_RELEASE`
-
-If only a draft submission exists, report that as a draft. If a legal agreement
-or account-holder action blocks the flow, stop and say who must act.
+Use an explicit `asc web` command only when the public API cannot perform the
+operation and the user accepts its experimental status. `asc web auth login`
+supports interactive two-factor authentication, but account-holder agreements,
+payment issues, CAPTCHA, and unsupported surfaces may still require the browser.

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -83,9 +83,13 @@ asc release stage \
   --output table
 ```
 
-After checking the resolved resources and plan, run the confirmed pipeline with
-strict readiness checks. It applies metadata, attaches the build, and only then
-validates the prepared version:
+A dry-run cannot attach the build. If its only readiness blocker is the missing
+relationship for the exact resolved build, the confirmed pipeline fixes that
+condition before its readiness step. Resolve every other blocker first.
+
+After checking the resolved resources and plan, run the confirmed preparation
+pipeline. It applies metadata and attaches the build. The final strict gate runs
+after any digital goods are submitted:
 
 ```bash  theme={null}
 asc release stage \
@@ -93,7 +97,6 @@ asc release stage \
   --version "$VERSION" \
   --build "$ASC_BUILD_ID" \
   --copy-metadata-from "1.2.2" \
-  --strict-validate \
   --confirm \
   --output table
 ```
@@ -142,20 +145,8 @@ preparation and continue to the readiness gate.
 
 ## 3. Gate readiness and submit
 
-After the build is attached, use strict validation so readiness warnings return
-a non-zero exit code:
-
-```bash  theme={null}
-asc validate \
-  --app "$ASC_APP_ID" \
-  --version "$VERSION" \
-  --platform IOS \
-  --strict \
-  --output table
-```
-
-For apps with digital goods, inspect product readiness before using the strict
-gate:
+After the build is attached, apps with digital goods must inspect and submit
+their products before using any strict readiness gate:
 
 ```bash  theme={null}
 asc validate iap --app "$ASC_APP_ID" --output json
@@ -191,6 +182,17 @@ After product submission, rerun the applicable validators in strict mode:
 ```bash  theme={null}
 asc validate iap --app "$ASC_APP_ID" --strict --output table
 asc validate subscriptions --app "$ASC_APP_ID" --strict --output table
+```
+
+Then run the unified strict app-version gate:
+
+```bash  theme={null}
+asc validate \
+  --app "$ASC_APP_ID" \
+  --version "$VERSION" \
+  --platform IOS \
+  --strict \
+  --output table
 ```
 
 Do not submit while a required metadata, build, product, privacy, or review

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -46,16 +46,20 @@ For a build that is already in App Store Connect, resolve a valid processed
 build and record its ID:
 
 ```bash  theme={null}
+export BUILD_NUMBER="42"
+
 asc builds info \
   --app "$ASC_APP_ID" \
-  --latest \
+  --build-number "$BUILD_NUMBER" \
   --version "$VERSION" \
   --platform IOS \
-  --processing-state VALID \
   --output json
 
 export ASC_BUILD_ID="BUILD_ID"
 ```
+
+Continue only when the response is for the expected build number and its
+processing state is `VALID`.
 
 Skip the build lookup when uploading a local IPA; resolve the build ID after
 upload and processing. Do not create a duplicate version. The staging and
@@ -108,21 +112,30 @@ asc publish appstore \
   --output table
 ```
 
-After checking the plan, repeat the command without `--dry-run`. Do not add
-`--submit`; strict validation must run against the build after it is attached.
-Record the build ID from the result, or resolve it after processing:
+After checking the plan, run the preparation command and request structured
+output:
 
 ```bash  theme={null}
-asc builds info \
+asc publish appstore \
   --app "$ASC_APP_ID" \
-  --latest \
+  --ipa "./build/ios/ipa/MyApp.ipa" \
   --version "$VERSION" \
-  --platform IOS \
-  --processing-state VALID \
+  --wait \
   --output json
-
-export ASC_BUILD_ID="BUILD_ID"
 ```
+
+Do not add `--submit`; strict validation must run against the build after it is
+attached. Set `ASC_BUILD_ID` to the exact `buildId` returned by this command and
+retain its `buildNumber`:
+
+```bash  theme={null}
+export ASC_BUILD_ID="BUILD_ID_FROM_PUBLISH_RESULT"
+export BUILD_NUMBER="BUILD_NUMBER_FROM_PUBLISH_RESULT"
+```
+
+Never re-resolve an uploaded build with `--latest`. If the result must be
+re-read, query the known build number and verify that the response has the same
+build ID and a `VALID` processing state.
 
 If the version is already prepared and has the intended build attached, skip
 preparation and continue to the readiness gate.

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -4,7 +4,7 @@
 > [App Store Submission](/guides/app-store-submission) for the full workflow and
 > troubleshooting guide.
 
-This page adds the agent-specific contract: resolve exact resources, use strict
+This page adds the agent-specific contract: resolve exact resources, use scoped
 validation, preview each mutation, and prove the final App Store Connect
 state before reporting success.
 
@@ -96,7 +96,7 @@ relationship for the exact resolved build, the confirmed pipeline fixes that
 condition before its readiness step. Resolve every other blocker first.
 
 After checking the resolved resources and plan, run the confirmed preparation
-pipeline. It applies metadata and attaches the build. The final strict gate runs
+pipeline. It applies metadata and attaches the build. The final release gate runs
 after any digital goods are submitted:
 
 ```bash  theme={null}
@@ -135,7 +135,7 @@ asc publish appstore \
   --output json
 ```
 
-Do not add `--submit`; strict validation must run against the build after it is
+Do not add `--submit`; release validation must run against the build after it is
 attached. Set `ASC_BUILD_ID` to the exact `buildId` returned by this command and
 retain its `buildNumber`:
 
@@ -154,7 +154,7 @@ preparation and continue to the readiness gate.
 ## 3. Gate readiness and submit
 
 After the build is attached, apps with digital goods must inspect and submit
-their products before using any strict readiness gate:
+their products before using the final readiness gate:
 
 ```bash  theme={null}
 asc validate iap --app "$ASC_APP_ID" --output json
@@ -185,23 +185,33 @@ subscriptions may need to be submitted with the app version in App Store
 Connect instead of through the public API. If that limitation applies, stop and
 complete or hand off the UI step with the exact subscription and version IDs.
 
-After product submission, rerun the applicable validators in strict mode:
+After product submission, rerun the applicable validators:
 
 ```bash  theme={null}
-asc validate iap --app "$ASC_APP_ID" --strict --output table
-asc validate subscriptions --app "$ASC_APP_ID" --strict --output table
+asc validate iap --app "$ASC_APP_ID" --output json
+asc validate subscriptions --app "$ASC_APP_ID" --output json
 ```
 
-Then run the unified strict app-version gate:
+For every selected product ID, require the review-readiness warning to disappear
+and verify a state such as `WAITING_FOR_REVIEW`, `IN_REVIEW`,
+`PENDING_BINARY_APPROVAL`, or `APPROVED`. These validators cover the full product
+catalog and do not accept a product filter. Do not add `--strict` as an app
+release gate when unrelated draft or legacy products exist.
+
+Then run the unified app-version validation:
 
 ```bash  theme={null}
 asc validate \
   --app "$ASC_APP_ID" \
   --version "$VERSION" \
   --platform IOS \
-  --strict \
-  --output table
+  --output json
 ```
+
+Require `summary.blocking` to be `0`, and resolve every warning that applies to
+the target version, build, or selected products. Non-strict output keeps
+unrelated product warnings advisory; it does not make them safe to ignore when
+their resource IDs are part of this release.
 
 Do not submit while a required metadata, build, product, privacy, or review
 check is failing. When all applicable gates pass, preview the submission:

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -21,11 +21,19 @@ state before reporting success.
 
 ## 1. Validate authentication and resolve the target
 
-Validate the stored credentials against App Store Connect:
+Select the intended credential source before making a network request. When
+using a named profile:
 
 ```bash  theme={null}
-asc auth status --validate
+export ASC_PROFILE="release"
+asc auth status --output table
 ```
+
+If `ASC_PROFILE` is unset, confirm that the status shows the intended default
+profile or environment credential. Do not use `asc auth status --validate` as
+the release gate because it validates every stored credential. The filtered
+`asc apps list` call below is the scoped network validation for the selected
+credential and must succeed.
 
 Resolve the app and release version:
 

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -5,16 +5,17 @@
 > troubleshooting guide.
 
 This page adds the agent-specific contract: resolve exact resources, use strict
-validation, preview one mutation path, and prove the final App Store Connect
+validation, preview each mutation, and prove the final App Store Connect
 state before reporting success.
 
 ## Operating rules
 
 * Run `--help` for every command before using it.
-* Resolve the app ID, version ID, and build ID before changing anything.
+* Resolve the app ID and version target before changing anything. Resolve the
+  build ID before staging or submitting.
 * Use public App Store Connect API commands before experimental web commands.
-* Preview mutations with `--dry-run`, then use `--confirm` only after checking
-  the resolved version and build.
+* Preview supported workflows with `--dry-run`. Use `--confirm` only after
+  checking every identifier available at that stage.
 * Never print credentials or personal identity values in logs or handoffs.
 * A successful mutation response is not proof that the version entered review.
 
@@ -26,7 +27,7 @@ Validate the stored credentials against App Store Connect:
 asc auth status --validate
 ```
 
-Resolve the app, version, and processed build:
+Resolve the app and release version:
 
 ```bash  theme={null}
 asc apps list --bundle-id "com.example.app" --output table
@@ -39,7 +40,12 @@ asc versions list \
   --version "$VERSION" \
   --platform IOS \
   --output json
+```
 
+For a build that is already in App Store Connect, resolve a valid processed
+build and record its ID:
+
+```bash  theme={null}
 asc builds info \
   --app "$ASC_APP_ID" \
   --latest \
@@ -47,20 +53,84 @@ asc builds info \
   --platform IOS \
   --processing-state VALID \
   --output json
+
+export ASC_BUILD_ID="BUILD_ID"
 ```
 
-Create the version only when the list result confirms it does not exist:
+Skip the build lookup when uploading a local IPA; resolve the build ID after
+upload and processing. Do not create a duplicate version. The staging and
+publishing commands below can create a missing version for their workflows.
+
+## 2. Prepare the version
+
+Choose the path that matches the current release state.
+
+### Stage an existing processed build
+
+Preview the staging plan:
 
 ```bash  theme={null}
-asc versions create \
+asc release stage \
   --app "$ASC_APP_ID" \
   --version "$VERSION" \
-  --platform IOS
+  --build "$ASC_BUILD_ID" \
+  --copy-metadata-from "1.2.2" \
+  --dry-run \
+  --output table
 ```
 
-## 2. Gate release readiness
+After checking the resolved resources and plan, run the confirmed pipeline with
+strict readiness checks. It applies metadata, attaches the build, and only then
+validates the prepared version:
 
-Use strict validation so readiness warnings return a non-zero exit code:
+```bash  theme={null}
+asc release stage \
+  --app "$ASC_APP_ID" \
+  --version "$VERSION" \
+  --build "$ASC_BUILD_ID" \
+  --copy-metadata-from "1.2.2" \
+  --strict-validate \
+  --confirm \
+  --output table
+```
+
+### Upload and attach a local IPA
+
+Preview the upload and preparation plan:
+
+```bash  theme={null}
+asc publish appstore \
+  --app "$ASC_APP_ID" \
+  --ipa "./build/ios/ipa/MyApp.ipa" \
+  --version "$VERSION" \
+  --wait \
+  --dry-run \
+  --output table
+```
+
+After checking the plan, repeat the command without `--dry-run`. Do not add
+`--submit`; strict validation must run against the build after it is attached.
+Record the build ID from the result, or resolve it after processing:
+
+```bash  theme={null}
+asc builds info \
+  --app "$ASC_APP_ID" \
+  --latest \
+  --version "$VERSION" \
+  --platform IOS \
+  --processing-state VALID \
+  --output json
+
+export ASC_BUILD_ID="BUILD_ID"
+```
+
+If the version is already prepared and has the intended build attached, skip
+preparation and continue to the readiness gate.
+
+## 3. Gate readiness and submit
+
+After the build is attached, use strict validation so readiness warnings return
+a non-zero exit code:
 
 ```bash  theme={null}
 asc validate \
@@ -78,51 +148,20 @@ asc validate iap --app "$ASC_APP_ID" --strict --output table
 asc validate subscriptions --app "$ASC_APP_ID" --strict --output table
 ```
 
-Do not continue while a required metadata, build, product, privacy, or review
-check is failing.
-
-## 3. Choose exactly one mutation path
-
-Preview the path that matches the release:
-
-### Stage an existing build without submitting
-
-```bash  theme={null}
-asc release stage \
-  --app "$ASC_APP_ID" \
-  --version "$VERSION" \
-  --build "BUILD_ID" \
-  --copy-metadata-from "1.2.2" \
-  --dry-run \
-  --output table
-```
-
-### Submit an already prepared version
+Do not submit while a required metadata, build, product, privacy, or review
+check is failing. When all applicable gates pass, preview the submission:
 
 ```bash  theme={null}
 asc review submit \
   --app "$ASC_APP_ID" \
   --version "$VERSION" \
-  --build "BUILD_ID" \
+  --build "$ASC_BUILD_ID" \
   --dry-run \
   --output table
 ```
 
-### Upload a local IPA and submit it
-
-```bash  theme={null}
-asc publish appstore \
-  --app "$ASC_APP_ID" \
-  --ipa "./build/ios/ipa/MyApp.ipa" \
-  --version "$VERSION" \
-  --wait \
-  --submit \
-  --dry-run \
-  --output table
-```
-
-After inspecting the preview, repeat that same command with `--confirm` instead
-of `--dry-run`.
+After checking the preview, repeat that command with `--confirm` instead of
+`--dry-run`.
 
 ## 4. Prove the final state
 

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -1,0 +1,199 @@
+# Agent iOS Release
+
+> Use `asc` for App Store submission before falling back to App Store Connect web UI
+
+This guide is for agents and release scripts that need to ship an iOS app
+without clicking through App Store Connect by hand. The goal is not just to run a
+command, but to prove the exact app version and build reached a real review
+state.
+
+## When to use this flow
+
+Use this flow when you need to:
+
+* upload an IPA and submit it for App Review
+* attach an already processed build to a new App Store version
+* copy or apply metadata before review
+* verify whether the submission is really `WAITING_FOR_REVIEW`
+
+Use the web UI only for Apple ID two-factor authentication, legal agreements,
+payment/account issues, CAPTCHA, government filing, or any App Store Connect
+surface that is not covered by public API or an explicit `asc web` command.
+
+## Safety rules for agents
+
+* Resolve IDs before mutating anything: app ID, version ID, build ID, and
+  submission ID when applicable.
+* Run `--help` for the command you plan to use; command surfaces can evolve.
+* Prefer `--dry-run` before `--confirm` where supported.
+* Never print API keys, private keys, passwords, phone numbers, or personal
+  identity values in logs or handoffs.
+* Do not report "submitted" until the CLI or App Store Connect shows a hard
+  review state for the exact version/build.
+
+## Resolve the target app, version, and build
+
+<Steps>
+  <Step title="Check authentication">
+    ```bash  theme={null}
+    asc auth status
+    ```
+  </Step>
+
+  <Step title="Resolve the app ID">
+    ```bash  theme={null}
+    asc apps list --bundle-id "com.example.app" --output table
+    ```
+
+    Or use `ASC_APP_ID` when the repository has a stable app target:
+
+    ```bash  theme={null}
+    export ASC_APP_ID="1234567890"
+    ```
+  </Step>
+
+  <Step title="Find or create the version">
+    ```bash  theme={null}
+    asc versions list --app "$ASC_APP_ID" --platform IOS --output json
+    asc versions create --app "$ASC_APP_ID" --version "1.2.3" --platform IOS
+    ```
+  </Step>
+
+  <Step title="Resolve the build">
+    ```bash  theme={null}
+    asc builds info \
+      --app "$ASC_APP_ID" \
+      --latest \
+      --version "1.2.3" \
+      --platform IOS \
+      --output json
+    ```
+  </Step>
+</Steps>
+
+## Validate before submission
+
+Run the release readiness check before staging or submitting:
+
+```bash  theme={null}
+asc validate \
+  --app "$ASC_APP_ID" \
+  --version "1.2.3" \
+  --platform IOS \
+  --output table
+```
+
+For apps with digital goods, also validate product readiness:
+
+```bash  theme={null}
+asc validate iap --app "$ASC_APP_ID" --output table
+asc validate subscriptions --app "$ASC_APP_ID" --output table
+```
+
+Treat validation failures as blockers. Fix metadata, screenshots, review
+details, build processing, IAP, subscription, Game Center, or privacy issues
+before submission.
+
+## Stage metadata and build attachment
+
+Use `release stage` when you need to prepare the version but stop before review
+submission:
+
+```bash  theme={null}
+asc release stage \
+  --app "$ASC_APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --metadata-dir "./metadata/version/1.2.3" \
+  --dry-run \
+  --output table
+```
+
+Apply the plan only after it names the intended version and build:
+
+```bash  theme={null}
+asc release stage \
+  --app "$ASC_APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --metadata-dir "./metadata/version/1.2.3" \
+  --confirm
+```
+
+When carrying an existing listing forward, copy from the live version instead of
+rebuilding metadata by hand:
+
+```bash  theme={null}
+asc release stage \
+  --app "$ASC_APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --copy-metadata-from "1.2.2" \
+  --confirm
+```
+
+## Submit for review
+
+Submit an already prepared version:
+
+```bash  theme={null}
+asc review submit \
+  --app "$ASC_APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --dry-run \
+  --output table
+```
+
+```bash  theme={null}
+asc review submit \
+  --app "$ASC_APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --confirm
+```
+
+If the IPA is local and the user wants a single upload-and-submit flow:
+
+```bash  theme={null}
+asc publish appstore \
+  --app "$ASC_APP_ID" \
+  --ipa "./build/ios/ipa/MyApp.ipa" \
+  --version "1.2.3" \
+  --wait \
+  --submit \
+  --dry-run \
+  --output table
+```
+
+```bash  theme={null}
+asc publish appstore \
+  --app "$ASC_APP_ID" \
+  --ipa "./build/ios/ipa/MyApp.ipa" \
+  --version "1.2.3" \
+  --wait \
+  --submit \
+  --confirm
+```
+
+## Verify the final state
+
+Do not stop at a successful mutation response. Re-read the version or submission
+state:
+
+```bash  theme={null}
+asc submit status --version-id "VERSION_ID" --output table
+asc versions view --version-id "VERSION_ID" --output json
+```
+
+Successful handoffs should name:
+
+* app ID or bundle ID
+* version string
+* build number or build ID
+* submission ID when available
+* observed state such as `WAITING_FOR_REVIEW`, `IN_REVIEW`, or
+  `PENDING_DEVELOPER_RELEASE`
+
+If only a draft submission exists, report that as a draft. If a legal agreement
+or account-holder action blocks the flow, stop and say who must act.


### PR DESCRIPTION
## Summary
- add an agent-focused iOS App Store release guide for CLI-first submissions
- document ID resolution, validation, staging, review submission, and hard status verification
- add the new guide to the Mintlify docs navigation

## Verification
- parsed docs.json with Node and confirmed guides/agent-ios-release is present in the Guides group
- reviewed the new guide for placeholder-only examples and no real account secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “iOS App Store release” checklist guide for automation agents, with strict operating rules for identifying exact app/version/build values, using dry-run previews before confirmation, validating digital-goods readiness, and verifying the final App Store Connect review state.
  * Updated the Documentation → Guides navigation to include the new iOS release checklist page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->