### PR TITLE
docs: update subscriptions monthly-commitment docs for API 4.4

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -369,12 +369,11 @@ asc subscriptions pricing availability edit \
 **Optional Flags:**
 
 * `--available-in-new-territories` - Automatically include new App Store territories
-* `--billing-mode` - Experimental billing mode target: `upfront` (default) or `monthly-commitment`
+* `--billing-mode` - Billing mode target: `upfront` (default) or `monthly-commitment`
 
-`monthly-commitment` is reserved for Apple's Monthly with 12-Month Commitment
-subscription option. The public App Store Connect API does not yet expose the
-needed billing-mode resource/field, so the CLI validates inputs and returns a
-clear upstream-API error until Apple publishes support.
+For `monthly-commitment`, prefer the dedicated commands below. The
+`--billing-mode monthly-commitment` flag on `availability edit` uses the same
+App Store Connect API 4.4 `subscriptionPlanAvailabilities` resource.
 
 ### List Available Territories
 
@@ -392,8 +391,8 @@ new product type or subscription period. App Store Connect shows both `1 Year
 Upfront` and `Monthly with 12-Month Commitment` availability for the same
 subscription product.
 
-This command surface is experimental. It is intentionally guarded until Apple
-publishes a stable public API for the billing mode.
+App Store Connect API 4.4 exposes `subscriptionPlanAvailabilities` for configuring
+monthly subscriptions with a 12-month commitment.
 
 ```bash  theme={null}
 asc subscriptions pricing monthly-commitment enable \
@@ -418,10 +417,7 @@ Current CLI behavior:
   upfront`.
 * Removes USA and Singapore from `--territories` with a warning because Apple
   excludes those storefronts.
-* Returns a clear "not yet supported by Apple's public App Store Connect API"
-  error before attempting changes, because Apple's public REST schema currently
-  has no billing-mode field on `subscriptionAvailabilities` or
-  `subscriptionPrices`.
+* Creates or updates `subscriptionPlanAvailabilities` with `planType=MONTHLY`.
 
 Monthly with 12-Month Commitment is available only outside the United States and
 Singapore, requires devices on OS version 26.4 or later, excludes watchOS, and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Update `commands/subscriptions.mdx` to reflect that monthly-commitment is supported via App Store Connect API 4.4 `subscriptionPlanAvailabilities`.
- Remove stale claims that the feature is experimental or returns an upstream "not yet supported" error.

## Validation

- [x] Docs-only change; no code or tests affected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

