### PR TITLE
[codex] Add monthly commitment web pricing workflow

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -131,14 +131,24 @@ Available commands:
 
 ### `asc web subscriptions`
 
-Subscription sale availability workflows over Apple web-session `/iris` endpoints.
+Subscription sale availability and private pricing workflows over Apple
+web-session `/iris` endpoints.
 
 Available commands:
 
 * `asc web subscriptions availability remove-from-sale` - remove an approved auto-renewable subscription from sale
+* `asc web subscriptions pricing monthly-commitment bootstrap` - create or reuse MONTHLY availability and attach paired UPFRONT/MONTHLY prices
+* `asc web subscriptions pricing adjusted-equalizations view` - inspect Apple's adjusted price matrix for a subscription price point
 
 <Warning>
   Removing an approved auto-renewable subscription from sale requires an Account Holder web session. App Store Connect rejects Admin and App Manager users for this action.
+</Warning>
+
+<Warning>
+  Prefer `asc subscriptions pricing monthly-commitment enable` for normal
+  monthly-commitment setup. The `asc web subscriptions pricing` commands are
+  private-endpoint escape hatches for App Store Connect's paired pricing and
+  adjusted-equalization workflows.
 </Warning>
 
 Example:
@@ -156,6 +166,27 @@ asc web subscriptions availability remove-from-sale \
   --subscription-id "SUB_ID" \
   --plan-availability-id "PLAN_AVAILABILITY_ID" \
   --confirm
+```
+
+Plan a paired monthly-commitment price bootstrap without mutating App Store
+Connect:
+
+```bash  theme={null}
+asc web subscriptions pricing monthly-commitment bootstrap \
+  --subscription-id "SUB_ID" \
+  --territory "NOR" \
+  --upfront-price "49" \
+  --monthly-price "5" \
+  --dry-run
+```
+
+Inspect Apple's adjusted equalizations for a monthly price point:
+
+```bash  theme={null}
+asc web subscriptions pricing adjusted-equalizations view \
+  --price-point-id "PRICE_POINT_ID" \
+  --plan-type "MONTHLY" \
+  --output json
 ```
 
 ### `asc web analytics`

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -138,7 +138,7 @@ Available commands:
 
 * `asc web subscriptions availability remove-from-sale` - remove an approved auto-renewable subscription from sale
 * `asc web subscriptions pricing monthly-commitment bootstrap` - create or reuse MONTHLY availability and attach paired UPFRONT/MONTHLY prices
-* `asc web subscriptions pricing adjusted-equalizations view` - inspect Apple's adjusted price matrix for a subscription price point
+* `asc web subscriptions pricing adjusted-equalizations view` - inspect Apple's adjusted price matrix for a MONTHLY subscription price point
 
 <Warning>
   Removing an approved auto-renewable subscription from sale requires an Account Holder web session. App Store Connect rejects Admin and App Manager users for this action.

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -440,6 +440,24 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapUsageExitCodes(t *test
 		wantErr string
 	}{
 		{
+			name: "missing subscription id",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+			},
+			wantErr: "--subscription-id is required",
+		},
+		{
+			name: "missing confirm",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "NOR",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+			},
+			wantErr: "--confirm is required",
+		},
+		{
 			name: "preserve requires start date",
 			args: []string{
 				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
@@ -458,6 +476,18 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapUsageExitCodes(t *test
 				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
 				"--subscription-id", "sub-1",
 				"--territory", "USA",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+				"--confirm",
+			},
+			wantErr: "--territory cannot be USA or Singapore for monthly-commitment pricing",
+		},
+		{
+			name: "rejects Singapore",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "SGP",
 				"--upfront-price-point-id", "upfront",
 				"--monthly-price-point-id", "monthly",
 				"--confirm",

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -301,6 +301,55 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunCreatesAvailability
 	}
 }
 
+func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapDryRunReportsPreviewWithoutCreation(t *testing.T) {
+	requests := 0
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				if req.Method != http.MethodGet || req.URL.Path != "/iris/v1/subscriptions/sub-1/planAvailabilities" {
+					t.Fatalf("unexpected dry-run request: %s %s", req.Method, req.URL.Path)
+				}
+				return webSubscriptionsJSONResponse(`{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT"},"relationships":{"availableTerritories":{"data":[{"type":"territories","id":"NOR"}]}}}]}`), nil
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+			"--subscription-id", "sub-1",
+			"--territory", "NOR",
+			"--upfront-price-point-id", "upfront-point",
+			"--monthly-price-point-id", "monthly-point",
+			"--dry-run",
+			"--output", "json",
+		}, "1.0.0")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var payload struct {
+		PlanAvailabilityCreated     bool `json:"planAvailabilityCreated"`
+		PlanAvailabilityWouldCreate bool `json:"planAvailabilityWouldCreate"`
+		PricesCreated               bool `json:"pricesCreated"`
+		DryRun                      bool `json:"dryRun"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if payload.PlanAvailabilityCreated || !payload.PlanAvailabilityWouldCreate || payload.PricesCreated || !payload.DryRun {
+		t.Fatalf("unexpected dry-run payload: %+v", payload)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one read and no mutations, got %d requests", requests)
+	}
+}
+
 func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunUsageErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -241,6 +241,107 @@ func TestWebSubscriptionsAvailabilityRemoveFromSaleRunUsageErrors(t *testing.T) 
 	}
 }
 
+func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunCreatesAvailabilityAndPrices(t *testing.T) {
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		requests := 0
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				switch requests {
+				case 1:
+					return webSubscriptionsJSONResponse(`{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT"},"relationships":{"availableTerritories":{"data":[{"type":"territories","id":"NOR"}]}}}]}`), nil
+				case 2:
+					if req.Method != http.MethodPost || req.URL.Path != "/iris/v1/subscriptionPlanAvailabilities" {
+						t.Fatalf("unexpected availability request: %s %s", req.Method, req.URL.Path)
+					}
+					return webSubscriptionsJSONResponse(`{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY"},"relationships":{"availableTerritories":{"data":[{"type":"territories","id":"NOR"}]}}}}`), nil
+				case 3:
+					if req.Method != http.MethodPatch || req.URL.Path != "/iris/v1/subscriptions/sub-1" {
+						t.Fatalf("unexpected pricing request: %s %s", req.Method, req.URL.Path)
+					}
+					return webSubscriptionsJSONResponse(`{"data":{"type":"subscriptions","id":"sub-1"}}`), nil
+				default:
+					t.Fatalf("unexpected request %d: %s %s", requests, req.Method, req.URL.Path)
+					return nil, nil
+				}
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+			"--subscription-id", "sub-1",
+			"--territory", "NOR",
+			"--upfront-price-point-id", "upfront-point",
+			"--monthly-price-point-id", "monthly-point",
+			"--confirm",
+			"--output", "json",
+		}, "1.0.0")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var payload struct {
+		PlanAvailabilityCreated bool `json:"planAvailabilityCreated"`
+		PricesCreated           bool `json:"pricesCreated"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if !payload.PlanAvailabilityCreated || !payload.PricesCreated {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunUsageErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "missing subscription id",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+			},
+			wantErr: "--subscription-id is required",
+		},
+		{
+			name: "missing confirm",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "NOR",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+			},
+			wantErr: "--confirm is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				code := cmd.Run(test.args, "1.0.0")
+				if code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
 func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, availabilityListCalls *int, patchCalls *int, postPatchRemoved ...bool) (*http.Response, error) {
 	t.Helper()
 

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -522,6 +522,91 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapUsageExitCodes(t *test
 	}
 }
 
+func TestWebSubscriptionsPricingAdjustedEqualizationsViewRun(t *testing.T) {
+	restoreSession := webcmd.SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{
+			Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodGet || req.URL.Path != "/iris/v1/subscriptionPricePoints/monthly-point/adjustedEqualizations" {
+					t.Fatalf("unexpected adjusted equalizations request: %s %s", req.Method, req.URL.String())
+				}
+				if got := req.URL.Query().Get("filter[planType]"); got != "MONTHLY" {
+					t.Fatalf("expected MONTHLY plan type, got %q", got)
+				}
+				return &http.Response{
+					StatusCode: http.StatusConflict,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(
+						`{"errors":[{"code":"STATE_ERROR.EQUALIZATION_FAILED","detail":"No compatible price point","meta":{"associatedErrors":{"prices":[{"code":"STATE_ERROR.NO_TIER_IN_TERRITORY","detail":"DEU"}]}}}]}`,
+					)),
+				}, nil
+			})},
+		}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"web", "subscriptions", "pricing", "adjusted-equalizations", "view",
+			"--price-point-id", "monthly-point",
+			"--plan-type", "MONTHLY",
+			"--output", "json",
+		}, "1.0.0")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var payload struct {
+		PlanType              string   `json:"planType"`
+		Status                int      `json:"status"`
+		Available             bool     `json:"available"`
+		Code                  string   `json:"code"`
+		MissingTerritoryCount int      `json:"missingTerritoryCount"`
+		MissingTerritories    []string `json:"missingTerritories"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if payload.PlanType != "MONTHLY" || payload.Status != http.StatusConflict || payload.Available {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Code != "STATE_ERROR.EQUALIZATION_FAILED" || payload.MissingTerritoryCount != 1 ||
+		len(payload.MissingTerritories) != 1 || payload.MissingTerritories[0] != "DEU" {
+		t.Fatalf("unexpected equalization failure details: %+v", payload)
+	}
+}
+
+func TestWebSubscriptionsPricingAdjustedEqualizationsRejectsUpfrontPlanType(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+	command := exec.Command(
+		binaryPath,
+		"web", "subscriptions", "pricing", "adjusted-equalizations", "view",
+		"--price-point-id", "upfront-point",
+		"--plan-type", "UPFRONT",
+	)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected process exit error, got %v", err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
+	}
+	if stdout.String() != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `--plan-type only supports "MONTHLY"`) {
+		t.Fatalf("expected MONTHLY-only error, got %q", stderr.String())
+	}
+}
+
 func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, availabilityListCalls *int, patchCalls *int, postPatchRemoved ...bool) (*http.Response, error) {
 	t.Helper()
 

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -1,10 +1,13 @@
 package cmdtest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -322,6 +325,43 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunUsageErrors(t *test
 			},
 			wantErr: "--confirm is required",
 		},
