### PR TITLE
Fix next-build-number with zero build upload

### DIFF
--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -286,7 +286,10 @@ func TestBuildsNextBuildNumberSkipsNonPositiveBuildUploadNumber(t *testing.T) {
 				t.Fatalf("expected filter[cfBundleShortVersionString]=1.2.3, got %q", query.Get("filter[cfBundleShortVersionString]"))
 			}
 			return jsonHTTPResponse(http.StatusOK, `{
-				"data":[{"type":"buildUploads","id":"expired-upload","attributes":{"cfBundleVersion":"0"}}],
+				"data":[
+					{"type":"buildUploads","id":"expired-upload","attributes":{"cfBundleVersion":"0"}},
+					{"type":"buildUploads","id":"spaced-zero-upload","attributes":{"cfBundleVersion":"0 .1"}}
+				],
 				"links":{"next":""}
 			}`), nil
 

--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -252,6 +252,90 @@ func TestBuildsNextBuildNumberWithFiltersUsesCanonicalQueryShape(t *testing.T) {
 	}
 }
 
+func TestBuildsNextBuildNumberSkipsNonPositiveBuildUploadNumber(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/preReleaseVersions":
+			query := req.URL.Query()
+			if query.Get("filter[app]") != "100000001" {
+				t.Fatalf("expected filter[app]=100000001, got %q", query.Get("filter[app]"))
+			}
+			if query.Get("filter[version]") != "1.2.3" {
+				t.Fatalf("expected filter[version]=1.2.3, got %q", query.Get("filter[version]"))
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"preReleaseVersions","id":"prv-1","attributes":{"version":"1.2.3","platform":"IOS"}}]}`), nil
+
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
+			query := req.URL.Query()
+			if query.Get("filter[expired]") != "false" {
+				t.Fatalf("expected filter[expired]=false, got %q", query.Get("filter[expired]"))
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
+
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
+			query := req.URL.Query()
+			if query.Get("filter[cfBundleShortVersionString]") != "1.2.3" {
+				t.Fatalf("expected filter[cfBundleShortVersionString]=1.2.3, got %q", query.Get("filter[cfBundleShortVersionString]"))
+			}
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[{"type":"buildUploads","id":"expired-upload","attributes":{"cfBundleVersion":"0"}}],
+				"links":{"next":""}
+			}`), nil
+
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "next-build-number",
+			"--app", "100000001",
+			"--version", "1.2.3",
+			"--exclude-expired",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var out struct {
+		LatestUploadBuildNumber *string  `json:"latestUploadBuildNumber"`
+		NextBuildNumber         string   `json:"nextBuildNumber"`
+		SourcesConsidered       []string `json:"sourcesConsidered"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if out.LatestUploadBuildNumber != nil {
+		t.Fatalf("expected invalid upload number to be ignored, got %v", *out.LatestUploadBuildNumber)
+	}
+	if out.NextBuildNumber != "1" {
+		t.Fatalf("expected nextBuildNumber=1, got %q", out.NextBuildNumber)
+	}
+	if len(out.SourcesConsidered) != 0 {
+		t.Fatalf("expected no sources considered, got %v", out.SourcesConsidered)
+	}
+}
+
 func TestBuildsNextBuildNumberVersionFilterIgnoresNearMatchPreReleaseVersions(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/shared/build_numbers.go
+++ b/internal/cli/shared/build_numbers.go
@@ -549,7 +549,9 @@ func isNonPositiveNumericBuildNumber(raw string) bool {
 	if len(segments) == 0 {
 		return false
 	}
-	for _, segment := range segments {
+	for i, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		segments[i] = segment
 		if segment == "" {
 			return false
 		}

--- a/internal/cli/shared/build_numbers.go
+++ b/internal/cli/shared/build_numbers.go
@@ -506,6 +506,9 @@ func findLatestBuildUploadNumber(ctx context.Context, client *asc.Client, appID,
 
 	processPage := func(page *asc.BuildUploadsResponse) error {
 		for _, upload := range page.Data {
+			if isNonPositiveNumericBuildNumber(upload.Attributes.CFBundleVersion) {
+				continue
+			}
 			parsed, err := parseBuildNumber(upload.Attributes.CFBundleVersion, fmt.Sprintf("build upload %s", upload.ID))
 			if err != nil {
 				return err
@@ -534,6 +537,31 @@ func findLatestBuildUploadNumber(ctx context.Context, client *asc.Client, appID,
 	}
 
 	return latestUploadValue, latestUploadNumber, hasUpload, nil
+}
+
+func isNonPositiveNumericBuildNumber(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+
+	segments := strings.Split(trimmed, ".")
+	if len(segments) == 0 {
+		return false
+	}
+	for _, segment := range segments {
+		if segment == "" {
+			return false
+		}
+		for _, ch := range segment {
+			if ch < '0' || ch > '9' {
+				return false
+			}
+		}
+	}
+
+	value, err := strconv.ParseInt(segments[0], 10, 64)
+	return err == nil && value < 1
 }
 
 type buildNumber struct {


### PR DESCRIPTION
## Summary

Fix `asc builds next-build-number` so completed or expired build uploads with `cfBundleVersion` set to `0` do not make the command fail while calculating the next build number.

## Why This Is Needed

App Store Connect can leave behind completed/expired build upload records whose `cfBundleVersion` is `0`. We saw this with a real upload returned by the build upload API. Today, `next-build-number --exclude-expired` still scans build uploads after filtering processed builds, parses every upload build number, and fails with:

```text
failed to paginate build uploads: page 1: build upload <id> build number "0" must be >= 1
```

That means a stale invalid upload can break build-number automation even though `0` can never be a valid next-build-number candidate. The command should ignore that upload and continue choosing from valid processed builds, valid uploads, or the configured initial build number.

## What Changed

- Skip build upload candidates whose numeric first component is below `1` before parsing them as valid build numbers.
- Keep existing strict errors for malformed non-numeric build upload values, so unexpected bad API data still surfaces.
- Add a CLI-level regression test covering `next-build-number --exclude-expired` with an upload whose `cfBundleVersion` is `0`.

## Behavior

Example invocation that previously failed:

```bash
asc builds next-build-number --app <appid> --version <version> --exclude-expired
```

With this change, an upload with `cfBundleVersion: "0"` is ignored as an invalid candidate instead of aborting the command.

## Validation

- `PATH="$(go env GOPATH)/bin:$PATH" make format`
- `make check-command-docs`
- `make lint` (used repo fallback to `go vet ./...` because `golangci-lint` is not installed locally)
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestBuildsNextBuildNumber' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/shared -run 'Test.*BuildNumber|Test.*BuildTimestamp' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build number calculation by skipping app store build uploads with non-positive `CFBundleVersion` values (e.g., `"0"`), preventing them from interfering with determining the next valid build number.
  * Added a CLI test covering scenarios where only non-positive build upload versions are returned, ensuring the next build number is computed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->