### PR TITLE
[codex] enforce introductory offer operation timeouts

### DIFF
--- a/cicd/overview.mdx
+++ b/cicd/overview.mdx
@@ -146,7 +146,7 @@ Customize `asc` behavior in CI:
 | Variable             | Purpose                                     | Default      |
 | -------------------- | ------------------------------------------- | ------------ |
 | `ASC_DEFAULT_OUTPUT` | Output format (`json`, `table`, `markdown`) | `json` in CI |
-| `ASC_TIMEOUT`        | Request timeout (e.g., `90s`, `2m`)         | `60s`        |
+| `ASC_TIMEOUT`        | Per-request timeout (e.g., `90s`, `2m`)     | `30s`        |
 | `ASC_UPLOAD_TIMEOUT` | Upload timeout (e.g., `5m`, `10m`)          | `5m`         |
 | `ASC_DEBUG`          | Enable debug logging (`true`, `api`)        | -            |
 | `ASC_STRICT_AUTH`    | Fail on multiple credential sources         | `false`      |

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -114,12 +114,14 @@ These variables configure default values for apps, vendors, and other resources.
 
 ## Timeout variables
 
-Configure request and upload timeouts.
+Configure request and upload timeouts. These values normally apply to each HTTP request, not to the full runtime of a multi-request command.
+
+For `subscriptions offers introductory create`, an explicit request timeout also bounds the complete create operation, including subscription lookup and all-territory workflows. Without an override, the create operation uses a 5-minute deadline while each request keeps the standard request timeout.
 
 <ParamField path="ASC_TIMEOUT" type="string">
   Request timeout (e.g., `90s`, `2m`, `120s`)
 
-  Default: `90s`
+  Default: `30s`
 </ParamField>
 
 <ParamField path="ASC_TIMEOUT_SECONDS" type="number">
@@ -131,7 +133,7 @@ Configure request and upload timeouts.
 <ParamField path="ASC_UPLOAD_TIMEOUT" type="string">
   Upload timeout for large files (e.g., `60s`, `5m`)
 
