### PR TITLE
apps wall: add Vigil: Situation Room

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1511,6 +1511,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f6/51/f5/f651f5b7-8052-5407-77ec-a4203bbf456c/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
+    "app": "Vigil: Situation Room",
+    "link": "https://apps.apple.com/us/app/vigil-situation-room/id6773060534?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5e/39/70/5e397004-de16-52f5-051c-03a5bf09db23/AppIcon.lsr/512x512bb.jpg"
+  },
+  {
     "app": "Visa Day Tracker: Residency",
     "link": "https://apps.apple.com/us/app/visa-day-tracker-residency/id6749048224?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/73/d0/88/73d088d4-104c-b8ea-4b0d-863da7932f6d/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Vigil: Situation Room` to the Wall of Apps

## Entry

- App ID: 6773060534
- App: Vigil: Situation Room
- Link: https://apps.apple.com/us/app/vigil-situation-room/id6773060534?uo=4

## Notes

- Submitted via `asc apps wall submit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new “Vigil: Situation Room” app entry to the app directory, including its App Store link and icon URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->