### PR TITLE
Sync OpenAPI snapshot to Apple 4.4 republish (2026-06-12)

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -24,4 +24,4 @@ still work in the API (parity checks can surface these gaps).
 2. Run `scripts/update-openapi-index.py` to regenerate `paths.txt`.
 3. Update the "Last synced" date below.
 
-Last synced: 2026-06-08
+Last synced: 2026-06-13


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Re-sync `docs/openapi/latest.json` from Apple's official zip (still version `4.4`, republished 2026-06-12).
- Removes phantom `deprecated: true` markers on screenshot/preview/event-media endpoints that were present in the June 8 publish but silently rolled back four days later without a version bump.
- Updates `docs/openapi/README.md` last-synced date to 2026-06-13.

### What changed in the spec

Apple's June 8 `4.4` zip marked **44 operations** and **36 query params** as deprecated across:

- `/v1/appScreenshots`, `/v1/appScreenshotSets`
- `/v1/appPreviews`, `/v1/appPreviewSets`
- `/v1/appEventScreenshots`, `/v1/appEventVideoClips`
- Related relationship/include/limit params on localization endpoints

Apple's June 12 republish removed all of those deprecation markers. After stripping `deprecated` flags, the two files are otherwise identical (same 929 paths, same 1346 schemas).

## Validation

- [x] `make format`
- [x] `make check-command-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed OpenAPI documentation snapshot to the latest sync date.
  * Removed deprecation status indicators from API endpoints, parameters, and schema definitions to reflect current API availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->