### PR TITLE
apps wall: add Peptide Protocol: Dose Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -917,6 +917,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/22/a4/41/22a441e6-20c5-a464-2b0f-3db405633856/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Peptide Protocol: Dose Tracker",
+    "link": "https://apps.apple.com/us/app/peptide-protocol-dose-tracker/id6762055081?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ff/c5/73/ffc57381-77f1-ded8-db61-f9272cf32cc5/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Petal - AI Voice Recorder",
     "link": "https://apps.apple.com/us/app/petal-ai-voice-recorder/id6759932376?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ec/77/3a/ec773a74-274b-bcd4-4587-7f28cbb0cee2/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Peptide Protocol: Dose Tracker` to the Wall of Apps

## Entry

- App ID: 6762055081
- App: Peptide Protocol: Dose Tracker
- Link: https://apps.apple.com/us/app/peptide-protocol-dose-tracker/id6762055081?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Peptide Protocol: Dose Tracker" to the apps collection, including its App Store link and icon, so users can discover and access the new app directly from the apps listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->