### PR TITLE
[codex] disclose telemetry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Automate iOS, macOS, tvOS, and visionOS release workflows from your terminal, ID
 - [Sponsors](#sponsors)
 - [Quick Start](#quick-start)
 - [Troubleshooting](#troubleshooting)
+- [Privacy and telemetry](#privacy-and-telemetry)
 - [Support](#support)
 - [Wall of Apps](#wall-of-apps)
 - [Common Workflows](#common-workflows)
@@ -177,6 +178,33 @@ depending on a command in CI or scripts:
 - Use an explicit format when scripting or sharing repro steps: `--output json`, `--output table`, or `--output markdown`
 - Use `--pretty` with JSON when you want readable output in terminals or bug reports
 - Set a personal default with `ASC_DEFAULT_OUTPUT`, but remember `--output` always wins
+
+## Privacy and telemetry
+
+`asc` sends pseudonymous command-level usage telemetry by default to help
+maintainers understand which commands are used and where reliability work is
+needed. Local events include a random installation ID, which lets events from
+one installation be grouped over time; it is not derived from an Apple account
+or machine identifier.
+
+Telemetry includes the CLI version, operating system and architecture,
+registered command path, duration and exit outcome, runtime context, invocation
+source, and random event and session IDs. It does **not** include raw arguments
+or flag values, credentials, private keys, Apple account, team, or issuer IDs,
+app or bundle IDs, API responses, usernames, hostnames, repository names, or
+file paths.
+
+Review or change telemetry at any time:
+
+```bash
+asc telemetry status
+asc telemetry disable
+asc telemetry reset-id
+```
+
+`ASC_TELEMETRY_DISABLED=1` and `DO_NOT_TRACK=1` also disable telemetry. See the
+[telemetry reference](commands/telemetry.mdx) for the exact event payload,
+runtime handling, collector endpoint, and all controls.
 
 ## Support
 

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -147,7 +147,7 @@ Commands are organized into logical families based on functionality:
 * `completion` - Print shell completion scripts
 * `diff` - Generate deterministic non-mutating diff plans
 * `schema` - Inspect App Store Connect API endpoint schemas at runtime
-* `telemetry` - Manage anonymous CLI telemetry settings
+* `telemetry` - Manage CLI telemetry settings
 
 ## TTY-Aware Output Defaults
 

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -1,11 +1,16 @@
 # telemetry
 
-> Manage anonymous CLI telemetry settings
+> Manage CLI telemetry settings
 
-The `telemetry` command controls anonymous product telemetry for the CLI.
+The `telemetry` command controls pseudonymous product telemetry for the CLI.
 Telemetry records coarse command-level usage so maintainers can understand which
 commands are used, which versions are active, and where reliability work is
 needed.
+
+For local runs, a random installation ID groups events from the same
+installation over time. Because that identifier persists until it is reset,
+the telemetry is pseudonymous rather than strictly anonymous. The ID is not
+derived from an Apple account, person, or hardware identifier.
 
 Telemetry is enabled by default for every runtime. It remains enabled in CI,
 Rork sandboxes, Rork GitHub workflows, and explicitly ephemeral environments;
@@ -29,19 +34,19 @@ asc telemetry <subcommand>
 
 <ParamField path="status">
   Show whether telemetry is enabled, the local state path, endpoint, and the
-  anonymous local install ID when one exists.
+  random local install ID when one exists.
 </ParamField>
 
 <ParamField path="enable">
-  Enable anonymous telemetry in local CLI state.
+  Enable telemetry in local CLI state.
 </ParamField>
 
 <ParamField path="disable">
-  Disable anonymous telemetry in local CLI state.
+  Disable telemetry in local CLI state.
 </ParamField>
 
 <ParamField path="reset-id">
-  Reset the anonymous local install ID.
+  Reset the random local install ID.
 </ParamField>
 
 ## Examples

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -190,19 +190,19 @@ Configure default output formats.
 
 ## Telemetry variables
 
-Anonymous command-level CLI telemetry is enabled by default in local, agent,
-CI, and other ephemeral runtimes. Disposable runtimes omit the durable local
-install ID without disabling event delivery. Use these variables to opt out or
-adjust runtime handling.
+Pseudonymous command-level CLI telemetry is enabled by default in local, agent,
+CI, and other ephemeral runtimes. Local events include a random installation ID;
+disposable runtimes omit that ID without disabling event delivery. Use these
+variables to opt out or adjust runtime handling.
 
 <ParamField path="ASC_TELEMETRY_DISABLED" type="boolean">
-  Disable anonymous telemetry for the current process
+  Disable telemetry for the current process
 
   Set to `true`, `1`, `yes`, `y`, or `on` to disable telemetry.
 </ParamField>
 
 <ParamField path="DO_NOT_TRACK" type="boolean">
-  Disable anonymous telemetry for the current process
+  Disable telemetry for the current process
 
   Set to `true`, `1`, `yes`, `y`, or `on` to disable telemetry.
 </ParamField>

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -142,7 +142,7 @@ asc <subcommand> [flags]
 - `version` - Print version information and exit.
 - `completion` - Print shell completion scripts.
 - `schema` - Inspect App Store Connect API endpoint schemas at runtime.
-- `telemetry` - Manage anonymous CLI telemetry settings.
+- `telemetry` - Manage CLI telemetry settings.
 
 ## Scripting Tips
 

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -198,7 +198,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `completion` - Print shell completion scripts.
 - `schema` - Inspect App Store Connect API endpoint schemas at runtime.
 - `snitch` - Report CLI friction as a GitHub issue.
-- `telemetry` - Manage anonymous CLI telemetry settings.
+- `telemetry` - Manage CLI telemetry settings.
 
 ## Global Flags
 

--- a/internal/cli/telemetry/telemetry.go
+++ b/internal/cli/telemetry/telemetry.go
@@ -16,13 +16,14 @@ func TelemetryCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "telemetry",
 		ShortUsage: "asc telemetry <subcommand>",
-		ShortHelp:  "Manage anonymous CLI telemetry settings.",
-		LongHelp: `Manage anonymous CLI telemetry settings.
+		ShortHelp:  "Manage CLI telemetry settings.",
+		LongHelp: `Manage pseudonymous CLI telemetry settings.
 
-Telemetry is enabled by default and sends anonymous command-level usage events
-to help improve asc. It does not collect raw arguments, Apple account
-identifiers, app identifiers, bundle identifiers, usernames, hostnames, repo
-names, or paths. Use "asc telemetry disable" to opt out.
+Telemetry is enabled by default and sends command-level usage events to help
+improve asc. Local events include a random installation ID so activity from one
+installation can be grouped over time. It does not collect raw arguments, Apple
+account identifiers, app identifiers, bundle identifiers, usernames, hostnames,
+repo names, or paths. Use "asc telemetry disable" to opt out.
 
 Examples:
   asc telemetry status
@@ -52,7 +53,7 @@ func statusCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "status",
 		ShortUsage: "asc telemetry status [flags]",
-		ShortHelp:  "Show anonymous telemetry status.",
+		ShortHelp:  "Show telemetry status.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -84,11 +85,11 @@ func defaultStatusOutputFormat() string {
 }
 
 func enableCommand() *ffcli.Command {
-	return stateCommand("enable", "Enable anonymous telemetry.", true)
+	return stateCommand("enable", "Enable telemetry.", true)
 }
 
 func disableCommand() *ffcli.Command {
-	return stateCommand("disable", "Disable anonymous telemetry.", false)
+	return stateCommand("disable", "Disable telemetry.", false)
 }
 
 func stateCommand(name, help string, enabled bool) *ffcli.Command {
@@ -121,7 +122,7 @@ func resetIDCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "reset-id",
 		ShortUsage: "asc telemetry reset-id",
-		ShortHelp:  "Reset the anonymous local install ID.",
+		ShortHelp:  "Reset the random local install ID.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {


### PR DESCRIPTION
## Summary

- add a prominent **Privacy and telemetry** section to the README
- describe local telemetry as pseudonymous because it uses a persistent random installation ID
- list the collected categories, explicit exclusions, and opt-out controls
- align `asc telemetry --help`, generated command docs, and Mintlify pages with the same wording

## Why

XcodeBuildMCP uses a short README disclosure that points to detailed telemetry documentation. This follows the same structure while linking to the existing `commands/telemetry.mdx` reference so the exact payload and collector behavior stay in one place.

A README-only edit would have left the CLI claiming the data was anonymous. A second privacy document would duplicate the existing detailed telemetry reference and increase drift risk.

## Behavior

Telemetry behavior is unchanged. Local events still include a random UUID from `~/.asc/telemetry.json`; CI and other disposable runtimes omit it. The documented controls remain:

```bash
asc telemetry status
asc telemetry disable
asc telemetry reset-id
```

`ASC_TELEMETRY_DISABLED=1` and `DO_NOT_TRACK=1` continue to take precedence over local state.

## Verification

- `go run . --help`
- `go run . telemetry --help`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run '^TestTelemetry' -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- repository pre-commit checks

No command flags, payload fields, output schemas, or exit codes changed.