### PR TITLE
feat(subscriptions): add --plan-type filter to monthly-commitment list

### DIFF
--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -223,5 +223,44 @@ func filterSubscriptionPlanAvailabilities(resp *SubscriptionPlanAvailabilitiesRe
 
 	out := *resp
 	out.Data = filtered
+	out.Links.Next = ""
+	out.Meta = adjustFilteredPagingMetadata(out.Meta, len(filtered))
 	return &out
+}
+
+func adjustFilteredPagingMetadata(meta json.RawMessage, filteredCount int) json.RawMessage {
+	if len(meta) == 0 {
+		return meta
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(meta, &parsed); err != nil {
+		return meta
+	}
+
+	pagingRaw, ok := parsed["paging"]
+	if !ok {
+		return meta
+	}
+
+	var paging map[string]any
+	if err := json.Unmarshal(pagingRaw, &paging); err != nil {
+		return meta
+	}
+	if _, hasTotal := paging["total"]; !hasTotal {
+		return meta
+	}
+
+	paging["total"] = filteredCount
+	updatedPaging, err := json.Marshal(paging)
+	if err != nil {
+		return meta
+	}
+	parsed["paging"] = updatedPaging
+
+	updated, err := json.Marshal(parsed)
+	if err != nil {
+		return meta
+	}
+	return updated
 }

--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -61,6 +61,26 @@ type SubscriptionPlanAvailabilityResponse = SingleResponse[SubscriptionPlanAvail
 // SubscriptionPlanAvailabilitiesResponse is the response from plan availability list endpoints.
 type SubscriptionPlanAvailabilitiesResponse = Response[SubscriptionPlanAvailabilityAttributes]
 
+// SubscriptionPlanAvailabilitiesOption is a functional option for plan availability list endpoints.
+type SubscriptionPlanAvailabilitiesOption func(*subscriptionPlanAvailabilitiesQuery)
+
+type subscriptionPlanAvailabilitiesQuery struct {
+	planTypes []SubscriptionPlanType
+}
+
+// WithSubscriptionPlanAvailabilitiesPlanTypes filters returned plan availabilities by plan type.
+// The App Store Connect API does not expose filter[planType] on planAvailabilities, so filtering
+// is applied client-side after the list response is fetched.
+func WithSubscriptionPlanAvailabilitiesPlanTypes(planTypes ...SubscriptionPlanType) SubscriptionPlanAvailabilitiesOption {
+	return func(q *subscriptionPlanAvailabilitiesQuery) {
+		for _, planType := range planTypes {
+			if planType != "" {
+				q.planTypes = append(q.planTypes, planType)
+			}
+		}
+	}
+}
+
 // CreateSubscriptionPlanAvailability sets subscription plan availability in territories.
 func (c *Client) CreateSubscriptionPlanAvailability(ctx context.Context, subID string, territoryIDs []string, attrs SubscriptionPlanAvailabilityAttributes) (*SubscriptionPlanAvailabilityResponse, error) {
 	subID = strings.TrimSpace(subID)
@@ -157,10 +177,17 @@ func (c *Client) UpdateSubscriptionPlanAvailability(ctx context.Context, planAva
 }
 
 // GetSubscriptionPlanAvailabilitiesForSubscription retrieves plan availabilities for a subscription.
-func (c *Client) GetSubscriptionPlanAvailabilitiesForSubscription(ctx context.Context, subID string) (*SubscriptionPlanAvailabilitiesResponse, error) {
+func (c *Client) GetSubscriptionPlanAvailabilitiesForSubscription(ctx context.Context, subID string, opts ...SubscriptionPlanAvailabilitiesOption) (*SubscriptionPlanAvailabilitiesResponse, error) {
 	subID = strings.TrimSpace(subID)
 	if subID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
+	}
+
+	query := &subscriptionPlanAvailabilitiesQuery{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(query)
+		}
 	}
 
 	path := fmt.Sprintf("/v1/subscriptions/%s/planAvailabilities", subID)
@@ -174,5 +201,27 @@ func (c *Client) GetSubscriptionPlanAvailabilitiesForSubscription(ctx context.Co
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	return &response, nil
+	return filterSubscriptionPlanAvailabilities(&response, query.planTypes), nil
+}
+
+func filterSubscriptionPlanAvailabilities(resp *SubscriptionPlanAvailabilitiesResponse, planTypes []SubscriptionPlanType) *SubscriptionPlanAvailabilitiesResponse {
+	if resp == nil || len(planTypes) == 0 {
+		return resp
+	}
+
+	allowed := make(map[SubscriptionPlanType]struct{}, len(planTypes))
+	for _, planType := range planTypes {
+		allowed[planType] = struct{}{}
+	}
+
+	filtered := make([]Resource[SubscriptionPlanAvailabilityAttributes], 0, len(resp.Data))
+	for _, item := range resp.Data {
+		if _, ok := allowed[item.Attributes.PlanType]; ok {
+			filtered = append(filtered, item)
+		}
+	}
+
+	out := *resp
+	out.Data = filtered
+	return &out
 }

--- a/internal/asc/subscription_plan_availability_test.go
+++ b/internal/asc/subscription_plan_availability_test.go
@@ -78,3 +78,31 @@ func TestUpdateSubscriptionPlanAvailability(t *testing.T) {
 		t.Fatalf("UpdateSubscriptionPlanAvailability() error: %v", err)
 	}
 }
+
+func TestGetSubscriptionPlanAvailabilitiesForSubscriptionFiltersPlanType(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[
+		{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}},
+		{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":false}}
+	]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptions/sub-1/planAvailabilities" {
+			t.Fatalf("expected path /v1/subscriptions/sub-1/planAvailabilities, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(
+		context.Background(),
+		"sub-1",
+		WithSubscriptionPlanAvailabilitiesPlanTypes(SubscriptionPlanTypeMonthly),
+	)
+	if err != nil {
+		t.Fatalf("GetSubscriptionPlanAvailabilitiesForSubscription() error: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "plan-monthly" {
+		t.Fatalf("expected only monthly plan availability, got %#v", resp.Data)
+	}
+}

--- a/internal/asc/subscription_plan_availability_test.go
+++ b/internal/asc/subscription_plan_availability_test.go
@@ -83,7 +83,7 @@ func TestGetSubscriptionPlanAvailabilitiesForSubscriptionFiltersPlanType(t *test
 	response := jsonResponse(http.StatusOK, `{"data":[
 		{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}},
 		{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":false}}
-	]}`)
+	],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/planAvailabilities?cursor=abc"},"meta":{"paging":{"total":2,"limit":50}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -104,5 +104,25 @@ func TestGetSubscriptionPlanAvailabilitiesForSubscriptionFiltersPlanType(t *test
 	}
 	if len(resp.Data) != 1 || resp.Data[0].ID != "plan-monthly" {
 		t.Fatalf("expected only monthly plan availability, got %#v", resp.Data)
+	}
+	if resp.Links.Next != "" {
+		t.Fatalf("expected next link to be cleared after filtering, got %q", resp.Links.Next)
+	}
+	if got := ParsePagingTotal(resp.Meta); got != 1 {
+		t.Fatalf("expected paging total 1 after filtering, got %d", got)
+	}
+}
+
+func TestAdjustFilteredPagingMetadata(t *testing.T) {
+	t.Parallel()
+
+	updated := adjustFilteredPagingMetadata(json.RawMessage(`{"paging":{"total":2,"limit":50}}`), 1)
+	if got := ParsePagingTotal(updated); got != 1 {
+		t.Fatalf("expected paging total 1, got %d", got)
+	}
+
+	unchanged := adjustFilteredPagingMetadata(json.RawMessage(`{"paging":{"limit":50}}`), 1)
+	if got := ParsePagingTotal(unchanged); got != 0 {
+		t.Fatalf("expected unchanged metadata without total, got %d", got)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -82,6 +82,11 @@ func TestSubscriptionsPricingMonthlyCommitmentValidationErrors(t *testing.T) {
 			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list", "--subscription-id", "sub-1", "--plan-type", "annual"},
 			wantErr: "--plan-type must be one of: MONTHLY, UPFRONT",
 		},
+		{
+			name:    "list empty plan type",
+			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list", "--subscription-id", "sub-1", "--plan-type", ""},
+			wantErr: "invalid value for --plan-type: cannot be empty",
+		},
 	}
 
 	for _, test := range tests {
@@ -136,6 +141,11 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 			name:    "list invalid plan type returns usage",
 			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list", "--subscription-id", "sub-1", "--plan-type", "annual"},
 			wantErr: "--plan-type must be one of: MONTHLY, UPFRONT",
+		},
+		{
+			name:    "list empty plan type returns usage",
+			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list", "--subscription-id", "sub-1", "--plan-type", ""},
+			wantErr: "invalid value for --plan-type: cannot be empty",
 		},
 		{
 			name:    "availability edit invalid billing mode returns usage",
@@ -198,6 +208,7 @@ func TestSubscriptionsPricingMonthlyCommitmentListFiltersPlanType(t *testing.T) 
 			"subscriptions", "pricing", "monthly-commitment", "list",
 			"--subscription-id", "8000000001",
 			"--plan-type", "UPFRONT",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -206,11 +217,16 @@ func TestSubscriptionsPricingMonthlyCommitmentListFiltersPlanType(t *testing.T) 
 	if runErr != nil {
 		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
 	}
-	if !strings.Contains(stdout, `"id":"plan-upfront"`) {
-		t.Fatalf("expected upfront plan availability, got %q", stdout)
+	var got struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
 	}
-	if strings.Contains(stdout, `"id":"plan-monthly"`) {
-		t.Fatalf("expected monthly plan availability to be filtered out, got %q", stdout)
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v; stdout=%q", err, stdout)
+	}
+	if len(got.Data) != 1 || got.Data[0].ID != "plan-upfront" {
+		t.Fatalf("expected only plan-upfront, got %#v", got.Data)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -77,6 +77,11 @@ func TestSubscriptionsPricingMonthlyCommitmentValidationErrors(t *testing.T) {
 			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list"},
 			wantErr: "--subscription-id is required",
 		},
+		{
+			name:    "list invalid plan type",
+			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list", "--subscription-id", "sub-1", "--plan-type", "annual"},
+			wantErr: "--plan-type must be one of: MONTHLY, UPFRONT",
+		},
 	}
 
 	for _, test := range tests {
@@ -128,6 +133,11 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 			wantErr: "territory \"list\" could not be mapped",
 		},
 		{
+			name:    "list invalid plan type returns usage",
+			args:    []string{"subscriptions", "pricing", "monthly-commitment", "list", "--subscription-id", "sub-1", "--plan-type", "annual"},
+			wantErr: "--plan-type must be one of: MONTHLY, UPFRONT",
+		},
+		{
 			name:    "availability edit invalid billing mode returns usage",
 			args:    []string{"subscriptions", "pricing", "availability", "edit", "--subscription-id", "sub-1", "--territories", "Norway", "--billing-mode", "list"},
 			wantErr: "--billing-mode must be one of: upfront, monthly-commitment",
@@ -158,6 +168,49 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
 			}
 		})
+	}
+}
+
+func TestSubscriptionsPricingMonthlyCommitmentListFiltersPlanType(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/subscriptions/8000000001/planAvailabilities" || req.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+		if got := req.URL.Query().Get("filter[planType]"); got != "" {
+			t.Fatalf("expected no server-side planType filter, got %q", got)
+		}
+		body := `{"data":[
+			{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}},
+			{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":false}}
+		]}`
+		return jsonResponse(http.StatusOK, body)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "monthly-commitment", "list",
+			"--subscription-id", "8000000001",
+			"--plan-type", "UPFRONT",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+	if !strings.Contains(stdout, `"id":"plan-upfront"`) {
+		t.Fatalf("expected upfront plan availability, got %q", stdout)
+	}
+	if strings.Contains(stdout, `"id":"plan-monthly"`) {
+		t.Fatalf("expected monthly plan availability to be filtered out, got %q", stdout)
 	}
 }
 

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -289,7 +289,16 @@ Examples:
 				return shared.UsageError("--subscription-id is required")
 			}
 			var planTypeFilter asc.SubscriptionPlanType
