### PR TITLE
[codex] Fix FREE_TRIAL offer code territory prices

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -66,7 +66,7 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 
 ## Subscription Offer Codes
 
-- `POST /v1/subscriptionOfferCodes`: for `FREE_TRIAL` offers the `prices` relationship **must be omitted entirely** — the API returns 409 if it is present (even as an empty list). The OpenAPI snapshot marks `prices` as required in the relationships schema, but that is incorrect for `FREE_TRIAL` mode. The CLI and client enforce this by omitting the relationship and rejecting `--prices` when `--offer-mode FREE_TRIAL` is set.
+- `POST /v1/subscriptionOfferCodes`: the `prices` relationship is required for every offer mode. For `FREE_TRIAL`, each inline price selects a territory but must omit `subscriptionPricePoint`; including one returns 409 `ENTITY_ERROR.RELATIONSHIP.INVALID`. Use `--prices "DEU,FRA"` for `FREE_TRIAL` and `--prices "DEU:PRICE_POINT_ID"` for paid modes.
 
 ## Monthly Subscriptions with a 12-Month Commitment
 

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -648,54 +648,53 @@ func (c *Client) CreateSubscriptionOfferCode(ctx context.Context, subscriptionID
 	if subscriptionID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
 	}
-	// FREE_TRIAL offers must not include a subscriptionPricePoint — the API rejects it.
-	if len(prices) > 0 && attrs.OfferMode == SubscriptionOfferModeFreeTrial {
-		return nil, fmt.Errorf("prices must not be set for FREE_TRIAL offer mode")
-	}
-	if len(prices) == 0 && attrs.OfferMode != SubscriptionOfferModeFreeTrial {
+	if len(prices) == 0 {
 		return nil, fmt.Errorf("at least one price is required")
 	}
 
-	var included []SubscriptionOfferCodePriceInlineCreate
-	var pricesRel *RelationshipList
-
-	if attrs.OfferMode != SubscriptionOfferModeFreeTrial {
-		priceData := make([]ResourceData, 0, len(prices))
-		included = make([]SubscriptionOfferCodePriceInlineCreate, 0, len(prices))
-		for idx, price := range prices {
-			territoryID := strings.ToUpper(strings.TrimSpace(price.TerritoryID))
-			pricePointID := strings.TrimSpace(price.PricePointID)
-			if territoryID == "" {
-				return nil, fmt.Errorf("territory ID is required")
-			}
-			if pricePointID == "" {
-				return nil, fmt.Errorf("price point ID is required")
-			}
-			resourceID := fmt.Sprintf("${local-price-%d}", idx+1)
-			priceData = append(priceData, ResourceData{
-				Type: ResourceTypeSubscriptionOfferCodePrices,
-				ID:   resourceID,
-			})
-			included = append(included, SubscriptionOfferCodePriceInlineCreate{
-				Type: ResourceTypeSubscriptionOfferCodePrices,
-				ID:   resourceID,
-				Relationships: SubscriptionOfferCodePriceRelationships{
-					Territory: Relationship{
-						Data: ResourceData{
-							Type: ResourceTypeTerritories,
-							ID:   territoryID,
-						},
-					},
-					SubscriptionPricePoint: Relationship{
-						Data: ResourceData{
-							Type: ResourceTypeSubscriptionPricePoints,
-							ID:   pricePointID,
-						},
-					},
-				},
-			})
+	isFreeTrial := attrs.OfferMode == SubscriptionOfferModeFreeTrial
+	priceData := make([]ResourceData, 0, len(prices))
+	included := make([]SubscriptionOfferCodePriceInlineCreate, 0, len(prices))
+	for idx, price := range prices {
+		territoryID := strings.ToUpper(strings.TrimSpace(price.TerritoryID))
+		pricePointID := strings.TrimSpace(price.PricePointID)
+		if territoryID == "" {
+			return nil, fmt.Errorf("territory ID is required")
 		}
-		pricesRel = &RelationshipList{Data: priceData}
+		if isFreeTrial && pricePointID != "" {
+			return nil, fmt.Errorf("price point must not be set for FREE_TRIAL offer mode")
+		}
+		if !isFreeTrial && pricePointID == "" {
+			return nil, fmt.Errorf("price point ID is required")
+		}
+
+		priceRelationships := SubscriptionOfferCodePriceRelationships{
+			Territory: Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeTerritories,
+					ID:   territoryID,
+				},
+			},
+		}
+		if pricePointID != "" {
+			priceRelationships.SubscriptionPricePoint = &Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeSubscriptionPricePoints,
+					ID:   pricePointID,
+				},
+			}
+		}
+
+		resourceID := fmt.Sprintf("${local-price-%d}", idx+1)
+		priceData = append(priceData, ResourceData{
+			Type: ResourceTypeSubscriptionOfferCodePrices,
+			ID:   resourceID,
+		})
+		included = append(included, SubscriptionOfferCodePriceInlineCreate{
+			Type:          ResourceTypeSubscriptionOfferCodePrices,
+			ID:            resourceID,
+			Relationships: priceRelationships,
+		})
 	}
 
 	payload := SubscriptionOfferCodeCreateRequest{
@@ -709,7 +708,7 @@ func (c *Client) CreateSubscriptionOfferCode(ctx context.Context, subscriptionID
 						ID:   subscriptionID,
 					},
 				},
-				Prices: pricesRel,
+				Prices: RelationshipList{Data: priceData},
 			},
 		},
 		Included: included,

--- a/internal/asc/offer_codes_custom_output.go
+++ b/internal/asc/offer_codes_custom_output.go
@@ -43,7 +43,11 @@ func offerCodePriceRelationshipIDs(raw json.RawMessage) (string, string, error) 
 	if err := json.Unmarshal(raw, &relationships); err != nil {
 		return "", "", fmt.Errorf("decode offer code price relationships: %w", err)
 	}
