### PR TITLE
feat(subscriptions): create MONTHLY prices in monthly-commitment enable

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -429,7 +429,9 @@ Current CLI behavior:
   upfront`.
 * Removes USA and Singapore from `--territories` with a warning because Apple
   excludes those storefronts.
-* Creates or updates `subscriptionPlanAvailabilities` with `planType=MONTHLY`.
+* Requires an existing UPFRONT subscription price in each eligible territory.
+* Creates or updates `subscriptionPlanAvailabilities` with `planType=MONTHLY`
+  before creating MONTHLY `subscriptionPrices`, as required by Apple.
 * Creates MONTHLY `subscriptionPrices` for each eligible territory at `--price`.
 
 Monthly with 12-Month Commitment is available only outside the United States and

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -429,6 +429,7 @@ Current CLI behavior:
   upfront`.
 * Removes USA and Singapore from `--territories` with a warning because Apple
   excludes those storefronts.
+* Creates MONTHLY `subscriptionPrices` for each eligible territory at `--price`.
 * Creates or updates `subscriptionPlanAvailabilities` with `planType=MONTHLY`.
 
 Monthly with 12-Month Commitment is available only outside the United States and

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -429,8 +429,8 @@ Current CLI behavior:
   upfront`.
 * Removes USA and Singapore from `--territories` with a warning because Apple
   excludes those storefronts.
-* Creates MONTHLY `subscriptionPrices` for each eligible territory at `--price`.
 * Creates or updates `subscriptionPlanAvailabilities` with `planType=MONTHLY`.
+* Creates MONTHLY `subscriptionPrices` for each eligible territory at `--price`.
 
 Monthly with 12-Month Commitment is available only outside the United States and
 Singapore, requires devices on OS version 26.4 or later, excludes watchOS, and

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -8039,6 +8039,26 @@ func TestCreateSubscriptionPrice(t *testing.T) {
 	}
 }
 
+func TestCreateSubscriptionPriceWithPlanType(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"MONTHLY"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		var payload SubscriptionPriceCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if payload.Data.Attributes == nil || payload.Data.Attributes.PlanType != SubscriptionPlanTypeMonthly {
+			t.Fatalf("expected planType MONTHLY, got %#v", payload.Data.Attributes)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.CreateSubscriptionPrice(context.Background(), "sub-1", "price-point-1", "NOR", SubscriptionPriceCreateAttributes{
+		PlanType: SubscriptionPlanTypeMonthly,
+	}); err != nil {
+		t.Fatalf("CreateSubscriptionPrice() error: %v", err)
+	}
+}
+
 func TestCreateSubscriptionPrice_RetriesUnexpectedServerError(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "2")
 	t.Setenv("ASC_BASE_DELAY", "1ms")

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -250,7 +250,7 @@ func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePo
 	}
 
 	var attributes *SubscriptionPriceCreateAttributes
-	if attrs.StartDate != "" || attrs.Preserved != nil {
+	if attrs.StartDate != "" || attrs.Preserved != nil || attrs.PlanType != "" {
 		attributes = &attrs
 	}
 
@@ -327,7 +327,7 @@ func (c *Client) CreateSubscriptionPrice(ctx context.Context, subID, pricePointI
 	}
 
 	var attributes *SubscriptionPriceCreateAttributes
-	if attrs.StartDate != "" || attrs.Preserved != nil {
+	if attrs.StartDate != "" || attrs.Preserved != nil || attrs.PlanType != "" {
 		attributes = &attrs
 	}
 

--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -24,6 +24,11 @@ type SubscriptionPlanAvailabilityAttributes struct {
 	PlanType                  SubscriptionPlanType `json:"planType,omitempty"`
 }
 
+// SubscriptionPlanAvailabilityUpdateAttributes describes mutable plan availability attributes.
+type SubscriptionPlanAvailabilityUpdateAttributes struct {
+	AvailableInNewTerritories *bool `json:"availableInNewTerritories,omitempty"`
+}
+
 // SubscriptionPlanAvailabilityRelationships describes relationships for plan availability.
 type SubscriptionPlanAvailabilityRelationships struct {
 	Subscription         *Relationship     `json:"subscription,omitempty"`
@@ -44,10 +49,10 @@ type SubscriptionPlanAvailabilityCreateRequest struct {
 
 // SubscriptionPlanAvailabilityUpdateData is the data portion of plan availability update requests.
 type SubscriptionPlanAvailabilityUpdateData struct {
-	Type          ResourceType                               `json:"type"`
-	ID            string                                     `json:"id"`
-	Attributes    *SubscriptionPlanAvailabilityAttributes    `json:"attributes,omitempty"`
-	Relationships *SubscriptionPlanAvailabilityRelationships `json:"relationships,omitempty"`
+	Type          ResourceType                                  `json:"type"`
+	ID            string                                        `json:"id"`
+	Attributes    *SubscriptionPlanAvailabilityUpdateAttributes `json:"attributes,omitempty"`
+	Relationships *SubscriptionPlanAvailabilityRelationships    `json:"relationships,omitempty"`
 }
 
 // SubscriptionPlanAvailabilityUpdateRequest is a request to update plan availability.
@@ -133,7 +138,7 @@ func (c *Client) CreateSubscriptionPlanAvailability(ctx context.Context, subID s
 }
 
 // UpdateSubscriptionPlanAvailability updates subscription plan availability in territories.
-func (c *Client) UpdateSubscriptionPlanAvailability(ctx context.Context, planAvailabilityID string, territoryIDs []string, attrs *SubscriptionPlanAvailabilityAttributes) (*SubscriptionPlanAvailabilityResponse, error) {
+func (c *Client) UpdateSubscriptionPlanAvailability(ctx context.Context, planAvailabilityID string, territoryIDs []string, attrs *SubscriptionPlanAvailabilityUpdateAttributes) (*SubscriptionPlanAvailabilityResponse, error) {
 	planAvailabilityID = strings.TrimSpace(planAvailabilityID)
 	territoryIDs = normalizeList(territoryIDs)
 	if planAvailabilityID == "" {

--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -209,6 +209,24 @@ func (c *Client) GetSubscriptionPlanAvailabilitiesForSubscription(ctx context.Co
 	return filterSubscriptionPlanAvailabilities(&response, query.planTypes), nil
 }
 
+// GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships retrieves
+// available territory linkages for a subscription plan availability.
+func (c *Client) GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(
+	ctx context.Context,
+	planAvailabilityID string,
+	opts ...LinkagesOption,
+) (*LinkagesResponse, error) {
+	return c.getResourceLinkages(
+		ctx,
+		planAvailabilityID,
+		"availableTerritories",
+		"planAvailabilityID",
+		"/v1/subscriptionPlanAvailabilities/%s/relationships/%s",
+		"subscriptionPlanAvailabilityAvailableTerritoriesRelationships",
+		opts...,
+	)
+}
+
 func filterSubscriptionPlanAvailabilities(resp *SubscriptionPlanAvailabilitiesResponse, planTypes []SubscriptionPlanType) *SubscriptionPlanAvailabilitiesResponse {
 	if resp == nil || len(planTypes) == 0 {
 		return resp

--- a/internal/asc/subscription_plan_availability_test.go
+++ b/internal/asc/subscription_plan_availability_test.go
@@ -113,6 +113,34 @@ func TestGetSubscriptionPlanAvailabilitiesForSubscriptionFiltersPlanType(t *test
 	}
 }
 
+func TestGetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"territories","id":"NOR"},{"type":"territories","id":"DEU"}],"links":{"next":""}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories" {
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		if got := req.URL.Query().Get("limit"); got != "200" {
+			t.Fatalf("expected limit 200, got %q", got)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	resp, err := client.GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(
+		context.Background(),
+		"plan-1",
+		WithLinkagesLimit(200),
+	)
+	if err != nil {
+		t.Fatalf("GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships() error: %v", err)
+	}
+	if len(resp.Data) != 2 || resp.Data[0].ID != "NOR" || resp.Data[1].ID != "DEU" {
+		t.Fatalf("expected NOR,DEU territory linkages, got %#v", resp.Data)
+	}
+}
+
 func TestAdjustFilteredPagingMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/asc/subscription_resources_queries_test.go
+++ b/internal/asc/subscription_resources_queries_test.go
@@ -30,3 +30,28 @@ func TestBuildSubscriptionPricesQueryRejectsEmptyPlanType(t *testing.T) {
 		t.Fatalf("expected no planType filter, got %q", got)
 	}
 }
+
+func TestBuildSubscriptionPricesQueryPlanTypeWithOtherFilters(t *testing.T) {
+	query := &subscriptionPricesQuery{}
+	WithSubscriptionPricesPlanType(SubscriptionPlanTypeUpfront)(query)
+	WithSubscriptionPricesTerritory("nor")(query)
+	WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"})(query)
+	WithSubscriptionPricesLimit(25)(query)
+
+	values, err := url.ParseQuery(buildSubscriptionPricesQuery(query))
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	if got := values.Get("filter[planType]"); got != "UPFRONT" {
+		t.Fatalf("expected filter[planType]=UPFRONT, got %q", got)
+	}
+	if got := values.Get("filter[territory]"); got != "NOR" {
+		t.Fatalf("expected filter[territory]=NOR, got %q", got)
+	}
+	if got := values.Get("include"); got != "subscriptionPricePoint,territory" {
+		t.Fatalf("expected combined include values, got %q", got)
+	}
+	if got := values.Get("limit"); got != "25" {
+		t.Fatalf("expected limit=25, got %q", got)
+	}
+}

--- a/internal/asc/subscriptions.go
+++ b/internal/asc/subscriptions.go
@@ -137,14 +137,16 @@ type SubscriptionPriceInlineRelationships struct {
 
 // SubscriptionPriceAttributes describes a subscription price resource.
 type SubscriptionPriceAttributes struct {
-	StartDate string `json:"startDate,omitempty"`
-	Preserved bool   `json:"preserved,omitempty"`
+	StartDate string               `json:"startDate,omitempty"`
+	Preserved bool                 `json:"preserved,omitempty"`
+	PlanType  SubscriptionPlanType `json:"planType,omitempty"`
 }
 
 // SubscriptionPriceCreateAttributes describes attributes for creating a price.
 type SubscriptionPriceCreateAttributes struct {
-	StartDate string `json:"startDate,omitempty"`
-	Preserved *bool  `json:"preserveCurrentPrice,omitempty"`
+	StartDate string               `json:"startDate,omitempty"`
+	Preserved *bool                `json:"preserveCurrentPrice,omitempty"`
+	PlanType  SubscriptionPlanType `json:"planType,omitempty"`
 }
 
 // SubscriptionPriceRelationships describes relationships for prices.

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
@@ -246,16 +247,27 @@ func TestSubscriptionsPricingMonthlyCommitmentDisableFiltersExcludedTerritories(
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
-			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}}]}`)
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories" && req.Method == http.MethodGet && req.URL.Query().Get("cursor") == "":
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected territory relationship limit 200, got %q", got)
+			}
+			return jsonResponse(http.StatusOK, `{
+				"data":[{"type":"territories","id":"NOR"},{"type":"territories","id":"DEU"}],
+				"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories?cursor=page-2"}
+			}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories" && req.Method == http.MethodGet && req.URL.Query().Get("cursor") == "page-2":
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"territories","id":"FRA"}],"links":{"next":""}}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1" && req.Method == http.MethodPatch:
 			var payload asc.SubscriptionPlanAvailabilityUpdateRequest
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode payload: %v", err)
 			}
-			if len(payload.Data.Relationships.AvailableTerritories.Data) != 0 {
-				t.Fatalf("expected empty territory list, got %#v", payload.Data.Relationships.AvailableTerritories.Data)
+			got := payload.Data.Relationships.AvailableTerritories.Data
+			if len(got) != 2 || got[0].ID != "DEU" || got[1].ID != "FRA" {
+				t.Fatalf("expected only DEU,FRA to remain, got %#v", got)
 			}
-			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}}}`)
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -354,9 +366,12 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableRejectsPriceOutsideRange(t *
 
 func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *testing.T) {
 	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "80ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
 
 	var postedPlanType string
 	var mutationOrder []string
+	var createDeadlineRemaining time.Duration
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
@@ -383,6 +398,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 				}`
 				return jsonResponse(http.StatusOK, body)
 			case "MONTHLY":
+				time.Sleep(60 * time.Millisecond)
 				return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
 			default:
 				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
@@ -393,6 +409,11 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 			return jsonResponse(http.StatusOK, body)
 		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
 			mutationOrder = append(mutationOrder, "price")
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Fatal("expected subscription price create request to carry a timeout deadline")
+			}
+			createDeadlineRemaining = time.Until(deadline)
 			var payload asc.SubscriptionPriceCreateRequest
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode create price payload: %v", err)
@@ -450,6 +471,9 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 	}
 	if got := strings.Join(mutationOrder, ","); got != "availability,price" {
 		t.Fatalf("expected availability before price creation, got %q", got)
+	}
+	if createDeadlineRemaining < 35*time.Millisecond {
+		t.Fatalf("expected a fresh timeout for price creation, got only %v remaining", createDeadlineRemaining)
 	}
 	if !strings.Contains(stdout, `"id":"plan-1"`) {
 		t.Fatalf("expected plan availability response, got %q", stdout)

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -63,6 +63,11 @@ func TestSubscriptionsPricingMonthlyCommitmentValidationErrors(t *testing.T) {
 			wantErr: "--price-territory cannot be USA or Singapore",
 		},
 		{
+			name:    "enable rejects available in new territories",
+			args:    []string{"subscriptions", "pricing", "monthly-commitment", "enable", "--subscription-id", "sub-1", "--price", "9.99", "--price-territory", "Norway", "--territories", "Norway", "--available-in-new-territories"},
+			wantErr: "--available-in-new-territories is not supported for MONTHLY plan availability",
+		},
+		{
 			name:    "disable missing territories",
 			args:    []string{"subscriptions", "pricing", "monthly-commitment", "disable", "--subscription-id", "sub-1"},
 			wantErr: "--territories is required",
@@ -151,6 +156,11 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 			name:    "availability edit invalid billing mode returns usage",
 			args:    []string{"subscriptions", "pricing", "availability", "edit", "--subscription-id", "sub-1", "--territories", "Norway", "--billing-mode", "list"},
 			wantErr: "--billing-mode must be one of: upfront, monthly-commitment",
+		},
+		{
+			name:    "availability edit rejects available in new territories for monthly",
+			args:    []string{"subscriptions", "pricing", "availability", "edit", "--subscription-id", "sub-1", "--territories", "Norway", "--billing-mode", "monthly-commitment", "--available-in-new-territories"},
+			wantErr: "--available-in-new-territories is not supported for MONTHLY plan availability",
 		},
 	}
 
@@ -346,6 +356,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 	setupAuth(t)
 
 	var postedPlanType string
+	var mutationOrder []string
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
@@ -381,6 +392,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 			body := `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00","proceeds":"7.00"}}],"links":{"next":""}}`
 			return jsonResponse(http.StatusOK, body)
 		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			mutationOrder = append(mutationOrder, "price")
 			var payload asc.SubscriptionPriceCreateRequest
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode create price payload: %v", err)
@@ -398,11 +410,15 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
 			return jsonResponse(http.StatusOK, `{"data":[]}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			mutationOrder = append(mutationOrder, "availability")
 			var payload asc.SubscriptionPlanAvailabilityCreateRequest
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode plan availability payload: %v", err)
 			}
 			postedPlanType = string(payload.Data.Attributes.PlanType)
+			if payload.Data.Attributes.AvailableInNewTerritories != nil {
+				t.Fatalf("MONTHLY create must omit availableInNewTerritories, got %#v", payload.Data.Attributes)
+			}
 			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -432,7 +448,215 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 	if postedPlanType != string(asc.SubscriptionPlanTypeMonthly) {
 		t.Fatalf("expected plan availability planType MONTHLY, got %q", postedPlanType)
 	}
+	if got := strings.Join(mutationOrder, ","); got != "availability,price" {
+		t.Fatalf("expected availability before price creation, got %q", got)
+	}
 	if !strings.Contains(stdout, `"id":"plan-1"`) {
 		t.Fatalf("expected plan availability response, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsPricingAvailabilityEditMonthlyCommitmentOmitsAvailableInNewTerritories(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/subscriptionPlanAvailabilities" || req.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		var payload asc.SubscriptionPlanAvailabilityCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode plan availability payload: %v", err)
+		}
+		if payload.Data.Attributes.PlanType != asc.SubscriptionPlanTypeMonthly {
+			t.Fatalf("expected MONTHLY plan type, got %#v", payload.Data.Attributes)
+		}
+		if payload.Data.Attributes.AvailableInNewTerritories != nil {
+			t.Fatalf("MONTHLY create must omit availableInNewTerritories, got %#v", payload.Data.Attributes)
+		}
+		return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "availability", "edit",
+		"--subscription-id", "8000000001",
+		"--billing-mode", "monthly-commitment",
+		"--territories", "Norway",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(t *testing.T) {
+	setupAuth(t)
+
+	subscriptionPricePosts := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[planType]") {
+			case "UPFRONT":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-upfront",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+					],
+					"links":{"next":""}
+				}`)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-monthly",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-existing"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-existing","attributes":{"customerPrice":"10.00"}}
+					],
+					"links":{"next":""}
+				}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-resolved","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			subscriptionPricePosts++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-created"}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if subscriptionPricePosts != 0 {
+		t.Fatalf("expected equivalent current MONTHLY price to be reused, got %d create request(s)", subscriptionPricePosts)
+	}
+}
+
+func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *testing.T) {
+	setupAuth(t)
+
+	sentPlanType := false
+	sentAvailableInNewTerritories := false
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[planType]") {
+			case "UPFRONT":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-upfront",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+					],
+					"links":{"next":""}
+				}`)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-monthly",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-monthly"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00"}}
+					],
+					"links":{"next":""}
+				}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1" && req.Method == http.MethodPatch:
+			var payload struct {
+				Data struct {
+					Attributes map[string]any `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode update payload: %v", err)
+			}
+			_, sentPlanType = payload.Data.Attributes["planType"]
+			_, sentAvailableInNewTerritories = payload.Data.Attributes["availableInNewTerritories"]
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if sentPlanType {
+		t.Fatal("update payload must not include create-only planType")
+	}
+	if sentAvailableInNewTerritories {
+		t.Fatal("MONTHLY update payload must not include availableInNewTerritories")
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -364,6 +364,72 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableRejectsPriceOutsideRange(t *
 	}
 }
 
