### PR TITLE
feat(users): warn when ACCESS_TO_REPORTS role is used

### DIFF
--- a/internal/cli/cmdtest/users_deprecated_roles_test.go
+++ b/internal/cli/cmdtest/users_deprecated_roles_test.go
@@ -2,9 +2,9 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 )
 
@@ -28,6 +28,7 @@ func TestUsersUpdateWarnsDeprecatedAccessToReportsRole(t *testing.T) {
 			"users", "update",
 			"--id", "user-1",
 			"--roles", "ACCESS_TO_REPORTS",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -37,8 +38,17 @@ func TestUsersUpdateWarnsDeprecatedAccessToReportsRole(t *testing.T) {
 		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
 	}
 	requireStderrContainsWarning(t, stderr, "Warning: ACCESS_TO_REPORTS is deprecated in App Store Connect API 4.4")
-	if !strings.Contains(stdout, `"id":"user-1"`) {
-		t.Fatalf("expected user response, got %q", stdout)
+
+	var got struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v; stdout=%q", err, stdout)
+	}
+	if got.Data.ID != "user-1" {
+		t.Fatalf("expected user-1, got %#v", got.Data)
 	}
 }
 
@@ -65,6 +75,7 @@ func TestUsersInviteWarnsDeprecatedAccessToReportsRole(t *testing.T) {
 			"--last-name", "Doe",
 			"--roles", "ACCESS_TO_REPORTS",
 			"--all-apps",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -74,7 +85,16 @@ func TestUsersInviteWarnsDeprecatedAccessToReportsRole(t *testing.T) {
 		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
 	}
 	requireStderrContainsWarning(t, stderr, "Warning: ACCESS_TO_REPORTS is deprecated in App Store Connect API 4.4")
-	if !strings.Contains(stdout, `"id":"invite-1"`) {
-		t.Fatalf("expected invite response, got %q", stdout)
+
+	var got struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v; stdout=%q", err, stdout)
+	}
+	if got.Data.ID != "invite-1" {
+		t.Fatalf("expected invite-1, got %#v", got.Data)
 	}
 }

--- a/internal/cli/cmdtest/users_deprecated_roles_test.go
+++ b/internal/cli/cmdtest/users_deprecated_roles_test.go
@@ -1,0 +1,80 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestUsersUpdateWarnsDeprecatedAccessToReportsRole(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/users/user-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+		return jsonResponse(http.StatusOK, `{"data":{"type":"users","id":"user-1","attributes":{"username":"user@example.com","roles":["ACCESS_TO_REPORTS"],"allAppsVisible":true,"provisioningAllowed":false}}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"users", "update",
+			"--id", "user-1",
+			"--roles", "ACCESS_TO_REPORTS",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+	requireStderrContainsWarning(t, stderr, "Warning: ACCESS_TO_REPORTS is deprecated in App Store Connect API 4.4")
+	if !strings.Contains(stdout, `"id":"user-1"`) {
+		t.Fatalf("expected user response, got %q", stdout)
+	}
+}
+
+func TestUsersInviteWarnsDeprecatedAccessToReportsRole(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/userInvitations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+		return jsonResponse(http.StatusOK, `{"data":{"type":"userInvitations","id":"invite-1","attributes":{"email":"user@example.com","roles":["ACCESS_TO_REPORTS"],"allAppsVisible":true,"provisioningAllowed":false}}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"users", "invite",
+			"--email", "user@example.com",
+			"--first-name", "Jane",
+			"--last-name", "Doe",
+			"--roles", "ACCESS_TO_REPORTS",
+			"--all-apps",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+	requireStderrContainsWarning(t, stderr, "Warning: ACCESS_TO_REPORTS is deprecated in App Store Connect API 4.4")
+	if !strings.Contains(stdout, `"id":"invite-1"`) {
+		t.Fatalf("expected invite response, got %q", stdout)
+	}
+}

--- a/internal/cli/users/role_warnings.go
+++ b/internal/cli/users/role_warnings.go
@@ -1,0 +1,20 @@
+package users
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const deprecatedAccessToReportsRole = "ACCESS_TO_REPORTS"
+
+const deprecatedAccessToReportsWarning = "Warning: ACCESS_TO_REPORTS is deprecated in App Store Connect API 4.4; see UserRole documentation for alternatives."
+
+func warnDeprecatedUserRoles(roles []string) {
+	for _, role := range roles {
+		if strings.EqualFold(strings.TrimSpace(role), deprecatedAccessToReportsRole) {
+			fmt.Fprintln(os.Stderr, deprecatedAccessToReportsWarning)
+			return
+		}
+	}
+}

--- a/internal/cli/users/role_warnings_test.go
+++ b/internal/cli/users/role_warnings_test.go
@@ -1,0 +1,50 @@
+package users
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestWarnDeprecatedUserRolesEmitsWarning(t *testing.T) {
+	stderr := captureStderr(t, func() {
+		warnDeprecatedUserRoles([]string{"DEVELOPER", "access_to_reports"})
+	})
+	if stderr != deprecatedAccessToReportsWarning+"\n" {
+		t.Fatalf("expected deprecation warning, got %q", stderr)
+	}
+}
+
+func TestWarnDeprecatedUserRolesNoWarningForOtherRoles(t *testing.T) {
+	stderr := captureStderr(t, func() {
+		warnDeprecatedUserRoles([]string{"ADMIN", "DEVELOPER"})
+	})
+	if stderr != "" {
+		t.Fatalf("expected no warning, got %q", stderr)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = old
+	return <-done
+}

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -213,6 +213,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
 				return flag.ErrHelp
 			}
+			warnDeprecatedUserRoles(roleValues)
 
 			visibleAppIDs := shared.SplitCSV(*visibleApps)
 
@@ -347,6 +348,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
 				return flag.ErrHelp
 			}
+			warnDeprecatedUserRoles(roleValues)
 
 			if *allApps && strings.TrimSpace(*visibleApps) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --all-apps and --visible-app cannot be used together")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Emit a stderr deprecation warning when `ACCESS_TO_REPORTS` appears in `--roles` for `asc users invite` and `asc users update`.
- Matches App Store Connect API 4.4 deprecation of the `ACCESS_TO_REPORTS` user role permission.

## Validation

- [x] `make format`
- [x] `make lint`
- [x] `go test ./internal/cli/users/... ./internal/cli/cmdtest/... -run 'DeprecatedAccessToReports|WarnDeprecated'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now emits a deprecation warning (once) when the deprecated ACCESS_TO_REPORTS role is supplied to user update or invite commands.
* **Tests**
  * Added unit and integration tests to verify the warning appears for deprecated roles and not for other roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->