-	return relationships.Territory.Data.ID, relationships.SubscriptionPricePoint.Data.ID, nil
+	pricePointID := ""
+	if relationships.SubscriptionPricePoint != nil {
+		pricePointID = relationships.SubscriptionPricePoint.Data.ID
+	}
+	return relationships.Territory.Data.ID, pricePointID, nil
 }
 
 func offerCodeValuesRows(result *OfferCodeValuesResult) ([]string, [][]string) {

--- a/internal/asc/offer_codes_custom_output_test.go
+++ b/internal/asc/offer_codes_custom_output_test.go
@@ -1,0 +1,28 @@
+package asc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOfferCodePriceRelationshipIDsWithoutPricePoint(t *testing.T) {
+	raw := json.RawMessage(`{
+		"territory": {
+			"data": {
+				"type": "territories",
+				"id": "DEU"
+			}
+		}
+	}`)
+
+	territoryID, pricePointID, err := offerCodePriceRelationshipIDs(raw)
+	if err != nil {
+		t.Fatalf("offerCodePriceRelationshipIDs() error: %v", err)
+	}
+	if territoryID != "DEU" {
+		t.Fatalf("expected territory DEU, got %q", territoryID)
+	}
+	if pricePointID != "" {
+		t.Fatalf("expected empty price point, got %q", pricePointID)
+	}
+}

--- a/internal/asc/offer_codes_subscription.go
+++ b/internal/asc/offer_codes_subscription.go
@@ -63,8 +63,8 @@ type SubscriptionOfferCodeOneTimeUseCodeUpdateRequest struct {
 
 // SubscriptionOfferCodePriceRelationships describes price relationships.
 type SubscriptionOfferCodePriceRelationships struct {
-	Territory              Relationship `json:"territory"`
-	SubscriptionPricePoint Relationship `json:"subscriptionPricePoint"`
+	Territory              Relationship  `json:"territory"`
+	SubscriptionPricePoint *Relationship `json:"subscriptionPricePoint,omitempty"`
 }
 
 // SubscriptionOfferCodePriceInlineCreate describes inline creation data for prices.

--- a/internal/asc/subscription_resources.go
+++ b/internal/asc/subscription_resources.go
@@ -250,8 +250,8 @@ type SubscriptionOfferCodeUpdateAttributes struct {
 
 // SubscriptionOfferCodeRelationships describes relationships for offer codes.
 type SubscriptionOfferCodeRelationships struct {
-	Subscription Relationship      `json:"subscription"`
-	Prices       *RelationshipList `json:"prices,omitempty"`
+	Subscription Relationship     `json:"subscription"`
+	Prices       RelationshipList `json:"prices"`
 }
 
 // SubscriptionOfferCodeCreateData is the data portion of an offer code create request.

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -804,21 +804,55 @@ func TestCreateSubscriptionOfferCodeFreeTrial(t *testing.T) {
 		if req.URL.Path != "/v1/subscriptionOfferCodes" {
 			t.Fatalf("expected path /v1/subscriptionOfferCodes, got %s", req.URL.Path)
 		}
-		var payload SubscriptionOfferCodeCreateRequest
+		var payload map[string]any
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 			t.Fatalf("failed to decode request: %v", err)
 		}
-		if payload.Data.Type != ResourceTypeSubscriptionOfferCodes {
-			t.Fatalf("expected type subscriptionOfferCodes, got %q", payload.Data.Type)
+		data, ok := payload["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected data object, got %T", payload["data"])
 		}
-		if payload.Data.Attributes.OfferMode != SubscriptionOfferModeFreeTrial {
-			t.Fatalf("expected offer mode FREE_TRIAL, got %q", payload.Data.Attributes.OfferMode)
+		attributes, ok := data["attributes"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected attributes object, got %T", data["attributes"])
 		}
-		if payload.Data.Relationships.Prices != nil {
-			t.Fatalf("expected no prices relationship for FREE_TRIAL, got %+v", payload.Data.Relationships.Prices)
+		if attributes["offerMode"] != string(SubscriptionOfferModeFreeTrial) {
+			t.Fatalf("expected offer mode FREE_TRIAL, got %#v", attributes["offerMode"])
 		}
-		if len(payload.Included) != 0 {
-			t.Fatalf("expected no included entries for FREE_TRIAL, got %d", len(payload.Included))
+		relationships, ok := data["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected relationships object, got %T", data["relationships"])
+		}
+		pricesRelationship, ok := relationships["prices"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected prices relationship for FREE_TRIAL, got %#v", relationships["prices"])
+		}
+		priceRefs, ok := pricesRelationship["data"].([]any)
+		if !ok || len(priceRefs) != 1 {
+			t.Fatalf("expected one price relationship, got %#v", pricesRelationship["data"])
+		}
+		included, ok := payload["included"].([]any)
+		if !ok || len(included) != 1 {
+			t.Fatalf("expected one included price, got %#v", payload["included"])
+		}
+		includedPrice, ok := included[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected included price object, got %T", included[0])
+		}
+		priceRelationships, ok := includedPrice["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected included price relationships, got %T", includedPrice["relationships"])
+		}
+		territory, ok := priceRelationships["territory"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected territory relationship, got %#v", priceRelationships["territory"])
+		}
+		territoryData, ok := territory["data"].(map[string]any)
+		if !ok || territoryData["id"] != "DEU" {
+			t.Fatalf("expected territory DEU, got %#v", territory["data"])
+		}
+		if _, ok := priceRelationships["subscriptionPricePoint"]; ok {
+			t.Fatalf("expected subscriptionPricePoint to be omitted, got %#v", priceRelationships["subscriptionPricePoint"])
 		}
 		assertAuthorized(t, req)
 	}, response)
@@ -831,12 +865,13 @@ func TestCreateSubscriptionOfferCodeFreeTrial(t *testing.T) {
 		OfferMode:             SubscriptionOfferModeFreeTrial,
 		NumberOfPeriods:       1,
 	}
-	if _, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, nil); err != nil {
+	prices := []SubscriptionOfferCodePrice{{TerritoryID: "DEU"}}
+	if _, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, prices); err != nil {
 		t.Fatalf("CreateSubscriptionOfferCode() error: %v", err)
 	}
 }
 
