### PR TITLE
[codex] Add StoreKit Retention Messaging API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,22 @@ See [guides/apple-ads-playbooks.mdx](guides/apple-ads-playbooks.mdx) for
 operator playbooks covering credential safety, org inspection, read-only smoke
 tests, reporting, raw API usage, and guarded mutations.
 
+### StoreKit Retention Messaging
+
+Retention Messaging uses a dedicated In-App Purchase API key, separate from
+App Store Connect API credentials:
+
+```bash
+asc storekit auth login --name Production --key-id "KEY_ID" --issuer-id "ISSUER_ID" --private-key ./SubscriptionKey.p8 --bundle-id com.example.app
+asc storekit auth doctor --environment sandbox --network
+asc storekit retention-messaging messages list --environment sandbox --output json
+asc storekit retention-messaging endpoint view --environment production
+```
+
+See [docs/architecture/storekit-retention-messaging.md](docs/architecture/storekit-retention-messaging.md)
+for the endpoint map, message and image requirements, environment variables,
+and the full sandbox verification sequence.
+
 ## Commands and Reference
 
 Use built-in help as the source of truth:
@@ -405,6 +421,7 @@ For full command families, flags, and discovery patterns, see:
 - [docs/COMMANDS.md](docs/COMMANDS.md) - Command families and reference navigation
 - [docs/WORKFLOWS.md](docs/WORKFLOWS.md) - Reusable workflow patterns, including local Xcode to TestFlight
 - [guides/apple-ads-playbooks.mdx](guides/apple-ads-playbooks.mdx) - Apple Ads operator playbooks
+- [docs/architecture/storekit-retention-messaging.md](docs/architecture/storekit-retention-messaging.md) - Retention Messaging setup and sandbox verification
 - [docs/API_NOTES.md](docs/API_NOTES.md) - API quirks and behaviors
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) - CLI development and testing notes
 - [docs/TESTING.md](docs/TESTING.md) - Testing patterns and conventions

--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -54,7 +54,7 @@ var rootUsageGroups = []rootCommandGroup{
 	},
 	{
 		title:    "MONETIZATION COMMANDS",
-		commands: []string{"iap", "app-events", "subscriptions"},
+		commands: []string{"iap", "storekit", "app-events", "subscriptions"},
 	},
 	{
 		title:    "SIGNING COMMANDS",

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -105,6 +105,7 @@ asc <subcommand> [flags]
 ### Monetization
 
 - `iap` - Manage in-app purchases in App Store Connect.
+- `storekit` - Manage StoreKit server APIs with In-App Purchase API keys.
 - `app-events` - Manage App Store in-app events.
 - `subscriptions` - Manage subscription groups and subscriptions.
 

--- a/docs/architecture/storekit-retention-messaging.md
+++ b/docs/architecture/storekit-retention-messaging.md
@@ -1,0 +1,194 @@
+# StoreKit Retention Messaging Support
+
+Status: Implemented as stable
+Research date: June 18, 2026
+Target API: Retention Messaging API 1.0
+Target command root: `asc storekit`
+
+## Design
+
+Retention Messaging is a StoreKit server API, not an App Store Connect API
+resource. It has different production and sandbox hosts, a different error
+envelope, and dedicated In-App Purchase API keys. It therefore lives in
+`internal/storekit` and under the stable Monetization command root:
+
+```text
+asc storekit auth ...
+asc storekit retention-messaging ...
+```
+
+This keeps StoreKit credentials out of the existing `asc auth` profile pool and
+prevents an In-App Purchase key from being selected for an App Store Connect
+request. The App Store Connect OpenAPI snapshot under `docs/openapi` does not
+contain these endpoints.
+
+Alternatives considered:
+
+- Putting the commands under `asc subscriptions` would imply App Store Connect
+  authentication and API ownership, both of which are incorrect.
+- A raw HTTP command would expose the endpoints but would not safely validate
+  image constraints, message limits, environment selection, or destructive
+  operations.
+
+## Endpoint mapping
+
+| CLI command | Method and path |
+| --- | --- |
+| `images upload` | `PUT /inApps/v1/messaging/image/{imageIdentifier}` |
+| `images list` | `GET /inApps/v1/messaging/image/list` |
+| `images delete` | `DELETE /inApps/v1/messaging/image/{imageIdentifier}` |
+| `messages upload` | `PUT /inApps/v1/messaging/message/{messageIdentifier}` |
+| `messages list` | `GET /inApps/v1/messaging/message/list` |
+| `messages delete` | `DELETE /inApps/v1/messaging/message/{messageIdentifier}` |
+| `defaults set` | `PUT /inApps/v1/messaging/default/{productId}/{locale}` |
+| `defaults view` | `GET /inApps/v1/messaging/default/{productId}/{locale}` |
+| `defaults delete` | `DELETE /inApps/v1/messaging/default/{productId}/{locale}` |
+| `endpoint set` | `PUT /inApps/v1/messaging/realtime/url` |
+| `endpoint view` | `GET /inApps/v1/messaging/realtime/url` |
+| `endpoint delete` | `DELETE /inApps/v1/messaging/realtime/url` |
+| `performance start` | `POST /inApps/v1/messaging/performanceTest` |
+| `performance view` / `wait` | `GET /inApps/v1/messaging/performanceTest/result/{requestId}` |
+
+The base host is selected explicitly:
+
+- `production`: `https://api.storekit.apple.com`
+- `sandbox`: `https://api.storekit-sandbox.apple.com`
+
+Performance-test commands reject the production environment. `performance
+wait` polls no faster than every 10 seconds to remain within Apple's sandbox
+rate limit.
+
+## Authentication
+
+Create an In-App Purchase API key in App Store Connect after Apple grants
+Retention Messaging access. A browser session logged into App Store Connect can
+be used to complete Apple's access-request form, but browser cookies are not API
+credentials and the CLI does not read them.
+
+Store a named profile:
+
+```bash
+asc storekit auth login \
+  --name Production \
+  --key-id "$KEY_ID" \
+  --issuer-id "$ISSUER_ID" \
+  --private-key ./SubscriptionKey.p8 \
+  --bundle-id com.example.app
+```
+
+The keychain is preferred. Use `--bypass-keychain` for config-backed local
+development or CI. Environment authentication supports:
+
+```text
+ASC_STOREKIT_KEY_ID
+ASC_STOREKIT_ISSUER_ID
+ASC_STOREKIT_PRIVATE_KEY_PATH
+ASC_STOREKIT_PRIVATE_KEY
+ASC_STOREKIT_PRIVATE_KEY_B64
+ASC_STOREKIT_BUNDLE_ID
+ASC_STOREKIT_ENVIRONMENT
+ASC_STOREKIT_PROFILE
+ASC_STOREKIT_STRICT_AUTH
+ASC_STOREKIT_BYPASS_KEYCHAIN
+```
+
+Every request gets a newly signed ES256 JWT with `iss`, `iat`, `exp`,
+`aud=appstoreconnect-v1`, and `bid=<bundle-id>`. The private key is parsed once
+per client but tokens are never cached.
+
+## Input and output contract
+
+- The environment is always explicit through `--environment` or
+  `ASC_STOREKIT_ENVIRONMENT`; there is no risky production default.
+- Image and message identifiers are caller-generated UUIDs.
+- Images must be PNG without transparency. `FULL_SIZE` requires width 3840 and
+  height 160–2160; `BULLET_POINT` requires 1024×1024.
+- Message payloads use `--file` and reject unknown JSON fields. The CLI validates
+  Apple's text limits and requires alternative text for every image.
+- Deletes and credential logout require `--confirm`.
+- TTY-aware `json`, `table`, and `markdown` output is available on API commands.
+- Invalid flags and local payloads return usage exit code `2`. API and transport
+  failures return exit code `1` with Apple's error code and message.
+- Upload image and upload message are not idempotent. The client never retries
+  an ambiguous upload automatically.
+
+Example message file:
+
+```json
+{
+  "header": "Keep everything you unlocked",
+  "body": "Continue your subscription and keep access to every feature.",
+  "image": {
+    "imageIdentifier": "22222222-2222-4222-8222-222222222222",
+    "altText": "The Example app on an iPhone"
+  },
+  "headerPosition": "ABOVE_IMAGE"
+}
+```
+
+## Sandbox verification
+
+Use a disposable app and resources. The full live verification sequence is:
+
+```bash
+asc storekit auth doctor --environment sandbox --network
+
+asc storekit retention-messaging images upload \
+  --image-id 11111111-1111-4111-8111-111111111111 \
+  --image-size FULL_SIZE \
+  --file ./retention.png \
+  --environment sandbox
+
+asc storekit retention-messaging messages upload \
+  --message-id 33333333-3333-4333-8333-333333333333 \
+  --file ./message.json \
+  --environment sandbox
+
+asc storekit retention-messaging messages list --environment sandbox
+
+asc storekit retention-messaging defaults set \
+  --product-id com.example.monthly \
+  --locale en-US \
+  --message-id 33333333-3333-4333-8333-333333333333 \
+  --environment sandbox
+
+asc storekit retention-messaging endpoint set \
+  --url https://example.com/retention-messaging-api/ \
+  --environment sandbox
+
+asc storekit retention-messaging performance start \
+  --original-transaction-id 2000000000000000 \
+  --environment sandbox \
+  --wait
+```
+
+The original transaction ID must come from an actual StoreKit sandbox
+subscription purchase. The endpoint must be publicly reachable over HTTPS and
+implement Apple's Get Retention Message request/response contract. After the
+test reports `PASS`, configure the production URL with `--environment
+production`.
+
+Clean up disposable resources with the matching `delete --confirm` commands.
+Sandbox uploads are automatically approved, so list responses can be verified
+without waiting for Apple review.
+
+## Compatibility and tests
+
+This adds a new root and a new optional `storekit` config object. Existing
+commands, App Store Connect profiles, and output formats are unchanged. There
+is no deprecation or migration.
+
+The RED-to-GREEN test plan covers:
+
+- all 14 documented HTTP operations, request methods, paths, query values,
+  content types, and response decoding;
+- ES256 header and StoreKit JWT claims;
+- dedicated config credential lifecycle and strict environment resolution;
+- command discovery, local payload validation, confirmation gates, and output;
+- API error and millisecond `Retry-After` decoding;
+- built-binary usage exit code `2`.
+
+Live network verification is conditional on Apple granting access and valid
+`ASC_STOREKIT_*` credentials being present. It is not replaced by an App Store
+Connect browser login.
+

--- a/internal/cli/cmdtest/storekit_retention_test.go
+++ b/internal/cli/cmdtest/storekit_retention_test.go
@@ -153,9 +153,9 @@ func TestStoreKitAuthLoginStoresDedicatedProfile(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
-			"storekit", "auth", "login", "--name", "Retention",
-			"--key-id", "STOREKIT_KEY", "--issuer-id", "STOREKIT_ISSUER",
-			"--private-key", keyPath, "--bundle-id", "com.example.app",
+			"storekit", "auth", "login", "--name", " Retention ",
+			"--key-id", " STOREKIT_KEY ", "--issuer-id", " STOREKIT_ISSUER ",
+			"--private-key", " " + keyPath + " ", "--bundle-id", " com.example.app ",
 			"--bypass-keychain",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)

--- a/internal/cli/cmdtest/storekit_retention_test.go
+++ b/internal/cli/cmdtest/storekit_retention_test.go
@@ -260,6 +260,41 @@ func TestStoreKitMessagesUploadSuccess(t *testing.T) {
 	}
 }
 