+func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesAllUpfrontPricesBeforeMutation(t *testing.T) {
+	setupAuth(t)
+
+	var availabilityMutated bool
+	var upfrontQueries int
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			if got := req.URL.Query().Get("filter[planType]"); got != "UPFRONT" {
+				t.Fatalf("expected UPFRONT price query, got %q", got)
+			}
+			upfrontQueries++
+			return jsonResponse(http.StatusOK, `{
+				"data":[{
+					"type":"subscriptionPrices","id":"price-upfront",
+					"attributes":{"startDate":"2024-01-01"},
+					"relationships":{
+						"territory":{"data":{"type":"territories","id":"NOR"}},
+						"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+					}
+				}],
+				"included":[
+					{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
+					{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+				],
+				"links":{"next":""}
+			}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			availabilityMutated = true
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway,Germany",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "current UPFRONT subscription price is missing for DEU") {
+		t.Fatalf("expected missing UPFRONT price error, got %v", err)
+	}
+	if availabilityMutated {
+		t.Fatal("expected all UPFRONT prices to be validated before mutating availability")
+	}
+	if upfrontQueries != 2 {
+		t.Fatalf("expected price-territory lookup plus all-territory preflight, got %d UPFRONT queries", upfrontQueries)
+	}
+}
+
 func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_TIMEOUT", "80ms")

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -290,6 +290,9 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableRejectsPriceOutsideRange(t *
 			if got := req.URL.Query().Get("filter[territory]"); got != "NOR" {
 				t.Fatalf("expected price territory NOR, got %q", got)
 			}
+			if got := req.URL.Query().Get("filter[planType]"); got != "UPFRONT" {
+				t.Fatalf("expected upfront planType filter, got %q", got)
+			}
 			body := `{
 				"data":[{
 					"type":"subscriptionPrices","id":"price-1",
@@ -336,5 +339,100 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableRejectsPriceOutsideRange(t *
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *testing.T) {
+	setupAuth(t)
+
+	var postedPlanType string
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			body := `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"name":"Yearly","productId":"com.example.yearly","subscriptionPeriod":"ONE_YEAR","state":"APPROVED"}}}`
+			return jsonResponse(http.StatusOK, body)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			query := req.URL.Query()
+			switch query.Get("filter[planType]") {
+			case "UPFRONT":
+				body := `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-upfront",
+						"attributes":{"planType":"UPFRONT","startDate":"2024-01-01"},
+						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+					],
+					"links":{"next":""}
+				}`
+				return jsonResponse(http.StatusOK, body)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00","proceeds":"7.00"}}],"links":{"next":""}}`
+			return jsonResponse(http.StatusOK, body)
+		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			var payload asc.SubscriptionPriceCreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create price payload: %v", err)
+			}
+			if payload.Data.Attributes == nil || payload.Data.Attributes.PlanType != asc.SubscriptionPlanTypeMonthly {
+				t.Fatalf("expected planType MONTHLY, got %#v", payload.Data.Attributes)
+			}
+			if payload.Data.Relationships == nil || payload.Data.Relationships.Territory == nil || payload.Data.Relationships.Territory.Data.ID != "NOR" {
+				t.Fatalf("expected NOR territory, got %#v", payload.Data.Relationships)
+			}
+			if payload.Data.Relationships.SubscriptionPricePoint == nil || payload.Data.Relationships.SubscriptionPricePoint.Data.ID != "pp-monthly" {
+				t.Fatalf("expected pp-monthly price point, got %#v", payload.Data.Relationships)
+			}
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-monthly","attributes":{"planType":"MONTHLY"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			var payload asc.SubscriptionPlanAvailabilityCreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode plan availability payload: %v", err)
+			}
+			postedPlanType = string(payload.Data.Attributes.PlanType)
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "monthly-commitment", "enable",
+			"--subscription-id", "8000000001",
+			"--price", "10.00",
+			"--price-territory", "Norway",
+			"--territories", "Norway",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v; stderr=%q stdout=%q", runErr, stderr, stdout)
+	}
+	if postedPlanType != string(asc.SubscriptionPlanTypeMonthly) {
+		t.Fatalf("expected plan availability planType MONTHLY, got %q", postedPlanType)
+	}
+	if !strings.Contains(stdout, `"id":"plan-1"`) {
+		t.Fatalf("expected plan availability response, got %q", stdout)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -741,6 +741,7 @@ func TestSubscriptionsPricingAvailabilityEditMonthlyCommitmentUpdatesExistingPla
 func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(t *testing.T) {
 	setupAuth(t)
 
+	monthlyPricePages := 0
 	subscriptionPricePosts := 0
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
@@ -765,11 +766,20 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 					"links":{"next":""}
 				}`)
 			case "MONTHLY":
-				return jsonResponse(http.StatusOK, `{
+				monthlyPricePages++
+				switch req.URL.Query().Get("cursor") {
+				case "":
+					return jsonResponse(http.StatusOK, `{
+						"data":[],
+						"links":{"next":"/v1/subscriptions/8000000001/prices?cursor=monthly-page-2"}
+					}`)
+				case "monthly-page-2":
+					return jsonResponse(http.StatusOK, `{
 					"data":[{
 						"type":"subscriptionPrices","id":"price-monthly",
 						"attributes":{"startDate":"2024-01-01"},
 						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-existing"}}
 						}
 					}],
@@ -778,6 +788,10 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 					],
 					"links":{"next":""}
 				}`)
+				default:
+					t.Fatalf("unexpected MONTHLY pagination query: %q", req.URL.RawQuery)
+					return nil, nil
+				}
 			default:
 				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
 				return nil, nil
@@ -815,6 +829,9 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 	if subscriptionPricePosts != 0 {
 		t.Fatalf("expected equivalent current MONTHLY price to be reused, got %d create request(s)", subscriptionPricePosts)
 	}
+	if monthlyPricePages != 2 {
+		t.Fatalf("expected MONTHLY idempotency to inspect both pages, got %d page request(s)", monthlyPricePages)
+	}
 }
 
 func TestSubscriptionsPricingMonthlyCommitmentEnableDoesNotReuseFutureMonthlyPrice(t *testing.T) {
@@ -849,6 +866,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableDoesNotReuseFutureMonthlyPri
 						"type":"subscriptionPrices","id":"price-monthly-future",
 						"attributes":{"startDate":"2099-01-01"},
 						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-future"}}
 						}
 					}],
@@ -901,6 +919,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 
 	sentPlanType := false
 	sentAvailableInNewTerritories := false
+	var updatedTerritoryIDs []string
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
@@ -929,6 +948,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 						"type":"subscriptionPrices","id":"price-monthly",
 						"attributes":{"startDate":"2024-01-01"},
 						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-monthly"}}
 						}
 					}],