-			if strings.TrimSpace(*planType) != "" {
+			planTypeProvided := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "plan-type" {
+					planTypeProvided = true
+				}
+			})
+			if planTypeProvided {
+				if strings.TrimSpace(*planType) == "" {
+					return shared.UsageError("invalid value for --plan-type: cannot be empty")
+				}
 				normalized, err := normalizeSubscriptionPlanType(*planType)
 				if err != nil {
 					return shared.UsageError(err.Error())

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -262,16 +262,22 @@ func SubscriptionsPricingMonthlyCommitmentListCommand() *ffcli.Command {
 
 	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
 	appID := addSubscriptionLookupAppFlag(fs)
+	planType := fs.String("plan-type", "", "Filter by plan type: MONTHLY or UPFRONT")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc subscriptions pricing monthly-commitment list --subscription-id \"SUB_ID\"",
+		ShortUsage: "asc subscriptions pricing monthly-commitment list --subscription-id \"SUB_ID\" [--plan-type MONTHLY|UPFRONT]",
 		ShortHelp:  "List monthly-commitment plan availability.",
 		LongHelp: `List Monthly with 12-Month Commitment plan availability.
 
+Use --plan-type to filter results by MONTHLY or UPFRONT. Filtering is applied
+client-side because the planAvailabilities list endpoint does not expose
+filter[planType] in the public OpenAPI schema.
+
 Examples:
-  asc subscriptions pricing monthly-commitment list --subscription-id "SUB_ID"`,
+  asc subscriptions pricing monthly-commitment list --subscription-id "SUB_ID"
+  asc subscriptions pricing monthly-commitment list --subscription-id "SUB_ID" --plan-type MONTHLY`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -281,6 +287,14 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				return shared.UsageError("--subscription-id is required")
+			}
+			var planTypeFilter asc.SubscriptionPlanType
+			if strings.TrimSpace(*planType) != "" {
+				normalized, err := normalizeSubscriptionPlanType(*planType)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
+				planTypeFilter = normalized
 			}
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -294,7 +308,12 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
+			opts := []asc.SubscriptionPlanAvailabilitiesOption{}
+			if planTypeFilter != "" {
+				opts = append(opts, asc.WithSubscriptionPlanAvailabilitiesPlanTypes(planTypeFilter))
+			}
+
+			resp, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id, opts...)
 			if err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment list: failed to fetch: %w", err)
 			}
@@ -313,6 +332,18 @@ func findMonthlySubscriptionPlanAvailability(resp *asc.SubscriptionPlanAvailabil
 		}
 	}
 	return asc.Resource[asc.SubscriptionPlanAvailabilityAttributes]{}, false
+}
+
+func normalizeSubscriptionPlanType(value string) (asc.SubscriptionPlanType, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	switch normalized {
+	case string(asc.SubscriptionPlanTypeMonthly):
+		return asc.SubscriptionPlanTypeMonthly, nil
+	case string(asc.SubscriptionPlanTypeUpfront):
+		return asc.SubscriptionPlanTypeUpfront, nil
+	default:
+		return "", fmt.Errorf("--plan-type must be one of: MONTHLY, UPFRONT")
+	}
 }
 
 func normalizeSubscriptionBillingMode(value string) (subscriptionBillingMode, error) {

--- a/internal/cli/subscriptions/monthly_commitment_test.go
+++ b/internal/cli/subscriptions/monthly_commitment_test.go
@@ -38,6 +38,37 @@ func TestNormalizeSubscriptionBillingModeRejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestNormalizeSubscriptionPlanType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "MONTHLY", want: "MONTHLY"},
+		{input: "monthly", want: "MONTHLY"},
+		{input: "UPFRONT", want: "UPFRONT"},
+		{input: "upfront", want: "UPFRONT"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			got, err := normalizeSubscriptionPlanType(test.input)
+			if err != nil {
+				t.Fatalf("normalizeSubscriptionPlanType() error = %v", err)
+			}
+			if string(got) != test.want {
+				t.Fatalf("normalizeSubscriptionPlanType() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSubscriptionPlanTypeRejectsUnknown(t *testing.T) {
+	_, err := normalizeSubscriptionPlanType("annual")
+	if err == nil || !strings.Contains(err.Error(), "--plan-type must be one of") {
+		t.Fatalf("expected plan type error, got %v", err)
+	}
+}
+
 func TestFilterMonthlyCommitmentTerritories(t *testing.T) {
 	eligible, excluded := filterMonthlyCommitmentTerritories([]string{"USA", "NOR", "SGP", "DEU", "USA"})
 	if got := strings.Join(eligible, ","); got != "NOR,DEU" {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `--plan-type MONTHLY|UPFRONT` to `asc subscriptions pricing monthly-commitment list`.
- Add client-side `WithSubscriptionPlanAvailabilitiesPlanTypes` filtering on `GetSubscriptionPlanAvailabilitiesForSubscription`.

The public `GET /v1/subscriptions/{id}/planAvailabilities` endpoint does not expose `filter[planType]` in OpenAPI 4.4, so filtering is applied after fetch.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `go test ./internal/asc/... ./internal/cli/subscriptions/... ./internal/cli/cmdtest/... -run 'MonthlyCommitment|PlanType|SubscriptionPlanAvailability'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --plan-type flag to subscription monthly-commitment listing with case-insensitive normalization and help text; enables client-side filtering of results by MONTHLY or UPFRONT and adjusts displayed paging when filtering is applied.

* **Tests**
  * Added tests covering plan-type parsing/validation, command behavior, filtering, and paging metadata adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->