### PR TITLE
feat(subscriptions): add --plan-type filter to prices list

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -222,10 +222,12 @@ List current prices for a subscription.
 
 ```bash  theme={null}
 asc subscriptions pricing prices list --subscription-id "SUB_ID"
+asc subscriptions pricing prices list --subscription-id "SUB_ID" --plan-type MONTHLY
 ```
 
 **Optional Flags:**
 
+* `--plan-type` - Filter by `MONTHLY` or `UPFRONT` billing plan prices
 * `--limit` - Results per page (1-200)
 * `--paginate` - Fetch all pages
 

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -80,6 +80,7 @@ type subscriptionPricePointsQuery struct {
 type subscriptionPricesQuery struct {
 	listQuery
 	territory        string
+	planType         SubscriptionPlanType
 	include          []string
 	pricePointFields []string
 	territoryFields  []string
@@ -301,6 +302,15 @@ func WithSubscriptionPricesTerritory(territory string) SubscriptionPricesOption 
 	}
 }
 
+// WithSubscriptionPricesPlanType filters subscription prices by plan type (MONTHLY or UPFRONT).
+func WithSubscriptionPricesPlanType(planType SubscriptionPlanType) SubscriptionPricesOption {
+	return func(q *subscriptionPricesQuery) {
+		if planType != "" {
+			q.planType = planType
+		}
+	}
+}
+
 // WithSubscriptionPricesInclude sets the relationships to include (e.g., "subscriptionPricePoint", "territory").
 func WithSubscriptionPricesInclude(include []string) SubscriptionPricesOption {
 	return func(q *subscriptionPricesQuery) {
@@ -403,6 +413,9 @@ func buildSubscriptionPricesQuery(query *subscriptionPricesQuery) string {
 	values := url.Values{}
 	if strings.TrimSpace(query.territory) != "" {
 		values.Set("filter[territory]", strings.TrimSpace(query.territory))
+	}
+	if query.planType != "" {
+		values.Set("filter[planType]", string(query.planType))
 	}
 	addCSV(values, "include", query.include)
 	addCSV(values, "fields[subscriptionPricePoints]", query.pricePointFields)

--- a/internal/asc/subscription_resources_queries_test.go
+++ b/internal/asc/subscription_resources_queries_test.go
@@ -1,0 +1,32 @@
+package asc
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestBuildSubscriptionPricesQueryPlanType(t *testing.T) {
+	query := &subscriptionPricesQuery{}
+	WithSubscriptionPricesPlanType(SubscriptionPlanTypeMonthly)(query)
+
+	values, err := url.ParseQuery(buildSubscriptionPricesQuery(query))
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	if got := values.Get("filter[planType]"); got != "MONTHLY" {
+		t.Fatalf("expected filter[planType]=MONTHLY, got %q", got)
+	}
+}
+
+func TestBuildSubscriptionPricesQueryRejectsEmptyPlanType(t *testing.T) {
+	query := &subscriptionPricesQuery{}
+	WithSubscriptionPricesPlanType("")(query)
+
+	values, err := url.ParseQuery(buildSubscriptionPricesQuery(query))
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	if got := values.Get("filter[planType]"); got != "" {
+		t.Fatalf("expected no planType filter, got %q", got)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
@@ -1,12 +1,14 @@
 package cmdtest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"io"
 	"net/http"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -103,6 +105,58 @@ func TestSubscriptionsPricingPricesListPlanTypeValidationErrors(t *testing.T) {
 			}
 			if !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsPricingPricesListPlanTypeUsageExitCodes(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{
+			name:    "invalid plan type",
+			value:   "annual",
+			wantErr: "--plan-type must be one of: MONTHLY, UPFRONT",
+		},
+		{
+			name:    "empty plan type",
+			value:   "",
+			wantErr: "invalid value for --plan-type: cannot be empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(
+				binaryPath,
+				"subscriptions", "pricing", "prices", "list",
+				"--subscription-id", "8000000001",
+				"--plan-type", test.value,
+			)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected process exit error, got %v", err)
+			}
+			if exitErr.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
+			}
+			if stdout.String() != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
 			}
 		})
 	}

