### PR TITLE
apps wall: add PicVore: Photo Cleaner

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -952,6 +952,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f3/90/bc/f390bc5a-185e-095a-7ea2-c4a105bd89f7/AppIcon-1x_U007emarketing-0-8-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "PicVore: Photo Cleaner",
+    "link": "https://apps.apple.com/us/app/picvore-photo-cleaner/id6759577942?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/58/a3/4b/58a34be8-0aed-098e-505b-a497386e5db8/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Pievra: Jules AI Coding Agent",
     "link": "https://apps.apple.com/us/app/pievra-jules-ai-coding-agent/id6758630855?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/32/40/cf/3240cf5f-61e5-d99e-b395-a24fae6bb6bd/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `PicVore: Photo Cleaner` to the Wall of Apps

## Entry

- App ID: 6759577942
- App: PicVore: Photo Cleaner
- Link: https://apps.apple.com/us/app/picvore-photo-cleaner/id6759577942?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PicVore: Photo Cleaner to the app directory, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->