### PR TITLE
Add --include flag to testflight crashes/feedback list

### DIFF
--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -403,6 +403,18 @@ func WithFeedbackIncludeScreenshots() FeedbackOption {
 	}
 }
 
+// WithFeedbackInclude specifies related resources to include in screenshot
+// feedback responses (e.g., "build" to surface the build the feedback was
+// submitted against, or "tester").
+func WithFeedbackInclude(include []string) FeedbackOption {
+	return func(q *feedbackQuery) {
+		normalized := normalizeList(include)
+		if len(normalized) > 0 {
+			q.include = normalized
+		}
+	}
+}
+
 // WithCrashDeviceModels filters crashes by device model(s).
 func WithCrashDeviceModels(models []string) CrashOption {
 	return func(q *crashQuery) {
@@ -1002,6 +1014,19 @@ func WithCrashSort(sort string) CrashOption {
 	return func(q *crashQuery) {
 		if strings.TrimSpace(sort) != "" {
 			q.sort = strings.TrimSpace(sort)
+		}
+	}
+}
+
+// WithCrashInclude specifies related resources to include in crash submission
+// responses (e.g., "build" to surface the build the crash occurred on, or
+// "tester"). Including "build" also returns the build's version and
+// preReleaseVersion so the marketing version can be resolved.
+func WithCrashInclude(include []string) CrashOption {
+	return func(q *crashQuery) {
+		normalized := normalizeList(include)
+		if len(normalized) > 0 {
+			q.include = normalized
 		}
 	}
 }

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -22,6 +23,7 @@ type feedbackQuery struct {
 	buildPreReleaseVersionIDs []string
 	testerIDs                 []string
 	sort                      string
+	include                   []string
 	includeScreenshots        bool
 }
 
@@ -35,6 +37,7 @@ type crashQuery struct {
 	buildPreReleaseVersionIDs []string
 	testerIDs                 []string
 	sort                      string
+	include                   []string
 }
 
 type reviewQuery struct {
@@ -762,7 +765,7 @@ func buildNominationsDetailQuery(query *nominationsQuery) string {
 func buildFeedbackQuery(query *feedbackQuery) string {
 	values := url.Values{}
 	if query.includeScreenshots {
-		values.Set("fields[betaFeedbackScreenshotSubmissions]", strings.Join([]string{
+		fields := []string{
 			"createdDate",
 			"comment",
 			"email",
@@ -771,7 +774,18 @@ func buildFeedbackQuery(query *feedbackQuery) string {
 			"appPlatform",
 			"devicePlatform",
 			"screenshots",
-		}, ","))
+		}
+		// A sparse fieldset omits any field not listed, including relationship
+		// fields. If the caller also requested relationships via include, those
+		// relationship names must be present here or ASC will not return the
+		// linked resources. `build`/`tester` are valid screenshot submission
+		// fields, so append whatever was included.
+		for _, rel := range normalizeList(query.include) {
+			if !slices.Contains(fields, rel) {
+				fields = append(fields, rel)
+			}
+		}
+		values.Set("fields[betaFeedbackScreenshotSubmissions]", strings.Join(fields, ","))
 	}
 	addCSV(values, "filter[deviceModel]", query.deviceModels)
 	addCSV(values, "filter[osVersion]", query.osVersions)
@@ -780,6 +794,7 @@ func buildFeedbackQuery(query *feedbackQuery) string {
 	addCSV(values, "filter[build]", query.buildIDs)
 	addCSV(values, "filter[build.preReleaseVersion]", query.buildPreReleaseVersionIDs)
 	addCSV(values, "filter[tester]", query.testerIDs)
+	addBetaSubmissionInclude(values, query.include)
 	if query.sort != "" {
 		values.Set("sort", query.sort)
 	}
@@ -796,11 +811,27 @@ func buildCrashQuery(query *crashQuery) string {
 	addCSV(values, "filter[build]", query.buildIDs)
 	addCSV(values, "filter[build.preReleaseVersion]", query.buildPreReleaseVersionIDs)
 	addCSV(values, "filter[tester]", query.testerIDs)
+	addBetaSubmissionInclude(values, query.include)
 	if query.sort != "" {
 		values.Set("sort", query.sort)
 	}
 	addLimit(values, query.limit)
 	return values.Encode()
+}
+
+// addBetaSubmissionInclude sets the `include` parameter for beta feedback crash
+// and screenshot submission queries. When the `build` relationship is requested
+// it also narrows `fields[builds]` to the build version (CFBundleVersion, i.e.
+// the build number) and its preReleaseVersion relationship, so callers can
+// resolve the marketing version (CFBundleShortVersionString) without parsing the
+// crash log. The submission endpoints only support including `build` and
+// `tester`.
+func addBetaSubmissionInclude(values url.Values, include []string) {
+	include = normalizeList(include)
+	addCSV(values, "include", include)
+	if slices.Contains(include, "build") {
+		addCSV(values, "fields[builds]", []string{"version", "preReleaseVersion"})
+	}
 }
 
 func buildBetaGroupsQuery(query *betaGroupsQuery) string {

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -190,6 +190,112 @@ func TestBuildCrashQuery(t *testing.T) {
 	}
 }
 
+func TestBuildCrashQueryIncludeBuild(t *testing.T) {
+	query := &crashQuery{}
+	WithCrashInclude([]string{"build"})(query)
+
+	values, err := url.ParseQuery(buildCrashQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+
+	if got := values.Get("include"); got != "build" {
+		t.Fatalf("expected include=build, got %q", got)
+	}
+	// Including the build relationship narrows the build fields so callers can
+	// resolve the build number (version) and marketing version (preReleaseVersion).
+	if got := values.Get("fields[builds]"); got != "version,preReleaseVersion" {
+		t.Fatalf("expected fields[builds]=version,preReleaseVersion, got %q", got)
+	}
+}
+
+func TestBuildCrashQueryIncludeTesterOnly(t *testing.T) {
+	query := &crashQuery{}
+	WithCrashInclude([]string{"tester"})(query)
+
+	values, err := url.ParseQuery(buildCrashQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+
+	if got := values.Get("include"); got != "tester" {
+		t.Fatalf("expected include=tester, got %q", got)
+	}
+	// fields[builds] should only be set when the build relationship is included.
+	if got := values.Get("fields[builds]"); got != "" {
+		t.Fatalf("expected no fields[builds] without build include, got %q", got)
+	}
+}
+
+func TestBuildCrashQueryNoIncludeByDefault(t *testing.T) {
+	values, err := url.ParseQuery(buildCrashQuery(&crashQuery{}))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values.Get("include"); got != "" {
+		t.Fatalf("expected no include by default, got %q", got)
+	}
+}
+
+func TestBuildFeedbackQueryIncludeBuild(t *testing.T) {
+	query := &feedbackQuery{}
+	WithFeedbackInclude([]string{"build"})(query)
+
+	values, err := url.ParseQuery(buildFeedbackQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+
+	if got := values.Get("include"); got != "build" {
+		t.Fatalf("expected include=build, got %q", got)
+	}
+	if got := values.Get("fields[builds]"); got != "version,preReleaseVersion" {
+		t.Fatalf("expected fields[builds]=version,preReleaseVersion, got %q", got)
+	}
+}
+
+// When --include-screenshots and --include build are combined, the requested
+// relationship must appear in the screenshot sparse fieldset, otherwise ASC
+// drops the included build from the response.
+func TestBuildFeedbackQueryIncludeBuildWithScreenshots(t *testing.T) {
+	query := &feedbackQuery{}
+	WithFeedbackIncludeScreenshots()(query)
+	WithFeedbackInclude([]string{"build"})(query)
+
+	values, err := url.ParseQuery(buildFeedbackQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+
+	if got := values.Get("include"); got != "build" {
+		t.Fatalf("expected include=build, got %q", got)
+	}
+	fields := values.Get("fields[betaFeedbackScreenshotSubmissions]")
+	if !strings.Contains(fields, "build") {
+		t.Fatalf("expected screenshot fieldset to contain build, got %q", fields)
+	}
+	if !strings.Contains(fields, "screenshots") {
+		t.Fatalf("expected screenshot fieldset to retain screenshots, got %q", fields)
+	}
+}
+
+func TestBuildCrashQueryIncludeBuildAndTester(t *testing.T) {
+	query := &crashQuery{}
+	WithCrashInclude([]string{"build", "tester"})(query)
+
+	values, err := url.ParseQuery(buildCrashQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+
+	if got := values.Get("include"); got != "build,tester" {
+		t.Fatalf("expected include=build,tester, got %q", got)
+	}
+	if got := values.Get("fields[builds]"); got != "version,preReleaseVersion" {
+		t.Fatalf("expected fields[builds]=version,preReleaseVersion, got %q", got)
+	}
+}
+
 func TestBuildBetaGroupsQuery(t *testing.T) {
 	query := &betaGroupsQuery{}
 	WithBetaGroupsLimit(10)(query)

--- a/internal/cli/cmdtest/crashes_feedback_include_test.go
+++ b/internal/cli/cmdtest/crashes_feedback_include_test.go
@@ -1,0 +1,184 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+// okJSONResponse builds a 200 JSON response for the mock transport.
+func okJSONResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func TestCrashesListIncludeBuildSendsBuildRelationship(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var gotQuery url.Values
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackCrashSubmissions" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		gotQuery = req.URL.Query()
+		return okJSONResponse(`{"data":[{"type":"betaFeedbackCrashSubmissions","id":"crash-1"}],` +
+			`"included":[{"type":"builds","id":"b1","attributes":{"version":"532621"}}]}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "crashes", "list", "--app", "123", "--include", "build"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if got := gotQuery.Get("include"); got != "build" {
+		t.Fatalf("include query = %q, want %q", got, "build")
+	}
+	if got := gotQuery.Get("fields[builds]"); got != "version,preReleaseVersion" {
+		t.Fatalf("fields[builds] query = %q, want %q", got, "version,preReleaseVersion")
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"crash-1"`) {
+		t.Fatalf("expected crash output, got %q", stdout)
+	}
+}
+
+func TestCrashesListInvalidIncludeReturnsUsageError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "crashes", "list", "--app", "123", "--include", "bogus"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if rootcmd.ExitCodeFromError(runErr) != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d (err=%v)", rootcmd.ExitCodeFromError(runErr), rootcmd.ExitUsage, runErr)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--include must be a comma-separated list of: build, tester") {
+		t.Fatalf("stderr = %q, want --include usage error", stderr)
+	}
+}
+
+func TestFeedbackListIncludeBuildSendsBuildRelationship(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var gotQuery url.Values
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackScreenshotSubmissions" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		gotQuery = req.URL.Query()
+		return okJSONResponse(`{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"fb-1"}],` +
+			`"included":[{"type":"builds","id":"b1","attributes":{"version":"532621"}}]}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "feedback", "list", "--app", "123", "--include", "build"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if got := gotQuery.Get("include"); got != "build" {
+		t.Fatalf("include query = %q, want %q", got, "build")
+	}
+	if got := gotQuery.Get("fields[builds]"); got != "version,preReleaseVersion" {
+		t.Fatalf("fields[builds] query = %q, want %q", got, "version,preReleaseVersion")
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"fb-1"`) {
+		t.Fatalf("expected feedback output, got %q", stdout)
+	}
+}
+
+func TestFeedbackListInvalidIncludeReturnsUsageError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "feedback", "list", "--app", "123", "--include", "bogus"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if rootcmd.ExitCodeFromError(runErr) != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d (err=%v)", rootcmd.ExitCodeFromError(runErr), rootcmd.ExitUsage, runErr)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--include must be a comma-separated list of: build, tester") {
+		t.Fatalf("stderr = %q, want --include usage error", stderr)
+	}
+}

--- a/internal/cli/cmdtest/crashes_feedback_include_test.go
+++ b/internal/cli/cmdtest/crashes_feedback_include_test.go
@@ -2,6 +2,7 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -13,6 +14,29 @@ import (
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
+
+type betaSubmissionListOutput struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+	Included []struct {
+		Type       string `json:"type"`
+		ID         string `json:"id"`
+		Attributes struct {
+			Version string `json:"version"`
+		} `json:"attributes"`
+	} `json:"included"`
+}
+
+func decodeBetaSubmissionListOutput(t *testing.T, stdout string) betaSubmissionListOutput {
+	t.Helper()
+
+	var output betaSubmissionListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, stdout)
+	}
+	return output
+}
 
 // okJSONResponse builds a 200 JSON response for the mock transport.
 func okJSONResponse(body string) *http.Response {
@@ -45,7 +69,7 @@ func TestCrashesListIncludeBuildSendsBuildRelationship(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "crashes", "list", "--app", "123", "--include", "build"}); err != nil {
+		if err := root.Parse([]string{"testflight", "crashes", "list", "--app", "123", "--include", "build", "--output", "json"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -62,8 +86,12 @@ func TestCrashesListIncludeBuildSendsBuildRelationship(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"crash-1"`) {
-		t.Fatalf("expected crash output, got %q", stdout)
+	output := decodeBetaSubmissionListOutput(t, stdout)
+	if len(output.Data) != 1 || output.Data[0].ID != "crash-1" {
+		t.Fatalf("unexpected crash data: %+v", output.Data)
+	}
+	if len(output.Included) != 1 || output.Included[0].Type != "builds" || output.Included[0].ID != "b1" || output.Included[0].Attributes.Version != "532621" {
+		t.Fatalf("unexpected included build: %+v", output.Included)
 	}
 }
 
@@ -125,7 +153,7 @@ func TestFeedbackListIncludeBuildSendsBuildRelationship(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "feedback", "list", "--app", "123", "--include", "build"}); err != nil {
+		if err := root.Parse([]string{"testflight", "feedback", "list", "--app", "123", "--include", "build", "--output", "json"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -142,8 +170,12 @@ func TestFeedbackListIncludeBuildSendsBuildRelationship(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"fb-1"`) {
-		t.Fatalf("expected feedback output, got %q", stdout)
+	output := decodeBetaSubmissionListOutput(t, stdout)
+	if len(output.Data) != 1 || output.Data[0].ID != "fb-1" {
+		t.Fatalf("unexpected feedback data: %+v", output.Data)
+	}
+	if len(output.Included) != 1 || output.Included[0].Type != "builds" || output.Included[0].ID != "b1" || output.Included[0].Attributes.Version != "532621" {
+		t.Fatalf("unexpected included build: %+v", output.Included)
 	}
 }
 

--- a/internal/cli/crashes/crashes.go
+++ b/internal/cli/crashes/crashes.go
@@ -23,6 +23,7 @@ type listCommandFlags struct {
 	buildID         *string
 	buildPreRelease *string
 	tester          *string
+	include         *string
 	sort            *string
 	limit           *int
 	next            *string
@@ -40,6 +41,7 @@ func bindListCommandFlags(fs *flag.FlagSet) listCommandFlags {
 		buildID:         fs.String("build", "", "Filter by build ID(s), comma-separated"),
 		buildPreRelease: fs.String("build-pre-release-version", "", "Filter by pre-release version ID(s), comma-separated"),
 		tester:          fs.String("tester", "", "Filter by tester ID(s), comma-separated"),
+		include:         fs.String("include", "", "Include related resources, comma-separated (build, tester)"),
 		sort:            fs.String("sort", "", "Sort by createdDate or -createdDate"),
 		limit:           fs.Int("limit", 0, "Maximum results per page (1-200)"),
 		next:            fs.String("next", "", "Fetch next page using a links.next URL"),
@@ -92,6 +94,9 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 	if err := shared.ValidateSort(*flags.sort, "createdDate", "-createdDate"); err != nil {
 		return fmt.Errorf("%s: %w", prefix, err)
 	}
+	if err := shared.ValidateInclude(*flags.include, "build", "tester"); err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
 
 	resolvedAppID := shared.ResolveAppID(*flags.appID)
 	if resolvedAppID == "" && strings.TrimSpace(*flags.next) == "" {
@@ -122,6 +127,7 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 		asc.WithCrashBuildIDs(shared.SplitCSV(*flags.buildID)),
 		asc.WithCrashBuildPreReleaseVersionIDs(shared.SplitCSV(*flags.buildPreRelease)),
 		asc.WithCrashTesterIDs(shared.SplitCSV(*flags.tester)),
+		asc.WithCrashInclude(shared.SplitCSV(*flags.include)),
 		asc.WithCrashLimit(*flags.limit),
 		asc.WithCrashNextURL(*flags.next),
 	}

--- a/internal/cli/crashes/crashes.go
+++ b/internal/cli/crashes/crashes.go
@@ -95,7 +95,8 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 		return fmt.Errorf("%s: %w", prefix, err)
 	}
 	if err := shared.ValidateInclude(*flags.include, "build", "tester"); err != nil {
-		return fmt.Errorf("%s: %w", prefix, err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n\n", err)
+		return flag.ErrHelp
 	}
 
 	resolvedAppID := shared.ResolveAppID(*flags.appID)

--- a/internal/cli/feedback/feedback.go
+++ b/internal/cli/feedback/feedback.go
@@ -24,6 +24,7 @@ type listCommandFlags struct {
 	buildID            *string
 	buildPreRelease    *string
 	tester             *string
+	include            *string
 	sort               *string
 	limit              *int
 	next               *string
@@ -42,6 +43,7 @@ func bindListCommandFlags(fs *flag.FlagSet) listCommandFlags {
 		buildID:            fs.String("build", "", "Filter by build ID(s), comma-separated"),
 		buildPreRelease:    fs.String("build-pre-release-version", "", "Filter by pre-release version ID(s), comma-separated"),
 		tester:             fs.String("tester", "", "Filter by tester ID(s), comma-separated"),
+		include:            fs.String("include", "", "Include related resources, comma-separated (build, tester)"),
 		sort:               fs.String("sort", "", "Sort by createdDate or -createdDate"),
 		limit:              fs.Int("limit", 0, "Maximum results per page (1-200)"),
 		next:               fs.String("next", "", "Fetch next page using a links.next URL"),
@@ -94,6 +96,9 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 	if err := shared.ValidateSort(*flags.sort, "createdDate", "-createdDate"); err != nil {
 		return fmt.Errorf("%s: %w", prefix, err)
 	}
+	if err := shared.ValidateInclude(*flags.include, "build", "tester"); err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
 
 	resolvedAppID := shared.ResolveAppID(*flags.appID)
 	if resolvedAppID == "" && strings.TrimSpace(*flags.next) == "" {
@@ -117,6 +122,7 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 		asc.WithFeedbackBuildIDs(shared.SplitCSV(*flags.buildID)),
 		asc.WithFeedbackBuildPreReleaseVersionIDs(shared.SplitCSV(*flags.buildPreRelease)),
 		asc.WithFeedbackTesterIDs(shared.SplitCSV(*flags.tester)),
+		asc.WithFeedbackInclude(shared.SplitCSV(*flags.include)),
 		asc.WithFeedbackLimit(*flags.limit),
 		asc.WithFeedbackNextURL(*flags.next),
 	}

--- a/internal/cli/feedback/feedback.go
+++ b/internal/cli/feedback/feedback.go
@@ -97,7 +97,8 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 		return fmt.Errorf("%s: %w", prefix, err)
 	}
 	if err := shared.ValidateInclude(*flags.include, "build", "tester"); err != nil {
-		return fmt.Errorf("%s: %w", prefix, err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n\n", err)
+		return flag.ErrHelp
 	}
 
 	resolvedAppID := shared.ResolveAppID(*flags.appID)

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -1546,6 +1546,17 @@ func validateSort(value string, allowed ...string) error {
 	return fmt.Errorf("--sort must be one of: %s", strings.Join(allowed, ", "))
 }
 
+// ValidateInclude validates a comma-separated --include value against the set
+// of allowed relationship names. An empty value is valid (no includes).
+func ValidateInclude(value string, allowed ...string) error {
+	for _, item := range SplitCSV(value) {
+		if !slices.Contains(allowed, item) {
+			return fmt.Errorf("--include must be a comma-separated list of: %s", strings.Join(allowed, ", "))
+		}
+	}
+	return nil
+}
+
 // Exported wrappers for shared helpers.
 func GetASCClient() (*asc.Client, error) {
 	// Auth resolution can block on macOS keychain prompts. Show a subtle spinner on stderr

--- a/internal/cli/shared/validate_include_test.go
+++ b/internal/cli/shared/validate_include_test.go
@@ -1,0 +1,32 @@
+package shared
+
+import "testing"
+
+func TestValidateInclude(t *testing.T) {
+	allowed := []string{"build", "tester"}
+
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "empty is valid", value: "", wantErr: false},
+		{name: "single allowed", value: "build", wantErr: false},
+		{name: "multiple allowed", value: "build,tester", wantErr: false},
+		{name: "whitespace tolerated", value: " build , tester ", wantErr: false},
+		{name: "unknown value", value: "crashLog", wantErr: true},
+		{name: "mixed valid and invalid", value: "build,bogus", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateInclude(tc.value, allowed...)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.value)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.value, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `--include` flag to `asc testflight crashes list` and `asc testflight feedback list`.

The beta-feedback submission endpoints (`betaFeedbackCrashSubmissions`, `betaFeedbackScreenshotSubmissions`) don't carry the app version or build number in their attributes — but both expose a `build` relationship. Today the CLI never requests it, so there's no way to learn which build a crash or piece of feedback came from without separately parsing the symbolicated crash log.

This flag lets callers pull that relationship in:

```
asc testflight crashes list   --app <APP_ID> --include build
asc testflight feedback list  --app <APP_ID> --include build,tester
```

When `build` is included, the request also sets `fields[builds]=version,preReleaseVersion`, so the response carries the build number (`CFBundleVersion`) directly and a `preReleaseVersion` pointer the caller can resolve to the marketing version (`CFBundleShortVersionString`). This mirrors how `asc builds list` already surfaces the marketing version via `include=preReleaseVersion`.

Allowed values are `build` and `tester` — the only relationships the App Store Connect API accepts in `include` for these endpoints (verified against the embedded OpenAPI schema).

## Why

`betaFeedbackCrashSubmissions`/`betaFeedbackScreenshotSubmissions` attributes contain device/OS/locale metadata but no version/build, while the API models the link via the `build` relationship (the endpoints even support `filter[build]` / `filter[build.preReleaseVersion]`). Exposing `include` closes that gap so the build a submission was recorded against can be retrieved structurally rather than scraped from log text.

## Notes

- **Sparse-fieldset interaction:** when `--include-screenshots` is combined with `--include`, the requested relationship names are added to `fields[betaFeedbackScreenshotSubmissions]`. Without this, the sparse screenshot fieldset would omit `build`/`tester` and the API would drop the included resources from the response. Covered by a regression test.
- **Backward compatible:** with no `--include`, neither `include` nor `fields[builds]` is sent, so existing output is unchanged.
- **Pagination:** `--paginate` aggregates the `included` resources across pages, and `--next` reuses the server's `links.next` URL (which already encodes `include`/`fields`).

## Tests

- Query-builder unit tests for `include=build`, `include=tester`, combined `build,tester`, and the no-include default (asserting `fields[builds]` is set only when `build` is included).
- Regression test for `--include-screenshots` + `--include build` keeping the relationship in the screenshot fieldset.
- `ValidateInclude` unit tests (empty / single / multiple / whitespace / unknown / mixed).

All existing tests pass (`go build ./...`, `go vet`, gofumpt, full suite including `cmdtest`, and the command-docs sync check).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--include` flag to both the crashes and feedback list commands (supported values: `build`, `tester`).
  * When specified, the output fetches and includes the requested related data.

* **Bug Fixes**
  * Improved query-building so requested relationships are preserved when combined (including screenshot + build scenarios).
  * Ensures build-related fields are returned only when `build` is included.

* **Tests**
  * Added unit and CLI tests for include parsing, correct request parameters, and invalid `--include` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->