### PR TITLE
fix(webhooks): avoid shutdown channel race

### DIFF
--- a/internal/cli/webhooks/webhooks_serve.go
+++ b/internal/cli/webhooks/webhooks_serve.go
@@ -264,7 +264,8 @@ func (r *webhookServeRuntime) newHandler() http.Handler {
 }
 
 func (r *webhookServeRuntime) startWorkers(_ context.Context) {
-	if r.eventQueue == nil {
+	eventQueue := r.eventQueue
+	if eventQueue == nil {
 		return
 	}
 
@@ -274,12 +275,12 @@ func (r *webhookServeRuntime) startWorkers(_ context.Context) {
 	}
 	r.workersWG.Add(workerCount)
 	for i := 0; i < workerCount; i++ {
-		go func() {
+		go func(queue <-chan webhookServeEvent) {
 			defer r.workersWG.Done()
-			for event := range r.eventQueue {
+			for event := range queue {
 				r.processEvent(event)
 			}
-		}()
+		}(eventQueue)
 	}
 }
 

--- a/internal/cli/webhooks/webhooks_serve_test.go
+++ b/internal/cli/webhooks/webhooks_serve_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -131,6 +132,18 @@ func TestWebhooksServeAllowsNonLoopbackWithAllowRemote(t *testing.T) {
 	if statusCode != http.StatusAccepted {
 		t.Fatalf("expected status %d, got %d", http.StatusAccepted, statusCode)
 	}
+}
+
+func TestWebhookServeRuntimeStopsWorkersImmediatelyAfterStart(t *testing.T) {
+	previousProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() { runtime.GOMAXPROCS(previousProcs) })
+
+	serveRuntime := &webhookServeRuntime{
+		eventQueue:  make(chan webhookServeEvent),
+		workerCount: webhooksServeDefaultWorkerCount,
+	}
+	serveRuntime.startWorkers(context.Background())
+	serveRuntime.stopWorkers()
 }
 
 func TestReadWebhookServeJSONPayloadAllowsMaxInt64Limit(t *testing.T) {


### PR DESCRIPTION
## Summary

- capture the webhook event queue before launching workers
- add a deterministic regression for immediate worker shutdown

## Why

Workers previously evaluated `r.eventQueue` after their goroutine started, while shutdown closed that channel and replaced the field with `nil`. That caused a data race and could leave late-starting workers blocked forever on a nil channel.

Capturing the queue once preserves the existing `nil` sentinel used to reject post-shutdown enqueue attempts without making workers read mutable shutdown state. Leaving the closed channel in the field would risk send-on-closed-channel panics; locking each worker read would add lifetime coupling without helping event processing.

## Behavior

The CLI interface is unchanged. `asc webhooks serve --port 0 --output json` still reports its listener and exits successfully on interrupt; shutdown no longer races worker startup.

## Verification

- RED: existing webhook serve tests under `go test -race` reported the `startWorkers` / `stopWorkers` field race
- RED: the new immediate-stop regression timed out with workers blocked on a nil channel
- GREEN: focused regression x20 and focused race suite x10
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/webhooks`
- Windows compile-only test for `./internal/cli/webhooks`
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- pre-commit `ASC_BYPASS_KEYCHAIN=1 go test -short ./...`
- built `/tmp/asc-webhook-race`; help exited 0; live serve + interrupt exited 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook processing to handle events with multiple workers, which can increase throughput and responsiveness.
  * Made worker shutdown more reliable when stopping the service immediately after startup.
* **Tests**
  * Added coverage for rapid start-and-stop behavior to help prevent shutdown regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->