-  Default: `60s`
+  Default: `5m`
 </ParamField>
 
 <ParamField path="ASC_UPLOAD_TIMEOUT_SECONDS" type="number">

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) {
@@ -61,6 +62,87 @@ func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) 
 	}
 	if err := root.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateSelectorAndPostShareOperationTimeout(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_TIMEOUT", "1s")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var lookupDeadline time.Time
+	var postDeadlineDelta time.Duration
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
+			var ok bool
+			lookupDeadline, ok = req.Context().Deadline()
+			if !ok {
+				t.Fatal("expected selector lookup deadline")
+			}
+			time.Sleep(250 * time.Millisecond)
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
+			if got := req.URL.Query().Get("filter[productId]"); got != "com.example.monthly" {
+				t.Fatalf("expected product-id selector filter, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}]}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			postDeadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Fatal("expected create request deadline")
+			}
+			postDeadlineDelta = postDeadline.Sub(lookupDeadline)
+			if postDeadlineDelta > 100*time.Millisecond {
+				return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"intro-new"}}`), nil
+			}
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	started := time.Now()
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--app", "app-1",
+			"--subscription-id", "com.example.monthly",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--territory", "USA",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatalf("expected create operation timeout, got nil; selector-to-POST deadline delta=%v", postDeadlineDelta)
+	}
+	if !strings.Contains(runErr.Error(), "context deadline exceeded") {
+		t.Fatalf("expected deadline error, got %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected no output before single-create timeout, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	if postDeadlineDelta < 0 || postDeadlineDelta > 100*time.Millisecond {
+		t.Fatalf("expected selector and POST to share one operation deadline, delta=%v", postDeadlineDelta)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("expected explicit 1s timeout to cap the operation, elapsed=%v", elapsed)
 	}
 }
 
@@ -224,6 +306,114 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesCreatesPerAvailabili
 	}
 	if got := strings.Join(postedTerritories, ","); got != "CAN,USA" {
 		t.Fatalf("expected POSTs for CAN,USA in availability order, got %s", got)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesTimeoutStopsContinueOnError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_TIMEOUT", "1s")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var operationDeadline time.Time
+	postedTerritories := make([]string, 0, 3)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			var ok bool
+			operationDeadline, ok = req.Context().Deadline()
+			if !ok {
+				t.Fatal("expected availability request deadline")
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"},{"type":"territories","id":"GBR"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/introductoryOffers":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			var payload struct {
+				Data struct {
+					Relationships struct {
+						Territory struct {
+							Data struct {
+								ID string `json:"id"`
+							} `json:"data"`
+						} `json:"territory"`
+					} `json:"relationships"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			postedTerritories = append(postedTerritories, payload.Data.Relationships.Territory.Data.ID)
+			if len(postedTerritories) == 1 {
+				if wait := time.Until(operationDeadline.Add(25 * time.Millisecond)); wait > 0 {
+					time.Sleep(wait)
+				}
+				return nil, context.DeadlineExceeded
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"intro-new"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	var summary struct {
+		Total    int `json:"total"`
+		Created  int `json:"created"`
+		Failed   int `json:"failed"`
+		Failures []struct {
+			Territory string `json:"territory"`
+			Error     string `json:"error"`
+		} `json:"failures"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--all-territories",
+			"--continue-on-error=true",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected operation timeout, got nil")
+	}
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if !strings.Contains(runErr.Error(), "context deadline exceeded") {
+		t.Fatalf("expected deadline error, got %v; stdout=%q; POSTs=%v", runErr, stdout, postedTerritories)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Total != 3 || summary.Created != 0 || summary.Failed != 1 {
+		t.Fatalf("unexpected timeout summary: %+v", summary)
+	}
+	if len(summary.Failures) != 1 || summary.Failures[0].Territory != "USA" || !strings.Contains(summary.Failures[0].Error, "context deadline exceeded") {
+		t.Fatalf("expected deterministic USA deadline failure, got %+v", summary.Failures)
+	}
+	if got := strings.Join(postedTerritories, ","); got != "USA" {
+		t.Fatalf("expected timeout to stop before CAN even with --continue-on-error=true, got POSTs for %s", got)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -11,7 +11,20 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
+
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}
 
 func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) {
 	setupAuth(t)
@@ -131,6 +144,9 @@ func TestSubscriptionsIntroductoryOffersCreateSelectorAndPostShareOperationTimeo
 	})
 	if runErr == nil {
 		t.Fatalf("expected create operation timeout, got nil; selector-to-POST deadline delta=%v", postDeadlineDelta)
+	}
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitError {
+		t.Fatalf("expected timeout exit code %d, got %d", rootcmd.ExitError, got)
 	}
 	if !strings.Contains(runErr.Error(), "context deadline exceeded") {
 		t.Fatalf("expected deadline error, got %v", runErr)
@@ -386,6 +402,7 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesTimeoutStopsContinue
 			"--number-of-periods", "1",
 			"--all-territories",
 			"--continue-on-error=true",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -396,6 +413,9 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesTimeoutStopsContinue
 	}
 	if _, ok := errors.AsType[ReportedError](runErr); !ok {
 		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitError {
+		t.Fatalf("expected timeout exit code %d, got %d", rootcmd.ExitError, got)
 	}
 	if !strings.Contains(runErr.Error(), "context deadline exceeded") {
 		t.Fatalf("expected deadline error, got %v; stdout=%q; POSTs=%v", runErr, stdout, postedTerritories)
@@ -415,6 +435,88 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesTimeoutStopsContinue
 	if got := strings.Join(postedTerritories, ","); got != "USA" {
 		t.Fatalf("expected timeout to stop before CAN even with --continue-on-error=true, got POSTs for %s", got)
 	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesSkipsExistingBeforeCancellationFailure(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	t.Cleanup(cancelRun)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionAvailability":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/introductoryOffers":
+			resp := jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"intro-existing","relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{}}`)
+			resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancelRun}
+			return resp, nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("canceled operation should not create another offer: %s", req.URL.Path)
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	var summary struct {
+		Total    int                                        `json:"total"`
+		Skipped  int                                        `json:"skipped"`
+		Failed   int                                        `json:"failed"`
+		Skips    []subscriptionIntroductoryOfferSummaryItem `json:"skips"`
+		Failures []subscriptionIntroductoryOfferSummaryItem `json:"failures"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--all-territories",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(runCtx)
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "context canceled") {
+		t.Fatalf("expected canceled operation error, got %v", runErr)
+	}
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Total != 2 || summary.Skipped != 1 || summary.Failed != 1 {
+		t.Fatalf("unexpected canceled summary: %+v", summary)
+	}
+	if len(summary.Skips) != 1 || summary.Skips[0].Territory != "USA" {
+		t.Fatalf("expected existing USA offer to remain skipped, got %+v", summary.Skips)
+	}
+	if len(summary.Failures) != 1 || summary.Failures[0].Territory != "CAN" || !strings.Contains(summary.Failures[0].Error, "context canceled") {
+		t.Fatalf("expected CAN cancellation failure, got %+v", summary.Failures)
+	}
+}
+
+type subscriptionIntroductoryOfferSummaryItem struct {
+	Territory string `json:"territory"`
+	Error     string `json:"error"`
 }
 
 func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesPartialFailureReturnsReportedError(t *testing.T) {

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -486,6 +486,7 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesSkipsExistingBeforeC
 			"--offer-mode", "FREE_TRIAL",
 			"--number-of-periods", "1",
 			"--all-territories",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/ascterritory"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+const subscriptionIntroductoryOfferCreateTimeout = 5 * time.Minute
 
 // SubscriptionsIntroductoryOffersCommand returns the introductory offers command group.
 func SubscriptionsIntroductoryOffersCommand() *ffcli.Command {
@@ -198,7 +201,10 @@ func SubscriptionsIntroductoryOffersCreateCommand() *ffcli.Command {
 Examples:
   asc subscriptions introductory-offers create --subscription-id "SUB_ID" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
   asc subscriptions introductory-offers create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
-  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --territory ALL --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1`,
+  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --territory ALL --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+
+Timeouts:
+  An explicit ASC_TIMEOUT caps the full create operation. Without an override, the operation uses a 5m fallback while individual requests retain the standard request timeout.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -269,7 +275,10 @@ Examples:
 				return fmt.Errorf("subscriptions introductory-offers create: %w", err)
 			}
 
-			id, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, id)
+			operationCtx, operationCancel := contextWithSubscriptionIntroductoryOfferCreateTimeout(ctx)
+			defer operationCancel()
+
+			id, err = resolveSubscriptionLookupIDWithTimeout(operationCtx, client, *appID, id)
 			if err != nil {
 				return err
 			}