@@ -945,10 +965,22 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
 		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
 			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories" && req.Method == http.MethodGet:
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected territory relationship limit 200, got %q", got)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"territories","id":"DEU"}],"links":{"next":""}}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1" && req.Method == http.MethodPatch:
 			var payload struct {
 				Data struct {
-					Attributes map[string]any `json:"attributes"`
+					Attributes    map[string]any `json:"attributes"`
+					Relationships struct {
+						AvailableTerritories struct {
+							Data []struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"availableTerritories"`
+					} `json:"relationships"`
 				} `json:"data"`
 			}
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
@@ -956,6 +988,9 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 			}
 			_, sentPlanType = payload.Data.Attributes["planType"]
 			_, sentAvailableInNewTerritories = payload.Data.Attributes["availableInNewTerritories"]
+			for _, territory := range payload.Data.Relationships.AvailableTerritories.Data {
+				updatedTerritoryIDs = append(updatedTerritoryIDs, territory.ID)
+			}
 			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -983,5 +1018,8 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 	}
 	if sentAvailableInNewTerritories {
 		t.Fatal("MONTHLY update payload must not include availableInNewTerritories")
+	}
+	if got := strings.Join(updatedTerritoryIDs, ","); got != "DEU,NOR" {
+		t.Fatalf("expected enable to preserve DEU while adding NOR, got %q", got)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -829,6 +829,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 	setupAuth(t)
 
 	monthlyPricePages := 0
+	pricePointRequests := 0
 	subscriptionPricePosts := 0
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
@@ -884,7 +885,8 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 				return nil, nil
 			}
 		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
-			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-resolved","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+			pricePointRequests++
+			return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
 		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
 			subscriptionPricePosts++
 			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-created"}}`)
@@ -918,6 +920,9 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 	}
 	if monthlyPricePages != 2 {
 		t.Fatalf("expected MONTHLY idempotency to inspect both pages, got %d page request(s)", monthlyPricePages)
+	}
+	if pricePointRequests != 0 {
+		t.Fatalf("expected equivalent current MONTHLY price to skip price-point lookup, got %d request(s)", pricePointRequests)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -430,6 +430,93 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesAllUpfrontPricesBef
 	}
 }
 
+func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesEachTerritoryPriceRangeBeforeMutation(t *testing.T) {
+	setupAuth(t)
+
+	var availabilityMutations int
+	var subscriptionPricePosts int
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[planType]") {
+			case "UPFRONT":
+				return jsonResponse(http.StatusOK, `{
+					"data":[
+						{
+							"type":"subscriptionPrices","id":"price-upfront-nor",
+							"attributes":{"startDate":"2024-01-01"},
+							"relationships":{
+								"territory":{"data":{"type":"territories","id":"NOR"}},
+								"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront-nor"}}
+							}
+						},
+						{
+							"type":"subscriptionPrices","id":"price-upfront-deu",
+							"attributes":{"startDate":"2024-01-01"},
+							"relationships":{
+								"territory":{"data":{"type":"territories","id":"DEU"}},
+								"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront-deu"}}
+							}
+						}
+					],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront-nor","attributes":{"customerPrice":"120.00"}},
+						{"type":"subscriptionPricePoints","id":"pp-upfront-deu","attributes":{"customerPrice":"70.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}},
+						{"type":"territories","id":"DEU","attributes":{"currency":"EUR"}}
+					],
+					"links":{"next":""}
+				}`)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			territoryID := req.URL.Query().Get("filter[territory]")
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly-`+strings.ToLower(territoryID)+`","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			availabilityMutations++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			subscriptionPricePosts++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-monthly","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway,Germany",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "DEU") ||
+		!strings.Contains(err.Error(), "monthly commitment total 120.00 is outside the allowed range [70.00, 105.00]") {
+		t.Fatalf("expected DEU pricing range rejection, got %v", err)
+	}
+	if availabilityMutations != 0 {
+		t.Fatalf("expected all territory price ranges to be validated before mutating availability, got %d mutation(s)", availabilityMutations)
+	}
+	if subscriptionPricePosts != 0 {
+		t.Fatalf("expected no monthly price writes when a territory range is invalid, got %d create request(s)", subscriptionPricePosts)
+	}
+}
+
 func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesAllMonthlyPricesBeforeMutation(t *testing.T) {
 	setupAuth(t)
 

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -430,6 +430,85 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesAllUpfrontPricesBef
 	}
 }
 
+func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesPreservedUpfrontPricesBeforeMutation(t *testing.T) {
+	setupAuth(t)
+
+	var availabilityMutations int
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[planType]") {
+			case "UPFRONT":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-upfront",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+					],
+					"links":{"next":""}
+				}`)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-monthly",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-monthly"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00"}}
+					],
+					"links":{"next":""}
+				}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"territories","id":"DEU"}],"links":{"next":""}}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1" && req.Method == http.MethodPatch:
+			availabilityMutations++
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "current UPFRONT subscription price is missing for DEU") {
+		t.Fatalf("expected missing preserved DEU UPFRONT price error, got %v", err)
+	}
+	if availabilityMutations != 0 {
+		t.Fatalf("expected preserved territories to be validated before updating availability, got %d mutation(s)", availabilityMutations)
+	}
+}
+
 func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesEachTerritoryPriceRangeBeforeMutation(t *testing.T) {
 	setupAuth(t)
 
@@ -1012,6 +1091,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 	sentPlanType := false
 	sentAvailableInNewTerritories := false
 	var updatedTerritoryIDs []string
+	var createdMonthlyTerritoryIDs []string
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
@@ -1020,17 +1100,29 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 			switch req.URL.Query().Get("filter[planType]") {
 			case "UPFRONT":
 				return jsonResponse(http.StatusOK, `{
-					"data":[{
-						"type":"subscriptionPrices","id":"price-upfront",
-						"attributes":{"startDate":"2024-01-01"},
-						"relationships":{
-							"territory":{"data":{"type":"territories","id":"NOR"}},
-							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+					"data":[
+						{
+							"type":"subscriptionPrices","id":"price-upfront-nor",
+							"attributes":{"startDate":"2024-01-01"},
+							"relationships":{
+								"territory":{"data":{"type":"territories","id":"NOR"}},
+								"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront-nor"}}
+							}
+						},
+						{
+							"type":"subscriptionPrices","id":"price-upfront-deu",
+							"attributes":{"startDate":"2024-01-01"},
+							"relationships":{
+								"territory":{"data":{"type":"territories","id":"DEU"}},
+								"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront-deu"}}
+							}
 						}
-					}],
+					],
 					"included":[
-						{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
-						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+						{"type":"subscriptionPricePoints","id":"pp-upfront-nor","attributes":{"customerPrice":"120.00"}},
+						{"type":"subscriptionPricePoints","id":"pp-upfront-deu","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}},
+						{"type":"territories","id":"DEU","attributes":{"currency":"EUR"}}
 					],
 					"links":{"next":""}
 				}`)
@@ -1054,7 +1146,20 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 				return nil, nil
 			}
 		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
-			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+			if got := req.URL.Query().Get("filter[territory]"); got != "DEU" {
+				t.Fatalf("expected price-point lookup for preserved DEU, got %q", got)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly-deu","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			var payload asc.SubscriptionPriceCreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create price payload: %v", err)
+			}
+			if payload.Data.Relationships == nil || payload.Data.Relationships.Territory == nil {
+				t.Fatalf("expected territory relationship, got %#v", payload.Data.Relationships)
+			}
+			createdMonthlyTerritoryIDs = append(createdMonthlyTerritoryIDs, payload.Data.Relationships.Territory.Data.ID)
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-monthly-deu","attributes":{"planType":"MONTHLY"}}}`)
 		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
 			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}]}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1/relationships/availableTerritories" && req.Method == http.MethodGet:
@@ -1113,5 +1218,8 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableOmitsPlanTypeOnUpdate(t *tes
 	}
 	if got := strings.Join(updatedTerritoryIDs, ","); got != "DEU,NOR" {
 		t.Fatalf("expected enable to preserve DEU while adding NOR, got %q", got)
+	}
+	if got := strings.Join(createdMonthlyTerritoryIDs, ","); got != "DEU" {
+		t.Fatalf("expected enable to configure the preserved DEU monthly price, got %q", got)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -430,6 +430,99 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesAllUpfrontPricesBef
 	}
 }
 
+func TestSubscriptionsPricingMonthlyCommitmentEnableValidatesAllMonthlyPricesBeforeMutation(t *testing.T) {
+	setupAuth(t)
+
+	var availabilityMutations int
+	var subscriptionPricePosts int
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[planType]") {
+			case "UPFRONT":
+				return jsonResponse(http.StatusOK, `{
+					"data":[
+						{
+							"type":"subscriptionPrices","id":"price-upfront-nor",
+							"attributes":{"startDate":"2024-01-01"},
+							"relationships":{
+								"territory":{"data":{"type":"territories","id":"NOR"}},
+								"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront-nor"}}
+							}
+						},
+						{
+							"type":"subscriptionPrices","id":"price-upfront-deu",
+							"attributes":{"startDate":"2024-01-01"},
+							"relationships":{
+								"territory":{"data":{"type":"territories","id":"DEU"}},
+								"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront-deu"}}
+							}
+						}
+					],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront-nor","attributes":{"customerPrice":"120.00"}},
+						{"type":"subscriptionPricePoints","id":"pp-upfront-deu","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}},
+						{"type":"territories","id":"DEU","attributes":{"currency":"EUR"}}
+					],
+					"links":{"next":""}
+				}`)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[territory]") {
+			case "NOR":
+				return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-monthly-nor","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+			case "DEU":
+				return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+			default:
+				t.Fatalf("unexpected price-points query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			availabilityMutations++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			subscriptionPricePosts++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-monthly","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway,Germany",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "resolve monthly price for DEU") {
+		t.Fatalf("expected missing DEU monthly price-point error, got %v", err)
+	}
+	if availabilityMutations != 0 {
+		t.Fatalf("expected monthly prices to be validated before mutating availability, got %d mutation(s)", availabilityMutations)
+	}
+	if subscriptionPricePosts != 0 {
+		t.Fatalf("expected no monthly price writes when preflight fails, got %d create request(s)", subscriptionPricePosts)
+	}
+}
+
 func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_TIMEOUT", "80ms")
@@ -437,6 +530,7 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 
 	var postedPlanType string
 	var mutationOrder []string
+	var availabilityDeadlineRemaining time.Duration
 	var createDeadlineRemaining time.Duration
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
@@ -498,6 +592,11 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 			return jsonResponse(http.StatusOK, `{"data":[]}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
 			mutationOrder = append(mutationOrder, "availability")
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Fatal("expected plan availability create request to carry a timeout deadline")
+			}
+			availabilityDeadlineRemaining = time.Until(deadline)
 			var payload asc.SubscriptionPlanAvailabilityCreateRequest
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode plan availability payload: %v", err)
@@ -537,6 +636,9 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableCreatesMonthlyPrices(t *test
 	}
 	if got := strings.Join(mutationOrder, ","); got != "availability,price" {
 		t.Fatalf("expected availability before price creation, got %q", got)
+	}
+	if availabilityDeadlineRemaining < 35*time.Millisecond {
+		t.Fatalf("expected a fresh timeout for plan availability creation, got only %v remaining", availabilityDeadlineRemaining)
 	}
 	if createDeadlineRemaining < 35*time.Millisecond {
 		t.Fatalf("expected a fresh timeout for price creation, got only %v remaining", createDeadlineRemaining)
@@ -712,6 +814,85 @@ func TestSubscriptionsPricingMonthlyCommitmentEnableSkipsEquivalentMonthlyPrice(
 	}
 	if subscriptionPricePosts != 0 {
 		t.Fatalf("expected equivalent current MONTHLY price to be reused, got %d create request(s)", subscriptionPricePosts)
+	}
+}
+
+func TestSubscriptionsPricingMonthlyCommitmentEnableDoesNotReuseFutureMonthlyPrice(t *testing.T) {
+	setupAuth(t)
+
+	subscriptionPricePosts := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"subscriptionPeriod":"ONE_YEAR"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/prices" && req.Method == http.MethodGet:
+			switch req.URL.Query().Get("filter[planType]") {
+			case "UPFRONT":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-upfront",
+						"attributes":{"startDate":"2024-01-01"},
+						"relationships":{
+							"territory":{"data":{"type":"territories","id":"NOR"}},
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-upfront"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-upfront","attributes":{"customerPrice":"120.00"}},
+						{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+					],
+					"links":{"next":""}
+				}`)
+			case "MONTHLY":
+				return jsonResponse(http.StatusOK, `{
+					"data":[{
+						"type":"subscriptionPrices","id":"price-monthly-future",
+						"attributes":{"startDate":"2099-01-01"},
+						"relationships":{
+							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-future"}}
+						}
+					}],
+					"included":[
+						{"type":"subscriptionPricePoints","id":"pp-future","attributes":{"customerPrice":"10.00"}}
+					],
+					"links":{"next":""}
+				}`)
+			default:
+				t.Fatalf("unexpected prices query: %q", req.URL.RawQuery)
+				return nil, nil
+			}
+		case req.URL.Path == "/v1/subscriptions/8000000001/pricePoints" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-current","attributes":{"customerPrice":"10.00"}}],"links":{"next":""}}`)
+		case req.URL.Path == "/v1/subscriptionPrices" && req.Method == http.MethodPost:
+			subscriptionPricePosts++
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-created","attributes":{"planType":"MONTHLY"}}}`)
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "monthly-commitment", "enable",
+		"--subscription-id", "8000000001",
+		"--price", "10.00",
+		"--price-territory", "Norway",
+		"--territories", "Norway",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if subscriptionPricePosts != 1 {
+		t.Fatalf("expected a current MONTHLY price to be created despite the matching future schedule, got %d create request(s)", subscriptionPricePosts)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -484,6 +484,9 @@ func TestSubscriptionsPricingAvailabilityEditMonthlyCommitmentOmitsAvailableInNe
 	setupAuth(t)
 
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet {
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		}
 		if req.URL.Path != "/v1/subscriptionPlanAvailabilities" || req.Method != http.MethodPost {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
@@ -513,6 +516,57 @@ func TestSubscriptionsPricingAvailabilityEditMonthlyCommitmentOmitsAvailableInNe
 	}
 	if err := root.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestSubscriptionsPricingAvailabilityEditMonthlyCommitmentUpdatesExistingPlanAvailability(t *testing.T) {
+	setupAuth(t)
+
+	var requests []string
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/8000000001/planAvailabilities" && req.Method == http.MethodGet:
+			requests = append(requests, "list")
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-1" && req.Method == http.MethodPatch:
+			requests = append(requests, "update")
+			var payload asc.SubscriptionPlanAvailabilityUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode plan availability payload: %v", err)
+			}
+			if payload.Data.Attributes != nil {
+				t.Fatalf("MONTHLY update must omit attributes, got %#v", payload.Data.Attributes)
+			}
+			got := payload.Data.Relationships.AvailableTerritories.Data
+			if len(got) != 1 || got[0].ID != "NOR" {
+				t.Fatalf("expected NOR territory update, got %#v", got)
+			}
+			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-1","attributes":{"planType":"MONTHLY"}}}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities" && req.Method == http.MethodPost:
+			requests = append(requests, "create")
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-2","attributes":{"planType":"MONTHLY"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "pricing", "availability", "edit",
+		"--subscription-id", "8000000001",
+		"--billing-mode", "monthly-commitment",
+		"--territories", "Norway",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if got := strings.Join(requests, ","); got != "list,update" {
+		t.Fatalf("expected existing MONTHLY availability to be updated, got %q", got)
 	}
 }
 

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -164,13 +164,6 @@ Examples:
 			if err := validateMonthlyCommitmentPriceRange(monthlyPrice, summary.CurrentPrice.Amount); err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
-			if err := validateMonthlyCommitmentUpfrontPrices(ctx, client, id, territoryIDs, monthlyPrice); err != nil {
-				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
-			}
-			monthlyPriceCreates, err := prepareMonthlySubscriptionPrices(ctx, client, id, territoryIDs, monthlyPrice)
-			if err != nil {
-				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
-			}
 
 			attrs := asc.SubscriptionPlanAvailabilityAttributes{
 				PlanType: asc.SubscriptionPlanTypeMonthly,
@@ -183,22 +176,35 @@ Examples:
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch plan availabilities: %w", err)
 			}
 