-func TestCreateSubscriptionOfferCodeFreeTrialRejectsPrices(t *testing.T) {
+func TestCreateSubscriptionOfferCodeFreeTrialRejectsPricePoint(t *testing.T) {
 	attrs := SubscriptionOfferCodeCreateAttributes{
 		OfferMode: SubscriptionOfferModeFreeTrial,
 	}
@@ -844,9 +879,24 @@ func TestCreateSubscriptionOfferCodeFreeTrialRejectsPrices(t *testing.T) {
 	client := &Client{} // no HTTP needed — validation fires before any call
 	_, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, prices)
 	if err == nil {
-		t.Fatal("expected error for FREE_TRIAL with prices, got nil")
+		t.Fatal("expected error for FREE_TRIAL with a price point, got nil")
 	}
-	const want = "prices must not be set for FREE_TRIAL offer mode"
+	const want = "price point must not be set for FREE_TRIAL offer mode"
+	if err.Error() != want {
+		t.Fatalf("expected %q, got %q", want, err.Error())
+	}
+}
+
+func TestCreateSubscriptionOfferCodeFreeTrialRequiresPrice(t *testing.T) {
+	attrs := SubscriptionOfferCodeCreateAttributes{
+		OfferMode: SubscriptionOfferModeFreeTrial,
+	}
+	client := &Client{} // no HTTP needed — validation fires before any call
+	_, err := client.CreateSubscriptionOfferCode(context.Background(), "sub-1", attrs, nil)
+	if err == nil {
+		t.Fatal("expected error for FREE_TRIAL without prices, got nil")
+	}
+	const want = "at least one price is required"
 	if err.Error() != want {
 		t.Fatalf("expected %q, got %q", want, err.Error())
 	}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1785,9 +1785,14 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 			wantErr: "--prices is required",
 		},
 		{
-			name:    "subscriptions offer-codes create free-trial with prices rejected",
+			name:    "subscriptions offer-codes create free-trial missing prices",
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1"},
+			wantErr: "--prices is required",
+		},
+		{
+			name:    "subscriptions offer-codes create free-trial with price point rejected",
 			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--prices", "USA:PRICE_ID"},
-			wantErr: "--prices must not be set for FREE_TRIAL offers",
+			wantErr: "--prices for FREE_TRIAL must use TERRITORY entries without price point IDs",
 		},
 		{
 			name:    "subscriptions offer-codes update missing active",

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -434,9 +434,14 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			wantErr: "--prices is required",
 		},
 		{
-			name:    "subscriptions offer-codes create free-trial with prices rejected",
+			name:    "subscriptions offer-codes create free-trial without prices",
+			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1"},
+			wantErr: "--prices is required",
+		},
+		{
+			name:    "subscriptions offer-codes create free-trial with price point rejected",
 			args:    []string{"subscriptions", "offers", "offer-codes", "create", "--subscription-id", "SUB_ID", "--name", "Spring", "--offer-eligibility", "STACK_WITH_INTRO_OFFERS", "--customer-eligibilities", "NEW", "--offer-duration", "ONE_MONTH", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--prices", "USA:PRICE_ID"},
-			wantErr: "--prices must not be set for FREE_TRIAL offers",
+			wantErr: "--prices for FREE_TRIAL must use TERRITORY entries without price point IDs",
 		},
 	}
 

--- a/internal/cli/cmdtest/offer_codes_legacy_validation_test.go
+++ b/internal/cli/cmdtest/offer_codes_legacy_validation_test.go
@@ -40,12 +40,29 @@ func TestLegacyOfferCodesCreateFreeTrialAcceptsTerritoryPrice(t *testing.T) {
 			t.Fatalf("decode request body: %v\nbody=%s", err, string(rawBody))
 		}
 
-		included := payload["included"].([]any)
+		included, ok := payload["included"].([]any)
+		if !ok {
+			t.Fatalf("expected included array, got %T", payload["included"])
+		}
 		if len(included) != 1 {
 			t.Fatalf("expected one included price, got %d", len(included))
 		}
-		relationships := included[0].(map[string]any)["relationships"].(map[string]any)
-		territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
+		includedPrice, ok := included[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected included price object, got %T", included[0])
+		}
+		relationships, ok := includedPrice["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected relationships object, got %T", includedPrice["relationships"])
+		}
+		territoryRelationship, ok := relationships["territory"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected territory relationship object, got %T", relationships["territory"])
+		}
+		territory, ok := territoryRelationship["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected territory data object, got %T", territoryRelationship["data"])
+		}
 		if territory["id"] != "USA" {
 			t.Fatalf("expected normalized territory USA, got %#v", territory["id"])
 		}