+func TestStoreKitPerformanceWaitReturnsErrorForFailedTest(t *testing.T) {
+	setupStoreKitAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/inApps/v1/messaging/performanceTest/result/request-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"result":"FAIL","successRate":90,"numPending":0}`)),
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"storekit", "retention-messaging", "performance", "wait",
+			"--request-id", "request-1", "--environment", "sandbox", "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), `performance test "request-1" failed`) {
+		t.Fatalf("run error = %v", runErr)
+	}
+	if stderr != "" || !strings.Contains(stdout, `"result":"FAIL"`) {
+		t.Fatalf("stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
 func TestStoreKitInvalidValuesAreUsageErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/cmdtest/storekit_retention_test.go
+++ b/internal/cli/cmdtest/storekit_retention_test.go
@@ -1,0 +1,359 @@
+package cmdtest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+func TestStoreKitRetentionMessagingCommandTree(t *testing.T) {
+	root := RootCommand("1.2.3")
+	paths := [][]string{
+		{"storekit", "auth", "login"},
+		{"storekit", "auth", "status"},
+		{"storekit", "auth", "switch"},
+		{"storekit", "auth", "doctor"},
+		{"storekit", "auth", "logout"},
+		{"storekit", "retention-messaging", "images", "list"},
+		{"storekit", "retention-messaging", "images", "upload"},
+		{"storekit", "retention-messaging", "images", "delete"},
+		{"storekit", "retention-messaging", "messages", "list"},
+		{"storekit", "retention-messaging", "messages", "upload"},
+		{"storekit", "retention-messaging", "messages", "delete"},
+		{"storekit", "retention-messaging", "defaults", "view"},
+		{"storekit", "retention-messaging", "defaults", "set"},
+		{"storekit", "retention-messaging", "defaults", "delete"},
+		{"storekit", "retention-messaging", "endpoint", "view"},
+		{"storekit", "retention-messaging", "endpoint", "set"},
+		{"storekit", "retention-messaging", "endpoint", "delete"},
+		{"storekit", "retention-messaging", "performance", "start"},
+		{"storekit", "retention-messaging", "performance", "view"},
+		{"storekit", "retention-messaging", "performance", "wait"},
+	}
+	for _, path := range paths {
+		if findSubcommand(root, path...) == nil {
+			t.Errorf("missing command path %s", strings.Join(path, " "))
+		}
+	}
+}
+
+func TestStoreKitRetentionRequiresExplicitEnvironment(t *testing.T) {
+	t.Setenv("ASC_STOREKIT_ENVIRONMENT", "")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"storekit", "retention-messaging", "messages", "list"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("run error = %v, want flag.ErrHelp", err)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--environment is required (or set ASC_STOREKIT_ENVIRONMENT)") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestStoreKitDeleteRequiresConfirm(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"storekit", "retention-messaging", "messages", "delete",
+			"--message-id", "33333333-3333-4333-8333-333333333333",
+			"--environment", "sandbox",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("run error = %v, want flag.ErrHelp", err)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestStoreKitMessagesListSuccess(t *testing.T) {
+	setupStoreKitAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Host != "api.storekit-sandbox.apple.com" || req.URL.Path != "/inApps/v1/messaging/message/list" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+			t.Fatalf("missing bearer token: %q", req.Header.Get("Authorization"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"messageIdentifiers":[{"messageIdentifier":"33333333-3333-4333-8333-333333333333","messageState":"APPROVED"}]}`,
+			)),
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"storekit", "retention-messaging", "messages", "list", "--environment", "sandbox", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	var response struct {
+		Messages []struct {
+			Identifier string `json:"messageIdentifier"`
+			State      string `json:"messageState"`
+		} `json:"messageIdentifiers"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", stdout, err)
+	}
+	if len(response.Messages) != 1 || response.Messages[0].State != "APPROVED" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestStoreKitAuthLoginStoresDedicatedProfile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	keyPath := filepath.Join(t.TempDir(), "SubscriptionKey.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"storekit", "auth", "login", "--name", "Retention",
+			"--key-id", "STOREKIT_KEY", "--issuer-id", "STOREKIT_ISSUER",
+			"--private-key", keyPath, "--bundle-id", "com.example.app",
+			"--bypass-keychain",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" || !strings.Contains(stdout, "Successfully registered StoreKit API key") {
+		t.Fatalf("stdout=%q stderr=%q", stdout, stderr)
+	}
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("LoadAt() error = %v", err)
+	}
+	if cfg.StoreKit.DefaultKeyName != "Retention" || len(cfg.StoreKit.Keys) != 1 || cfg.StoreKit.Keys[0].BundleID != "com.example.app" {
+		t.Fatalf("StoreKit config = %#v", cfg.StoreKit)
+	}
+	if len(cfg.Keys) != 0 {
+		t.Fatalf("App Store Connect credentials changed: %#v", cfg.Keys)
+	}
+}
+
+func TestStoreKitAuthStatusValidatesEnvironmentCredentials(t *testing.T) {
+	setupStoreKitAuth(t)
+	requests := 0
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"messageIdentifiers":[]}`)),
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"storekit", "auth", "status", "--validate", "--environment", "sandbox", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" || requests != 1 {
+		t.Fatalf("stderr=%q requests=%d", stderr, requests)
+	}
+	if !strings.Contains(stdout, `"name":"environment"`) || strings.Contains(stdout, "PRIVATE KEY") || strings.Contains(stdout, "SubscriptionKey.p8") {
+		t.Fatalf("unsafe or incomplete status output: %q", stdout)
+	}
+}
+
+func TestStoreKitMessagesUploadSuccess(t *testing.T) {
+	setupStoreKitAuth(t)
+	messagePath := filepath.Join(t.TempDir(), "message.json")
+	messageJSON := `{"header":"Stay with Example","body":"Keep everything you have unlocked."}`
+	if err := os.WriteFile(messagePath, []byte(messageJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut || req.URL.Path != "/inApps/v1/messaging/message/33333333-3333-4333-8333-333333333333" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["header"] != "Stay with Example" {
+			t.Fatalf("payload = %#v", payload)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"storekit", "retention-messaging", "messages", "upload",
+			"--message-id", "33333333-3333-4333-8333-333333333333",
+			"--file", messagePath, "--environment", "sandbox", "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", stdout, err)
+	}
+	if result["success"] != true || result["action"] != "uploaded" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestStoreKitInvalidValuesAreUsageErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "environment",
+			args:    []string{"storekit", "retention-messaging", "messages", "list", "--environment", "staging"},
+			wantErr: "environment must be one of: production, sandbox",
+		},
+		{
+			name:    "image size",
+			args:    []string{"storekit", "retention-messaging", "images", "upload", "--image-id", "11111111-1111-4111-8111-111111111111", "--file", "unused.png", "--image-size", "small", "--environment", "sandbox"},
+			wantErr: "--image-size must be one of: FULL_SIZE, BULLET_POINT",
+		},
+		{
+			name:    "endpoint URL",
+			args:    []string{"storekit", "retention-messaging", "endpoint", "set", "--url", "http://example.com", "--environment", "sandbox"},
+			wantErr: "--url must be an absolute HTTPS URL",
+		},
+		{
+			name:    "poll interval",
+			args:    []string{"storekit", "retention-messaging", "performance", "wait", "--request-id", "request-1", "--interval", "1s", "--environment", "sandbox"},
+			wantErr: "--interval must be at least 10s",
+		},
+		{
+			name:    "performance production",
+			args:    []string{"storekit", "retention-messaging", "performance", "view", "--request-id", "request-1", "--environment", "production"},
+			wantErr: "performance tests require --environment sandbox",
+		},
+		{
+			name:    "start interval without wait",
+			args:    []string{"storekit", "retention-messaging", "performance", "start", "--original-transaction-id", "2000000000000000", "--interval", "20s", "--environment", "sandbox"},
+			wantErr: "--interval and --timeout require --wait",
+		},
+		{
+			name: "auth login environment without network",
+			args: []string{
+				"storekit", "auth", "login", "--name", "Retention", "--key-id", "KEY",
+				"--issuer-id", "ISSUER", "--private-key", "unused.p8", "--bundle-id", "com.example.app",
+				"--skip-validation", "--environment", "sandbox",
+			},
+			wantErr: "--environment requires --network",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(tt.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("run error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if stdout != "" || !strings.Contains(stderr, tt.wantErr) {
+				t.Fatalf("stdout=%q stderr=%q, want %q", stdout, stderr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStoreKitBuiltBinaryUsageExitCode(t *testing.T) {
+	binaryPath := buildASCBlackBoxBinary(t)
+	cmd := exec.Command(binaryPath, "storekit", "retention-messaging", "messages", "list")
+	cmd.Env = append(os.Environ(), "ASC_STOREKIT_ENVIRONMENT=", "ASC_STOREKIT_KEY_ID=", "ASC_STOREKIT_ISSUER_ID=")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+		t.Fatalf("error = %v, want exit code 2", err)
+	}
+	if stdout.String() != "" || !strings.Contains(stderr.String(), "--environment is required") {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func setupStoreKitAuth(t *testing.T) {
+	t.Helper()
+	keyPath := filepath.Join(t.TempDir(), "SubscriptionKey.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_STOREKIT_KEY_ID", "STOREKIT_KEY")
+	t.Setenv("ASC_STOREKIT_ISSUER_ID", "STOREKIT_ISSUER")
+	t.Setenv("ASC_STOREKIT_PRIVATE_KEY_PATH", keyPath)
+	t.Setenv("ASC_STOREKIT_PRIVATE_KEY", "")
+	t.Setenv("ASC_STOREKIT_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STOREKIT_BUNDLE_ID", "com.example.app")
+	t.Setenv("ASC_STOREKIT_PROFILE", "")
+	t.Setenv("ASC_STOREKIT_STRICT_AUTH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing-config.json"))
+}

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -182,6 +182,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `signing` - Manage signing certificates and profiles.
 - `notarization` - Manage macOS notarization submissions.
 - `iap` - Manage in-app purchases.
+- `storekit` - Manage StoreKit server APIs with dedicated In-App Purchase API keys.
 - `app-events` - Manage App Store in-app events.
 - `subscriptions` - Manage subscription groups and subscriptions.
 - `submit` - Submission lifecycle tools; use `validate` for readiness and `publish appstore --submit` to ship.
@@ -218,6 +219,9 @@ Use `asc <command> --help` for subcommands and flags.
 - `ASC_TIMEOUT`, `ASC_TIMEOUT_SECONDS` - Request timeout
 - `ASC_UPLOAD_TIMEOUT`, `ASC_UPLOAD_TIMEOUT_SECONDS` - Upload timeout
 - `ASC_DEBUG` - Debug output (`api` enables HTTP logs)
+- `ASC_STOREKIT_KEY_ID`, `ASC_STOREKIT_ISSUER_ID`, `ASC_STOREKIT_PRIVATE_KEY_PATH` - StoreKit In-App Purchase API authentication
+- `ASC_STOREKIT_PRIVATE_KEY`, `ASC_STOREKIT_PRIVATE_KEY_B64` - Inline StoreKit private key alternatives
+- `ASC_STOREKIT_BUNDLE_ID`, `ASC_STOREKIT_ENVIRONMENT`, `ASC_STOREKIT_PROFILE` - StoreKit app, environment, and profile selection
 - Web password environment variable (`ASC_WEB` + `_PASSWORD`) - Password source for `asc web auth login` and `asc web apps create`
 - `ASC_WEB_SESSION_CACHE`, `ASC_WEB_SESSION_CACHE_DIR`, `ASC_WEB_SESSION_CACHE_BACKEND` - Web-session cache controls for unofficial web flows
 - `ASC_IRIS_SESSION_CACHE`, `ASC_IRIS_SESSION_CACHE_DIR` - Deprecated legacy app-create cache settings; imported into the web session cache during the transition window

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -221,7 +221,8 @@ Use `asc <command> --help` for subcommands and flags.
 - `ASC_DEBUG` - Debug output (`api` enables HTTP logs)
 - `ASC_STOREKIT_KEY_ID`, `ASC_STOREKIT_ISSUER_ID`, `ASC_STOREKIT_PRIVATE_KEY_PATH` - StoreKit In-App Purchase API authentication
 - `ASC_STOREKIT_PRIVATE_KEY`, `ASC_STOREKIT_PRIVATE_KEY_B64` - Inline StoreKit private key alternatives
-- `ASC_STOREKIT_BUNDLE_ID`, `ASC_STOREKIT_ENVIRONMENT`, `ASC_STOREKIT_PROFILE` - StoreKit app, environment, and profile selection
+- `ASC_STOREKIT_BUNDLE_ID`, `ASC_STOREKIT_ENVIRONMENT`, `ASC_STOREKIT_PROFILE`, `ASC_STOREKIT_STRICT_AUTH` - StoreKit app, environment, profile, and mixed-source auth behavior
+- `ASC_STOREKIT_BYPASS_KEYCHAIN` - Disable StoreKit keychain usage and use config-backed storage
 - Web password environment variable (`ASC_WEB` + `_PASSWORD`) - Password source for `asc web auth login` and `asc web apps create`
 - `ASC_WEB_SESSION_CACHE`, `ASC_WEB_SESSION_CACHE_DIR`, `ASC_WEB_SESSION_CACHE_BACKEND` - Web-session cache controls for unofficial web flows
 - `ASC_IRIS_SESSION_CACHE`, `ASC_IRIS_SESSION_CACHE_DIR` - Deprecated legacy app-create cache settings; imported into the web session cache during the transition window

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -66,6 +66,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/signing"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/snitch"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/status"
+	storekitcmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/storekit"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/submit"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/subscriptions"
 	telemetrycmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/telemetry"
@@ -163,6 +164,7 @@ func Subcommands(version string) []*ffcli.Command {
 		signing.SigningCommand(),
 		notarization.NotarizationCommand(),
 		iap.IAPCommand(),
+		storekitcmd.Command(),
 		app_events.Command(),
 		subscriptions.SubscriptionsCommand(),
 		submit.SubmitCommand(),

--- a/internal/cli/storekit/args.go
+++ b/internal/cli/storekit/args.go
@@ -1,0 +1,33 @@
+package storekit
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func rejectUnexpectedArgs(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+}
+
+func flagWasSet(fs *flag.FlagSet, names ...string) bool {
+	set := map[string]struct{}{}
+	fs.Visit(func(item *flag.Flag) { set[item.Name] = struct{}{} })
+	for _, name := range names {
+		if _, ok := set[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}

--- a/internal/cli/storekit/auth.go
+++ b/internal/cli/storekit/auth.go
@@ -1,0 +1,350 @@
+package storekit
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/99designs/keyring"
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	authsvc "github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+	storekitapi "github.com/rudrankriyam/App-Store-Connect-CLI/internal/storekit"
+)
+
+func AuthCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit auth", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "auth",
+		ShortUsage: "asc storekit auth <subcommand> [flags]",
+		ShortHelp:  "Manage In-App Purchase API credentials for StoreKit.",
+		LongHelp: `Manage StoreKit In-App Purchase API credentials.
+
+These credentials are independent of asc auth and App Store Connect API keys.
+
+Examples:
+  asc storekit auth login --name Production --key-id KEY_ID --issuer-id ISSUER_ID --private-key ./SubscriptionKey.p8 --bundle-id com.example.app
+  asc storekit auth status
+  asc storekit auth doctor --environment sandbox --network`,
+		FlagSet: fs,
+		Subcommands: []*ffcli.Command{
+			authLoginCommand(),
+			authStatusCommand(),
+			authSwitchCommand(),
+			authDoctorCommand(),
+			authLogoutCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func authLoginCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit auth login", flag.ExitOnError)
+	name := fs.String("name", "", "Friendly name for this StoreKit key")
+	keyID := fs.String("key-id", "", "In-App Purchase API key ID")
+	issuerID := fs.String("issuer-id", "", "In-App Purchase API issuer ID")
+	privateKey := fs.String("private-key", "", "Path to the In-App Purchase EC private key")
+	bundleID := fs.String("bundle-id", "", "App bundle identifier")
+	environment := fs.String("environment", "", "Network validation environment: production or sandbox")
+	bypassKeychain := fs.Bool("bypass-keychain", false, "Store the key path in config.json instead of keychain")
+	local := fs.Bool("local", false, "When bypassing keychain, write to ./.asc/config.json")
+	network := fs.Bool("network", false, "Validate credentials with the Retention Messaging API")
+	skipValidation := fs.Bool("skip-validation", false, "Skip private key and network validation")
+	return &ffcli.Command{
+		Name:       "login",
+		ShortUsage: "asc storekit auth login [flags]",
+		ShortHelp:  "Register an In-App Purchase API key.",
+		LongHelp: `Register an In-App Purchase API key for StoreKit server APIs.
+
+Examples:
+  asc storekit auth login --name Production --key-id KEY_ID --issuer-id ISSUER_ID --private-key ./SubscriptionKey.p8 --bundle-id com.example.app
+  asc storekit auth login --network --environment sandbox --name Sandbox --key-id KEY_ID --issuer-id ISSUER_ID --private-key ./SubscriptionKey.p8 --bundle-id com.example.app`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
+			required := []struct{ value, name string }{
+				{*name, "--name"},
+				{*keyID, "--key-id"},
+				{*issuerID, "--issuer-id"},
+				{*privateKey, "--private-key"},
+				{*bundleID, "--bundle-id"},
+			}
+			for _, item := range required {
+				if strings.TrimSpace(item.value) == "" {
+					return shared.UsageError(item.name + " is required")
+				}
+			}
+			if *skipValidation && *network {
+				return shared.UsageError("--skip-validation and --network are mutually exclusive")
+			}
+			if flagWasSet(fs, "environment") && !*network {
+				return shared.UsageError("--environment requires --network")
+			}
+			if *local && !*bypassKeychain && !storekitapi.ShouldBypassKeychain() {
+				return shared.UsageError("--local requires --bypass-keychain or ASC_STOREKIT_BYPASS_KEYCHAIN")
+			}
+			if !*skipValidation {
+				if err := authsvc.ValidateKeyFile(*privateKey); err != nil {
+					return fmt.Errorf("storekit auth login: invalid private key: %w", err)
+				}
+			}
+			credentials := storekitapi.Credentials{
+				KeyID: *keyID, IssuerID: *issuerID, PrivateKeyPath: *privateKey, BundleID: *bundleID,
+			}
+			if !*skipValidation {
+				localClient, err := storekitapi.NewClient(credentials, storekitapi.Sandbox)
+				if err != nil {
+					return fmt.Errorf("storekit auth login: %w", err)
+				}
+				if err := localClient.Validate(); err != nil {
+					return fmt.Errorf("storekit auth login: invalid StoreKit signing key: %w", err)
+				}
+			}
+			if *network {
+				target, err := resolveEnvironment(environment)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
+				client, err := storekitapi.NewClient(credentials, target)
+				if err != nil {
+					return fmt.Errorf("storekit auth login: %w", err)
+				}
+				requestCtx, cancel := shared.ContextWithTimeout(ctx)
+				defer cancel()
+				if _, err := client.ListMessages(requestCtx); err != nil {
+					return fmt.Errorf("storekit auth login: network validation failed: %w", err)
+				}
+			}
+			if *bypassKeychain || storekitapi.ShouldBypassKeychain() {
+				if *local {
+					path, err := config.LocalPath()
+					if err != nil {
+						return fmt.Errorf("storekit auth login: %w", err)
+					}
+					if err := storekitapi.StoreCredentialsConfigAt(*name, credentials, path); err != nil {
+						return fmt.Errorf("storekit auth login: store credentials: %w", err)
+					}
+				} else if err := storekitapi.StoreCredentialsConfig(*name, credentials); err != nil {
+					return fmt.Errorf("storekit auth login: store credentials: %w", err)
+				}
+			} else if err := storekitapi.StoreCredentials(*name, credentials); err != nil {
+				return fmt.Errorf("storekit auth login: store credentials: %w", err)
+			}
+			fmt.Printf("Successfully registered StoreKit API key %q for %s\n", strings.TrimSpace(*name), strings.TrimSpace(*bundleID))
+			return nil
+		},
+	}
+}
+
+type authStatusOutput struct {
+	ActiveSource string          `json:"active_source,omitempty"`
+	ActiveError  string          `json:"active_error,omitempty"`
+	Environment  string          `json:"environment,omitempty"`
+	Credentials  []authStatusRow `json:"credentials"`
+}
+
+type authStatusRow struct {
+	Name      string `json:"name"`
+	KeyID     string `json:"key_id"`
+	IssuerID  string `json:"issuer_id"`
+	BundleID  string `json:"bundle_id"`
+	IsDefault bool   `json:"default"`
+	Source    string `json:"source"`
+}
+
+func authStatusCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit auth status", flag.ExitOnError)
+	output := shared.BindOutputFlags(fs)
+	validate := fs.Bool("validate", false, "Validate every stored credential via network")
+	environment := fs.String("environment", "", "Validation environment: production or sandbox")
+	return &ffcli.Command{
+		Name:       "status",
+		ShortUsage: "asc storekit auth status [flags]",
+		ShortHelp:  "Show StoreKit authentication status.",
+		LongHelp: `Show StoreKit authentication status.
+
+Examples:
+  asc storekit auth status
+  asc storekit auth status --validate --environment sandbox --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
+			if flagWasSet(fs, "environment") && !*validate {
+				return shared.UsageError("--environment requires --validate")
+			}
+			credentials, err := storekitapi.ListCredentials()
+			if err != nil && !errors.Is(err, config.ErrNotFound) {
+				return fmt.Errorf("storekit auth status: %w", err)
+			}
+			activeCredentials, activeSource, activeErr := resolveCredentialsWithSource(commonFlags{})
+			if activeErr == nil && activeSource == "ASC_STOREKIT_* environment credentials" {
+				credentials = append(credentials, storekitapi.StoredCredential{
+					Credentials: activeCredentials,
+					Name:        "environment",
+					IsDefault:   true,
+					Source:      activeSource,
+				})
+			}
+			rows := make([]authStatusRow, 0, len(credentials))
+			for _, credential := range credentials {
+				rows = append(rows, authStatusRow{
+					Name: credential.Name, KeyID: credential.KeyID, IssuerID: credential.IssuerID,
+					BundleID: credential.BundleID, IsDefault: credential.IsDefault, Source: credential.Source,
+				})
+			}
+			result := authStatusOutput{Credentials: rows, ActiveSource: activeSource}
+			if activeErr != nil {
+				result.ActiveError = activeErr.Error()
+				fmt.Fprintf(os.Stderr, "Warning: active StoreKit authentication could not be resolved: %v\n", activeErr)
+			}
+			if *validate {
+				if len(credentials) == 0 {
+					return fmt.Errorf("storekit auth status: no credentials available to validate: %w", activeErr)
+				}
+				target, err := resolveEnvironment(environment)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
+				result.Environment = string(target)
+				failures := 0
+				for _, credential := range credentials {
+					client, clientErr := storekitapi.NewClient(credential.Credentials, target)
+					if clientErr == nil {
+						requestCtx, cancel := shared.ContextWithTimeout(ctx)
+						_, clientErr = client.ListMessages(requestCtx)
+						cancel()
+					}
+					if clientErr != nil {
+						failures++
+						fmt.Fprintf(os.Stderr, "StoreKit profile %q validation failed: %v\n", credential.Name, clientErr)
+					}
+				}
+				if failures > 0 {
+					return shared.NewReportedError(fmt.Errorf("storekit auth status: validation failed for %d credential(s)", failures))
+				}
+			}
+			tableRows := make([][]string, 0, len(rows))
+			for _, credential := range rows {
+				tableRows = append(tableRows, []string{credential.Name, credential.KeyID, credential.IssuerID, credential.BundleID, boolString(credential.IsDefault), credential.Source})
+			}
+			return printOutput(result, *output.Output, *output.Pretty,
+				[]string{"Name", "Key ID", "Issuer ID", "Bundle ID", "Default", "Source"}, tableRows)
+		},
+	}
+}
+
+func authSwitchCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit auth switch", flag.ExitOnError)
+	name := fs.String("name", "", "StoreKit credential name")
+	return &ffcli.Command{
+		Name:       "switch",
+		ShortUsage: "asc storekit auth switch --name NAME",
+		ShortHelp:  "Set the default StoreKit credential.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*name) == "" {
+				return shared.UsageError("--name is required")
+			}
+			if err := storekitapi.SetDefaultCredentials(*name); err != nil {
+				return fmt.Errorf("storekit auth switch: %w", err)
+			}
+			fmt.Printf("Default StoreKit profile set to %q\n", strings.TrimSpace(*name))
+			return nil
+		},
+	}
+}
+
+func authDoctorCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit auth doctor", flag.ExitOnError)
+	common := bindCommonFlags(fs)
+	network := fs.Bool("network", false, "Validate credentials with the Retention Messaging API")
+	return &ffcli.Command{
+		Name:       "doctor",
+		ShortUsage: "asc storekit auth doctor --environment ENV [flags]",
+		ShortHelp:  "Diagnose StoreKit credentials and JWT signing.",
+		LongHelp: `Diagnose StoreKit credential resolution and JWT signing.
+
+Examples:
+  asc storekit auth doctor --environment sandbox
+  asc storekit auth doctor --environment sandbox --network`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
+			client, environment, err := resolveClient(ctx, common)
+			if err != nil {
+				return usageOrWrap("storekit auth doctor", err)
+			}
+			if err := client.Validate(); err != nil {
+				return fmt.Errorf("storekit auth doctor: JWT signing failed: %w", err)
+			}
+			if *network {
+				requestCtx, cancel := shared.ContextWithTimeout(ctx)
+				defer cancel()
+				if _, err := client.ListMessages(requestCtx); err != nil {
+					return fmt.Errorf("storekit auth doctor: network validation failed: %w", err)
+				}
+			}
+			fmt.Printf("StoreKit credentials are valid for %s%s\n", environment, map[bool]string{true: " (network verified)", false: ""}[*network])
+			return nil
+		},
+	}
+}
+
+func authLogoutCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit auth logout", flag.ExitOnError)
+	name := fs.String("name", "", "StoreKit credential name")
+	all := fs.Bool("all", false, "Remove all StoreKit credentials")
+	confirm := fs.Bool("confirm", false, "Confirm credential removal")
+	return &ffcli.Command{
+		Name:       "logout",
+		ShortUsage: "asc storekit auth logout (--name NAME | --all) --confirm",
+		ShortHelp:  "Remove StoreKit credentials.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
+			if !*confirm {
+				return shared.UsageError("--confirm is required")
+			}
+			if *all == (strings.TrimSpace(*name) != "") {
+				return shared.UsageError("exactly one of --name or --all is required")
+			}
+			if *all {
+				if err := storekitapi.RemoveAllCredentials(); err != nil {
+					return fmt.Errorf("storekit auth logout: %w", err)
+				}
+				fmt.Println("Removed all StoreKit credentials")
+				return nil
+			}
+			if err := storekitapi.RemoveCredentials(*name); err != nil {
+				if errors.Is(err, keyring.ErrKeyNotFound) {
+					return fmt.Errorf("storekit auth logout: credentials not found for profile %q", strings.TrimSpace(*name))
+				}
+				return fmt.Errorf("storekit auth logout: %w", err)
+			}
+			fmt.Printf("Removed StoreKit profile %q\n", strings.TrimSpace(*name))
+			return nil
+		},
+	}
+}

--- a/internal/cli/storekit/auth.go
+++ b/internal/cli/storekit/auth.go
@@ -71,12 +71,17 @@ Examples:
 			if err := rejectUnexpectedArgs(args); err != nil {
 				return err
 			}
+			cleanName := strings.TrimSpace(*name)
+			cleanKeyID := strings.TrimSpace(*keyID)
+			cleanIssuerID := strings.TrimSpace(*issuerID)
+			cleanPrivateKey := strings.TrimSpace(*privateKey)
+			cleanBundleID := strings.TrimSpace(*bundleID)
 			required := []struct{ value, name string }{
-				{*name, "--name"},
-				{*keyID, "--key-id"},
-				{*issuerID, "--issuer-id"},
-				{*privateKey, "--private-key"},
-				{*bundleID, "--bundle-id"},
+				{cleanName, "--name"},
+				{cleanKeyID, "--key-id"},
+				{cleanIssuerID, "--issuer-id"},
+				{cleanPrivateKey, "--private-key"},
+				{cleanBundleID, "--bundle-id"},
 			}
 			for _, item := range required {
 				if strings.TrimSpace(item.value) == "" {
@@ -93,12 +98,12 @@ Examples:
 				return shared.UsageError("--local requires --bypass-keychain or ASC_STOREKIT_BYPASS_KEYCHAIN")
 			}
 			if !*skipValidation {
-				if err := authsvc.ValidateKeyFile(*privateKey); err != nil {
+				if err := authsvc.ValidateKeyFile(cleanPrivateKey); err != nil {
 					return fmt.Errorf("storekit auth login: invalid private key: %w", err)
 				}
 			}
 			credentials := storekitapi.Credentials{
-				KeyID: *keyID, IssuerID: *issuerID, PrivateKeyPath: *privateKey, BundleID: *bundleID,
+				KeyID: cleanKeyID, IssuerID: cleanIssuerID, PrivateKeyPath: cleanPrivateKey, BundleID: cleanBundleID,
 			}
 			if !*skipValidation {
 				localClient, err := storekitapi.NewClient(credentials, storekitapi.Sandbox)
@@ -130,16 +135,16 @@ Examples:
 					if err != nil {
 						return fmt.Errorf("storekit auth login: %w", err)
 					}
-					if err := storekitapi.StoreCredentialsConfigAt(*name, credentials, path); err != nil {
+					if err := storekitapi.StoreCredentialsConfigAt(cleanName, credentials, path); err != nil {
 						return fmt.Errorf("storekit auth login: store credentials: %w", err)
 					}
-				} else if err := storekitapi.StoreCredentialsConfig(*name, credentials); err != nil {
+				} else if err := storekitapi.StoreCredentialsConfig(cleanName, credentials); err != nil {
 					return fmt.Errorf("storekit auth login: store credentials: %w", err)
 				}
-			} else if err := storekitapi.StoreCredentials(*name, credentials); err != nil {
+			} else if err := storekitapi.StoreCredentials(cleanName, credentials); err != nil {
 				return fmt.Errorf("storekit auth login: store credentials: %w", err)
 			}
-			fmt.Printf("Successfully registered StoreKit API key %q for %s\n", strings.TrimSpace(*name), strings.TrimSpace(*bundleID))
+			fmt.Printf("Successfully registered StoreKit API key %q for %s\n", cleanName, cleanBundleID)
 			return nil
 		},
 	}
@@ -258,13 +263,14 @@ func authSwitchCommand() *ffcli.Command {
 			if err := rejectUnexpectedArgs(args); err != nil {
 				return err
 			}
-			if strings.TrimSpace(*name) == "" {
+			cleanName := strings.TrimSpace(*name)
+			if cleanName == "" {
 				return shared.UsageError("--name is required")
 			}
-			if err := storekitapi.SetDefaultCredentials(*name); err != nil {
+			if err := storekitapi.SetDefaultCredentials(cleanName); err != nil {
 				return fmt.Errorf("storekit auth switch: %w", err)
 			}
-			fmt.Printf("Default StoreKit profile set to %q\n", strings.TrimSpace(*name))
+			fmt.Printf("Default StoreKit profile set to %q\n", cleanName)
 			return nil
 		},
 	}
@@ -327,7 +333,8 @@ func authLogoutCommand() *ffcli.Command {
 			if !*confirm {
 				return shared.UsageError("--confirm is required")
 			}
-			if *all == (strings.TrimSpace(*name) != "") {
+			cleanName := strings.TrimSpace(*name)
+			if *all == (cleanName != "") {
 				return shared.UsageError("exactly one of --name or --all is required")
 			}
 			if *all {
@@ -337,13 +344,13 @@ func authLogoutCommand() *ffcli.Command {
 				fmt.Println("Removed all StoreKit credentials")
 				return nil
 			}
-			if err := storekitapi.RemoveCredentials(*name); err != nil {
+			if err := storekitapi.RemoveCredentials(cleanName); err != nil {
 				if errors.Is(err, keyring.ErrKeyNotFound) {
-					return fmt.Errorf("storekit auth logout: credentials not found for profile %q", strings.TrimSpace(*name))
+					return fmt.Errorf("storekit auth logout: credentials not found for profile %q", cleanName)
 				}
 				return fmt.Errorf("storekit auth logout: %w", err)
 			}
-			fmt.Printf("Removed StoreKit profile %q\n", strings.TrimSpace(*name))
+			fmt.Printf("Removed StoreKit profile %q\n", cleanName)
 			return nil
 		},
 	}

--- a/internal/cli/storekit/output.go
+++ b/internal/cli/storekit/output.go
@@ -1,0 +1,20 @@
+package storekit
+
+import (
+	"strconv"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func printOutput(data any, format string, pretty bool, headers []string, rows [][]string) error {
+	return shared.PrintOutputWithRenderers(
+		data,
+		format,
+		pretty,
+		func() error { asc.RenderTable(headers, rows); return nil },
+		func() error { asc.RenderMarkdown(headers, rows); return nil },
+	)
+}
+
+func boolString(value bool) string { return strconv.FormatBool(value) }

--- a/internal/cli/storekit/resolve.go
+++ b/internal/cli/storekit/resolve.go
@@ -61,12 +61,8 @@ func resolveCredentialsWithSource(flags commonFlags) (storekitapi.Credentials, s
 		profileSource = "ASC_STOREKIT_PROFILE"
 	}
 	strict := parseBoolEnv("ASC_STOREKIT_STRICT_AUTH")
-	environmentCredentials, environmentSet, err := credentialsFromEnvironment()
-	if err != nil {
-		return storekitapi.Credentials{}, "", err
-	}
 	if profile != "" {
-		if strict && environmentSet {
+		if strict && hasEnvironmentKeyCredentials() {
 			return storekitapi.Credentials{}, "", fmt.Errorf("mixed StoreKit authentication sources detected: profile and ASC_STOREKIT_* key credentials")
 		}
 		credentials, _, err := storekitapi.GetCredentialsWithSource(profile)
@@ -78,6 +74,10 @@ func resolveCredentialsWithSource(flags commonFlags) (storekitapi.Credentials, s
 			return storekitapi.Credentials{}, "", fmt.Errorf("--bundle-id is required (or set ASC_STOREKIT_BUNDLE_ID or store it in the StoreKit profile)")
 		}
 		return credentials, profileSource, nil
+	}
+	environmentCredentials, environmentSet, err := credentialsFromEnvironment()
+	if err != nil {
+		return storekitapi.Credentials{}, "", err
 	}
 	if environmentSet {
 		environmentCredentials.BundleID = resolveBundleID(flags.BundleID, environmentCredentials.BundleID)
@@ -121,6 +121,21 @@ func credentialsFromEnvironment() (storekitapi.Credentials, bool, error) {
 		return storekitapi.Credentials{}, false, fmt.Errorf("incomplete StoreKit environment credentials: set ASC_STOREKIT_KEY_ID, ASC_STOREKIT_ISSUER_ID, and one of ASC_STOREKIT_PRIVATE_KEY_PATH, ASC_STOREKIT_PRIVATE_KEY, or ASC_STOREKIT_PRIVATE_KEY_B64")
 	}
 	return credentials, complete, nil
+}
+
+func hasEnvironmentKeyCredentials() bool {
+	for _, name := range []string{
+		"ASC_STOREKIT_KEY_ID",
+		"ASC_STOREKIT_ISSUER_ID",
+		"ASC_STOREKIT_PRIVATE_KEY_PATH",
+		"ASC_STOREKIT_PRIVATE_KEY",
+		"ASC_STOREKIT_PRIVATE_KEY_B64",
+	} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveBundleID(flagValue *string, stored string) string {

--- a/internal/cli/storekit/resolve.go
+++ b/internal/cli/storekit/resolve.go
@@ -1,0 +1,143 @@
+package storekit
+
+import (
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	storekitapi "github.com/rudrankriyam/App-Store-Connect-CLI/internal/storekit"
+)
+
+type commonFlags struct {
+	Profile     *string
+	BundleID    *string
+	Environment *string
+}
+
+func bindCommonFlags(fs *flag.FlagSet) commonFlags {
+	return commonFlags{
+		Profile:     fs.String("storekit-profile", "", "StoreKit credential profile (or ASC_STOREKIT_PROFILE)"),
+		BundleID:    fs.String("bundle-id", "", "App bundle identifier (or ASC_STOREKIT_BUNDLE_ID)"),
+		Environment: fs.String("environment", "", "StoreKit environment: production or sandbox"),
+	}
+}
+
+func resolveClient(ctx context.Context, flags commonFlags) (*storekitapi.Client, storekitapi.Environment, error) {
+	environment, err := resolveEnvironment(flags.Environment)
+	if err != nil {
+		return nil, "", err
+	}
+	credentials, _, err := resolveCredentialsWithSource(flags)
+	if err != nil {
+		return nil, "", err
+	}
+	_ = ctx
+	client, err := storekitapi.NewClient(credentials, environment)
+	if err != nil {
+		return nil, "", err
+	}
+	return client, environment, nil
+}
+
+func resolveEnvironment(flagValue *string) (storekitapi.Environment, error) {
+	value := stringValue(flagValue)
+	if value == "" {
+		value = strings.TrimSpace(os.Getenv("ASC_STOREKIT_ENVIRONMENT"))
+	}
+	if value == "" {
+		return "", fmt.Errorf("--environment is required (or set ASC_STOREKIT_ENVIRONMENT)")
+	}
+	return storekitapi.ParseEnvironment(value)
+}
+
+func resolveCredentialsWithSource(flags commonFlags) (storekitapi.Credentials, string, error) {
+	profile := stringValue(flags.Profile)
+	profileSource := "--storekit-profile"
+	if profile == "" {
+		profile = strings.TrimSpace(os.Getenv("ASC_STOREKIT_PROFILE"))
+		profileSource = "ASC_STOREKIT_PROFILE"
+	}
+	strict := parseBoolEnv("ASC_STOREKIT_STRICT_AUTH")
+	environmentCredentials, environmentSet, err := credentialsFromEnvironment()
+	if err != nil {
+		return storekitapi.Credentials{}, "", err
+	}
+	if profile != "" {
+		if strict && environmentSet {
+			return storekitapi.Credentials{}, "", fmt.Errorf("mixed StoreKit authentication sources detected: profile and ASC_STOREKIT_* key credentials")
+		}
+		credentials, _, err := storekitapi.GetCredentialsWithSource(profile)
+		if err != nil {
+			return storekitapi.Credentials{}, "", err
+		}
+		credentials.BundleID = resolveBundleID(flags.BundleID, credentials.BundleID)
+		if credentials.BundleID == "" {
+			return storekitapi.Credentials{}, "", fmt.Errorf("--bundle-id is required (or set ASC_STOREKIT_BUNDLE_ID or store it in the StoreKit profile)")
+		}
+		return credentials, profileSource, nil
+	}
+	if environmentSet {
+		environmentCredentials.BundleID = resolveBundleID(flags.BundleID, environmentCredentials.BundleID)
+		if environmentCredentials.BundleID == "" {
+			return storekitapi.Credentials{}, "", fmt.Errorf("--bundle-id is required (or set ASC_STOREKIT_BUNDLE_ID)")
+		}
+		return environmentCredentials, "ASC_STOREKIT_* environment credentials", nil
+	}
+	credentials, source, err := storekitapi.GetCredentialsWithSource("")
+	if err != nil {
+		return storekitapi.Credentials{}, "", err
+	}
+	credentials.BundleID = resolveBundleID(flags.BundleID, credentials.BundleID)
+	if credentials.BundleID == "" {
+		return storekitapi.Credentials{}, "", fmt.Errorf("--bundle-id is required (or set ASC_STOREKIT_BUNDLE_ID or store it in the StoreKit profile)")
+	}
+	return credentials, source, nil
+}
+
+func credentialsFromEnvironment() (storekitapi.Credentials, bool, error) {
+	credentials := storekitapi.Credentials{
+		KeyID:          strings.TrimSpace(os.Getenv("ASC_STOREKIT_KEY_ID")),
+		IssuerID:       strings.TrimSpace(os.Getenv("ASC_STOREKIT_ISSUER_ID")),
+		PrivateKeyPath: strings.TrimSpace(os.Getenv("ASC_STOREKIT_PRIVATE_KEY_PATH")),
+		PrivateKeyPEM:  strings.TrimSpace(os.Getenv("ASC_STOREKIT_PRIVATE_KEY")),
+		BundleID:       strings.TrimSpace(os.Getenv("ASC_STOREKIT_BUNDLE_ID")),
+	}
+	encoded := strings.TrimSpace(os.Getenv("ASC_STOREKIT_PRIVATE_KEY_B64"))
+	if encoded != "" {
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return storekitapi.Credentials{}, false, fmt.Errorf("ASC_STOREKIT_PRIVATE_KEY_B64 is not valid base64: %w", err)
+		}
+		if credentials.PrivateKeyPEM == "" {
+			credentials.PrivateKeyPEM = string(decoded)
+		}
+	}
+	anyKeyValue := credentials.KeyID != "" || credentials.IssuerID != "" || credentials.PrivateKeyPath != "" || credentials.PrivateKeyPEM != ""
+	complete := credentials.KeyID != "" && credentials.IssuerID != "" && (credentials.PrivateKeyPath != "" || credentials.PrivateKeyPEM != "")
+	if anyKeyValue && !complete {
+		return storekitapi.Credentials{}, false, fmt.Errorf("incomplete StoreKit environment credentials: set ASC_STOREKIT_KEY_ID, ASC_STOREKIT_ISSUER_ID, and one of ASC_STOREKIT_PRIVATE_KEY_PATH, ASC_STOREKIT_PRIVATE_KEY, or ASC_STOREKIT_PRIVATE_KEY_B64")
+	}
+	return credentials, complete, nil
+}
+
+func resolveBundleID(flagValue *string, stored string) string {
+	if value := stringValue(flagValue); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(os.Getenv("ASC_STOREKIT_BUNDLE_ID")); value != "" {
+		return value
+	}
+	return strings.TrimSpace(stored)
+}
+
+func parseBoolEnv(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/storekit/resolve_test.go
+++ b/internal/cli/storekit/resolve_test.go
@@ -1,0 +1,68 @@
+package storekit
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	storekitapi "github.com/rudrankriyam/App-Store-Connect-CLI/internal/storekit"
+)
+
+func TestResolveCredentialsWithExplicitProfileIgnoresIncompleteEnvironmentCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_STOREKIT_KEY_ID", "stray-key-id")
+	stored := storekitapi.Credentials{
+		KeyID:          "PROFILE_KEY",
+		IssuerID:       "PROFILE_ISSUER",
+		PrivateKeyPath: "/profiles/SubscriptionKey.p8",
+		BundleID:       "com.example.profile",
+	}
+	if err := storekitapi.StoreCredentialsConfigAt("saved", stored, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error = %v", err)
+	}
+	profile := "saved"
+
+	credentials, source, err := resolveCredentialsWithSource(commonFlags{Profile: &profile})
+	if err != nil {
+		t.Fatalf("resolveCredentialsWithSource() error = %v", err)
+	}
+	if source != "--storekit-profile" || credentials.KeyID != stored.KeyID || credentials.BundleID != stored.BundleID {
+		t.Fatalf("credentials = %#v source=%q", credentials, source)
+	}
+}
+
+func TestResolveCredentialsWithExplicitProfileStrictAuthRejectsIncompleteEnvironmentCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_STOREKIT_KEY_ID", "stray-key-id")
+	t.Setenv("ASC_STOREKIT_STRICT_AUTH", "1")
+	stored := storekitapi.Credentials{
+		KeyID:          "PROFILE_KEY",
+		IssuerID:       "PROFILE_ISSUER",
+		PrivateKeyPath: "/profiles/SubscriptionKey.p8",
+		BundleID:       "com.example.profile",
+	}
+	if err := storekitapi.StoreCredentialsConfigAt("saved", stored, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error = %v", err)
+	}
+	profile := "saved"
+
+	_, _, err := resolveCredentialsWithSource(commonFlags{Profile: &profile})
+	if err == nil || !strings.Contains(err.Error(), "mixed StoreKit authentication sources") {
+		t.Fatalf("resolveCredentialsWithSource() error = %v", err)
+	}
+}
+
+func TestResolveCredentialsWithoutProfileRejectsIncompleteEnvironmentCredentials(t *testing.T) {
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_STOREKIT_KEY_ID", "partial-key-id")
+
+	_, _, err := resolveCredentialsWithSource(commonFlags{})
+	if err == nil || !strings.Contains(err.Error(), "incomplete StoreKit environment credentials") {
+		t.Fatalf("resolveCredentialsWithSource() error = %v", err)
+	}
+}

--- a/internal/cli/storekit/retention.go
+++ b/internal/cli/storekit/retention.go
@@ -581,7 +581,7 @@ func performanceWaitCommand() *ffcli.Command {
 		if err != nil {
 			return fmt.Errorf("storekit retention-messaging performance wait: %w", err)
 		}
-		return printPerformanceResult(result, *output.Output, *output.Pretty)
+		return printWaitedPerformanceResult(result, *output.Output, *output.Pretty)
 	})
 }
 

--- a/internal/cli/storekit/retention.go
+++ b/internal/cli/storekit/retention.go
@@ -1,0 +1,771 @@
+package storekit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	storekitapi "github.com/rudrankriyam/App-Store-Connect-CLI/internal/storekit"
+)
+
+func RetentionMessagingCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "retention-messaging",
+		ShortUsage: "asc storekit retention-messaging <subcommand> [flags]",
+		ShortHelp:  "Manage subscription Retention Messaging resources.",
+		LongHelp: `Manage Apple's subscription Retention Messaging resources.
+
+Access requires Apple approval and a dedicated In-App Purchase API key.
+
+Examples:
+  asc storekit retention-messaging images list --environment sandbox
+  asc storekit retention-messaging messages upload --message-id UUID --file message.json --environment sandbox
+  asc storekit retention-messaging defaults set --product-id com.example.monthly --locale en-US --message-id UUID --environment production
+  asc storekit retention-messaging endpoint set --url https://example.com/retention --environment production`,
+		FlagSet: fs,
+		Subcommands: []*ffcli.Command{
+			imagesCommand(),
+			messagesCommand(),
+			defaultsCommand(),
+			endpointCommand(),
+			performanceCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func imagesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging images", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "images",
+		ShortUsage: "asc storekit retention-messaging images <subcommand> [flags]",
+		ShortHelp:  "Upload, list, and delete retention images.",
+		FlagSet:    fs,
+		Subcommands: []*ffcli.Command{
+			imagesListCommand(), imagesUploadCommand(), imagesDeleteCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func imagesListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging images list", flag.ExitOnError)
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("list", "asc storekit retention-messaging images list --environment ENV [flags]", "List retention images.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		client, _, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging images list", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.ListImages(requestCtx)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging images list: %w", err)
+		}
+		rows := make([][]string, 0, len(result.ImageIdentifiers))
+		for _, image := range result.ImageIdentifiers {
+			rows = append(rows, []string{image.ImageIdentifier, string(image.ImageSize), image.ImageState})
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Image ID", "Size", "State"}, rows)
+	})
+}
+
+func imagesUploadCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging images upload", flag.ExitOnError)
+	imageID := fs.String("image-id", "", "Client-generated image UUID")
+	file := fs.String("file", "", "Path to a PNG image")
+	size := fs.String("image-size", string(storekitapi.ImageSizeFull), "Image size: FULL_SIZE or BULLET_POINT")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("upload", "asc storekit retention-messaging images upload --image-id UUID --file IMAGE.png --environment ENV [flags]", "Upload a PNG retention image.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if err := requireFlag("--image-id", *imageID); err != nil {
+			return err
+		}
+		if err := validateUUIDFlag("--image-id", *imageID); err != nil {
+			return err
+		}
+		if err := requireFlag("--file", *file); err != nil {
+			return err
+		}
+		imageSize := storekitapi.ImageSize(strings.ToUpper(strings.TrimSpace(*size)))
+		if imageSize != storekitapi.ImageSizeFull && imageSize != storekitapi.ImageSizeBulletPoint {
+			return shared.UsageError("--image-size must be one of: FULL_SIZE, BULLET_POINT")
+		}
+		data, err := readPNG(*file, imageSize)
+		if err != nil {
+			return shared.UsageError(err.Error())
+		}
+		client, environment, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging images upload", err)
+		}
+		requestCtx, cancel := shared.ContextWithUploadTimeout(ctx)
+		defer cancel()
+		if err := client.UploadImage(requestCtx, *imageID, imageSize, data); err != nil {
+			return fmt.Errorf("storekit retention-messaging images upload: %w", err)
+		}
+		result := mutation("image", *imageID, "uploaded", environment)
+		return printMutation(result, *output.Output, *output.Pretty)
+	})
+}
+
+func imagesDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging images delete", flag.ExitOnError)
+	imageID := fs.String("image-id", "", "Image UUID")
+	confirm := fs.Bool("confirm", false, "Confirm image deletion")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("delete", "asc storekit retention-messaging images delete --image-id UUID --environment ENV --confirm [flags]", "Delete a retention image.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if !*confirm {
+			return shared.UsageError("--confirm is required")
+		}
+		if err := requireFlag("--image-id", *imageID); err != nil {
+			return err
+		}
+		if err := validateUUIDFlag("--image-id", *imageID); err != nil {
+			return err
+		}
+		client, environment, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging images delete", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		if err := client.DeleteImage(requestCtx, *imageID); err != nil {
+			return fmt.Errorf("storekit retention-messaging images delete: %w", err)
+		}
+		return printMutation(mutation("image", *imageID, "deleted", environment), *output.Output, *output.Pretty)
+	})
+}
+
+func messagesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging messages", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "messages",
+		ShortUsage: "asc storekit retention-messaging messages <subcommand> [flags]",
+		ShortHelp:  "Upload, list, and delete retention messages.",
+		FlagSet:    fs,
+		Subcommands: []*ffcli.Command{
+			messagesListCommand(), messagesUploadCommand(), messagesDeleteCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func messagesListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging messages list", flag.ExitOnError)
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("list", "asc storekit retention-messaging messages list --environment ENV [flags]", "List retention messages.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		client, _, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging messages list", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.ListMessages(requestCtx)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging messages list: %w", err)
+		}
+		rows := make([][]string, 0, len(result.MessageIdentifiers))
+		for _, message := range result.MessageIdentifiers {
+			rows = append(rows, []string{message.MessageIdentifier, message.MessageState})
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Message ID", "State"}, rows)
+	})
+}
+
+func messagesUploadCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging messages upload", flag.ExitOnError)
+	messageID := fs.String("message-id", "", "Client-generated message UUID")
+	file := fs.String("file", "", "Path to a retention message JSON file")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("upload", "asc storekit retention-messaging messages upload --message-id UUID --file MESSAGE.json --environment ENV [flags]", "Upload a retention message.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if err := requireFlag("--message-id", *messageID); err != nil {
+			return err
+		}
+		if err := validateUUIDFlag("--message-id", *messageID); err != nil {
+			return err
+		}
+		if err := requireFlag("--file", *file); err != nil {
+			return err
+		}
+		message, err := readMessage(*file)
+		if err != nil {
+			return shared.UsageError(err.Error())
+		}
+		client, environment, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging messages upload", err)
+		}
+		requestCtx, cancel := shared.ContextWithUploadTimeout(ctx)
+		defer cancel()
+		if err := client.UploadMessage(requestCtx, *messageID, message); err != nil {
+			return fmt.Errorf("storekit retention-messaging messages upload: %w", err)
+		}
+		return printMutation(mutation("message", *messageID, "uploaded", environment), *output.Output, *output.Pretty)
+	})
+}
+
+func messagesDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging messages delete", flag.ExitOnError)
+	messageID := fs.String("message-id", "", "Message UUID")
+	confirm := fs.Bool("confirm", false, "Confirm message deletion")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("delete", "asc storekit retention-messaging messages delete --message-id UUID --environment ENV --confirm [flags]", "Delete a retention message.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if !*confirm {
+			return shared.UsageError("--confirm is required")
+		}
+		if err := requireFlag("--message-id", *messageID); err != nil {
+			return err
+		}
+		if err := validateUUIDFlag("--message-id", *messageID); err != nil {
+			return err
+		}
+		client, environment, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging messages delete", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		if err := client.DeleteMessage(requestCtx, *messageID); err != nil {
+			return fmt.Errorf("storekit retention-messaging messages delete: %w", err)
+		}
+		return printMutation(mutation("message", *messageID, "deleted", environment), *output.Output, *output.Pretty)
+	})
+}
+
+func defaultsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging defaults", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "defaults",
+		ShortUsage: "asc storekit retention-messaging defaults <subcommand> [flags]",
+		ShortHelp:  "View, set, and delete product-locale default messages.",
+		FlagSet:    fs,
+		Subcommands: []*ffcli.Command{
+			defaultViewCommand(), defaultSetCommand(), defaultDeleteCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func bindDefaultFlags(fs *flag.FlagSet) (*string, *string) {
+	return fs.String("product-id", "", "Subscription product ID"), fs.String("locale", "", "App Store locale, for example en-US")
+}
+
+func defaultViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging defaults view", flag.ExitOnError)
+	productID, locale := bindDefaultFlags(fs)
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("view", "asc storekit retention-messaging defaults view --product-id ID --locale LOCALE --environment ENV [flags]", "View the default retention message.", fs, func(ctx context.Context, args []string) error {
+		if err := validateDefaultInvocation(args, *productID, *locale); err != nil {
+			return err
+		}
+		client, _, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging defaults view", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.GetDefault(requestCtx, *productID, *locale)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging defaults view: %w", err)
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Message ID"}, [][]string{{result.MessageIdentifier}})
+	})
+}
+
+func defaultSetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging defaults set", flag.ExitOnError)
+	productID, locale := bindDefaultFlags(fs)
+	messageID := fs.String("message-id", "", "Approved retention message UUID")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("set", "asc storekit retention-messaging defaults set --product-id ID --locale LOCALE --message-id UUID --environment ENV [flags]", "Set the default retention message.", fs, func(ctx context.Context, args []string) error {
+		if err := validateDefaultInvocation(args, *productID, *locale); err != nil {
+			return err
+		}
+		if err := requireFlag("--message-id", *messageID); err != nil {
+			return err
+		}
+		if err := validateUUIDFlag("--message-id", *messageID); err != nil {
+			return err
+		}
+		client, _, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging defaults set", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.SetDefault(requestCtx, *productID, *locale, *messageID)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging defaults set: %w", err)
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Message ID"}, [][]string{{result.MessageIdentifier}})
+	})
+}
+
+func defaultDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging defaults delete", flag.ExitOnError)
+	productID, locale := bindDefaultFlags(fs)
+	confirm := fs.Bool("confirm", false, "Confirm default deletion")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("delete", "asc storekit retention-messaging defaults delete --product-id ID --locale LOCALE --environment ENV --confirm [flags]", "Delete the default retention message.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if !*confirm {
+			return shared.UsageError("--confirm is required")
+		}
+		if err := validateDefaultInvocation(nil, *productID, *locale); err != nil {
+			return err
+		}
+		client, environment, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging defaults delete", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		if err := client.DeleteDefault(requestCtx, *productID, *locale); err != nil {
+			return fmt.Errorf("storekit retention-messaging defaults delete: %w", err)
+		}
+		identifier := strings.TrimSpace(*productID) + "/" + strings.TrimSpace(*locale)
+		return printMutation(mutation("default", identifier, "deleted", environment), *output.Output, *output.Pretty)
+	})
+}
+
+func endpointCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging endpoint", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "endpoint",
+		ShortUsage: "asc storekit retention-messaging endpoint <subcommand> [flags]",
+		ShortHelp:  "View, set, and delete the realtime endpoint URL.",
+		FlagSet:    fs,
+		Subcommands: []*ffcli.Command{
+			endpointViewCommand(), endpointSetCommand(), endpointDeleteCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func endpointViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging endpoint view", flag.ExitOnError)
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("view", "asc storekit retention-messaging endpoint view --environment ENV [flags]", "View the realtime retention endpoint URL.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		client, _, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging endpoint view", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.GetRealtimeURL(requestCtx)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging endpoint view: %w", err)
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Endpoint URL"}, [][]string{{result.RealtimeURL}})
+	})
+}
+
+func endpointSetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging endpoint set", flag.ExitOnError)
+	realtimeURL := fs.String("url", "", "Complete HTTPS Get Retention Message endpoint URL")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("set", "asc storekit retention-messaging endpoint set --url HTTPS_URL --environment ENV [flags]", "Set the realtime retention endpoint URL.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if err := requireFlag("--url", *realtimeURL); err != nil {
+			return err
+		}
+		if err := storekitapi.ValidateRealtimeURL(*realtimeURL); err != nil {
+			return shared.UsageError("--url " + strings.TrimPrefix(err.Error(), "realtime URL "))
+		}
+		client, _, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging endpoint set", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.SetRealtimeURL(requestCtx, *realtimeURL)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging endpoint set: %w", err)
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Endpoint URL"}, [][]string{{result.RealtimeURL}})
+	})
+}
+
+func endpointDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging endpoint delete", flag.ExitOnError)
+	confirm := fs.Bool("confirm", false, "Confirm endpoint URL deletion")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("delete", "asc storekit retention-messaging endpoint delete --environment ENV --confirm [flags]", "Delete the realtime retention endpoint URL.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if !*confirm {
+			return shared.UsageError("--confirm is required")
+		}
+		client, environment, err := resolveClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging endpoint delete", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		if err := client.DeleteRealtimeURL(requestCtx); err != nil {
+			return fmt.Errorf("storekit retention-messaging endpoint delete: %w", err)
+		}
+		return printMutation(mutation("endpoint", "", "deleted", environment), *output.Output, *output.Pretty)
+	})
+}
+
+func performanceCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging performance", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "performance",
+		ShortUsage: "asc storekit retention-messaging performance <subcommand> [flags]",
+		ShortHelp:  "Start and inspect sandbox endpoint performance tests.",
+		LongHelp: `Start and inspect Retention Messaging endpoint performance tests.
+
+Apple exposes these operations only in the sandbox environment.`,
+		FlagSet: fs,
+		Subcommands: []*ffcli.Command{
+			performanceStartCommand(), performanceViewCommand(), performanceWaitCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(ctx context.Context, args []string) error { return flag.ErrHelp },
+	}
+}
+
+func performanceStartCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging performance start", flag.ExitOnError)
+	originalTransactionID := fs.String("original-transaction-id", "", "Sandbox subscription original transaction ID")
+	wait := fs.Bool("wait", false, "Wait until the performance test finishes")
+	interval := fs.Duration("interval", 10*time.Second, "Polling interval when --wait is set (minimum 10s)")
+	timeout := fs.Duration("timeout", 10*time.Minute, "Maximum wait time")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("start", "asc storekit retention-messaging performance start --original-transaction-id ID --environment sandbox [flags]", "Start a sandbox endpoint performance test.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if err := requireFlag("--original-transaction-id", *originalTransactionID); err != nil {
+			return err
+		}
+		if !*wait && flagWasSet(fs, "interval", "timeout") {
+			return shared.UsageError("--interval and --timeout require --wait")
+		}
+		if *wait {
+			if err := validateWaitDurations(*interval, *timeout); err != nil {
+				return err
+			}
+		}
+		client, err := resolveSandboxClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging performance start", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		result, err := client.StartPerformanceTest(requestCtx, *originalTransactionID)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging performance start: %w", err)
+		}
+		if *wait {
+			final, err := waitForPerformance(ctx, client, result.RequestID, *interval, *timeout)
+			if err != nil {
+				return fmt.Errorf("storekit retention-messaging performance start: %w", err)
+			}
+			return printWaitedPerformanceResult(final, *output.Output, *output.Pretty)
+		}
+		return printOutput(result, *output.Output, *output.Pretty, []string{"Request ID"}, [][]string{{result.RequestID}})
+	})
+}
+
+func performanceViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging performance view", flag.ExitOnError)
+	requestID := fs.String("request-id", "", "Performance test request ID")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("view", "asc storekit retention-messaging performance view --request-id ID --environment sandbox [flags]", "View a sandbox performance test result.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if err := requireFlag("--request-id", *requestID); err != nil {
+			return err
+		}
+		client, err := resolveSandboxClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging performance view", err)
+		}
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		result, err := client.GetPerformanceTestResult(requestCtx, *requestID)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging performance view: %w", err)
+		}
+		if result.RequestID == "" {
+			result.RequestID = strings.TrimSpace(*requestID)
+		}
+		return printWaitedPerformanceResult(result, *output.Output, *output.Pretty)
+	})
+}
+
+func performanceWaitCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit retention-messaging performance wait", flag.ExitOnError)
+	requestID := fs.String("request-id", "", "Performance test request ID")
+	interval := fs.Duration("interval", 10*time.Second, "Polling interval (minimum 10s)")
+	timeout := fs.Duration("timeout", 10*time.Minute, "Maximum wait time")
+	common := bindCommonFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return leafCommand("wait", "asc storekit retention-messaging performance wait --request-id ID --environment sandbox [flags]", "Wait for a sandbox performance test to finish.", fs, func(ctx context.Context, args []string) error {
+		if err := rejectUnexpectedArgs(args); err != nil {
+			return err
+		}
+		if err := requireFlag("--request-id", *requestID); err != nil {
+			return err
+		}
+		if err := validateWaitDurations(*interval, *timeout); err != nil {
+			return err
+		}
+		client, err := resolveSandboxClient(ctx, common)
+		if err != nil {
+			return usageOrWrap("storekit retention-messaging performance wait", err)
+		}
+		result, err := waitForPerformance(ctx, client, *requestID, *interval, *timeout)
+		if err != nil {
+			return fmt.Errorf("storekit retention-messaging performance wait: %w", err)
+		}
+		return printPerformanceResult(result, *output.Output, *output.Pretty)
+	})
+}
+
+func leafCommand(name, usage, help string, fs *flag.FlagSet, exec func(context.Context, []string) error) *ffcli.Command {
+	return &ffcli.Command{Name: name, ShortUsage: usage, ShortHelp: help, FlagSet: fs, UsageFunc: shared.DefaultUsageFunc, Exec: exec}
+}
+
+func requireFlag(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return shared.UsageError(name + " is required")
+	}
+	return nil
+}
+
+func validateUUIDFlag(name, value string) error {
+	if _, err := uuid.Parse(strings.TrimSpace(value)); err != nil {
+		return shared.UsageError(name + " must be a UUID")
+	}
+	return nil
+}
+
+func usageOrWrap(command string, err error) error {
+	message := err.Error()
+	if strings.HasPrefix(message, "--") || strings.HasPrefix(message, "environment must") || strings.HasPrefix(message, "performance tests require") || strings.HasPrefix(message, "incomplete StoreKit environment") || strings.HasPrefix(message, "mixed StoreKit authentication") {
+		return shared.UsageError(message)
+	}
+	return fmt.Errorf("%s: %w", command, err)
+}
+
+func resolveSandboxClient(ctx context.Context, common commonFlags) (*storekitapi.Client, error) {
+	environment, err := resolveEnvironment(common.Environment)
+	if err != nil {
+		return nil, err
+	}
+	if environment != storekitapi.Sandbox {
+		return nil, fmt.Errorf("performance tests require --environment sandbox")
+	}
+	client, _, err := resolveClient(ctx, common)
+	return client, err
+}
+
+func mutation(resource, identifier, action string, environment storekitapi.Environment) storekitapi.MutationResult {
+	return storekitapi.MutationResult{Resource: resource, Identifier: strings.TrimSpace(identifier), Action: action, Environment: environment, Success: true}
+}
+
+func printMutation(result storekitapi.MutationResult, format string, pretty bool) error {
+	return printOutput(result, format, pretty,
+		[]string{"Resource", "Identifier", "Action", "Environment", "Success"},
+		[][]string{{result.Resource, result.Identifier, result.Action, string(result.Environment), boolString(result.Success)}})
+}
+
+func readPNG(path string, size storekitapi.ImageSize) ([]byte, error) {
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return nil, fmt.Errorf("--file: %w", err)
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("--file must be a valid PNG: %w", err)
+	}
+	if err := validateImageDimensions(config.Width, config.Height, size); err != nil {
+		return nil, err
+	}
+	decoded, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("--file must be a valid PNG: %w", err)
+	}
+	if hasTransparency(decoded) {
+		return nil, fmt.Errorf("--file must not contain transparency")
+	}
+	return data, nil
+}
+
+func validateImageDimensions(width, height int, size storekitapi.ImageSize) error {
+	switch size {
+	case storekitapi.ImageSizeFull:
+		if width != 3840 || height < 160 || height > 2160 {
+			return fmt.Errorf("--file must be 3840 pixels wide and 160-2160 pixels high for FULL_SIZE (got %dx%d)", width, height)
+		}
+	case storekitapi.ImageSizeBulletPoint:
+		if width != 1024 || height != 1024 {
+			return fmt.Errorf("--file must be 1024x1024 pixels for BULLET_POINT (got %dx%d)", width, height)
+		}
+	}
+	return nil
+}
+
+func hasTransparency(decoded image.Image) bool {
+	bounds := decoded.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			_, _, _, alpha := decoded.At(x, y).RGBA()
+			if alpha != 0xffff {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func readMessage(path string) (storekitapi.Message, error) {
+	file, err := os.Open(strings.TrimSpace(path))
+	if err != nil {
+		return storekitapi.Message{}, fmt.Errorf("--file: %w", err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(io.LimitReader(file, 1<<20))
+	decoder.DisallowUnknownFields()
+	var message storekitapi.Message
+	if err := decoder.Decode(&message); err != nil {
+		return storekitapi.Message{}, fmt.Errorf("--file must contain a valid retention message JSON object: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return storekitapi.Message{}, fmt.Errorf("--file must contain exactly one JSON object")
+	}
+	if err := storekitapi.ValidateMessage(message); err != nil {
+		return storekitapi.Message{}, fmt.Errorf("--file: %w", err)
+	}
+	return message, nil
+}
+
+func validateDefaultInvocation(args []string, productID, locale string) error {
+	if err := rejectUnexpectedArgs(args); err != nil {
+		return err
+	}
+	if err := requireFlag("--product-id", productID); err != nil {
+		return err
+	}
+	return requireFlag("--locale", locale)
+}
+
+func validateWaitDurations(interval, timeout time.Duration) error {
+	if interval < 10*time.Second {
+		return shared.UsageError("--interval must be at least 10s for the sandbox rate limit")
+	}
+	if timeout <= 0 {
+		return shared.UsageError("--timeout must be positive")
+	}
+	return nil
+}
+
+func waitForPerformance(ctx context.Context, client *storekitapi.Client, requestID string, interval, timeout time.Duration) (*storekitapi.PerformanceTestResult, error) {
+	waitCtx, cancel := context.WithTimeout(shared.ContextWithoutTimeout(ctx), timeout)
+	defer cancel()
+	for {
+		requestCtx, requestCancel := shared.ContextWithTimeout(waitCtx)
+		result, err := client.GetPerformanceTestResult(requestCtx, requestID)
+		requestCancel()
+		if err != nil {
+			return nil, err
+		}
+		if result.RequestID == "" {
+			result.RequestID = strings.TrimSpace(requestID)
+		}
+		if !strings.EqualFold(result.Result, "PENDING") {
+			return result, nil
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("timed out waiting for performance test %q: %w", requestID, waitCtx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func printPerformanceResult(result *storekitapi.PerformanceTestResult, format string, pretty bool) error {
+	return printOutput(result, format, pretty,
+		[]string{"Request ID", "Result", "Success Rate", "Pending"},
+		[][]string{{result.RequestID, result.Result, fmt.Sprintf("%d", result.SuccessRate), fmt.Sprintf("%d", result.NumPending)}})
+}
+
+func printWaitedPerformanceResult(result *storekitapi.PerformanceTestResult, format string, pretty bool) error {
+	if err := printPerformanceResult(result, format, pretty); err != nil {
+		return err
+	}
+	return performanceResultError(result)
+}
+
+func performanceResultError(result *storekitapi.PerformanceTestResult) error {
+	if strings.EqualFold(result.Result, "FAIL") {
+		return fmt.Errorf("performance test %q failed", result.RequestID)
+	}
+	return nil
+}

--- a/internal/cli/storekit/retention_test.go
+++ b/internal/cli/storekit/retention_test.go
@@ -1,0 +1,64 @@
+package storekit
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	storekitapi "github.com/rudrankriyam/App-Store-Connect-CLI/internal/storekit"
+)
+
+func TestReadPNGValidatesDocumentedImageRequirements(t *testing.T) {
+	valid := writeTestPNG(t, image.Rect(0, 0, 3840, 160), color.NRGBA{R: 20, G: 30, B: 40, A: 255})
+	if _, err := readPNG(valid, storekitapi.ImageSizeFull); err != nil {
+		t.Fatalf("readPNG(valid) error = %v", err)
+	}
+
+	wrongSize := writeTestPNG(t, image.Rect(0, 0, 100, 100), color.NRGBA{A: 255})
+	if _, err := readPNG(wrongSize, storekitapi.ImageSizeFull); err == nil || !strings.Contains(err.Error(), "3840 pixels wide") {
+		t.Fatalf("readPNG(wrong size) error = %v", err)
+	}
+
+	transparent := writeTestPNG(t, image.Rect(0, 0, 1024, 1024), color.NRGBA{R: 20, A: 100})
+	if _, err := readPNG(transparent, storekitapi.ImageSizeBulletPoint); err == nil || !strings.Contains(err.Error(), "must not contain transparency") {
+		t.Fatalf("readPNG(transparent) error = %v", err)
+	}
+}
+
+func TestPerformanceWaitFailsWhenAppleReportsFail(t *testing.T) {
+	failed := &storekitapi.PerformanceTestResult{RequestID: "request-1", Result: "FAIL"}
+	if err := performanceResultError(failed); err == nil || !strings.Contains(err.Error(), "request-1") {
+		t.Fatalf("performanceResultError(FAIL) = %v", err)
+	}
+	passed := &storekitapi.PerformanceTestResult{RequestID: "request-2", Result: "PASS"}
+	if err := performanceResultError(passed); err != nil {
+		t.Fatalf("performanceResultError(PASS) = %v", err)
+	}
+}
+
+func writeTestPNG(t *testing.T, bounds image.Rectangle, fill color.NRGBA) string {
+	t.Helper()
+	img := image.NewNRGBA(bounds)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			img.SetNRGBA(x, y, fill)
+		}
+	}
+	path := filepath.Join(t.TempDir(), "image.png")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := png.Encode(file, img); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/cli/storekit/root.go
+++ b/internal/cli/storekit/root.go
@@ -1,0 +1,37 @@
+package storekit
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// Command returns the StoreKit API command group.
+func Command() *ffcli.Command {
+	fs := flag.NewFlagSet("storekit", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "storekit",
+		ShortUsage: "asc storekit <subcommand> [flags]",
+		ShortHelp:  "Manage StoreKit server APIs with In-App Purchase API keys.",
+		LongHelp: `Manage StoreKit server APIs with dedicated In-App Purchase API keys.
+
+StoreKit credentials are separate from App Store Connect API credentials.
+
+Examples:
+  asc storekit auth login --name Production --key-id KEY_ID --issuer-id ISSUER_ID --private-key ./SubscriptionKey.p8 --bundle-id com.example.app
+  asc storekit retention-messaging messages list --environment sandbox
+  asc storekit retention-messaging endpoint set --url https://example.com/retention --environment production`,
+		FlagSet: fs,
+		Subcommands: []*ffcli.Command{
+			AuthCommand(),
+			RetentionMessagingCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,23 @@ type AdsConfig struct {
 	OrgID            string                `json:"org_id,omitempty"`
 }
 
+// StoreKitCredential stores a named In-App Purchase API credential.
+// Private key material stays in the keychain; config-backed credentials store
+// only a path to the key file.
+type StoreKitCredential struct {
+	Name           string `json:"name"`
+	KeyID          string `json:"key_id"`
+	IssuerID       string `json:"issuer_id"`
+	PrivateKeyPath string `json:"private_key_path"`
+	BundleID       string `json:"bundle_id"`
+}
+
+// StoreKitConfig stores StoreKit-specific authentication configuration.
+type StoreKitConfig struct {
+	DefaultKeyName string               `json:"default_key_name,omitempty"`
+	Keys           []StoreKitCredential `json:"keys,omitempty"`
+}
+
 // Config holds the application configuration
 type Config struct {
 	KeyID            string             `json:"key_id"`
@@ -212,7 +229,8 @@ type Config struct {
 	RetryLog             string        `json:"retry_log"`
 	Debug                string        `json:"debug"`
 
-	Ads AdsConfig `json:"ads,omitempty"`
+	Ads      AdsConfig      `json:"ads,omitempty"`
+	StoreKit StoreKitConfig `json:"storekit,omitempty"`
 }
 
 // ErrNotFound is returned when the config file doesn't exist

--- a/internal/storekit/auth_store.go
+++ b/internal/storekit/auth_store.go
@@ -181,6 +181,9 @@ func SetDefaultCredentials(name string) error {
 	}
 	for _, credential := range credentials {
 		if credential.Name == name {
+			if credential.Source == "config" && strings.TrimSpace(credential.SourcePath) != "" {
+				return saveDefaultNameAt(name, credential.SourcePath)
+			}
 			return saveDefaultName(name)
 		}
 	}
@@ -363,10 +366,33 @@ func storeInConfigAt(name string, payload credentialPayload, path string) error 
 }
 
 func removeFromConfigIfPresent(name string) error {
-	path, err := config.Path()
+	paths, err := configStoragePaths()
 	if err != nil {
 		return err
 	}
+	removed := false
+	var mutationErrors []error
+	for _, path := range paths {
+		err := removeFromConfigAtIfPresent(name, path)
+		if err == nil {
+			removed = true
+			continue
+		}
+		if errors.Is(err, config.ErrNotFound) || errors.Is(err, keyring.ErrKeyNotFound) {
+			continue
+		}
+		mutationErrors = append(mutationErrors, fmt.Errorf("update StoreKit config %q: %w", path, err))
+	}
+	if len(mutationErrors) > 0 {
+		return errors.Join(mutationErrors...)
+	}
+	if !removed {
+		return keyring.ErrKeyNotFound
+	}
+	return nil
+}
+
+func removeFromConfigAtIfPresent(name, path string) error {
 	cfg, err := config.LoadAt(path)
 	if err != nil {
 		return err
@@ -391,19 +417,29 @@ func removeFromConfigIfPresent(name string) error {
 }
 
 func clearConfigCredentials() error {
-	path, err := config.Path()
+	paths, err := configStoragePaths()
 	if err != nil {
 		return err
 	}
-	cfg, err := config.LoadAt(path)
-	if err != nil {
-		if errors.Is(err, config.ErrNotFound) {
-			return nil
+	var mutationErrors []error
+	for _, path := range paths {
+		cfg, err := config.LoadAt(path)
+		if err != nil {
+			if errors.Is(err, config.ErrNotFound) {
+				continue
+			}
+			mutationErrors = append(mutationErrors, fmt.Errorf("load StoreKit config %q: %w", path, err))
+			continue
 		}
-		return err
+		if !hasStoreKitConfig(cfg) {
+			continue
+		}
+		cfg.StoreKit = config.StoreKitConfig{}
+		if err := config.SaveAt(path, cfg); err != nil {
+			mutationErrors = append(mutationErrors, fmt.Errorf("clear StoreKit config %q: %w", path, err))
+		}
 	}
-	cfg.StoreKit = config.StoreKitConfig{}
-	return config.SaveAt(path, cfg)
+	return errors.Join(mutationErrors...)
 }
 
 func saveDefaultName(name string) error {
@@ -411,6 +447,10 @@ func saveDefaultName(name string) error {
 	if err != nil {
 		return err
 	}
+	return saveDefaultNameAt(name, path)
+}
+
+func saveDefaultNameAt(name, path string) error {
 	cfg, err := config.LoadAt(path)
 	if err != nil {
 		if !errors.Is(err, config.ErrNotFound) {
@@ -423,22 +463,47 @@ func saveDefaultName(name string) error {
 }
 
 func clearDefaultNameIf(name string) error {
-	path, err := config.Path()
+	paths, err := configStoragePaths()
 	if err != nil {
 		return err
 	}
-	cfg, err := config.LoadAt(path)
-	if err != nil {
-		if errors.Is(err, config.ErrNotFound) {
-			return nil
+	var mutationErrors []error
+	for _, path := range paths {
+		cfg, err := config.LoadAt(path)
+		if err != nil {
+			if errors.Is(err, config.ErrNotFound) {
+				continue
+			}
+			mutationErrors = append(mutationErrors, fmt.Errorf("load StoreKit config %q: %w", path, err))
+			continue
 		}
-		return err
+		if cfg.StoreKit.DefaultKeyName == name {
+			cfg.StoreKit.DefaultKeyName = ""
+			if err := config.SaveAt(path, cfg); err != nil {
+				mutationErrors = append(mutationErrors, fmt.Errorf("update StoreKit config %q: %w", path, err))
+			}
+		}
 	}
-	if cfg.StoreKit.DefaultKeyName == name {
-		cfg.StoreKit.DefaultKeyName = ""
-		return config.SaveAt(path, cfg)
+	return errors.Join(mutationErrors...)
+}
+
+func configStoragePaths() ([]string, error) {
+	activePath, err := config.Path()
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	paths := []string{activePath}
+	if strings.TrimSpace(os.Getenv("ASC_CONFIG_PATH")) != "" {
+		return paths, nil
+	}
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		return nil, err
+	}
+	if globalPath != activePath {
+		paths = append(paths, globalPath)
+	}
+	return paths, nil
 }
 
 func listFromConfig() ([]StoredCredential, error) {

--- a/internal/storekit/auth_store.go
+++ b/internal/storekit/auth_store.go
@@ -167,7 +167,7 @@ func ListCredentials() ([]StoredCredential, error) {
 	if keychainErr != nil || ShouldBypassKeychain() {
 		return normalizeDefaults(configCredentials), nil
 	}
-	return normalizeDefaults(mergeCredentials(keychainCredentials, configCredentials)), nil
+	return normalizeDefaults(mergeCredentials(configCredentials, keychainCredentials)), nil
 }
 
 func SetDefaultCredentials(name string) error {

--- a/internal/storekit/auth_store.go
+++ b/internal/storekit/auth_store.go
@@ -114,9 +114,14 @@ func GetCredentialsWithSource(profile string) (Credentials, string, error) {
 		} else if ok {
 			return selected.Credentials, "config", nil
 		}
+		if selected, ok, err := findCredentialInResolvedConfig(profile); err == nil && ok {
+			return selected.Credentials, "config", nil
+		}
 	} else if selected, ok, err := findDefaultCredentialInActiveConfig(); err != nil {
 		return Credentials{}, "", err
 	} else if ok {
+		return selected.Credentials, "config", nil
+	} else if selected, ok, err := findDefaultCredentialInResolvedConfig(); err == nil && ok {
 		return selected.Credentials, "config", nil
 	}
 	if !ShouldBypassKeychain() {
@@ -540,6 +545,28 @@ func findDefaultCredentialInActiveConfig() (StoredCredential, bool, error) {
 		if errors.Is(err, config.ErrNotFound) {
 			return StoredCredential{}, false, nil
 		}
+		return StoredCredential{}, false, err
+	}
+	defaultName := strings.TrimSpace(cfg.StoreKit.DefaultKeyName)
+	if defaultName == "" {
+		return StoredCredential{}, false, nil
+	}
+	selected, ok := selectCredential(defaultName, storedCredentialsFromConfig(cfg, path))
+	return selected, ok, nil
+}
+
+func findCredentialInResolvedConfig(profile string) (StoredCredential, bool, error) {
+	cfg, path, err := loadConfigWithPath()
+	if err != nil {
+		return StoredCredential{}, false, err
+	}
+	selected, ok := selectCredential(profile, storedCredentialsFromConfig(cfg, path))
+	return selected, ok, nil
+}
+
+func findDefaultCredentialInResolvedConfig() (StoredCredential, bool, error) {
+	cfg, path, err := loadConfigWithPath()
+	if err != nil {
 		return StoredCredential{}, false, err
 	}
 	defaultName := strings.TrimSpace(cfg.StoreKit.DefaultKeyName)

--- a/internal/storekit/auth_store.go
+++ b/internal/storekit/auth_store.go
@@ -1,0 +1,605 @@
+package storekit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/99designs/keyring"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+)
+
+const (
+	storeKitKeyringService       = "asc"
+	storeKitKeyringItemPrefix    = "asc:storekit-credential:"
+	storeKitBypassKeychainEnvVar = "ASC_STOREKIT_BYPASS_KEYCHAIN"
+)
+
+type StoredCredential struct {
+	Credentials `json:"-"`
+	Name        string `json:"name"`
+	IsDefault   bool   `json:"default"`
+	Source      string `json:"source"`
+	SourcePath  string `json:"source_path,omitempty"`
+}
+
+type credentialPayload struct {
+	KeyID          string `json:"key_id"`
+	IssuerID       string `json:"issuer_id"`
+	PrivateKeyPath string `json:"private_key_path,omitempty"`
+	PrivateKeyPEM  string `json:"private_key_pem,omitempty"`
+	BundleID       string `json:"bundle_id"`
+}
+
+// ShouldBypassKeychain reports whether StoreKit keychain access is disabled.
+func ShouldBypassKeychain() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(storeKitBypassKeychainEnvVar))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// StoreCredentials stores a credential in the system keychain when available.
+func StoreCredentials(name string, credentials Credentials) error {
+	payload, err := payloadFromCredentials(credentials, true)
+	if err != nil {
+		return err
+	}
+	if !ShouldBypassKeychain() {
+		if err := storeInKeychain(name, payload); err == nil {
+			_ = removeFromConfigIfPresent(name)
+			return saveDefaultName(name)
+		} else if !isKeyringUnavailable(err) {
+			return err
+		}
+	}
+	return StoreCredentialsConfig(name, credentials)
+}
+
+func StoreCredentialsConfig(name string, credentials Credentials) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	return StoreCredentialsConfigAt(name, credentials, path)
+}
+
+func StoreCredentialsConfigAt(name string, credentials Credentials, path string) error {
+	payload, err := payloadFromCredentials(credentials, false)
+	if err != nil {
+		return err
+	}
+	return storeInConfigAt(name, payload, path)
+}
+
+func payloadFromCredentials(credentials Credentials, includePEM bool) (credentialPayload, error) {
+	credentials = normalizeCredentials(credentials)
+	payload := credentialPayload{
+		KeyID:          credentials.KeyID,
+		IssuerID:       credentials.IssuerID,
+		PrivateKeyPath: credentials.PrivateKeyPath,
+		BundleID:       credentials.BundleID,
+	}
+	if includePEM && credentials.PrivateKeyPEM != "" {
+		payload.PrivateKeyPEM = credentials.PrivateKeyPEM
+	} else if includePEM && credentials.PrivateKeyPath != "" {
+		data, err := os.ReadFile(credentials.PrivateKeyPath)
+		if err != nil {
+			return payload, fmt.Errorf("read private key for keychain storage: %w", err)
+		}
+		payload.PrivateKeyPEM = string(data)
+	}
+	if err := validateCredentials(Credentials{
+		KeyID:          payload.KeyID,
+		IssuerID:       payload.IssuerID,
+		PrivateKeyPath: payload.PrivateKeyPath,
+		PrivateKeyPEM:  payload.PrivateKeyPEM,
+		BundleID:       payload.BundleID,
+	}); err != nil {
+		return payload, err
+	}
+	return payload, nil
+}
+
+func GetCredentialsWithSource(profile string) (Credentials, string, error) {
+	if strings.TrimSpace(profile) != "" {
+		if selected, ok, err := findCredentialInActiveConfig(profile); err != nil {
+			return Credentials{}, "", err
+		} else if ok {
+			return selected.Credentials, "config", nil
+		}
+	} else if selected, ok, err := findDefaultCredentialInActiveConfig(); err != nil {
+		return Credentials{}, "", err
+	} else if ok {
+		return selected.Credentials, "config", nil
+	}
+	if !ShouldBypassKeychain() {
+		credentials, err := listFromKeychain()
+		if err == nil {
+			if selected, ok := selectCredential(profile, credentials); ok {
+				return selected.Credentials, "keychain", nil
+			}
+			if strings.TrimSpace(profile) != "" {
+				if configCredential, configErr := getCredentialFromConfig(profile); configErr == nil {
+					return configCredential.Credentials, "config", nil
+				}
+				return Credentials{}, "", fmt.Errorf("StoreKit credentials not found for profile %q", profile)
+			}
+			if configCredential, configErr := getCredentialFromConfig(""); configErr == nil {
+				return configCredential.Credentials, "config", nil
+			}
+			if len(credentials) > 0 {
+				return Credentials{}, "", fmt.Errorf("default StoreKit credentials not found")
+			}
+		} else if !isKeyringUnavailable(err) {
+			return Credentials{}, "", err
+		}
+	}
+	selected, err := getCredentialFromConfig(profile)
+	if err != nil {
+		return Credentials{}, "", err
+	}
+	return selected.Credentials, "config", nil
+}
+
+func ListCredentials() ([]StoredCredential, error) {
+	var keychainCredentials []StoredCredential
+	var keychainErr error
+	if !ShouldBypassKeychain() {
+		keychainCredentials, keychainErr = listFromKeychain()
+		if keychainErr != nil && !isKeyringUnavailable(keychainErr) {
+			return nil, keychainErr
+		}
+	}
+	configCredentials, configErr := listFromConfig()
+	if configErr != nil && !errors.Is(configErr, config.ErrNotFound) {
+		if len(keychainCredentials) == 0 {
+			return nil, configErr
+		}
+		configCredentials = nil
+	}
+	if keychainErr != nil || ShouldBypassKeychain() {
+		return normalizeDefaults(configCredentials), nil
+	}
+	return normalizeDefaults(mergeCredentials(keychainCredentials, configCredentials)), nil
+}
+
+func SetDefaultCredentials(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
+	credentials, err := ListCredentials()
+	if err != nil {
+		return err
+	}
+	for _, credential := range credentials {
+		if credential.Name == name {
+			return saveDefaultName(name)
+		}
+	}
+	return fmt.Errorf("StoreKit credentials not found for profile %q", name)
+}
+
+func RemoveCredentials(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
+	removed := false
+	var keychainErr error
+	if !ShouldBypassKeychain() {
+		keychainErr = removeFromKeychain(name)
+		if keychainErr == nil {
+			removed = true
+		}
+	}
+	configErr := removeFromConfigIfPresent(name)
+	if configErr == nil {
+		removed = true
+	}
+	if keychainErr != nil && !isKeyringUnavailable(keychainErr) && !errors.Is(keychainErr, keyring.ErrKeyNotFound) {
+		return keychainErr
+	}
+	if configErr != nil && !errors.Is(configErr, config.ErrNotFound) && !errors.Is(configErr, keyring.ErrKeyNotFound) {
+		return configErr
+	}
+	if !removed {
+		return keyring.ErrKeyNotFound
+	}
+	return clearDefaultNameIf(name)
+}
+
+func RemoveAllCredentials() error {
+	configErr := clearConfigCredentials()
+	if ShouldBypassKeychain() {
+		return configErr
+	}
+	keychainErr := removeAllFromKeychain()
+	if keychainErr != nil && !isKeyringUnavailable(keychainErr) {
+		return keychainErr
+	}
+	return configErr
+}
+
+func keyringConfig() keyring.Config {
+	return keyring.Config{
+		ServiceName:                    storeKitKeyringService,
+		KeychainTrustApplication:       true,
+		KeychainSynchronizable:         false,
+		KeychainAccessibleWhenUnlocked: true,
+		AllowedBackends: []keyring.BackendType{
+			keyring.KeychainBackend,
+			keyring.WinCredBackend,
+			keyring.SecretServiceBackend,
+			keyring.KWalletBackend,
+			keyring.KeyCtlBackend,
+		},
+	}
+}
+
+var openStoreKitKeyring = func() (keyring.Keyring, error) {
+	return keyring.Open(keyringConfig())
+}
+
+func storeInKeychain(name string, payload credentialPayload) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
+	kr, err := openStoreKitKeyring()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return kr.Set(keyring.Item{
+		Key:         storeKitKeyringItemPrefix + name,
+		Data:        data,
+		Label:       "ASC StoreKit In-App Purchase API Key (" + name + ")",
+		Description: "StoreKit Retention Messaging credentials for " + payload.BundleID,
+	})
+}
+
+func listFromKeychain() ([]StoredCredential, error) {
+	kr, err := openStoreKitKeyring()
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		return nil, err
+	}
+	credentials := []StoredCredential{}
+	for _, key := range keys {
+		if !strings.HasPrefix(key, storeKitKeyringItemPrefix) {
+			continue
+		}
+		item, err := kr.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		var payload credentialPayload
+		if err := json.Unmarshal(item.Data, &payload); err != nil {
+			return nil, fmt.Errorf("invalid StoreKit keychain entry %q: %w", key, err)
+		}
+		name := strings.TrimPrefix(key, storeKitKeyringItemPrefix)
+		credentials = append(credentials, storedFromPayload(name, payload, "keychain", "system keychain"))
+	}
+	return credentials, nil
+}
+
+func removeFromKeychain(name string) error {
+	kr, err := openStoreKitKeyring()
+	if err != nil {
+		return err
+	}
+	return kr.Remove(storeKitKeyringItemPrefix + strings.TrimSpace(name))
+}
+
+func removeAllFromKeychain() error {
+	kr, err := openStoreKitKeyring()
+	if err != nil {
+		return err
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if strings.HasPrefix(key, storeKitKeyringItemPrefix) {
+			if err := kr.Remove(key); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func isKeyringUnavailable(err error) bool {
+	return errors.Is(err, keyring.ErrNoAvailImpl)
+}
+
+func storeInConfigAt(name string, payload credentialPayload, path string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if !errors.Is(err, config.ErrNotFound) {
+			return err
+		}
+		cfg = &config.Config{}
+	}
+	replacement := config.StoreKitCredential{
+		Name:           name,
+		KeyID:          payload.KeyID,
+		IssuerID:       payload.IssuerID,
+		PrivateKeyPath: payload.PrivateKeyPath,
+		BundleID:       payload.BundleID,
+	}
+	replaced := false
+	for i := range cfg.StoreKit.Keys {
+		if cfg.StoreKit.Keys[i].Name == name {
+			cfg.StoreKit.Keys[i] = replacement
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		cfg.StoreKit.Keys = append(cfg.StoreKit.Keys, replacement)
+	}
+	cfg.StoreKit.DefaultKeyName = name
+	return config.SaveAt(path, cfg)
+}
+
+func removeFromConfigIfPresent(name string) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		return err
+	}
+	filtered := cfg.StoreKit.Keys[:0]
+	removed := false
+	for _, credential := range cfg.StoreKit.Keys {
+		if credential.Name == name {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, credential)
+	}
+	if !removed {
+		return keyring.ErrKeyNotFound
+	}
+	cfg.StoreKit.Keys = filtered
+	if cfg.StoreKit.DefaultKeyName == name {
+		cfg.StoreKit.DefaultKeyName = ""
+	}
+	return config.SaveAt(path, cfg)
+}
+
+func clearConfigCredentials() error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	cfg.StoreKit = config.StoreKitConfig{}
+	return config.SaveAt(path, cfg)
+}
+
+func saveDefaultName(name string) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if !errors.Is(err, config.ErrNotFound) {
+			return err
+		}
+		cfg = &config.Config{}
+	}
+	cfg.StoreKit.DefaultKeyName = strings.TrimSpace(name)
+	return config.SaveAt(path, cfg)
+}
+
+func clearDefaultNameIf(name string) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if cfg.StoreKit.DefaultKeyName == name {
+		cfg.StoreKit.DefaultKeyName = ""
+		return config.SaveAt(path, cfg)
+	}
+	return nil
+}
+
+func listFromConfig() ([]StoredCredential, error) {
+	cfg, path, err := loadConfigWithPath()
+	if err != nil {
+		return nil, err
+	}
+	return storedCredentialsFromConfig(cfg, path), nil
+}
+
+func findCredentialInActiveConfig(profile string) (StoredCredential, bool, error) {
+	path, err := config.Path()
+	if err != nil {
+		return StoredCredential{}, false, err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return StoredCredential{}, false, nil
+		}
+		return StoredCredential{}, false, err
+	}
+	selected, ok := selectCredential(profile, storedCredentialsFromConfig(cfg, path))
+	return selected, ok, nil
+}
+
+func findDefaultCredentialInActiveConfig() (StoredCredential, bool, error) {
+	path, err := config.Path()
+	if err != nil {
+		return StoredCredential{}, false, err
+	}
+	cfg, err := config.LoadAt(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return StoredCredential{}, false, nil
+		}
+		return StoredCredential{}, false, err
+	}
+	defaultName := strings.TrimSpace(cfg.StoreKit.DefaultKeyName)
+	if defaultName == "" {
+		return StoredCredential{}, false, nil
+	}
+	selected, ok := selectCredential(defaultName, storedCredentialsFromConfig(cfg, path))
+	return selected, ok, nil
+}
+
+func storedCredentialsFromConfig(cfg *config.Config, path string) []StoredCredential {
+	credentials := make([]StoredCredential, 0, len(cfg.StoreKit.Keys))
+	for _, credential := range cfg.StoreKit.Keys {
+		payload := credentialPayload{
+			KeyID:          credential.KeyID,
+			IssuerID:       credential.IssuerID,
+			PrivateKeyPath: credential.PrivateKeyPath,
+			BundleID:       credential.BundleID,
+		}
+		credentials = append(credentials, storedFromPayload(credential.Name, payload, "config", path))
+	}
+	return credentials
+}
+
+func getCredentialFromConfig(profile string) (StoredCredential, error) {
+	credentials, err := listFromConfig()
+	if err != nil {
+		return StoredCredential{}, err
+	}
+	if selected, ok := selectCredential(profile, credentials); ok {
+		return selected, nil
+	}
+	if strings.TrimSpace(profile) != "" {
+		return StoredCredential{}, fmt.Errorf("StoreKit credentials not found for profile %q", profile)
+	}
+	return StoredCredential{}, fmt.Errorf("default StoreKit credentials not found")
+}
+
+func loadConfigWithPath() (*config.Config, string, error) {
+	path, err := config.Path()
+	if err != nil {
+		return nil, "", err
+	}
+	cfg, err := config.LoadAt(path)
+	if err == nil {
+		return cfg, path, nil
+	}
+	if !errors.Is(err, config.ErrNotFound) || strings.TrimSpace(os.Getenv("ASC_CONFIG_PATH")) != "" {
+		return nil, "", err
+	}
+	globalPath, globalErr := config.GlobalPath()
+	if globalErr != nil || globalPath == path {
+		return nil, "", err
+	}
+	cfg, err = config.LoadAt(globalPath)
+	if err != nil {
+		return nil, "", err
+	}
+	return cfg, globalPath, nil
+}
+
+func storedFromPayload(name string, payload credentialPayload, source, sourcePath string) StoredCredential {
+	return StoredCredential{
+		Credentials: Credentials{
+			KeyID:          payload.KeyID,
+			IssuerID:       payload.IssuerID,
+			PrivateKeyPath: payload.PrivateKeyPath,
+			PrivateKeyPEM:  payload.PrivateKeyPEM,
+			BundleID:       payload.BundleID,
+			Profile:        name,
+		},
+		Name:       name,
+		Source:     source,
+		SourcePath: sourcePath,
+	}
+}
+
+func selectCredential(profile string, credentials []StoredCredential) (StoredCredential, bool) {
+	profile = strings.TrimSpace(profile)
+	if profile != "" {
+		for _, credential := range credentials {
+			if credential.Name == profile {
+				return credential, true
+			}
+		}
+		return StoredCredential{}, false
+	}
+	credentials = normalizeDefaults(credentials)
+	for _, credential := range credentials {
+		if credential.IsDefault {
+			return credential, true
+		}
+	}
+	return StoredCredential{}, false
+}
+
+func normalizeDefaults(credentials []StoredCredential) []StoredCredential {
+	if len(credentials) == 0 {
+		return credentials
+	}
+	defaultName := ""
+	if cfg, _, err := loadConfigWithPath(); err == nil {
+		defaultName = strings.TrimSpace(cfg.StoreKit.DefaultKeyName)
+	}
+	for i := range credentials {
+		credentials[i].IsDefault = credentials[i].Name == defaultName
+	}
+	if defaultName == "" && len(credentials) == 1 {
+		credentials[0].IsDefault = true
+	}
+	sort.Slice(credentials, func(i, j int) bool { return credentials[i].Name < credentials[j].Name })
+	return credentials
+}
+
+func mergeCredentials(primary, secondary []StoredCredential) []StoredCredential {
+	seen := map[string]struct{}{}
+	merged := make([]StoredCredential, 0, len(primary)+len(secondary))
+	for _, credential := range primary {
+		seen[credential.Name] = struct{}{}
+		merged = append(merged, credential)
+	}
+	for _, credential := range secondary {
+		if _, ok := seen[credential.Name]; !ok {
+			merged = append(merged, credential)
+		}
+	}
+	return merged
+}

--- a/internal/storekit/auth_store.go
+++ b/internal/storekit/auth_store.go
@@ -520,6 +520,20 @@ func loadConfigWithPath() (*config.Config, string, error) {
 	}
 	cfg, err := config.LoadAt(path)
 	if err == nil {
+		if strings.TrimSpace(os.Getenv("ASC_CONFIG_PATH")) != "" || hasStoreKitConfig(cfg) {
+			return cfg, path, nil
+		}
+		globalPath, globalErr := config.GlobalPath()
+		if globalErr != nil || globalPath == path {
+			return cfg, path, nil
+		}
+		globalConfig, globalErr := config.LoadAt(globalPath)
+		if globalErr == nil {
+			return globalConfig, globalPath, nil
+		}
+		if !errors.Is(globalErr, config.ErrNotFound) {
+			return nil, "", globalErr
+		}
 		return cfg, path, nil
 	}
 	if !errors.Is(err, config.ErrNotFound) || strings.TrimSpace(os.Getenv("ASC_CONFIG_PATH")) != "" {
@@ -534,6 +548,10 @@ func loadConfigWithPath() (*config.Config, string, error) {
 		return nil, "", err
 	}
 	return cfg, globalPath, nil
+}
+
+func hasStoreKitConfig(cfg *config.Config) bool {
+	return cfg != nil && (strings.TrimSpace(cfg.StoreKit.DefaultKeyName) != "" || len(cfg.StoreKit.Keys) > 0)
 }
 
 func storedFromPayload(name string, payload credentialPayload, source, sourcePath string) StoredCredential {

--- a/internal/storekit/auth_store.go
+++ b/internal/storekit/auth_store.go
@@ -131,8 +131,12 @@ func GetCredentialsWithSource(profile string) (Credentials, string, error) {
 				return selected.Credentials, "keychain", nil
 			}
 			if strings.TrimSpace(profile) != "" {
-				if configCredential, configErr := getCredentialFromConfig(profile); configErr == nil {
+				configCredential, configErr := getCredentialFromConfig(profile)
+				if configErr == nil {
 					return configCredential.Credentials, "config", nil
+				}
+				if !errors.Is(configErr, config.ErrNotFound) {
+					return Credentials{}, "", configErr
 				}
 				return Credentials{}, "", fmt.Errorf("StoreKit credentials not found for profile %q", profile)
 			}

--- a/internal/storekit/auth_store_test.go
+++ b/internal/storekit/auth_store_test.go
@@ -90,6 +90,13 @@ func TestGetCredentialsPrefersActiveConfigOverSameNamedKeychainProfile(t *testin
 	if source != "config" || credentials.KeyID != "CONFIG_KEY" {
 		t.Fatalf("credentials = %#v source=%q", credentials, source)
 	}
+	listed, err := ListCredentials()
+	if err != nil {
+		t.Fatalf("ListCredentials() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].Source != "config" || listed[0].KeyID != "CONFIG_KEY" {
+		t.Fatalf("ListCredentials() = %#v", listed)
+	}
 }
 
 func TestGetCredentialsFallsBackToGlobalWhenLocalConfigHasNoStoreKitKeys(t *testing.T) {

--- a/internal/storekit/auth_store_test.go
+++ b/internal/storekit/auth_store_test.go
@@ -1,0 +1,100 @@
+package storekit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/99designs/keyring"
+)
+
+func TestStoredCredentialNeverMarshalsPrivateKeyMaterial(t *testing.T) {
+	stored := StoredCredential{
+		Credentials: Credentials{PrivateKeyPEM: "TOP-SECRET-PEM", PrivateKeyPath: "/secret/key.p8"},
+		Name:        "Primary",
+		Source:      "keychain",
+	}
+	data, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if string(data) == "" || containsAny(string(data), "TOP-SECRET-PEM", "/secret/key.p8", "PrivateKeyPEM") {
+		t.Fatalf("marshaled credential leaked private key material: %s", data)
+	}
+}
+
+func TestConfigCredentialLifecycle(t *testing.T) {
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", path)
+	credentials := testCredentials(t)
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	if err := os.WriteFile(keyPath, []byte(credentials.PrivateKeyPEM), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	credentials.PrivateKeyPath = keyPath
+	credentials.PrivateKeyPEM = ""
+
+	if err := StoreCredentialsConfig("Primary", credentials); err != nil {
+		t.Fatalf("StoreCredentialsConfig() error = %v", err)
+	}
+	stored, source, err := GetCredentialsWithSource("")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource() error = %v", err)
+	}
+	if source != "config" || stored.KeyID != credentials.KeyID || stored.BundleID != credentials.BundleID {
+		t.Fatalf("stored = %#v source=%q", stored, source)
+	}
+	if err := SetDefaultCredentials("Primary"); err != nil {
+		t.Fatalf("SetDefaultCredentials() error = %v", err)
+	}
+	if err := RemoveCredentials("Primary"); err != nil {
+		t.Fatalf("RemoveCredentials() error = %v", err)
+	}
+	if _, _, err := GetCredentialsWithSource(""); err == nil {
+		t.Fatal("expected missing default credentials error")
+	}
+}
+
+func TestGetCredentialsPrefersActiveConfigOverSameNamedKeychainProfile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	configCredentials := testCredentials(t)
+	configCredentials.KeyID = "CONFIG_KEY"
+	configCredentials.PrivateKeyPath = "/config/key.p8"
+	configCredentials.PrivateKeyPEM = ""
+	if err := StoreCredentialsConfigAt("shared", configCredentials, configPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt() error = %v", err)
+	}
+
+	payload, err := json.Marshal(credentialPayload{
+		KeyID: "KEYCHAIN_KEY", IssuerID: "KEYCHAIN_ISSUER", PrivateKeyPEM: "keychain-pem", BundleID: "com.keychain.app",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := openStoreKitKeyring
+	openStoreKitKeyring = func() (keyring.Keyring, error) {
+		return keyring.NewArrayKeyring([]keyring.Item{{Key: storeKitKeyringItemPrefix + "shared", Data: payload}}), nil
+	}
+	t.Cleanup(func() { openStoreKitKeyring = original })
+
+	credentials, source, err := GetCredentialsWithSource("shared")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource() error = %v", err)
+	}
+	if source != "config" || credentials.KeyID != "CONFIG_KEY" {
+		t.Fatalf("credentials = %#v source=%q", credentials, source)
+	}
+}
+
+func containsAny(value string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		if strings.Contains(value, candidate) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storekit/auth_store_test.go
+++ b/internal/storekit/auth_store_test.go
@@ -131,6 +131,128 @@ func TestGetCredentialsFallsBackToGlobalWhenLocalConfigHasNoStoreKitKeys(t *test
 	}
 }
 
+func TestSetDefaultCredentialsUpdatesGlobalCredentialSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_CONFIG_PATH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials := testCredentials(t)
+	credentials.PrivateKeyPath = "/global/SubscriptionKey.p8"
+	credentials.PrivateKeyPEM = ""
+	if err := StoreCredentialsConfigAt("first", credentials, globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(first) error = %v", err)
+	}
+	if err := StoreCredentialsConfigAt("second", credentials, globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(second) error = %v", err)
+	}
+
+	projectDir := t.TempDir()
+	localPath := filepath.Join(projectDir, ".asc", "config.json")
+	if err := config.SaveAt(localPath, &config.Config{AppID: "local-app"}); err != nil {
+		t.Fatalf("SaveAt(local) error = %v", err)
+	}
+	t.Chdir(projectDir)
+
+	if err := SetDefaultCredentials("first"); err != nil {
+		t.Fatalf("SetDefaultCredentials(first) error = %v", err)
+	}
+	localConfig, err := config.LoadAt(localPath)
+	if err != nil {
+		t.Fatalf("LoadAt(local) error = %v", err)
+	}
+	if localConfig.StoreKit.DefaultKeyName != "" {
+		t.Fatalf("local default = %q, want empty", localConfig.StoreKit.DefaultKeyName)
+	}
+	globalConfig, err := config.LoadAt(globalPath)
+	if err != nil {
+		t.Fatalf("LoadAt(global) error = %v", err)
+	}
+	if globalConfig.StoreKit.DefaultKeyName != "first" {
+		t.Fatalf("global default = %q, want first", globalConfig.StoreKit.DefaultKeyName)
+	}
+}
+
+func TestRemoveCredentialsRemovesGlobalFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_CONFIG_PATH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials := testCredentials(t)
+	credentials.PrivateKeyPath = "/global/SubscriptionKey.p8"
+	credentials.PrivateKeyPEM = ""
+	if err := StoreCredentialsConfigAt("global", credentials, globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(global) error = %v", err)
+	}
+
+	projectDir := t.TempDir()
+	localPath := filepath.Join(projectDir, ".asc", "config.json")
+	if err := config.SaveAt(localPath, &config.Config{AppID: "local-app"}); err != nil {
+		t.Fatalf("SaveAt(local) error = %v", err)
+	}
+	t.Chdir(projectDir)
+
+	if err := RemoveCredentials("global"); err != nil {
+		t.Fatalf("RemoveCredentials(global) error = %v", err)
+	}
+	globalConfig, err := config.LoadAt(globalPath)
+	if err != nil {
+		t.Fatalf("LoadAt(global) error = %v", err)
+	}
+	if len(globalConfig.StoreKit.Keys) != 0 || globalConfig.StoreKit.DefaultKeyName != "" {
+		t.Fatalf("global StoreKit config was not cleared: %#v", globalConfig.StoreKit)
+	}
+}
+
+func TestRemoveAllCredentialsClearsLocalAndGlobalConfigs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_CONFIG_PATH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials := testCredentials(t)
+	credentials.PrivateKeyPath = "/global/SubscriptionKey.p8"
+	credentials.PrivateKeyPEM = ""
+	if err := StoreCredentialsConfigAt("global", credentials, globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(global) error = %v", err)
+	}
+
+	projectDir := t.TempDir()
+	localPath := filepath.Join(projectDir, ".asc", "config.json")
+	if err := config.SaveAt(localPath, &config.Config{AppID: "local-app"}); err != nil {
+		t.Fatalf("SaveAt(local) error = %v", err)
+	}
+	t.Chdir(projectDir)
+
+	if err := RemoveAllCredentials(); err != nil {
+		t.Fatalf("RemoveAllCredentials() error = %v", err)
+	}
+	globalConfig, err := config.LoadAt(globalPath)
+	if err != nil {
+		t.Fatalf("LoadAt(global) error = %v", err)
+	}
+	if len(globalConfig.StoreKit.Keys) != 0 || globalConfig.StoreKit.DefaultKeyName != "" {
+		t.Fatalf("global StoreKit config was not cleared: %#v", globalConfig.StoreKit)
+	}
+	localConfig, err := config.LoadAt(localPath)
+	if err != nil {
+		t.Fatalf("LoadAt(local) error = %v", err)
+	}
+	if localConfig.AppID != "local-app" || len(localConfig.StoreKit.Keys) != 0 || localConfig.StoreKit.DefaultKeyName != "" {
+		t.Fatalf("local non-StoreKit config changed or StoreKit config remains: %#v", localConfig)
+	}
+}
+
 func containsAny(value string, candidates ...string) bool {
 	for _, candidate := range candidates {
 		if strings.Contains(value, candidate) {

--- a/internal/storekit/auth_store_test.go
+++ b/internal/storekit/auth_store_test.go
@@ -190,6 +190,50 @@ func TestGetCredentialsPrefersGlobalConfigOverSameNamedKeychainProfile(t *testin
 	}
 }
 
+func TestGetCredentialsPreservesInvalidFallbackConfigError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_CONFIG_PATH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "0")
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(global) error = %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("{invalid-json"), 0o600); err != nil {
+		t.Fatalf("WriteFile(global) error = %v", err)
+	}
+
+	payload, err := json.Marshal(credentialPayload{
+		KeyID: "OTHER_KEY", IssuerID: "OTHER_ISSUER", PrivateKeyPEM: "keychain-pem", BundleID: "com.keychain.app",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := openStoreKitKeyring
+	openStoreKitKeyring = func() (keyring.Keyring, error) {
+		return keyring.NewArrayKeyring([]keyring.Item{{Key: storeKitKeyringItemPrefix + "other", Data: payload}}), nil
+	}
+	t.Cleanup(func() { openStoreKitKeyring = original })
+
+	projectDir := t.TempDir()
+	localPath := filepath.Join(projectDir, ".asc", "config.json")
+	if err := config.SaveAt(localPath, &config.Config{AppID: "local-app"}); err != nil {
+		t.Fatalf("SaveAt(local) error = %v", err)
+	}
+	t.Chdir(projectDir)
+
+	_, _, err = GetCredentialsWithSource("wanted")
+	if err == nil || !strings.Contains(err.Error(), "failed to parse config") {
+		t.Fatalf("GetCredentialsWithSource(wanted) error = %v", err)
+	}
+	if strings.Contains(err.Error(), "credentials not found") {
+		t.Fatalf("GetCredentialsWithSource(wanted) dropped config error: %v", err)
+	}
+}
+
 func TestSetDefaultCredentialsUpdatesGlobalCredentialSource(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/storekit/auth_store_test.go
+++ b/internal/storekit/auth_store_test.go
@@ -131,6 +131,65 @@ func TestGetCredentialsFallsBackToGlobalWhenLocalConfigHasNoStoreKitKeys(t *test
 	}
 }
 
+func TestGetCredentialsPrefersGlobalConfigOverSameNamedKeychainProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_CONFIG_PATH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "0")
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	configCredentials := testCredentials(t)
+	configCredentials.KeyID = "GLOBAL_CONFIG_KEY"
+	configCredentials.PrivateKeyPath = "/global/SubscriptionKey.p8"
+	configCredentials.PrivateKeyPEM = ""
+	if err := StoreCredentialsConfigAt("shared", configCredentials, globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(global) error = %v", err)
+	}
+
+	payload, err := json.Marshal(credentialPayload{
+		KeyID: "KEYCHAIN_KEY", IssuerID: "KEYCHAIN_ISSUER", PrivateKeyPEM: "keychain-pem", BundleID: "com.keychain.app",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := openStoreKitKeyring
+	openStoreKitKeyring = func() (keyring.Keyring, error) {
+		return keyring.NewArrayKeyring([]keyring.Item{{Key: storeKitKeyringItemPrefix + "shared", Data: payload}}), nil
+	}
+	t.Cleanup(func() { openStoreKitKeyring = original })
+
+	projectDir := t.TempDir()
+	localPath := filepath.Join(projectDir, ".asc", "config.json")
+	if err := config.SaveAt(localPath, &config.Config{AppID: "local-app"}); err != nil {
+		t.Fatalf("SaveAt(local) error = %v", err)
+	}
+	t.Chdir(projectDir)
+
+	resolved, source, err := GetCredentialsWithSource("shared")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource(shared) error = %v", err)
+	}
+	if source != "config" || resolved.KeyID != "GLOBAL_CONFIG_KEY" {
+		t.Fatalf("credentials = %#v source=%q", resolved, source)
+	}
+	defaultCredentials, defaultSource, err := GetCredentialsWithSource("")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource(default) error = %v", err)
+	}
+	if defaultSource != "config" || defaultCredentials.KeyID != "GLOBAL_CONFIG_KEY" {
+		t.Fatalf("default credentials = %#v source=%q", defaultCredentials, defaultSource)
+	}
+	listed, err := ListCredentials()
+	if err != nil {
+		t.Fatalf("ListCredentials() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].Source != source || listed[0].KeyID != resolved.KeyID {
+		t.Fatalf("ListCredentials() = %#v, resolved = %#v source=%q", listed, resolved, source)
+	}
+}
+
 func TestSetDefaultCredentialsUpdatesGlobalCredentialSource(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/storekit/auth_store_test.go
+++ b/internal/storekit/auth_store_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/99designs/keyring"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
 )
 
 func TestStoredCredentialNeverMarshalsPrivateKeyMaterial(t *testing.T) {
@@ -87,6 +89,38 @@ func TestGetCredentialsPrefersActiveConfigOverSameNamedKeychainProfile(t *testin
 	}
 	if source != "config" || credentials.KeyID != "CONFIG_KEY" {
 		t.Fatalf("credentials = %#v source=%q", credentials, source)
+	}
+}
+
+func TestGetCredentialsFallsBackToGlobalWhenLocalConfigHasNoStoreKitKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ASC_CONFIG_PATH", "")
+	t.Setenv("ASC_STOREKIT_BYPASS_KEYCHAIN", "1")
+	globalPath, err := config.GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials := testCredentials(t)
+	credentials.PrivateKeyPath = "/global/SubscriptionKey.p8"
+	credentials.PrivateKeyPEM = ""
+	if err := StoreCredentialsConfigAt("global", credentials, globalPath); err != nil {
+		t.Fatalf("StoreCredentialsConfigAt(global) error = %v", err)
+	}
+
+	projectDir := t.TempDir()
+	localPath := filepath.Join(projectDir, ".asc", "config.json")
+	if err := config.SaveAt(localPath, &config.Config{AppID: "local-app"}); err != nil {
+		t.Fatalf("SaveAt(local) error = %v", err)
+	}
+	t.Chdir(projectDir)
+
+	resolved, source, err := GetCredentialsWithSource("global")
+	if err != nil {
+		t.Fatalf("GetCredentialsWithSource(global) error = %v", err)
+	}
+	if source != "config" || resolved.KeyID != credentials.KeyID || resolved.Profile != "global" {
+		t.Fatalf("credentials = %#v source=%q", resolved, source)
 	}
 }
 

--- a/internal/storekit/client.go
+++ b/internal/storekit/client.go
@@ -1,0 +1,214 @@
+package storekit
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
+)
+
+const tokenLifetime = 20 * time.Minute
+
+type ClientOption func(*Client)
+
+type Client struct {
+	httpClient  *http.Client
+	baseURL     string
+	environment Environment
+	credentials Credentials
+	now         func() time.Time
+
+	privateKeyMu sync.Mutex
+	privateKey   *ecdsa.PrivateKey
+}
+
+func NewClient(credentials Credentials, environment Environment, opts ...ClientOption) (*Client, error) {
+	credentials = normalizeCredentials(credentials)
+	if err := validateCredentials(credentials); err != nil {
+		return nil, err
+	}
+	if environment != Production && environment != Sandbox {
+		return nil, fmt.Errorf("environment must be one of: production, sandbox")
+	}
+	client := &Client{
+		httpClient:  &http.Client{Timeout: asc.ResolveTimeout()},
+		baseURL:     environment.baseURL(),
+		environment: environment,
+		credentials: credentials,
+		now:         time.Now,
+	}
+	for _, option := range opts {
+		option(client)
+	}
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{Timeout: asc.ResolveTimeout()}
+	}
+	client.baseURL = strings.TrimRight(strings.TrimSpace(client.baseURL), "/")
+	if client.baseURL == "" {
+		return nil, fmt.Errorf("base URL is required")
+	}
+	if client.now == nil {
+		client.now = time.Now
+	}
+	return client, nil
+}
+
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(client *Client) { client.httpClient = httpClient }
+}
+
+// WithBaseURL overrides the complete Retention Messaging API base URL.
+// It exists for tests and Apple-compatible proxies.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(client *Client) { client.baseURL = baseURL }
+}
+
+func WithNow(now func() time.Time) ClientOption {
+	return func(client *Client) { client.now = now }
+}
+
+// Validate signs a token and parses the configured private key without making
+// a network request.
+func (c *Client) Validate() error {
+	_, err := c.signedToken()
+	return err
+}
+
+func normalizeCredentials(credentials Credentials) Credentials {
+	credentials.KeyID = strings.TrimSpace(credentials.KeyID)
+	credentials.IssuerID = strings.TrimSpace(credentials.IssuerID)
+	credentials.PrivateKeyPath = strings.TrimSpace(credentials.PrivateKeyPath)
+	credentials.PrivateKeyPEM = strings.TrimSpace(credentials.PrivateKeyPEM)
+	credentials.BundleID = strings.TrimSpace(credentials.BundleID)
+	credentials.Profile = strings.TrimSpace(credentials.Profile)
+	return credentials
+}
+
+func validateCredentials(credentials Credentials) error {
+	if credentials.KeyID == "" {
+		return fmt.Errorf("key ID is required")
+	}
+	if credentials.IssuerID == "" {
+		return fmt.Errorf("issuer ID is required")
+	}
+	if credentials.PrivateKeyPath == "" && credentials.PrivateKeyPEM == "" {
+		return fmt.Errorf("private key is required")
+	}
+	if credentials.BundleID == "" {
+		return fmt.Errorf("bundle ID is required")
+	}
+	return nil
+}
+
+func (c *Client) signedToken() (string, error) {
+	key, err := c.loadPrivateKey()
+	if err != nil {
+		return "", err
+	}
+	now := c.now().UTC()
+	claims := jwt.MapClaims{
+		"iss": c.credentials.IssuerID,
+		"iat": now.Unix(),
+		"exp": now.Add(tokenLifetime).Unix(),
+		"aud": "appstoreconnect-v1",
+		"bid": c.credentials.BundleID,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = c.credentials.KeyID
+	token.Header["typ"] = "JWT"
+	signed, err := token.SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("sign StoreKit token: %w", err)
+	}
+	return signed, nil
+}
+
+func (c *Client) loadPrivateKey() (*ecdsa.PrivateKey, error) {
+	c.privateKeyMu.Lock()
+	defer c.privateKeyMu.Unlock()
+	if c.privateKey != nil {
+		return c.privateKey, nil
+	}
+	var (
+		key *ecdsa.PrivateKey
+		err error
+	)
+	if c.credentials.PrivateKeyPEM != "" {
+		key, err = auth.LoadPrivateKeyFromPEM([]byte(c.credentials.PrivateKeyPEM))
+	} else {
+		key, err = auth.LoadPrivateKey(c.credentials.PrivateKeyPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load StoreKit private key: %w", err)
+	}
+	if key.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("StoreKit private key must use the P-256 curve")
+	}
+	c.privateKey = key
+	return key, nil
+}
+
+func (c *Client) request(ctx context.Context, method, path, contentType string, body []byte, response any) error {
+	token, err := c.signedToken()
+	if err != nil {
+		return err
+	}
+	requestURL, err := url.Parse(c.baseURL + "/" + strings.TrimLeft(path, "/"))
+	if err != nil {
+		return fmt.Errorf("build StoreKit request URL: %w", err)
+	}
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, requestURL.String(), reader)
+	if err != nil {
+		return fmt.Errorf("create StoreKit request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("StoreKit request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read StoreKit response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return parseAPIError(responseBody, resp.StatusCode, resp.Header.Get("Retry-After"))
+	}
+	if response == nil || len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, response); err != nil {
+		return fmt.Errorf("decode StoreKit response: %w", err)
+	}
+	return nil
+}
+
+func jsonBody(value any) ([]byte, error) {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode StoreKit request: %w", err)
+	}
+	return body, nil
+}

--- a/internal/storekit/client_test.go
+++ b/internal/storekit/client_test.go
@@ -244,10 +244,21 @@ func TestValidateMessageRequiresImageAccessibilityText(t *testing.T) {
 	if err := ValidateMessage(message); err == nil || !strings.Contains(err.Error(), "bullet point 1 alt text is required") {
 		t.Fatalf("ValidateMessage() error = %v", err)
 	}
+	message.BulletPoints = nil
+	message.HeaderPosition = HeaderAboveImage
+	if err := ValidateMessage(message); err == nil || !strings.Contains(err.Error(), "ABOVE_IMAGE requires an image") {
+		t.Fatalf("ValidateMessage() error = %v", err)
+	}
+	message.HeaderPosition = ""
+	message.BulletPoints = make([]MessageBulletPoint, 6)
+	if err := ValidateMessage(message); err == nil || !strings.Contains(err.Error(), "at most 5 bullet points") {
+		t.Fatalf("ValidateMessage() error = %v", err)
+	}
 }
 
 func testCredentials(t *testing.T) Credentials {
 	t.Helper()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)

--- a/internal/storekit/client_test.go
+++ b/internal/storekit/client_test.go
@@ -187,6 +187,53 @@ func TestClientDecodesAPIErrorAndRetryAfter(t *testing.T) {
 	}
 }
 
+func TestClientDecodesNumericAPIErrorCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"errorCode":4000001,"errorMessage":"Too many bullet points"}`)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(testCredentials(t), Sandbox, WithHTTPClient(server.Client()), WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, err = client.ListMessages(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want *APIError", err, err)
+	}
+	if apiErr.Code != "4000001" || apiErr.Message != "Too many bullet points" {
+		t.Fatalf("APIError = %#v", apiErr)
+	}
+}
+
+func TestConfigureReturnsRequestedValueForEmptySuccessResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	client, err := NewClient(testCredentials(t), Sandbox, WithHTTPClient(server.Client()), WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	configuredDefault, err := client.SetDefault(context.Background(), "monthly", "en-US", "33333333-3333-4333-8333-333333333333")
+	if err != nil {
+		t.Fatalf("SetDefault() error = %v", err)
+	}
+	if configuredDefault.MessageIdentifier != "33333333-3333-4333-8333-333333333333" {
+		t.Fatalf("SetDefault() = %#v", configuredDefault)
+	}
+	configuredURL, err := client.SetRealtimeURL(context.Background(), "https://example.com/retention")
+	if err != nil {
+		t.Fatalf("SetRealtimeURL() error = %v", err)
+	}
+	if configuredURL.RealtimeURL != "https://example.com/retention" {
+		t.Fatalf("SetRealtimeURL() = %#v", configuredURL)
+	}
+}
+
 func TestValidateMessageRequiresImageAccessibilityText(t *testing.T) {
 	message := Message{Header: "Stay", Body: "Keep your subscription", Image: &MessageImage{ImageIdentifier: "22222222-2222-4222-8222-222222222222"}}
 	if err := ValidateMessage(message); err == nil || !strings.Contains(err.Error(), "image alt text is required") {

--- a/internal/storekit/client_test.go
+++ b/internal/storekit/client_test.go
@@ -1,0 +1,218 @@
+package storekit
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestClientSignsStoreKitJWT(t *testing.T) {
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	client, err := NewClient(testCredentials(t), Sandbox, WithNow(func() time.Time { return now }))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	tokenString, err := client.signedToken()
+	if err != nil {
+		t.Fatalf("signedToken() error = %v", err)
+	}
+
+	parsed, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("ParseUnverified() error = %v", err)
+	}
+	if parsed.Method.Alg() != "ES256" {
+		t.Fatalf("alg = %q, want ES256", parsed.Method.Alg())
+	}
+	if got := parsed.Header["kid"]; got != "STOREKIT_KEY" {
+		t.Fatalf("kid = %v, want STOREKIT_KEY", got)
+	}
+	if got := parsed.Header["typ"]; got != "JWT" {
+		t.Fatalf("typ = %v, want JWT", got)
+	}
+	claims := parsed.Claims.(jwt.MapClaims)
+	if got := claims["iss"]; got != "STOREKIT_ISSUER" {
+		t.Fatalf("iss = %v, want STOREKIT_ISSUER", got)
+	}
+	if got := claims["aud"]; got != "appstoreconnect-v1" {
+		t.Fatalf("aud = %v, want appstoreconnect-v1", got)
+	}
+	if got := claims["bid"]; got != "com.example.app" {
+		t.Fatalf("bid = %v, want com.example.app", got)
+	}
+	if got := int64(claims["iat"].(float64)); got != now.Unix() {
+		t.Fatalf("iat = %d, want %d", got, now.Unix())
+	}
+	if got := int64(claims["exp"].(float64)); got != now.Add(20*time.Minute).Unix() {
+		t.Fatalf("exp = %d, want %d", got, now.Add(20*time.Minute).Unix())
+	}
+}
+
+func TestRetentionMessagingEndpoints(t *testing.T) {
+	type invocation struct {
+		name        string
+		method      string
+		path        string
+		query       string
+		contentType string
+		response    string
+		call        func(context.Context, *Client) error
+	}
+
+	message := Message{
+		Header: "Still enjoying Example?",
+		Body:   "Keep your subscription and keep everything you have unlocked.",
+		Image:  &MessageImage{ImageIdentifier: "22222222-2222-4222-8222-222222222222", AltText: "Example app"},
+	}
+	tests := []invocation{
+		{name: "upload image", method: http.MethodPut, path: "/inApps/v1/messaging/image/11111111-1111-4111-8111-111111111111", query: "imageSize=FULL_SIZE", contentType: "image/png", call: func(ctx context.Context, c *Client) error {
+			return c.UploadImage(ctx, "11111111-1111-4111-8111-111111111111", ImageSizeFull, []byte("\x89PNG\r\n\x1a\nimage"))
+		}},
+		{name: "delete image", method: http.MethodDelete, path: "/inApps/v1/messaging/image/11111111-1111-4111-8111-111111111111", call: func(ctx context.Context, c *Client) error {
+			return c.DeleteImage(ctx, "11111111-1111-4111-8111-111111111111")
+		}},
+		{name: "list images", method: http.MethodGet, path: "/inApps/v1/messaging/image/list", response: `{"imageIdentifiers":[]}`, call: func(ctx context.Context, c *Client) error { _, err := c.ListImages(ctx); return err }},
+		{name: "upload message", method: http.MethodPut, path: "/inApps/v1/messaging/message/33333333-3333-4333-8333-333333333333", contentType: "application/json", call: func(ctx context.Context, c *Client) error {
+			return c.UploadMessage(ctx, "33333333-3333-4333-8333-333333333333", message)
+		}},
+		{name: "delete message", method: http.MethodDelete, path: "/inApps/v1/messaging/message/33333333-3333-4333-8333-333333333333", call: func(ctx context.Context, c *Client) error {
+			return c.DeleteMessage(ctx, "33333333-3333-4333-8333-333333333333")
+		}},
+		{name: "list messages", method: http.MethodGet, path: "/inApps/v1/messaging/message/list", response: `{"messageIdentifiers":[]}`, call: func(ctx context.Context, c *Client) error { _, err := c.ListMessages(ctx); return err }},
+		{name: "set default", method: http.MethodPut, path: "/inApps/v1/messaging/default/monthly/en-US", contentType: "application/json", response: `{"messageIdentifier":"33333333-3333-4333-8333-333333333333"}`, call: func(ctx context.Context, c *Client) error {
+			_, err := c.SetDefault(ctx, "monthly", "en-US", "33333333-3333-4333-8333-333333333333")
+			return err
+		}},
+		{name: "get default", method: http.MethodGet, path: "/inApps/v1/messaging/default/monthly/en-US", response: `{"messageIdentifier":"33333333-3333-4333-8333-333333333333"}`, call: func(ctx context.Context, c *Client) error {
+			_, err := c.GetDefault(ctx, "monthly", "en-US")
+			return err
+		}},
+		{name: "delete default", method: http.MethodDelete, path: "/inApps/v1/messaging/default/monthly/en-US", call: func(ctx context.Context, c *Client) error { return c.DeleteDefault(ctx, "monthly", "en-US") }},
+		{name: "set endpoint", method: http.MethodPut, path: "/inApps/v1/messaging/realtime/url", contentType: "application/json", response: `{"realtimeURL":"https://example.com/retention"}`, call: func(ctx context.Context, c *Client) error {
+			_, err := c.SetRealtimeURL(ctx, "https://example.com/retention")
+			return err
+		}},
+		{name: "get endpoint", method: http.MethodGet, path: "/inApps/v1/messaging/realtime/url", response: `{"realtimeURL":"https://example.com/retention"}`, call: func(ctx context.Context, c *Client) error { _, err := c.GetRealtimeURL(ctx); return err }},
+		{name: "delete endpoint", method: http.MethodDelete, path: "/inApps/v1/messaging/realtime/url", call: func(ctx context.Context, c *Client) error { return c.DeleteRealtimeURL(ctx) }},
+		{name: "start performance test", method: http.MethodPost, path: "/inApps/v1/messaging/performanceTest", contentType: "application/json", response: `{"config":{"duration":60},"requestId":"request-1"}`, call: func(ctx context.Context, c *Client) error {
+			_, err := c.StartPerformanceTest(ctx, "2000000000000000")
+			return err
+		}},
+		{name: "get performance test", method: http.MethodGet, path: "/inApps/v1/messaging/performanceTest/result/request-1", response: `{"requestId":"request-1","result":"PASS","successRate":1}`, call: func(ctx context.Context, c *Client) error {
+			_, err := c.GetPerformanceTestResult(ctx, "request-1")
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.method {
+					t.Errorf("method = %s, want %s", r.Method, tt.method)
+				}
+				if r.URL.Path != tt.path {
+					t.Errorf("path = %s, want %s", r.URL.Path, tt.path)
+				}
+				if r.URL.RawQuery != tt.query {
+					t.Errorf("query = %q, want %q", r.URL.RawQuery, tt.query)
+				}
+				if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+					t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+				}
+				if tt.contentType != "" && r.Header.Get("Content-Type") != tt.contentType {
+					t.Errorf("Content-Type = %q, want %q", r.Header.Get("Content-Type"), tt.contentType)
+				}
+				if tt.method == http.MethodPut || tt.method == http.MethodPost {
+					body, err := io.ReadAll(r.Body)
+					if err != nil || len(body) == 0 {
+						t.Errorf("expected request body, body=%q err=%v", body, err)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if tt.response == "" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				_, _ = io.WriteString(w, tt.response)
+			}))
+			defer server.Close()
+
+			client, err := NewClient(testCredentials(t), Sandbox, WithHTTPClient(server.Client()), WithBaseURL(server.URL+"/inApps/v1/messaging"))
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+			if err := tt.call(context.Background(), client); err != nil {
+				t.Fatalf("call error = %v", err)
+			}
+		})
+	}
+}
+
+func TestClientDecodesAPIErrorAndRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1781798400000")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]string{"errorCode": "RATE_LIMIT_EXCEEDED", "errorMessage": "Slow down"})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(testCredentials(t), Sandbox, WithHTTPClient(server.Client()), WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, err = client.ListMessages(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusTooManyRequests || apiErr.Code != "RATE_LIMIT_EXCEEDED" || apiErr.Message != "Slow down" {
+		t.Fatalf("APIError = %#v", apiErr)
+	}
+	if got := apiErr.RetryAfter.UnixMilli(); got != 1781798400000 {
+		t.Fatalf("RetryAfter = %d", got)
+	}
+}
+
+func TestValidateMessageRequiresImageAccessibilityText(t *testing.T) {
+	message := Message{Header: "Stay", Body: "Keep your subscription", Image: &MessageImage{ImageIdentifier: "22222222-2222-4222-8222-222222222222"}}
+	if err := ValidateMessage(message); err == nil || !strings.Contains(err.Error(), "image alt text is required") {
+		t.Fatalf("ValidateMessage() error = %v", err)
+	}
+	message.Image = nil
+	message.BulletPoints = []MessageBulletPoint{{ImageIdentifier: "22222222-2222-4222-8222-222222222222", Text: "One benefit"}}
+	if err := ValidateMessage(message); err == nil || !strings.Contains(err.Error(), "bullet point 1 alt text is required") {
+		t.Fatalf("ValidateMessage() error = %v", err)
+	}
+}
+
+func testCredentials(t *testing.T) Credentials {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error = %v", err)
+	}
+	return Credentials{
+		KeyID:         "STOREKIT_KEY",
+		IssuerID:      "STOREKIT_ISSUER",
+		PrivateKeyPEM: string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
+		BundleID:      "com.example.app",
+	}
+}

--- a/internal/storekit/errors.go
+++ b/internal/storekit/errors.go
@@ -1,0 +1,66 @@
+package storekit
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// APIError describes an error returned by the Retention Messaging API.
+type APIError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	RetryAfter time.Time
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("StoreKit API HTTP %d", e.StatusCode)}
+	if e.Code != "" {
+		parts = append(parts, e.Code)
+	}
+	message := strings.TrimSpace(e.Message)
+	if message == "" {
+		message = strings.TrimSpace(e.Body)
+	}
+	if message == "" {
+		message = http.StatusText(e.StatusCode)
+	}
+	if message != "" {
+		parts = append(parts, message)
+	}
+	return strings.Join(parts, ": ")
+}
+
+func parseAPIError(body []byte, statusCode int, retryAfter string) error {
+	var response struct {
+		Code    string `json:"errorCode"`
+		Message string `json:"errorMessage"`
+	}
+	_ = json.Unmarshal(body, &response)
+	err := &APIError{
+		StatusCode: statusCode,
+		Code:       strings.TrimSpace(response.Code),
+		Message:    strings.TrimSpace(response.Message),
+		Body:       sanitizedBody(body),
+	}
+	if milliseconds, parseErr := strconv.ParseInt(strings.TrimSpace(retryAfter), 10, 64); parseErr == nil && milliseconds > 0 {
+		err.RetryAfter = time.UnixMilli(milliseconds)
+	}
+	return err
+}
+
+func sanitizedBody(body []byte) string {
+	value := strings.TrimSpace(string(body))
+	if len(value) > 4096 {
+		return value[:4096]
+	}
+	return value
+}

--- a/internal/storekit/errors.go
+++ b/internal/storekit/errors.go
@@ -1,6 +1,7 @@
 package storekit
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -41,13 +42,13 @@ func (e *APIError) Error() string {
 
 func parseAPIError(body []byte, statusCode int, retryAfter string) error {
 	var response struct {
-		Code    string `json:"errorCode"`
-		Message string `json:"errorMessage"`
+		Code    json.RawMessage `json:"errorCode"`
+		Message string          `json:"errorMessage"`
 	}
 	_ = json.Unmarshal(body, &response)
 	err := &APIError{
 		StatusCode: statusCode,
-		Code:       strings.TrimSpace(response.Code),
+		Code:       decodeErrorCode(response.Code),
 		Message:    strings.TrimSpace(response.Message),
 		Body:       sanitizedBody(body),
 	}
@@ -55,6 +56,24 @@ func parseAPIError(body []byte, statusCode int, retryAfter string) error {
 		err.RetryAfter = time.UnixMilli(milliseconds)
 	}
 	return err
+}
+
+func decodeErrorCode(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var stringCode string
+	if err := json.Unmarshal(raw, &stringCode); err == nil {
+		return strings.TrimSpace(stringCode)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var number json.Number
+	if err := decoder.Decode(&number); err == nil {
+		return number.String()
+	}
+	return ""
 }
 
 func sanitizedBody(body []byte) string {

--- a/internal/storekit/retention.go
+++ b/internal/storekit/retention.go
@@ -1,0 +1,244 @@
+package storekit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+func (c *Client) UploadImage(ctx context.Context, identifier string, size ImageSize, data []byte) error {
+	if err := validateUUID("image identifier", identifier); err != nil {
+		return err
+	}
+	if size != ImageSizeFull && size != ImageSizeBulletPoint {
+		return fmt.Errorf("image size must be one of: FULL_SIZE, BULLET_POINT")
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("image data is required")
+	}
+	path := "image/" + url.PathEscape(strings.TrimSpace(identifier)) + "?imageSize=" + url.QueryEscape(string(size))
+	return c.request(ctx, http.MethodPut, path, "image/png", data, nil)
+}
+
+func (c *Client) DeleteImage(ctx context.Context, identifier string) error {
+	if err := validateUUID("image identifier", identifier); err != nil {
+		return err
+	}
+	return c.request(ctx, http.MethodDelete, "image/"+url.PathEscape(strings.TrimSpace(identifier)), "", nil, nil)
+}
+
+func (c *Client) ListImages(ctx context.Context) (*ImageListResponse, error) {
+	var response ImageListResponse
+	if err := c.request(ctx, http.MethodGet, "image/list", "", nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) UploadMessage(ctx context.Context, identifier string, message Message) error {
+	if err := validateUUID("message identifier", identifier); err != nil {
+		return err
+	}
+	if err := ValidateMessage(message); err != nil {
+		return err
+	}
+	body, err := jsonBody(message)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, http.MethodPut, "message/"+url.PathEscape(strings.TrimSpace(identifier)), "application/json", body, nil)
+}
+
+func (c *Client) DeleteMessage(ctx context.Context, identifier string) error {
+	if err := validateUUID("message identifier", identifier); err != nil {
+		return err
+	}
+	return c.request(ctx, http.MethodDelete, "message/"+url.PathEscape(strings.TrimSpace(identifier)), "", nil, nil)
+}
+
+func (c *Client) ListMessages(ctx context.Context) (*MessageListResponse, error) {
+	var response MessageListResponse
+	if err := c.request(ctx, http.MethodGet, "message/list", "", nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) SetDefault(ctx context.Context, productID, locale, messageIdentifier string) (*DefaultMessageResponse, error) {
+	if strings.TrimSpace(productID) == "" {
+		return nil, fmt.Errorf("product ID is required")
+	}
+	if strings.TrimSpace(locale) == "" {
+		return nil, fmt.Errorf("locale is required")
+	}
+	if err := validateUUID("message identifier", messageIdentifier); err != nil {
+		return nil, err
+	}
+	body, err := jsonBody(DefaultMessageResponse{MessageIdentifier: strings.TrimSpace(messageIdentifier)})
+	if err != nil {
+		return nil, err
+	}
+	var response DefaultMessageResponse
+	path := defaultPath(productID, locale)
+	if err := c.request(ctx, http.MethodPut, path, "application/json", body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetDefault(ctx context.Context, productID, locale string) (*DefaultMessageResponse, error) {
+	if strings.TrimSpace(productID) == "" {
+		return nil, fmt.Errorf("product ID is required")
+	}
+	if strings.TrimSpace(locale) == "" {
+		return nil, fmt.Errorf("locale is required")
+	}
+	var response DefaultMessageResponse
+	if err := c.request(ctx, http.MethodGet, defaultPath(productID, locale), "", nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) DeleteDefault(ctx context.Context, productID, locale string) error {
+	if strings.TrimSpace(productID) == "" {
+		return fmt.Errorf("product ID is required")
+	}
+	if strings.TrimSpace(locale) == "" {
+		return fmt.Errorf("locale is required")
+	}
+	return c.request(ctx, http.MethodDelete, defaultPath(productID, locale), "", nil, nil)
+}
+
+func defaultPath(productID, locale string) string {
+	return "default/" + url.PathEscape(strings.TrimSpace(productID)) + "/" + url.PathEscape(strings.TrimSpace(locale))
+}
+
+func (c *Client) SetRealtimeURL(ctx context.Context, realtimeURL string) (*RealtimeURLResponse, error) {
+	if err := ValidateRealtimeURL(realtimeURL); err != nil {
+		return nil, err
+	}
+	body, err := jsonBody(RealtimeURLResponse{RealtimeURL: strings.TrimSpace(realtimeURL)})
+	if err != nil {
+		return nil, err
+	}
+	var response RealtimeURLResponse
+	if err := c.request(ctx, http.MethodPut, "realtime/url", "application/json", body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetRealtimeURL(ctx context.Context) (*RealtimeURLResponse, error) {
+	var response RealtimeURLResponse
+	if err := c.request(ctx, http.MethodGet, "realtime/url", "", nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) DeleteRealtimeURL(ctx context.Context) error {
+	return c.request(ctx, http.MethodDelete, "realtime/url", "", nil, nil)
+}
+
+func (c *Client) StartPerformanceTest(ctx context.Context, originalTransactionID string) (*PerformanceTestStartResponse, error) {
+	if strings.TrimSpace(originalTransactionID) == "" {
+		return nil, fmt.Errorf("original transaction ID is required")
+	}
+	body, err := jsonBody(map[string]string{"originalTransactionId": strings.TrimSpace(originalTransactionID)})
+	if err != nil {
+		return nil, err
+	}
+	var response PerformanceTestStartResponse
+	if err := c.request(ctx, http.MethodPost, "performanceTest", "application/json", body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetPerformanceTestResult(ctx context.Context, requestID string) (*PerformanceTestResult, error) {
+	if strings.TrimSpace(requestID) == "" {
+		return nil, fmt.Errorf("request ID is required")
+	}
+	var response PerformanceTestResult
+	path := "performanceTest/result/" + url.PathEscape(strings.TrimSpace(requestID))
+	if err := c.request(ctx, http.MethodGet, path, "", nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// ValidateMessage checks documented Retention Messaging limits before upload.
+func ValidateMessage(message Message) error {
+	if strings.TrimSpace(message.Header) == "" {
+		return fmt.Errorf("message header is required")
+	}
+	if utf8.RuneCountInString(message.Header) > 66 {
+		return fmt.Errorf("message header must be at most 66 characters")
+	}
+	if strings.TrimSpace(message.Body) == "" {
+		return fmt.Errorf("message body is required")
+	}
+	if utf8.RuneCountInString(message.Body) > 144 {
+		return fmt.Errorf("message body must be at most 144 characters")
+	}
+	if message.HeaderPosition != "" && message.HeaderPosition != HeaderAboveBody && message.HeaderPosition != HeaderAboveImage {
+		return fmt.Errorf("header position must be one of: ABOVE_BODY, ABOVE_IMAGE")
+	}
+	if message.Image != nil {
+		if err := validateUUID("image identifier", message.Image.ImageIdentifier); err != nil {
+			return err
+		}
+		if strings.TrimSpace(message.Image.AltText) == "" {
+			return fmt.Errorf("image alt text is required")
+		}
+		if utf8.RuneCountInString(message.Image.AltText) > 150 {
+			return fmt.Errorf("image alt text must be at most 150 characters")
+		}
+	}
+	for i, bullet := range message.BulletPoints {
+		if strings.TrimSpace(bullet.Text) == "" {
+			return fmt.Errorf("bullet point %d text is required", i+1)
+		}
+		if utf8.RuneCountInString(bullet.Text) > 66 {
+			return fmt.Errorf("bullet point %d text must be at most 66 characters", i+1)
+		}
+		if err := validateUUID(fmt.Sprintf("bullet point %d image identifier", i+1), bullet.ImageIdentifier); err != nil {
+			return err
+		}
+		if strings.TrimSpace(bullet.AltText) == "" {
+			return fmt.Errorf("bullet point %d alt text is required", i+1)
+		}
+		if utf8.RuneCountInString(bullet.AltText) > 150 {
+			return fmt.Errorf("bullet point %d alt text must be at most 150 characters", i+1)
+		}
+	}
+	return nil
+}
+
+func ValidateRealtimeURL(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("realtime URL is required")
+	}
+	if utf8.RuneCountInString(value) > 256 {
+		return fmt.Errorf("realtime URL must be at most 256 characters")
+	}
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("realtime URL must be an absolute HTTPS URL")
+	}
+	return nil
+}
+
+func validateUUID(label, value string) error {
+	if _, err := uuid.Parse(strings.TrimSpace(value)); err != nil {
+		return fmt.Errorf("%s must be a UUID", label)
+	}
+	return nil
+}

--- a/internal/storekit/retention.go
+++ b/internal/storekit/retention.go
@@ -83,9 +83,9 @@ func (c *Client) SetDefault(ctx context.Context, productID, locale, messageIdent
 	if err != nil {
 		return nil, err
 	}
-	var response DefaultMessageResponse
+	response := DefaultMessageResponse{MessageIdentifier: strings.TrimSpace(messageIdentifier)}
 	path := defaultPath(productID, locale)
-	if err := c.request(ctx, http.MethodPut, path, "application/json", body, &response); err != nil {
+	if err := c.request(ctx, http.MethodPut, path, "application/json", body, nil); err != nil {
 		return nil, err
 	}
 	return &response, nil
@@ -127,8 +127,8 @@ func (c *Client) SetRealtimeURL(ctx context.Context, realtimeURL string) (*Realt
 	if err != nil {
 		return nil, err
 	}
-	var response RealtimeURLResponse
-	if err := c.request(ctx, http.MethodPut, "realtime/url", "application/json", body, &response); err != nil {
+	response := RealtimeURLResponse{RealtimeURL: strings.TrimSpace(realtimeURL)}
+	if err := c.request(ctx, http.MethodPut, "realtime/url", "application/json", body, nil); err != nil {
 		return nil, err
 	}
 	return &response, nil

--- a/internal/storekit/retention.go
+++ b/internal/storekit/retention.go
@@ -190,6 +190,9 @@ func ValidateMessage(message Message) error {
 	if message.HeaderPosition != "" && message.HeaderPosition != HeaderAboveBody && message.HeaderPosition != HeaderAboveImage {
 		return fmt.Errorf("header position must be one of: ABOVE_BODY, ABOVE_IMAGE")
 	}
+	if message.HeaderPosition == HeaderAboveImage && message.Image == nil {
+		return fmt.Errorf("header position ABOVE_IMAGE requires an image")
+	}
 	if message.Image != nil {
 		if err := validateUUID("image identifier", message.Image.ImageIdentifier); err != nil {
 			return err
@@ -200,6 +203,9 @@ func ValidateMessage(message Message) error {
 		if utf8.RuneCountInString(message.Image.AltText) > 150 {
 			return fmt.Errorf("image alt text must be at most 150 characters")
 		}
+	}
+	if len(message.BulletPoints) > 5 {
+		return fmt.Errorf("message must contain at most 5 bullet points")
 	}
 	for i, bullet := range message.BulletPoints {
 		if strings.TrimSpace(bullet.Text) == "" {

--- a/internal/storekit/types.go
+++ b/internal/storekit/types.go
@@ -1,0 +1,164 @@
+// Package storekit implements Apple's In-App Purchase and StoreKit server APIs.
+//
+// StoreKit API credentials are intentionally separate from App Store Connect
+// API credentials. Retention Messaging signs a fresh JWT for every request.
+package storekit
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ProductionBaseURL = "https://api.storekit.apple.com/inApps/v1/messaging"
+	SandboxBaseURL    = "https://api.storekit-sandbox.apple.com/inApps/v1/messaging"
+)
+
+// Environment selects the StoreKit server environment.
+type Environment string
+
+const (
+	Production Environment = "production"
+	Sandbox    Environment = "sandbox"
+)
+
+// ParseEnvironment validates a StoreKit environment.
+func ParseEnvironment(value string) (Environment, error) {
+	switch Environment(strings.ToLower(strings.TrimSpace(value))) {
+	case Production:
+		return Production, nil
+	case Sandbox:
+		return Sandbox, nil
+	default:
+		return "", fmt.Errorf("environment must be one of: production, sandbox")
+	}
+}
+
+func (e Environment) baseURL() string {
+	if e == Sandbox {
+		return SandboxBaseURL
+	}
+	return ProductionBaseURL
+}
+
+// Credentials holds an In-App Purchase API key and its target app bundle ID.
+type Credentials struct {
+	KeyID          string
+	IssuerID       string
+	PrivateKeyPath string
+	PrivateKeyPEM  string
+	BundleID       string
+	Profile        string
+}
+
+// ImageSize is the placement for a Retention Messaging image.
+type ImageSize string
+
+const (
+	ImageSizeFull        ImageSize = "FULL_SIZE"
+	ImageSizeBulletPoint ImageSize = "BULLET_POINT"
+)
+
+// ImageState is Apple's review state for an uploaded image.
+type ImageState string
+
+const (
+	StatePending  = "PENDING"
+	StateApproved = "APPROVED"
+	StateRejected = "REJECTED"
+)
+
+type ImageIdentifier struct {
+	ImageIdentifier string    `json:"imageIdentifier"`
+	ImageSize       ImageSize `json:"imageSize"`
+	ImageState      string    `json:"imageState"`
+}
+
+type ImageListResponse struct {
+	ImageIdentifiers []ImageIdentifier `json:"imageIdentifiers"`
+}
+
+// HeaderPosition controls where the header appears in a retention message.
+type HeaderPosition string
+
+const (
+	HeaderAboveBody  HeaderPosition = "ABOVE_BODY"
+	HeaderAboveImage HeaderPosition = "ABOVE_IMAGE"
+)
+
+type MessageImage struct {
+	ImageIdentifier string `json:"imageIdentifier"`
+	AltText         string `json:"altText"`
+}
+
+type MessageBulletPoint struct {
+	ImageIdentifier string `json:"imageIdentifier"`
+	AltText         string `json:"altText"`
+	Text            string `json:"text"`
+}
+
+type Message struct {
+	Header         string               `json:"header"`
+	Body           string               `json:"body"`
+	Image          *MessageImage        `json:"image,omitempty"`
+	BulletPoints   []MessageBulletPoint `json:"bulletPoints,omitempty"`
+	HeaderPosition HeaderPosition       `json:"headerPosition,omitempty"`
+}
+
+type MessageIdentifier struct {
+	MessageIdentifier string `json:"messageIdentifier"`
+	MessageState      string `json:"messageState"`
+}
+
+type MessageListResponse struct {
+	MessageIdentifiers []MessageIdentifier `json:"messageIdentifiers"`
+}
+
+type DefaultMessageResponse struct {
+	MessageIdentifier string `json:"messageIdentifier"`
+}
+
+type RealtimeURLResponse struct {
+	RealtimeURL string `json:"realtimeURL"`
+}
+
+type PerformanceTestConfig struct {
+	MaxConcurrentRequests int64 `json:"maxConcurrentRequests"`
+	ResponseTimeThreshold int64 `json:"responseTimeThreshold"`
+	SuccessRateThreshold  int32 `json:"successRateThreshold"`
+	TotalDuration         int64 `json:"totalDuration"`
+	TotalRequests         int   `json:"totalRequests"`
+}
+
+type PerformanceTestStartResponse struct {
+	Config    PerformanceTestConfig `json:"config"`
+	RequestID string                `json:"requestId"`
+}
+
+type PerformanceResponseTimes struct {
+	Average int64 `json:"average,omitempty"`
+	P50     int64 `json:"p50,omitempty"`
+	P90     int64 `json:"p90,omitempty"`
+	P95     int64 `json:"p95,omitempty"`
+	P99     int64 `json:"p99,omitempty"`
+}
+
+type PerformanceTestResult struct {
+	Config        PerformanceTestConfig    `json:"config"`
+	Failures      map[string]int32         `json:"failures,omitempty"`
+	NumPending    int                      `json:"numPending,omitempty"`
+	RequestID     string                   `json:"requestId,omitempty"`
+	ResponseTimes PerformanceResponseTimes `json:"responseTimes,omitempty"`
+	Result        string                   `json:"result"`
+	SuccessRate   int32                    `json:"successRate,omitempty"`
+	Target        string                   `json:"target,omitempty"`
+}
+
+// MutationResult is the stable CLI response for an empty successful mutation.
+type MutationResult struct {
+	Resource    string      `json:"resource"`
+	Identifier  string      `json:"identifier,omitempty"`
+	Action      string      `json:"action"`
+	Environment Environment `json:"environment"`
+	Success     bool        `json:"success"`
+}


### PR DESCRIPTION
## What

Adds a stable `asc storekit` command family with dedicated In-App Purchase API-key authentication and complete Retention Messaging API coverage:

- images: list, upload, delete
- messages: list, upload, delete
- defaults: view, set, delete
- endpoint: view, set, delete
- performance: start, view, wait
- auth: login, status, switch, doctor, logout

## Why

Retention Messaging is a StoreKit server API, not an App Store Connect API resource. It uses separate production/sandbox hosts, dedicated In-App Purchase keys, StoreKit-specific JWT claims, and a non-JSON:API error model. Keeping it under `asc storekit` prevents StoreKit credentials from entering the ordinary ASC credential pool.

## Behavior and safety

- Explicit `--environment production|sandbox`; no production default
- Dedicated keychain/config profiles and `ASC_STOREKIT_*` CI variables
- Fresh ES256 JWT per request with `iss`, `iat`, `exp`, `aud`, and `bid`
- All 14 Apple API operations covered
- Strict message limits, UUID validation, PNG dimensions, and no-transparency checks
- `--confirm` gates for deletes/logout
- Sandbox-only performance tests with rate-safe polling
- JSON/table/markdown output and built-binary usage exit-code coverage
- No automatic retry for non-idempotent image/message uploads
- Auth status output cannot serialize private-key material

## Compatibility

New command/config namespace only. Existing App Store Connect commands and profiles are unchanged. The public ASC OpenAPI snapshot is intentionally untouched because these endpoints belong to the Retention Messaging API.

## Verification

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc-storekit .`
- Protocol tests cover JWT claims, all 14 HTTP routes, response/error decoding, key storage precedence, CLI validation, and exit code `2`.

A live Apple sandbox smoke test was not run: no `ASC_STOREKIT_*` credentials or StoreKit profile are available on this machine. The documented live sequence starts with `asc storekit auth doctor --environment sandbox --network` once Apple grants Retention Messaging access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `asc storekit` command group for StoreKit Retention Messaging.
  * Added `storekit auth` commands (`login`, `status`, `switch`, `doctor`, `logout`) with environment enforcement and optional keychain bypass.
  * Added retention messaging management for images, messages, product-locale defaults, realtime endpoint configuration, and sandbox performance tests.
* **Documentation**
  * Expanded README and command reference, and added architecture docs and StoreKit environment variable guidance.
* **Tests**
  * Added end-to-end and unit tests for the command tree, environment requirements, confirmation gates, validation, and success/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->