@@ -288,7 +297,7 @@ Examples:
 
 			if useAllTerritories {
 				return createSubscriptionIntroductoryOffersForAllTerritories(
-					ctx,
+					operationCtx,
 					client,
 					id,
 					attrs,
@@ -299,7 +308,7 @@ Examples:
 				)
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			requestCtx, cancel := shared.ContextWithTimeout(operationCtx)
 			defer cancel()
 
 			resp, err := client.CreateSubscriptionIntroductoryOffer(
@@ -371,7 +380,14 @@ func createSubscriptionIntroductoryOffersForAllTerritories(
 		Total:           len(territories),
 	}
 
+	var operationErr error
 	for _, territoryID := range territories {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			appendSubscriptionIntroductoryOfferCreateBulkFailure(summary, territoryID, ctxErr)
+			operationErr = ctxErr
+			break
+		}
+
 		if _, ok := existing[territoryID]; ok {
 			appendSubscriptionIntroductoryOfferCreateBulkSkip(summary, territoryID, "introductory offer already exists for territory")
 			continue
@@ -387,6 +403,10 @@ func createSubscriptionIntroductoryOffersForAllTerritories(
 		createCancel()
 		if err != nil {
 			appendSubscriptionIntroductoryOfferCreateBulkFailure(summary, territoryID, err)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				operationErr = ctxErr
+				break
+			}
 			if !continueOnError {
 				break
 			}
@@ -405,10 +425,17 @@ func createSubscriptionIntroductoryOffersForAllTerritories(
 	); err != nil {
 		return err
 	}
+	if operationErr != nil {
+		return shared.NewReportedError(fmt.Errorf("subscriptions introductory-offers create: operation stopped: %w", operationErr))
+	}
 	if summary.Failed > 0 {
 		return shared.NewReportedError(fmt.Errorf("subscriptions introductory-offers create: %d territor%s failed", summary.Failed, pluralizeIntroductoryOfferCreateTerritories(summary.Failed)))
 	}
 	return nil
+}
+
+func contextWithSubscriptionIntroductoryOfferCreateTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return shared.ContextWithResolvedTimeout(ctx, subscriptionIntroductoryOfferCreateTimeout)
 }
 
 func fetchIntroductoryOfferAvailabilityTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (string, []string, error) {

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -382,15 +382,15 @@ func createSubscriptionIntroductoryOffersForAllTerritories(
 
 	var operationErr error
 	for _, territoryID := range territories {
+		if _, ok := existing[territoryID]; ok {
+			appendSubscriptionIntroductoryOfferCreateBulkSkip(summary, territoryID, "introductory offer already exists for territory")
+			continue
+		}
+
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			appendSubscriptionIntroductoryOfferCreateBulkFailure(summary, territoryID, ctxErr)
 			operationErr = ctxErr
 			break
-		}
-
-		if _, ok := existing[territoryID]; ok {
-			appendSubscriptionIntroductoryOfferCreateBulkSkip(summary, territoryID, "introductory offer already exists for territory")
-			continue
 		}
 
 		if dryRun {

--- a/internal/cli/subscriptions/introductory_offers_timeout_test.go
+++ b/internal/cli/subscriptions/introductory_offers_timeout_test.go
@@ -2,6 +2,7 @@ package subscriptions
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -50,5 +51,25 @@ func TestContextWithSubscriptionIntroductoryOfferCreateTimeoutRespectsASCTimeout
 	remaining := time.Until(deadline)
 	if remaining < 44*time.Second || remaining > 46*time.Second {
 		t.Fatalf("expected create operation timeout near 45s from ASC_TIMEOUT, got %v", remaining)
+	}
+}
+
+func TestContextWithSubscriptionIntroductoryOfferCreateTimeoutRespectsASCTimeoutSeconds(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "")
+	if err := os.Unsetenv("ASC_TIMEOUT"); err != nil {
+		t.Fatalf("unset ASC_TIMEOUT: %v", err)
+	}
+	t.Setenv("ASC_TIMEOUT_SECONDS", "45")
+
+	ctx, cancel := contextWithSubscriptionIntroductoryOfferCreateTimeout(context.Background())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected create operation deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining < 44*time.Second || remaining > 46*time.Second {
+		t.Fatalf("expected create operation timeout near 45s from ASC_TIMEOUT_SECONDS, got %v", remaining)
 	}
 }

--- a/internal/cli/subscriptions/introductory_offers_timeout_test.go
+++ b/internal/cli/subscriptions/introductory_offers_timeout_test.go
@@ -1,0 +1,54 @@
+package subscriptions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestContextWithSubscriptionIntroductoryOfferCreateTimeoutUsesOperationDefault(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+
+	ctx, cancel := contextWithSubscriptionIntroductoryOfferCreateTimeout(context.Background())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected create operation deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining < 4*time.Minute+59*time.Second || remaining > 5*time.Minute+time.Second {
+		t.Fatalf("expected create operation timeout near 5m, got %v", remaining)
+	}
+
+	requestCtx, requestCancel := shared.ContextWithTimeout(ctx)
+	defer requestCancel()
+	requestDeadline, ok := requestCtx.Deadline()
+	if !ok {
+		t.Fatal("expected individual request deadline")
+	}
+	requestRemaining := time.Until(requestDeadline)
+	if requestRemaining < 29*time.Second || requestRemaining > 31*time.Second {
+		t.Fatalf("expected individual request timeout near 30s, got %v", requestRemaining)
+	}
+}
+
+func TestContextWithSubscriptionIntroductoryOfferCreateTimeoutRespectsASCTimeout(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "45s")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+
+	ctx, cancel := contextWithSubscriptionIntroductoryOfferCreateTimeout(context.Background())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected create operation deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining < 44*time.Second || remaining > 46*time.Second {
+		t.Fatalf("expected create operation timeout near 45s from ASC_TIMEOUT, got %v", remaining)
+	}
+}


### PR DESCRIPTION
## Summary

- bound `subscriptions offers introductory create` with one operation context spanning selector lookup, discovery, and creation
- use `ASC_TIMEOUT` / `ASC_TIMEOUT_SECONDS` (or config equivalents) as the explicit operation deadline, with a 5-minute fallback so the 30-second request default does not break healthy all-territory runs
- stop bulk creation on operation deadline even with `--continue-on-error=true`, while preserving the partial structured summary
- document request-versus-operation semantics and correct the documented request/upload defaults to 30 seconds / 5 minutes

## Root cause

The command created a fresh `ASC_TIMEOUT` context for each lookup, discovery, pagination, and create request. A multi-request workflow could therefore run well beyond an explicit timeout, and `--continue-on-error=true` could keep starting more territory requests after deadline failures.

The fix adds a parent create-operation context. Each HTTP request still receives its normal request timeout as a child, but no child can outlive the operation deadline.

## Behavior

```bash
ASC_TIMEOUT=90s asc subscriptions offers introductory create \
  --app "APP_ID" \
  --subscription-id "com.example.monthly" \
  --offer-duration ONE_MONTH \
  --offer-mode FREE_TRIAL \
  --number-of-periods 1 \
  --territory USA
```

The 90-second budget now covers selector lookup plus the create request. All-territory invocations use the same end-to-end budget and stop after the in-flight deadline failure; JSON/table/markdown output still reports the partial bulk result and the process exits 1.

Without an override, the create operation gets a 5-minute parent while individual requests retain the standard 30-second request timeout.

## Alternatives considered

- Keep `ASC_TIMEOUT` request-only and clarify docs: rejected because it does not satisfy the expected command-level cancellation contract.
- Use the 30-second default for the entire operation: rejected because healthy all-territory workflows can legitimately require many requests.
- Add a new `--operation-timeout` flag: deferred to avoid expanding the stable command surface when the existing timeout setting can provide the expected behavior compatibly.

## Validation

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run '^TestSubscriptionsIntroductoryOffersCreate' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/subscriptions -run 'IntroductoryOffer|IntroductoryOffers' -count=1`
- repeated the two slow-transport timeout tests three times
- `make generate-command-docs`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc-issue-1675 .`
- built binary: help exit `0`, invalid `--offer-mode` exit `2`, and timeout contract present in help

No live App Store Connect mutation was needed; deterministic CLI-level slow transports cover selector, request, partial-output, and cancellation behavior.

Fixes #1675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a consistent overall create-operation timeout for `asc subscriptions introductory-offers create`, including “all territories” bulk runs; processing now stops when the deadline is reached (even with `--continue-on-error`).
  * Improved the interruption behavior and error surfacing, including correct handling of cancellations during bulk processing.
* **Documentation**
  * Clarified timeout semantics (typically per HTTP request) and updated defaults: `ASC_TIMEOUT` now defaults to **30s**, and `ASC_UPLOAD_TIMEOUT` to **5m**.
  * Updated CI/CD timeout documentation and the CLI help text for the operation timeout behavior.
* **Tests**
  * Added/expanded timeout and cancellation tests to verify deadline propagation, bulk-stop behavior, and expected error/output outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->