--- a/internal/cli/cmdtest/offer_codes_legacy_validation_test.go
+++ b/internal/cli/cmdtest/offer_codes_legacy_validation_test.go
@@ -1,0 +1,132 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/offercodes"
+)
+
+func TestLegacyOfferCodesCreateFreeTrialAcceptsTerritoryPrice(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptionOfferCodes" {
+			t.Fatalf("expected path /v1/subscriptionOfferCodes, got %s", req.URL.Path)
+		}
+
+		rawBody, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(rawBody, &payload); err != nil {
+			t.Fatalf("decode request body: %v\nbody=%s", err, string(rawBody))
+		}
+
+		included := payload["included"].([]any)
+		if len(included) != 1 {
+			t.Fatalf("expected one included price, got %d", len(included))
+		}
+		relationships := included[0].(map[string]any)["relationships"].(map[string]any)
+		territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
+		if territory["id"] != "USA" {
+			t.Fatalf("expected normalized territory USA, got %#v", territory["id"])
+		}
+		if _, ok := relationships["subscriptionPricePoint"]; ok {
+			t.Fatalf("expected subscriptionPricePoint to be omitted, got %#v", relationships["subscriptionPricePoint"])
+		}
+
+		body := `{"data":{"type":"subscriptionOfferCodes","id":"legacy-free-trial","attributes":{"name":"Legacy Free Trial","active":true}}}`
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	command := offercodes.OfferCodesCreateCommand()
+	command.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := command.Parse([]string{
+			"--subscription-id", "8000000001",
+			"--name", "Legacy Free Trial",
+			"--customer-eligibilities", "NEW",
+			"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
+			"--duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--prices", "us",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := command.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var output struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\nstdout=%s", err, stdout)
+	}
+	if output.Data.ID != "legacy-free-trial" {
+		t.Fatalf("expected created offer code id legacy-free-trial, got %q", output.Data.ID)
+	}
+}
+
+func TestLegacyOfferCodesCreateInvalidFreeTrialPriceReturnsUsageExitCode(t *testing.T) {
+	command := offercodes.OfferCodesCreateCommand()
+	command.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := command.Parse([]string{
+			"--subscription-id", "8000000001",
+			"--name", "Legacy Free Trial",
+			"--customer-eligibilities", "NEW",
+			"--offer-eligibility", "STACK_WITH_INTRO_OFFERS",
+			"--duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--prices", "USA:PRICE_POINT_ID",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = command.Run(context.Background())
+	})
+
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+		t.Fatalf("expected exit code %d, got %d from %v", rootcmd.ExitUsage, got, runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --prices for FREE_TRIAL must use TERRITORY entries without price point IDs") {
+		t.Fatalf("expected FREE_TRIAL price validation in stderr, got %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/stable_selector_resolution_test.go
+++ b/internal/cli/cmdtest/stable_selector_resolution_test.go
@@ -549,6 +549,7 @@ func TestSubscriptionsOfferCodesCreateFreeTrialStopsBeforeMutationWhenLookupFail
 		"--offer-duration", "ONE_MONTH",
 		"--offer-mode", "FREE_TRIAL",
 		"--number-of-periods", "1",
+		"--prices", "DE",
 	})
 	if runErr == nil {
 		t.Fatal("expected lookup error")
@@ -561,7 +562,7 @@ func TestSubscriptionsOfferCodesCreateFreeTrialStopsBeforeMutationWhenLookupFail
 	}
 }
 
