### PR TITLE
apps wall: add Unseen Accessibility

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1471,6 +1471,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6a/1e/8f/6a1e8f8e-1f53-fcde-f26b-f814416eeb69/glass-0-0-85-220-0-6-0-2x-sRGB.png/512x512bb.png"
   },
   {
+    "app": "Unseen Accessibility",
+    "link": "https://apps.apple.com/us/app/unseen-accessibility/id6770270032?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/59/52/01/595201c5-02a2-75ac-0e10-a00f7a4bd04c/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "UrbanAir: Unlock all escooters",
     "link": "https://apps.apple.com/us/app/urbanair-unlock-all-escooters/id1491025864?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple122/v4/7f/75/08/7f750858-b379-719d-f98c-06e4fbc9a984/AppIcon-0-0-1x_U007emarketing-0-0-0-10-0-0-sRGB-0-0-0-GLES2_U002c0-512MB-85-220-0-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Unseen Accessibility` to the Wall of Apps

## Entry

- App ID: 6770270032
- App: Unseen Accessibility
- Link: https://apps.apple.com/us/app/unseen-accessibility/id6770270032?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Unseen Accessibility" app to the featured applications collection with its App Store link and icon reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->