+		{
+			name: "preserve requires start date",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "NOR",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+				"--preserve-current-price",
+				"--confirm",
+			},
+			wantErr: "--preserve-current-price requires --start-date",
+		},
+		{
+			name: "rejects United States",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "USA",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+				"--confirm",
+			},
+			wantErr: "--territory cannot be USA or Singapore for monthly-commitment pricing",
+		},
+		{
+			name: "rejects Singapore",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "SGP",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+				"--confirm",
+			},
+			wantErr: "--territory cannot be USA or Singapore for monthly-commitment pricing",
+		},
 	}
 
 	for _, test := range tests {
@@ -337,6 +377,67 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunUsageErrors(t *test
 			}
 			if !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapUsageExitCodes(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "preserve requires start date",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "NOR",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+				"--preserve-current-price",
+				"--confirm",
+			},
+			wantErr: "--preserve-current-price requires --start-date",
+		},
+		{
+			name: "rejects excluded territory",
+			args: []string{
+				"web", "subscriptions", "pricing", "monthly-commitment", "bootstrap",
+				"--subscription-id", "sub-1",
+				"--territory", "USA",
+				"--upfront-price-point-id", "upfront",
+				"--monthly-price-point-id", "monthly",
+				"--confirm",
+			},
+			wantErr: "--territory cannot be USA or Singapore for monthly-commitment pricing",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, test.args...)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected process exit error, got %v", err)
+			}
+			if exitErr.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
+			}
+			if stdout.String() != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr.String())
 			}
 		})
 	}

--- a/internal/cli/web/web_subscriptions.go
+++ b/internal/cli/web/web_subscriptions.go
@@ -51,6 +51,7 @@ Manage subscription workflows that App Store Connect exposes only through web-se
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			WebSubscriptionsAvailabilityCommand(),
+			WebSubscriptionsPricingCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -20,16 +21,28 @@ var (
 	createWebSubscriptionPlanPricesFn = func(ctx context.Context, client *webcore.Client, subscriptionID, upfrontPricePointID, monthlyPricePointID string) (*webcore.SubscriptionPlanPricesResult, error) {
 		return client.CreateSubscriptionPlanPrices(ctx, subscriptionID, upfrontPricePointID, monthlyPricePointID)
 	}
+	setWebSubscriptionPlanPricesFn = func(ctx context.Context, client *webcore.Client, subscriptionID string, prices []webcore.SubscriptionPlanPrice) (*webcore.SubscriptionPlanPricesResult, error) {
+		return client.SetSubscriptionPlanPrices(ctx, subscriptionID, prices)
+	}
+	resolveWebSubscriptionPricePointFn = func(ctx context.Context, client *webcore.Client, subscriptionID, territory, customerPrice string) (*webcore.SubscriptionPricePoint, error) {
+		return client.ResolveSubscriptionPricePoint(ctx, subscriptionID, territory, customerPrice)
+	}
+	getWebSubscriptionAdjustedEqualizationsFn = func(ctx context.Context, client *webcore.Client, pricePointID, planType string) (*webcore.SubscriptionAdjustedEqualizationsResult, error) {
+		return client.GetSubscriptionAdjustedEqualizations(ctx, pricePointID, planType)
+	}
 )
 
 type webSubscriptionMonthlyCommitmentBootstrapResult struct {
-	SubscriptionID      string `json:"subscriptionId"`
-	Territory           string `json:"territory"`
-	PlanAvailabilityID  string `json:"planAvailabilityId"`
-	PlanAvailabilityNew bool   `json:"planAvailabilityCreated"`
-	UpfrontPricePointID string `json:"upfrontPricePointId"`
-	MonthlyPricePointID string `json:"monthlyPricePointId"`
-	PricesCreated       bool   `json:"pricesCreated"`
+	SubscriptionID       string `json:"subscriptionId"`
+	Territory            string `json:"territory"`
+	PlanAvailabilityID   string `json:"planAvailabilityId"`
+	PlanAvailabilityNew  bool   `json:"planAvailabilityCreated"`
+	UpfrontPricePointID  string `json:"upfrontPricePointId"`
+	MonthlyPricePointID  string `json:"monthlyPricePointId"`
+	PricesCreated        bool   `json:"pricesCreated"`
+	DryRun               bool   `json:"dryRun"`
+	StartDate            string `json:"startDate,omitempty"`
+	PreserveCurrentPrice bool   `json:"preserveCurrentPrice,omitempty"`
 }
 
 // WebSubscriptionsPricingCommand returns the web subscription pricing command group.