-			var availabilityResp *asc.SubscriptionPlanAvailabilityResponse
-			if monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing); ok {
+			availabilityTerritoryIDs := territoryIDs
+			monthlyPlan, hasMonthlyPlan := findMonthlySubscriptionPlanAvailability(existing)
+			if hasMonthlyPlan {
 				currentTerritoryIDs, fetchErr := subscriptionPlanAvailabilityTerritories(ctx, client, monthlyPlan.ID)
 				if fetchErr != nil {
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch available territories: %w", fetchErr)
 				}
-				updatedTerritoryIDs := unionSubscriptionPlanAvailabilityTerritories(currentTerritoryIDs, territoryIDs)
+				availabilityTerritoryIDs = unionSubscriptionPlanAvailabilityTerritories(currentTerritoryIDs, territoryIDs)
+			}
+
+			if err := validateMonthlyCommitmentUpfrontPrices(ctx, client, id, availabilityTerritoryIDs, monthlyPrice); err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
+			}
+			monthlyPriceCreates, err := prepareMonthlySubscriptionPrices(ctx, client, id, availabilityTerritoryIDs, monthlyPrice)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
+			}
+
+			var availabilityResp *asc.SubscriptionPlanAvailabilityResponse
+			if hasMonthlyPlan {
 				availabilityWriteCtx, availabilityWriteCancel := shared.ContextWithTimeout(ctx)
-				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(availabilityWriteCtx, monthlyPlan.ID, updatedTerritoryIDs, nil)
+				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(availabilityWriteCtx, monthlyPlan.ID, availabilityTerritoryIDs, nil)
 				availabilityWriteCancel()
 				if err != nil {
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to update plan availability: %w", err)
 				}
 			} else {
 				availabilityWriteCtx, availabilityWriteCancel := shared.ContextWithTimeout(ctx)
-				availabilityResp, err = client.CreateSubscriptionPlanAvailability(availabilityWriteCtx, id, territoryIDs, attrs)
+				availabilityResp, err = client.CreateSubscriptionPlanAvailability(availabilityWriteCtx, id, availabilityTerritoryIDs, attrs)
 				availabilityWriteCancel()
 				if err != nil {
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to create plan availability: %w", err)

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -80,7 +81,8 @@ The subscription must use subscriptionPeriod ONE_YEAR. USA and Singapore are
 removed from --territories because Apple excludes those storefronts. The CLI
 also checks that the 12-payment total is at least the upfront annual price and
 no more than 1.5x the upfront annual price when the current upfront price can be
-read from App Store Connect.
+read from App Store Connect. The CLI creates MONTHLY subscriptionPrices for each
+eligible territory before updating subscriptionPlanAvailabilities.
 
 Examples:
   asc subscriptions pricing monthly-commitment enable --subscription-id "SUB_ID" --price "9.99" --price-territory "Norway" --territories "Norway,Germany,France"`,
@@ -155,6 +157,10 @@ Examples:
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: current upfront price is missing for %s", priceTerritoryID)
 			}
 			if err := validateMonthlyCommitmentPriceRange(monthlyPrice, summary.CurrentPrice.Amount); err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
+			}
+
+			if err := ensureMonthlySubscriptionPrices(requestCtx, client, id, territoryIDs, monthlyPrice); err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
 
@@ -449,4 +455,57 @@ func formatMoneyRat(value *big.Rat) string {
 		return ""
 	}
 	return value.FloatString(2)
+}
+
+func ensureMonthlySubscriptionPrices(
+	ctx context.Context,
+	client *asc.Client,
+	subscriptionID string,
+	territoryIDs []string,
+	monthlyPrice string,
+) error {
+	now := time.Now().UTC()
+	for _, territoryID := range territoryIDs {
+		tierCtx, tierCancel := shared.ContextWithTimeout(ctx)
+		tiers, err := shared.ResolveSubscriptionTiers(tierCtx, client, subscriptionID, territoryID, false)
+		tierCancel()
+		if err != nil {
+			return fmt.Errorf("resolve tiers for %s: %w", territoryID, err)
+		}
+
+		pricePointID, err := shared.ResolvePricePointByPrice(tiers, monthlyPrice)
+		if err != nil {
+			return fmt.Errorf("resolve monthly price for %s: %w", territoryID, err)
+		}
+
+		pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
+		pricesResp, err := client.GetSubscriptionPrices(
+			pricesCtx,
+			subscriptionID,
+			asc.WithSubscriptionPricesTerritory(territoryID),
+			asc.WithSubscriptionPricesPlanType(asc.SubscriptionPlanTypeMonthly),
+			asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint"}),
+			asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice"}),
+			asc.WithSubscriptionPricesLimit(10),
+		)
+		pricesCancel()
+		if err != nil {
+			return fmt.Errorf("fetch monthly prices for %s: %w", territoryID, err)
+		}
+
+		pricePointValues, _ := parseSubscriptionPricesIncluded(pricesResp.Included)
+		if current, ok := selectCurrentSubscriptionPriceValue(pricesResp.Data, pricePointValues, now); ok {
+			if resolved, exists := pricePointValues[pricePointID]; exists && resolved.CustomerPrice == current.CustomerPrice {
+				continue
+			}
+		}
+
+		_, err = client.CreateSubscriptionPrice(ctx, subscriptionID, pricePointID, territoryID, asc.SubscriptionPriceCreateAttributes{
+			PlanType: asc.SubscriptionPlanTypeMonthly,
+		})
+		if err != nil {
+			return fmt.Errorf("create monthly price for %s: %w", territoryID, err)
+		}
+	}
+	return nil
 }

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -184,21 +184,26 @@ Examples:
 			}
 
 			var availabilityResp *asc.SubscriptionPlanAvailabilityResponse
-			availabilityWriteCtx, availabilityWriteCancel := shared.ContextWithTimeout(ctx)
 			if monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing); ok {
-				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(availabilityWriteCtx, monthlyPlan.ID, territoryIDs, nil)
+				currentTerritoryIDs, fetchErr := subscriptionPlanAvailabilityTerritories(ctx, client, monthlyPlan.ID)
+				if fetchErr != nil {
+					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch available territories: %w", fetchErr)
+				}
+				updatedTerritoryIDs := unionSubscriptionPlanAvailabilityTerritories(currentTerritoryIDs, territoryIDs)
+				availabilityWriteCtx, availabilityWriteCancel := shared.ContextWithTimeout(ctx)
+				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(availabilityWriteCtx, monthlyPlan.ID, updatedTerritoryIDs, nil)
+				availabilityWriteCancel()
 				if err != nil {
-					availabilityWriteCancel()
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to update plan availability: %w", err)
 				}
 			} else {
+				availabilityWriteCtx, availabilityWriteCancel := shared.ContextWithTimeout(ctx)
 				availabilityResp, err = client.CreateSubscriptionPlanAvailability(availabilityWriteCtx, id, territoryIDs, attrs)
+				availabilityWriteCancel()
 				if err != nil {
-					availabilityWriteCancel()
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to create plan availability: %w", err)
 				}
 			}
-			availabilityWriteCancel()
 
 			if err := createMonthlySubscriptionPrices(ctx, client, id, monthlyPriceCreates); err != nil {
 				return fmt.Errorf(
@@ -540,6 +545,30 @@ func prepareMonthlySubscriptionPrices(
 	monthlyPrice string,
 ) ([]monthlySubscriptionPriceCreate, error) {
 	now := time.Now().UTC()
+	pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
+	resolvedPrices, err := fetchResolvedSubscriptionPrices(
+		pricesCtx,
+		client,
+		subscriptionID,
+		200,
+		"",
+		now,
+		asc.SubscriptionPlanTypeMonthly,
+	)
+	pricesCancel()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch MONTHLY subscription prices: %w", err)
+	}
+
+	currentPrices := make(map[string]string, len(resolvedPrices.Prices))
+	for _, price := range resolvedPrices.Prices {
+		territoryID := strings.ToUpper(strings.TrimSpace(price.Territory))
+		if territoryID == "" {
+			continue
+		}
+		currentPrices[territoryID] = strings.TrimSpace(price.CustomerPrice)
+	}
+
 	creates := make([]monthlySubscriptionPriceCreate, 0, len(territoryIDs))
 	for _, territoryID := range territoryIDs {
 		tierCtx, tierCancel := shared.ContextWithTimeout(ctx)
@@ -561,26 +590,9 @@ func prepareMonthlySubscriptionPrices(
 			}
 		}
 
-		pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
-		pricesResp, err := client.GetSubscriptionPrices(
-			pricesCtx,
-			subscriptionID,
-			asc.WithSubscriptionPricesTerritory(territoryID),
-			asc.WithSubscriptionPricesPlanType(asc.SubscriptionPlanTypeMonthly),
-			asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint"}),
-			asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice"}),
-			asc.WithSubscriptionPricesLimit(10),
-		)
-		pricesCancel()
-		if err != nil {
-			return nil, fmt.Errorf("fetch monthly prices for %s: %w", territoryID, err)
-		}
-
-		pricePointValues, _ := parseSubscriptionPricesIncluded(pricesResp.Included)
-		if current, ok := selectInEffectSubscriptionPriceValue(pricesResp.Data, pricePointValues, now); ok {
-			if monthlyCommitmentPricesEqual(current.CustomerPrice, resolvedMonthlyPrice) {
-				continue
-			}
+		if currentPrice := currentPrices[strings.ToUpper(strings.TrimSpace(territoryID))]; currentPrice != "" &&
+			monthlyCommitmentPricesEqual(currentPrice, resolvedMonthlyPrice) {
+			continue
 		}
 
 		creates = append(creates, monthlySubscriptionPriceCreate{
@@ -628,12 +640,32 @@ func remainingSubscriptionPlanAvailabilityTerritories(
 	planAvailabilityID string,
 	removedTerritoryIDs []string,
 ) ([]string, error) {
+	currentTerritoryIDs, err := subscriptionPlanAvailabilityTerritories(ctx, client, planAvailabilityID)
+	if err != nil {
+		return nil, err
+	}
+
 	removed := make(map[string]struct{}, len(removedTerritoryIDs))
 	for _, territoryID := range removedTerritoryIDs {
 		removed[strings.ToUpper(strings.TrimSpace(territoryID))] = struct{}{}
 	}
 
-	remaining := make([]string, 0)
+	remaining := make([]string, 0, len(currentTerritoryIDs))
+	for _, territoryID := range currentTerritoryIDs {
+		if _, remove := removed[territoryID]; remove {
+			continue
+		}
+		remaining = append(remaining, territoryID)
+	}
+	return remaining, nil
+}
+
+func subscriptionPlanAvailabilityTerritories(
+	ctx context.Context,
+	client *asc.Client,
+	planAvailabilityID string,
+) ([]string, error) {
+	territoryIDs := make([]string, 0)
 	seenTerritories := make(map[string]struct{})
 	seenNextURLs := make(map[string]struct{})
 	nextURL := ""
@@ -663,19 +695,35 @@ func remainingSubscriptionPlanAvailabilityTerritories(
 			if territoryID == "" {
 				continue
 			}
-			if _, remove := removed[territoryID]; remove {
-				continue
-			}
 			if _, seen := seenTerritories[territoryID]; seen {
 				continue
 			}
 			seenTerritories[territoryID] = struct{}{}
-			remaining = append(remaining, territoryID)
+			territoryIDs = append(territoryIDs, territoryID)
 		}
 
 		nextURL = strings.TrimSpace(resp.Links.Next)
 		if nextURL == "" {
-			return remaining, nil
+			return territoryIDs, nil
 		}
 	}
+}
+
+func unionSubscriptionPlanAvailabilityTerritories(existing []string, added []string) []string {
+	territoryIDs := make([]string, 0, len(existing)+len(added))
+	seen := make(map[string]struct{}, len(existing)+len(added))
+	for _, values := range [][]string{existing, added} {
+		for _, territoryID := range values {
+			territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
+			if territoryID == "" {
+				continue
+			}
+			if _, ok := seen[territoryID]; ok {
+				continue
+			}
+			seen[territoryID] = struct{}{}
+			territoryIDs = append(territoryIDs, territoryID)
+		}
+	}
+	return territoryIDs
 }

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -82,7 +82,8 @@ removed from --territories because Apple excludes those storefronts. The CLI
 also checks that the 12-payment total is at least the upfront annual price and
 no more than 1.5x the upfront annual price when the current upfront price can be
 read from App Store Connect. The CLI configures MONTHLY plan availability before
-creating MONTHLY subscriptionPrices for each eligible territory.
+creating MONTHLY subscriptionPrices because Apple rejects the reverse order.
+Each eligible territory must already have an UPFRONT subscription price.
 
 Examples:
   asc subscriptions pricing monthly-commitment enable --subscription-id "SUB_ID" --price "9.99" --price-territory "Norway" --territories "Norway,Germany,France"`,

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -164,7 +164,7 @@ Examples:
 			if err := validateMonthlyCommitmentPriceRange(monthlyPrice, summary.CurrentPrice.Amount); err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
-			if err := validateMonthlyCommitmentUpfrontPrices(ctx, client, id, territoryIDs); err != nil {
+			if err := validateMonthlyCommitmentUpfrontPrices(ctx, client, id, territoryIDs, monthlyPrice); err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
 			monthlyPriceCreates, err := prepareMonthlySubscriptionPrices(ctx, client, id, territoryIDs, monthlyPrice)
@@ -494,6 +494,7 @@ func validateMonthlyCommitmentUpfrontPrices(
 	client *asc.Client,
 	subscriptionID string,
 	territoryIDs []string,
+	monthlyPrice string,
 ) error {
 	pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
 	defer pricesCancel()
@@ -511,23 +512,32 @@ func validateMonthlyCommitmentUpfrontPrices(
 		return fmt.Errorf("failed to fetch UPFRONT subscription prices: %w", err)
 	}
 
-	available := make(map[string]struct{}, len(resolved.Prices))
+	upfrontPrices := make(map[string]string, len(resolved.Prices))
 	for _, price := range resolved.Prices {
-		if strings.TrimSpace(price.CustomerPrice) == "" {
+		territoryID := strings.ToUpper(strings.TrimSpace(price.Territory))
+		customerPrice := strings.TrimSpace(price.CustomerPrice)
+		if territoryID == "" || customerPrice == "" {
 			continue
 		}
-		available[strings.ToUpper(strings.TrimSpace(price.Territory))] = struct{}{}
+		upfrontPrices[territoryID] = customerPrice
 	}
 
 	missing := make([]string, 0)
 	for _, territoryID := range territoryIDs {
 		territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
-		if _, ok := available[territoryID]; !ok {
+		if upfrontPrices[territoryID] == "" {
 			missing = append(missing, territoryID)
 		}
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("current UPFRONT subscription price is missing for %s", strings.Join(missing, ","))
+	}
+
+	for _, territoryID := range territoryIDs {
+		territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
+		if err := validateMonthlyCommitmentPriceRange(monthlyPrice, upfrontPrices[territoryID]); err != nil {
+			return fmt.Errorf("monthly price is invalid for %s: %w", territoryID, err)
+		}
 	}
 	return nil
 }

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -163,6 +163,9 @@ Examples:
 			if err := validateMonthlyCommitmentPriceRange(monthlyPrice, summary.CurrentPrice.Amount); err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
+			if err := validateMonthlyCommitmentUpfrontPrices(ctx, client, id, territoryIDs); err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
+			}
 
 			attrs := asc.SubscriptionPlanAvailabilityAttributes{
 				PlanType: asc.SubscriptionPlanTypeMonthly,
@@ -468,6 +471,49 @@ func formatMoneyRat(value *big.Rat) string {
 		return ""
 	}
 	return value.FloatString(2)
+}
+
+func validateMonthlyCommitmentUpfrontPrices(
+	ctx context.Context,
+	client *asc.Client,
+	subscriptionID string,
+	territoryIDs []string,
+) error {
+	pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
+	defer pricesCancel()
+
+	resolved, err := fetchResolvedSubscriptionPrices(
+		pricesCtx,
+		client,
+		subscriptionID,
+		200,
+		"",
+		time.Now().UTC(),
+		asc.SubscriptionPlanTypeUpfront,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to fetch UPFRONT subscription prices: %w", err)
+	}
+
+	available := make(map[string]struct{}, len(resolved.Prices))
+	for _, price := range resolved.Prices {
+		if strings.TrimSpace(price.CustomerPrice) == "" {
+			continue
+		}
+		available[strings.ToUpper(strings.TrimSpace(price.Territory))] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	for _, territoryID := range territoryIDs {
+		territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
+		if _, ok := available[territoryID]; !ok {
+			missing = append(missing, territoryID)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("current UPFRONT subscription price is missing for %s", strings.Join(missing, ","))
+	}
+	return nil
 }
 
 func ensureMonthlySubscriptionPrices(

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -581,6 +581,12 @@ func prepareMonthlySubscriptionPrices(
 
 	creates := make([]monthlySubscriptionPriceCreate, 0, len(territoryIDs))
 	for _, territoryID := range territoryIDs {
+		normalizedTerritoryID := strings.ToUpper(strings.TrimSpace(territoryID))
+		if currentPrice := currentPrices[normalizedTerritoryID]; currentPrice != "" &&
+			monthlyCommitmentPricesEqual(currentPrice, monthlyPrice) {
+			continue
+		}
+
 		tierCtx, tierCancel := shared.ContextWithTimeout(ctx)
 		tiers, err := shared.ResolveSubscriptionTiers(tierCtx, client, subscriptionID, territoryID, false)
 		tierCancel()
@@ -600,7 +606,7 @@ func prepareMonthlySubscriptionPrices(
 			}
 		}
 
-		if currentPrice := currentPrices[strings.ToUpper(strings.TrimSpace(territoryID))]; currentPrice != "" &&
+		if currentPrice := currentPrices[normalizedTerritoryID]; currentPrice != "" &&
 			monthlyCommitmentPricesEqual(currentPrice, resolvedMonthlyPrice) {
 			continue
 		}

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -185,7 +185,7 @@ Examples:
 				}
 			}
 
-			if err := ensureMonthlySubscriptionPrices(requestCtx, client, id, territoryIDs, monthlyPrice); err != nil {
+			if err := ensureMonthlySubscriptionPrices(ctx, client, id, territoryIDs, monthlyPrice); err != nil {
 				return fmt.Errorf(
 					"subscriptions pricing monthly-commitment enable: plan availability %q is ready, but failed to configure MONTHLY prices: %w",
 					availabilityResp.Data.ID,
@@ -248,9 +248,8 @@ Examples:
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
 			existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
+			cancel()
 			if err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment disable: failed to fetch plan availabilities: %w", err)
 			}
@@ -259,7 +258,14 @@ Examples:
 				return fmt.Errorf("subscriptions pricing monthly-commitment disable: no monthly-commitment plan availability found for subscription %q", id)
 			}
 
-			resp, err := client.UpdateSubscriptionPlanAvailability(requestCtx, monthlyPlan.ID, nil, nil)
+			remainingTerritoryIDs, err := remainingSubscriptionPlanAvailabilityTerritories(ctx, client, monthlyPlan.ID, territoryIDs)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment disable: failed to fetch available territories: %w", err)
+			}
+
+			updateCtx, updateCancel := shared.ContextWithTimeout(ctx)
+			resp, err := client.UpdateSubscriptionPlanAvailability(updateCtx, monthlyPlan.ID, remainingTerritoryIDs, nil)
+			updateCancel()
 			if err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment disable: failed to update plan availability: %w", err)
 			}
@@ -513,9 +519,11 @@ func ensureMonthlySubscriptionPrices(
 			}
 		}
 
-		_, err = client.CreateSubscriptionPrice(ctx, subscriptionID, pricePointID, territoryID, asc.SubscriptionPriceCreateAttributes{
+		createCtx, createCancel := shared.ContextWithTimeout(ctx)
+		_, err = client.CreateSubscriptionPrice(createCtx, subscriptionID, pricePointID, territoryID, asc.SubscriptionPriceCreateAttributes{
 			PlanType: asc.SubscriptionPlanTypeMonthly,
 		})
+		createCancel()
 		if err != nil {
 			return fmt.Errorf("create monthly price for %s: %w", territoryID, err)
 		}
@@ -533,4 +541,62 @@ func monthlyCommitmentPricesEqual(left string, right string) bool {
 		return false
 	}
 	return leftPrice.Cmp(rightPrice) == 0
+}
+
+func remainingSubscriptionPlanAvailabilityTerritories(
+	ctx context.Context,
+	client *asc.Client,
+	planAvailabilityID string,
+	removedTerritoryIDs []string,
+) ([]string, error) {
+	removed := make(map[string]struct{}, len(removedTerritoryIDs))
+	for _, territoryID := range removedTerritoryIDs {
+		removed[strings.ToUpper(strings.TrimSpace(territoryID))] = struct{}{}
+	}
+
+	remaining := make([]string, 0)
+	seenTerritories := make(map[string]struct{})
+	seenNextURLs := make(map[string]struct{})
+	nextURL := ""
+	for {
+		opts := []asc.LinkagesOption{asc.WithLinkagesLimit(200)}
+		if nextURL != "" {
+			if _, seen := seenNextURLs[nextURL]; seen {
+				return nil, fmt.Errorf("repeated pagination URL: %s", nextURL)
+			}
+			seenNextURLs[nextURL] = struct{}{}
+			opts = []asc.LinkagesOption{asc.WithLinkagesNextURL(nextURL)}
+		}
+
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		resp, err := client.GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(
+			requestCtx,
+			planAvailabilityID,
+			opts...,
+		)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, territory := range resp.Data {
+			territoryID := strings.ToUpper(strings.TrimSpace(territory.ID))
+			if territoryID == "" {
+				continue
+			}
+			if _, remove := removed[territoryID]; remove {
+				continue
+			}
+			if _, seen := seenTerritories[territoryID]; seen {
+				continue
+			}
+			seenTerritories[territoryID] = struct{}{}
+			remaining = append(remaining, territoryID)
+		}
+
+		nextURL = strings.TrimSpace(resp.Links.Next)
+		if nextURL == "" {
+			return remaining, nil
+		}
+	}
 }

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -68,7 +68,7 @@ func SubscriptionsPricingMonthlyCommitmentEnableCommand() *ffcli.Command {
 	price := fs.String("price", "", "Monthly customer price; total commitment is price x 12")
 	priceTerritory := fs.String("price-territory", "", "Territory used to compare the upfront annual price")
 	territories := fs.String("territories", "", "Territories to enable, comma-separated; USA and Singapore are excluded")
-	availableInNew := fs.Bool("available-in-new-territories", false, "Include new eligible territories automatically")
+	availableInNew := fs.Bool("available-in-new-territories", false, "Unsupported for MONTHLY plan availability")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -81,8 +81,8 @@ The subscription must use subscriptionPeriod ONE_YEAR. USA and Singapore are
 removed from --territories because Apple excludes those storefronts. The CLI
 also checks that the 12-payment total is at least the upfront annual price and
 no more than 1.5x the upfront annual price when the current upfront price can be
-read from App Store Connect. The CLI creates MONTHLY subscriptionPrices for each
-eligible territory before updating subscriptionPlanAvailabilities.
+read from App Store Connect. The CLI configures MONTHLY plan availability before
+creating MONTHLY subscriptionPrices for each eligible territory.
 
 Examples:
   asc subscriptions pricing monthly-commitment enable --subscription-id "SUB_ID" --price "9.99" --price-territory "Norway" --territories "Norway,Germany,France"`,
@@ -94,6 +94,9 @@ Examples:
 			}
 			if len(args) > 0 {
 				return shared.UsageError("subscriptions pricing monthly-commitment enable does not accept positional arguments")
+			}
+			if *availableInNew {
+				return shared.UsageError("--available-in-new-territories is not supported for MONTHLY plan availability")
 			}
 
 			id := strings.TrimSpace(*subscriptionID)
@@ -160,14 +163,8 @@ Examples:
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
 
-			if err := ensureMonthlySubscriptionPrices(requestCtx, client, id, territoryIDs, monthlyPrice); err != nil {
-				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
-			}
-
-			availableInNewValue := *availableInNew
 			attrs := asc.SubscriptionPlanAvailabilityAttributes{
-				AvailableInNewTerritories: &availableInNewValue,
-				PlanType:                  asc.SubscriptionPlanTypeMonthly,
+				PlanType: asc.SubscriptionPlanTypeMonthly,
 			}
 
 			existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
@@ -175,19 +172,28 @@ Examples:
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch plan availabilities: %w", err)
 			}
 
+			var availabilityResp *asc.SubscriptionPlanAvailabilityResponse
 			if monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing); ok {
-				resp, err := client.UpdateSubscriptionPlanAvailability(requestCtx, monthlyPlan.ID, territoryIDs, &attrs)
+				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(requestCtx, monthlyPlan.ID, territoryIDs, nil)
 				if err != nil {
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to update plan availability: %w", err)
 				}
-				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			} else {
+				availabilityResp, err = client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, attrs)
+				if err != nil {
+					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to create plan availability: %w", err)
+				}
 			}
 
-			resp, err := client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, attrs)
-			if err != nil {
-				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to create plan availability: %w", err)
+			if err := ensureMonthlySubscriptionPrices(requestCtx, client, id, territoryIDs, monthlyPrice); err != nil {
+				return fmt.Errorf(
+					"subscriptions pricing monthly-commitment enable: plan availability %q is ready, but failed to configure MONTHLY prices: %w",
+					availabilityResp.Data.ID,
+					err,
+				)
 			}
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+
+			return shared.PrintOutput(availabilityResp, *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -477,6 +483,13 @@ func ensureMonthlySubscriptionPrices(
 		if err != nil {
 			return fmt.Errorf("resolve monthly price for %s: %w", territoryID, err)
 		}
+		resolvedMonthlyPrice := monthlyPrice
+		for _, tier := range tiers {
+			if strings.TrimSpace(tier.PricePointID) == pricePointID {
+				resolvedMonthlyPrice = tier.CustomerPrice
+				break
+			}
+		}
 
 		pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
 		pricesResp, err := client.GetSubscriptionPrices(
@@ -495,7 +508,7 @@ func ensureMonthlySubscriptionPrices(
 
 		pricePointValues, _ := parseSubscriptionPricesIncluded(pricesResp.Included)
 		if current, ok := selectCurrentSubscriptionPriceValue(pricesResp.Data, pricePointValues, now); ok {
-			if resolved, exists := pricePointValues[pricePointID]; exists && resolved.CustomerPrice == current.CustomerPrice {
+			if monthlyCommitmentPricesEqual(current.CustomerPrice, resolvedMonthlyPrice) {
 				continue
 			}
 		}
@@ -508,4 +521,16 @@ func ensureMonthlySubscriptionPrices(
 		}
 	}
 	return nil
+}
+
+func monthlyCommitmentPricesEqual(left string, right string) bool {
+	leftPrice, err := parsePositiveMoneyRat(left, "current monthly price")
+	if err != nil {
+		return false
+	}
+	rightPrice, err := parsePositiveMoneyRat(right, "requested monthly price")
+	if err != nil {
+		return false
+	}
+	return leftPrice.Cmp(rightPrice) == 0
 }

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -142,10 +142,9 @@ Examples:
 				return err
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
-			subResp, err := client.GetSubscription(requestCtx, id)
+			subCtx, subCancel := shared.ContextWithTimeout(ctx)
+			subResp, err := client.GetSubscription(subCtx, id)
+			subCancel()
 			if err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch subscription: %w", err)
 			}
@@ -153,7 +152,9 @@ Examples:
 				return shared.UsageError("--subscription-id must refer to a ONE_YEAR subscription for monthly-commitment billing")
 			}
 
-			summary, err := resolveSubscriptionPriceSummary(requestCtx, client, subWithGroup{Sub: subResp.Data}, priceTerritoryID)
+			summaryCtx, summaryCancel := shared.ContextWithTimeout(ctx)
+			summary, err := resolveSubscriptionPriceSummary(summaryCtx, client, subWithGroup{Sub: subResp.Data}, priceTerritoryID)
+			summaryCancel()
 			if err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch upfront price: %w", err)
 			}
@@ -166,30 +167,40 @@ Examples:
 			if err := validateMonthlyCommitmentUpfrontPrices(ctx, client, id, territoryIDs); err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
 			}
+			monthlyPriceCreates, err := prepareMonthlySubscriptionPrices(ctx, client, id, territoryIDs, monthlyPrice)
+			if err != nil {
+				return fmt.Errorf("subscriptions pricing monthly-commitment enable: %w", err)
+			}
 
 			attrs := asc.SubscriptionPlanAvailabilityAttributes{
 				PlanType: asc.SubscriptionPlanTypeMonthly,
 			}
 
-			existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, id)
+			availabilityListCtx, availabilityListCancel := shared.ContextWithTimeout(ctx)
+			existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(availabilityListCtx, id)
+			availabilityListCancel()
 			if err != nil {
 				return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to fetch plan availabilities: %w", err)
 			}
 
 			var availabilityResp *asc.SubscriptionPlanAvailabilityResponse
+			availabilityWriteCtx, availabilityWriteCancel := shared.ContextWithTimeout(ctx)
 			if monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing); ok {
-				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(requestCtx, monthlyPlan.ID, territoryIDs, nil)
+				availabilityResp, err = client.UpdateSubscriptionPlanAvailability(availabilityWriteCtx, monthlyPlan.ID, territoryIDs, nil)
 				if err != nil {
+					availabilityWriteCancel()
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to update plan availability: %w", err)
 				}
 			} else {
-				availabilityResp, err = client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, attrs)
+				availabilityResp, err = client.CreateSubscriptionPlanAvailability(availabilityWriteCtx, id, territoryIDs, attrs)
 				if err != nil {
+					availabilityWriteCancel()
 					return fmt.Errorf("subscriptions pricing monthly-commitment enable: failed to create plan availability: %w", err)
 				}
 			}
+			availabilityWriteCancel()
 
-			if err := ensureMonthlySubscriptionPrices(ctx, client, id, territoryIDs, monthlyPrice); err != nil {
+			if err := createMonthlySubscriptionPrices(ctx, client, id, monthlyPriceCreates); err != nil {
 				return fmt.Errorf(
 					"subscriptions pricing monthly-commitment enable: plan availability %q is ready, but failed to configure MONTHLY prices: %w",
 					availabilityResp.Data.ID,
@@ -516,25 +527,31 @@ func validateMonthlyCommitmentUpfrontPrices(
 	return nil
 }
 
-func ensureMonthlySubscriptionPrices(
+type monthlySubscriptionPriceCreate struct {
+	territoryID  string
+	pricePointID string
+}
+
+func prepareMonthlySubscriptionPrices(
 	ctx context.Context,
 	client *asc.Client,
 	subscriptionID string,
 	territoryIDs []string,
 	monthlyPrice string,
-) error {
+) ([]monthlySubscriptionPriceCreate, error) {
 	now := time.Now().UTC()
+	creates := make([]monthlySubscriptionPriceCreate, 0, len(territoryIDs))
 	for _, territoryID := range territoryIDs {
 		tierCtx, tierCancel := shared.ContextWithTimeout(ctx)
 		tiers, err := shared.ResolveSubscriptionTiers(tierCtx, client, subscriptionID, territoryID, false)
 		tierCancel()
 		if err != nil {
-			return fmt.Errorf("resolve tiers for %s: %w", territoryID, err)
+			return nil, fmt.Errorf("resolve tiers for %s: %w", territoryID, err)
 		}
 
 		pricePointID, err := shared.ResolvePricePointByPrice(tiers, monthlyPrice)
 		if err != nil {
-			return fmt.Errorf("resolve monthly price for %s: %w", territoryID, err)
+			return nil, fmt.Errorf("resolve monthly price for %s: %w", territoryID, err)
 		}
 		resolvedMonthlyPrice := monthlyPrice
 		for _, tier := range tiers {
@@ -556,23 +573,38 @@ func ensureMonthlySubscriptionPrices(
 		)
 		pricesCancel()
 		if err != nil {
-			return fmt.Errorf("fetch monthly prices for %s: %w", territoryID, err)
+			return nil, fmt.Errorf("fetch monthly prices for %s: %w", territoryID, err)
 		}
 
 		pricePointValues, _ := parseSubscriptionPricesIncluded(pricesResp.Included)
-		if current, ok := selectCurrentSubscriptionPriceValue(pricesResp.Data, pricePointValues, now); ok {
+		if current, ok := selectInEffectSubscriptionPriceValue(pricesResp.Data, pricePointValues, now); ok {
 			if monthlyCommitmentPricesEqual(current.CustomerPrice, resolvedMonthlyPrice) {
 				continue
 			}
 		}
 
+		creates = append(creates, monthlySubscriptionPriceCreate{
+			territoryID:  territoryID,
+			pricePointID: pricePointID,
+		})
+	}
+	return creates, nil
+}
+
+func createMonthlySubscriptionPrices(
+	ctx context.Context,
+	client *asc.Client,
+	subscriptionID string,
+	creates []monthlySubscriptionPriceCreate,
+) error {
+	for _, create := range creates {
 		createCtx, createCancel := shared.ContextWithTimeout(ctx)
-		_, err = client.CreateSubscriptionPrice(createCtx, subscriptionID, pricePointID, territoryID, asc.SubscriptionPriceCreateAttributes{
+		_, err := client.CreateSubscriptionPrice(createCtx, subscriptionID, create.pricePointID, create.territoryID, asc.SubscriptionPriceCreateAttributes{
 			PlanType: asc.SubscriptionPlanTypeMonthly,
 		})
 		createCancel()
 		if err != nil {
-			return fmt.Errorf("create monthly price for %s: %w", territoryID, err)
+			return fmt.Errorf("create monthly price for %s: %w", create.territoryID, err)
 		}
 	}
 	return nil

--- a/internal/cli/subscriptions/pricing.go
+++ b/internal/cli/subscriptions/pricing.go
@@ -275,6 +275,7 @@ func resolveSubscriptionPriceSummary(
 		pricesCtx,
 		sub.Sub.ID,
 		asc.WithSubscriptionPricesTerritory(territory),
+		asc.WithSubscriptionPricesPlanType(asc.SubscriptionPlanTypeUpfront),
 		asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
 		asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
 		asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),

--- a/internal/cli/subscriptions/pricing.go
+++ b/internal/cli/subscriptions/pricing.go
@@ -327,6 +327,23 @@ func selectCurrentSubscriptionPriceValue(
 	pricePointValues map[string]subscriptionPricePointValue,
 	now time.Time,
 ) (subscriptionPricePointValue, bool) {
+	return selectSubscriptionPriceValue(prices, pricePointValues, now, true)
+}
+
+func selectInEffectSubscriptionPriceValue(
+	prices []asc.Resource[asc.SubscriptionPriceAttributes],
+	pricePointValues map[string]subscriptionPricePointValue,
+	now time.Time,
+) (subscriptionPricePointValue, bool) {
+	return selectSubscriptionPriceValue(prices, pricePointValues, now, false)
+}
+
+func selectSubscriptionPriceValue(
+	prices []asc.Resource[asc.SubscriptionPriceAttributes],
+	pricePointValues map[string]subscriptionPricePointValue,
+	now time.Time,
+	allowFutureFallback bool,
+) (subscriptionPricePointValue, bool) {
 	asOf := dateOnlyUTC(now)
 
 	var bestCurrent *subscriptionPriceCandidate
@@ -377,7 +394,7 @@ func selectCurrentSubscriptionPriceValue(
 		return bestCurrent.value, true
 	case bestUndated != nil:
 		return bestUndated.value, true
-	case bestFuture != nil:
+	case allowFutureFallback && bestFuture != nil:
 		return bestFuture.value, true
 	default:
 		return subscriptionPricePointValue{}, false

--- a/internal/cli/subscriptions/pricing.go
+++ b/internal/cli/subscriptions/pricing.go
@@ -327,23 +327,6 @@ func selectCurrentSubscriptionPriceValue(
 	pricePointValues map[string]subscriptionPricePointValue,
 	now time.Time,
 ) (subscriptionPricePointValue, bool) {
-	return selectSubscriptionPriceValue(prices, pricePointValues, now, true)
-}
-
-func selectInEffectSubscriptionPriceValue(
-	prices []asc.Resource[asc.SubscriptionPriceAttributes],
-	pricePointValues map[string]subscriptionPricePointValue,
-	now time.Time,
-) (subscriptionPricePointValue, bool) {
-	return selectSubscriptionPriceValue(prices, pricePointValues, now, false)
-}
-
-func selectSubscriptionPriceValue(
-	prices []asc.Resource[asc.SubscriptionPriceAttributes],
-	pricePointValues map[string]subscriptionPricePointValue,
-	now time.Time,
-	allowFutureFallback bool,
-) (subscriptionPricePointValue, bool) {
 	asOf := dateOnlyUTC(now)
 
 	var bestCurrent *subscriptionPriceCandidate
@@ -394,7 +377,7 @@ func selectSubscriptionPriceValue(
 		return bestCurrent.value, true
 	case bestUndated != nil:
 		return bestUndated.value, true
-	case allowFutureFallback && bestFuture != nil:
+	case bestFuture != nil:
 		return bestFuture.value, true
 	default:
 		return subscriptionPricePointValue{}, false

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1344,6 +1344,9 @@ Examples:
 				return shared.UsageError(err.Error())
 			}
 			if normalizedBillingMode == subscriptionBillingModeMonthlyCommitment {
+				if *availableInNew {
+					return shared.UsageError("--available-in-new-territories is not supported for MONTHLY plan availability")
+				}
 				territoryIDs, excluded := filterMonthlyCommitmentTerritories(territoryIDs)
 				printMonthlyCommitmentTerritoryWarning(excluded)
 				if len(territoryIDs) == 0 {
@@ -1365,10 +1368,8 @@ Examples:
 			defer cancel()
 
 			if normalizedBillingMode == subscriptionBillingModeMonthlyCommitment {
-				availableInNewValue := *availableInNew
 				resp, err := client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, asc.SubscriptionPlanAvailabilityAttributes{
-					AvailableInNewTerritories: &availableInNewValue,
-					PlanType:                  asc.SubscriptionPlanTypeMonthly,
+					PlanType: asc.SubscriptionPlanTypeMonthly,
 				})
 				if err != nil {
 					return fmt.Errorf("subscriptions availability edit: failed to set monthly-commitment plan availability: %w", err)

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1364,18 +1364,34 @@ Examples:
 				return err
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
 			if normalizedBillingMode == subscriptionBillingModeMonthlyCommitment {
-				resp, err := client.CreateSubscriptionPlanAvailability(requestCtx, id, territoryIDs, asc.SubscriptionPlanAvailabilityAttributes{
-					PlanType: asc.SubscriptionPlanTypeMonthly,
-				})
+				listCtx, listCancel := shared.ContextWithTimeout(ctx)
+				existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(listCtx, id)
+				listCancel()
+				if err != nil {
+					return fmt.Errorf("subscriptions availability edit: failed to fetch monthly-commitment plan availability: %w", err)
+				}
+
+				var resp *asc.SubscriptionPlanAvailabilityResponse
+				if monthlyPlan, ok := findMonthlySubscriptionPlanAvailability(existing); ok {
+					updateCtx, updateCancel := shared.ContextWithTimeout(ctx)
+					resp, err = client.UpdateSubscriptionPlanAvailability(updateCtx, monthlyPlan.ID, territoryIDs, nil)
+					updateCancel()
+				} else {
+					createCtx, createCancel := shared.ContextWithTimeout(ctx)
+					resp, err = client.CreateSubscriptionPlanAvailability(createCtx, id, territoryIDs, asc.SubscriptionPlanAvailabilityAttributes{
+						PlanType: asc.SubscriptionPlanTypeMonthly,
+					})
+					createCancel()
+				}
 				if err != nil {
 					return fmt.Errorf("subscriptions availability edit: failed to set monthly-commitment plan availability: %w", err)
 				}
 				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
 
 			attrs := asc.SubscriptionAvailabilityAttributes{
 				AvailableInNewTerritories: *availableInNew,


### PR DESCRIPTION
## What
- create `MONTHLY` subscription prices for each eligible territory during `monthly-commitment enable`
- use `filter[planType]=UPFRONT` for the annual comparison price and `MONTHLY` for idempotency checks
- keep plan availability create/update payloads aligned with App Store Connect API 4.4 request schemas
- preserve non-target territories during `monthly-commitment disable`, including paginated relationship responses
- make `pricing availability edit --billing-mode monthly-commitment` repeatable by PATCHing an existing MONTHLY plan availability
- apply a fresh `ASC_TIMEOUT` context to each outbound mutation

## API behavior
Apple requires an UPFRONT price in every target territory. Apple also rejects MONTHLY price creation before MONTHLY plan availability exists, so the command intentionally writes plan availability first and then creates prices. If a later price mutation fails, the error reports the ready plan availability ID so the partial state is explicit.

A future scheduled price does not suppress creation of the requested current price. The command skips creation only when the effective current MONTHLY price already matches `--price`.

## Live verification
Used the throwaway app `ASC Test 20260216074703` (`6759231657`) with public API credentials:

- proved price-before-availability returns Apple 409, while availability-before-price succeeds
- created MONTHLY availability and `5 NOK` pricing, then reran idempotently with no extra price POST
- selective disable on disposable subscription `6780034896`: territories were `DEU,NOR` before disabling Norway and `DEU` afterward
- repeat edit on disposable subscription `6780037247`: first monthly availability edit created the plan for `NOR`; the second reused the same plan ID and updated it to `DEU`
- deleted every disposable subscription after verification

## Checks
- `make format`
- `make generate-command-docs`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused ASC query, monthly command, timeout, pagination, usage-exit, and repeat-edit tests
- built-binary help and live smoke tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI behavior for monthly commitment setup, detailing required upfront subscription prices and pricing creation sequence.

* **Bug Fixes**
  * Enhanced validation to reject incompatible options in monthly commitment workflows and enforce proper pricing prerequisites before mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->