### PR TITLE
apps wall: add WatchRadar: Watches Identifier

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1531,6 +1531,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e0/4b/bd/e04bbd15-6b77-184e-381f-3d5e5654d97b/app-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "WatchRadar: Watches Identifier",
+    "link": "https://apps.apple.com/us/app/watchradar-watches-identifier/id6760263209?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c9/7e/e0/c97ee08b-0e99-5233-ebcc-acba477cafd3/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Weather mini - Trip Forecasts",
     "link": "https://apps.apple.com/us/app/weather-mini-trip-forecasts/id892589817",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3c/c6/c1/3cc6c19c-acec-fb4d-ee88-63a1bfc422c4/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `WatchRadar: Watches Identifier` to the Wall of Apps

## Entry

- App ID: 6760263209
- App: WatchRadar: Watches Identifier
- Link: https://apps.apple.com/us/app/watchradar-watches-identifier/id6760263209?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "WatchRadar: Watches Identifier" to the app directory, including its name, link, and icon for discovery within the apps listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->