### PR TITLE
apps wall: add Mafy - Dog Care Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -728,6 +728,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/05/6a/92/056a928c-8748-1457-e513-43e96ce8a97e/Lumical-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Mafy - Dog Care Tracker",
+    "link": "https://apps.apple.com/us/app/mafy-dog-care-tracker/id6736774671?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/00/95/ed/0095ed43-61ca-da3c-f01d-9d7fb43137dc/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Magic Sticker Printer",
     "link": "https://apps.apple.com/app/id6759186064",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/70/6a/e1/706ae16e-f081-eef4-6970-9d6896c4dbf4/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1373,7 +1373,8 @@
   },
   {
     "app": "Sunbreak: Nightly App Blocker",
-    "link": "https://apps.apple.com/us/app/sunbreak-nightly-app-blocker/id6752121964"
+    "link": "https://apps.apple.com/us/app/sunbreak-nightly-app-blocker/id6752121964",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6d/87/66/6d87668f-1acf-38dc-9242-4e571ea81a0e/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
     "app": "Super Shot: EXIF Photo Frame",


### PR DESCRIPTION
## Summary

- add `Mafy - Dog Care Tracker` to the Wall of Apps

## Entry

- App ID: 6736774671
- App: Mafy - Dog Care Tracker
- Link: https://apps.apple.com/us/app/mafy-dog-care-tracker/id6736774671?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added **“Mafy - Dog Care Tracker”** to the app collection, including its App Store link and icon.  
  * Updated **“Sunbreak: Nightly App Blocker”** to include an icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->