### PR TITLE
apps wall: add Matchday - Soccer Planner

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -743,6 +743,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/25/2c/78/252c787f-d9e8-738e-51fb-61c64ee95c32/AppIcon-1x_U007emarketing-0-10-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Matchday - Soccer Planner",
+    "link": "https://apps.apple.com/us/app/matchday-soccer-planner/id6776015801?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d5/d8/af/d5d8af6c-325a-56f9-6c88-36b787e6bdc5/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "MD Clock - Flip Clock",
     "link": "https://apps.apple.com/us/app/md-clock-flip-clock/id1536358464?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4c/07/b7/4c07b7c5-0612-7f65-0b65-91594843e0fb/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Matchday - Soccer Planner` to the Wall of Apps

## Entry

- App ID: 6776015801
- App: Matchday - Soccer Planner
- Link: https://apps.apple.com/us/app/matchday-soccer-planner/id6776015801?uo=4

## Notes

- Submitted via `asc apps wall submit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Matchday - Soccer Planner” entry to the app listings, including its Apple App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->