@@ -48,6 +61,7 @@ Manage subscription pricing through Apple's internal web API.
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			WebSubscriptionsPricingAdjustedEqualizationsCommand(),
 			WebSubscriptionsPricingMonthlyCommitmentCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -88,20 +102,27 @@ func WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand() *ffcli.Command {
 	territory := fs.String("territory", "", "Three-letter territory ID, for example NOR")
 	upfrontPricePointID := fs.String("upfront-price-point-id", "", "UPFRONT subscription price point ID")
 	monthlyPricePointID := fs.String("monthly-price-point-id", "", "MONTHLY subscription price point ID")
+	upfrontPrice := fs.String("upfront-price", "", "UPFRONT customer price to resolve in --territory")
+	monthlyPrice := fs.String("monthly-price", "", "MONTHLY customer price to resolve in --territory")
+	startDate := fs.String("start-date", "", "Schedule both prices on YYYY-MM-DD")
+	preserveCurrentPrice := fs.Bool("preserve-current-price", false, "Preserve current pricing for existing subscribers")
+	dryRun := fs.Bool("dry-run", false, "Resolve and print the plan without creating or changing resources")
 	confirm := fs.Bool("confirm", false, "Confirm creating monthly availability and paired prices")
 	authFlags := bindWebSessionFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "bootstrap",
-		ShortUsage: "asc web subscriptions pricing monthly-commitment bootstrap --subscription-id SUB_ID --territory NOR --upfront-price-point-id ID --monthly-price-point-id ID --confirm [flags]",
+		ShortUsage: "asc web subscriptions pricing monthly-commitment bootstrap --subscription-id SUB_ID --territory NOR (--upfront-price PRICE | --upfront-price-point-id ID) (--monthly-price PRICE | --monthly-price-point-id ID) [--dry-run | --confirm] [flags]",
 		ShortHelp:  "[experimental] Create monthly plan availability and paired prices.",
 		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
 
 Create MONTHLY plan availability, then attach paired UPFRONT and MONTHLY prices
 using the same private inline subscription PATCH as App Store Connect.
 
-Run once per base territory. Price point IDs must belong to the selected territory.
+Prices may be supplied as exact customer prices or price point IDs. Use
+--start-date for a scheduled paired price change. --dry-run performs all reads
+and price resolution but does not mutate App Store Connect.
 
 ` + webWarningText,
 		FlagSet:   fs,
@@ -114,17 +135,25 @@ Run once per base territory. Price point IDs must belong to the selected territo
 			territoryID := strings.ToUpper(strings.TrimSpace(*territory))
 			upfrontID := strings.TrimSpace(*upfrontPricePointID)
 			monthlyID := strings.TrimSpace(*monthlyPricePointID)
+			upfrontAmount := strings.TrimSpace(*upfrontPrice)
+			monthlyAmount := strings.TrimSpace(*monthlyPrice)
+			scheduledDate := strings.TrimSpace(*startDate)
 			switch {
 			case id == "":
 				return shared.UsageError("--subscription-id is required")
 			case len(territoryID) != 3:
 				return shared.UsageError("--territory must be a three-letter territory ID")
-			case upfrontID == "":
-				return shared.UsageError("--upfront-price-point-id is required")
-			case monthlyID == "":
-				return shared.UsageError("--monthly-price-point-id is required")
-			case !*confirm:
+			case (upfrontID == "") == (upfrontAmount == ""):
+				return shared.UsageError("exactly one of --upfront-price or --upfront-price-point-id is required")
+			case (monthlyID == "") == (monthlyAmount == ""):
+				return shared.UsageError("exactly one of --monthly-price or --monthly-price-point-id is required")
+			case !*dryRun && !*confirm:
 				return shared.UsageError("--confirm is required")
+			}
+			if scheduledDate != "" {
+				if _, err := time.Parse("2006-01-02", scheduledDate); err != nil {
+					return shared.UsageError("--start-date must use YYYY-MM-DD")
+				}
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -134,6 +163,20 @@ Run once per base territory. Price point IDs must belong to the selected territo
 				return err
 			}
 			client := newWebClientFn(session)
+			if upfrontAmount != "" {
+				point, err := resolveWebSubscriptionPricePointFn(requestCtx, client, id, territoryID, upfrontAmount)
+				if err != nil {
+					return fmt.Errorf("resolve upfront price: %w", err)
+				}
+				upfrontID = point.ID
+			}
+			if monthlyAmount != "" {
+				point, err := resolveWebSubscriptionPricePointFn(requestCtx, client, id, territoryID, monthlyAmount)
+				if err != nil {
+					return fmt.Errorf("resolve monthly price: %w", err)
+				}
+				monthlyID = point.ID
+			}
 
 			availabilities, err := listWebSubscriptionPlanAvailabilitiesFn(requestCtx, client, id)
 			if err != nil {
@@ -141,6 +184,17 @@ Run once per base territory. Price point IDs must belong to the selected territo
 			}
 			monthlyAvailability, found := findPlanAvailabilityByType(availabilities, "MONTHLY")
 			created := false
+			if *dryRun {
+				result := webSubscriptionMonthlyCommitmentBootstrapResult{
+					SubscriptionID: id, Territory: territoryID,
+					PlanAvailabilityID:  monthlyAvailability.ID,
+					PlanAvailabilityNew: !found,
+					UpfrontPricePointID: upfrontID, MonthlyPricePointID: monthlyID,
+					DryRun: true, StartDate: scheduledDate,
+					PreserveCurrentPrice: *preserveCurrentPrice,
+				}
+				return shared.PrintOutput(result, *output.Output, *output.Pretty)
+			}
 			if !found {
 				monthlyAvailability, err = dereferencePlanAvailability(createWebSubscriptionPlanAvailabilityFn(requestCtx, client, id, "MONTHLY", []string{territoryID}, false))
 				if err != nil {
@@ -151,18 +205,28 @@ Run once per base territory. Price point IDs must belong to the selected territo
 				return fmt.Errorf("MONTHLY plan availability %q exists but does not include %s; update its territories before bootstrapping prices", monthlyAvailability.ID, territoryID)
 			}
 
-			prices, err := createWebSubscriptionPlanPricesFn(requestCtx, client, id, upfrontID, monthlyID)
+			var prices *webcore.SubscriptionPlanPricesResult
+			if scheduledDate == "" {
+				prices, err = createWebSubscriptionPlanPricesFn(requestCtx, client, id, upfrontID, monthlyID)
+			} else {
+				prices, err = setWebSubscriptionPlanPricesFn(requestCtx, client, id, []webcore.SubscriptionPlanPrice{
+					{PlanType: "UPFRONT", PricePointID: upfrontID, StartDate: scheduledDate, PreserveCurrentPrice: *preserveCurrentPrice},
+					{PlanType: "MONTHLY", PricePointID: monthlyID, StartDate: scheduledDate, PreserveCurrentPrice: *preserveCurrentPrice},
+				})
+			}
 			if err != nil {
 				return fmt.Errorf("monthly availability ready, but paired price creation failed: %w", err)
 			}
 			result := webSubscriptionMonthlyCommitmentBootstrapResult{
-				SubscriptionID:      id,
-				Territory:           territoryID,
-				PlanAvailabilityID:  monthlyAvailability.ID,
-				PlanAvailabilityNew: created,
-				UpfrontPricePointID: prices.UpfrontPricePointID,
-				MonthlyPricePointID: prices.MonthlyPricePointID,
-				PricesCreated:       true,
+				SubscriptionID:       id,
+				Territory:            territoryID,
+				PlanAvailabilityID:   monthlyAvailability.ID,
+				PlanAvailabilityNew:  created,
+				UpfrontPricePointID:  prices.UpfrontPricePointID,
+				MonthlyPricePointID:  prices.MonthlyPricePointID,
+				PricesCreated:        true,
+				StartDate:            scheduledDate,
+				PreserveCurrentPrice: *preserveCurrentPrice,
 			}
 			return shared.PrintOutputWithRenderers(
 				result,
@@ -171,6 +235,57 @@ Run once per base territory. Price point IDs must belong to the selected territo
 				func() error { return renderWebMonthlyCommitmentBootstrapTable(result) },
 				func() error { return renderWebMonthlyCommitmentBootstrapMarkdown(result) },
 			)
+		},
+	}
+}
+
+// WebSubscriptionsPricingAdjustedEqualizationsCommand returns the adjusted equalizations group.
+func WebSubscriptionsPricingAdjustedEqualizationsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions pricing adjusted-equalizations", flag.ExitOnError)
+	return &ffcli.Command{
+		Name: "adjusted-equalizations", ShortUsage: "asc web subscriptions pricing adjusted-equalizations view [flags]",
+		ShortHelp: "[experimental] Inspect Apple's adjusted subscription price matrix.",
+		FlagSet:   fs, UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{WebSubscriptionsPricingAdjustedEqualizationsViewCommand()},
+		Exec:        func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+// WebSubscriptionsPricingAdjustedEqualizationsViewCommand inspects one price point.
+func WebSubscriptionsPricingAdjustedEqualizationsViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions pricing adjusted-equalizations view", flag.ExitOnError)
+	pricePointID := fs.String("price-point-id", "", "Subscription price point ID")
+	planType := fs.String("plan-type", "MONTHLY", "Plan type: MONTHLY or UPFRONT")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "view",
+		ShortUsage: "asc web subscriptions pricing adjusted-equalizations view --price-point-id PRICE_POINT_ID [--plan-type MONTHLY|UPFRONT] [flags]",
+		ShortHelp:  "[experimental] View a generated adjusted subscription price matrix.",
+		FlagSet:    fs, UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web subscriptions pricing adjusted-equalizations view does not accept positional arguments")
+			}
+			id := strings.TrimSpace(*pricePointID)
+			normalizedPlanType := strings.ToUpper(strings.TrimSpace(*planType))
+			if id == "" {
+				return shared.UsageError("--price-point-id is required")
+			}
+			if normalizedPlanType != "MONTHLY" && normalizedPlanType != "UPFRONT" {
+				return shared.UsageError(`--plan-type must be "MONTHLY" or "UPFRONT"`)
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			result, err := getWebSubscriptionAdjustedEqualizationsFn(requestCtx, newWebClientFn(session), id, normalizedPlanType)
+			if err != nil {
+				return withWebAuthHint(err, "web subscriptions pricing adjusted-equalizations view")
+			}
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
 		},
 	}
 }

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -33,16 +33,17 @@ var (
 )
 
 type webSubscriptionMonthlyCommitmentBootstrapResult struct {
-	SubscriptionID       string `json:"subscriptionId"`
-	Territory            string `json:"territory"`
-	PlanAvailabilityID   string `json:"planAvailabilityId"`
-	PlanAvailabilityNew  bool   `json:"planAvailabilityCreated"`
-	UpfrontPricePointID  string `json:"upfrontPricePointId"`
-	MonthlyPricePointID  string `json:"monthlyPricePointId"`
-	PricesCreated        bool   `json:"pricesCreated"`
-	DryRun               bool   `json:"dryRun"`
-	StartDate            string `json:"startDate,omitempty"`
-	PreserveCurrentPrice bool   `json:"preserveCurrentPrice,omitempty"`
+	SubscriptionID              string `json:"subscriptionId"`
+	Territory                   string `json:"territory"`
+	PlanAvailabilityID          string `json:"planAvailabilityId"`
+	PlanAvailabilityNew         bool   `json:"planAvailabilityCreated"`
+	PlanAvailabilityWouldCreate bool   `json:"planAvailabilityWouldCreate,omitempty"`
+	UpfrontPricePointID         string `json:"upfrontPricePointId"`
+	MonthlyPricePointID         string `json:"monthlyPricePointId"`
+	PricesCreated               bool   `json:"pricesCreated"`
+	DryRun                      bool   `json:"dryRun"`
+	StartDate                   string `json:"startDate,omitempty"`
+	PreserveCurrentPrice        bool   `json:"preserveCurrentPrice,omitempty"`
 }
 
 // WebSubscriptionsPricingCommand returns the web subscription pricing command group.
@@ -199,9 +200,9 @@ resolution but does not mutate App Store Connect.
 			if *dryRun {
 				result := webSubscriptionMonthlyCommitmentBootstrapResult{
 					SubscriptionID: id, Territory: territoryID,
-					PlanAvailabilityID:  monthlyAvailability.ID,
-					PlanAvailabilityNew: !found,
-					UpfrontPricePointID: upfrontID, MonthlyPricePointID: monthlyID,
+					PlanAvailabilityID:          monthlyAvailability.ID,
+					PlanAvailabilityWouldCreate: !found,
+					UpfrontPricePointID:         upfrontID, MonthlyPricePointID: monthlyID,
 					DryRun: true, StartDate: scheduledDate,
 					PreserveCurrentPrice: *preserveCurrentPrice,
 				}

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -266,13 +266,13 @@ func WebSubscriptionsPricingAdjustedEqualizationsCommand() *ffcli.Command {
 func WebSubscriptionsPricingAdjustedEqualizationsViewCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web subscriptions pricing adjusted-equalizations view", flag.ExitOnError)
 	pricePointID := fs.String("price-point-id", "", "Subscription price point ID")
-	planType := fs.String("plan-type", "MONTHLY", "Plan type: MONTHLY or UPFRONT")
+	planType := fs.String("plan-type", "MONTHLY", "Plan type (MONTHLY only)")
 	authFlags := bindWebSessionFlags(fs)
 	output := shared.BindOutputFlags(fs)
 	return &ffcli.Command{
 		Name:       "view",
-		ShortUsage: "asc web subscriptions pricing adjusted-equalizations view --price-point-id PRICE_POINT_ID [--plan-type MONTHLY|UPFRONT] [flags]",
-		ShortHelp:  "[experimental] View a generated adjusted subscription price matrix.",
+		ShortUsage: "asc web subscriptions pricing adjusted-equalizations view --price-point-id PRICE_POINT_ID [--plan-type MONTHLY] [flags]",
+		ShortHelp:  "[experimental] View a generated MONTHLY subscription price matrix.",
 		FlagSet:    fs, UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
@@ -283,8 +283,8 @@ func WebSubscriptionsPricingAdjustedEqualizationsViewCommand() *ffcli.Command {
 			if id == "" {
 				return shared.UsageError("--price-point-id is required")
 			}
-			if normalizedPlanType != "MONTHLY" && normalizedPlanType != "UPFRONT" {
-				return shared.UsageError(`--plan-type must be "MONTHLY" or "UPFRONT"`)
+			if normalizedPlanType != "MONTHLY" {
+				return shared.UsageError(`--plan-type only supports "MONTHLY"; Apple's private endpoint rejects UPFRONT`)
 			}
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -105,7 +105,7 @@ func WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand() *ffcli.Command {
 	upfrontPrice := fs.String("upfront-price", "", "UPFRONT customer price to resolve in --territory")
 	monthlyPrice := fs.String("monthly-price", "", "MONTHLY customer price to resolve in --territory")
 	startDate := fs.String("start-date", "", "Schedule both prices on YYYY-MM-DD")
-	preserveCurrentPrice := fs.Bool("preserve-current-price", false, "Preserve current pricing for existing subscribers")
+	preserveCurrentPrice := fs.Bool("preserve-current-price", false, "Preserve current pricing for existing subscribers; requires --start-date")
 	dryRun := fs.Bool("dry-run", false, "Resolve and print the plan without creating or changing resources")
 	confirm := fs.Bool("confirm", false, "Confirm creating monthly availability and paired prices")
 	authFlags := bindWebSessionFlags(fs)
@@ -120,9 +120,14 @@ func WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand() *ffcli.Command {
 Create MONTHLY plan availability, then attach paired UPFRONT and MONTHLY prices
 using the same private inline subscription PATCH as App Store Connect.
 
+Prefer asc subscriptions pricing monthly-commitment enable for normal setup.
+Use this private command only when you specifically need App Store Connect's
+paired web pricing workflow or a paired scheduled price change.
+
 Prices may be supplied as exact customer prices or price point IDs. Use
---start-date for a scheduled paired price change. --dry-run performs all reads
-and price resolution but does not mutate App Store Connect.
+--start-date for a scheduled paired price change. --preserve-current-price
+applies only to scheduled changes. --dry-run performs all reads and price
+resolution but does not mutate App Store Connect.
 
 ` + webWarningText,
 		FlagSet:   fs,
@@ -143,10 +148,14 @@ and price resolution but does not mutate App Store Connect.
 				return shared.UsageError("--subscription-id is required")
 			case len(territoryID) != 3:
 				return shared.UsageError("--territory must be a three-letter territory ID")
+			case territoryID == "USA" || territoryID == "SGP":
+				return shared.UsageError("--territory cannot be USA or Singapore for monthly-commitment pricing")
 			case (upfrontID == "") == (upfrontAmount == ""):
 				return shared.UsageError("exactly one of --upfront-price or --upfront-price-point-id is required")
 			case (monthlyID == "") == (monthlyAmount == ""):
 				return shared.UsageError("exactly one of --monthly-price or --monthly-price-point-id is required")
+			case *preserveCurrentPrice && scheduledDate == "":
+				return shared.UsageError("--preserve-current-price requires --start-date")
 			case !*dryRun && !*confirm:
 				return shared.UsageError("--confirm is required")
 			}
@@ -310,7 +319,9 @@ func containsTerritory(territories []string, territory string) bool {
 }
 
 func availabilityExcludesTerritory(availability webcore.SubscriptionPlanAvailability, territory string) bool {
-	return availability.AvailableTerritoriesLoaded && !containsTerritory(availability.AvailableTerritories, territory)
+	return availability.AvailableTerritoriesLoaded &&
+		len(availability.AvailableTerritories) < webcore.SubscriptionPlanAvailabilityTerritoryLimit &&
+		!containsTerritory(availability.AvailableTerritories, territory)
 }
 
 func dereferencePlanAvailability(availability *webcore.SubscriptionPlanAvailability, err error) (webcore.SubscriptionPlanAvailability, error) {

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -201,7 +201,7 @@ and price resolution but does not mutate App Store Connect.
 					return withWebAuthHint(err, "web subscriptions pricing monthly-commitment bootstrap")
 				}
 				created = true
-			} else if !containsTerritory(monthlyAvailability.AvailableTerritories, territoryID) {
+			} else if availabilityExcludesTerritory(monthlyAvailability, territoryID) {
 				return fmt.Errorf("MONTHLY plan availability %q exists but does not include %s; update its territories before bootstrapping prices", monthlyAvailability.ID, territoryID)
 			}
 
@@ -306,6 +306,10 @@ func containsTerritory(territories []string, territory string) bool {
 		}
 	}
 	return false
+}
+
+func availabilityExcludesTerritory(availability webcore.SubscriptionPlanAvailability, territory string) bool {
+	return availability.AvailableTerritoriesLoaded && !containsTerritory(availability.AvailableTerritories, territory)
 }
 
 func dereferencePlanAvailability(availability *webcore.SubscriptionPlanAvailability, err error) (webcore.SubscriptionPlanAvailability, error) {

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -1,0 +1,225 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+var (
+	createWebSubscriptionPlanAvailabilityFn = func(ctx context.Context, client *webcore.Client, subscriptionID, planType string, territoryIDs []string, availableInNewTerritories bool) (*webcore.SubscriptionPlanAvailability, error) {
+		return client.CreateSubscriptionPlanAvailability(ctx, subscriptionID, planType, territoryIDs, availableInNewTerritories)
+	}
+	createWebSubscriptionPlanPricesFn = func(ctx context.Context, client *webcore.Client, subscriptionID, upfrontPricePointID, monthlyPricePointID string) (*webcore.SubscriptionPlanPricesResult, error) {
+		return client.CreateSubscriptionPlanPrices(ctx, subscriptionID, upfrontPricePointID, monthlyPricePointID)
+	}
+)
+
+type webSubscriptionMonthlyCommitmentBootstrapResult struct {
+	SubscriptionID      string `json:"subscriptionId"`
+	Territory           string `json:"territory"`
+	PlanAvailabilityID  string `json:"planAvailabilityId"`
+	PlanAvailabilityNew bool   `json:"planAvailabilityCreated"`
+	UpfrontPricePointID string `json:"upfrontPricePointId"`
+	MonthlyPricePointID string `json:"monthlyPricePointId"`
+	PricesCreated       bool   `json:"pricesCreated"`
+}
+
+// WebSubscriptionsPricingCommand returns the web subscription pricing command group.
+func WebSubscriptionsPricingCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions pricing", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "pricing",
+		ShortUsage: "asc web subscriptions pricing <subcommand> [flags]",
+		ShortHelp:  "[experimental] Manage subscription pricing via web sessions.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Manage subscription pricing through Apple's internal web API.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebSubscriptionsPricingMonthlyCommitmentCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebSubscriptionsPricingMonthlyCommitmentCommand returns the monthly commitment group.
+func WebSubscriptionsPricingMonthlyCommitmentCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions pricing monthly-commitment", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "monthly-commitment",
+		ShortUsage: "asc web subscriptions pricing monthly-commitment <subcommand> [flags]",
+		ShortHelp:  "[experimental] Bootstrap monthly-with-commitment pricing.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Bootstrap monthly-with-12-month-commitment pricing through Apple's internal web API.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand creates availability and prices.
+func WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web subscriptions pricing monthly-commitment bootstrap", flag.ExitOnError)
+
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID")
+	territory := fs.String("territory", "", "Three-letter territory ID, for example NOR")
+	upfrontPricePointID := fs.String("upfront-price-point-id", "", "UPFRONT subscription price point ID")
+	monthlyPricePointID := fs.String("monthly-price-point-id", "", "MONTHLY subscription price point ID")
+	confirm := fs.Bool("confirm", false, "Confirm creating monthly availability and paired prices")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "bootstrap",
+		ShortUsage: "asc web subscriptions pricing monthly-commitment bootstrap --subscription-id SUB_ID --territory NOR --upfront-price-point-id ID --monthly-price-point-id ID --confirm [flags]",
+		ShortHelp:  "[experimental] Create monthly plan availability and paired prices.",
+		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+
+Create MONTHLY plan availability, then attach paired UPFRONT and MONTHLY prices
+using the same private inline subscription PATCH as App Store Connect.
+
+Run once per base territory. Price point IDs must belong to the selected territory.
+
+` + webWarningText,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web subscriptions pricing monthly-commitment bootstrap does not accept positional arguments")
+			}
+			id := strings.TrimSpace(*subscriptionID)
+			territoryID := strings.ToUpper(strings.TrimSpace(*territory))
+			upfrontID := strings.TrimSpace(*upfrontPricePointID)
+			monthlyID := strings.TrimSpace(*monthlyPricePointID)
+			switch {
+			case id == "":
+				return shared.UsageError("--subscription-id is required")
+			case len(territoryID) != 3:
+				return shared.UsageError("--territory must be a three-letter territory ID")
+			case upfrontID == "":
+				return shared.UsageError("--upfront-price-point-id is required")
+			case monthlyID == "":
+				return shared.UsageError("--monthly-price-point-id is required")
+			case !*confirm:
+				return shared.UsageError("--confirm is required")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			availabilities, err := listWebSubscriptionPlanAvailabilitiesFn(requestCtx, client, id)
+			if err != nil {
+				return withWebAuthHint(err, "web subscriptions pricing monthly-commitment bootstrap")
+			}
+			monthlyAvailability, found := findPlanAvailabilityByType(availabilities, "MONTHLY")
+			created := false
+			if !found {
+				monthlyAvailability, err = dereferencePlanAvailability(createWebSubscriptionPlanAvailabilityFn(requestCtx, client, id, "MONTHLY", []string{territoryID}, false))
+				if err != nil {
+					return withWebAuthHint(err, "web subscriptions pricing monthly-commitment bootstrap")
+				}
+				created = true
+			} else if !containsTerritory(monthlyAvailability.AvailableTerritories, territoryID) {
+				return fmt.Errorf("MONTHLY plan availability %q exists but does not include %s; update its territories before bootstrapping prices", monthlyAvailability.ID, territoryID)
+			}
+
+			prices, err := createWebSubscriptionPlanPricesFn(requestCtx, client, id, upfrontID, monthlyID)
+			if err != nil {
+				return fmt.Errorf("monthly availability ready, but paired price creation failed: %w", err)
+			}
+			result := webSubscriptionMonthlyCommitmentBootstrapResult{
+				SubscriptionID:      id,
+				Territory:           territoryID,
+				PlanAvailabilityID:  monthlyAvailability.ID,
+				PlanAvailabilityNew: created,
+				UpfrontPricePointID: prices.UpfrontPricePointID,
+				MonthlyPricePointID: prices.MonthlyPricePointID,
+				PricesCreated:       true,
+			}
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderWebMonthlyCommitmentBootstrapTable(result) },
+				func() error { return renderWebMonthlyCommitmentBootstrapMarkdown(result) },
+			)
+		},
+	}
+}
+
+func findPlanAvailabilityByType(availabilities []webcore.SubscriptionPlanAvailability, planType string) (webcore.SubscriptionPlanAvailability, bool) {
+	for _, availability := range availabilities {
+		if strings.EqualFold(strings.TrimSpace(availability.PlanType), planType) {
+			return availability, true
+		}
+	}
+	return webcore.SubscriptionPlanAvailability{}, false
+}
+
+func containsTerritory(territories []string, territory string) bool {
+	for _, candidate := range territories {
+		if strings.EqualFold(strings.TrimSpace(candidate), territory) {
+			return true
+		}
+	}
+	return false
+}
+
+func dereferencePlanAvailability(availability *webcore.SubscriptionPlanAvailability, err error) (webcore.SubscriptionPlanAvailability, error) {
+	if err != nil {
+		return webcore.SubscriptionPlanAvailability{}, err
+	}
+	if availability == nil || strings.TrimSpace(availability.ID) == "" {
+		return webcore.SubscriptionPlanAvailability{}, fmt.Errorf("apple returned an empty plan availability")
+	}
+	return *availability, nil
+}
+
+func renderWebMonthlyCommitmentBootstrapTable(result webSubscriptionMonthlyCommitmentBootstrapResult) error {
+	asc.RenderTable(
+		[]string{"Subscription ID", "Territory", "Plan Availability ID", "Availability Created", "Prices Created"},
+		[][]string{{
+			result.SubscriptionID,
+			result.Territory,
+			result.PlanAvailabilityID,
+			fmt.Sprintf("%t", result.PlanAvailabilityNew),
+			fmt.Sprintf("%t", result.PricesCreated),
+		}},
+	)
+	return nil
+}
+
+func renderWebMonthlyCommitmentBootstrapMarkdown(result webSubscriptionMonthlyCommitmentBootstrapResult) error {
+	fmt.Println("| Subscription ID | Territory | Plan Availability ID | Availability Created | Prices Created |")
+	fmt.Println("|---|---|---|---|---|")
+	fmt.Printf("| %s | %s | %s | %t | %t |\n", result.SubscriptionID, result.Territory, result.PlanAvailabilityID, result.PlanAvailabilityNew, result.PricesCreated)
+	return nil
+}

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -184,6 +184,9 @@ and price resolution but does not mutate App Store Connect.
 			}
 			monthlyAvailability, found := findPlanAvailabilityByType(availabilities, "MONTHLY")
 			created := false
