### PR TITLE
apps wall: add Midnight: Couples App & Games

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -778,6 +778,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/50/8e/ed/508eedf3-5d31-7f42-c7dc-4c5551ce5d4a/AppIcon-0-0-1x_U007epad-0-0-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Midnight: Couples App & Games",
+    "link": "https://apps.apple.com/us/app/midnight-couples-app-games/id6758623374?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e5/81/e1/e581e1f6-fed0-f6b0-0e70-cb2ad5a0c764/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "MileIO",
     "link": "https://apps.apple.com/app/id6758225631",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/09/0a/21/090a21e8-5b19-ec94-c5d0-6c2d0f5175bd/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Midnight: Couples App & Games` to the Wall of Apps

## Entry

- App ID: 6758623374
- App: Midnight: Couples App & Games
- Link: https://apps.apple.com/us/app/midnight-couples-app-games/id6758623374?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Midnight: Couples App & Games" to the app directory with corresponding App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->