### PR TITLE
apps wall: add Tessera - Car Black Box

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1391,6 +1391,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f4/f1/65/f4f165e3-9826-8ced-d9be-d33b8a8e154c/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Tessera - Car Black Box",
+    "link": "https://apps.apple.com/us/app/tessera-car-black-box/id6778605690?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6a/8b/a1/6a8ba19d-72e9-bd02-a39a-188c9d936f9f/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "text to speech · speakeasy",
     "link": "https://apps.apple.com/app/id6758816495",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/0a/49/48/0a49486e-92b3-37b5-8bb8-c038aee9a0a4/speakeasy-icon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Tessera - Car Black Box` to the Wall of Apps

## Entry

- App ID: 6778605690
- App: Tessera - Car Black Box
- Link: https://apps.apple.com/us/app/tessera-car-black-box/id6778605690?uo=4

## Notes

- Submitted via `asc apps wall submit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tessera - Car Black Box app to the app showcase with App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->