+			if found && availabilityExcludesTerritory(monthlyAvailability, territoryID) {
+				return fmt.Errorf("MONTHLY plan availability %q exists but does not include %s; update its territories before bootstrapping prices", monthlyAvailability.ID, territoryID)
+			}
 			if *dryRun {
 				result := webSubscriptionMonthlyCommitmentBootstrapResult{
 					SubscriptionID: id, Territory: territoryID,
@@ -201,8 +204,6 @@ and price resolution but does not mutate App Store Connect.
 					return withWebAuthHint(err, "web subscriptions pricing monthly-commitment bootstrap")
 				}
 				created = true
-			} else if availabilityExcludesTerritory(monthlyAvailability, territoryID) {
-				return fmt.Errorf("MONTHLY plan availability %q exists but does not include %s; update its territories before bootstrapping prices", monthlyAvailability.ID, territoryID)
 			}
 
 			var prices *webcore.SubscriptionPlanPricesResult

--- a/internal/cli/web/web_subscriptions_pricing_test.go
+++ b/internal/cli/web/web_subscriptions_pricing_test.go
@@ -1,0 +1,25 @@
+package web
+
+import (
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestExistingMonthlyAvailabilityOnlyRejectsConfirmedMissingTerritory(t *testing.T) {
+	unloaded := webcore.SubscriptionPlanAvailability{
+		ID:                         "plan-monthly",
+		PlanType:                   "MONTHLY",
+		AvailableTerritoriesLoaded: false,
+	}
+	if availabilityExcludesTerritory(unloaded, "NOR") {
+		t.Fatal("unloaded relationship must not be treated as confirmed missing")
+	}
+
+	loaded := unloaded
+	loaded.AvailableTerritoriesLoaded = true
+	loaded.AvailableTerritories = []string{"DEU"}
+	if !availabilityExcludesTerritory(loaded, "NOR") {
+		t.Fatal("loaded relationship should confirm the territory is missing")
+	}
+}

--- a/internal/cli/web/web_subscriptions_pricing_test.go
+++ b/internal/cli/web/web_subscriptions_pricing_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"testing"
 
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
@@ -14,6 +15,16 @@ func TestExistingMonthlyAvailabilityOnlyRejectsConfirmedMissingTerritory(t *test
 	}
 	if availabilityExcludesTerritory(unloaded, "NOR") {
 		t.Fatal("unloaded relationship must not be treated as confirmed missing")
+	}
+
+	capped := unloaded
+	capped.AvailableTerritoriesLoaded = true
+	capped.AvailableTerritories = make([]string, 200)
+	for i := range capped.AvailableTerritories {
+		capped.AvailableTerritories[i] = fmt.Sprintf("T%03d", i)
+	}
+	if availabilityExcludesTerritory(capped, "NOR") {
+		t.Fatal("territory relationship at the response cap must not be treated as complete")
 	}
 
 	loaded := unloaded

--- a/internal/web/subscription_adjusted_equalizations.go
+++ b/internal/web/subscription_adjusted_equalizations.go
@@ -1,0 +1,137 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+const subscriptionEqualizationFailedCode = "STATE_ERROR.EQUALIZATION_FAILED"
+
+// SubscriptionAdjustedEqualization is one territory-specific price point.
+type SubscriptionAdjustedEqualization struct {
+	ID            string `json:"id"`
+	Territory     string `json:"territory,omitempty"`
+	CustomerPrice string `json:"customerPrice,omitempty"`
+	Currency      string `json:"currency,omitempty"`
+}
+
+// SubscriptionAdjustedEqualizationsResult is a sanitized adjusted-equalizations response.
+type SubscriptionAdjustedEqualizationsResult struct {
+	PricePointID          string                             `json:"pricePointId"`
+	PlanType              string                             `json:"planType"`
+	Status                int                                `json:"status"`
+	Available             bool                               `json:"available"`
+	Code                  string                             `json:"code,omitempty"`
+	Detail                string                             `json:"detail,omitempty"`
+	MissingTerritoryCount int                                `json:"missingTerritoryCount,omitempty"`
+	MissingTerritories    []string                           `json:"missingTerritories,omitempty"`
+	Equalizations         []SubscriptionAdjustedEqualization `json:"equalizations,omitempty"`
+}
+
+type adjustedEqualizationErrorPayload struct {
+	Errors []struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+		Meta   struct {
+			AssociatedErrors map[string][]struct {
+				Code   string `json:"code"`
+				Detail string `json:"detail"`
+			} `json:"associatedErrors"`
+		} `json:"meta"`
+	} `json:"errors"`
+}
+
+// GetSubscriptionAdjustedEqualizations retrieves Apple's private adjusted price matrix.
+func (c *Client) GetSubscriptionAdjustedEqualizations(ctx context.Context, pricePointID, planType string) (*SubscriptionAdjustedEqualizationsResult, error) {
+	pricePointID = strings.TrimSpace(pricePointID)
+	if pricePointID == "" {
+		return nil, fmt.Errorf("subscription price point id is required")
+	}
+	planType = strings.ToUpper(strings.TrimSpace(planType))
+	if planType != "MONTHLY" && planType != "UPFRONT" {
+		return nil, fmt.Errorf(`plan type must be "MONTHLY" or "UPFRONT"`)
+	}
+
+	query := url.Values{}
+	query.Set("include", "territory")
+	query.Set("limit", "200")
+	query.Set("filter[planType]", planType)
+	path := queryPath("/subscriptionPricePoints/"+url.PathEscape(pricePointID)+"/adjustedEqualizations", query)
+	responseBody, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.Status != http.StatusConflict {
+			return nil, err
+		}
+		return decodeAdjustedEqualizationConflict(pricePointID, planType, apiErr)
+	}
+
+	var payload jsonAPIListPayload
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription adjusted equalizations response: %w", err)
+	}
+	result := &SubscriptionAdjustedEqualizationsResult{
+		PricePointID: pricePointID,
+		PlanType:     planType,
+		Status:       http.StatusOK,
+		Available:    true,
+	}
+	for _, resource := range payload.Data {
+		territory := ""
+		if refs := parseRelationshipRefs(resource.Relationships["territory"].Data); len(refs) > 0 {
+			territory = strings.ToUpper(strings.TrimSpace(refs[0].ID))
+		}
+		result.Equalizations = append(result.Equalizations, SubscriptionAdjustedEqualization{
+			ID:            strings.TrimSpace(resource.ID),
+			Territory:     territory,
+			CustomerPrice: stringAttr(resource.Attributes, "customerPrice"),
+			Currency:      stringAttr(resource.Attributes, "currency"),
+		})
+	}
+	return result, nil
+}
+
+func decodeAdjustedEqualizationConflict(pricePointID, planType string, apiErr *APIError) (*SubscriptionAdjustedEqualizationsResult, error) {
+	var payload adjustedEqualizationErrorPayload
+	if err := json.Unmarshal(apiErr.rawResponseBody(), &payload); err != nil || len(payload.Errors) == 0 {
+		return nil, apiErr
+	}
+	primary := payload.Errors[0]
+	if strings.TrimSpace(primary.Code) != subscriptionEqualizationFailedCode {
+		return nil, apiErr
+	}
+	missingCount := 0
+	territorySet := map[string]struct{}{}
+	for _, associatedErrors := range primary.Meta.AssociatedErrors {
+		for _, associated := range associatedErrors {
+			if !strings.EqualFold(strings.TrimSpace(associated.Code), "STATE_ERROR.NO_TIER_IN_TERRITORY") {
+				continue
+			}
+			missingCount++
+			if territory := strings.ToUpper(strings.TrimSpace(associated.Detail)); territory != "" {
+				territorySet[territory] = struct{}{}
+			}
+		}
+	}
+	territories := make([]string, 0, len(territorySet))
+	for territory := range territorySet {
+		territories = append(territories, territory)
+	}
+	sort.Strings(territories)
+	return &SubscriptionAdjustedEqualizationsResult{
+		PricePointID:          pricePointID,
+		PlanType:              planType,
+		Status:                apiErr.Status,
+		Available:             false,
+		Code:                  strings.TrimSpace(primary.Code),
+		Detail:                strings.TrimSpace(primary.Detail),
+		MissingTerritoryCount: missingCount,
+		MissingTerritories:    territories,
+	}, nil
+}