--- a/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
@@ -59,6 +59,104 @@ func TestSubscriptionsPricingPricesListSendsPlanTypeFilter(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsPricingPricesListPaginatePreservesPlanTypeFilter(t *testing.T) {
+	setupAuth(t)
+
+	requests := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("filter[planType]"); got != "MONTHLY" {
+			t.Fatalf("request %d: expected filter[planType]=MONTHLY, got %q", requests, got)
+		}
+		switch requests {
+		case 1:
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-monthly-1"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/8000000001/prices?cursor=next"}}`
+			return jsonResponse(http.StatusOK, body)
+		case 2:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-monthly-2"}],"links":{"next":""}}`)
+		default:
+			t.Fatalf("unexpected request count: %d", requests)
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--plan-type", "MONTHLY",
+			"--paginate",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+	if requests != 2 {
+		t.Fatalf("expected two paginated requests, got %d", requests)
+	}
+
+	var got struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v; stdout=%q", err, stdout)
+	}
+	if len(got.Data) != 2 || got.Data[0].ID != "price-monthly-1" || got.Data[1].ID != "price-monthly-2" {
+		t.Fatalf("unexpected data: %#v", got.Data)
+	}
+}
+
+func TestSubscriptionsPricingPricesListNextPreservesPlanTypeFilter(t *testing.T) {
+	setupAuth(t)
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/subscriptions/8000000001/prices?cursor=next"
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("cursor"); got != "next" {
+			t.Fatalf("expected cursor=next, got %q", got)
+		}
+		if got := req.URL.Query().Get("filter[planType]"); got != "UPFRONT" {
+			t.Fatalf("expected filter[planType]=UPFRONT, got %q", got)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-upfront"}],"links":{"next":""}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--next", nextURL,
+			"--plan-type", "UPFRONT",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
 func TestSubscriptionsPricingPricesListPlanTypeValidationErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
@@ -1,0 +1,109 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionsPricingPricesListSendsPlanTypeFilter(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("filter[planType]"); got != "MONTHLY" {
+			t.Fatalf("expected filter[planType]=MONTHLY, got %q", got)
+		}
+		body := `{"data":[{"type":"subscriptionPrices","id":"price-monthly","attributes":{"planType":"MONTHLY","startDate":"2026-01-01","preserved":false}}]}`
+		return jsonResponse(http.StatusOK, body)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--plan-type", "MONTHLY",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+
+	var got struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v; stdout=%q", err, stdout)
+	}
+	if len(got.Data) != 1 || got.Data[0].ID != "price-monthly" {
+		t.Fatalf("unexpected data: %#v", got.Data)
+	}
+}
+
+func TestSubscriptionsPricingPricesListPlanTypeValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "invalid plan type",
+			args: []string{
+				"subscriptions", "pricing", "prices", "list",
+				"--subscription-id", "8000000001",
+				"--plan-type", "annual",
+			},
+			wantErr: "--plan-type must be one of: MONTHLY, UPFRONT",
+		},
+		{
+			name: "empty plan type",
+			args: []string{
+				"subscriptions", "pricing", "prices", "list",
+				"--subscription-id", "8000000001",
+				"--plan-type", "",
+			},
+			wantErr: "invalid value for --plan-type: cannot be empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
@@ -119,6 +119,58 @@ func TestSubscriptionsPricingPricesListPaginatePreservesPlanTypeFilter(t *testin
 	}
 }
 