-func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndOmitsPrices(t *testing.T) {
+func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndIncludesTerritoryOnlyPrice(t *testing.T) {
 	setupStableSelectorAuth(t)
 
 	originalTransport := http.DefaultTransport
@@ -596,11 +597,36 @@ func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndOmitsPrices(t *testing
 			if !ok {
 				t.Fatalf("expected payload.data.relationships to be an object, got %T", data["relationships"])
 			}
-			if _, ok := relationships["prices"]; ok {
-				t.Fatalf("expected no prices relationship for FREE_TRIAL, but found one: %#v", relationships["prices"])
+			pricesRelationship, ok := relationships["prices"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected prices relationship for FREE_TRIAL, got %#v", relationships["prices"])
 			}
-			if _, ok := payload["included"]; ok {
-				t.Fatalf("expected no included entries for FREE_TRIAL, but found some: %#v", payload["included"])
+			priceRefs, ok := pricesRelationship["data"].([]any)
+			if !ok || len(priceRefs) != 1 {
+				t.Fatalf("expected one price relationship, got %#v", pricesRelationship["data"])
+			}
+			included, ok := payload["included"].([]any)
+			if !ok || len(included) != 1 {
+				t.Fatalf("expected one included price, got %#v", payload["included"])
+			}
+			includedPrice, ok := included[0].(map[string]any)
+			if !ok {
+				t.Fatalf("expected included price object, got %T", included[0])
+			}
+			priceRelationships, ok := includedPrice["relationships"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected included price relationships, got %T", includedPrice["relationships"])
+			}
+			territory, ok := priceRelationships["territory"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected territory relationship, got %#v", priceRelationships["territory"])
+			}
+			territoryData, ok := territory["data"].(map[string]any)
+			if !ok || territoryData["id"] != "DEU" {
+				t.Fatalf("expected normalized territory DEU, got %#v", territory["data"])
+			}
+			if _, ok := priceRelationships["subscriptionPricePoint"]; ok {
+				t.Fatalf("expected subscriptionPricePoint to be omitted, got %#v", priceRelationships["subscriptionPricePoint"])
 			}
 			body := `{"data":{"type":"subscriptionOfferCodes","id":"sub-offer-ft-2","attributes":{"name":"SPRING","active":true}}}`
 			return &http.Response{
@@ -624,6 +650,7 @@ func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndOmitsPrices(t *testing
 		"--offer-duration", "ONE_MONTH",
 		"--offer-mode", "FREE_TRIAL",
 		"--number-of-periods", "1",
+		"--prices", "DE",
 	})
 	if runErr != nil {
 		t.Fatalf("expected nil error, got %v", runErr)
@@ -644,7 +671,7 @@ func TestSubscriptionsOfferCodesCreateFreeTrialResolvesAndOmitsPrices(t *testing
 	}
 }
 
-func TestSubscriptionsOfferCodesCreateFreeTrialWithPricesIsRejected(t *testing.T) {
+func TestSubscriptionsOfferCodesCreateFreeTrialWithPricePointIsRejected(t *testing.T) {
 	_, stderr, runErr := runRootCommand(t, []string{
 		"subscriptions", "offers", "offer-codes", "create",
 		"--subscription-id", "8000000001",
@@ -657,23 +684,24 @@ func TestSubscriptionsOfferCodesCreateFreeTrialWithPricesIsRejected(t *testing.T
 		"--prices", "usa:pp-us",
 	})
 	if runErr == nil {
-		t.Fatal("expected error for FREE_TRIAL with prices, got nil")
+		t.Fatal("expected error for FREE_TRIAL with a price point, got nil")
 	}
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp (exit 2), got %v", runErr)
 	}
-	if !strings.Contains(stderr, "--prices must not be set for FREE_TRIAL") {
+	if !strings.Contains(stderr, "--prices for FREE_TRIAL must use TERRITORY entries without price point IDs") {
 		t.Fatalf("expected validation message in stderr, got %q", stderr)
 	}
 }
 
-func TestSubscriptionsOfferCodesCreateNonFreeTrialWithoutPricesIsRejected(t *testing.T) {
+func TestSubscriptionsOfferCodesCreateWithoutPricesIsRejected(t *testing.T) {
 	tests := []struct {
 		name      string
 		offerMode string
 	}{
 		{"pay_as_you_go", "PAY_AS_YOU_GO"},
 		{"pay_up_front", "PAY_UP_FRONT"},
+		{"free_trial", "FREE_TRIAL"},
 	}
 
 	for _, tc := range tests {

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -148,6 +148,9 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	if !strings.Contains(offerCodesUsage, `--prices "US:PRICE_POINT_ID"`) {
 		t.Fatalf("expected subscriptions offers offer-codes help to show territory-qualified price examples, got %q", offerCodesUsage)
 	}
+	if !strings.Contains(offerCodesUsage, `--prices "US"`) {
+		t.Fatalf("expected subscriptions offers offer-codes help to show FREE_TRIAL territory examples, got %q", offerCodesUsage)
+	}
 	if strings.Contains(offerCodesUsage, `--prices "PRICE_ID"`) {
 		t.Fatalf("expected subscriptions offers offer-codes help to drop stale price example, got %q", offerCodesUsage)
 	}

--- a/internal/cli/cmdtest/subscriptions_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/subscriptions_offer_codes_output_test.go
@@ -133,7 +133,7 @@ func TestSubscriptionsOfferCodesCreateNormalizesValuesAndBuildsPayload(t *testin
 	}
 }
 
-func TestSubscriptionsOfferCodesCreateFreeTrialOmitsPrices(t *testing.T) {
+func TestSubscriptionsOfferCodesCreateFreeTrialIncludesTerritoryOnlyPrice(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -169,11 +169,36 @@ func TestSubscriptionsOfferCodesCreateFreeTrialOmitsPrices(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected payload.data.relationships to be an object, got %T", data["relationships"])
 		}
-		if _, ok := relationships["prices"]; ok {
-			t.Fatalf("expected no prices relationship for FREE_TRIAL, but found one: %#v", relationships["prices"])
+		pricesRelationship, ok := relationships["prices"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected prices relationship for FREE_TRIAL, got %#v", relationships["prices"])
 		}
-		if _, ok := payload["included"]; ok {
-			t.Fatalf("expected no included entries for FREE_TRIAL, but found some: %#v", payload["included"])
+		priceRefs, ok := pricesRelationship["data"].([]any)
+		if !ok || len(priceRefs) != 1 {
+			t.Fatalf("expected one price relationship, got %#v", pricesRelationship["data"])
+		}
+		included, ok := payload["included"].([]any)
+		if !ok || len(included) != 1 {
+			t.Fatalf("expected one included price, got %#v", payload["included"])
+		}
+		includedPrice, ok := included[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected included price object, got %T", included[0])
+		}
+		priceRelationships, ok := includedPrice["relationships"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected included price relationships, got %T", includedPrice["relationships"])
+		}
+		territory, ok := priceRelationships["territory"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected territory relationship, got %#v", priceRelationships["territory"])
+		}
+		territoryData, ok := territory["data"].(map[string]any)
+		if !ok || territoryData["id"] != "DEU" {
+			t.Fatalf("expected normalized territory DEU, got %#v", territory["data"])
+		}
+		if _, ok := priceRelationships["subscriptionPricePoint"]; ok {
+			t.Fatalf("expected subscriptionPricePoint to be omitted, got %#v", priceRelationships["subscriptionPricePoint"])
 		}
 
 		body := `{"data":{"type":"subscriptionOfferCodes","id":"sub-offer-ft-1","attributes":{"name":"One Year Free","active":true}}}`
@@ -197,6 +222,7 @@ func TestSubscriptionsOfferCodesCreateFreeTrialOmitsPrices(t *testing.T) {
 			"--offer-duration", "one_year",
 			"--offer-mode", "free_trial",
 			"--number-of-periods", "1",
+			"--prices", "de",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -222,13 +248,14 @@ func TestSubscriptionsOfferCodesCreateFreeTrialOmitsPrices(t *testing.T) {
 	}
 }
 
-func TestSubscriptionsOfferCodesCreateNonFreeTrialRequiresPrices(t *testing.T) {
+func TestSubscriptionsOfferCodesCreateRequiresPrices(t *testing.T) {
 	tests := []struct {
 		name      string
 		offerMode string
 	}{
 		{"pay_as_you_go", "pay_as_you_go"},
 		{"pay_up_front", "pay_up_front"},
+		{"free_trial", "free_trial"},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/offercodes/offer_codes_test.go
+++ b/internal/cli/offercodes/offer_codes_test.go
@@ -1,6 +1,10 @@
 package offercodes
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
 
 func TestOfferCodesCommandConstructors(t *testing.T) {
 	constructors := []func() any{
@@ -17,7 +21,7 @@ func TestOfferCodesCommandConstructors(t *testing.T) {
 }
 
 func TestParseOfferCodePrices(t *testing.T) {
-	prices, err := parseOfferCodePrices("US:pp-1, France:pp-2")
+	prices, err := parseOfferCodePrices("US:pp-1, France:pp-2", asc.SubscriptionOfferModePayAsYouGo)
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -31,7 +35,7 @@ func TestParseOfferCodePrices(t *testing.T) {
 		t.Fatalf("unexpected second price: %+v", prices[1])
 	}
 
-	prices, err = parseOfferCodePrices("Moldova, Republic of:pp-1,Bolivia, Plurinational State of:pp-2")
+	prices, err = parseOfferCodePrices("Moldova, Republic of:pp-1,Bolivia, Plurinational State of:pp-2", asc.SubscriptionOfferModePayUpFront)
 	if err != nil {
 		t.Fatalf("unexpected parse error for comma-containing territory names: %v", err)
 	}
@@ -45,10 +49,27 @@ func TestParseOfferCodePrices(t *testing.T) {
 		t.Fatalf("unexpected second comma-name price: %+v", prices[1])
 	}
 
-	if _, err := parseOfferCodePrices("usa-pp-1"); err == nil {
+	freeTrialPrices, err := parseOfferCodePrices("DE, France", asc.SubscriptionOfferModeFreeTrial)
+	if err != nil {
+		t.Fatalf("unexpected FREE_TRIAL parse error: %v", err)
+	}
+	if len(freeTrialPrices) != 2 {
+		t.Fatalf("expected 2 FREE_TRIAL prices, got %d", len(freeTrialPrices))
+	}
+	if freeTrialPrices[0].TerritoryID != "DEU" || freeTrialPrices[0].PricePointID != "" {
+		t.Fatalf("unexpected first FREE_TRIAL price: %+v", freeTrialPrices[0])
+	}
+	if freeTrialPrices[1].TerritoryID != "FRA" || freeTrialPrices[1].PricePointID != "" {
+		t.Fatalf("unexpected second FREE_TRIAL price: %+v", freeTrialPrices[1])
+	}
+
+	if _, err := parseOfferCodePrices("usa-pp-1", asc.SubscriptionOfferModePayAsYouGo); err == nil {
 		t.Fatal("expected parse error for malformed prices")
 	}
-	if _, err := parseOfferCodePrices("Atlantis:pp-1"); err == nil {
+	if _, err := parseOfferCodePrices("Atlantis:pp-1", asc.SubscriptionOfferModePayAsYouGo); err == nil {
 		t.Fatal("expected parse error for invalid territory")
+	}
+	if _, err := parseOfferCodePrices("USA:pp-1", asc.SubscriptionOfferModeFreeTrial); err == nil {
+		t.Fatal("expected FREE_TRIAL price point rejection")
 	}
 }

--- a/internal/cli/offercodes/subscription_offer_codes.go
+++ b/internal/cli/offercodes/subscription_offer_codes.go
@@ -70,7 +70,22 @@ var offerCodeCustomerEligibilityMap = map[string]asc.SubscriptionCustomerEligibi
 	string(asc.SubscriptionCustomerEligibilityExpired):  asc.SubscriptionCustomerEligibilityExpired,
 }
 
-func parseOfferCodePrices(value string) ([]asc.SubscriptionOfferCodePrice, error) {
+func parseOfferCodePrices(value string, mode asc.SubscriptionOfferMode) ([]asc.SubscriptionOfferCodePrice, error) {
+	if mode == asc.SubscriptionOfferModeFreeTrial {
+		if strings.Contains(value, ":") {
+			return nil, fmt.Errorf("--prices for FREE_TRIAL must use TERRITORY entries without price point IDs")
+		}
+		territoryIDs, err := shared.NormalizeASCTerritoryCSV(value)
+		if err != nil {
+			return nil, err
+		}
+		prices := make([]asc.SubscriptionOfferCodePrice, 0, len(territoryIDs))
+		for _, territoryID := range territoryIDs {
+			prices = append(prices, asc.SubscriptionOfferCodePrice{TerritoryID: territoryID})
+		}
+		return prices, nil
+	}
+
 	entries, err := shared.ParseASCTerritoryValueCSV(value)
 	if err != nil {
 		return nil, err
@@ -124,7 +139,7 @@ func OfferCodesCreateCommand() *ffcli.Command {
 	var numberOfPeriods optionalInt
 	fs.Var(&numberOfPeriods, "number-of-periods", "Number of periods (required)")
 	autoRenewEnabled := fs.String("auto-renew-enabled", "", "Auto-renew enabled (true/false)")
-	prices := fs.String("prices", "", "Offer code prices: TERRITORY:PRICE_POINT_ID entries (required)")
+	prices := fs.String("prices", "", "Offer code prices (required): TERRITORY entries for FREE_TRIAL or TERRITORY:PRICE_POINT_ID entries for paid modes; territory accepts alpha-2, alpha-3, or exact English country name")
 	priceIDs := fs.String("price-id", "", "Deprecated: use --prices")
 	output := shared.BindOutputFlags(fs)
 
@@ -135,7 +150,7 @@ func OfferCodesCreateCommand() *ffcli.Command {
 		LongHelp: `Create a subscription offer code.
 
 Examples:
-  asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "USA"
   asc offer-codes create --subscription-id "SUB_ID" --name "SPRING" --customer-eligibilities NEW --offer-eligibility STACK_WITH_INTRO_OFFERS --duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "USA:PRICE_POINT_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -200,16 +215,12 @@ Examples:
 			if pricesValue == "" {
 				pricesValue = strings.TrimSpace(*priceIDs)
 			}
-			priceEntries, err := parseOfferCodePrices(pricesValue)
+			priceEntries, err := parseOfferCodePrices(pricesValue, offerModeValue)
 			if err != nil {
 				return fmt.Errorf("offer-codes create: %w", err)
 			}
-			if len(priceEntries) == 0 && offerModeValue != asc.SubscriptionOfferModeFreeTrial {
+			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
-			}
-			if len(priceEntries) > 0 && offerModeValue == asc.SubscriptionOfferModeFreeTrial {
-				fmt.Fprintln(os.Stderr, "Error: --prices must not be set for FREE_TRIAL offers")
 				return flag.ErrHelp
 			}
 

--- a/internal/cli/offercodes/subscription_offer_codes.go
+++ b/internal/cli/offercodes/subscription_offer_codes.go
@@ -217,7 +217,8 @@ Examples:
 			}
 			priceEntries, err := parseOfferCodePrices(pricesValue, offerModeValue)
 			if err != nil {
-				return fmt.Errorf("offer-codes create: %w", err)
+				fmt.Fprintln(os.Stderr, "Error:", err.Error())
+				return flag.ErrHelp
 			}
 			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -203,7 +203,22 @@ func normalizeSubscriptionCustomerEligibilities(value string) ([]asc.Subscriptio
 	return eligibilities, nil
 }
 
-func parseSubscriptionOfferCodePrices(value string) ([]asc.SubscriptionOfferCodePrice, error) {
+func parseSubscriptionOfferCodePrices(value string, mode asc.SubscriptionOfferMode) ([]asc.SubscriptionOfferCodePrice, error) {
+	if mode == asc.SubscriptionOfferModeFreeTrial {
+		if strings.Contains(value, ":") {
+			return nil, fmt.Errorf("--prices for FREE_TRIAL must use TERRITORY entries without price point IDs")
+		}
+		territoryIDs, err := shared.NormalizeASCTerritoryCSV(value)
+		if err != nil {
+			return nil, err
+		}
+		prices := make([]asc.SubscriptionOfferCodePrice, 0, len(territoryIDs))
+		for _, territoryID := range territoryIDs {
+			prices = append(prices, asc.SubscriptionOfferCodePrice{TerritoryID: territoryID})
+		}
+		return prices, nil
+	}
+
 	entries, err := shared.ParseASCTerritoryValueCSV(value)
 	if err != nil {
 		return nil, err

--- a/internal/cli/subscriptions/helpers_more_test.go
+++ b/internal/cli/subscriptions/helpers_more_test.go
@@ -67,7 +67,7 @@ func TestNormalizeSubscriptionCustomerEligibilities(t *testing.T) {
 }
 
 func TestParseSubscriptionOfferCodePrices(t *testing.T) {
-	prices, err := parseSubscriptionOfferCodePrices("US:pp-1, France:pp-2")
+	prices, err := parseSubscriptionOfferCodePrices("US:pp-1, France:pp-2", asc.SubscriptionOfferModePayAsYouGo)
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestParseSubscriptionOfferCodePrices(t *testing.T) {
 		t.Fatalf("unexpected second price: %+v", prices[1])
 	}
 
-	prices, err = parseSubscriptionOfferCodePrices("Moldova, Republic of:pp-1,Bolivia, Plurinational State of:pp-2")
+	prices, err = parseSubscriptionOfferCodePrices("Moldova, Republic of:pp-1,Bolivia, Plurinational State of:pp-2", asc.SubscriptionOfferModePayUpFront)
 	if err != nil {
 		t.Fatalf("unexpected parse error for comma-containing territory names: %v", err)
 	}
@@ -95,13 +95,30 @@ func TestParseSubscriptionOfferCodePrices(t *testing.T) {
 		t.Fatalf("unexpected second comma-name price: %+v", prices[1])
 	}
 
-	if _, err := parseSubscriptionOfferCodePrices("usa-pp-1"); err == nil {
+	freeTrialPrices, err := parseSubscriptionOfferCodePrices("DE, France", asc.SubscriptionOfferModeFreeTrial)
+	if err != nil {
+		t.Fatalf("unexpected FREE_TRIAL parse error: %v", err)
+	}
+	if len(freeTrialPrices) != 2 {
+		t.Fatalf("expected 2 FREE_TRIAL prices, got %d", len(freeTrialPrices))
+	}
+	if freeTrialPrices[0].TerritoryID != "DEU" || freeTrialPrices[0].PricePointID != "" {
+		t.Fatalf("unexpected first FREE_TRIAL price: %+v", freeTrialPrices[0])
+	}
+	if freeTrialPrices[1].TerritoryID != "FRA" || freeTrialPrices[1].PricePointID != "" {
+		t.Fatalf("unexpected second FREE_TRIAL price: %+v", freeTrialPrices[1])
+	}
+
+	if _, err := parseSubscriptionOfferCodePrices("usa-pp-1", asc.SubscriptionOfferModePayAsYouGo); err == nil {
 		t.Fatal("expected parse error for malformed input")
 	}
-	if _, err := parseSubscriptionOfferCodePrices("usa:"); err == nil {
+	if _, err := parseSubscriptionOfferCodePrices("usa:", asc.SubscriptionOfferModePayAsYouGo); err == nil {
 		t.Fatal("expected parse error for missing price point id")
 	}
-	if _, err := parseSubscriptionOfferCodePrices("Atlantis:pp-1"); err == nil {
+	if _, err := parseSubscriptionOfferCodePrices("Atlantis:pp-1", asc.SubscriptionOfferModePayAsYouGo); err == nil {
 		t.Fatal("expected parse error for invalid territory")
+	}
+	if _, err := parseSubscriptionOfferCodePrices("USA:pp-1", asc.SubscriptionOfferModeFreeTrial); err == nil {
+		t.Fatal("expected FREE_TRIAL price point rejection")
 	}
 }

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -27,7 +27,7 @@ func SubscriptionsOfferCodesCommand() *ffcli.Command {
 Examples:
   asc subscriptions offers offer-codes list --subscription-id "SUB_ID"
   asc subscriptions offers offer-codes list --subscription-id "SUB_ID" --output table
-  asc subscriptions offers offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US"
   asc subscriptions offers offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"
   asc subscriptions offers offer-codes generate --offer-code-id "OFFER_CODE_ID" --quantity 10 --expiration-date "2026-02-01"
   asc subscriptions offers offer-codes one-time-codes list --offer-code-id "OFFER_CODE_ID"
@@ -225,7 +225,7 @@ func SubscriptionsOfferCodesCreateCommand() *ffcli.Command {
 	offerDuration := fs.String("offer-duration", "", "Offer duration: "+strings.Join(subscriptionOfferDurationValues, ", "))
 	offerMode := fs.String("offer-mode", "", "Offer mode: "+strings.Join(subscriptionOfferModeValues, ", "))
 	numberOfPeriods := fs.Int("number-of-periods", 0, "Number of periods (required)")
-	prices := fs.String("prices", "", "Offer code prices: TERRITORY:PRICE_POINT_ID entries (territory accepts alpha-2, alpha-3, or exact English country name)")
+	prices := fs.String("prices", "", "Offer code prices (required): TERRITORY entries for FREE_TRIAL or TERRITORY:PRICE_POINT_ID entries for paid modes; territory accepts alpha-2, alpha-3, or exact English country name")
 	var autoRenewEnabled shared.OptionalBool
 	fs.Var(&autoRenewEnabled, "auto-renew-enabled", "Enable auto-renew: true or false")
 	output := shared.BindOutputFlags(fs)
@@ -237,7 +237,7 @@ func SubscriptionsOfferCodesCreateCommand() *ffcli.Command {
 		LongHelp: `Create an offer code.
 
 Examples:
-  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US"
   asc subscriptions offer-codes create --subscription-id "SUB_ID" --name "SPRING" --offer-eligibility STACK_WITH_INTRO_OFFERS --customer-eligibilities NEW --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -283,17 +283,13 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			priceEntries, err := parseSubscriptionOfferCodePrices(*prices)
+			priceEntries, err := parseSubscriptionOfferCodePrices(*prices, mode)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp
 			}
-			if len(priceEntries) == 0 && mode != asc.SubscriptionOfferModeFreeTrial {
+			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
-			}
-			if len(priceEntries) > 0 && mode == asc.SubscriptionOfferModeFreeTrial {
-				fmt.Fprintln(os.Stderr, "Error: --prices must not be set for FREE_TRIAL offers")
 				return flag.ErrHelp
 			}
 


### PR DESCRIPTION
## Summary

- require the `prices` relationship for subscription offer codes in every offer mode
- accept territory-only `--prices` entries for `FREE_TRIAL`, while paid modes continue to require `TERRITORY:PRICE_POINT_ID`
- omit `subscriptionPricePoint` from inline FREE_TRIAL price resources
- update help, API notes, payload tests, CLI tests, selector tests, and exit-code coverage

Fixes #1659.

## Root cause

The previous #1502 fix treated Apple's earlier 409 as meaning the entire `prices` relationship must be omitted for `FREE_TRIAL`. Current live behavior is more specific: `prices` is required for territory selection, but each FREE_TRIAL inline price must omit `subscriptionPricePoint`.

## CLI behavior

```bash
# FREE_TRIAL: territory entries only
asc subscriptions offers offer-codes create \
  --subscription-id "SUB_ID" \
  --name "One Year Free" \
  --offer-eligibility REPLACE_INTRO_OFFERS \
  --customer-eligibilities NEW,EXISTING,EXPIRED \
  --offer-duration ONE_YEAR \
  --offer-mode FREE_TRIAL \
  --number-of-periods 1 \
  --prices "DEU,FRA"

# Paid modes: territory and price point pairs
asc subscriptions offers offer-codes create \
  --subscription-id "SUB_ID" \
  --name "Spring" \
  --offer-eligibility STACK_WITH_INTRO_OFFERS \
  --customer-eligibilities NEW \
  --offer-duration ONE_MONTH \
  --offer-mode PAY_AS_YOU_GO \
  --number-of-periods 1 \
  --prices "DEU:PRICE_POINT_ID"
```

Missing `--prices`, FREE_TRIAL entries containing a price point, and paid entries missing a price point return usage exit code `2` with mode-specific errors.

## Design

This keeps the existing `--prices` surface and makes its syntax mode-aware. A separate `--territories` flag would be clearer in isolation but would split one API relationship across two flags and add unnecessary compatibility surface. Accepting `TERRITORY:` was also rejected because an empty-value syntax is easy to mistype and conflicts with the existing parser's validation contract.

## Payload flow

```mermaid
flowchart LR
    A["offer-codes create"] --> B{"--offer-mode"}
    B -->|FREE_TRIAL| C["--prices DEU,FRA"]
    C --> D["Inline price resources"]
    D --> E["territory: present"]
    D --> F["subscriptionPricePoint: omitted"]
    B -->|Paid modes| G["--prices DEU:PRICE_POINT_ID"]
    G --> H["Inline price resources"]
    H --> I["territory: present"]
    H --> J["subscriptionPricePoint: present"]
    E --> K["POST /v1/subscriptionOfferCodes"]
    F --> K
    I --> K
    J --> K
```

## Verification

- reproduced current-main failure with a built binary: FREE_TRIAL plus `--prices DEU:PRICE_POINT_ID` exited `2` before HTTP
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- built-binary invalid cases: missing FREE_TRIAL prices, FREE_TRIAL price point, and paid territory-only input all exited `2`
- live smoke against disposable app `6759231657`, subscription `6759789022`: FREE_TRIAL create with `--prices JPN` returned HTTP `201` and one price whose encoded price component was empty
- temporary live offer `c755f2ea-bdc5-4798-b3bb-d4df163adda1` (`codex-issue-1659-1781555790`) was deactivated after verification; App Store Connect exposes no delete command for this resource


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API Notes and CLI help to clarify `subscriptionOfferCodes` `prices` rules by offer mode, including `FREE_TRIAL` requiring territory-only entries.

* **New Features**
  * `FREE_TRIAL` offer code creation now supports `--prices` in territory-only format (for example, `--prices "US"`).

* **Bug Fixes**
  * Validation and payload generation updated so `FREE_TRIAL` requires `prices` and omits `subscriptionPricePoint`; relationship encoding is now consistent across offer modes.

* **Tests**
  * Expanded coverage for `FREE_TRIAL` request bodies, validation error messages, and legacy formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
