### PR TITLE
test: fix app-info batch counter race

### DIFF
--- a/internal/cli/cmdtest/app_info_set_batch_test.go
+++ b/internal/cli/cmdtest/app_info_set_batch_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
@@ -337,7 +338,7 @@ func TestAppInfoSetBatchApplyCreateWarningsStaySorted(t *testing.T) {
 		http.DefaultTransport = originalTransport
 	})
 
-	createCount := 0
+	var createCount atomic.Int32
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
 		case "/v1/apps/app-1/appStoreVersions":
@@ -348,7 +349,7 @@ func TestAppInfoSetBatchApplyCreateWarningsStaySorted(t *testing.T) {
 			if req.Method != http.MethodPost {
 				t.Fatalf("expected POST for create, got %s", req.Method)
 			}
-			createCount++
+			createCount.Add(1)
 			body := `{"data":{"type":"appStoreVersionLocalizations","id":"loc-created","attributes":{"locale":"created"}}}`
 			return appInfoSetBatchJSONResponse(http.StatusCreated, body), nil
 		default:
@@ -374,8 +375,8 @@ func TestAppInfoSetBatchApplyCreateWarningsStaySorted(t *testing.T) {
 		}
 	})
 
-	if createCount != 2 {
-		t.Fatalf("expected 2 create calls, got %d", createCount)
+	if got := createCount.Load(); got != 2 {
+		t.Fatalf("expected 2 create calls, got %d", got)
 	}
 	firstIdx := strings.Index(stderr, "created locale de-DE now participates in submission validation")
 	secondIdx := strings.Index(stderr, "created locale fr-FR now participates in submission validation")


### PR DESCRIPTION
## Summary

- replace the concurrent app-info batch test's shared integer counter with `atomic.Int32`
- keep the production batch implementation and warning-order assertions unchanged

This pre-existing test race surfaced during the broader retry/resume audit. An atomic counter is sufficient because the test only needs a concurrency-safe total; a mutex would add ceremony without protecting any compound state.

## Verification

- RED: `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run '^TestAppInfoSetBatchApplyCreateWarningsStaySorted$' -count=1` (race reproduced)
- GREEN: same focused race command
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./internal/cli/cmdtest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved internal test reliability by using atomic counting for request tracking.
  * Strengthened assertions around create-call behavior to better detect concurrency-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->