--- a/internal/web/subscription_adjusted_equalizations.go
+++ b/internal/web/subscription_adjusted_equalizations.go
@@ -54,8 +54,8 @@ func (c *Client) GetSubscriptionAdjustedEqualizations(ctx context.Context, price
 		return nil, fmt.Errorf("subscription price point id is required")
 	}
 	planType = strings.ToUpper(strings.TrimSpace(planType))
-	if planType != "MONTHLY" && planType != "UPFRONT" {
-		return nil, fmt.Errorf(`plan type must be "MONTHLY" or "UPFRONT"`)
+	if planType != "MONTHLY" {
+		return nil, fmt.Errorf(`plan type must be "MONTHLY"`)
 	}
 
 	query := url.Values{}

--- a/internal/web/subscription_adjusted_equalizations_test.go
+++ b/internal/web/subscription_adjusted_equalizations_test.go
@@ -1,0 +1,29 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetSubscriptionAdjustedEqualizationsSanitizesKnownConflict(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"errors":[{"code":"STATE_ERROR.EQUALIZATION_FAILED","detail":"No compatible price point","meta":{"associatedErrors":{"prices":[{"code":"STATE_ERROR.NO_TIER_IN_TERRITORY","detail":"DEU"},{"code":"STATE_ERROR.NO_TIER_IN_TERRITORY","detail":"FRA"}]}}}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	result, err := client.GetSubscriptionAdjustedEqualizations(context.Background(), "point-1", "monthly")
+	if err != nil {
+		t.Fatalf("GetSubscriptionAdjustedEqualizations() error = %v", err)
+	}
+	if result.Available || result.Status != http.StatusConflict || result.MissingTerritoryCount != 2 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(result.MissingTerritories) != 2 || result.MissingTerritories[0] != "DEU" || result.MissingTerritories[1] != "FRA" {
+		t.Fatalf("unexpected territories: %#v", result.MissingTerritories)
+	}
+}

--- a/internal/web/subscription_adjusted_equalizations_test.go
+++ b/internal/web/subscription_adjusted_equalizations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -25,5 +26,13 @@ func TestGetSubscriptionAdjustedEqualizationsSanitizesKnownConflict(t *testing.T
 	}
 	if len(result.MissingTerritories) != 2 || result.MissingTerritories[0] != "DEU" || result.MissingTerritories[1] != "FRA" {
 		t.Fatalf("unexpected territories: %#v", result.MissingTerritories)
+	}
+}
+
+func TestGetSubscriptionAdjustedEqualizationsRejectsUpfrontPlanType(t *testing.T) {
+	client := &Client{}
+	_, err := client.GetSubscriptionAdjustedEqualizations(context.Background(), "point-1", "UPFRONT")
+	if err == nil || !strings.Contains(err.Error(), `plan type must be "MONTHLY"`) {
+		t.Fatalf("expected MONTHLY-only error, got %v", err)
 	}
 }

--- a/internal/web/subscription_plan_availability.go
+++ b/internal/web/subscription_plan_availability.go
@@ -84,6 +84,73 @@ func (c *Client) ListSubscriptionPlanAvailabilities(ctx context.Context, subscri
 	return availabilities, nil
 }
 
+// CreateSubscriptionPlanAvailability creates a subscription billing-plan availability.
+func (c *Client) CreateSubscriptionPlanAvailability(ctx context.Context, subscriptionID, planType string, territoryIDs []string, availableInNewTerritories bool) (*SubscriptionPlanAvailability, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	planType = strings.ToUpper(strings.TrimSpace(planType))
+	if subscriptionID == "" {
+		return nil, fmt.Errorf("subscription id is required")
+	}
+	if planType != "UPFRONT" && planType != "MONTHLY" {
+		return nil, fmt.Errorf(`plan type must be "UPFRONT" or "MONTHLY"`)
+	}
+
+	territories := make([]map[string]string, 0, len(territoryIDs))
+	seen := make(map[string]struct{}, len(territoryIDs))
+	for _, territoryID := range territoryIDs {
+		territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
+		if territoryID == "" {
+			continue
+		}
+		if _, ok := seen[territoryID]; ok {
+			continue
+		}
+		seen[territoryID] = struct{}{}
+		territories = append(territories, map[string]string{
+			"type": "territories",
+			"id":   territoryID,
+		})
+	}
+	if len(territories) == 0 {
+		return nil, fmt.Errorf("at least one territory id is required")
+	}
+
+	attributes := map[string]any{
+		"planType": planType,
+	}
+	if planType == "UPFRONT" {
+		attributes["availableInNewTerritories"] = availableInNewTerritories
+	}
+	requestBody := map[string]any{
+		"data": map[string]any{
+			"type":       "subscriptionPlanAvailabilities",
+			"attributes": attributes,
+			"relationships": map[string]any{
+				"availableTerritories": map[string]any{"data": territories},
+				"subscription": map[string]any{
+					"data": map[string]string{
+						"type": "subscriptions",
+						"id":   subscriptionID,
+					},
+				},
+			},
+		},
+	}
+
+	responseBody, err := c.doRequest(ctx, http.MethodPost, "/subscriptionPlanAvailabilities", requestBody)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Data jsonAPIResource `json:"data"`
+	}
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription plan availability create response: %w", err)
+	}
+	availability := decodeSubscriptionPlanAvailabilityResource(payload.Data)
+	return &availability, nil
+}
+
 // RemoveSubscriptionPlanAvailabilityFromSale clears all available territories for a subscription plan availability.
 func (c *Client) RemoveSubscriptionPlanAvailabilityFromSale(ctx context.Context, planAvailabilityID string) (*SubscriptionPlanAvailability, error) {
 	planAvailabilityID = strings.TrimSpace(planAvailabilityID)

--- a/internal/web/subscription_plan_availability.go
+++ b/internal/web/subscription_plan_availability.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+// SubscriptionPlanAvailabilityTerritoryLimit is the maximum related territory count requested.
+const SubscriptionPlanAvailabilityTerritoryLimit = 200
+
 // SubscriptionPlanAvailability models the internal web API subscription plan availability resource.
 type SubscriptionPlanAvailability struct {
 	ID                         string   `json:"id"`
@@ -64,7 +67,7 @@ func (c *Client) ListSubscriptionPlanAvailabilities(ctx context.Context, subscri
 
 	query := url.Values{}
 	query.Set("include", "availableTerritories")
-	query.Set("limit[availableTerritories]", "200")
+	query.Set("limit[availableTerritories]", fmt.Sprintf("%d", SubscriptionPlanAvailabilityTerritoryLimit))
 	path := queryPath("/subscriptions/"+url.PathEscape(subscriptionID)+"/planAvailabilities", query)
 
 	responseBody, err := c.doRequest(ctx, http.MethodGet, path, nil)

--- a/internal/web/subscription_plan_availability_test.go
+++ b/internal/web/subscription_plan_availability_test.go
@@ -118,6 +118,47 @@ func TestRemoveSubscriptionPlanAvailabilityFromSaleBuildsExpectedRequest(t *test
 	}
 }
 
+func TestCreateSubscriptionPlanAvailabilityBuildsExpectedRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/iris/v1/subscriptionPlanAvailabilities" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body struct {
+			Data jsonAPIResource `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := stringAttr(body.Data.Attributes, "planType"); got != "MONTHLY" {
+			t.Fatalf("expected MONTHLY, got %q", got)
+		}
+		subscription := parseRelationshipRefs(body.Data.Relationships["subscription"].Data)
+		if len(subscription) != 1 || subscription[0].ID != "sub-1" {
+			t.Fatalf("unexpected subscription relationship: %#v", subscription)
+		}
+		territories := parseRelationshipRefs(body.Data.Relationships["availableTerritories"].Data)
+		if len(territories) != 1 || territories[0].ID != "NOR" {
+			t.Fatalf("unexpected territories: %#v", territories)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":false},"relationships":{"availableTerritories":{"data":[{"type":"territories","id":"NOR"}]}}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	got, err := client.CreateSubscriptionPlanAvailability(context.Background(), "sub-1", "MONTHLY", []string{"nor"}, false)
+	if err != nil {
+		t.Fatalf("CreateSubscriptionPlanAvailability() error = %v", err)
+	}
+	if got.ID != "plan-monthly" || got.PlanType != "MONTHLY" {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+}
+
 func TestSubscriptionPlanAvailabilityRequiresIDs(t *testing.T) {
 	client := &Client{}
 	if _, err := client.ListSubscriptionPlanAvailabilities(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "subscription id is required") {

--- a/internal/web/subscription_price_points.go
+++ b/internal/web/subscription_price_points.go
@@ -1,0 +1,77 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SubscriptionPricePoint is a web subscription price point.
+type SubscriptionPricePoint struct {
+	ID            string `json:"id"`
+	Territory     string `json:"territory"`
+	CustomerPrice string `json:"customerPrice"`
+	Currency      string `json:"currency,omitempty"`
+}
+
+// ListSubscriptionPricePoints lists price points for one subscription territory.
+func (c *Client) ListSubscriptionPricePoints(ctx context.Context, subscriptionID, territory string) ([]SubscriptionPricePoint, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	territory = strings.ToUpper(strings.TrimSpace(territory))
+	if subscriptionID == "" {
+		return nil, fmt.Errorf("subscription id is required")
+	}
+	if len(territory) != 3 {
+		return nil, fmt.Errorf("territory must be a three-letter territory id")
+	}
+	query := url.Values{}
+	query.Set("filter[territory]", territory)
+	query.Set("include", "territory")
+	query.Set("limit", "1000")
+	path := queryPath("/subscriptions/"+url.PathEscape(subscriptionID)+"/pricePoints", query)
+	responseBody, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var payload jsonAPIListPayload
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription price points response: %w", err)
+	}
+	result := make([]SubscriptionPricePoint, 0, len(payload.Data))
+	for _, resource := range payload.Data {
+		pointTerritory := territory
+		if refs := parseRelationshipRefs(resource.Relationships["territory"].Data); len(refs) > 0 {
+			pointTerritory = strings.ToUpper(strings.TrimSpace(refs[0].ID))
+		}
+		result = append(result, SubscriptionPricePoint{
+			ID:            strings.TrimSpace(resource.ID),
+			Territory:     pointTerritory,
+			CustomerPrice: stringAttr(resource.Attributes, "customerPrice"),
+			Currency:      stringAttr(resource.Attributes, "currency"),
+		})
+	}
+	return result, nil
+}
+
+// ResolveSubscriptionPricePoint resolves an exact decimal customer price.
+func (c *Client) ResolveSubscriptionPricePoint(ctx context.Context, subscriptionID, territory, customerPrice string) (*SubscriptionPricePoint, error) {
+	requested, ok := new(big.Rat).SetString(strings.TrimSpace(customerPrice))
+	if !ok || requested.Sign() <= 0 {
+		return nil, fmt.Errorf("customer price must be a positive decimal")
+	}
+	points, err := c.ListSubscriptionPricePoints(ctx, subscriptionID, territory)
+	if err != nil {
+		return nil, err
+	}
+	for i := range points {
+		candidate, ok := new(big.Rat).SetString(strings.TrimSpace(points[i].CustomerPrice))
+		if ok && requested.Cmp(candidate) == 0 {
+			return &points[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no subscription price point matches customer price %s in %s", strings.TrimSpace(customerPrice), strings.ToUpper(strings.TrimSpace(territory)))
+}

--- a/internal/web/subscription_price_points_test.go
+++ b/internal/web/subscription_price_points_test.go
@@ -1,0 +1,28 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolveSubscriptionPricePointMatchesEquivalentDecimal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("filter[territory]") != "NOR" {
+			t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"type":"subscriptionPricePoints","id":"point-1","attributes":{"customerPrice":"5.00"},"relationships":{"territory":{"data":{"type":"territories","id":"NOR"}}}}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	point, err := client.ResolveSubscriptionPricePoint(context.Background(), "sub-1", "nor", "5")
+	if err != nil {
+		t.Fatalf("ResolveSubscriptionPricePoint() error = %v", err)
+	}
+	if point.ID != "point-1" {
+		t.Fatalf("point.ID = %q", point.ID)
+	}
+}

--- a/internal/web/subscription_pricing.go
+++ b/internal/web/subscription_pricing.go
@@ -1,0 +1,92 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SubscriptionPlanPricesResult identifies the paired billing-plan prices created.
+type SubscriptionPlanPricesResult struct {
+	SubscriptionID      string `json:"subscriptionId"`
+	UpfrontPricePointID string `json:"upfrontPricePointId"`
+	MonthlyPricePointID string `json:"monthlyPricePointId"`
+}
+
+// CreateSubscriptionPlanPrices creates paired upfront and monthly prices through
+// the inline subscription PATCH used by App Store Connect.
+func (c *Client) CreateSubscriptionPlanPrices(ctx context.Context, subscriptionID, upfrontPricePointID, monthlyPricePointID string) (*SubscriptionPlanPricesResult, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	upfrontPricePointID = strings.TrimSpace(upfrontPricePointID)
+	monthlyPricePointID = strings.TrimSpace(monthlyPricePointID)
+	if subscriptionID == "" {
+		return nil, fmt.Errorf("subscription id is required")
+	}
+	if upfrontPricePointID == "" {
+		return nil, fmt.Errorf("upfront price point id is required")
+	}
+	if monthlyPricePointID == "" {
+		return nil, fmt.Errorf("monthly price point id is required")
+	}
+
+	upfrontID := "${current-upfront}"
+	monthlyID := "${current-monthly}"
+	priceRef := func(id string) map[string]string {
+		return map[string]string{"type": "subscriptionPrices", "id": id}
+	}
+	includedPrice := func(id, planType, pricePointID string) map[string]any {
+		return map[string]any{
+			"type":       "subscriptionPrices",
+			"id":         id,
+			"attributes": map[string]string{"planType": planType},
+			"relationships": map[string]any{
+				"subscriptionPricePoint": map[string]any{
+					"data": map[string]string{
+						"type": "subscriptionPricePoints",
+						"id":   pricePointID,
+					},
+				},
+			},
+		}
+	}
+	requestBody := map[string]any{
+		"data": map[string]any{
+			"type": "subscriptions",
+			"id":   subscriptionID,
+			"relationships": map[string]any{
+				"prices": map[string]any{
+					"data": []map[string]string{
+						priceRef(upfrontID),
+						priceRef(monthlyID),
+					},
+				},
+			},
+		},
+		"included": []map[string]any{
+			includedPrice(upfrontID, "UPFRONT", upfrontPricePointID),
+			includedPrice(monthlyID, "MONTHLY", monthlyPricePointID),
+		},
+	}
+
+	responseBody, err := c.doRequest(ctx, http.MethodPatch, "/subscriptions/"+url.PathEscape(subscriptionID), requestBody)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Data jsonAPIResource `json:"data"`
+	}
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription pricing response: %w", err)
+	}
+	if returnedID := strings.TrimSpace(payload.Data.ID); returnedID != "" && returnedID != subscriptionID {
+		return nil, fmt.Errorf("apple returned subscription %q after patching %q", returnedID, subscriptionID)
+	}
+	return &SubscriptionPlanPricesResult{
+		SubscriptionID:      subscriptionID,
+		UpfrontPricePointID: upfrontPricePointID,
+		MonthlyPricePointID: monthlyPricePointID,
+	}, nil
+}

--- a/internal/web/subscription_pricing.go
+++ b/internal/web/subscription_pricing.go
@@ -16,20 +16,31 @@ type SubscriptionPlanPricesResult struct {
 	MonthlyPricePointID string `json:"monthlyPricePointId"`
 }
 
+// SubscriptionPlanPrice identifies one billing plan's price and scheduling attributes.
+type SubscriptionPlanPrice struct {
+	PlanType             string
+	PricePointID         string
+	StartDate            string
+	PreserveCurrentPrice bool
+}
+
 // CreateSubscriptionPlanPrices creates paired upfront and monthly prices through
 // the inline subscription PATCH used by App Store Connect.
 func (c *Client) CreateSubscriptionPlanPrices(ctx context.Context, subscriptionID, upfrontPricePointID, monthlyPricePointID string) (*SubscriptionPlanPricesResult, error) {
+	return c.SetSubscriptionPlanPrices(ctx, subscriptionID, []SubscriptionPlanPrice{
+		{PlanType: "UPFRONT", PricePointID: upfrontPricePointID},
+		{PlanType: "MONTHLY", PricePointID: monthlyPricePointID},
+	})
+}
+
+// SetSubscriptionPlanPrices creates or schedules paired plan prices through the inline PATCH.
+func (c *Client) SetSubscriptionPlanPrices(ctx context.Context, subscriptionID string, prices []SubscriptionPlanPrice) (*SubscriptionPlanPricesResult, error) {
 	subscriptionID = strings.TrimSpace(subscriptionID)
-	upfrontPricePointID = strings.TrimSpace(upfrontPricePointID)
-	monthlyPricePointID = strings.TrimSpace(monthlyPricePointID)
 	if subscriptionID == "" {
 		return nil, fmt.Errorf("subscription id is required")
 	}
-	if upfrontPricePointID == "" {
-		return nil, fmt.Errorf("upfront price point id is required")
-	}
-	if monthlyPricePointID == "" {
-		return nil, fmt.Errorf("monthly price point id is required")
+	if len(prices) != 2 {
+		return nil, fmt.Errorf("exactly two subscription plan prices are required")
 	}
 
 	upfrontID := "${current-upfront}"
@@ -37,20 +48,42 @@ func (c *Client) CreateSubscriptionPlanPrices(ctx context.Context, subscriptionI
 	priceRef := func(id string) map[string]string {
 		return map[string]string{"type": "subscriptionPrices", "id": id}
 	}
-	includedPrice := func(id, planType, pricePointID string) map[string]any {
+	includedPrice := func(id string, price SubscriptionPlanPrice) map[string]any {
+		attributes := map[string]any{"planType": price.PlanType}
+		if strings.TrimSpace(price.StartDate) != "" {
+			attributes["startDate"] = strings.TrimSpace(price.StartDate)
+			attributes["preserveCurrentPrice"] = price.PreserveCurrentPrice
+		}
 		return map[string]any{
 			"type":       "subscriptionPrices",
 			"id":         id,
-			"attributes": map[string]string{"planType": planType},
+			"attributes": attributes,
 			"relationships": map[string]any{
 				"subscriptionPricePoint": map[string]any{
 					"data": map[string]string{
 						"type": "subscriptionPricePoints",
-						"id":   pricePointID,
+						"id":   price.PricePointID,
 					},
 				},
 			},
 		}
+	}
+	byType := map[string]SubscriptionPlanPrice{}
+	for _, price := range prices {
+		price.PlanType = strings.ToUpper(strings.TrimSpace(price.PlanType))
+		price.PricePointID = strings.TrimSpace(price.PricePointID)
+		if price.PlanType != "UPFRONT" && price.PlanType != "MONTHLY" {
+			return nil, fmt.Errorf(`plan type must be "UPFRONT" or "MONTHLY"`)
+		}
+		if price.PricePointID == "" {
+			return nil, fmt.Errorf("%s price point id is required", strings.ToLower(price.PlanType))
+		}
+		byType[price.PlanType] = price
+	}
+	upfront, upfrontOK := byType["UPFRONT"]
+	monthly, monthlyOK := byType["MONTHLY"]
+	if !upfrontOK || !monthlyOK {
+		return nil, fmt.Errorf("both UPFRONT and MONTHLY prices are required")
 	}
 	requestBody := map[string]any{
 		"data": map[string]any{
@@ -66,8 +99,8 @@ func (c *Client) CreateSubscriptionPlanPrices(ctx context.Context, subscriptionI
 			},
 		},
 		"included": []map[string]any{
-			includedPrice(upfrontID, "UPFRONT", upfrontPricePointID),
-			includedPrice(monthlyID, "MONTHLY", monthlyPricePointID),
+			includedPrice(upfrontID, upfront),
+			includedPrice(monthlyID, monthly),
 		},
 	}
 
@@ -86,7 +119,7 @@ func (c *Client) CreateSubscriptionPlanPrices(ctx context.Context, subscriptionI
 	}
 	return &SubscriptionPlanPricesResult{
 		SubscriptionID:      subscriptionID,
-		UpfrontPricePointID: upfrontPricePointID,
-		MonthlyPricePointID: monthlyPricePointID,
+		UpfrontPricePointID: upfront.PricePointID,
+		MonthlyPricePointID: monthly.PricePointID,
 	}, nil
 }

--- a/internal/web/subscription_pricing_test.go
+++ b/internal/web/subscription_pricing_test.go
@@ -47,3 +47,37 @@ func TestCreateSubscriptionPlanPricesBuildsExpectedInlinePatch(t *testing.T) {
 		t.Fatalf("unexpected result: %#v", got)
 	}
 }
+
+func TestSetSubscriptionPlanPricesIncludesScheduleAttributes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Included []jsonAPIResource `json:"included"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Included) != 2 {
+			t.Fatalf("expected two included prices, got %d", len(body.Included))
+		}
+		for _, price := range body.Included {
+			if got := stringAttr(price.Attributes, "startDate"); got != "2026-07-01" {
+				t.Fatalf("startDate = %q", got)
+			}
+			if got, ok := price.Attributes["preserveCurrentPrice"].(bool); !ok || !got {
+				t.Fatalf("preserveCurrentPrice = %#v", price.Attributes["preserveCurrentPrice"])
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"type":"subscriptions","id":"sub-1"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	_, err := client.SetSubscriptionPlanPrices(context.Background(), "sub-1", []SubscriptionPlanPrice{
+		{PlanType: "UPFRONT", PricePointID: "upfront", StartDate: "2026-07-01", PreserveCurrentPrice: true},
+		{PlanType: "MONTHLY", PricePointID: "monthly", StartDate: "2026-07-01", PreserveCurrentPrice: true},
+	})
+	if err != nil {
+		t.Fatalf("SetSubscriptionPlanPrices() error = %v", err)
+	}
+}

--- a/internal/web/subscription_pricing_test.go
+++ b/internal/web/subscription_pricing_test.go
@@ -1,0 +1,49 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateSubscriptionPlanPricesBuildsExpectedInlinePatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/iris/v1/subscriptions/sub-1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body struct {
+			Data     jsonAPIResource   `json:"data"`
+			Included []jsonAPIResource `json:"included"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		prices := parseRelationshipRefs(body.Data.Relationships["prices"].Data)
+		if len(prices) != 2 || len(body.Included) != 2 {
+			t.Fatalf("expected two inline prices, got refs=%#v included=%#v", prices, body.Included)
+		}
+		if got := stringAttr(body.Included[0].Attributes, "planType"); got != "UPFRONT" {
+			t.Fatalf("expected UPFRONT first, got %q", got)
+		}
+		if got := stringAttr(body.Included[1].Attributes, "planType"); got != "MONTHLY" {
+			t.Fatalf("expected MONTHLY second, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"type":"subscriptions","id":"sub-1"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL + "/iris/v1"}
+	got, err := client.CreateSubscriptionPlanPrices(context.Background(), "sub-1", "upfront-point", "monthly-point")
+	if err != nil {
+		t.Fatalf("CreateSubscriptionPlanPrices() error = %v", err)
+	}
+	if got.SubscriptionID != "sub-1" || got.UpfrontPricePointID != "upfront-point" || got.MonthlyPricePointID != "monthly-point" {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+}


### PR DESCRIPTION
## What
- add `asc web subscriptions pricing monthly-commitment bootstrap`
- create or reuse the private `MONTHLY` plan availability before attaching paired prices
- accept exact numeric customer prices (`--upfront-price`, `--monthly-price`) or raw price-point IDs
- add `--dry-run` planning with zero POST/PATCH requests and separate `planAvailabilityWouldCreate` preview state
- support paired scheduled changes through `--start-date` and `--preserve-current-price`
- add MONTHLY-only `asc web subscriptions pricing adjusted-equalizations view`
- convert Apple's known equalization 409 into sanitized structured output, including incompatible territory count/list
- reject unsupported UPFRONT equalization requests locally because Apple's private endpoint returns HTTP 400
- reject USA and Singapore before private API calls
- avoid treating a 200-territory relationship response as complete

## Scope

Prefer the supported public API for normal monthly-commitment setup:

```sh
asc subscriptions pricing monthly-commitment list ...
asc subscriptions pricing monthly-commitment enable ...
asc subscriptions pricing monthly-commitment disable ...
```

The public `enable` flow was verified successfully during this audit. This PR is
an experimental private-endpoint escape hatch only for App Store Connect's
paired inline pricing workflow, paired scheduled changes, and MONTHLY adjusted
equalization inspection.

## Examples
```sh
asc web subscriptions pricing monthly-commitment bootstrap \
  --subscription-id 6779873316 \
  --territory NOR \
  --upfront-price 49 \
  --monthly-price 5 \
  --dry-run \
  --output json

asc web subscriptions pricing monthly-commitment bootstrap \
  --subscription-id 6779873316 \
  --territory NOR \
  --upfront-price 49 \
  --monthly-price 5 \
  --start-date 2026-07-01 \
  --preserve-current-price \
  --confirm

asc web subscriptions pricing adjusted-equalizations view \
  --price-point-id PRICE_POINT_ID \
  --plan-type MONTHLY \
  --output json
```

## Live verification

Verified with a user-owned web session on throwaway subscription `6779873316`:

- initial bootstrap created MONTHLY plan availability `eyJhIjoiNjc3OTg3MzMxNiIsInAiOiIxIn0` and paired prices
- fresh-session numeric dry-run on the current branch resolved `49 NOK` and `5 NOK` to the exact NOR price-point IDs and performed no mutation
- MONTHLY adjusted equalizations returned exit `0` with sanitized structured status `409`, code `STATE_ERROR.EQUALIZATION_FAILED`, and 173 incompatible territories
- UPFRONT adjusted equalizations were live-probed and Apple returned HTTP `400`; the command now rejects that unsupported mode locally with exit `2`
- the private `/iris` plan-availability relationship with `limit=200` returned all 175 territories on subscription `6759788055`, confirming the public OpenAPI 50-item cap does not apply to this route

The public API counterpart was also live-verified on a disposable subscription:
MONTHLY availability and a `5 NOK` price were created, an idempotent rerun made
no price POST, and the temporary subscription was deleted.

## Checks
- `make format`
- `make generate-command-docs`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary exit `2` checks for invalid territory, missing required flags, `--preserve-current-price` without `--start-date`, and unsupported UPFRONT equalizations
- built binary help and live smoke tests

