### PR TITLE
apps wall: add Hush for visionOS

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -573,6 +573,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/7b/43/73/7b4373fc-26e2-030b-7162-2f0ab0a7681d/AppIcon-0-0-1x_U007ewatch-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Hush for visionOS",
+    "link": "https://apps.apple.com/us/app/hush-for-visionos/id6770631510?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f2/00/bf/f200bf3b-4f19-5cf4-d08b-f65e39137346/AppIcon.lsr/512x512bb.jpg"
+  },
+  {
     "app": "iCardSort",
     "link": "https://apps.apple.com/us/app/icardsort/id384552728?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/91/5d/55/915d552c-3b3d-a636-622c-525e4d4ca4e2/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Hush for visionOS` to the Wall of Apps

## Entry

- App ID: 6770631510
- App: Hush for visionOS
- Link: https://apps.apple.com/us/app/hush-for-visionos/id6770631510?uo=4

## Notes

- Submitted via `asc apps wall submit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Hush for visionOS” application entry to the apps directory, including App Store link and icon details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->