### PR TITLE
apps wall: add Cairn - Your Expense Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -150,6 +150,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f8/91/a8/f891a8c5-d49e-a5bf-83f4-cbe86e0eac04/CabinLink-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Cairn - Your Expense Tracker",
+    "link": "https://apps.apple.com/us/app/cairn-your-expense-tracker/id6762088614?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/3d/7e/ab/3d7eabc0-2f4d-52b4-b629-5b979d65de14/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Cal AI - Calorie Tracker",
     "link": "https://apps.apple.com/us/app/cal-ai-calorie-tracker/id6480417616?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5e/5d/e9/5e5de9bc-18ef-3c07-79f0-e0a9e3009629/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Cairn - Your Expense Tracker` to the Wall of Apps

## Entry

- App ID: 6762088614
- App: Cairn - Your Expense Tracker
- Link: https://apps.apple.com/us/app/cairn-your-expense-tracker/id6762088614?uo=4

## Notes

- Submitted via `asc apps wall submit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Cairn - Your Expense Tracker” to the app gallery, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->