+func TestSubscriptionsPricingPricesListPaginatePreservesPlanTypeFilterOnRelativeNextURL(t *testing.T) {
+	setupAuth(t)
+
+	requests := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("filter[planType]"); got != "MONTHLY" {
+			t.Fatalf("request %d: expected filter[planType]=MONTHLY, got %q", requests, got)
+		}
+		switch requests {
+		case 1:
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-monthly-1"}],"links":{"next":"/v1/subscriptions/8000000001/prices?cursor=next"}}`
+			return jsonResponse(http.StatusOK, body)
+		case 2:
+			if got := req.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("expected cursor=next, got %q", got)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-monthly-2"}],"links":{"next":""}}`)
+		default:
+			t.Fatalf("unexpected request count: %d", requests)
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--plan-type", "MONTHLY",
+			"--paginate",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requests != 2 {
+		t.Fatalf("expected two paginated requests, got %d", requests)
+	}
+}
+
 func TestSubscriptionsPricingPricesListNextPreservesPlanTypeFilter(t *testing.T) {
 	setupAuth(t)
 

--- a/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
@@ -164,6 +164,93 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsPricingPricesListResolvedPlanTypeSupportsRelativeNextURL(t *testing.T) {
+	setupAuth(t)
+
+	requestCount := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		query := req.URL.Query()
+		if got := query.Get("filter[planType]"); got != "MONTHLY" {
+			t.Fatalf("request %d: expected filter[planType]=MONTHLY, got %q", requestCount, got)
+		}
+		if got := query.Get("include"); got != "subscriptionPricePoint,territory" {
+			t.Fatalf("request %d: expected resolved includes, got %q", requestCount, got)
+		}
+
+		switch requestCount {
+		case 1:
+			return jsonResponse(http.StatusOK, `{
+				"data":[{
+					"type":"subscriptionPrices",
+					"id":"price-nor",
+					"relationships":{
+						"territory":{"data":{"type":"territories","id":"NOR"}},
+						"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-nor"}}
+					}
+				}],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"pp-nor","attributes":{"customerPrice":"5.00"}},
+					{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+				],
+				"links":{"next":"/v1/subscriptions/8000000001/prices?cursor=next"}
+			}`)
+		case 2:
+			if got := query.Get("cursor"); got != "next" {
+				t.Fatalf("expected cursor=next, got %q", got)
+			}
+			return jsonResponse(http.StatusOK, `{
+				"data":[{
+					"type":"subscriptionPrices",
+					"id":"price-deu",
+					"relationships":{
+						"territory":{"data":{"type":"territories","id":"DEU"}},
+						"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-deu"}}
+					}
+				}],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"pp-deu","attributes":{"customerPrice":"4.99"}},
+					{"type":"territories","id":"DEU","attributes":{"currency":"EUR"}}
+				],
+				"links":{"next":""}
+			}`)
+		default:
+			t.Fatalf("unexpected request count: %d", requestCount)
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--resolved",
+			"--plan-type", "MONTHLY",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+
+	var result shared.ResolvedPricesResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if len(result.Prices) != 2 {
+		t.Fatalf("expected two resolved prices, got %+v", result.Prices)
+	}
+}
+
 func TestSubscriptionsPricingPricesListResolvedTable(t *testing.T) {
 	setupAuth(t)
 

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -526,7 +526,7 @@ func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID st
 	verifyCtx, verifyCancel := shared.ContextWithTimeout(ctx)
 	defer verifyCancel()
 
-	resolved, err := fetchResolvedSubscriptionPrices(verifyCtx, client, subID, 200, "", effectiveAt)
+	resolved, err := fetchResolvedSubscriptionPrices(verifyCtx, client, subID, 200, "", effectiveAt, "")
 	if err != nil {
 		return 0, failures, err
 	}

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -49,7 +49,7 @@ func fetchResolvedSubscriptionPrices(
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
 	if err := asc.PaginateEach(ctx, firstPage, func(ctx context.Context, next string) (asc.PaginatedResponse, error) {
-		nextURL, err := shared.MergeNextURLQuery(next, resolvedSubscriptionPricesQuery(limit, planType))
+		nextURL, err := mergeSubscriptionPricesNextQuery(next, resolvedSubscriptionPricesQuery(limit, planType))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -132,6 +132,7 @@ func consumeResolvedSubscriptionPricePageForPlanType(
 		}
 
 		startAt := parseSubscriptionPricingDate(price.Attributes.StartDate)
+		// Preserve the legacy undated-price skip unless a plan-specific view was requested.
 		if startAt == nil {
 			if planType == "" {
 				continue

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -67,7 +67,7 @@ func fetchResolvedSubscriptionPrices(
 		if !ok {
 			return fmt.Errorf("unexpected subscription prices response type %T", page)
 		}
-		return consumeResolvedSubscriptionPricePage(candidates, resp, now)
+		return consumeResolvedSubscriptionPricePageForPlanType(candidates, resp, now, planType)
 	}); err != nil {
 		return nil, err
 	}
@@ -99,6 +99,15 @@ func consumeResolvedSubscriptionPricePage(
 	page *asc.SubscriptionPricesResponse,
 	now time.Time,
 ) error {
+	return consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, "")
+}
+
+func consumeResolvedSubscriptionPricePageForPlanType(
+	candidates map[string]resolvedSubscriptionPriceCandidate,
+	page *asc.SubscriptionPricesResponse,
+	now time.Time,
+	planType asc.SubscriptionPlanType,
+) error {
 	if page == nil {
 		return nil
 	}
@@ -123,7 +132,14 @@ func consumeResolvedSubscriptionPricePage(
 		}
 
 		startAt := parseSubscriptionPricingDate(price.Attributes.StartDate)
-		if startAt == nil || startAt.After(asOf) {
+		if startAt == nil {
+			if planType == "" {
+				continue
+			}
+			undatedPlanStart := time.Time{}
+			startAt = &undatedPlanStart
+		}
+		if startAt.After(asOf) {
 			continue
 		}
 

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -25,6 +25,7 @@ func fetchResolvedSubscriptionPrices(
 	limit int,
 	nextURL string,
 	now time.Time,
+	planType asc.SubscriptionPlanType,
 ) (*shared.ResolvedPricesResult, error) {
 	if limit <= 0 {
 		limit = 200
@@ -37,6 +38,9 @@ func fetchResolvedSubscriptionPrices(
 		asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
 		asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
 	}
+	if planType != "" {
+		opts = append(opts, asc.WithSubscriptionPricesPlanType(planType))
+	}
 
 	firstPage, err := client.GetSubscriptionPrices(ctx, subscriptionID, opts...)
 	if err != nil {
@@ -45,7 +49,7 @@ func fetchResolvedSubscriptionPrices(
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
 	if err := asc.PaginateEach(ctx, firstPage, func(ctx context.Context, next string) (asc.PaginatedResponse, error) {
-		nextURL, err := shared.MergeNextURLQuery(next, resolvedSubscriptionPricesQuery(limit))
+		nextURL, err := shared.MergeNextURLQuery(next, resolvedSubscriptionPricesQuery(limit, planType))
 		if err != nil {
 			return nil, err
 		}
@@ -56,6 +60,7 @@ func fetchResolvedSubscriptionPrices(
 			asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
 			asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
 			asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
+			asc.WithSubscriptionPricesPlanType(planType),
 		)
 	}, func(page asc.PaginatedResponse) error {
 		resp, ok := page.(*asc.SubscriptionPricesResponse)
@@ -75,13 +80,16 @@ func fetchResolvedSubscriptionPrices(
 	return &shared.ResolvedPricesResult{Prices: rows}, nil
 }
 
-func resolvedSubscriptionPricesQuery(limit int) url.Values {
+func resolvedSubscriptionPricesQuery(limit int, planType asc.SubscriptionPlanType) url.Values {
 	values := url.Values{}
 	values.Set("include", "subscriptionPricePoint,territory")
 	values.Set("fields[subscriptionPricePoints]", "customerPrice,proceeds,proceedsYear2")
 	values.Set("fields[territories]", "currency")
 	if limit > 0 {
 		values.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if planType != "" {
+		values.Set("filter[planType]", string(planType))
 	}
 	return values
 }

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -14,7 +14,7 @@ import (
 
 type resolvedSubscriptionPriceCandidate struct {
 	row       shared.ResolvedPriceRow
-	startAt   time.Time
+	startAt   *time.Time
 	preserved bool
 }
 
@@ -136,10 +136,8 @@ func consumeResolvedSubscriptionPricePageForPlanType(
 			if planType == "" {
 				continue
 			}
-			undatedPlanStart := time.Time{}
-			startAt = &undatedPlanStart
 		}
-		if startAt.After(asOf) {
+		if startAt != nil && startAt.After(asOf) {
 			continue
 		}
 
@@ -161,7 +159,7 @@ func consumeResolvedSubscriptionPricePageForPlanType(
 				StartDate:     strings.TrimSpace(price.Attributes.StartDate),
 				Preserved:     boolPtr(price.Attributes.Preserved),
 			},
-			startAt:   *startAt,
+			startAt:   startAt,
 			preserved: price.Attributes.Preserved,
 		}
 
@@ -175,10 +173,16 @@ func consumeResolvedSubscriptionPricePageForPlanType(
 }
 
 func subscriptionResolvedCandidateIsNewer(candidate, existing resolvedSubscriptionPriceCandidate) bool {
-	if candidate.startAt.After(existing.startAt) {
+	if candidate.startAt == nil || existing.startAt == nil {
+		if candidate.startAt != nil {
+			return true
+		}
+		if existing.startAt != nil {
+			return false
+		}
+	} else if candidate.startAt.After(*existing.startAt) {
 		return true
-	}
-	if candidate.startAt.Before(existing.startAt) {
+	} else if candidate.startAt.Before(*existing.startAt) {
 		return false
 	}
 	if candidate.preserved != existing.preserved {

--- a/internal/cli/subscriptions/resolved_prices_test.go
+++ b/internal/cli/subscriptions/resolved_prices_test.go
@@ -156,6 +156,35 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedUpfrontPrice(t *test
 	}
 }
 
+func TestConsumeResolvedSubscriptionPricePage_PrefersDatedCurrentOverUndatedFallback(t *testing.T) {
+	now := time.Date(2026, time.June, 13, 12, 0, 0, 0, time.UTC)
+
+	page := &asc.SubscriptionPricesResponse{
+		Data: []asc.Resource[asc.SubscriptionPriceAttributes]{
+			newResolvedSubscriptionPriceResource("price-initial", "NOR", "pp-initial", "", false),
+			newResolvedSubscriptionPriceResource("price-current", "NOR", "pp-current", "2026-01-01", false),
+		},
+		Included: mustMarshalJSON(t, []map[string]any{
+			subscriptionPricePointIncluded("pp-initial", "49.0", "34.0", "34.0"),
+			subscriptionPricePointIncluded("pp-current", "59.0", "41.0", "41.0"),
+			territoryIncluded("NOR", "NOK"),
+		}),
+	}
+
+	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
+	if err := consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, asc.SubscriptionPlanTypeUpfront); err != nil {
+		t.Fatalf("consumeResolvedSubscriptionPricePageForPlanType() error = %v", err)
+	}
+
+	row, ok := candidates["NOR"]
+	if !ok {
+		t.Fatal("expected a resolved UPFRONT price")
+	}
+	if row.row.PriceID != "price-current" || row.row.CustomerPrice != "59.0" {
+		t.Fatalf("expected latest dated price to beat the undated initial fallback, got %+v", row.row)
+	}
+}
+
 func newResolvedSubscriptionPriceResource(
 	priceID string,
 	territoryID string,

--- a/internal/cli/subscriptions/resolved_prices_test.go
+++ b/internal/cli/subscriptions/resolved_prices_test.go
@@ -102,6 +102,60 @@ func TestConsumeResolvedSubscriptionPricePage_DoesNotFallbackToFutureOrUndated(t
 	}
 }
 
+func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedMonthlyPrice(t *testing.T) {
+	now := time.Date(2026, time.June, 13, 12, 0, 0, 0, time.UTC)
+
+	page := &asc.SubscriptionPricesResponse{
+		Data: []asc.Resource[asc.SubscriptionPriceAttributes]{
+			newResolvedSubscriptionPriceResource("price-monthly", "NOR", "pp-monthly", "", false),
+		},
+		Included: mustMarshalJSON(t, []map[string]any{
+			subscriptionPricePointIncluded("pp-monthly", "5.0", "3.4", "3.4"),
+			territoryIncluded("NOR", "NOK"),
+		}),
+	}
+
+	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
+	if err := consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, asc.SubscriptionPlanTypeMonthly); err != nil {
+		t.Fatalf("consumeResolvedSubscriptionPricePageForPlanType() error = %v", err)
+	}
+
+	row, ok := candidates["NOR"]
+	if !ok {
+		t.Fatal("expected undated MONTHLY price to resolve as the active price")
+	}
+	if row.row.CustomerPrice != "5.0" {
+		t.Fatalf("expected MONTHLY customer price 5.0, got %+v", row.row)
+	}
+}
+
+func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedUpfrontPrice(t *testing.T) {
+	now := time.Date(2026, time.June, 13, 12, 0, 0, 0, time.UTC)
+
+	page := &asc.SubscriptionPricesResponse{
+		Data: []asc.Resource[asc.SubscriptionPriceAttributes]{
+			newResolvedSubscriptionPriceResource("price-upfront", "NOR", "pp-upfront", "", false),
+		},
+		Included: mustMarshalJSON(t, []map[string]any{
+			subscriptionPricePointIncluded("pp-upfront", "49.0", "34.0", "34.0"),
+			territoryIncluded("NOR", "NOK"),
+		}),
+	}
+
+	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
+	if err := consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, asc.SubscriptionPlanTypeUpfront); err != nil {
+		t.Fatalf("consumeResolvedSubscriptionPricePageForPlanType() error = %v", err)
+	}
+
+	row, ok := candidates["NOR"]
+	if !ok {
+		t.Fatal("expected undated UPFRONT price to resolve as the active price")
+	}
+	if row.row.CustomerPrice != "49.0" {
+		t.Fatalf("expected UPFRONT customer price 49.0, got %+v", row.row)
+	}
+}
+
 func newResolvedSubscriptionPriceResource(
 	priceID string,
 	territoryID string,

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -860,7 +860,7 @@ Examples:
 
 			nextURL := strings.TrimSpace(*next)
 			if nextURL != "" && planTypeFilter != "" {
-				nextURL, err = shared.MergeNextURLQuery(nextURL, subscriptionPricesPlanTypeQuery(planTypeFilter))
+				nextURL, err = mergeSubscriptionPricesPlanType(nextURL, planTypeFilter)
 				if err != nil {
 					return fmt.Errorf("subscriptions prices list: %w", err)
 				}
@@ -881,7 +881,7 @@ Examples:
 				}
 
 				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-					nextURL, err := shared.MergeNextURLQuery(nextURL, subscriptionPricesPlanTypeQuery(planTypeFilter))
+					nextURL, err := mergeSubscriptionPricesPlanType(nextURL, planTypeFilter)
 					if err != nil {
 						return nil, err
 					}
@@ -904,12 +904,24 @@ Examples:
 	}
 }
 
-func subscriptionPricesPlanTypeQuery(planType asc.SubscriptionPlanType) url.Values {
-	values := url.Values{}
-	if planType != "" {
-		values.Set("filter[planType]", string(planType))
+func mergeSubscriptionPricesPlanType(next string, planType asc.SubscriptionPlanType) (string, error) {
+	if planType == "" {
+		return next, nil
 	}
-	return values
+
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return "", err
+	}
+	additions := url.Values{"filter[planType]": []string{string(planType)}}
+	if parsed.IsAbs() || parsed.Host != "" {
+		return shared.MergeNextURLQuery(next, additions)
+	}
+
+	query := parsed.Query()
+	query.Set("filter[planType]", string(planType))
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }
 
 // SubscriptionsPricesAddCommand returns the subscriptions prices add subcommand.

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -776,6 +776,7 @@ func SubscriptionsPricesListCommand() *ffcli.Command {
 
 	subID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
 	appID := addSubscriptionLookupAppFlag(fs)
+	planType := fs.String("plan-type", "", "Filter by plan type: MONTHLY or UPFRONT")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -784,14 +785,17 @@ func SubscriptionsPricesListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc subscriptions prices list --subscription-id \"SUB_ID\"",
+		ShortUsage: "asc subscriptions prices list --subscription-id \"SUB_ID\" [--plan-type MONTHLY|UPFRONT]",
 		ShortHelp:  "List prices for a subscription.",
 		LongHelp: `List prices for a subscription.
+
+Use --plan-type to filter by MONTHLY or UPFRONT billing plan prices.
 
 Examples:
   asc subscriptions prices list --subscription-id "SUB_ID"
   asc subscriptions prices list --subscription-id "SUB_ID" --paginate
-  asc subscriptions prices list --subscription-id "SUB_ID" --resolved`,
+  asc subscriptions prices list --subscription-id "SUB_ID" --resolved
+  asc subscriptions prices list --subscription-id "SUB_ID" --plan-type MONTHLY`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -812,6 +816,24 @@ Examples:
 				return flag.ErrHelp
 			}
 
+			var planTypeFilter asc.SubscriptionPlanType
+			planTypeProvided := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "plan-type" {
+					planTypeProvided = true
+				}
+			})
+			if planTypeProvided {
+				if strings.TrimSpace(*planType) == "" {
+					return shared.UsageError("invalid value for --plan-type: cannot be empty")
+				}
+				normalized, err := normalizeSubscriptionPlanType(*planType)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
+				planTypeFilter = normalized
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("subscriptions prices list: %w", err)
@@ -828,7 +850,7 @@ Examples:
 			defer cancel()
 
 			if *resolved {
-				resp, err := fetchResolvedSubscriptionPrices(requestCtx, client, id, *limit, *next, time.Now().UTC())
+				resp, err := fetchResolvedSubscriptionPrices(requestCtx, client, id, *limit, *next, time.Now().UTC(), planTypeFilter)
 				if err != nil {
 					return fmt.Errorf("subscriptions prices list: failed to resolve: %w", err)
 				}
@@ -838,6 +860,9 @@ Examples:
 			opts := []asc.SubscriptionPricesOption{
 				asc.WithSubscriptionPricesLimit(*limit),
 				asc.WithSubscriptionPricesNextURL(*next),
+			}
+			if planTypeFilter != "" {
+				opts = append(opts, asc.WithSubscriptionPricesPlanType(planTypeFilter))
 			}
 
 			if *paginate {

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -869,7 +869,7 @@ Examples:
 				asc.WithSubscriptionPricesLimit(*limit),
 				asc.WithSubscriptionPricesNextURL(nextURL),
 			}
-			if planTypeFilter != "" {
+			if planTypeFilter != "" && nextURL == "" {
 				opts = append(opts, asc.WithSubscriptionPricesPlanType(planTypeFilter))
 			}
 

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -909,17 +909,36 @@ func mergeSubscriptionPricesPlanType(next string, planType asc.SubscriptionPlanT
 		return next, nil
 	}
 
+	return mergeSubscriptionPricesNextQuery(
+		next,
+		url.Values{"filter[planType]": []string{string(planType)}},
+	)
+}
+
+func mergeSubscriptionPricesNextQuery(next string, additions url.Values) (string, error) {
+	next = strings.TrimSpace(next)
+	if next == "" {
+		return "", nil
+	}
+
 	parsed, err := url.Parse(next)
 	if err != nil {
 		return "", err
 	}
-	additions := url.Values{"filter[planType]": []string{string(planType)}}
 	if parsed.IsAbs() || parsed.Host != "" {
 		return shared.MergeNextURLQuery(next, additions)
 	}
 
 	query := parsed.Query()
-	query.Set("filter[planType]", string(planType))
+	for key, values := range additions {
+		query.Del(key)
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				query.Add(key, value)
+			}
+		}
+	}
 	parsed.RawQuery = query.Encode()
 	return parsed.String(), nil
 }

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -857,9 +858,16 @@ Examples:
 				return shared.PrintResolvedPrices(resp, *output.Output, *output.Pretty)
 			}
 
+			nextURL := strings.TrimSpace(*next)
+			if nextURL != "" && planTypeFilter != "" {
+				nextURL, err = shared.MergeNextURLQuery(nextURL, subscriptionPricesPlanTypeQuery(planTypeFilter))
+				if err != nil {
+					return fmt.Errorf("subscriptions prices list: %w", err)
+				}
+			}
 			opts := []asc.SubscriptionPricesOption{
 				asc.WithSubscriptionPricesLimit(*limit),
-				asc.WithSubscriptionPricesNextURL(*next),
+				asc.WithSubscriptionPricesNextURL(nextURL),
 			}
 			if planTypeFilter != "" {
 				opts = append(opts, asc.WithSubscriptionPricesPlanType(planTypeFilter))
@@ -873,6 +881,10 @@ Examples:
 				}
 
 				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					nextURL, err := shared.MergeNextURLQuery(nextURL, subscriptionPricesPlanTypeQuery(planTypeFilter))
+					if err != nil {
+						return nil, err
+					}
 					return client.GetSubscriptionPrices(ctx, id, asc.WithSubscriptionPricesNextURL(nextURL))
 				})
 				if err != nil {
@@ -890,6 +902,14 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func subscriptionPricesPlanTypeQuery(planType asc.SubscriptionPlanType) url.Values {
+	values := url.Values{}
+	if planType != "" {
+		values.Set("filter[planType]", string(planType))
+	}
+	return values
 }
 
 // SubscriptionsPricesAddCommand returns the subscriptions prices add subcommand.

--- a/internal/cli/subscriptions/subscriptions_command_test.go
+++ b/internal/cli/subscriptions/subscriptions_command_test.go
@@ -1,8 +1,11 @@
 package subscriptions
 
 import (
+	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestSubscriptionsPricesListCommand_HasResolvedFlag(t *testing.T) {
@@ -13,5 +16,34 @@ func TestSubscriptionsPricesListCommand_HasResolvedFlag(t *testing.T) {
 	}
 	if !strings.Contains(cmd.LongHelp, "--resolved") {
 		t.Fatalf("expected long help to mention --resolved, got %q", cmd.LongHelp)
+	}
+}
+
+func TestMergeSubscriptionPricesPlanTypePreservesRelativeNextURL(t *testing.T) {
+	next := "/v1/subscriptions/sub-1/prices?cursor=next"
+	merged, err := mergeSubscriptionPricesPlanType(next, asc.SubscriptionPlanTypeMonthly)
+	if err != nil {
+		t.Fatalf("mergeSubscriptionPricesPlanType() error = %v", err)
+	}
+	parsed, err := url.Parse(merged)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	if parsed.Path != "/v1/subscriptions/sub-1/prices" || parsed.Query().Get("cursor") != "next" {
+		t.Fatalf("relative next URL changed unexpectedly: %q", merged)
+	}
+	if got := parsed.Query().Get("filter[planType]"); got != "MONTHLY" {
+		t.Fatalf("expected filter[planType]=MONTHLY, got %q", got)
+	}
+}
+
+func TestMergeSubscriptionPricesPlanTypeLeavesUnfilteredRelativeNextURLUntouched(t *testing.T) {
+	next := "/v1/subscriptions/sub-1/prices?cursor=next"
+	merged, err := mergeSubscriptionPricesPlanType(next, "")
+	if err != nil {
+		t.Fatalf("mergeSubscriptionPricesPlanType() error = %v", err)
+	}
+	if merged != next {
+		t.Fatalf("expected unfiltered relative next URL to be unchanged, got %q", merged)
 	}
 }


### PR DESCRIPTION
Adds App Store Connect API 4.4 `filter[planType]` support to `asc subscriptions pricing prices list`.

## Changes
- Adds `--plan-type MONTHLY|UPFRONT` with usage-error exit code `2` for empty or invalid values.
- Sends `filter[planType]` through raw and `--resolved` price-list paths.
- Preserves the filter across `--paginate`, explicit `--next`, absolute next links, and Apple relative next links.
- Keeps resolved-price include/field/limit parameters across every page.
- Treats undated filtered prices as active while preserving existing unfiltered schedule semantics.

## Verification
- Live API: resolved `MONTHLY` price `5.0` for NOR.
- Live API: resolved `UPFRONT` price `49.0` for DEU and NOR.
- Built-binary invalid and empty `--plan-type` cases exit `2` with usage errors.
- Relative and absolute pagination regression coverage for raw and resolved output.

## Guardrails
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
