### PR TITLE
docs: document --plan-type on monthly-commitment list

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -407,7 +407,17 @@ asc subscriptions pricing monthly-commitment disable \
 
 asc subscriptions pricing monthly-commitment list \
   --subscription-id "SUB_ID"
+
+asc subscriptions pricing monthly-commitment list \
+  --subscription-id "SUB_ID" \
+  --plan-type MONTHLY
 ```
+
+**Optional Flags:**
+
+* `--plan-type` - Filter results by `MONTHLY` or `UPFRONT`. Filtering is applied
+  client-side because `GET /v1/subscriptions/{id}/planAvailabilities` does not
+  expose `filter[planType]` in the public OpenAPI schema.
 
 Current CLI behavior:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the existing `--plan-type MONTHLY|UPFRONT` flag on `asc subscriptions pricing monthly-commitment list`, including an example and a note that filtering is client-side.

## Changes
- Add `--plan-type` example and optional-flag docs to `commands/subscriptions.mdx`

## Commands run
- `make check-command-docs` (not required; docs-only MDX change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45e13c3b-7015-4759-9583-9e3a913a6892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

