### PR TITLE
feat: add resumable high-level workflow recovery

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -167,6 +168,16 @@ type AppInfoLocalizationAttributes struct {
 	PrivacyPolicyURL  string `json:"privacyPolicyUrl,omitempty"`
 	PrivacyChoicesURL string `json:"privacyChoicesUrl,omitempty"`
 	PrivacyPolicyText string `json:"privacyPolicyText,omitempty"`
+}
+
+type localizationFieldsUpdateData struct {
+	Type       ResourceType      `json:"type"`
+	ID         string            `json:"id"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+type localizationFieldsUpdateRequest struct {
+	Data localizationFieldsUpdateData `json:"data"`
 }
 
 // AppInfoAttributes describes app info resources.
@@ -1253,6 +1264,30 @@ func (c *Client) UpdateAppStoreVersionLocalization(ctx context.Context, localiza
 	return &response, nil
 }
 
+// UpdateAppStoreVersionLocalizationFields updates exactly the supplied fields,
+// preserving explicit empty strings while leaving omitted fields unchanged.
+func (c *Client) UpdateAppStoreVersionLocalizationFields(ctx context.Context, localizationID string, fields map[string]string) (*AppStoreVersionLocalizationResponse, error) {
+	payload := localizationFieldsUpdateRequest{Data: localizationFieldsUpdateData{
+		Type:       ResourceTypeAppStoreVersionLocalizations,
+		ID:         localizationID,
+		Attributes: fields,
+	}}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s", localizationID)
+	data, err := c.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return nil, err
+	}
+	var response AppStoreVersionLocalizationResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &response, nil
+}
+
 // DeleteAppStoreVersionLocalization deletes a localization by ID.
 func (c *Client) DeleteAppStoreVersionLocalization(ctx context.Context, localizationID string) error {
 	path := fmt.Sprintf("/v1/appStoreVersionLocalizations/%s", localizationID)
@@ -1553,6 +1588,30 @@ func (c *Client) UpdateAppInfoLocalization(ctx context.Context, localizationID s
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
+	return &response, nil
+}
+
+// UpdateAppInfoLocalizationFields updates exactly the supplied fields,
+// preserving explicit empty strings while leaving omitted fields unchanged.
+func (c *Client) UpdateAppInfoLocalizationFields(ctx context.Context, localizationID string, fields map[string]string) (*AppInfoLocalizationResponse, error) {
+	payload := localizationFieldsUpdateRequest{Data: localizationFieldsUpdateData{
+		Type:       ResourceTypeAppInfoLocalizations,
+		ID:         localizationID,
+		Attributes: fields,
+	}}
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v1/appInfoLocalizations/%s", localizationID)
+	data, err := c.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return nil, err
+	}
+	var response AppInfoLocalizationResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
 	return &response, nil
 }
 

--- a/internal/asc/client_app_events_test.go
+++ b/internal/asc/client_app_events_test.go
@@ -739,7 +739,7 @@ func TestAppEventMethodsRequireIDs(t *testing.T) {
 }
 
 func TestAppEventMethodsReturnAPIError(t *testing.T) {
-	response := jsonResponse(http.StatusInternalServerError, `{"errors":[{"title":"Server error","detail":"boom"}]}`)
+	response := jsonResponse(http.StatusBadRequest, `{"errors":[{"title":"Invalid request","detail":"boom"}]}`)
 	tests := []struct {
 		name string
 		call func(client *Client) error

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -280,7 +280,8 @@ func isTransientTransportError(err error) bool {
 
 func isRetryableHTTPStatus(statusCode int) bool {
 	switch statusCode {
-	case http.StatusTooManyRequests,
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
 		http.StatusInternalServerError,
 		http.StatusBadGateway,
 		http.StatusServiceUnavailable,
@@ -327,6 +328,8 @@ func shouldLimitMutatingMethod(method string) bool {
 func buildRetryableError(statusCode int, retryAfter time.Duration, respBody []byte) error {
 	base := "API request failed"
 	switch statusCode {
+	case http.StatusRequestTimeout:
+		base = "App Store Connect request timeout"
 	case http.StatusTooManyRequests:
 		base = "rate limited by App Store Connect"
 	case http.StatusInternalServerError:

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -94,7 +96,7 @@ func GenerateJWT(keyID, issuerID string, privateKey *ecdsa.PrivateKey) (string, 
 }
 
 // do performs an HTTP request and returns the response.
-// GET/HEAD requests use retry logic for rate limiting by default.
+// GET/HEAD requests use retry logic for transient failures by default.
 func (c *Client) do(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
 	var bodyBytes []byte
 	if body != nil {
@@ -212,7 +214,11 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 				"elapsed", elapsed.String(),
 			)
 		}
-		return nil, fmt.Errorf("request failed: %w", err)
+		requestErr := fmt.Errorf("request failed: %w", err)
+		if isTransientTransportError(err) {
+			return nil, &RetryableError{Err: requestErr}
+		}
+		return nil, requestErr
 	}
 	defer resp.Body.Close()
 
@@ -229,8 +235,7 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(resp.Body)
 
-		// Check for rate limiting (429) or service unavailable (503)
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+		if isRetryableHTTPStatus(resp.StatusCode) {
 			retryAfter := parseRetryAfterHeader(resp.Header.Get("Retry-After"))
 			return nil, &RetryableError{
 				Err:        buildRetryableError(resp.StatusCode, retryAfter, respBody),
@@ -244,7 +249,46 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 		return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
 	}
 
-	return io.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		readErr := fmt.Errorf("failed to read response body: %w", err)
+		if isTransientTransportError(err) {
+			return nil, &RetryableError{Err: readErr}
+		}
+		return nil, readErr
+	}
+	return data, nil
+}
+
+func isTransientTransportError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EPIPE)
+}
+
+func isRetryableHTTPStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 // sanitizeAuthHeader redacts the JWT token from Authorization header for logging.
@@ -285,8 +329,14 @@ func buildRetryableError(statusCode int, retryAfter time.Duration, respBody []by
 	switch statusCode {
 	case http.StatusTooManyRequests:
 		base = "rate limited by App Store Connect"
+	case http.StatusInternalServerError:
+		base = "App Store Connect internal server error"
+	case http.StatusBadGateway:
+		base = "App Store Connect bad gateway"
 	case http.StatusServiceUnavailable:
 		base = "App Store Connect service unavailable"
+	case http.StatusGatewayTimeout:
+		base = "App Store Connect gateway timeout"
 	}
 
 	message := fmt.Sprintf("%s (status %d)", base, statusCode)

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -405,6 +405,7 @@ func TestGetApps_RetriesTransientServerErrors(t *testing.T) {
 		name   string
 		status int
 	}{
+		{name: "request timeout", status: http.StatusRequestTimeout},
 		{name: "internal server error", status: http.StatusInternalServerError},
 		{name: "bad gateway", status: http.StatusBadGateway},
 		{name: "gateway timeout", status: http.StatusGatewayTimeout},
@@ -8288,7 +8289,7 @@ func TestCreateSubscriptionPriceWithPlanType(t *testing.T) {
 	}
 }
 
-func TestCreateSubscriptionPrice_DoesNotReplayUnexpectedServerError(t *testing.T) {
+func TestCreateSubscriptionPrice_DoesNotReplayRequestTimeout(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "2")
 	t.Setenv("ASC_BASE_DELAY", "1ms")
 	t.Setenv("ASC_MAX_DELAY", "2ms")
@@ -8313,7 +8314,7 @@ func TestCreateSubscriptionPrice_DoesNotReplayUnexpectedServerError(t *testing.T
 				}
 				assertAuthorized(t, req)
 
-				return jsonResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"An unexpected error occurred.","detail":"An unexpected error occurred on the server side."}]}`), nil
+				return jsonResponse(http.StatusRequestTimeout, `{"errors":[{"status":"408","code":"REQUEST_TIMEOUT","title":"Request timeout","detail":"The request may have completed."}]}`), nil
 			}),
 		},
 		keyID:      "KEY123",

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -3153,6 +3153,45 @@ func TestUpdateAppStoreVersionLocalization_OmitsLocale(t *testing.T) {
 	}
 }
 
+func TestUpdateAppStoreVersionLocalizationFields_PreservesExplicitEmpty(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"description":"Updated","promotionalText":""}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var envelope struct {
+			Data struct {
+				Type       string            `json:"type"`
+				ID         string            `json:"id"`
+				Attributes map[string]string `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if envelope.Data.Type != string(ResourceTypeAppStoreVersionLocalizations) || envelope.Data.ID != "loc-1" {
+			t.Fatalf("unexpected resource identity: %+v", envelope.Data)
+		}
+		if value, ok := envelope.Data.Attributes["promotionalText"]; !ok || value != "" {
+			t.Fatalf("expected explicit empty promotionalText, got %+v", envelope.Data.Attributes)
+		}
+		if _, ok := envelope.Data.Attributes["keywords"]; ok {
+			t.Fatalf("expected omitted keywords, got %+v", envelope.Data.Attributes)
+		}
+	}, response)
+
+	if _, err := client.UpdateAppStoreVersionLocalizationFields(context.Background(), "loc-1", map[string]string{
+		"description":     "Updated",
+		"promotionalText": "",
+	}); err != nil {
+		t.Fatalf("UpdateAppStoreVersionLocalizationFields() error: %v", err)
+	}
+}
+
 func TestDeleteAppStoreVersionLocalization_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusNoContent, "")
 	client := newTestClient(t, func(req *http.Request) {
@@ -3579,6 +3618,45 @@ func TestUpdateAppInfoLocalization_OmitsLocale(t *testing.T) {
 	}
 	if _, err := client.UpdateAppInfoLocalization(context.Background(), "loc-1", attrs); err != nil {
 		t.Fatalf("UpdateAppInfoLocalization() error: %v", err)
+	}
+}
+
+func TestUpdateAppInfoLocalizationFields_PreservesExplicitEmpty(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"name":"Updated","subtitle":""}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appInfoLocalizations/loc-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var envelope struct {
+			Data struct {
+				Type       string            `json:"type"`
+				ID         string            `json:"id"`
+				Attributes map[string]string `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if envelope.Data.Type != string(ResourceTypeAppInfoLocalizations) || envelope.Data.ID != "loc-1" {
+			t.Fatalf("unexpected resource identity: %+v", envelope.Data)
+		}
+		if value, ok := envelope.Data.Attributes["subtitle"]; !ok || value != "" {
+			t.Fatalf("expected explicit empty subtitle, got %+v", envelope.Data.Attributes)
+		}
+		if _, ok := envelope.Data.Attributes["privacyPolicyUrl"]; ok {
+			t.Fatalf("expected omitted privacyPolicyUrl, got %+v", envelope.Data.Attributes)
+		}
+	}, response)
+
+	if _, err := client.UpdateAppInfoLocalizationFields(context.Background(), "loc-1", map[string]string{
+		"name":     "Updated",
+		"subtitle": "",
+	}); err != nil {
+		t.Fatalf("UpdateAppInfoLocalizationFields() error: %v", err)
 	}
 }
 

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -22,6 +22,23 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
+type timeoutTransportError struct{}
+
+func (timeoutTransportError) Error() string { return "transport timeout" }
+func (timeoutTransportError) Timeout() bool { return true }
+
+type unexpectedEOFReader struct {
+	read bool
+}
+
+func (r *unexpectedEOFReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	return copy(p, `{"data":`), io.ErrUnexpectedEOF
+}
+
 func newTestClient(t *testing.T, check func(*http.Request), responses ...*http.Response) *Client {
 	t.Helper()
 	if len(responses) == 0 {
@@ -380,6 +397,140 @@ func TestGetApps_RateLimitedIncludesRetryAfter(t *testing.T) {
 	}
 	if got := GetRetryAfter(err); got != 2*time.Minute {
 		t.Fatalf("expected retry-after 2m, got %s", got)
+	}
+}
+
+func TestGetApps_RetriesTransientServerErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "internal server error", status: http.StatusInternalServerError},
+		{name: "bad gateway", status: http.StatusBadGateway},
+		{name: "gateway timeout", status: http.StatusGatewayTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ASC_MAX_RETRIES", "1")
+			t.Setenv("ASC_BASE_DELAY", "1ms")
+			t.Setenv("ASC_MAX_DELAY", "1ms")
+			resetConfigCacheForTest()
+			t.Cleanup(resetConfigCacheForTest)
+
+			attempts := 0
+			client := newTestClient(
+				t, func(req *http.Request) {
+					attempts++
+					if req.Method != http.MethodGet {
+						t.Fatalf("expected GET, got %s", req.Method)
+					}
+				},
+				jsonResponse(tt.status, `{"errors":[{"code":"UNEXPECTED_ERROR","detail":"temporary"}]}`),
+				jsonResponse(http.StatusOK, `{"data":[]}`),
+			)
+
+			if _, err := client.GetApps(context.Background()); err != nil {
+				t.Fatalf("GetApps() error: %v", err)
+			}
+			if attempts != 2 {
+				t.Fatalf("expected 2 attempts, got %d", attempts)
+			}
+		})
+	}
+}
+
+func TestGetApps_RetriesTransportTimeout(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	resetConfigCacheForTest()
+	t.Cleanup(resetConfigCacheForTest)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	attempts := 0
+	client := &Client{
+		httpClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, timeoutTransportError{}
+			}
+			return jsonResponse(http.StatusOK, `{"data":[]}`), nil
+		})},
+		keyID:      "KEY123",
+		issuerID:   "ISS456",
+		privateKey: key,
+	}
+
+	if _, err := client.GetApps(context.Background()); err != nil {
+		t.Fatalf("GetApps() error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestGetApps_RetriesTruncatedSuccessBody(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	resetConfigCacheForTest()
+	t.Cleanup(resetConfigCacheForTest)
+
+	attempts := 0
+	client := newTestClient(
+		t, func(req *http.Request) {
+			attempts++
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+		},
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(&unexpectedEOFReader{}),
+		},
+		jsonResponse(http.StatusOK, `{"data":[]}`),
+	)
+
+	if _, err := client.GetApps(context.Background()); err != nil {
+		t.Fatalf("GetApps() error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestGetApps_DoesNotRetryDeadlineExceeded(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "3")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	resetConfigCacheForTest()
+	t.Cleanup(resetConfigCacheForTest)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	attempts := 0
+	client := &Client{
+		httpClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return nil, context.DeadlineExceeded
+		})},
+		keyID:      "KEY123",
+		issuerID:   "ISS456",
+		privateKey: key,
+	}
+
+	_, err = client.GetApps(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
 	}
 }
 
@@ -7918,7 +8069,7 @@ func TestSetSubscriptionInitialPrice(t *testing.T) {
 	}
 }
 
-func TestSetSubscriptionInitialPrice_RetriesUnexpectedServerError(t *testing.T) {
+func TestSetSubscriptionInitialPrice_DoesNotReplayUnexpectedServerError(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "2")
 	t.Setenv("ASC_BASE_DELAY", "1ms")
 	t.Setenv("ASC_MAX_DELAY", "2ms")
@@ -7943,10 +8094,7 @@ func TestSetSubscriptionInitialPrice_RetriesUnexpectedServerError(t *testing.T) 
 				}
 				assertAuthorized(t, req)
 
-				if attempts < 3 {
-					return jsonResponse(http.StatusGatewayTimeout, `{"errors":[{"status":"504","code":"UNEXPECTED_ERROR","title":"timeout","detail":"timed out"}]}`), nil
-				}
-				return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.sub.monthly"}}}`), nil
+				return jsonResponse(http.StatusGatewayTimeout, `{"errors":[{"status":"504","code":"UNEXPECTED_ERROR","title":"timeout","detail":"timed out"}]}`), nil
 			}),
 		},
 		keyID:      "KEY123",
@@ -7955,11 +8103,14 @@ func TestSetSubscriptionInitialPrice_RetriesUnexpectedServerError(t *testing.T) 
 	}
 
 	_, err = client.SetSubscriptionInitialPrice(context.Background(), "sub-1", "price-point-1", "USA", SubscriptionPriceCreateAttributes{})
-	if err != nil {
-		t.Fatalf("SetSubscriptionInitialPrice() error: %v", err)
+	if err == nil {
+		t.Fatal("expected error")
 	}
-	if attempts != 3 {
-		t.Fatalf("expected 3 attempts (2 retries + success), got %d", attempts)
+	if !IsRetryable(err) {
+		t.Fatalf("expected retryable error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
 	}
 }
 
@@ -8059,7 +8210,7 @@ func TestCreateSubscriptionPriceWithPlanType(t *testing.T) {
 	}
 }
 
-func TestCreateSubscriptionPrice_RetriesUnexpectedServerError(t *testing.T) {
+func TestCreateSubscriptionPrice_DoesNotReplayUnexpectedServerError(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "2")
 	t.Setenv("ASC_BASE_DELAY", "1ms")
 	t.Setenv("ASC_MAX_DELAY", "2ms")
@@ -8084,10 +8235,7 @@ func TestCreateSubscriptionPrice_RetriesUnexpectedServerError(t *testing.T) {
 				}
 				assertAuthorized(t, req)
 
-				if attempts < 3 {
-					return jsonResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"An unexpected error occurred.","detail":"An unexpected error occurred on the server side."}]}`), nil
-				}
-				return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01","preserved":true}}}`), nil
+				return jsonResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"An unexpected error occurred.","detail":"An unexpected error occurred on the server side."}]}`), nil
 			}),
 		},
 		keyID:      "KEY123",
@@ -8096,11 +8244,14 @@ func TestCreateSubscriptionPrice_RetriesUnexpectedServerError(t *testing.T) {
 	}
 
 	_, err = client.CreateSubscriptionPrice(context.Background(), "sub-1", "price-point-1", "USA", SubscriptionPriceCreateAttributes{})
-	if err != nil {
-		t.Fatalf("CreateSubscriptionPrice() error: %v", err)
+	if err == nil {
+		t.Fatal("expected error")
 	}
-	if attempts != 3 {
-		t.Fatalf("expected 3 attempts (2 retries + success), got %d", attempts)
+	if !IsRetryable(err) {
+		t.Fatalf("expected retryable error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
 	}
 }
 
@@ -8179,7 +8330,7 @@ func TestCreateSubscriptionAvailability(t *testing.T) {
 	}
 }
 
-func TestCreateSubscriptionAvailability_RetriesUnexpectedServerError(t *testing.T) {
+func TestCreateSubscriptionAvailability_DoesNotReplayUnexpectedServerError(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "2")
 	t.Setenv("ASC_BASE_DELAY", "1ms")
 	t.Setenv("ASC_MAX_DELAY", "2ms")
@@ -8204,10 +8355,7 @@ func TestCreateSubscriptionAvailability_RetriesUnexpectedServerError(t *testing.
 				}
 				assertAuthorized(t, req)
 
-				if attempts < 3 {
-					return jsonResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"unexpected","detail":"retry me"}]}`), nil
-				}
-				return jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`), nil
+				return jsonResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"unexpected","detail":"retry me"}]}`), nil
 			}),
 		},
 		keyID:      "KEY123",
@@ -8216,11 +8364,14 @@ func TestCreateSubscriptionAvailability_RetriesUnexpectedServerError(t *testing.
 	}
 
 	_, err = client.CreateSubscriptionAvailability(context.Background(), "sub-1", []string{"USA", "CAN"}, SubscriptionAvailabilityAttributes{AvailableInNewTerritories: true})
-	if err != nil {
-		t.Fatalf("CreateSubscriptionAvailability() error: %v", err)
+	if err == nil {
+		t.Fatal("expected error")
 	}
-	if attempts != 3 {
-		t.Fatalf("expected 3 attempts (2 retries + success), got %d", attempts)
+	if !IsRetryable(err) {
+		t.Fatalf("expected retryable error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
 	}
 }
 

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -513,13 +513,20 @@ func (c *Client) GetSubscriptionAvailabilityAvailableTerritories(ctx context.Con
 }
 
 // GetSubscriptionAppStoreReviewScreenshotForSubscription retrieves the review screenshot for a subscription.
-func (c *Client) GetSubscriptionAppStoreReviewScreenshotForSubscription(ctx context.Context, subID string) (*SubscriptionAppStoreReviewScreenshotResponse, error) {
+func (c *Client) GetSubscriptionAppStoreReviewScreenshotForSubscription(ctx context.Context, subID string, opts ...SubscriptionAppStoreReviewScreenshotOption) (*SubscriptionAppStoreReviewScreenshotResponse, error) {
 	subID = strings.TrimSpace(subID)
 	if subID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
 	}
 
+	query := &subscriptionAppStoreReviewScreenshotQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptions/%s/appStoreReviewScreenshot", subID)
+	if queryString := buildSubscriptionAppStoreReviewScreenshotQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -3,7 +3,6 @@ package asc
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -291,13 +290,11 @@ func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePo
 	}
 
 	path := fmt.Sprintf("/v1/subscriptions/%s", subID)
-	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
-		body, err := BuildRequestBody(payload)
-		if err != nil {
-			return nil, err
-		}
-		return c.do(ctx, http.MethodPatch, path, body)
-	})
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.do(ctx, http.MethodPatch, path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -362,13 +359,11 @@ func (c *Client) CreateSubscriptionPrice(ctx context.Context, subID, pricePointI
 		},
 	}
 
-	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
-		body, err := BuildRequestBody(payload)
-		if err != nil {
-			return nil, err
-		}
-		return c.do(ctx, http.MethodPost, "/v1/subscriptionPrices", body)
-	})
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.do(ctx, http.MethodPost, "/v1/subscriptionPrices", body)
 	if err != nil {
 		return nil, err
 	}
@@ -379,40 +374,6 @@ func (c *Client) CreateSubscriptionPrice(ctx context.Context, subID, pricePointI
 	}
 
 	return &response, nil
-}
-
-func (c *Client) doRetriedSubscriptionMutation(ctx context.Context, request func() ([]byte, error)) ([]byte, error) {
-	retryOpts := ResolveRetryOptions()
-	return WithRetry(ctx, func() ([]byte, error) {
-		data, err := request()
-		if err != nil {
-			if IsRetryable(err) {
-				return nil, err
-			}
-			if isRetryableSubscriptionMutationError(err) {
-				return nil, &RetryableError{Err: err}
-			}
-			return nil, err
-		}
-		return data, nil
-	}, retryOpts)
-}
-
-func isRetryableSubscriptionMutationError(err error) bool {
-	apiErr, ok := errors.AsType[*APIError](err)
-	if !ok || apiErr == nil {
-		return false
-	}
-
-	switch apiErr.StatusCode {
-	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusGatewayTimeout:
-		// App Store Connect intermittently returns UNEXPECTED_ERROR on this endpoint.
-		// Retry these transient server-side failures.
-		code := strings.ToUpper(strings.TrimSpace(apiErr.Code))
-		return code == "" || code == "UNEXPECTED_ERROR"
-	default:
-		return false
-	}
 }
 
 // DeleteSubscriptionPrice deletes a subscription price.
@@ -457,13 +418,11 @@ func (c *Client) CreateSubscriptionAvailability(ctx context.Context, subID strin
 		},
 	}
 
-	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
-		body, err := BuildRequestBody(payload)
-		if err != nil {
-			return nil, err
-		}
-		return c.do(ctx, http.MethodPost, "/v1/subscriptionAvailabilities", body)
-	})
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.do(ctx, http.MethodPost, "/v1/subscriptionAvailabilities", body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asc/output_localizations.go
+++ b/internal/asc/output_localizations.go
@@ -38,19 +38,28 @@ type LocalizationDownloadResult struct {
 
 // LocalizationUploadLocaleResult represents a per-locale upload result.
 type LocalizationUploadLocaleResult struct {
-	Locale         string `json:"locale"`
-	Action         string `json:"action"`
-	LocalizationID string `json:"localizationId,omitempty"`
+	Locale         string            `json:"locale"`
+	Action         string            `json:"action"`
+	Status         string            `json:"status"`
+	LocalizationID string            `json:"localizationId,omitempty"`
+	Error          string            `json:"error,omitempty"`
+	DesiredValues  map[string]string `json:"desiredValues,omitempty"`
 }
 
 // LocalizationUploadResult represents CLI output for localization uploads.
 type LocalizationUploadResult struct {
-	Type      string                           `json:"type"`
-	VersionID string                           `json:"versionId,omitempty"`
-	AppID     string                           `json:"appId,omitempty"`
-	AppInfoID string                           `json:"appInfoId,omitempty"`
-	DryRun    bool                             `json:"dryRun"`
-	Results   []LocalizationUploadLocaleResult `json:"results"`
+	Type                 string                           `json:"type"`
+	VersionID            string                           `json:"versionId,omitempty"`
+	AppID                string                           `json:"appId,omitempty"`
+	AppInfoID            string                           `json:"appInfoId,omitempty"`
+	DryRun               bool                             `json:"dryRun"`
+	InputPath            string                           `json:"inputPath,omitempty"`
+	Total                int                              `json:"total"`
+	Succeeded            int                              `json:"succeeded"`
+	Failed               int                              `json:"failed"`
+	FailureArtifactPath  string                           `json:"failureArtifactPath,omitempty"`
+	FailureArtifactError string                           `json:"failureArtifactError,omitempty"`
+	Results              []LocalizationUploadLocaleResult `json:"results"`
 }
 
 // AppInfoSetLocaleResult represents a per-locale app-info set operation result.
@@ -139,13 +148,15 @@ func localizationDownloadResultRows(result *LocalizationDownloadResult) ([]strin
 }
 
 func localizationUploadResultRows(result *LocalizationUploadResult) ([]string, [][]string) {
-	headers := []string{"Locale", "Action", "Localization ID"}
+	headers := []string{"Locale", "Action", "Status", "Localization ID", "Error"}
 	rows := make([][]string, 0, len(result.Results))
 	for _, item := range result.Results {
 		rows = append(rows, []string{
 			item.Locale,
 			item.Action,
+			item.Status,
 			item.LocalizationID,
+			compactWhitespace(item.Error),
 		})
 	}
 	return headers, rows

--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -118,13 +118,11 @@ func (c *Client) CreateSubscriptionPlanAvailability(ctx context.Context, subID s
 		},
 	}
 
-	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
-		body, err := BuildRequestBody(payload)
-		if err != nil {
-			return nil, err
-		}
-		return c.do(ctx, http.MethodPost, "/v1/subscriptionPlanAvailabilities", body)
-	})
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.do(ctx, http.MethodPost, "/v1/subscriptionPlanAvailabilities", body)
 	if err != nil {
 		return nil, err
 	}
@@ -161,14 +159,12 @@ func (c *Client) UpdateSubscriptionPlanAvailability(ctx context.Context, planAva
 		},
 	}
 
-	data, err := c.doRetriedSubscriptionMutation(ctx, func() ([]byte, error) {
-		body, err := BuildRequestBody(payload)
-		if err != nil {
-			return nil, err
-		}
-		path := fmt.Sprintf("/v1/subscriptionPlanAvailabilities/%s", planAvailabilityID)
-		return c.do(ctx, http.MethodPatch, path, body)
-	})
+	body, err := BuildRequestBody(payload)
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v1/subscriptionPlanAvailabilities/%s", planAvailabilityID)
+	data, err := c.do(ctx, http.MethodPatch, path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asc/subscription_plan_availability_test.go
+++ b/internal/asc/subscription_plan_availability_test.go
@@ -79,6 +79,63 @@ func TestUpdateSubscriptionPlanAvailability(t *testing.T) {
 	}
 }
 
+func TestSubscriptionPlanAvailabilityMutationsDoNotReplayTransientErrors(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "2")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		call   func(*Client) error
+	}{
+		{
+			name:   "create",
+			method: http.MethodPost,
+			path:   "/v1/subscriptionPlanAvailabilities",
+			call: func(client *Client) error {
+				_, err := client.CreateSubscriptionPlanAvailability(
+					context.Background(),
+					"sub-1",
+					[]string{"NOR"},
+					SubscriptionPlanAvailabilityAttributes{PlanType: SubscriptionPlanTypeMonthly},
+				)
+				return err
+			},
+		},
+		{
+			name:   "update",
+			method: http.MethodPatch,
+			path:   "/v1/subscriptionPlanAvailabilities/plan-1",
+			call: func(client *Client) error {
+				_, err := client.UpdateSubscriptionPlanAvailability(context.Background(), "plan-1", []string{"NOR"}, nil)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := 0
+			client := newTestClient(t, func(req *http.Request) {
+				attempts++
+				if req.Method != tt.method || req.URL.Path != tt.path {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+				}
+			}, jsonResponse(http.StatusGatewayTimeout, `{"errors":[{"status":"504","code":"UNEXPECTED_ERROR","detail":"ambiguous"}]}`))
+
+			err := tt.call(client)
+			if err == nil || !IsRetryable(err) {
+				t.Fatalf("expected retryable error, got %v", err)
+			}
+			if attempts != 1 {
+				t.Fatalf("expected one mutation attempt, got %d", attempts)
+			}
+		})
+	}
+}
+
 func TestGetSubscriptionPlanAvailabilitiesForSubscriptionFiltersPlanType(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[
 		{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":true}},

--- a/internal/asc/subscription_resources.go
+++ b/internal/asc/subscription_resources.go
@@ -104,20 +104,22 @@ type SubscriptionImageUpdateRequest struct {
 
 // SubscriptionIntroductoryOfferAttributes describes a subscription introductory offer.
 type SubscriptionIntroductoryOfferAttributes struct {
-	StartDate       string                    `json:"startDate,omitempty"`
-	EndDate         string                    `json:"endDate,omitempty"`
-	Duration        SubscriptionOfferDuration `json:"duration,omitempty"`
-	OfferMode       SubscriptionOfferMode     `json:"offerMode,omitempty"`
-	NumberOfPeriods int                       `json:"numberOfPeriods,omitempty"`
+	StartDate                  string                    `json:"startDate,omitempty"`
+	EndDate                    string                    `json:"endDate,omitempty"`
+	Duration                   SubscriptionOfferDuration `json:"duration,omitempty"`
+	OfferMode                  SubscriptionOfferMode     `json:"offerMode,omitempty"`
+	NumberOfPeriods            int                       `json:"numberOfPeriods,omitempty"`
+	TargetSubscriptionPlanType SubscriptionPlanType      `json:"targetSubscriptionPlanType,omitempty"`
 }
 
 // SubscriptionIntroductoryOfferCreateAttributes describes attributes for creating an introductory offer.
 type SubscriptionIntroductoryOfferCreateAttributes struct {
-	StartDate       string                    `json:"startDate,omitempty"`
-	EndDate         string                    `json:"endDate,omitempty"`
-	Duration        SubscriptionOfferDuration `json:"duration"`
-	OfferMode       SubscriptionOfferMode     `json:"offerMode"`
-	NumberOfPeriods int                       `json:"numberOfPeriods"`
+	StartDate                  string                    `json:"startDate,omitempty"`
+	EndDate                    string                    `json:"endDate,omitempty"`
+	Duration                   SubscriptionOfferDuration `json:"duration"`
+	OfferMode                  SubscriptionOfferMode     `json:"offerMode"`
+	NumberOfPeriods            int                       `json:"numberOfPeriods"`
+	TargetSubscriptionPlanType SubscriptionPlanType      `json:"targetSubscriptionPlanType,omitempty"`
 }
 
 // SubscriptionIntroductoryOfferUpdateAttributes describes attributes for updating an introductory offer.

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -84,6 +84,7 @@ type subscriptionPricesQuery struct {
 	territory        string
 	planType         SubscriptionPlanType
 	include          []string
+	priceFields      []string
 	pricePointFields []string
 	territoryFields  []string
 }
@@ -334,6 +335,13 @@ func WithSubscriptionPricesInclude(include []string) SubscriptionPricesOption {
 	}
 }
 
+// WithSubscriptionPricesFields sets fields for returned subscription prices.
+func WithSubscriptionPricesFields(fields []string) SubscriptionPricesOption {
+	return func(q *subscriptionPricesQuery) {
+		q.priceFields = normalizeList(fields)
+	}
+}
+
 // WithSubscriptionPricesPricePointFields sets fields for included subscriptionPricePoints.
 func WithSubscriptionPricesPricePointFields(fields []string) SubscriptionPricesOption {
 	return func(q *subscriptionPricesQuery) {
@@ -436,6 +444,7 @@ func buildSubscriptionPricesQuery(query *subscriptionPricesQuery) string {
 		values.Set("filter[planType]", string(query.planType))
 	}
 	addCSV(values, "include", query.include)
+	addCSV(values, "fields[subscriptionPrices]", query.priceFields)
 	addCSV(values, "fields[subscriptionPricePoints]", query.pricePointFields)
 	addCSV(values, "fields[territories]", query.territoryFields)
 	addLimit(values, query.limit)

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -48,6 +48,8 @@ type subscriptionImagesQuery struct {
 
 type subscriptionIntroductoryOffersQuery struct {
 	listQuery
+	fields  []string
+	include []string
 }
 
 type subscriptionPromotionalOffersQuery struct {
@@ -141,6 +143,20 @@ func WithSubscriptionIntroductoryOffersNextURL(next string) SubscriptionIntroduc
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithSubscriptionIntroductoryOffersFields sets fields for returned introductory offers.
+func WithSubscriptionIntroductoryOffersFields(fields []string) SubscriptionIntroductoryOffersOption {
+	return func(q *subscriptionIntroductoryOffersQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionIntroductoryOffersInclude sets introductory offer relationships to include.
+func WithSubscriptionIntroductoryOffersInclude(include []string) SubscriptionIntroductoryOffersOption {
+	return func(q *subscriptionIntroductoryOffersQuery) {
+		q.include = normalizeList(include)
 	}
 }
 
@@ -364,6 +380,8 @@ func buildSubscriptionImagesQuery(query *subscriptionImagesQuery) string {
 
 func buildSubscriptionIntroductoryOffersQuery(query *subscriptionIntroductoryOffersQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptionIntroductoryOffers]", query.fields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -38,6 +38,9 @@ type SubscriptionPricesOption func(*subscriptionPricesQuery)
 // SubscriptionGroupLocalizationsOption is a functional option for subscription group localization list endpoints.
 type SubscriptionGroupLocalizationsOption func(*subscriptionGroupLocalizationsQuery)
 
+// SubscriptionAppStoreReviewScreenshotOption configures the subscription screenshot relationship endpoint.
+type SubscriptionAppStoreReviewScreenshotOption func(*subscriptionAppStoreReviewScreenshotQuery)
+
 type subscriptionLocalizationsQuery struct {
 	listQuery
 	fields []string
@@ -92,6 +95,10 @@ type subscriptionPricesQuery struct {
 
 type subscriptionGroupLocalizationsQuery struct {
 	listQuery
+	fields []string
+}
+
+type subscriptionAppStoreReviewScreenshotQuery struct {
 	fields []string
 }
 
@@ -390,6 +397,13 @@ func WithSubscriptionGroupLocalizationsFields(fields []string) SubscriptionGroup
 	}
 }
 
+// WithSubscriptionAppStoreReviewScreenshotFields limits returned screenshot fields.
+func WithSubscriptionAppStoreReviewScreenshotFields(fields []string) SubscriptionAppStoreReviewScreenshotOption {
+	return func(q *subscriptionAppStoreReviewScreenshotQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
 func buildSubscriptionLocalizationsQuery(query *subscriptionLocalizationsQuery) string {
 	values := url.Values{}
 	addCSV(values, "fields[subscriptionLocalizations]", query.fields)
@@ -472,5 +486,11 @@ func buildSubscriptionGroupLocalizationsQuery(query *subscriptionGroupLocalizati
 	values := url.Values{}
 	addCSV(values, "fields[subscriptionGroupLocalizations]", query.fields)
 	addLimit(values, query.limit)
+	return values.Encode()
+}
+
+func buildSubscriptionAppStoreReviewScreenshotQuery(query *subscriptionAppStoreReviewScreenshotQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[subscriptionAppStoreReviewScreenshots]", query.fields)
 	return values.Encode()
 }

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -40,6 +40,7 @@ type SubscriptionGroupLocalizationsOption func(*subscriptionGroupLocalizationsQu
 
 type subscriptionLocalizationsQuery struct {
 	listQuery
+	fields []string
 }
 
 type subscriptionImagesQuery struct {
@@ -91,6 +92,7 @@ type subscriptionPricesQuery struct {
 
 type subscriptionGroupLocalizationsQuery struct {
 	listQuery
+	fields []string
 }
 
 // WithSubscriptionLocalizationsLimit sets the max number of localizations to return.
@@ -108,6 +110,13 @@ func WithSubscriptionLocalizationsNextURL(next string) SubscriptionLocalizations
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithSubscriptionLocalizationsFields sets fields for returned subscription localizations.
+func WithSubscriptionLocalizationsFields(fields []string) SubscriptionLocalizationsOption {
+	return func(q *subscriptionLocalizationsQuery) {
+		q.fields = normalizeList(fields)
 	}
 }
 
@@ -374,8 +383,16 @@ func WithSubscriptionGroupLocalizationsNextURL(next string) SubscriptionGroupLoc
 	}
 }
 
+// WithSubscriptionGroupLocalizationsFields sets fields for returned subscription group localizations.
+func WithSubscriptionGroupLocalizationsFields(fields []string) SubscriptionGroupLocalizationsOption {
+	return func(q *subscriptionGroupLocalizationsQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
 func buildSubscriptionLocalizationsQuery(query *subscriptionLocalizationsQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptionLocalizations]", query.fields)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -453,6 +470,7 @@ func buildSubscriptionPricesQuery(query *subscriptionPricesQuery) string {
 
 func buildSubscriptionGroupLocalizationsQuery(query *subscriptionGroupLocalizationsQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptionGroupLocalizations]", query.fields)
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/subscription_resources_queries_test.go
+++ b/internal/asc/subscription_resources_queries_test.go
@@ -44,6 +44,19 @@ func TestBuildSubscriptionPricesQueryPlanType(t *testing.T) {
 	}
 }
 
+func TestBuildSubscriptionPricesQueryFields(t *testing.T) {
+	query := &subscriptionPricesQuery{}
+	WithSubscriptionPricesFields([]string{"startDate", "preserved", "planType", "territory", "subscriptionPricePoint"})(query)
+
+	values, err := url.ParseQuery(buildSubscriptionPricesQuery(query))
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	if got := values.Get("fields[subscriptionPrices]"); got != "startDate,preserved,planType,territory,subscriptionPricePoint" {
+		t.Fatalf("unexpected subscription price fields: %q", got)
+	}
+}
+
 func TestBuildSubscriptionPricesQueryRejectsEmptyPlanType(t *testing.T) {
 	query := &subscriptionPricesQuery{}
 	WithSubscriptionPricesPlanType("")(query)

--- a/internal/asc/subscription_resources_queries_test.go
+++ b/internal/asc/subscription_resources_queries_test.go
@@ -31,6 +31,28 @@ func TestBuildSubscriptionIntroductoryOffersQueryFieldsAndInclude(t *testing.T) 
 	}
 }
 
+func TestBuildSubscriptionLocalizationQueriesFields(t *testing.T) {
+	subscriptionQuery := &subscriptionLocalizationsQuery{}
+	WithSubscriptionLocalizationsFields([]string{"name", "locale", "description"})(subscriptionQuery)
+	subscriptionValues, err := url.ParseQuery(buildSubscriptionLocalizationsQuery(subscriptionQuery))
+	if err != nil {
+		t.Fatalf("parse subscription localization query: %v", err)
+	}
+	if got := subscriptionValues.Get("fields[subscriptionLocalizations]"); got != "name,locale,description" {
+		t.Fatalf("unexpected subscription localization fields: %q", got)
+	}
+
+	groupQuery := &subscriptionGroupLocalizationsQuery{}
+	WithSubscriptionGroupLocalizationsFields([]string{"name", "locale", "customAppName"})(groupQuery)
+	groupValues, err := url.ParseQuery(buildSubscriptionGroupLocalizationsQuery(groupQuery))
+	if err != nil {
+		t.Fatalf("parse group localization query: %v", err)
+	}
+	if got := groupValues.Get("fields[subscriptionGroupLocalizations]"); got != "name,locale,customAppName" {
+		t.Fatalf("unexpected group localization fields: %q", got)
+	}
+}
+
 func TestBuildSubscriptionPricesQueryPlanType(t *testing.T) {
 	query := &subscriptionPricesQuery{}
 	WithSubscriptionPricesPlanType(SubscriptionPlanTypeMonthly)(query)

--- a/internal/asc/subscription_resources_queries_test.go
+++ b/internal/asc/subscription_resources_queries_test.go
@@ -5,6 +5,32 @@ import (
 	"testing"
 )
 
+func TestBuildSubscriptionIntroductoryOffersQueryFieldsAndInclude(t *testing.T) {
+	query := &subscriptionIntroductoryOffersQuery{}
+	WithSubscriptionIntroductoryOffersFields([]string{
+		"startDate",
+		"endDate",
+		"duration",
+		"offerMode",
+		"numberOfPeriods",
+		"targetSubscriptionPlanType",
+		"territory",
+		"subscriptionPricePoint",
+	})(query)
+	WithSubscriptionIntroductoryOffersInclude([]string{"territory", "subscriptionPricePoint"})(query)
+
+	values, err := url.ParseQuery(buildSubscriptionIntroductoryOffersQuery(query))
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	if got := values.Get("fields[subscriptionIntroductoryOffers]"); got != "startDate,endDate,duration,offerMode,numberOfPeriods,targetSubscriptionPlanType,territory,subscriptionPricePoint" {
+		t.Fatalf("unexpected introductory offer fields: %q", got)
+	}
+	if got := values.Get("include"); got != "territory,subscriptionPricePoint" {
+		t.Fatalf("unexpected introductory offer include: %q", got)
+	}
+}
+
 func TestBuildSubscriptionPricesQueryPlanType(t *testing.T) {
 	query := &subscriptionPricesQuery{}
 	WithSubscriptionPricesPlanType(SubscriptionPlanTypeMonthly)(query)

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -1208,10 +1208,17 @@ func TestGetSubscriptionAppStoreReviewScreenshotForSubscription(t *testing.T) {
 		if req.URL.Path != "/v1/subscriptions/sub-1/appStoreReviewScreenshot" {
 			t.Fatalf("expected path /v1/subscriptions/sub-1/appStoreReviewScreenshot, got %s", req.URL.Path)
 		}
+		if got := req.URL.Query().Get("fields[subscriptionAppStoreReviewScreenshots]"); got != "fileName,fileSize,sourceFileChecksum,uploadOperations,assetDeliveryState" {
+			t.Fatalf("unexpected screenshot fields: %q", got)
+		}
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(context.Background(), "sub-1"); err != nil {
+	if _, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(
+		context.Background(),
+		"sub-1",
+		WithSubscriptionAppStoreReviewScreenshotFields([]string{"fileName", "fileSize", "sourceFileChecksum", "uploadOperations", "assetDeliveryState"}),
+	); err != nil {
 		t.Fatalf("GetSubscriptionAppStoreReviewScreenshotForSubscription() error: %v", err)
 	}
 }

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -10,6 +10,7 @@ import (
 	"hash"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -28,6 +29,19 @@ type UploadOption func(*UploadOptions)
 type uploadTask struct {
 	index int
 	op    UploadOperation
+}
+
+type sanitizedUploadError struct {
+	message string
+	err     error
+}
+
+func (e *sanitizedUploadError) Error() string {
+	return e.message
+}
+
+func (e *sanitizedUploadError) Unwrap() error {
+	return e.err
 }
 
 // WithUploadConcurrency sets the number of concurrent upload workers.
@@ -207,7 +221,7 @@ func executeUploadOperation(ctx context.Context, file *os.File, task uploadTask,
 		reader := io.NewSectionReader(file, task.op.Offset, task.op.Length)
 		req, err := http.NewRequestWithContext(requestCtx, method, task.op.URL, reader)
 		if err != nil {
-			return struct{}{}, err
+			return struct{}{}, newSanitizedUploadError("create upload request", task.op.URL, err)
 		}
 		req.ContentLength = task.op.Length
 		for _, header := range task.op.RequestHeaders {
@@ -219,7 +233,7 @@ func executeUploadOperation(ctx context.Context, file *os.File, task uploadTask,
 			if parentErr := ctx.Err(); parentErr != nil {
 				return struct{}{}, parentErr
 			}
-			requestErr := fmt.Errorf("upload request failed: %w", err)
+			requestErr := newSanitizedUploadError("upload request", task.op.URL, err)
 			if replaySafe && (errors.Is(err, context.DeadlineExceeded) || isTransientTransportError(err)) {
 				return struct{}{}, &RetryableError{Err: requestErr}
 			}
@@ -245,6 +259,23 @@ func executeUploadOperation(ctx context.Context, file *os.File, task uploadTask,
 		return fmt.Errorf("upload operation %d: %w", task.index, err)
 	}
 	return nil
+}
+
+func newSanitizedUploadError(operation, rawURL string, err error) error {
+	safeURL := sanitizeURLForLog(rawURL)
+	parsedURL, parseErr := url.Parse(safeURL)
+	if parseErr != nil {
+		safeURL = "[REDACTED]"
+	} else {
+		parsedURL.RawQuery = ""
+		parsedURL.ForceQuery = false
+		parsedURL.Fragment = ""
+		safeURL = parsedURL.String()
+	}
+	return &sanitizedUploadError{
+		message: fmt.Sprintf("%s failed for %s", operation, safeURL),
+		err:     err,
+	}
 }
 
 // VerifySourceFileChecksums computes and compares checksums provided by the API.

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // UploadOptions configure how upload operations are executed.
@@ -143,6 +144,7 @@ func ExecuteUploadOperations(ctx context.Context, filePath string, operations []
 
 	jobs := make(chan uploadTask)
 	var wg sync.WaitGroup
+	var completed atomic.Int64
 
 	worker := func() {
 		defer wg.Done()
@@ -154,6 +156,7 @@ func ExecuteUploadOperations(ctx context.Context, filePath string, operations []
 				setErr(err)
 				return
 			}
+			completed.Add(1)
 		}
 	}
 
@@ -176,7 +179,14 @@ sendLoop:
 	if firstErr != nil {
 		return firstErr
 	}
-	return ctx.Err()
+	completedCount := completed.Load()
+	if completedCount == int64(len(operations)) {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return fmt.Errorf("upload operations incomplete: completed %d of %d", completedCount, len(operations))
 }
 
 func openUploadSourceFile(filePath string) (*os.File, error) {

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -159,7 +159,10 @@ sendLoop:
 	close(jobs)
 
 	wg.Wait()
-	return firstErr
+	if firstErr != nil {
+		return firstErr
+	}
+	return ctx.Err()
 }
 
 func openUploadSourceFile(filePath string) (*os.File, error) {
@@ -192,10 +195,17 @@ func executeUploadOperation(ctx context.Context, file *os.File, task uploadTask,
 	if method == "" {
 		method = http.MethodPut
 	}
+	replaySafe := method == http.MethodPut
 
 	_, err := WithRetry(ctx, func() (struct{}, error) {
+		if err := ctx.Err(); err != nil {
+			return struct{}{}, err
+		}
+		requestCtx, cancel := context.WithTimeout(ctx, ResolveUploadTimeout())
+		defer cancel()
+
 		reader := io.NewSectionReader(file, task.op.Offset, task.op.Length)
-		req, err := http.NewRequestWithContext(ctx, method, task.op.URL, reader)
+		req, err := http.NewRequestWithContext(requestCtx, method, task.op.URL, reader)
 		if err != nil {
 			return struct{}{}, err
 		}
@@ -206,15 +216,19 @@ func executeUploadOperation(ctx context.Context, file *os.File, task uploadTask,
 
 		resp, err := uploadOpts.Client.Do(req)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return struct{}{}, err
+			if parentErr := ctx.Err(); parentErr != nil {
+				return struct{}{}, parentErr
 			}
-			return struct{}{}, &RetryableError{Err: fmt.Errorf("upload request failed: %w", err)}
+			requestErr := fmt.Errorf("upload request failed: %w", err)
+			if replaySafe && (errors.Is(err, context.DeadlineExceeded) || isTransientTransportError(err)) {
+				return struct{}{}, &RetryableError{Err: requestErr}
+			}
+			return struct{}{}, requestErr
 		}
 		defer resp.Body.Close()
 		_, _ = io.Copy(io.Discard, resp.Body)
 
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+		if replaySafe && isRetryableHTTPStatus(resp.StatusCode) {
 			retryAfter := parseRetryAfterHeader(resp.Header.Get("Retry-After"))
 			return struct{}{}, &RetryableError{
 				Err:        buildRetryableError(resp.StatusCode, retryAfter, nil),

--- a/internal/asc/upload_test.go
+++ b/internal/asc/upload_test.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -124,7 +125,7 @@ func TestExecuteUploadOperations_FailsOnHTTPError(t *testing.T) {
 		},
 	}
 
-	err := ExecuteUploadOperations(context.Background(), filePath, ops, WithUploadConcurrency(1))
+	err := ExecuteUploadOperations(context.Background(), filePath, ops, WithUploadConcurrency(1), withUploadRetryOptions(0))
 	if err == nil {
 		t.Fatalf("expected error from ExecuteUploadOperations")
 	}
@@ -149,6 +150,202 @@ func TestExecuteUploadOperations_FailsOnInvalidRange(t *testing.T) {
 	err := ExecuteUploadOperations(context.Background(), filePath, ops)
 	if err == nil {
 		t.Fatalf("expected range validation error")
+	}
+}
+
+func TestExecuteUploadOperations_PreCanceledContextDoesNotSucceed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var requests int32
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		atomic.AddInt32(&requests, 1)
+		return nil, errors.New("unexpected upload request")
+	})}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ExecuteUploadOperations(ctx, filePath, []UploadOperation{{
+		Method: http.MethodPut,
+		URL:    "https://example.test/upload",
+		Length: 3,
+	}}, WithUploadHTTPClient(client))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("expected no upload requests, got %d", got)
+	}
+}
+
+func TestExecuteUploadOperations_UsesFreshTimeoutForEachOperation(t *testing.T) {
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "150ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abcdef"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var requests int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		request := atomic.AddInt32(&requests, 1)
+		deadline, ok := req.Context().Deadline()
+		if !ok {
+			return nil, errors.New("upload request has no deadline")
+		}
+		if remaining := time.Until(deadline); remaining < 100*time.Millisecond {
+			return nil, fmt.Errorf("upload request %d inherited stale deadline: %s", request, remaining)
+		}
+		if request == 1 {
+			select {
+			case <-time.After(75 * time.Millisecond):
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	err := ExecuteUploadOperations(context.Background(), filePath, []UploadOperation{
+		{Method: http.MethodPut, URL: "https://example.test/part-1", Length: 3, Offset: 0},
+		{Method: http.MethodPut, URL: "https://example.test/part-2", Length: 3, Offset: 3},
+	}, WithUploadConcurrency(1), WithUploadHTTPClient(client), withUploadRetryOptions(0))
+	if err != nil {
+		t.Fatalf("ExecuteUploadOperations() error: %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("expected two upload requests, got %d", got)
+	}
+}
+
+func TestExecuteUploadOperations_RetriesPUTAfterAttemptTimeout(t *testing.T) {
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "20ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var requests int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&requests, 1) == 1 {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	err := ExecuteUploadOperations(context.Background(), filePath, []UploadOperation{{
+		Method: http.MethodPut,
+		URL:    "https://example.test/upload",
+		Length: 3,
+	}}, WithUploadHTTPClient(client), withUploadRetryOptions(1))
+	if err != nil {
+		t.Fatalf("ExecuteUploadOperations() error: %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("expected timed-out PUT to retry once, got %d requests", got)
+	}
+}
+
+func TestExecuteUploadOperations_RetriesPUTTransientStatuses(t *testing.T) {
+	statuses := []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	for _, status := range statuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Setenv("ASC_MAX_RETRIES", "1")
+			t.Setenv("ASC_BASE_DELAY", "1ms")
+			t.Setenv("ASC_MAX_DELAY", "1ms")
+			dir := t.TempDir()
+			filePath := filepath.Join(dir, "app.ipa")
+			if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			requests := 0
+			client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				requests++
+				responseStatus := status
+				if requests == 2 {
+					responseStatus = http.StatusOK
+				}
+				return &http.Response{
+					StatusCode: responseStatus,
+					Status:     fmt.Sprintf("%d %s", responseStatus, http.StatusText(responseStatus)),
+					Body:       io.NopCloser(strings.NewReader("")),
+					Header:     make(http.Header),
+				}, nil
+			})}
+
+			err := ExecuteUploadOperations(context.Background(), filePath, []UploadOperation{{
+				Method: http.MethodPut,
+				URL:    "https://example.test/upload",
+				Length: 3,
+			}}, WithUploadHTTPClient(client), withUploadRetryOptions(1))
+			if err != nil {
+				t.Fatalf("ExecuteUploadOperations() error: %v", err)
+			}
+			if requests != 2 {
+				t.Fatalf("expected one retry for status %d, got %d requests", status, requests)
+			}
+		})
+	}
+}
+
+func TestExecuteUploadOperations_DoesNotReplayNonPUT(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "3")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	requests := 0
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		requests++
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	err := ExecuteUploadOperations(context.Background(), filePath, []UploadOperation{{
+		Method: http.MethodPost,
+		URL:    "https://example.test/upload",
+		Length: 3,
+	}}, WithUploadHTTPClient(client))
+	if err == nil {
+		t.Fatal("expected non-PUT upload error")
+	}
+	if requests != 1 {
+		t.Fatalf("expected non-PUT operation not to replay, got %d requests", requests)
 	}
 }
 
@@ -270,6 +467,16 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
+}
+
+func withUploadRetryOptions(maxRetries int) UploadOption {
+	return func(opts *UploadOptions) {
+		opts.RetryOpts = RetryOptions{
+			MaxRetries: maxRetries,
+			BaseDelay:  time.Millisecond,
+			MaxDelay:   time.Millisecond,
+		}
+	}
 }
 
 func TestComputeFileChecksum_MD5(t *testing.T) {

--- a/internal/asc/upload_test.go
+++ b/internal/asc/upload_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -346,6 +347,111 @@ func TestExecuteUploadOperations_DoesNotReplayNonPUT(t *testing.T) {
 	}
 	if requests != 1 {
 		t.Fatalf("expected non-PUT operation not to replay, got %d requests", requests)
+	}
+}
+
+func TestExecuteUploadOperations_RedactsSignedURLInRequestConstructionError(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var requests int32
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		atomic.AddInt32(&requests, 1)
+		return nil, errors.New("unexpected upload request")
+	})}
+	err := ExecuteUploadOperations(context.Background(), filePath, []UploadOperation{{
+		Method: http.MethodPut,
+		URL:    "https://upload.example.test/object%zz?X-Amz-Signature=secret-signature&uploadId=secret-upload-id",
+		Length: 3,
+	}}, WithUploadHTTPClient(client), withUploadRetryOptions(0))
+	if err == nil {
+		t.Fatal("expected request construction error")
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("expected no transport call, got %d", got)
+	}
+	assertUploadErrorRedactsSignedURL(t, err)
+}
+
+func TestExecuteUploadOperations_RedactsSignedURLInTransportErrors(t *testing.T) {
+	sentinel := errors.New("permanent transport failure for X-Amz-Signature=secret-signature&uploadId=secret-upload-id")
+	tests := []struct {
+		name         string
+		transportErr error
+		maxRetries   int
+		wantAttempts int32
+		wantCause    error
+	}{
+		{
+			name:         "transient retry exhaustion",
+			transportErr: context.DeadlineExceeded,
+			maxRetries:   1,
+			wantAttempts: 2,
+			wantCause:    context.DeadlineExceeded,
+		},
+		{
+			name:         "permanent transport error",
+			transportErr: sentinel,
+			maxRetries:   3,
+			wantAttempts: 1,
+			wantCause:    sentinel,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "app.ipa")
+			if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			var attempts int32
+			client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				atomic.AddInt32(&attempts, 1)
+				return nil, test.transportErr
+			})}
+			err := ExecuteUploadOperations(context.Background(), filePath, []UploadOperation{{
+				Method: http.MethodPut,
+				URL:    "https://upload.example.test/object/path?X-Amz-Credential=secret-credential&X-Amz-Signature=secret-signature&uploadId=secret-upload-id&correlationKey=secret-correlation-key",
+				Length: 3,
+			}}, WithUploadHTTPClient(client), withUploadRetryOptions(test.maxRetries))
+			if err == nil {
+				t.Fatal("expected transport error")
+			}
+			if !errors.Is(err, test.wantCause) {
+				t.Fatalf("expected error to preserve %v, got %v", test.wantCause, err)
+			}
+			var urlErr *url.Error
+			if !errors.As(err, &urlErr) {
+				t.Fatalf("expected error to preserve url.Error, got %T: %v", err, err)
+			}
+			if got := atomic.LoadInt32(&attempts); got != test.wantAttempts {
+				t.Fatalf("expected %d attempts, got %d", test.wantAttempts, got)
+			}
+			assertUploadErrorRedactsSignedURL(t, err)
+			if !strings.Contains(err.Error(), "https://upload.example.test/object/path") {
+				t.Fatalf("expected safe upload origin/path in error, got %v", err)
+			}
+		})
+	}
+}
+
+func assertUploadErrorRedactsSignedURL(t *testing.T, err error) {
+	t.Helper()
+	for _, secret := range []string{
+		"X-Amz-Credential",
+		"X-Amz-Signature",
+		"secret-credential",
+		"secret-signature",
+		"uploadId",
+		"secret-upload-id",
+		"correlationKey",
+		"secret-correlation-key",
+	} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("upload error leaked %q: %v", secret, err)
+		}
 	}
 }
 

--- a/internal/asc/upload_test.go
+++ b/internal/asc/upload_test.go
@@ -182,6 +182,35 @@ func TestExecuteUploadOperations_PreCanceledContextDoesNotSucceed(t *testing.T) 
 	}
 }
 
+func TestExecuteUploadOperations_SucceedsWhenParentCanceledAfterFinalPUT(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       &cancelOnCloseReadCloser{cancel: cancel},
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	err := ExecuteUploadOperations(ctx, filePath, []UploadOperation{{
+		Method: http.MethodPut,
+		URL:    "https://example.test/upload",
+		Length: 3,
+	}}, WithUploadHTTPClient(client), withUploadRetryOptions(0))
+	if err != nil {
+		t.Fatalf("expected completed upload to succeed, got %v", err)
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("expected transport cleanup to cancel parent, got %v", ctx.Err())
+	}
+}
+
 func TestExecuteUploadOperations_UsesFreshTimeoutForEachOperation(t *testing.T) {
 	t.Setenv("ASC_UPLOAD_TIMEOUT", "150ms")
 	t.Setenv("ASC_MAX_RETRIES", "0")
@@ -573,6 +602,19 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
+}
+
+type cancelOnCloseReadCloser struct {
+	cancel context.CancelFunc
+}
+
+func (*cancelOnCloseReadCloser) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (r *cancelOnCloseReadCloser) Close() error {
+	r.cancel()
+	return nil
 }
 
 func withUploadRetryOptions(maxRetries int) UploadOption {

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -439,12 +438,18 @@ Examples:
 					return flag.ErrHelp
 				}
 
-				client, err := shared.GetASCClient()
+				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
+				if err := shared.ValidateVersionLocalizationValueSet(valuesByLocale); err != nil {
+					return shared.UsageError(err.Error())
+				}
 
-				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
+				client, err := shared.GetASCClient()
 				if err != nil {
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
@@ -464,15 +469,15 @@ Examples:
 				}
 				shared.FinalizeLocalizationUploadResult(&result, "app-setup localizations upload")
 
-				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+				if err := shared.PrintOutputWithRenderers(
+					&result, *output.Output, *output.Pretty,
+					func() error { return shared.RenderLocalizationUploadResult(&result, false) },
+					func() error { return shared.RenderLocalizationUploadResult(&result, true) },
+				); err != nil {
 					return err
 				}
 				if uploadErr != nil || result.FailureArtifactError != "" {
-					return shared.NewReportedError(errors.Join(
-						fmt.Errorf("app-setup localizations upload: %d locale(s) failed", result.Failed),
-						uploadErr,
-						appSetupLocalizationUploadArtifactError(result.FailureArtifactError),
-					))
+					return appSetupLocalizationUploadReportedError(result.Failed, uploadErr, result.FailureArtifactError)
 				}
 				return nil
 			case shared.LocalizationTypeAppInfo:
@@ -480,6 +485,16 @@ Examples:
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
 					return flag.ErrHelp
+				}
+				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
+				if err != nil {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
+					return fmt.Errorf("app-setup localizations upload: %w", err)
+				}
+				if err := shared.ValidateAppInfoLocalizationValueSet(valuesByLocale); err != nil {
+					return shared.UsageError(err.Error())
 				}
 
 				client, err := shared.GetASCClient()
@@ -490,11 +505,6 @@ Examples:
 				appInfo, err := shared.RetryReadWithFreshTimeout(ctx, func(resolveCtx context.Context) (string, error) {
 					return shared.ResolveAppInfoID(resolveCtx, client, resolvedAppID, strings.TrimSpace(*appInfoID))
 				})
-				if err != nil {
-					return fmt.Errorf("app-setup localizations upload: %w", err)
-				}
-
-				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
@@ -515,15 +525,15 @@ Examples:
 				}
 				shared.FinalizeLocalizationUploadResult(&result, "app-setup localizations upload")
 
-				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+				if err := shared.PrintOutputWithRenderers(
+					&result, *output.Output, *output.Pretty,
+					func() error { return shared.RenderLocalizationUploadResult(&result, false) },
+					func() error { return shared.RenderLocalizationUploadResult(&result, true) },
+				); err != nil {
 					return err
 				}
 				if uploadErr != nil || result.FailureArtifactError != "" {
-					return shared.NewReportedError(errors.Join(
-						fmt.Errorf("app-setup localizations upload: %d locale(s) failed", result.Failed),
-						uploadErr,
-						appSetupLocalizationUploadArtifactError(result.FailureArtifactError),
-					))
+					return appSetupLocalizationUploadReportedError(result.Failed, uploadErr, result.FailureArtifactError)
 				}
 				return nil
 			default:
@@ -533,9 +543,13 @@ Examples:
 	}
 }
 
-func appSetupLocalizationUploadArtifactError(message string) error {
-	if strings.TrimSpace(message) == "" {
-		return nil
+func appSetupLocalizationUploadReportedError(failed int, uploadErr error, artifactError string) error {
+	message := fmt.Sprintf("app-setup localizations upload: %d locale(s) failed", failed)
+	if uploadErr != nil {
+		message += ": " + uploadErr.Error()
 	}
-	return fmt.Errorf("write failure artifact: %s", message)
+	if strings.TrimSpace(artifactError) != "" {
+		message += "; write failure artifact: " + artifactError
+	}
+	return shared.NewReportedError(fmt.Errorf("%s", message))
 }

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -456,6 +456,9 @@ Examples:
 
 				results, err := shared.UploadVersionLocalizations(ctx, client, strings.TrimSpace(*versionID), valuesByLocale, *dryRun)
 				if err != nil && len(results) == 0 {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
 				uploadErr := err
@@ -511,6 +514,9 @@ Examples:
 
 				results, err := shared.UploadAppInfoLocalizations(ctx, client, appInfo, valuesByLocale, *dryRun)
 				if err != nil && len(results) == 0 {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
 				uploadErr := err

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -443,27 +444,37 @@ Examples:
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
 
-				requestCtx, cancel := shared.ContextWithTimeout(ctx)
-				defer cancel()
-
 				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
 
-				results, err := shared.UploadVersionLocalizations(requestCtx, client, strings.TrimSpace(*versionID), valuesByLocale, *dryRun)
-				if err != nil {
+				results, err := shared.UploadVersionLocalizations(ctx, client, strings.TrimSpace(*versionID), valuesByLocale, *dryRun)
+				if err != nil && len(results) == 0 {
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
+				uploadErr := err
 
 				result := asc.LocalizationUploadResult{
 					Type:      normalizedType,
 					VersionID: strings.TrimSpace(*versionID),
 					DryRun:    *dryRun,
+					InputPath: strings.TrimSpace(*path),
 					Results:   results,
 				}
+				shared.FinalizeLocalizationUploadResult(&result, "app-setup localizations upload")
 
-				return shared.PrintOutput(&result, *output.Output, *output.Pretty)
+				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+					return err
+				}
+				if uploadErr != nil || result.FailureArtifactError != "" {
+					return shared.NewReportedError(errors.Join(
+						fmt.Errorf("app-setup localizations upload: %d locale(s) failed", result.Failed),
+						uploadErr,
+						appSetupLocalizationUploadArtifactError(result.FailureArtifactError),
+					))
+				}
+				return nil
 			case shared.LocalizationTypeAppInfo:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
@@ -476,10 +487,9 @@ Examples:
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
 
-				requestCtx, cancel := shared.ContextWithTimeout(ctx)
-				defer cancel()
-
-				appInfo, err := shared.ResolveAppInfoID(requestCtx, client, resolvedAppID, strings.TrimSpace(*appInfoID))
+				appInfo, err := shared.RetryReadWithFreshTimeout(ctx, func(resolveCtx context.Context) (string, error) {
+					return shared.ResolveAppInfoID(resolveCtx, client, resolvedAppID, strings.TrimSpace(*appInfoID))
+				})
 				if err != nil {
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
@@ -489,23 +499,43 @@ Examples:
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
 
-				results, err := shared.UploadAppInfoLocalizations(requestCtx, client, appInfo, valuesByLocale, *dryRun)
-				if err != nil {
+				results, err := shared.UploadAppInfoLocalizations(ctx, client, appInfo, valuesByLocale, *dryRun)
+				if err != nil && len(results) == 0 {
 					return fmt.Errorf("app-setup localizations upload: %w", err)
 				}
+				uploadErr := err
 
 				result := asc.LocalizationUploadResult{
 					Type:      normalizedType,
 					AppID:     resolvedAppID,
 					AppInfoID: appInfo,
 					DryRun:    *dryRun,
+					InputPath: strings.TrimSpace(*path),
 					Results:   results,
 				}
+				shared.FinalizeLocalizationUploadResult(&result, "app-setup localizations upload")
 
-				return shared.PrintOutput(&result, *output.Output, *output.Pretty)
+				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+					return err
+				}
+				if uploadErr != nil || result.FailureArtifactError != "" {
+					return shared.NewReportedError(errors.Join(
+						fmt.Errorf("app-setup localizations upload: %d locale(s) failed", result.Failed),
+						uploadErr,
+						appSetupLocalizationUploadArtifactError(result.FailureArtifactError),
+					))
+				}
+				return nil
 			default:
 				return fmt.Errorf("app-setup localizations upload: unsupported type %q", normalizedType)
 			}
 		},
 	}
+}
+
+func appSetupLocalizationUploadArtifactError(message string) error {
+	if strings.TrimSpace(message) == "" {
+		return nil
+	}
+	return fmt.Errorf("write failure artifact: %s", message)
 }

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -76,14 +76,23 @@ func TestRun_IntroductoryOffersImportPartialFailureReturnsExitError(t *testing.T
 		http.DefaultTransport = originalTransport
 	})
 
-	requestCount := 0
+	getCount := 0
+	postCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requestCount++
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers" {
+			getCount++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionIntroductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
+		postCount++
 
-		switch requestCount {
+		switch postCount {
 		case 1:
 			body := `{"data":{"type":"subscriptionIntroductoryOffers","id":"offer-1"}}`
 			return &http.Response{
@@ -99,7 +108,7 @@ func TestRun_IntroductoryOffersImportPartialFailureReturnsExitError(t *testing.T
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
 		default:
-			t.Fatalf("unexpected request count %d", requestCount)
+			t.Fatalf("unexpected POST count %d", postCount)
 			return nil, nil
 		}
 	})
@@ -128,6 +137,9 @@ func TestRun_IntroductoryOffersImportPartialFailureReturnsExitError(t *testing.T
 	}
 	if !strings.Contains(stdout, `"failed":1`) {
 		t.Fatalf("expected failure summary in stdout, got %q", stdout)
+	}
+	if getCount != 2 || postCount != 2 {
+		t.Fatalf("expected initial GET, two POSTs, and one readback GET; got GET=%d POST=%d", getCount, postCount)
 	}
 }
 

--- a/internal/cli/cmdtest/introductory_offers_import_run_test.go
+++ b/internal/cli/cmdtest/introductory_offers_import_run_test.go
@@ -2,10 +2,12 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,6 +24,9 @@ func TestSubscriptionsIntroductoryOffersImport_CreateSuccessSummary(t *testing.T
 
 	requestCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		requestCount++
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
@@ -178,6 +183,7 @@ func TestSubscriptionsIntroductoryOffersImport_DryRunAcceptsSupportedThreeLetter
 func TestSubscriptionsIntroductoryOffersImport_PartialFailureReturnsReportedErrorAndSummary(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Chdir(t.TempDir())
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -186,6 +192,9 @@ func TestSubscriptionsIntroductoryOffersImport_PartialFailureReturnsReportedErro
 
 	requestCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		requestCount++
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionIntroductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
@@ -269,6 +278,7 @@ func TestSubscriptionsIntroductoryOffersImport_PartialFailureReturnsReportedErro
 func TestSubscriptionsIntroductoryOffersImport_StopOnFirstFailureWhenRequested(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Chdir(t.TempDir())
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -277,6 +287,9 @@ func TestSubscriptionsIntroductoryOffersImport_StopOnFirstFailureWhenRequested(t
 
 	requestCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		requestCount++
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionIntroductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
@@ -361,6 +374,9 @@ func TestSubscriptionsIntroductoryOffersImport_RowValuesOverrideDefaults(t *test
 	})
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionIntroductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
@@ -446,6 +462,9 @@ func TestSubscriptionsIntroductoryOffersImport_NormalizesInheritedDefaultEnums(t
 	})
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionIntroductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
@@ -498,5 +517,438 @@ func TestSubscriptionsIntroductoryOffersImport_NormalizesInheritedDefaultEnums(t
 	}
 	if !strings.Contains(stdout, `"created":1`) {
 		t.Fatalf("expected created summary in stdout, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_SkipsExactExistingOffer(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	postCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers":
+			assertIntroductoryOfferImportStateQuery(t, req)
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-existing","attributes":{"startDate":"2020-01-01","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost:
+			postCount++
+			t.Fatalf("exact existing offer must not be posted again")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := writeTempIntroOffersCSV(t, "territory\nUSA\n")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "import",
+			"--subscription-id", "8000000003",
+			"--input", csvPath,
+			"--offer-duration", "ONE_WEEK",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var summary struct {
+		Created int `json:"created"`
+		Skipped int `json:"skipped"`
+		Results []struct {
+			Status string `json:"status"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v", err)
+	}
+	if summary.Created != 0 || summary.Skipped != 1 || postCount != 0 || len(summary.Results) != 1 || summary.Results[0].Status != "skipped" {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_ReconcilesAmbiguousCreateWithoutReplay(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "2")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	postCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers":
+			assertIntroductoryOfferImportStateQuery(t, req)
+			readCount++
+			if readCount == 1 {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+			}
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-created","attributes":{"startDate":"2020-01-01","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			postCount++
+			return jsonHTTPResponse(http.StatusGatewayTimeout, `{"errors":[{"status":"504","code":"UNEXPECTED_ERROR","detail":"ambiguous"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := writeTempIntroOffersCSV(t, "territory\nUSA\n")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "import",
+			"--subscription-id", "8000000003",
+			"--input", csvPath,
+			"--offer-duration", "ONE_WEEK",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var summary struct {
+		Reconciled int `json:"reconciled"`
+		Failed     int `json:"failed"`
+		Results    []struct {
+			Status string `json:"status"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v", err)
+	}
+	if summary.Reconciled != 1 || summary.Failed != 0 || postCount != 1 || readCount != 2 || len(summary.Results) != 1 || summary.Results[0].Status != "reconciled" {
+		t.Fatalf("unexpected recovery: summary=%+v posts=%d reads=%d", summary, postCount, readCount)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_PaginatesIndexAndUsesEncodedTerritoryFallback(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	encodedUSAID := base64.RawURLEncoding.EncodeToString([]byte(`{"i":"USA"}`))
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers":
+			assertIntroductoryOfferImportStateQuery(t, req)
+			readCount++
+			if req.URL.Query().Get("cursor") == "page-2" {
+				body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-afg","attributes":{"startDate":"2020-01-01","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"AFG"}}}}],"links":{}}`
+				return jsonHTTPResponse(http.StatusOK, body), nil
+			}
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"` + encodedUSAID + `","attributes":{"startDate":"2020-01-01","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"}}],"links":{"next":"/v1/subscriptions/8000000003/introductoryOffers?cursor=page-2"}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("indexed exact offers must not be posted again")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := writeTempIntroOffersCSV(t, "territory\nUSA\nAFG\n")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "import",
+			"--subscription-id", "8000000003",
+			"--input", csvPath,
+			"--offer-duration", "ONE_WEEK",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	var summary struct {
+		Skipped int `json:"skipped"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v", err)
+	}
+	if summary.Skipped != 2 || readCount != 2 {
+		t.Fatalf("expected two skips from two indexed pages, summary=%+v reads=%d", summary, readCount)
+	}
+}
+
+func assertIntroductoryOfferImportStateQuery(t *testing.T, req *http.Request) {
+	t.Helper()
+	wantFields := "startDate,endDate,duration,offerMode,numberOfPeriods,targetSubscriptionPlanType,territory,subscriptionPricePoint"
+	if got := req.URL.Query().Get("fields[subscriptionIntroductoryOffers]"); got != wantFields {
+		t.Fatalf("unexpected introductory offer fields: %q", got)
+	}
+	if got := req.URL.Query().Get("include"); got != "territory,subscriptionPricePoint" {
+		t.Fatalf("unexpected introductory offer include: %q", got)
+	}
+	if got := req.URL.Query().Get("limit"); got != "200" {
+		t.Fatalf("unexpected introductory offer limit: %q", got)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_PaidOfferMatchesPricePoint(t *testing.T) {
+	tests := []struct {
+		name          string
+		pricePointID  string
+		wantCreated   int
+		wantSkipped   int
+		wantPostCount int
+	}{
+		{name: "exact price point skips", pricePointID: "point-1", wantSkipped: 1},
+		{name: "different price point creates", pricePointID: "point-2", wantCreated: 1, wantPostCount: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			postCount := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers":
+					assertIntroductoryOfferImportStateQuery(t, req)
+					body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-paid","attributes":{"startDate":"2020-01-01","duration":"ONE_MONTH","offerMode":"PAY_AS_YOU_GO","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"point-1"}}}}],"links":{}}`
+					return jsonHTTPResponse(http.StatusOK, body), nil
+				case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+					postCount++
+					body, err := io.ReadAll(req.Body)
+					if err != nil {
+						t.Fatalf("ReadAll() error: %v", err)
+					}
+					if !strings.Contains(string(body), `"id":"`+test.pricePointID+`"`) {
+						t.Fatalf("expected target price point in payload, got %s", body)
+					}
+					return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"offer-new"}}`), nil
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			})
+
+			csvPath := writeTempIntroOffersCSV(t, "territory,offer_mode,offer_duration,number_of_periods,price_point_id\nUSA,PAY_AS_YOU_GO,ONE_MONTH,1,"+test.pricePointID+"\n")
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"subscriptions", "offers", "introductory", "import",
+					"--subscription-id", "8000000003", "--input", csvPath, "--output", "json",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			var summary struct {
+				Created int `json:"created"`
+				Skipped int `json:"skipped"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+				t.Fatalf("parse summary: %v", err)
+			}
+			if summary.Created != test.wantCreated || summary.Skipped != test.wantSkipped || postCount != test.wantPostCount {
+				t.Fatalf("unexpected summary=%+v posts=%d", summary, postCount)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_RetriesTimedOutInitialStateRead(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000003/introductoryOffers" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		assertIntroductoryOfferImportStateQuery(t, req)
+		readCount++
+		if readCount == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-existing","attributes":{"startDate":"2020-01-01","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{}}`
+		return jsonHTTPResponse(http.StatusOK, body), nil
+	})
+
+	csvPath := writeTempIntroOffersCSV(t, "territory\nUSA\n")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "import",
+			"--subscription-id", "8000000003", "--input", csvPath,
+			"--offer-duration", "ONE_WEEK", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"skipped":1`) || readCount != 2 {
+		t.Fatalf("expected fresh-context retry and skip, reads=%d output=%s", readCount, stdout)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_PrintsFailuresWhenArtifactWriteFails(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(".asc", []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","detail":"invalid offer"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := writeTempIntroOffersCSV(t, "territory\nUSA\n")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "import",
+			"--subscription-id", "8000000003", "--input", csvPath,
+			"--offer-duration", "ONE_WEEK", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1", "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %v", runErr)
+	}
+	var summary struct {
+		Failed               int    `json:"failed"`
+		FailureArtifactError string `json:"failureArtifactError"`
+		Results              []struct {
+			Status         string `json:"status"`
+			Error          string `json:"error"`
+			TargetPlanType string `json:"targetSubscriptionPlanType"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v\n%s", err, stdout)
+	}
+	if summary.Failed != 1 || summary.FailureArtifactError == "" || len(summary.Results) != 1 || summary.Results[0].Status != "failed" || summary.Results[0].Error == "" || summary.Results[0].TargetPlanType != "UPFRONT" {
+		t.Fatalf("unexpected failure summary: %+v", summary)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersImport_WritesVersionedFailureArtifact(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	t.Chdir(t.TempDir())
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000003/introductoryOffers":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionIntroductoryOffers":
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","detail":"still unavailable"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := writeTempIntroOffersCSV(t, "territory\nUSA\n")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "import",
+			"--subscription-id", "8000000003",
+			"--input", csvPath,
+			"--offer-duration", "ONE_WEEK",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %v", runErr)
+	}
+
+	var summary struct {
+		FailureArtifactPath string `json:"failureArtifactPath"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v", err)
+	}
+	data, err := os.ReadFile(summary.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	var artifact struct {
+		SchemaVersion int `json:"schemaVersion"`
+		Failed        int `json:"failed"`
+		Results       []struct {
+			Status          string `json:"status"`
+			Territory       string `json:"territory"`
+			OfferMode       string `json:"offerMode"`
+			OfferDuration   string `json:"offerDuration"`
+			NumberOfPeriods int    `json:"numberOfPeriods"`
+			StartDate       string `json:"startDate"`
+			EndDate         string `json:"endDate"`
+			PricePointID    string `json:"pricePointId"`
+			TargetPlanType  string `json:"targetSubscriptionPlanType"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		t.Fatalf("parse artifact: %v", err)
+	}
+	if artifact.SchemaVersion != 1 || artifact.Failed != 1 || len(artifact.Results) != 1 || artifact.Results[0].Status != "failed" {
+		t.Fatalf("unexpected artifact: %+v", artifact)
+	}
+	result := artifact.Results[0]
+	if result.Territory != "USA" || result.OfferMode != "FREE_TRIAL" || result.OfferDuration != "ONE_WEEK" || result.NumberOfPeriods != 1 || result.StartDate != "" || result.EndDate != "" || result.PricePointID != "" || result.TargetPlanType != "UPFRONT" {
+		t.Fatalf("artifact is missing desired introductory-offer state: %+v", result)
 	}
 }

--- a/internal/cli/cmdtest/introductory_offers_import_run_test.go
+++ b/internal/cli/cmdtest/introductory_offers_import_run_test.go
@@ -782,6 +782,7 @@ func TestSubscriptionsIntroductoryOffersImport_RetriesTimedOutInitialStateRead(t
 	t.Setenv("ASC_MAX_RETRIES", "1")
 	t.Setenv("ASC_BASE_DELAY", "1ms")
 	t.Setenv("ASC_MAX_DELAY", "1ms")
+	t.Setenv("ASC_TIMEOUT", "50ms")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -793,7 +794,11 @@ func TestSubscriptionsIntroductoryOffersImport_RetriesTimedOutInitialStateRead(t
 		assertIntroductoryOfferImportStateQuery(t, req)
 		readCount++
 		if readCount == 1 {
-			return nil, context.DeadlineExceeded
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		if err := req.Context().Err(); err != nil {
+			t.Fatalf("expected fresh request context, got %v", err)
 		}
 		body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-existing","attributes":{"startDate":"2020-01-01","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{}}`
 		return jsonHTTPResponse(http.StatusOK, body), nil

--- a/internal/cli/cmdtest/localizations_upload_test.go
+++ b/internal/cli/cmdtest/localizations_upload_test.go
@@ -552,7 +552,7 @@ func TestLocalizationUploadCommandsRejectLateEmptyLocaleBeforeAuth(t *testing.T)
 	if err := os.WriteFile(filepath.Join(dir, "en-US.strings"), []byte("\"description\" = \"Valid\";\n"), 0o644); err != nil {
 		t.Fatalf("write valid locale: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "fr-FR.strings"), []byte("\"promotionalText\" = \"\";\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "fr-FR.strings"), []byte("// intentionally empty\n"), 0o644); err != nil {
 		t.Fatalf("write empty locale: %v", err)
 	}
 	originalTransport := http.DefaultTransport
@@ -573,7 +573,7 @@ func TestLocalizationUploadCommandsRejectLateEmptyLocaleBeforeAuth(t *testing.T)
 				t.Fatalf("expected exit %d for %v, got %d", cmd.ExitUsage, args, code)
 			}
 		})
-		if stdout != "" || !strings.Contains(stderr, `localization values for locale "fr-FR" are empty`) {
+		if stdout != "" || !strings.Contains(stderr, `no localization values for locale "fr-FR"`) {
 			t.Fatalf("unexpected validation output for %v: stdout=%q stderr=%q", args, stdout, stderr)
 		}
 	}

--- a/internal/cli/cmdtest/localizations_upload_test.go
+++ b/internal/cli/cmdtest/localizations_upload_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -375,4 +376,141 @@ func TestLocalizationsUploadUpdateOnlyDoesNotWarn(t *testing.T) {
 	if len(out.Results) != 1 || out.Results[0].Locale != "en-US" || out.Results[0].Action != "update" {
 		t.Fatalf("expected single update result, got %+v", out.Results)
 	}
+}
+
+func TestLocalizationsUploadPartialFailurePrintsSummaryAndArtifact(t *testing.T) {
+	result, runErr := runPartialLocalizationsUpload(t, false)
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if result.Total != 3 || result.Succeeded != 2 || result.Failed != 1 || result.FailureArtifactPath == "" || result.FailureArtifactError != "" {
+		t.Fatalf("unexpected partial summary: %+v", result)
+	}
+	payload, err := os.ReadFile(result.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("read failure artifact: %v", err)
+	}
+	if !strings.Contains(string(payload), `"schemaVersion": 1`) || !strings.Contains(string(payload), `"description": "New French"`) {
+		t.Fatalf("failure artifact is not resumable: %s", payload)
+	}
+}
+
+func TestLocalizationsUploadArtifactWriteFailureStillPrintsSummary(t *testing.T) {
+	result, runErr := runPartialLocalizationsUpload(t, true)
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if result.Total != 3 || result.Succeeded != 2 || result.Failed != 1 || result.FailureArtifactPath != "" || result.FailureArtifactError == "" {
+		t.Fatalf("expected printed artifact failure summary: %+v", result)
+	}
+}
+
+func TestLocalizationsUploadInitialReadFailureIsNotZeroFailureSummary(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "en-US.strings"), []byte("\"description\" = \"Desired\";\n\"whatsNew\" = \"Notes\";\n"), 0o644); err != nil {
+		t.Fatalf("write strings: %v", err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"SERVER_ERROR","detail":"unavailable"}]}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "upload", "--version", "version-1", "--path", dir, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected initial read failure")
+	}
+	if _, ok := errors.AsType[ReportedError](runErr); ok {
+		t.Fatalf("expected ordinary global error, got ReportedError: %v", runErr)
+	}
+	if stdout != "" || strings.Contains(runErr.Error(), "0 locale(s) failed") {
+		t.Fatalf("unexpected zero-failure summary: stdout=%q err=%v", stdout, runErr)
+	}
+}
+
+type partialLocalizationUploadResult struct {
+	Total                int    `json:"total"`
+	Succeeded            int    `json:"succeeded"`
+	Failed               int    `json:"failed"`
+	FailureArtifactPath  string `json:"failureArtifactPath"`
+	FailureArtifactError string `json:"failureArtifactError"`
+}
+
+func runPartialLocalizationsUpload(t *testing.T, blockArtifact bool) (partialLocalizationUploadResult, error) {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	inputDir := filepath.Join(workDir, "input")
+	if err := os.MkdirAll(inputDir, 0o755); err != nil {
+		t.Fatalf("mkdir input: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "en-US.strings"), []byte("\"description\" = \"New English\";\n\"whatsNew\" = \"English notes\";\n"), 0o644); err != nil {
+		t.Fatalf("write English: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "fr-FR.strings"), []byte("\"description\" = \"New French\";\n\"whatsNew\" = \"French notes\";\n"), 0o644); err != nil {
+		t.Fatalf("write French: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "ja.strings"), []byte("\"description\" = \"New Japanese\";\n\"whatsNew\" = \"Japanese notes\";\n"), 0o644); err != nil {
+		t.Fatalf("write Japanese: %v", err)
+	}
+	if blockArtifact {
+		if err := os.WriteFile(".asc", []byte("not a directory"), 0o644); err != nil {
+			t.Fatalf("write artifact blocker: %v", err)
+		}
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"en-id","attributes":{"locale":"en-US","description":"Old English"}},{"type":"appStoreVersionLocalizations","id":"fr-id","attributes":{"locale":"fr-FR","description":"Old French"}},{"type":"appStoreVersionLocalizations","id":"ja-id","attributes":{"locale":"ja","description":"Old Japanese"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/en-id":
+			patches++
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"en-id","attributes":{"locale":"en-US","description":"New English","whatsNew":"English notes"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/fr-id":
+			patches++
+			return jsonHTTPResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"ENTITY_ERROR","detail":"French rejected"}]}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/ja-id":
+			patches++
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"ja-id","attributes":{"locale":"ja","description":"New Japanese","whatsNew":"Japanese notes"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"localizations", "upload", "--version", "version-1", "--path", inputDir, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if patches != 3 {
+		t.Fatalf("expected later locale after failure, patches=%d", patches)
+	}
+	var result partialLocalizationUploadResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse summary: %v; stdout=%q", err, stdout)
+	}
+	return result, runErr
 }

--- a/internal/cli/cmdtest/localizations_upload_test.go
+++ b/internal/cli/cmdtest/localizations_upload_test.go
@@ -379,7 +379,7 @@ func TestLocalizationsUploadUpdateOnlyDoesNotWarn(t *testing.T) {
 }
 
 func TestLocalizationsUploadPartialFailurePrintsSummaryAndArtifact(t *testing.T) {
-	result, runErr := runPartialLocalizationsUpload(t, false)
+	result, _, runErr := runPartialLocalizationsUpload(t, false, false, "json")
 	if _, ok := errors.AsType[ReportedError](runErr); !ok {
 		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
 	}
@@ -396,12 +396,119 @@ func TestLocalizationsUploadPartialFailurePrintsSummaryAndArtifact(t *testing.T)
 }
 
 func TestLocalizationsUploadArtifactWriteFailureStillPrintsSummary(t *testing.T) {
-	result, runErr := runPartialLocalizationsUpload(t, true)
+	result, _, runErr := runPartialLocalizationsUpload(t, true, false, "json")
 	if _, ok := errors.AsType[ReportedError](runErr); !ok {
 		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
 	}
 	if result.Total != 3 || result.Succeeded != 2 || result.Failed != 1 || result.FailureArtifactPath != "" || result.FailureArtifactError == "" {
 		t.Fatalf("expected printed artifact failure summary: %+v", result)
+	}
+}
+
+func TestAppSetupLocalizationsUploadPartialFailurePrintsSummaryAndArtifact(t *testing.T) {
+	result, _, runErr := runPartialLocalizationsUpload(t, false, true, "json")
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if result.Total != 3 || result.Succeeded != 2 || result.Failed != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("unexpected app-setup partial summary: %+v", result)
+	}
+}
+
+func TestAppInfoLocalizationsUploadPartialFailureContinuesAndArtifacts(t *testing.T) {
+	result, runErr := runPartialAppInfoLocalizationUpload(t)
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if result.Total != 3 || result.Succeeded != 2 || result.Failed != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("unexpected app-info partial summary: %+v", result)
+	}
+	payload, err := os.ReadFile(result.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("read app-info artifact: %v", err)
+	}
+	if !strings.Contains(string(payload), `"subtitle": "French subtitle"`) {
+		t.Fatalf("app-info artifact missing desired fields: %s", payload)
+	}
+}
+
+func TestAppInfoLocalizationsUploadUsesFreshReadbackAfterMutationTimeout(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "20ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "en-US.strings"), []byte("\"name\" = \"New Name\";\n"), 0o644); err != nil {
+		t.Fatalf("write app-info strings: %v", err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			reads++
+			name := "Old Name"
+			if reads > 1 {
+				name = "New Name"
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-id","attributes":{"locale":"en-US","name":"`+name+`"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/loc-id":
+			patches++
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"localizations", "upload", "--type", "app-info", "--app", "app-1", "--app-info", "appinfo-1", "--path", dir, "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if reads != 2 || patches != 1 || !strings.Contains(stdout, `"action":"reconcile"`) {
+		t.Fatalf("unexpected app-info timeout recovery: reads=%d patches=%d stdout=%s", reads, patches, stdout)
+	}
+}
+
+func TestLocalizationsUploadTableIncludesFailureArtifact(t *testing.T) {
+	_, stdout, runErr := runPartialLocalizationsUpload(t, false, false, "table")
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	for _, expected := range []string{"Total", "Succeeded", "Failed", "Failure Artifact", ".asc/reports/localizations-upload/"} {
+		if !strings.Contains(stdout, expected) {
+			t.Fatalf("table output missing %q: %s", expected, stdout)
+		}
+	}
+}
+
+func TestLocalizationsUploadMarkdownIncludesArtifactWriteFailure(t *testing.T) {
+	_, stdout, runErr := runPartialLocalizationsUpload(t, true, false, "markdown")
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if !strings.Contains(stdout, "Failure Artifact Error") || !strings.Contains(stdout, "not a directory") {
+		t.Fatalf("markdown output missing artifact write failure: %s", stdout)
+	}
+}
+
+func TestLocalizationsUploadPartialBatchExitsOne(t *testing.T) {
+	result, stdout, code := runPartialLocalizationsUploadExit(t)
+	if code != cmd.ExitError {
+		t.Fatalf("expected partial batch exit %d, got %d; stdout=%s", cmd.ExitError, code, stdout)
+	}
+	if result.Failed != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("expected structured partial summary before exit: %+v", result)
 	}
 }
 
@@ -418,26 +525,82 @@ func TestLocalizationsUploadInitialReadFailureIsNotZeroFailureSummary(t *testing
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
-		return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"SERVER_ERROR","detail":"unavailable"}]}`), nil
+		return jsonHTTPResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"CONFLICT","detail":"conflicting state"}]}`), nil
 	})
 
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-	var runErr error
-	stdout, _ := captureOutput(t, func() {
-		if err := root.Parse([]string{"localizations", "upload", "--version", "version-1", "--path", dir, "--output", "json"}); err != nil {
-			t.Fatalf("parse: %v", err)
-		}
-		runErr = root.Run(context.Background())
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = cmd.Run([]string{"localizations", "upload", "--version", "version-1", "--path", dir, "--output", "json"}, "1.2.3")
 	})
-	if runErr == nil {
-		t.Fatal("expected initial read failure")
+	if exitCode != cmd.ExitConflict {
+		t.Fatalf("expected typed pre-batch exit %d, got %d; stderr=%s", cmd.ExitConflict, exitCode, stderr)
 	}
-	if _, ok := errors.AsType[ReportedError](runErr); ok {
-		t.Fatalf("expected ordinary global error, got ReportedError: %v", runErr)
+	if stdout != "" || strings.Contains(stderr, "0 locale(s) failed") {
+		t.Fatalf("unexpected zero-failure summary: stdout=%q stderr=%q", stdout, stderr)
 	}
-	if stdout != "" || strings.Contains(runErr.Error(), "0 locale(s) failed") {
-		t.Fatalf("unexpected zero-failure summary: stdout=%q err=%v", stdout, runErr)
+}
+
+func TestLocalizationUploadCommandsRejectLateEmptyLocaleBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "en-US.strings"), []byte("\"description\" = \"Valid\";\n"), 0o644); err != nil {
+		t.Fatalf("write valid locale: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "fr-FR.strings"), []byte("\"promotionalText\" = \"\";\n"), 0o644); err != nil {
+		t.Fatalf("write empty locale: %v", err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	for _, args := range [][]string{
+		{"localizations", "upload", "--version", "version-1", "--path", dir},
+		{"app-setup", "localizations", "upload", "--version", "version-1", "--path", dir},
+	} {
+		stdout, stderr := captureOutput(t, func() {
+			if code := cmd.Run(args, "1.2.3"); code != cmd.ExitUsage {
+				t.Fatalf("expected exit %d for %v, got %d", cmd.ExitUsage, args, code)
+			}
+		})
+		if stdout != "" || !strings.Contains(stderr, `localization values for locale "fr-FR" are empty`) {
+			t.Fatalf("unexpected validation output for %v: stdout=%q stderr=%q", args, stdout, stderr)
+		}
+	}
+	if requests != 0 {
+		t.Fatalf("expected zero network requests, got %d", requests)
+	}
+}
+
+func TestLocalizationsUploadInvalidLocaleFlagExitsUsage(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	path := filepath.Join(t.TempDir(), "input.strings")
+	if err := os.WriteFile(path, []byte("\"description\" = \"Valid\";\n"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"localizations", "upload", "--version", "version-1", "--path", path, "--locale", "x"}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit %d, got %d", cmd.ExitUsage, code)
+		}
+	})
+	if stdout != "" || !strings.Contains(stderr, `invalid locale "x"`) {
+		t.Fatalf("unexpected invalid-locale output: stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 
@@ -449,7 +612,17 @@ type partialLocalizationUploadResult struct {
 	FailureArtifactError string `json:"failureArtifactError"`
 }
 
-func runPartialLocalizationsUpload(t *testing.T, blockArtifact bool) (partialLocalizationUploadResult, error) {
+func runPartialLocalizationsUpload(t *testing.T, blockArtifact, appSetup bool, output string) (partialLocalizationUploadResult, string, error) {
+	result, stdout, _, runErr := runPartialLocalizationsUploadCore(t, blockArtifact, appSetup, output, false)
+	return result, stdout, runErr
+}
+
+func runPartialLocalizationsUploadExit(t *testing.T) (partialLocalizationUploadResult, string, int) {
+	result, stdout, code, _ := runPartialLocalizationsUploadCore(t, false, false, "json", true)
+	return result, stdout, code
+}
+
+func runPartialLocalizationsUploadCore(t *testing.T, blockArtifact, appSetup bool, output string, viaEntryPoint bool) (partialLocalizationUploadResult, string, int, error) {
 	t.Helper()
 	setupAuth(t)
 	t.Setenv("ASC_MAX_RETRIES", "0")
@@ -496,11 +669,20 @@ func runPartialLocalizationsUpload(t *testing.T, blockArtifact bool) (partialLoc
 		}
 	})
 
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
 	var runErr error
+	exitCode := cmd.ExitSuccess
 	stdout, _ := captureOutput(t, func() {
-		if err := root.Parse([]string{"localizations", "upload", "--version", "version-1", "--path", inputDir, "--output", "json"}); err != nil {
+		args := []string{"localizations", "upload", "--version", "version-1", "--path", inputDir, "--output", output}
+		if appSetup {
+			args = append([]string{"app-setup"}, args...)
+		}
+		if viaEntryPoint {
+			exitCode = cmd.Run(args, "1.2.3")
+			return
+		}
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+		if err := root.Parse(args); err != nil {
 			t.Fatalf("parse: %v", err)
 		}
 		runErr = root.Run(context.Background())
@@ -509,8 +691,73 @@ func runPartialLocalizationsUpload(t *testing.T, blockArtifact bool) (partialLoc
 		t.Fatalf("expected later locale after failure, patches=%d", patches)
 	}
 	var result partialLocalizationUploadResult
+	if output == "json" {
+		if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+			t.Fatalf("parse summary: %v; stdout=%q", err, stdout)
+		}
+	}
+	return result, stdout, exitCode, runErr
+}
+
+func runPartialAppInfoLocalizationUpload(t *testing.T) (partialLocalizationUploadResult, error) {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	inputDir := filepath.Join(workDir, "input")
+	if err := os.MkdirAll(inputDir, 0o755); err != nil {
+		t.Fatalf("mkdir input: %v", err)
+	}
+	files := map[string]string{
+		"en-US.strings": "\"name\" = \"English\";\n\"subtitle\" = \"English subtitle\";\n",
+		"fr-FR.strings": "\"name\" = \"French\";\n\"subtitle\" = \"French subtitle\";\n",
+		"ja.strings":    "\"name\" = \"Japanese\";\n\"subtitle\" = \"Japanese subtitle\";\n",
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(inputDir, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"en-id","attributes":{"locale":"en-US","name":"Old English"}},{"type":"appInfoLocalizations","id":"fr-id","attributes":{"locale":"fr-FR","name":"Old French"}},{"type":"appInfoLocalizations","id":"ja-id","attributes":{"locale":"ja","name":"Old Japanese"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/en-id":
+			patches++
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"en-id","attributes":{"locale":"en-US","name":"English","subtitle":"English subtitle"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/fr-id":
+			patches++
+			return jsonHTTPResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"ENTITY_ERROR","detail":"French rejected"}]}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/ja-id":
+			patches++
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"ja-id","attributes":{"locale":"ja","name":"Japanese","subtitle":"Japanese subtitle"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"localizations", "upload", "--type", "app-info", "--app", "app-1", "--app-info", "appinfo-1", "--path", inputDir, "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if patches != 3 {
+		t.Fatalf("expected app-info locale after failure, patches=%d", patches)
+	}
+	var result partialLocalizationUploadResult
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
-		t.Fatalf("parse summary: %v; stdout=%q", err, stdout)
+		t.Fatalf("parse app-info summary: %v; stdout=%q", err, stdout)
 	}
 	return result, runErr
 }

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -411,6 +412,117 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 	}
 	if len(artifact.Failures) != 1 || artifact.Failures[0].Scope != "version" || artifact.Failures[0].Locale != "fr-FR" || artifact.Failures[0].Action != "update" || artifact.Failures[0].LocalizationID != "loc-ver-fr" || artifact.Failures[0].DesiredFields["description"] != "Local French" {
 		t.Fatalf("unexpected failure artifact: %+v", artifact)
+	}
+}
+
+func TestMetadataApplyIgnoresRemoteOnlyEmptyLocalizationAcrossResume(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Chdir(t.TempDir())
+
+	metadataDir := filepath.Join(t.TempDir(), "metadata")
+	versionDir := filepath.Join(metadataDir, "version", "1.2.3")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir version metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "bn-BD.json"), []byte(`{"description":"Desired Bangla"}`), 0o600); err != nil {
+		t.Fatalf("write version metadata: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	remoteDescription := "Old Bangla"
+	patches := 0
+	deletes := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			body := fmt.Sprintf(`{"data":[{"type":"appStoreVersionLocalizations","id":"loc-bn","attributes":{"locale":"bn-BD","description":%q}},{"type":"appStoreVersionLocalizations","id":"loc-empty","attributes":{"locale":"en-US","description":"","keywords":"","marketingUrl":"","promotionalText":"","supportUrl":"","whatsNew":""}}],"links":{}}`, remoteDescription)
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case "/v1/appStoreVersionLocalizations/loc-bn":
+			if req.Method != http.MethodPatch {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+			patches++
+			assertMetadataPatchPayload(t, req, "appStoreVersionLocalizations", "loc-bn", map[string]string{"description": "Desired Bangla"})
+			if patches == 1 {
+				return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"temporary Apple rejection"}]}`), nil
+			}
+			remoteDescription = "Desired Bangla"
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-bn","attributes":{"locale":"bn-BD","description":"Desired Bangla"}}}`), nil
+		case "/v1/appStoreVersionLocalizations/loc-empty":
+			deletes++
+			t.Fatalf("empty remote-only localization must not be deleted: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	type result struct {
+		Applied   bool              `json:"applied"`
+		DryRun    bool              `json:"dryRun"`
+		Updates   []json.RawMessage `json:"updates"`
+		Deletes   []json.RawMessage `json:"deletes"`
+		Total     int               `json:"total"`
+		Succeeded int               `json:"succeeded"`
+		Failed    int               `json:"failed"`
+	}
+	runApply := func(t *testing.T, dryRun bool) (result, error) {
+		t.Helper()
+		args := []string{"metadata", "apply", "--app", "app-1", "--version", "1.2.3", "--dir", metadataDir, "--output", "json"}
+		if dryRun {
+			args = append(args, "--dry-run")
+		}
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+		var runErr error
+		stdout, stderr := captureOutput(t, func() {
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			runErr = root.Run(context.Background())
+		})
+		if stderr != "" {
+			t.Fatalf("unexpected stderr: %q", stderr)
+		}
+		var parsed result
+		if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+			t.Fatalf("decode output: %v\n%s", err, stdout)
+		}
+		return parsed, runErr
+	}
+
+	initialPlan, err := runApply(t, true)
+	if err != nil || !initialPlan.DryRun || len(initialPlan.Updates) != 1 || len(initialPlan.Deletes) != 0 {
+		t.Fatalf("unexpected initial plan: result=%+v err=%v", initialPlan, err)
+	}
+	partial, err := runApply(t, false)
+	if _, ok := errors.AsType[ReportedError](err); !ok || partial.Total != 1 || partial.Succeeded != 0 || partial.Failed != 1 {
+		t.Fatalf("expected one reported mutation failure: result=%+v err=%T %v", partial, err, err)
+	}
+	resumePlan, err := runApply(t, true)
+	if err != nil || len(resumePlan.Updates) != 1 || len(resumePlan.Deletes) != 0 {
+		t.Fatalf("unexpected resume plan: result=%+v err=%v", resumePlan, err)
+	}
+	resumed, err := runApply(t, false)
+	if err != nil || resumed.Total != 1 || resumed.Succeeded != 1 || resumed.Failed != 0 || !resumed.Applied {
+		t.Fatalf("unexpected resume result: result=%+v err=%v", resumed, err)
+	}
+	noOp, err := runApply(t, false)
+	if err != nil || noOp.Total != 0 || noOp.Failed != 0 || !noOp.Applied || len(noOp.Deletes) != 0 {
+		t.Fatalf("unexpected no-op result: result=%+v err=%v", noOp, err)
+	}
+	if patches != 2 || deletes != 0 {
+		t.Fatalf("unexpected mutations: patches=%d deletes=%d", patches, deletes)
 	}
 }
 

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -2,6 +2,7 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -9,7 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	metadatacli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/metadata"
 )
 
 func TestMetadataApplyValidationErrors(t *testing.T) {
@@ -142,12 +148,85 @@ func TestMetadataApplyDryRunSuggestsApplyCommandForAmbiguousAppInfos(t *testing.
 	}
 }
 
-func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
+func TestMetadataApplyPreflightsAllCreatesBeforeMutation(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	t.Setenv("ASC_APP_ID", "")
 
 	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"Updated name"}`), 0o644); err != nil {
+		t.Fatalf("write en-US file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "fr-FR.json"), []byte(`{"subtitle":"Missing create name"}`), 0o644); err != nil {
+		t.Fatalf("write fr-FR file: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	mutations := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			mutations++
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Old name"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", runErr)
+	}
+	if mutations != 0 || stdout != "" {
+		t.Fatalf("expected no mutation/output, mutations=%d stdout=%q", mutations, stdout)
+	}
+	if !strings.Contains(stderr, `app-info localization "fr-FR" requires name`) {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	workDir := t.TempDir()
+	previousDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previousDir) })
+
+	dir := filepath.Join(workDir, "metadata")
 	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
 		t.Fatalf("mkdir app-info: %v", err)
 	}
@@ -157,8 +236,11 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"App Name","subtitle":"Local subtitle"}`), 0o644); err != nil {
 		t.Fatalf("write app-info file: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Local description"}`), 0o644); err != nil {
-		t.Fatalf("write version file: %v", err)
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "fr-FR.json"), []byte(`{"description":"Local French"}`), 0o644); err != nil {
+		t.Fatalf("write French version file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "ja.json"), []byte(`{"description":"Local Japanese"}`), 0o644); err != nil {
+		t.Fatalf("write Japanese version file: %v", err)
 	}
 
 	originalTransport := http.DefaultTransport
@@ -191,7 +273,10 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
 		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
-			body := `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-ver-en","attributes":{"locale":"en-US","description":"Remote description"}}],"links":{"next":""}}`
+			body := `{"data":[
+				{"type":"appStoreVersionLocalizations","id":"loc-ver-fr","attributes":{"locale":"fr-FR","description":"Remote French"}},
+				{"type":"appStoreVersionLocalizations","id":"loc-ver-ja","attributes":{"locale":"ja","description":"Remote Japanese"}}
+			],"links":{"next":""}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -200,6 +285,10 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 		case "/v1/appInfoLocalizations/loc-app-en":
 			if req.Method == http.MethodPatch {
 				patchCount++
+				assertMetadataPatchPayload(t, req, "appInfoLocalizations", "loc-app-en", map[string]string{
+					"name":     "App Name",
+					"subtitle": "Local subtitle",
+				})
 				body := `{"data":{"type":"appInfoLocalizations","id":"loc-app-en","attributes":{"locale":"en-US","name":"App Name","subtitle":"Local subtitle"}}}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -207,12 +296,24 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
 				}, nil
 			}
-		case "/v1/appStoreVersionLocalizations/loc-ver-en":
+		case "/v1/appStoreVersionLocalizations/loc-ver-fr":
 			if req.Method == http.MethodPatch {
 				patchCount++
+				assertMetadataPatchPayload(t, req, "appStoreVersionLocalizations", "loc-ver-fr", map[string]string{"description": "Local French"})
 				body := `{"errors":[{"status":"500","code":"INTERNAL_ERROR","title":"Internal Error","detail":"boom"}]}`
 				return &http.Response{
 					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+				}, nil
+			}
+		case "/v1/appStoreVersionLocalizations/loc-ver-ja":
+			if req.Method == http.MethodPatch {
+				patchCount++
+				assertMetadataPatchPayload(t, req, "appStoreVersionLocalizations", "loc-ver-ja", map[string]string{"description": "Local Japanese"})
+				body := `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ver-ja","attributes":{"locale":"ja","description":"Local Japanese"}}}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
 				}, nil
@@ -232,28 +333,957 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 			"--app", "app-1",
 			"--version", "1.2.3",
 			"--dir", dir,
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())
 	})
 
-	if runErr == nil {
-		t.Fatal("expected apply failure error")
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected reported partial failure, got %T: %v", runErr, runErr)
 	}
-	if patchCount != 2 {
-		t.Fatalf("expected two patch attempts before failure, got %d", patchCount)
+	if patchCount != 3 {
+		t.Fatalf("expected all three patch attempts despite the middle failure, got %d", patchCount)
 	}
-	if !strings.Contains(runErr.Error(), "metadata apply: update version localization en-US") {
-		t.Fatalf("expected apply-prefixed version-localization failure, got %v", runErr)
-	}
-	if !strings.Contains(runErr.Error(), "description") {
-		t.Fatalf("expected version-localization failure to include attempted fields, got %v", runErr)
-	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout on failure, got %q", stdout)
+	if !strings.Contains(runErr.Error(), "metadata apply: 1 localization(s) failed") {
+		t.Fatalf("expected batch failure summary, got %v", runErr)
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr on failure, got %q", stderr)
 	}
+
+	var result struct {
+		Applied             bool   `json:"applied"`
+		Total               int    `json:"total"`
+		Succeeded           int    `json:"succeeded"`
+		Failed              int    `json:"failed"`
+		FailureArtifactPath string `json:"failureArtifactPath"`
+		Actions             []struct {
+			Scope         string            `json:"scope"`
+			Locale        string            `json:"locale"`
+			Status        string            `json:"status"`
+			DesiredFields map[string]string `json:"desiredFields"`
+			Error         string            `json:"error"`
+		} `json:"actions"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%q", err, stdout)
+	}
+	if result.Applied || result.Total != 3 || result.Succeeded != 2 || result.Failed != 1 {
+		t.Fatalf("unexpected partial summary: %+v", result)
+	}
+	if len(result.Actions) != 3 || result.Actions[0].Status != "succeeded" || result.Actions[1].Status != "failed" || result.Actions[2].Status != "succeeded" {
+		t.Fatalf("unexpected action sequence: %+v", result.Actions)
+	}
+	if result.Actions[1].Scope != "version" || result.Actions[1].Locale != "fr-FR" || result.Actions[1].DesiredFields["description"] != "Local French" {
+		t.Fatalf("unexpected failed action: %+v", result.Actions[1])
+	}
+	if !strings.Contains(result.Actions[1].Error, "boom") {
+		t.Fatalf("expected row error in structured output, got %+v", result.Actions[1])
+	}
+
+	artifactData, err := os.ReadFile(result.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("read failure artifact: %v", err)
+	}
+	var artifact struct {
+		SchemaVersion int    `json:"schemaVersion"`
+		Command       string `json:"command"`
+		AppID         string `json:"appId"`
+		AppInfoID     string `json:"appInfoId"`
+		Version       string `json:"version"`
+		VersionID     string `json:"versionId"`
+		Dir           string `json:"dir"`
+		Failures      []struct {
+			Scope          string            `json:"scope"`
+			Locale         string            `json:"locale"`
+			Action         string            `json:"action"`
+			LocalizationID string            `json:"localizationId"`
+			DesiredFields  map[string]string `json:"desiredFields"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal(artifactData, &artifact); err != nil {
+		t.Fatalf("parse failure artifact: %v", err)
+	}
+	if artifact.SchemaVersion != 1 || artifact.Command != "apply" || artifact.AppID != "app-1" || artifact.AppInfoID != "appinfo-1" || artifact.Version != "1.2.3" || artifact.VersionID != "version-1" || artifact.Dir != dir {
+		t.Fatalf("unexpected failure artifact identity: %+v", artifact)
+	}
+	if len(artifact.Failures) != 1 || artifact.Failures[0].Scope != "version" || artifact.Failures[0].Locale != "fr-FR" || artifact.Failures[0].Action != "update" || artifact.Failures[0].LocalizationID != "loc-ver-fr" || artifact.Failures[0].DesiredFields["description"] != "Local French" {
+		t.Fatalf("unexpected failure artifact: %+v", artifact)
+	}
+}
+
+func assertMetadataPatchPayload(t *testing.T, req *http.Request, resourceType, id string, fields map[string]string) {
+	t.Helper()
+	var payload struct {
+		Data struct {
+			Type       string            `json:"type"`
+			ID         string            `json:"id"`
+			Attributes map[string]string `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode PATCH payload: %v", err)
+	}
+	if payload.Data.Type != resourceType || payload.Data.ID != id {
+		t.Fatalf("unexpected PATCH identity: %+v", payload.Data)
+	}
+	if len(payload.Data.Attributes) != len(fields) {
+		t.Fatalf("expected only specified fields %v, got %v", fields, payload.Data.Attributes)
+	}
+	for field, value := range fields {
+		if payload.Data.Attributes[field] != value {
+			t.Fatalf("unexpected PATCH field %s: got %q want %q", field, payload.Data.Attributes[field], value)
+		}
+	}
+}
+
+func TestMetadataApplyReportsFailureArtifactWriteErrorAfterSummary(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	workDir := t.TempDir()
+	previousDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previousDir) })
+	if err := os.WriteFile(filepath.Join(workDir, ".asc"), []byte("blocks report directory"), 0o644); err != nil {
+		t.Fatalf("write blocking .asc file: %v", err)
+	}
+
+	dir := filepath.Join(workDir, "metadata")
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Local description"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US","description":"Remote description"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersionLocalizations/loc-en":
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","detail":"invalid description"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected reported error, got %T: %v", runErr, runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Failed               int    `json:"failed"`
+		FailureArtifactPath  string `json:"failureArtifactPath"`
+		FailureArtifactError string `json:"failureArtifactError"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%q", err, stdout)
+	}
+	if result.Failed != 1 || result.FailureArtifactPath != "" || !strings.Contains(result.FailureArtifactError, "not a directory") {
+		t.Fatalf("unexpected artifact failure summary: %+v", result)
+	}
+	if !strings.Contains(runErr.Error(), "write failure artifact") {
+		t.Fatalf("expected artifact failure in reported error, got %v", runErr)
+	}
+}
+
+func TestMetadataApplyFailedCreateDoesNotPrintAppliedWarning(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	dir := filepath.Join(workDir, "metadata")
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Incomplete create","whatsNew":"Notes"}`), 0o644); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	posts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations", "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersionLocalizations":
+			posts++
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","detail":"create rejected"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "apply", "--app", "app-1", "--version", "1.2.3", "--dir", dir, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected reported partial failure, got %T: %v", runErr, runErr)
+	}
+	if posts != 1 || stderr != "" || strings.Contains(stderr, "Warning:") {
+		t.Fatalf("failed create must not print applied warning: posts=%d stderr=%q", posts, stderr)
+	}
+	var result struct {
+		Failed              int    `json:"failed"`
+		FailureArtifactPath string `json:"failureArtifactPath"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	if result.Failed != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("unexpected failed create summary: %+v", result)
+	}
+	payload, err := os.ReadFile(result.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	if !strings.Contains(string(payload), `"action":"create"`) || !strings.Contains(string(payload), `"locale":"en-US"`) || !strings.Contains(string(payload), `"description":"Incomplete create"`) {
+		t.Fatalf("failed create artifact is not replayable: %s", payload)
+	}
+}
+
+func TestMetadataApplyReconcilesRequestTimeoutWithFreshReadback(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_TIMEOUT", "20ms")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Local description"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	versionReads := 0
+	patchCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			versionReads++
+			description := "Remote description"
+			if versionReads > 1 {
+				description = "Local description"
+			}
+			body := `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-ver-en","attributes":{"locale":"en-US","description":"` + description + `"}}],"links":{"next":""}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case "/v1/appStoreVersionLocalizations/loc-ver-en":
+			if req.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", req.Method)
+			}
+			patchCount++
+			<-req.Context().Done()
+			time.Sleep(5 * time.Millisecond)
+			return nil, req.Context().Err()
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Applied bool `json:"applied"`
+		Actions []struct {
+			Scope  string `json:"scope"`
+			Locale string `json:"locale"`
+			Action string `json:"action"`
+		} `json:"actions"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	if !result.Applied || patchCount != 1 || versionReads != 2 {
+		t.Fatalf("unexpected recovery: result=%+v patches=%d reads=%d", result, patchCount, versionReads)
+	}
+	if len(result.Actions) != 1 || result.Actions[0].Scope != "version" || result.Actions[0].Locale != "en-US" || result.Actions[0].Action != "reconcile" {
+		t.Fatalf("unexpected actions: %+v", result.Actions)
+	}
+}
+
+func TestMetadataApplyChecksStateAgainBeforeMutationReplay(t *testing.T) {
+	tests := []struct {
+		name            string
+		matchSecondRead bool
+		wantPatches     int
+		wantAction      string
+	}{
+		{name: "eventual readback match avoids replay", matchSecondRead: true, wantPatches: 1, wantAction: "reconcile"},
+		{name: "negative second readback permits replay", wantPatches: 2, wantAction: "update"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			t.Setenv("ASC_APP_ID", "")
+			t.Setenv("ASC_MAX_RETRIES", "1")
+			t.Setenv("ASC_BASE_DELAY", "1ms")
+			t.Setenv("ASC_MAX_DELAY", "1ms")
+
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+				t.Fatalf("mkdir version dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Local description"}`), 0o644); err != nil {
+				t.Fatalf("write version file: %v", err)
+			}
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			versionReads := 0
+			patchCount := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/v1/apps/app-1/appInfos":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+				case "/v1/apps/app-1/appStoreVersions":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+				case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+				case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+					versionReads++
+					description := "Remote description"
+					if test.matchSecondRead && versionReads == 3 {
+						description = "Local description"
+					}
+					body := `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-ver-en","attributes":{"locale":"en-US","description":"` + description + `"}}],"links":{"next":""}}`
+					return jsonHTTPResponse(http.StatusOK, body), nil
+				case "/v1/appStoreVersionLocalizations/loc-ver-en":
+					if req.Method != http.MethodPatch {
+						t.Fatalf("expected PATCH, got %s", req.Method)
+					}
+					patchCount++
+					if patchCount == 1 {
+						return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+					}
+					return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ver-en","attributes":{"description":"Local description"}}}`), nil
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+					return nil, nil
+				}
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"metadata", "apply",
+					"--app", "app-1",
+					"--version", "1.2.3",
+					"--dir", dir,
+					"--output", "json",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			var result struct {
+				Actions []struct {
+					Action string `json:"action"`
+				} `json:"actions"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("parse output: %v", err)
+			}
+			if patchCount != test.wantPatches || versionReads != 3 {
+				t.Fatalf("unexpected recovery calls: patches=%d reads=%d", patchCount, versionReads)
+			}
+			if len(result.Actions) != 1 || result.Actions[0].Action != test.wantAction {
+				t.Fatalf("unexpected action result: %+v", result.Actions)
+			}
+		})
+	}
+}
+
+func TestMetadataApplyReconcilesAmbiguousCreateWithoutDuplicate(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"Created name"}`), 0o644); err != nil {
+		t.Fatalf("write app-info: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	appInfoReads := 0
+	posts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			appInfoReads++
+			if appInfoReads == 1 {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"created-en","attributes":{"locale":"en-US","name":"Created name"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appInfoLocalizations":
+			posts++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous create"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "apply", "--app", "app-1", "--version", "1.2.3", "--dir", dir, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" || posts != 1 || appInfoReads != 2 {
+		t.Fatalf("unexpected create recovery: posts=%d reads=%d stderr=%q", posts, appInfoReads, stderr)
+	}
+	if !strings.Contains(stdout, `"action":"reconcile"`) || !strings.Contains(stdout, `"localizationId":"created-en"`) {
+		t.Fatalf("expected reconciled create identity, got %s", stdout)
+	}
+}
+
+func TestMetadataApplyReconcilesAmbiguousDeleteWithoutReplay(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"Existing name"}`), 0o644); err != nil {
+		t.Fatalf("write app-info: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	versionReads := 0
+	deletes := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Existing name"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			versionReads++
+			if versionReads == 1 {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"delete-fr","attributes":{"locale":"fr-FR","description":"Old"}}],"links":{"next":""}}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersionLocalizations/delete-fr":
+			deletes++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous delete"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "apply", "--app", "app-1", "--version", "1.2.3", "--dir", dir,
+			"--allow-deletes", "--confirm", "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" || deletes != 1 || versionReads != 2 {
+		t.Fatalf("unexpected delete recovery: deletes=%d reads=%d stderr=%q", deletes, versionReads, stderr)
+	}
+	if !strings.Contains(stdout, `"action":"reconcile"`) || !strings.Contains(stdout, `"localizationId":"delete-fr"`) {
+		t.Fatalf("expected reconciled delete identity, got %s", stdout)
+	}
+}
+
+func TestMetadataApplyRetriesInitialReadWithFreshDeadline(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_TIMEOUT", "20ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Local description","keywords":"one,two","supportUrl":"https://example.com/support","whatsNew":"New"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	versionResolverReads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appStoreVersions":
+			versionResolverReads++
+			if versionResolverReads == 1 {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}
+			if err := req.Context().Err(); err != nil {
+				t.Fatalf("retry received expired context: %v", err)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" || versionResolverReads < 2 {
+		t.Fatalf("unexpected retry result: reads=%d stderr=%q", versionResolverReads, stderr)
+	}
+}
+
+func TestMetadataApplyUsesFreshDeadlineForEachSnapshotPage(t *testing.T) {
+	setupAuth(t)
+	resetCmdtestState()
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"Local name"}`), 0o644); err != nil {
+		t.Fatalf("write app-info: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	appInfoReads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			appInfoReads++
+			if appInfoReads == 1 {
+				time.Sleep(60 * time.Millisecond)
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":"/v1/appInfos/appinfo-1/appInfoLocalizations?cursor=next"}}`), nil
+			}
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 70*time.Millisecond {
+				t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	result, _, err := metadatacli.ExecutePushWithWarnings(context.Background(), metadatacli.PushExecutionOptions{
+		CommandName: "apply",
+		AppID:       "app-1",
+		Version:     "1.2.3",
+		Dir:         dir,
+		DryRun:      true,
+	})
+	if err != nil {
+		t.Fatalf("ExecutePushWithWarnings() error: %v", err)
+	}
+	if appInfoReads != 2 || !result.DryRun {
+		t.Fatalf("unexpected paginated snapshot: reads=%d result=%+v", appInfoReads, result)
+	}
+}
+
+func TestMetadataApplyCancellationArtifactsRemainingActionsAcrossScopes(t *testing.T) {
+	setupAuth(t)
+	resetCmdtestState()
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	dir := filepath.Join(workDir, "metadata")
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"English new"}`), 0o644); err != nil {
+		t.Fatalf("write en-US: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "fr-FR.json"), []byte(`{"name":"French new"}`), 0o644); err != nil {
+		t.Fatalf("write fr-FR: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "ja.json"), []byte(`{"description":"Japanese new"}`), 0o644); err != nil {
+		t.Fatalf("write ja: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	mutations := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[
+				{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"English old"}},
+				{"type":"appInfoLocalizations","id":"loc-fr","attributes":{"locale":"fr-FR","name":"French old"}}
+			],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja","description":"Japanese old"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfoLocalizations/loc-en":
+			mutations++
+			body := &cancelOnEOFReadCloser{
+				reader: strings.NewReader(`{"data":{"type":"appInfoLocalizations","id":"loc-en","attributes":{"name":"English new"}}}`),
+				cancel: cancel,
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: body, Header: http.Header{"Content-Type": []string{"application/json"}}}, nil
+		case "/v1/appInfoLocalizations/loc-fr", "/v1/appStoreVersionLocalizations/loc-ja":
+			mutations++
+			t.Fatalf("unexpected mutation after cancellation: %s", req.URL.Path)
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	result, warnings, err := metadatacli.ExecutePushWithWarnings(ctx, metadatacli.PushExecutionOptions{
+		CommandName: "apply",
+		AppID:       "app-1",
+		Version:     "1.2.3",
+		Dir:         dir,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no create warnings, got %+v", warnings)
+	}
+	if result.Applied || result.Total != 3 || result.Succeeded != 1 || result.Failed != 2 || mutations != 1 {
+		t.Fatalf("unexpected cancellation summary: result=%+v mutations=%d", result, mutations)
+	}
+	if len(result.Actions) != 3 || result.Actions[0].Status != "succeeded" || result.Actions[1].Status != "failed" || result.Actions[2].Status != "failed" {
+		t.Fatalf("unexpected cancellation actions: %+v", result.Actions)
+	}
+	if result.Actions[1].Locale != "fr-FR" || result.Actions[1].LocalizationID != "loc-fr" || result.Actions[1].DesiredFields["name"] != "French new" {
+		t.Fatalf("missing remaining app-info identity: %+v", result.Actions[1])
+	}
+	if result.Actions[2].Scope != "version" || result.Actions[2].Locale != "ja" || result.Actions[2].LocalizationID != "loc-ja" || result.Actions[2].DesiredFields["description"] != "Japanese new" {
+		t.Fatalf("missing remaining version identity: %+v", result.Actions[2])
+	}
+	if result.FailureArtifactPath == "" {
+		t.Fatalf("expected cancellation retry artifact: %+v", result)
+	}
+	artifact, readErr := os.ReadFile(result.FailureArtifactPath)
+	if readErr != nil {
+		t.Fatalf("read cancellation artifact: %v", readErr)
+	}
+	for _, expected := range []string{`"localizationId":"loc-fr"`, `"name":"French new"`, `"localizationId":"loc-ja"`, `"description":"Japanese new"`} {
+		if !strings.Contains(string(artifact), expected) {
+			t.Fatalf("cancellation artifact missing %q: %s", expected, artifact)
+		}
+	}
+}
+
+type cancelOnEOFReadCloser struct {
+	reader io.Reader
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelOnEOFReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err == io.EOF {
+		r.once.Do(r.cancel)
+	}
+	return n, err
+}
+
+func (r *cancelOnEOFReadCloser) Close() error {
+	return nil
+}
+
+func TestMetadataApplyPartialBatchExitCode(t *testing.T) {
+	run := runFailedMetadataApply(t, "json", true, false)
+	if run.code != rootcmd.ExitError {
+		t.Fatalf("expected partial exit %d, got %d; stderr=%q", rootcmd.ExitError, run.code, run.stderr)
+	}
+	if run.stderr != "" {
+		t.Fatalf("expected reported error to avoid duplicate stderr, got %q", run.stderr)
+	}
+	var result struct {
+		Failed              int    `json:"failed"`
+		FailureArtifactPath string `json:"failureArtifactPath"`
+	}
+	if err := json.Unmarshal([]byte(run.stdout), &result); err != nil {
+		t.Fatalf("parse structured output: %v\nstdout=%q", err, run.stdout)
+	}
+	if result.Failed != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("expected structured partial summary, got %+v", result)
+	}
+}
+
+func TestMetadataApplyPartialTableIncludesRecoveryDetails(t *testing.T) {
+	run := runFailedMetadataApply(t, "table", false, false)
+	if _, ok := errors.AsType[ReportedError](run.err); !ok {
+		t.Fatalf("expected reported error, got %T: %v", run.err, run.err)
+	}
+	for _, expected := range []string{"Total: 1", "Succeeded: 0", "Failed: 1", "Failure Artifact: .asc/reports/metadata-apply/"} {
+		if !strings.Contains(run.stdout, expected) {
+			t.Fatalf("table output missing %q: %s", expected, run.stdout)
+		}
+	}
+}
+
+func TestMetadataApplyPartialMarkdownIncludesArtifactWriteError(t *testing.T) {
+	run := runFailedMetadataApply(t, "markdown", false, true)
+	if _, ok := errors.AsType[ReportedError](run.err); !ok {
+		t.Fatalf("expected reported error, got %T: %v", run.err, run.err)
+	}
+	if !strings.Contains(run.stdout, "**Failure Artifact Error:**") || !strings.Contains(run.stdout, "not a directory") {
+		t.Fatalf("markdown output missing artifact error: %s", run.stdout)
+	}
+}
+
+func TestMetadataApplyInitialConflictPreservesTypedExit(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Desired"}`), 0o644); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"CONFLICT","detail":"snapshot conflict"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"metadata", "apply", "--app", "app-1", "--version", "1.2.3", "--dir", dir, "--output", "json"}, "1.2.3")
+	})
+	if code != rootcmd.ExitConflict {
+		t.Fatalf("expected conflict exit %d, got %d; stderr=%q", rootcmd.ExitConflict, code, stderr)
+	}
+	if stdout != "" || strings.Contains(stderr, "0 localization(s) failed") || strings.Contains(stderr, "Failure Artifact") {
+		t.Fatalf("unexpected pre-batch summary: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+type metadataApplyRun struct {
+	code   int
+	err    error
+	stdout string
+	stderr string
+}
+
+func runFailedMetadataApply(t *testing.T, output string, useEntrypoint bool, blockArtifact bool) metadataApplyRun {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	if blockArtifact {
+		if err := os.WriteFile(filepath.Join(workDir, ".asc"), []byte("block reports"), 0o644); err != nil {
+			t.Fatalf("write blocking .asc: %v", err)
+		}
+	}
+	dir := filepath.Join(workDir, "metadata")
+	if err := os.MkdirAll(filepath.Join(dir, "version", "1.2.3"), 0o755); err != nil {
+		t.Fatalf("mkdir version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "version", "1.2.3", "en-US.json"), []byte(`{"description":"Desired"}`), 0o644); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US","description":"Old"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersionLocalizations/loc-en":
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","detail":"rejected"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	args := []string{"metadata", "apply", "--app", "app-1", "--version", "1.2.3", "--dir", dir, "--output", output}
+	var run metadataApplyRun
+	run.stdout, run.stderr = captureOutput(t, func() {
+		if useEntrypoint {
+			run.code = rootcmd.Run(args, "1.2.3")
+			return
+		}
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		run.err = root.Run(context.Background())
+	})
+	return run
 }

--- a/internal/cli/cmdtest/metadata_keywords_test.go
+++ b/internal/cli/cmdtest/metadata_keywords_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMetadataHelpShowsKeywordsWorkflow(t *testing.T) {
@@ -1240,6 +1241,79 @@ func TestMetadataKeywordsPlanBuildsKeywordOnlyRemotePlan(t *testing.T) {
 	}
 	if len(payload.Warnings[0].MissingFields) != 2 || payload.Warnings[0].MissingFields[0] != "description" || payload.Warnings[0].MissingFields[1] != "supportUrl" {
 		t.Fatalf("expected missing description/supportUrl warning, got %+v", payload.Warnings[0])
+	}
+}
+
+func TestMetadataKeywordsPlanUsesFreshReadinessContextAfterSlowPagination(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	dir := t.TempDir()
+	versionDir := filepath.Join(dir, "version", "1.2.3")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "ja.json"), []byte(`{"keywords":"nihongo"}`), 0o644); err != nil {
+		t.Fatalf("write ja: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	localizationReads := 0
+	readinessReads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s %s", req.Method, req.URL.Path)
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appStoreVersions":
+			if req.URL.Query().Get("filter[appStoreState]") != "" {
+				return metadataKeywordsJSONResponse(`{"data":[{"type":"appStoreVersions","id":"released","attributes":{"versionString":"1.0","platform":"IOS","appStoreState":"READY_FOR_SALE"}}],"links":{"next":""}}`)
+			}
+			return metadataKeywordsJSONResponse(`{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`)
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			localizationReads++
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 70*time.Millisecond {
+				t.Fatalf("expected fresh localization page deadline, remaining=%s", time.Until(deadline))
+			}
+			time.Sleep(60 * time.Millisecond)
+			if localizationReads == 1 {
+				return metadataKeywordsJSONResponse(`{"data":[],"links":{"next":"/v1/appStoreVersions/version-1/appStoreVersionLocalizations?cursor=next"}}`)
+			}
+			return metadataKeywordsJSONResponse(`{"data":[],"links":{"next":""}}`)
+		case "/v1/appStoreVersions/version-1":
+			readinessReads++
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 70*time.Millisecond {
+				t.Fatalf("expected fresh readiness deadline, remaining=%s", time.Until(deadline))
+			}
+			return metadataKeywordsJSONResponse(`{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "keywords", "plan", "--app", "app-1", "--version", "1.2.3", "--dir", dir}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" || localizationReads != 2 || readinessReads != 1 {
+		t.Fatalf("unexpected request counts: localization=%d readiness=%d stderr=%q", localizationReads, readinessReads, stderr)
+	}
+	if !strings.Contains(stdout, `"whatsNew"`) {
+		t.Fatalf("expected update-context warning to require whatsNew: %s", stdout)
 	}
 }
 

--- a/internal/cli/cmdtest/metadata_push_test.go
+++ b/internal/cli/cmdtest/metadata_push_test.go
@@ -1857,6 +1857,7 @@ func TestMetadataPushApplyFailsOnPartialMutation(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	t.Setenv("ASC_APP_ID", "")
+	t.Chdir(t.TempDir())
 
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
@@ -1949,17 +1950,25 @@ func TestMetadataPushApplyFailsOnPartialMutation(t *testing.T) {
 		runErr = root.Run(context.Background())
 	})
 
-	if runErr == nil {
-		t.Fatal("expected apply failure error")
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected reported partial failure, got %T: %v", runErr, runErr)
 	}
 	if patchCount != 2 {
 		t.Fatalf("expected two patch attempts before failure, got %d", patchCount)
 	}
-	if !strings.Contains(runErr.Error(), "metadata push: update version localization en-US") {
-		t.Fatalf("expected wrapped version-localization failure, got %v", runErr)
+	if !strings.Contains(runErr.Error(), "metadata push: 1 localization(s) failed") {
+		t.Fatalf("expected batch failure summary, got %v", runErr)
 	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout on failure, got %q", stdout)
+	var result struct {
+		Succeeded           int    `json:"succeeded"`
+		Failed              int    `json:"failed"`
+		FailureArtifactPath string `json:"failureArtifactPath"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse partial output: %v\nstdout=%q", err, stdout)
+	}
+	if result.Succeeded != 1 || result.Failed != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("unexpected partial summary: %+v", result)
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr on failure, got %q", stderr)

--- a/internal/cli/cmdtest/subscriptions_localizations_sync_test.go
+++ b/internal/cli/cmdtest/subscriptions_localizations_sync_test.go
@@ -1,0 +1,720 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestSubscriptionsLocalizationsSyncUpsertsExactFields(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requests := make([]string, 0, 4)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionLocalizations" && req.URL.Query().Get("cursor") == "":
+			if got := req.URL.Query().Get("fields[subscriptionLocalizations]"); got != "description,locale,name" {
+				t.Fatalf("expected sparse localization fields, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Pro","description":"Current"}},{"type":"subscriptionLocalizations","id":"loc-fr","attributes":{"locale":"fr-FR","name":"Pro","description":"Ancienne"}}],"links":{"next":"/v1/subscriptions/8000000001/subscriptionLocalizations?cursor=2"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/subscriptionLocalizations" && req.URL.Query().Get("cursor") == "2":
+			if got := req.URL.Query().Get("fields[subscriptionLocalizations]"); got != "description,locale,name" {
+				t.Fatalf("expected sparse fields on page 2, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionLocalizations":
+			var payload struct {
+				Data struct {
+					Attributes map[string]any `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create payload: %v", err)
+			}
+			want := map[string]any{"locale": "de-DE", "name": "Pro DE"}
+			if !reflect.DeepEqual(payload.Data.Attributes, want) {
+				t.Fatalf("expected exact create attributes %#v, got %#v", want, payload.Data.Attributes)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionLocalizations","id":"loc-de","attributes":{"locale":"de-DE","name":"Pro DE"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionLocalizations/loc-fr":
+			var payload struct {
+				Data struct {
+					Attributes map[string]any `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode update payload: %v", err)
+			}
+			want := map[string]any{"description": ""}
+			if !reflect.DeepEqual(payload.Data.Attributes, want) {
+				t.Fatalf("expected clear-only update %#v, got %#v", want, payload.Data.Attributes)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionLocalizations","id":"loc-fr","attributes":{"locale":"fr-FR","name":"Pro","description":""}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	input := writeLocalizationSyncInput(t, `{
+  "fr_FR": {"description": ""},
+  "en-US": {"name": "Pro", "description": "Current"},
+  "de-DE": {"name": "Pro DE"}
+}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var summary struct {
+		Total     int `json:"total"`
+		Created   int `json:"created"`
+		Updated   int `json:"updated"`
+		Unchanged int `json:"unchanged"`
+		Failed    int `json:"failed"`
+		Results   []struct {
+			Locale string `json:"locale"`
+		} `json:"results"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary: %v\n%s", err, stdout)
+	}
+	if summary.Total != 3 || summary.Created != 1 || summary.Updated != 1 || summary.Unchanged != 1 || summary.Failed != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	locales := []string{summary.Results[0].Locale, summary.Results[1].Locale, summary.Results[2].Locale}
+	if !reflect.DeepEqual(locales, []string{"de-DE", "en-US", "fr-FR"}) {
+		t.Fatalf("expected deterministic locale order, got %v", locales)
+	}
+	wantRequests := []string{
+		"GET /v1/subscriptions/8000000001/subscriptionLocalizations",
+		"GET /v1/subscriptions/8000000001/subscriptionLocalizations",
+		"POST /v1/subscriptionLocalizations",
+		"PATCH /v1/subscriptionLocalizations/loc-fr",
+	}
+	if !reflect.DeepEqual(requests, wantRequests) {
+		t.Fatalf("expected requests %v, got %v", wantRequests, requests)
+	}
+}
+
+func TestSubscriptionsLocalizationsSyncReconcilesAmbiguousCreate(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	creates := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case http.MethodGet:
+			reads++
+			if reads == 1 {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Pro"}}],"links":{}}`), nil
+		case http.MethodPost:
+			creates++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	input := writeLocalizationSyncInput(t, `{"en-US":{"name":"Pro"}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var summary struct {
+		Reconciled int `json:"reconciled"`
+		Failed     int `json:"failed"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" || creates != 1 || reads != 2 {
+		t.Fatalf("unexpected reconcile calls: reads=%d creates=%d stderr=%q", reads, creates, stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.Reconciled != 1 || summary.Failed != 0 {
+		t.Fatalf("unexpected reconcile summary: %+v", summary)
+	}
+}
+
+func TestSubscriptionsLocalizationsSyncReconcilesAmbiguousUpdate(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	patches := 0
+	currentName := "Old"
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case http.MethodGet:
+			reads++
+			body := `{"data":[{"type":"subscriptionLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"` + currentName + `"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case http.MethodPatch:
+			patches++
+			currentName = "New"
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	input := writeLocalizationSyncInput(t, `{"en-US":{"name":"New"}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var summary struct {
+		Reconciled int `json:"reconciled"`
+		Failed     int `json:"failed"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" || reads != 2 || patches != 1 {
+		t.Fatalf("unexpected reconcile calls: reads=%d patches=%d stderr=%q", reads, patches, stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.Reconciled != 1 || summary.Failed != 0 {
+		t.Fatalf("unexpected reconcile summary: %+v", summary)
+	}
+}
+
+func TestSubscriptionsLocalizationsSyncContinuesAndWritesFailureArtifact(t *testing.T) {
+	setupAuth(t)
+	t.Chdir(t.TempDir())
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	creates := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case http.MethodGet:
+			reads++
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case http.MethodPost:
+			creates++
+			if creates == 1 {
+				return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"bad localization"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"English"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	input := writeLocalizationSyncInput(t, `{"de-DE":{"name":"Deutsch"},"en-US":{"name":"English"}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	var summary struct {
+		Created             int    `json:"created"`
+		Failed              int    `json:"failed"`
+		FailureArtifactPath string `json:"failureArtifactPath"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T %v", runErr, runErr)
+	}
+	if stderr != "" || creates != 2 || reads != 2 {
+		t.Fatalf("expected continuation after failure, reads=%d creates=%d stderr=%q", reads, creates, stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.Created != 1 || summary.Failed != 1 || summary.FailureArtifactPath == "" {
+		t.Fatalf("unexpected partial summary: %+v", summary)
+	}
+	payload, err := os.ReadFile(summary.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("read failure artifact: %v", err)
+	}
+	if !strings.Contains(string(payload), `"schemaVersion": 1`) || !strings.Contains(string(payload), `"locale": "de-DE"`) || !strings.Contains(string(payload), `"name": "Deutsch"`) {
+		t.Fatalf("unexpected failure artifact: %s", payload)
+	}
+	var artifact struct {
+		RetryInput map[string]map[string]string `json:"retryInput"`
+	}
+	if err := json.Unmarshal(payload, &artifact); err != nil {
+		t.Fatalf("decode failure artifact: %v", err)
+	}
+	wantRetryInput := map[string]map[string]string{"de-DE": {"name": "Deutsch"}}
+	if !reflect.DeepEqual(artifact.RetryInput, wantRetryInput) {
+		t.Fatalf("expected replayable input %#v, got %#v", wantRetryInput, artifact.RetryInput)
+	}
+}
+
+func TestSubscriptionsGroupsLocalizationsSyncClearsCustomAppName(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case http.MethodGet:
+			if got := req.URL.Query().Get("fields[subscriptionGroupLocalizations]"); got != "customAppName,locale,name" {
+				t.Fatalf("expected sparse group fields, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionGroupLocalizations","id":"group-loc-en","attributes":{"locale":"en-US","name":"Premium","customAppName":"Old"}}],"links":{}}`), nil
+		case http.MethodPatch:
+			var payload struct {
+				Data struct {
+					Attributes map[string]any `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode patch: %v", err)
+			}
+			want := map[string]any{"customAppName": ""}
+			if !reflect.DeepEqual(payload.Data.Attributes, want) {
+				t.Fatalf("expected clear-only group patch %#v, got %#v", want, payload.Data.Attributes)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionGroupLocalizations","id":"group-loc-en","attributes":{"locale":"en-US","name":"Premium","customAppName":""}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	input := writeLocalizationSyncInput(t, `{"en-US":{"customAppName":""}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "groups", "localizations", "sync", "--group-id", "group-1", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if stderr != "" || !strings.Contains(stdout, `"updated":1`) {
+		t.Fatalf("unexpected output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestSubscriptionsLocalizationsSyncRejectsDuplicateCanonicalLocale(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	input := writeLocalizationSyncInput(t, `{"en_US":{"name":"One"},"en-US":{"name":"Two"}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected usage error, got %T %v", err, err)
+		}
+	})
+	if stdout != "" || !strings.Contains(stderr, `duplicate canonical locale "en-US"`) {
+		t.Fatalf("unexpected validation output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestSubscriptionsLocalizationSyncRejectsUnsafeInvocationBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "subscription positional",
+			args:    []string{"subscriptions", "localizations", "sync", "stray", "--subscription-id", "8000000001"},
+			input:   `{"en-US":{"name":"English"}}`,
+			wantErr: "does not accept positional arguments",
+		},
+		{
+			name:    "group positional",
+			args:    []string{"subscriptions", "groups", "localizations", "sync", "stray", "--group-id", "group-1"},
+			input:   `{"en-US":{"name":"English"}}`,
+			wantErr: "does not accept positional arguments",
+		},
+		{
+			name:    "unsupported output",
+			args:    []string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--output", "yaml"},
+			input:   `{"en-US":{"name":"English"}}`,
+			wantErr: "unsupported format: yaml",
+		},
+		{
+			name:    "pretty table",
+			args:    []string{"subscriptions", "groups", "localizations", "sync", "--group-id", "group-1", "--output", "table", "--pretty"},
+			input:   `{"en-US":{"name":"English"}}`,
+			wantErr: "--pretty is only valid with JSON output",
+		},
+		{
+			name:    "subscription blank name",
+			args:    []string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001"},
+			input:   `{"en-US":{"name":"  "}}`,
+			wantErr: `field "name" must not be empty`,
+		},
+		{
+			name:    "group blank name",
+			args:    []string{"subscriptions", "groups", "localizations", "sync", "--group-id", "group-1"},
+			input:   `{"en-US":{"name":""}}`,
+			wantErr: `field "name" must not be empty`,
+		},
+		{
+			name:    "trailing second value",
+			args:    []string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001"},
+			input:   `{"en-US":{"name":"English"}} {}`,
+			wantErr: "invalid JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+				return nil, nil
+			})
+
+			input := writeLocalizationSyncInput(t, tt.input)
+			args := append(append([]string{}, tt.args...), "--input", input)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected usage error, got %T %v", err, err)
+				}
+			})
+			if stdout != "" || !strings.Contains(stderr, tt.wantErr) {
+				t.Fatalf("expected %q, stdout=%q stderr=%q", tt.wantErr, stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsGroupsLocalizationsSyncReassertsFieldsOnNextPage(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	pages := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionGroups/group-1/subscriptionGroupLocalizations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		pages++
+		deadline, ok := req.Context().Deadline()
+		if !ok || time.Until(deadline) < 350*time.Millisecond {
+			t.Fatalf("page %d expected fresh request deadline, remaining=%s", pages, time.Until(deadline))
+		}
+		if got := req.URL.Query().Get("fields[subscriptionGroupLocalizations]"); got != "customAppName,locale,name" {
+			t.Fatalf("page %d missing sparse fields: %q", pages, got)
+		}
+		if pages == 1 {
+			time.Sleep(300 * time.Millisecond)
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":"/v1/subscriptionGroups/group-1/subscriptionGroupLocalizations?cursor=2"}}`), nil
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionGroupLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Premium"}}],"links":{}}`), nil
+	})
+
+	input := writeLocalizationSyncInput(t, `{"en-US":{"name":"Premium"}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "groups", "localizations", "sync", "--group-id", "group-1", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if pages != 2 || stderr != "" || !strings.Contains(stdout, `"unchanged":1`) {
+		t.Fatalf("unexpected pagination result: pages=%d stdout=%q stderr=%q", pages, stdout, stderr)
+	}
+}
+
+func TestRunSubscriptionsLocalizationsSyncExitCodes(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		setupAuth(t)
+		originalTransport := http.DefaultTransport
+		t.Cleanup(func() { http.DefaultTransport = originalTransport })
+		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"English"}}],"links":{}}`), nil
+		})
+		input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
+		stdout, stderr := captureOutput(t, func() {
+			code := rootcmd.Run([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}, "1.2.3")
+			if code != rootcmd.ExitSuccess {
+				t.Fatalf("expected exit %d, got %d", rootcmd.ExitSuccess, code)
+			}
+		})
+		if stderr != "" || !strings.Contains(stdout, `"unchanged":1`) {
+			t.Fatalf("unexpected success output: stdout=%q stderr=%q", stdout, stderr)
+		}
+	})
+
+	t.Run("partial failure", func(t *testing.T) {
+		setupAuth(t)
+		t.Chdir(t.TempDir())
+		originalTransport := http.DefaultTransport
+		t.Cleanup(func() { http.DefaultTransport = originalTransport })
+		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodGet {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+			}
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"invalid"}]}`), nil
+		})
+		input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
+		stdout, stderr := captureOutput(t, func() {
+			code := rootcmd.Run([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}, "1.2.3")
+			if code != rootcmd.ExitError {
+				t.Fatalf("expected exit %d, got %d", rootcmd.ExitError, code)
+			}
+		})
+		if stderr != "" || !strings.Contains(stdout, `"failed":1`) {
+			t.Fatalf("unexpected failure output: stdout=%q stderr=%q", stdout, stderr)
+		}
+	})
+
+	t.Run("usage", func(t *testing.T) {
+		setupAuth(t)
+		input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
+		stdout, stderr := captureOutput(t, func() {
+			code := rootcmd.Run([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "yaml"}, "1.2.3")
+			if code != rootcmd.ExitUsage {
+				t.Fatalf("expected exit %d, got %d", rootcmd.ExitUsage, code)
+			}
+		})
+		if stdout != "" || !strings.Contains(stderr, "unsupported format: yaml") {
+			t.Fatalf("unexpected usage output: stdout=%q stderr=%q", stdout, stderr)
+		}
+	})
+}
+
+func TestSubscriptionsLocalizationsSyncBuiltBinaryInvalidOutputExitUsage(t *testing.T) {
+	bin := buildCLIBinary(t)
+	input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
+	cmd := exec.Command(
+		bin,
+		"subscriptions", "localizations", "sync",
+		"--subscription-id", "8000000001",
+		"--input", input,
+		"--output", "yaml",
+	)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != rootcmd.ExitUsage {
+		t.Fatalf("expected exit %d, got %v", rootcmd.ExitUsage, err)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "unsupported format: yaml") {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestSubscriptionsLocalizationSyncPreflightsEveryCreateBeforeMutating(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		input     string
+		listPath  string
+		wantError string
+	}{
+		{
+			name:      "subscription",
+			args:      []string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001"},
+			input:     `{"de-DE":{"name":"Deutsch"},"en-US":{"description":"Missing name"}}`,
+			listPath:  "/v1/subscriptions/8000000001/subscriptionLocalizations",
+			wantError: `locale "en-US" does not exist remotely and requires a non-empty name`,
+		},
+		{
+			name:      "group",
+			args:      []string{"subscriptions", "groups", "localizations", "sync", "--group-id", "group-1"},
+			input:     `{"de-DE":{"name":"Deutsch"},"en-US":{"customAppName":"Missing name"}}`,
+			listPath:  "/v1/subscriptionGroups/group-1/subscriptionGroupLocalizations",
+			wantError: `locale "en-US" does not exist remotely and requires a non-empty name`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			requests := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				if req.Method != http.MethodGet || req.URL.Path != tt.listPath {
+					t.Fatalf("preflight must not mutate: %s %s", req.Method, req.URL.Path)
+				}
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+			})
+
+			input := writeLocalizationSyncInput(t, tt.input)
+			args := append(append([]string{}, tt.args...), "--input", input)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected usage error, got %T %v", err, err)
+				}
+			})
+			if stdout != "" || !strings.Contains(stderr, tt.wantError) || requests != 1 {
+				t.Fatalf("unexpected preflight result: requests=%d stdout=%q stderr=%q", requests, stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsLocalizationsSyncReportsArtifactWriteFailure(t *testing.T) {
+	setupAuth(t)
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(".asc", []byte("blocks report directory"), 0o600); err != nil {
+		t.Fatalf("write report blocker: %v", err)
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case http.MethodGet:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case http.MethodPost:
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"bad localization"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	var summary struct {
+		FailureArtifactPath  string `json:"failureArtifactPath"`
+		FailureArtifactError string `json:"failureArtifactError"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T %v", runErr, runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.FailureArtifactPath != "" || summary.FailureArtifactError == "" {
+		t.Fatalf("expected retained artifact error without path, got %+v", summary)
+	}
+}
+
+func TestSubscriptionsLocalizationsSyncRendersTableAndMarkdown(t *testing.T) {
+	for _, format := range []string{"table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			setupAuth(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"English"}}],"links":{}}`), nil
+			})
+
+			input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{"subscriptions", "localizations", "sync", "--subscription-id", "8000000001", "--input", input, "--output", format}); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run: %v", err)
+				}
+			})
+			if stderr != "" || !strings.Contains(stdout, "Target ID") || !strings.Contains(stdout, "Locale") || !strings.Contains(stdout, "en-US") {
+				t.Fatalf("unexpected %s output: stdout=%q stderr=%q", format, stdout, stderr)
+			}
+			if format == "markdown" && !strings.Contains(stdout, "|") {
+				t.Fatalf("expected markdown table, got %q", stdout)
+			}
+		})
+	}
+}
+
+func writeLocalizationSyncInput(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "localizations.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write localization input: %v", err)
+	}
+	return path
+}

--- a/internal/cli/cmdtest/subscriptions_prices_import_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_import_test.go
@@ -72,10 +72,14 @@ func TestSubscriptionsPricesImport_DryRunResolvesASCExportAliasWithoutMutations(
 			t.Fatalf("unexpected path: %s", req.URL.Path)
 		}
 		territory := req.URL.Query().Get("filter[territory]")
+		assertSubscriptionPricePointImportQuery(t, req, territory)
 		seenTerritories[territory]++
 
 		switch territory {
 		case "USA":
+			if req.URL.Query().Get("cursor") == "" {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":"/v1/subscriptions/8000000001/pricePoints?cursor=usa-2"}}`), nil
+			}
 			body := `{"data":[{"type":"subscriptionPricePoints","id":"pp-usa","attributes":{"customerPrice":"19.99"}}],"links":{}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -175,6 +179,9 @@ func TestSubscriptionsPricesImport_PartialFailureReturnsReportedErrorAndSummary(
 			if !strings.Contains(string(payload), `"id":"pp-usa"`) {
 				t.Fatalf("expected resolved price point id in payload, got %s", string(payload))
 			}
+			if !strings.Contains(string(payload), `"planType":"UPFRONT"`) {
+				t.Fatalf("expected explicit UPFRONT plan type in payload, got %s", string(payload))
+			}
 			body := `{"data":{"type":"subscriptionPrices","id":"price-1"}}`
 			return &http.Response{
 				StatusCode: http.StatusCreated,
@@ -248,10 +255,16 @@ func TestSubscriptionsPricesImport_SkipsExactExistingPrice(t *testing.T) {
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 	postCount := 0
+	readCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
-			body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"2026-08-01","preserved":true},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+			assertSubscriptionPriceImportStateQuery(t, req)
+			readCount++
+			if req.URL.Query().Get("cursor") == "" {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":"/v1/subscriptions/8000000001/prices?cursor=page-2"}}`), nil
+			}
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"2026-08-01","preserved":true,"planType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPost:
 			postCount++
@@ -291,7 +304,7 @@ func TestSubscriptionsPricesImport_SkipsExactExistingPrice(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
 		t.Fatalf("parse JSON summary: %v", err)
 	}
-	if summary.Created != 0 || summary.Skipped != 1 || summary.Failed != 0 || postCount != 0 {
+	if summary.Created != 0 || summary.Skipped != 1 || summary.Failed != 0 || postCount != 0 || readCount != 2 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
 	if len(summary.Results) != 1 || summary.Results[0].Status != "skipped" {
@@ -310,11 +323,12 @@ func TestSubscriptionsPricesImport_ReconcilesAmbiguousCreateWithoutReplay(t *tes
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			assertSubscriptionPriceImportStateQuery(t, req)
 			readCount++
 			if readCount == 1 {
 				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
 			}
-			body := `{"data":[{"type":"subscriptionPrices","id":"price-created","attributes":{"startDate":"2026-08-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-created","attributes":{"startDate":"2026-08-01","preserved":false,"planType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			postCount++
@@ -369,8 +383,9 @@ func TestSubscriptionsPricesImport_SkipsImmediatePriceWithConcreteEffectiveDate(
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			assertSubscriptionPriceImportStateQuery(t, req)
 			readCount++
-			body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"` + time.Now().UTC().Format("2006-01-02") + `","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"` + time.Now().UTC().Format("2006-01-02") + `","preserved":false,"planType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodPost:
 			t.Fatalf("current immediate price must not be posted again")
@@ -403,6 +418,236 @@ func TestSubscriptionsPricesImport_SkipsImmediatePriceWithConcreteEffectiveDate(
 	}
 	if summary.Skipped != 1 || readCount != 1 {
 		t.Fatalf("expected one indexed skip, summary=%+v reads=%d", summary, readCount)
+	}
+}
+
+func TestSubscriptionsPricesImport_RetriesTimedOutInitialStateRead(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	t.Setenv("ASC_TIMEOUT", "50ms")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		assertSubscriptionPriceImportStateQuery(t, req)
+		readCount++
+		if readCount == 1 {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		if err := req.Context().Err(); err != nil {
+			t.Fatalf("expected fresh state-read context, got %v", err)
+		}
+		body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"2026-08-01","preserved":false,"planType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+		return jsonHTTPResponse(http.StatusOK, body), nil
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	if err := os.WriteFile(csvPath, []byte("territory,price,start_date,price_point_id\nUSA,19.99,2026-08-01,pp-usa\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"skipped":1`) || readCount != 2 {
+		t.Fatalf("expected fresh-context retry and skip, reads=%d output=%s", readCount, stdout)
+	}
+}
+
+func TestSubscriptionsPricesImport_RetriesTimedOutPricePointRead(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	t.Setenv("ASC_TIMEOUT", "50ms")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/pricePoints" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		assertSubscriptionPricePointImportQuery(t, req, "USA")
+		readCount++
+		if readCount == 1 {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		if err := req.Context().Err(); err != nil {
+			t.Fatalf("expected fresh price-point context, got %v", err)
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-usa","attributes":{"customerPrice":"19.99"}}],"links":{}}`), nil
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	if err := os.WriteFile(csvPath, []byte("territory,price\nUSA,19.99\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--dry-run", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"created":1`) || readCount != 2 {
+		t.Fatalf("expected fresh-context price-point retry, reads=%d output=%s", readCount, stdout)
+	}
+}
+
+func TestSubscriptionsPricesImport_RetriesTimedOutSelectorResolution(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	t.Setenv("ASC_TIMEOUT", "50ms")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	groupReads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
+			groupReads++
+			if groupReads == 1 {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}
+			if err := req.Context().Err(); err != nil {
+				t.Fatalf("expected fresh selector context, got %v", err)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionGroups","id":"group-1"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
+			if got := req.URL.Query().Get("filter[productId]"); got != "com.example.monthly" {
+				t.Fatalf("unexpected product ID filter: %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"8000000001","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	if err := os.WriteFile(csvPath, []byte("territory,price,price_point_id\nUSA,19.99,pp-usa\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "import",
+			"--subscription-id", "com.example.monthly", "--app", "app-1", "--input", csvPath, "--dry-run", "--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"subscriptionId":"8000000001"`) || groupReads != 2 {
+		t.Fatalf("expected selector retry and resolved ID, reads=%d output=%s", groupReads, stdout)
+	}
+}
+
+func TestSubscriptionsPricesImport_PrintsFailuresWhenArtifactWriteFails(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(".asc", []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","detail":"invalid price"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	if err := os.WriteFile(csvPath, []byte("territory,price,price_point_id\nUSA,19.99,pp-usa\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %v", runErr)
+	}
+	var summary struct {
+		Failed               int    `json:"failed"`
+		FailureArtifactError string `json:"failureArtifactError"`
+		Results              []struct {
+			Status   string `json:"status"`
+			Error    string `json:"error"`
+			PlanType string `json:"planType"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v\n%s", err, stdout)
+	}
+	if summary.Failed != 1 || summary.FailureArtifactError == "" || len(summary.Results) != 1 || summary.Results[0].Status != "failed" || summary.Results[0].Error == "" || summary.Results[0].PlanType != "UPFRONT" {
+		t.Fatalf("unexpected failure summary: %+v", summary)
+	}
+}
+
+func assertSubscriptionPriceImportStateQuery(t *testing.T, req *http.Request) {
+	t.Helper()
+	if got := req.URL.Query().Get("fields[subscriptionPrices]"); got != "startDate,preserved,planType,territory,subscriptionPricePoint" {
+		t.Fatalf("unexpected subscription price fields: %q", got)
+	}
+	if got := req.URL.Query().Get("include"); got != "territory,subscriptionPricePoint" {
+		t.Fatalf("unexpected subscription price include: %q", got)
+	}
+	if got := req.URL.Query().Get("filter[planType]"); got != "UPFRONT" {
+		t.Fatalf("unexpected subscription price plan filter: %q", got)
+	}
+	if got := req.URL.Query().Get("limit"); got != "200" {
+		t.Fatalf("unexpected subscription price limit: %q", got)
+	}
+}
+
+func assertSubscriptionPricePointImportQuery(t *testing.T, req *http.Request, territory string) {
+	t.Helper()
+	if got := req.URL.Query().Get("fields[subscriptionPricePoints]"); got != "customerPrice" {
+		t.Fatalf("unexpected price point fields: %q", got)
+	}
+	if got := req.URL.Query().Get("filter[territory]"); got != territory {
+		t.Fatalf("unexpected price point territory: %q", got)
+	}
+	if got := req.URL.Query().Get("limit"); got != "200" {
+		t.Fatalf("unexpected price point limit: %q", got)
 	}
 }
 
@@ -468,6 +713,7 @@ func TestSubscriptionsPricesImport_WritesVersionedFailureArtifact(t *testing.T) 
 			PricePointID         string `json:"pricePointId"`
 			StartDate            string `json:"startDate"`
 			PreserveCurrentPrice bool   `json:"preserveCurrentPrice"`
+			PlanType             string `json:"planType"`
 		} `json:"results"`
 	}
 	if err := json.Unmarshal(data, &artifact); err != nil {
@@ -477,7 +723,7 @@ func TestSubscriptionsPricesImport_WritesVersionedFailureArtifact(t *testing.T) 
 		t.Fatalf("unexpected artifact: %+v", artifact)
 	}
 	result := artifact.Results[0]
-	if result.Territory != "USA" || result.Price != "19.99" || result.PricePointID != "pp-usa" || result.StartDate != "" || result.PreserveCurrentPrice {
+	if result.Territory != "USA" || result.Price != "19.99" || result.PricePointID != "pp-usa" || result.StartDate != "" || result.PreserveCurrentPrice || result.PlanType != "UPFRONT" {
 		t.Fatalf("artifact is missing desired price state: %+v", result)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_prices_import_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_import_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSubscriptionsPricesImport_InvalidBooleanReturnsUsageError(t *testing.T) {
@@ -143,6 +144,7 @@ func TestSubscriptionsPricesImport_DryRunResolvesASCExportAliasWithoutMutations(
 
 func TestSubscriptionsPricesImport_PartialFailureReturnsReportedErrorAndSummary(t *testing.T) {
 	setupAuth(t)
+	t.Chdir(t.TempDir())
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -162,6 +164,8 @@ func TestSubscriptionsPricesImport_PartialFailureReturnsReportedErrorAndSummary(
 				Body:       io.NopCloser(strings.NewReader(body)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			createCount++
 			payload, err := io.ReadAll(req.Body)
@@ -207,7 +211,7 @@ func TestSubscriptionsPricesImport_PartialFailureReturnsReportedErrorAndSummary(
 
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath}); err != nil {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())
@@ -235,5 +239,245 @@ func TestSubscriptionsPricesImport_PartialFailureReturnsReportedErrorAndSummary(
 	}
 	if createCount != 1 {
 		t.Fatalf("expected one successful create, got %d", createCount)
+	}
+}
+
+func TestSubscriptionsPricesImport_SkipsExactExistingPrice(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	postCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"2026-08-01","preserved":true},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost:
+			postCount++
+			t.Fatalf("exact existing price must not be posted again")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	csvBody := "territory,price,start_date,preserved,price_point_id\nUSA,19.99,2026-08-01,true,pp-usa\n"
+	if err := os.WriteFile(csvPath, []byte(csvBody), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var summary struct {
+		Created int `json:"created"`
+		Skipped int `json:"skipped"`
+		Failed  int `json:"failed"`
+		Results []struct {
+			Status string `json:"status"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Created != 0 || summary.Skipped != 1 || summary.Failed != 0 || postCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if len(summary.Results) != 1 || summary.Results[0].Status != "skipped" {
+		t.Fatalf("expected skipped row result, got %+v", summary.Results)
+	}
+}
+
+func TestSubscriptionsPricesImport_ReconcilesAmbiguousCreateWithoutReplay(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "2")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	postCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			readCount++
+			if readCount == 1 {
+				return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+			}
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-created","attributes":{"startDate":"2026-08-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			postCount++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","detail":"ambiguous"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	csvBody := "territory,price,start_date,price_point_id\nUSA,19.99,2026-08-01,pp-usa\n"
+	if err := os.WriteFile(csvPath, []byte(csvBody), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var summary struct {
+		Reconciled int `json:"reconciled"`
+		Failed     int `json:"failed"`
+		Results    []struct {
+			Status string `json:"status"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Reconciled != 1 || summary.Failed != 0 || postCount != 1 || readCount != 2 {
+		t.Fatalf("unexpected recovery result: summary=%+v posts=%d reads=%d", summary, postCount, readCount)
+	}
+	if len(summary.Results) != 1 || summary.Results[0].Status != "reconciled" {
+		t.Fatalf("expected reconciled row result, got %+v", summary.Results)
+	}
+}
+
+func TestSubscriptionsPricesImport_SkipsImmediatePriceWithConcreteEffectiveDate(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	readCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			readCount++
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-existing","attributes":{"startDate":"` + time.Now().UTC().Format("2006-01-02") + `","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("current immediate price must not be posted again")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	if err := os.WriteFile(csvPath, []byte("territory,price,price_point_id\nUSA,19.99,pp-usa\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	var summary struct {
+		Skipped int `json:"skipped"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v", err)
+	}
+	if summary.Skipped != 1 || readCount != 1 {
+		t.Fatalf("expected one indexed skip, summary=%+v reads=%d", summary, readCount)
+	}
+}
+
+func TestSubscriptionsPricesImport_WritesVersionedFailureArtifact(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	t.Chdir(t.TempDir())
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","detail":"still unavailable"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	csvBody := "territory,price,price_point_id\nUSA,19.99,pp-usa\n"
+	if err := os.WriteFile(csvPath, []byte(csvBody), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"subscriptions", "pricing", "prices", "import", "--subscription-id", "8000000001", "--input", csvPath, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %v", runErr)
+	}
+
+	var summary struct {
+		Failed              int    `json:"failed"`
+		FailureArtifactPath string `json:"failureArtifactPath"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.Failed != 1 || summary.FailureArtifactPath == "" {
+		t.Fatalf("expected failure artifact, got %+v", summary)
+	}
+	data, err := os.ReadFile(summary.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	var artifact struct {
+		SchemaVersion int `json:"schemaVersion"`
+		Failed        int `json:"failed"`
+		Results       []struct {
+			Status               string `json:"status"`
+			Territory            string `json:"territory"`
+			Price                string `json:"price"`
+			PricePointID         string `json:"pricePointId"`
+			StartDate            string `json:"startDate"`
+			PreserveCurrentPrice bool   `json:"preserveCurrentPrice"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		t.Fatalf("parse artifact: %v", err)
+	}
+	if artifact.SchemaVersion != 1 || artifact.Failed != 1 || len(artifact.Results) != 1 || artifact.Results[0].Status != "failed" {
+		t.Fatalf("unexpected artifact: %+v", artifact)
+	}
+	result := artifact.Results[0]
+	if result.Territory != "USA" || result.Price != "19.99" || result.PricePointID != "pp-usa" || result.StartDate != "" || result.PreserveCurrentPrice {
+		t.Fatalf("artifact is missing desired price state: %+v", result)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
@@ -7,9 +7,51 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+func TestSubscriptionsPricingPricesListResolvedUsesFreshDeadlinePerPage(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	requestCount := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			time.Sleep(60 * time.Millisecond)
+			return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":"/v1/subscriptions/8000000001/prices?cursor=next"}}`)
+		}
+		deadline, ok := req.Context().Deadline()
+		if !ok || time.Until(deadline) < 70*time.Millisecond {
+			t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
+		}
+		return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--resolved",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two page requests, got %d; stdout=%q", requestCount, stdout)
+	}
+}
 
 func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 	setupAuth(t)

--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -740,7 +740,7 @@ func TestSubscriptionsPricingEqualize_RetriesInitialPriceAfterNegativeReadback(t
 	if postCount != 1 {
 		t.Fatalf("expected one follow-up POST, got %d", postCount)
 	}
-	if strings.Join(steps, ",") != "availability,pricing-territories,territories,patch,verify,patch,price" {
+	if strings.Join(steps, ",") != "availability,pricing-territories,territories,patch,verify,verify,patch,price" {
 		t.Fatalf("expected availability validation before pricing, got %v", steps)
 	}
 

--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -652,8 +652,11 @@ func TestSubscriptionsPricingEqualize_ApplyFailsWhenAvailabilityDoesNotCoverAllT
 	}
 }
 
-func TestSubscriptionsPricingEqualize_InitialPriceUsesPatchThenCreatesRemainingTerritories(t *testing.T) {
+func TestSubscriptionsPricingEqualize_RetriesInitialPriceAfterNegativeReadback(t *testing.T) {
 	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -686,9 +689,15 @@ func TestSubscriptionsPricingEqualize_InitialPriceUsesPatchThenCreatesRemainingT
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/relationships/prices":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			steps = append(steps, "verify")
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"included":[],"links":{}}`), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/8000000001":
 			steps = append(steps, "patch")
 			patchCount++
+			if patchCount == 1 {
+				return jsonHTTPResponse(http.StatusGatewayTimeout, `{"errors":[{"status":"504","code":"UNEXPECTED_ERROR","detail":"ambiguous timeout"}]}`), nil
+			}
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001"}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			steps = append(steps, "price")
@@ -716,6 +725,7 @@ func TestSubscriptionsPricingEqualize_InitialPriceUsesPatchThenCreatesRemainingT
 			"--subscription-id", "8000000001",
 			"--base-price", "0.99",
 			"--confirm",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -724,13 +734,13 @@ func TestSubscriptionsPricingEqualize_InitialPriceUsesPatchThenCreatesRemainingT
 		}
 	})
 
-	if patchCount != 1 {
-		t.Fatalf("expected one initial PATCH, got %d", patchCount)
+	if patchCount != 2 {
+		t.Fatalf("expected one replay after negative readback, got %d PATCHes", patchCount)
 	}
 	if postCount != 1 {
 		t.Fatalf("expected one follow-up POST, got %d", postCount)
 	}
-	if strings.Join(steps, ",") != "availability,pricing-territories,territories,patch,price" {
+	if strings.Join(steps, ",") != "availability,pricing-territories,territories,patch,verify,patch,price" {
 		t.Fatalf("expected availability validation before pricing, got %v", steps)
 	}
 
@@ -1310,6 +1320,8 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableTerritoryFailures(t *testi
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-existing"}],"links":{}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"8000000001","attributes":{"state":"READY_TO_SUBMIT"}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"included":[],"links":{}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
@@ -1416,14 +1428,11 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableFailuresButKeepsNonRetryab
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/prices":
 			body := `{
 				"data":[
-					{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + basePricePointID + `"}}}},
-					{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + canPricePointID + `"}}}}
+					{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2025-01-01","preserved":false},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"` + basePricePointID + `"}}}}
 				],
 				"included":[
 					{"type":"subscriptionPricePoints","id":"` + basePricePointID + `","attributes":{"customerPrice":"0.99","proceeds":"0.70","proceedsYear2":"0.84"}},
-					{"type":"subscriptionPricePoints","id":"` + canPricePointID + `","attributes":{"customerPrice":"1.29","proceeds":"0.90","proceedsYear2":"1.05"}},
-					{"type":"territories","id":"USA","attributes":{"currency":"USD"}},
-					{"type":"territories","id":"CAN","attributes":{"currency":"CAD"}}
+					{"type":"territories","id":"USA","attributes":{"currency":"USD"}}
 				],
 				"links":{"next":""}
 			}`
@@ -1504,7 +1513,7 @@ func TestSubscriptionsPricingEqualize_RetriesRetryableFailuresButKeepsNonRetryab
 	}
 }
 
-func TestSubscriptionsPricingEqualize_ReconcilesConflictAfterRetryableFailure(t *testing.T) {
+func TestSubscriptionsPricingEqualize_ReconcilesBeforeRetryingMutation(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_MAX_RETRIES", "0")
 
@@ -1563,10 +1572,10 @@ func TestSubscriptionsPricingEqualize_ReconcilesConflictAfterRetryableFailure(t 
 				return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-usa"}}`), nil
 			case strings.Contains(string(body), `"id":"CAN"`):
 				canAttempts++
-				if canAttempts == 1 {
-					return jsonHTTPResponse(http.StatusTooManyRequests, `{"errors":[{"status":"429","code":"RATE_LIMIT_EXCEEDED","title":"Too Many Requests","detail":"retry later"}]}`), nil
+				if canAttempts > 1 {
+					t.Fatalf("unsafe replay: CAN was already visible during reconciliation")
 				}
-				return jsonHTTPResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR","title":"Conflict","detail":"duplicate"}]}`), nil
+				return jsonHTTPResponse(http.StatusTooManyRequests, `{"errors":[{"status":"429","code":"RATE_LIMIT_EXCEEDED","title":"Too Many Requests","detail":"retry later"}]}`), nil
 			default:
 				t.Fatalf("unexpected subscription price body: %s", string(body))
 				return nil, nil
@@ -1587,6 +1596,7 @@ func TestSubscriptionsPricingEqualize_ReconcilesConflictAfterRetryableFailure(t 
 			"--base-price", "0.99",
 			"--confirm",
 			"--workers", "2",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -1595,8 +1605,8 @@ func TestSubscriptionsPricingEqualize_ReconcilesConflictAfterRetryableFailure(t 
 		}
 	})
 
-	if canAttempts != 2 {
-		t.Fatalf("expected CAN create to be retried once before reconciliation, got %d attempts", canAttempts)
+	if canAttempts != 1 {
+		t.Fatalf("expected CAN create not to replay after successful readback, got %d attempts", canAttempts)
 	}
 	if verifyReads != 1 {
 		t.Fatalf("expected one verification read, got %d", verifyReads)
@@ -1692,6 +1702,7 @@ func TestSubscriptionsPricingEqualize_ReconcilesInitialPriceFailureBeforeStoppin
 			"--subscription-id", "8000000001",
 			"--base-price", "0.99",
 			"--confirm",
+			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}

--- a/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
+++ b/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
@@ -1,0 +1,796 @@
+package cmdtest
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubscriptionsReviewScreenshotCreateSkipsCompleteMatchingAsset(t *testing.T) {
+	setupAuth(t)
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected state reads only, got %s %s", req.Method, req.URL.Path)
+		}
+		if req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1" {
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotFullResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE")), nil
+		}
+		if req.URL.Path != "/v1/subscriptions/8000000001/appStoreReviewScreenshot" {
+			t.Fatalf("unexpected state read: %s", req.URL.Path)
+		}
+		assertSubscriptionReviewScreenshotSparseFields(t, req)
+		return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), strings.ToUpper(checksum), "COMPLETE", false)), nil
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil || stderr != "" || requests != 2 {
+		t.Fatalf("unexpected skip result: requests=%d stdout=%q stderr=%q err=%v", requests, stdout, stderr, err)
+	}
+	attributes := subscriptionReviewScreenshotOutputAttributes(t, stdout)
+	imageAsset, ok := attributes["imageAsset"].(map[string]any)
+	if attributes["assetToken"] != "asset-token" || !ok || imageAsset["templateUrl"] != "https://example.test/image/{w}x{h}.png" {
+		t.Fatalf("unexpected skip attributes: %#v", attributes)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateResumesMatchingReservation(t *testing.T) {
+	setupAuth(t)
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	sequence := make([]string, 0, 4)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			sequence = append(sequence, "read")
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			sequence = append(sequence, "upload")
+			body, err := io.ReadAll(req.Body)
+			if err != nil || string(body) != string(content) {
+				t.Fatalf("unexpected upload body: %q err=%v", body, err)
+			}
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			sequence = append(sequence, "commit")
+			assertSubscriptionReviewScreenshotCommit(t, req, checksum)
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			sequence = append(sequence, "poll")
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotFullResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE")), nil
+		default:
+			t.Fatalf("unexpected request: %s %s host=%s", req.Method, req.URL.Path, req.URL.Host)
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil || stderr != "" {
+		t.Fatalf("unexpected resume result: stdout=%q stderr=%q err=%v", stdout, stderr, err)
+	}
+	if want := []string{"read", "upload", "commit", "poll"}; !reflect.DeepEqual(sequence, want) {
+		t.Fatalf("expected sequence %v, got %v", want, sequence)
+	}
+	attributes := subscriptionReviewScreenshotOutputAttributes(t, stdout)
+	imageAsset, ok := attributes["imageAsset"].(map[string]any)
+	if attributes["assetToken"] != "asset-token" || !ok || imageAsset["templateUrl"] != "https://example.test/image/{w}x{h}.png" {
+		t.Fatalf("unexpected upload attributes: %#v", attributes)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateRejectsConflictingReservationDuringReconciliation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, _ := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	posts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			reads++
+			if reads == 1 {
+				return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-2", "other.png", int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots":
+			posts++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+		default:
+			t.Fatalf("conflicting reservation must stop recovery: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err == nil || !strings.Contains(err.Error(), "different incomplete") {
+		t.Fatalf("expected conflicting reservation error, got %v", err)
+	}
+	if stdout != "" || stderr != "" || posts != 1 || reads != 2 {
+		t.Fatalf("unexpected conflict result: reads=%d posts=%d stdout=%q stderr=%q", reads, posts, stdout, stderr)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateRejectsConflictingCommitDuringReconciliation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, _ := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	puts := 0
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			reads++
+			if reads == 1 {
+				return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-2", filepath.Base(path), int64(len(content)), "different", "PROCESSING", false)), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			puts++
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			patches++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+		default:
+			t.Fatalf("conflicting commit must stop recovery: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err == nil || !strings.Contains(err.Error(), "instead of upload reservation") {
+		t.Fatalf("expected conflicting commit error, got %v", err)
+	}
+	if stdout != "" || stderr != "" || puts != 1 || patches != 1 || reads != 2 {
+		t.Fatalf("unexpected conflict result: reads=%d puts=%d patches=%d stdout=%q stderr=%q", reads, puts, patches, stdout, stderr)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreatePollsMatchingProcessingAsset(t *testing.T) {
+	setupAuth(t)
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("processing resume must not mutate: %s %s", req.Method, req.URL.Path)
+		}
+		reads++
+		if req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot" {
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		}
+		if req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1" {
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		}
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil || stderr != "" || reads != 2 {
+		t.Fatalf("unexpected processing result: reads=%d stdout=%q stderr=%q err=%v", reads, stdout, stderr, err)
+	}
+	attributes := subscriptionReviewScreenshotOutputAttributes(t, stdout)
+	deliveryState, ok := attributes["assetDeliveryState"].(map[string]any)
+	if !ok || deliveryState["state"] != "COMPLETE" {
+		t.Fatalf("unexpected processing attributes: %#v", attributes)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateRejectsChangedChecksumDuringPoll(t *testing.T) {
+	setupAuth(t)
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("checksum race must not mutate: %s %s", req.Method, req.URL.Path)
+		}
+		reads++
+		switch req.URL.Path {
+		case "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "different", "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err == nil || !strings.Contains(err.Error(), "checksum changed") {
+		t.Fatalf("expected checksum race error, got %v", err)
+	}
+	if stdout != "" || stderr != "" || reads != 2 {
+		t.Fatalf("unexpected checksum race result: reads=%d stdout=%q stderr=%q", reads, stdout, stderr)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateStopsWhenPollDeadlineExpires(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "20ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("poll timeout must not mutate: %s %s", req.Method, req.URL.Path)
+		}
+		reads++
+		return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected poll deadline exceeded, got %v", err)
+	}
+	if stdout != "" || stderr != "" || reads != 2 {
+		t.Fatalf("unexpected poll timeout result: reads=%d stdout=%q stderr=%q", reads, stdout, stderr)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateReconcilesAmbiguousReservation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reads := 0
+	posts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			reads++
+			if reads == 1 {
+				return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots":
+			posts++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil || stderr != "" || posts != 1 || reads != 2 {
+		t.Fatalf("unexpected reservation reconcile: reads=%d posts=%d stderr=%q err=%v", reads, posts, stderr, err)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateReconcilesAmbiguousCommit(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	relationshipReads := 0
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			relationshipReads++
+			if relationshipReads == 1 {
+				return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			patches++
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil || stderr != "" || patches != 1 || relationshipReads != 2 {
+		t.Fatalf("unexpected commit reconcile: reads=%d patches=%d stderr=%q err=%v", relationshipReads, patches, stderr, err)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateRejectsMismatchedCommitResponse(t *testing.T) {
+	setupAuth(t)
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	puts := 0
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			puts++
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			patches++
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-other", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		default:
+			t.Fatalf("mismatched commit must not be polled: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err == nil || !strings.Contains(err.Error(), "instead of upload reservation") {
+		t.Fatalf("expected mismatched commit error, got %v", err)
+	}
+	if stdout != "" || stderr != "" || puts != 1 || patches != 1 {
+		t.Fatalf("unexpected mismatched commit result: puts=%d patches=%d stdout=%q stderr=%q", puts, patches, stdout, stderr)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateTreatsNullRelationshipAsAbsentBeforeReservationReplay(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	sequence := make([]string, 0, 5)
+	reads := 0
+	posts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			reads++
+			sequence = append(sequence, "read")
+			return jsonHTTPResponse(http.StatusOK, `{"data":null,"links":{"self":"https://api.appstoreconnect.apple.com/v1/subscriptions/8000000001/appStoreReviewScreenshot"}}`), nil
+		case req.Method == http.MethodPost:
+			posts++
+			sequence = append(sequence, "post")
+			if posts == 1 {
+				return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusCreated, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPut:
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch:
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_, _, err := runSubscriptionReviewScreenshotCreate(t, path)
+	want := []string{"read", "post", "read", "read", "post"}
+	if err != nil || reads != 3 || posts != 2 || !reflect.DeepEqual(sequence, want) {
+		t.Fatalf("expected bounded replay %v, got sequence=%v reads=%d posts=%d err=%v", want, sequence, reads, posts, err)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateReadsTwiceBeforeCommitReplay(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	relationshipReads := 0
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			relationshipReads++
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPut:
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch:
+			patches++
+			if patches == 1 {
+				return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_, _, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil || relationshipReads != 3 || patches != 2 {
+		t.Fatalf("expected two negative commit readbacks before replay, reads=%d patches=%d err=%v", relationshipReads, patches, err)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateUsesFreshStageDeadlines(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "500ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		if !ok || time.Until(deadline) < 350*time.Millisecond {
+			t.Fatalf("expected fresh deadline for %s %s, remaining=%s", req.Method, req.URL.Path, time.Until(deadline))
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			time.Sleep(300 * time.Millisecond)
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`), nil
+		case req.Method == http.MethodPost:
+			time.Sleep(300 * time.Millisecond)
+			return jsonHTTPResponse(http.StatusCreated, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+		case req.Method == http.MethodPut:
+			time.Sleep(300 * time.Millisecond)
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch:
+			time.Sleep(300 * time.Millisecond)
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_, _, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err != nil {
+		t.Fatalf("unexpected fresh-stage result: %v", err)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateUsesFreshTimeoutForEachUploadPart(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_UPLOAD_TIMEOUT", "150ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+	firstLength := int64(len(content) / 2)
+	operations := []map[string]any{
+		{"method": "PUT", "url": "https://upload.example/part-1", "length": firstLength, "offset": int64(0)},
+		{"method": "PUT", "url": "https://upload.example/part-2", "length": int64(len(content)) - firstLength, "offset": firstLength},
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	sequence := make([]string, 0, 7)
+	partTwoAttempts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			sequence = append(sequence, "read")
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponseWithOperations("shot-1", filepath.Base(path), int64(len(content)), operations)), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 100*time.Millisecond {
+				t.Fatalf("upload part inherited stale deadline: %s", time.Until(deadline))
+			}
+			sequence = append(sequence, req.URL.Path)
+			if req.URL.Path == "/part-1" {
+				time.Sleep(75 * time.Millisecond)
+				return jsonHTTPResponse(http.StatusOK, ``), nil
+			}
+			partTwoAttempts++
+			if partTwoAttempts == 1 {
+				return jsonHTTPResponse(http.StatusServiceUnavailable, ``), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			sequence = append(sequence, "commit")
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+			sequence = append(sequence, "poll")
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_, _, err := runSubscriptionReviewScreenshotCreate(t, path)
+	want := []string{"read", "/part-1", "/part-2", "/part-2", "commit", "poll"}
+	if err != nil || !reflect.DeepEqual(sequence, want) {
+		t.Fatalf("expected multipart sequence %v, got %v err=%v", want, sequence, err)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateDoesNotCommitAfterUploadFailure(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	path, content, _ := writeSubscriptionReviewScreenshotFixture(t)
+	firstLength := int64(len(content) / 2)
+	operations := []map[string]any{
+		{"method": "PUT", "url": "https://upload.example/part-1", "length": firstLength, "offset": int64(0)},
+		{"method": "PUT", "url": "https://upload.example/part-2", "length": int64(len(content)) - firstLength, "offset": firstLength},
+	}
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	puts := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponseWithOperations("shot-1", filepath.Base(path), int64(len(content)), operations)), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			puts++
+			if req.URL.Path == "/part-2" {
+				return jsonHTTPResponse(http.StatusBadRequest, ``), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, ``), nil
+		default:
+			t.Fatalf("failed upload must not be committed: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+	if err == nil || !strings.Contains(err.Error(), "upload request failed") {
+		t.Fatalf("expected upload failure, got %v", err)
+	}
+	if stdout != "" || stderr != "" || puts != 2 {
+		t.Fatalf("unexpected failed upload result: puts=%d stdout=%q stderr=%q", puts, stdout, stderr)
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateRejectsUnsafeExistingState(t *testing.T) {
+	tests := []struct {
+		name     string
+		checksum func(string) string
+		state    string
+		ops      bool
+		fileName string
+		status   int
+		body     string
+		want     string
+	}{
+		{name: "complete conflict", checksum: func(string) string { return "different" }, state: "COMPLETE", want: "different checksum"},
+		{name: "failed delivery", checksum: func(value string) string { return value }, state: "FAILED", want: "delivery failed"},
+		{name: "missing operations", checksum: func(string) string { return "" }, state: "", want: "no upload operations"},
+		{name: "incomplete identity mismatch", checksum: func(string) string { return "" }, state: "", ops: true, fileName: "other.png", want: "different incomplete"},
+		{name: "forbidden read", status: http.StatusForbidden, body: `{"errors":[{"status":"403","code":"FORBIDDEN","detail":"denied"}]}`, want: "denied"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_MAX_RETRIES", "0")
+			path, content, checksum := writeSubscriptionReviewScreenshotFixture(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			requests := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				if req.Method != http.MethodGet {
+					t.Fatalf("unsafe state must not mutate: %s %s", req.Method, req.URL.Path)
+				}
+				if tt.status != 0 {
+					return jsonHTTPResponse(tt.status, tt.body), nil
+				}
+				fileName := tt.fileName
+				if fileName == "" {
+					fileName = filepath.Base(path)
+				}
+				return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", fileName, int64(len(content)), tt.checksum(checksum), tt.state, tt.ops)), nil
+			})
+
+			stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+			if err == nil || !strings.Contains(err.Error(), tt.want) || stdout != "" || stderr != "" || requests != 1 {
+				t.Fatalf("expected %q: requests=%d stdout=%q stderr=%q err=%v", tt.want, requests, stdout, stderr, err)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsReviewScreenshotCreateRejectsUnsafeInvocationBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name    string
+		extra   []string
+		wantErr string
+	}{
+		{name: "positional", extra: []string{"stray"}, wantErr: "does not accept positional arguments"},
+		{name: "unsupported output", extra: []string{"--output", "yaml"}, wantErr: "unsupported format: yaml"},
+		{name: "pretty table", extra: []string{"--output", "table", "--pretty"}, wantErr: "--pretty is only valid with JSON output"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			path, _, _ := writeSubscriptionReviewScreenshotFixture(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+				return nil, nil
+			})
+			args := []string{"subscriptions", "review", "screenshots", "create"}
+			args = append(args, tt.extra...)
+			args = append(args, "--subscription-id", "8000000001", "--file", path)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				err := root.Run(context.Background())
+				if err == nil {
+					t.Fatal("expected usage error")
+				}
+			})
+			if stdout != "" || !strings.Contains(stderr, tt.wantErr) {
+				t.Fatalf("expected %q, stdout=%q stderr=%q", tt.wantErr, stdout, stderr)
+			}
+		})
+	}
+}
+
+func runSubscriptionReviewScreenshotCreate(t *testing.T, path string) (string, string, error) {
+	t.Helper()
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "review", "screenshots", "create",
+			"--subscription-id", "8000000001",
+			"--file", path,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func writeSubscriptionReviewScreenshotFixture(t *testing.T) (string, []byte, string) {
+	t.Helper()
+	content := []byte("subscription-review-screenshot")
+	path := filepath.Join(t.TempDir(), "review.png")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write screenshot fixture: %v", err)
+	}
+	sum := md5.Sum(content)
+	return path, content, hex.EncodeToString(sum[:])
+}
+
+func subscriptionReviewScreenshotResponse(id, fileName string, fileSize int64, checksum, state string, uploadOperations bool) string {
+	attributes := map[string]any{
+		"fileName":           fileName,
+		"fileSize":           fileSize,
+		"sourceFileChecksum": checksum,
+	}
+	if state != "" {
+		attributes["assetDeliveryState"] = map[string]any{"state": state, "errors": []map[string]string{{"code": "DELIVERY_ERROR", "message": "delivery failed"}}}
+	}
+	if uploadOperations {
+		attributes["uploadOperations"] = []map[string]any{{
+			"method": "PUT",
+			"url":    "https://upload.example/part",
+			"length": fileSize,
+			"offset": int64(0),
+		}}
+	}
+	payload := map[string]any{
+		"data": map[string]any{
+			"type":       "subscriptionAppStoreReviewScreenshots",
+			"id":         id,
+			"attributes": attributes,
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func subscriptionReviewScreenshotFullResponse(id, fileName string, fileSize int64, checksum, state string) string {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(subscriptionReviewScreenshotResponse(id, fileName, fileSize, checksum, state, false)), &payload); err != nil {
+		panic(err)
+	}
+	data := payload["data"].(map[string]any)
+	attributes := data["attributes"].(map[string]any)
+	attributes["assetToken"] = "asset-token"
+	attributes["imageAsset"] = map[string]any{
+		"templateUrl": "https://example.test/image/{w}x{h}.png",
+		"width":       1280,
+		"height":      720,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func subscriptionReviewScreenshotResponseWithOperations(id, fileName string, fileSize int64, operations []map[string]any) string {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(subscriptionReviewScreenshotResponse(id, fileName, fileSize, "", "", false)), &payload); err != nil {
+		panic(err)
+	}
+	data := payload["data"].(map[string]any)
+	attributes := data["attributes"].(map[string]any)
+	attributes["uploadOperations"] = operations
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func subscriptionReviewScreenshotOutputAttributes(t *testing.T, stdout string) map[string]any {
+	t.Helper()
+	var payload struct {
+		Data struct {
+			Attributes map[string]any `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("parse screenshot output: %v\n%s", err, stdout)
+	}
+	if payload.Data.Attributes == nil {
+		t.Fatalf("screenshot output is missing attributes: %s", stdout)
+	}
+	return payload.Data.Attributes
+}
+
+func assertSubscriptionReviewScreenshotSparseFields(t *testing.T, req *http.Request) {
+	t.Helper()
+	want := "fileName,fileSize,sourceFileChecksum,uploadOperations,assetDeliveryState"
+	if got := req.URL.Query().Get("fields[subscriptionAppStoreReviewScreenshots]"); got != want {
+		t.Fatalf("expected sparse fields %q, got %q", want, got)
+	}
+}
+
+func assertSubscriptionReviewScreenshotCommit(t *testing.T, req *http.Request, checksum string) {
+	t.Helper()
+	var payload struct {
+		Data struct {
+			Attributes map[string]any `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode commit: %v", err)
+	}
+	want := map[string]any{"sourceFileChecksum": checksum, "uploaded": true}
+	if !reflect.DeepEqual(payload.Data.Attributes, want) {
+		t.Fatalf("expected commit attributes %#v, got %#v", want, payload.Data.Attributes)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_review_screenshots_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_review_screenshots_create_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,6 +24,7 @@ func TestSubscriptionsReviewScreenshotsCreatePrintsVerifiedScreenshot(t *testing
 	if err != nil {
 		t.Fatalf("stat review screenshot fixture: %v", err)
 	}
+	checksum := reviewScreenshotFileMD5(t, imagePath)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -31,6 +34,9 @@ func TestSubscriptionsReviewScreenshotsCreatePrintsVerifiedScreenshot(t *testing
 	getRequests := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			assertSubscriptionReviewScreenshotSparseFields(t, req)
+			return jsonResponse(http.StatusOK, `{"data":null}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots":
 			body := fmt.Sprintf(`{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","fileSize":%d,"uploadOperations":[{"method":"PUT","url":"https://upload.example.com/upload/shot-1","length":%d,"offset":0}]}}}`, imageInfo.Size(), imageInfo.Size())
 			return jsonResponse(http.StatusCreated, body)
@@ -44,7 +50,8 @@ func TestSubscriptionsReviewScreenshotsCreatePrintsVerifiedScreenshot(t *testing
 			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
 			getRequests++
-			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+			body := fmt.Sprintf(`{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","sourceFileChecksum":%q,"assetDeliveryState":{"state":"COMPLETE"}}}}`, checksum)
+			return jsonResponse(http.StatusOK, body)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -104,6 +111,7 @@ func TestSubscriptionsReviewScreenshotsCreateFailsWhenDeliveryVerificationFails(
 	if err != nil {
 		t.Fatalf("stat review screenshot fixture: %v", err)
 	}
+	checksum := reviewScreenshotFileMD5(t, imagePath)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -113,6 +121,9 @@ func TestSubscriptionsReviewScreenshotsCreateFailsWhenDeliveryVerificationFails(
 	getRequests := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+			assertSubscriptionReviewScreenshotSparseFields(t, req)
+			return jsonResponse(http.StatusOK, `{"data":null}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots":
 			body := fmt.Sprintf(`{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","fileSize":%d,"uploadOperations":[{"method":"PUT","url":"https://upload.example.com/upload/shot-1","length":%d,"offset":0}]}}}`, imageInfo.Size(), imageInfo.Size())
 			return jsonResponse(http.StatusCreated, body)
@@ -126,7 +137,8 @@ func TestSubscriptionsReviewScreenshotsCreateFailsWhenDeliveryVerificationFails(
 			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
 			getRequests++
-			return jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","assetDeliveryState":{"state":"FAILED","errors":[{"message":"Virus scan failed"}]}}}}`)
+			body := fmt.Sprintf(`{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","sourceFileChecksum":%q,"assetDeliveryState":{"state":"FAILED","errors":[{"message":"Virus scan failed"}]}}}}`, checksum)
+			return jsonResponse(http.StatusOK, body)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -164,4 +176,14 @@ func TestSubscriptionsReviewScreenshotsCreateFailsWhenDeliveryVerificationFails(
 	if getRequests != 1 {
 		t.Fatalf("expected 1 GET request from polling, got %d", getRequests)
 	}
+}
+
+func reviewScreenshotFileMD5(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read review screenshot fixture: %v", err)
+	}
+	sum := md5.Sum(contents)
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/cli/cmdtest/test_main_test.go
+++ b/internal/cli/cmdtest/test_main_test.go
@@ -17,6 +17,7 @@ func TestMain(m *testing.M) {
 
 	_ = os.Setenv("ASC_CONFIG_PATH", testConfigPath)
 	_ = os.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	_ = os.Setenv("ASC_MAX_RETRIES", "0")
 	_ = os.Setenv("ASC_TELEMETRY_DISABLED", "1")
 	_ = os.Setenv("HOME", tempDir)
 

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -2,7 +2,6 @@ package localizations
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -147,7 +146,6 @@ Examples:
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
 					return flag.ErrHelp
 				}
-
 				client, err := shared.GetASCClient()
 				if err != nil {
 					return fmt.Errorf("localizations list: %w", err)
@@ -323,7 +321,6 @@ Examples:
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
 					return flag.ErrHelp
 				}
-
 				client, err := shared.GetASCClient()
 				if err != nil {
 					return fmt.Errorf("localizations download: %w", err)
@@ -454,6 +451,9 @@ Examples:
 
 				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
 					return fmt.Errorf("localizations upload: %w", err)
 				}
 				if err := shared.ValidateVersionLocalizationValueSet(valuesByLocale); err != nil {
@@ -486,18 +486,18 @@ Examples:
 				}
 				shared.FinalizeLocalizationUploadResult(&result, "localizations upload")
 
-				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+				if err := shared.PrintOutputWithRenderers(
+					&result, *output.Output, *output.Pretty,
+					func() error { return shared.RenderLocalizationUploadResult(&result, false) },
+					func() error { return shared.RenderLocalizationUploadResult(&result, true) },
+				); err != nil {
 					return err
 				}
 				if err := shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings); err != nil {
 					return err
 				}
 				if uploadErr != nil || result.FailureArtifactError != "" {
-					return shared.NewReportedError(errors.Join(
-						fmt.Errorf("localizations upload: %d locale(s) failed", result.Failed),
-						uploadErr,
-						localizationUploadArtifactError(result.FailureArtifactError),
-					))
+					return localizationUploadReportedError(result.Failed, uploadErr, result.FailureArtifactError)
 				}
 				return nil
 			case shared.LocalizationTypeAppInfo:
@@ -505,6 +505,16 @@ Examples:
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
 					return flag.ErrHelp
+				}
+				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
+				if err != nil {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
+					return fmt.Errorf("localizations upload: %w", err)
+				}
+				if err := shared.ValidateAppInfoLocalizationValueSet(valuesByLocale); err != nil {
+					return shared.UsageError(err.Error())
 				}
 
 				client, err := shared.GetASCClient()
@@ -515,11 +525,6 @@ Examples:
 				appInfo, err := shared.RetryReadWithFreshTimeout(ctx, func(resolveCtx context.Context) (string, error) {
 					return shared.ResolveAppInfoID(resolveCtx, client, resolvedAppID, strings.TrimSpace(*appInfoID))
 				})
-				if err != nil {
-					return fmt.Errorf("localizations upload: %w", err)
-				}
-
-				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {
 					return fmt.Errorf("localizations upload: %w", err)
 				}
@@ -540,15 +545,15 @@ Examples:
 				}
 				shared.FinalizeLocalizationUploadResult(&result, "localizations upload")
 
-				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+				if err := shared.PrintOutputWithRenderers(
+					&result, *output.Output, *output.Pretty,
+					func() error { return shared.RenderLocalizationUploadResult(&result, false) },
+					func() error { return shared.RenderLocalizationUploadResult(&result, true) },
+				); err != nil {
 					return err
 				}
 				if uploadErr != nil || result.FailureArtifactError != "" {
-					return shared.NewReportedError(errors.Join(
-						fmt.Errorf("localizations upload: %d locale(s) failed", result.Failed),
-						uploadErr,
-						localizationUploadArtifactError(result.FailureArtifactError),
-					))
+					return localizationUploadReportedError(result.Failed, uploadErr, result.FailureArtifactError)
 				}
 				return nil
 			default:
@@ -558,11 +563,15 @@ Examples:
 	}
 }
 
-func localizationUploadArtifactError(message string) error {
-	if strings.TrimSpace(message) == "" {
-		return nil
+func localizationUploadReportedError(failed int, uploadErr error, artifactError string) error {
+	message := fmt.Sprintf("localizations upload: %d locale(s) failed", failed)
+	if uploadErr != nil {
+		message += ": " + uploadErr.Error()
 	}
-	return fmt.Errorf("write failure artifact: %s", message)
+	if strings.TrimSpace(artifactError) != "" {
+		message += "; write failure artifact: " + artifactError
+	}
+	return shared.NewReportedError(fmt.Errorf("%s", message))
 }
 
 func sharedVersionLocalizationValuesNeedUpdateContext(valuesByLocale map[string]map[string]string) bool {

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -2,6 +2,7 @@ package localizations
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -464,29 +465,41 @@ Examples:
 					return fmt.Errorf("localizations upload: %w", err)
 				}
 
-				requestCtx, cancel := shared.ContextWithTimeout(ctx)
-				defer cancel()
-
 				submitOpts := shared.SubmitReadinessOptions{}
 				if sharedVersionLocalizationValuesNeedUpdateContext(valuesByLocale) {
-					submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(requestCtx, client, strings.TrimSpace(*versionID), "", "")
+					readinessCtx, readinessCancel := shared.ContextWithTimeout(ctx)
+					submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(readinessCtx, client, strings.TrimSpace(*versionID), "", "")
+					readinessCancel()
 				}
-				results, warnings, err := shared.UploadPrevalidatedVersionLocalizationsWithWarnings(requestCtx, client, strings.TrimSpace(*versionID), valuesByLocale, *dryRun, submitOpts)
-				if err != nil {
+				results, warnings, err := shared.UploadPrevalidatedVersionLocalizationsWithWarnings(ctx, client, strings.TrimSpace(*versionID), valuesByLocale, *dryRun, submitOpts)
+				if err != nil && len(results) == 0 {
 					return fmt.Errorf("localizations upload: %w", err)
 				}
+				uploadErr := err
 
 				result := asc.LocalizationUploadResult{
 					Type:      normalizedType,
 					VersionID: strings.TrimSpace(*versionID),
 					DryRun:    *dryRun,
+					InputPath: strings.TrimSpace(*path),
 					Results:   results,
 				}
+				shared.FinalizeLocalizationUploadResult(&result, "localizations upload")
 
 				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
 					return err
 				}
-				return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings)
+				if err := shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings); err != nil {
+					return err
+				}
+				if uploadErr != nil || result.FailureArtifactError != "" {
+					return shared.NewReportedError(errors.Join(
+						fmt.Errorf("localizations upload: %d locale(s) failed", result.Failed),
+						uploadErr,
+						localizationUploadArtifactError(result.FailureArtifactError),
+					))
+				}
+				return nil
 			case shared.LocalizationTypeAppInfo:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
@@ -499,10 +512,9 @@ Examples:
 					return fmt.Errorf("localizations upload: %w", err)
 				}
 
-				requestCtx, cancel := shared.ContextWithTimeout(ctx)
-				defer cancel()
-
-				appInfo, err := shared.ResolveAppInfoID(requestCtx, client, resolvedAppID, strings.TrimSpace(*appInfoID))
+				appInfo, err := shared.RetryReadWithFreshTimeout(ctx, func(resolveCtx context.Context) (string, error) {
+					return shared.ResolveAppInfoID(resolveCtx, client, resolvedAppID, strings.TrimSpace(*appInfoID))
+				})
 				if err != nil {
 					return fmt.Errorf("localizations upload: %w", err)
 				}
@@ -512,25 +524,45 @@ Examples:
 					return fmt.Errorf("localizations upload: %w", err)
 				}
 
-				results, err := shared.UploadAppInfoLocalizations(requestCtx, client, appInfo, valuesByLocale, *dryRun)
-				if err != nil {
+				results, err := shared.UploadAppInfoLocalizations(ctx, client, appInfo, valuesByLocale, *dryRun)
+				if err != nil && len(results) == 0 {
 					return fmt.Errorf("localizations upload: %w", err)
 				}
+				uploadErr := err
 
 				result := asc.LocalizationUploadResult{
 					Type:      normalizedType,
 					AppID:     resolvedAppID,
 					AppInfoID: appInfo,
 					DryRun:    *dryRun,
+					InputPath: strings.TrimSpace(*path),
 					Results:   results,
 				}
+				shared.FinalizeLocalizationUploadResult(&result, "localizations upload")
 
-				return shared.PrintOutput(&result, *output.Output, *output.Pretty)
+				if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+					return err
+				}
+				if uploadErr != nil || result.FailureArtifactError != "" {
+					return shared.NewReportedError(errors.Join(
+						fmt.Errorf("localizations upload: %d locale(s) failed", result.Failed),
+						uploadErr,
+						localizationUploadArtifactError(result.FailureArtifactError),
+					))
+				}
+				return nil
 			default:
 				return fmt.Errorf("localizations upload: unsupported type %q", normalizedType)
 			}
 		},
 	}
+}
+
+func localizationUploadArtifactError(message string) error {
+	if strings.TrimSpace(message) == "" {
+		return nil
+	}
+	return fmt.Errorf("write failure artifact: %s", message)
 }
 
 func sharedVersionLocalizationValuesNeedUpdateContext(valuesByLocale map[string]map[string]string) bool {

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -473,6 +473,9 @@ Examples:
 				}
 				results, warnings, err := shared.UploadPrevalidatedVersionLocalizationsWithWarnings(ctx, client, strings.TrimSpace(*versionID), valuesByLocale, *dryRun, submitOpts)
 				if err != nil && len(results) == 0 {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
 					return fmt.Errorf("localizations upload: %w", err)
 				}
 				uploadErr := err
@@ -531,6 +534,9 @@ Examples:
 
 				results, err := shared.UploadAppInfoLocalizations(ctx, client, appInfo, valuesByLocale, *dryRun)
 				if err != nil && len(results) == 0 {
+					if shared.IsLocalizationInputError(err) {
+						return shared.UsageError(err.Error())
+					}
 					return fmt.Errorf("localizations upload: %w", err)
 				}
 				uploadErr := err

--- a/internal/cli/metadata/execute_push.go
+++ b/internal/cli/metadata/execute_push.go
@@ -80,27 +80,35 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 		return PushPlanResult{}, nil, fmt.Errorf("%s: %w", errorPrefix, err)
 	}
 
-	requestCtx, cancel := shared.ContextWithTimeout(ctx)
-	defer cancel()
-
-	versionIDValue, versionStateValue, err := resolveVersionID(requestCtx, client, resolvedAppID, versionValue, platformValue)
+	type versionResolution struct {
+		id    string
+		state string
+	}
+	resolvedVersion, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (versionResolution, error) {
+		id, state, resolveErr := resolveVersionID(requestCtx, client, resolvedAppID, versionValue, platformValue)
+		return versionResolution{id: id, state: state}, resolveErr
+	})
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return PushPlanResult{}, nil, err
 		}
 		return PushPlanResult{}, nil, fmt.Errorf("%s: %w", errorPrefix, err)
 	}
-	appInfoIDValue, err := resolveMetadataPushAppInfoID(
-		requestCtx,
-		client,
-		opts.CommandName,
-		resolvedAppID,
-		strings.TrimSpace(opts.AppInfoID),
-		versionValue,
-		platformValue,
-		dirValue,
-		versionStateValue,
-	)
+	versionIDValue := resolvedVersion.id
+	versionStateValue := resolvedVersion.state
+	appInfoIDValue, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (string, error) {
+		return resolveMetadataPushAppInfoID(
+			requestCtx,
+			client,
+			opts.CommandName,
+			resolvedAppID,
+			strings.TrimSpace(opts.AppInfoID),
+			versionValue,
+			platformValue,
+			dirValue,
+			versionStateValue,
+		)
+	})
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return PushPlanResult{}, nil, err
@@ -108,11 +116,11 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 		return PushPlanResult{}, nil, fmt.Errorf("%s: %w", errorPrefix, err)
 	}
 
-	remoteAppInfoItems, err := fetchAppInfoLocalizations(requestCtx, client, appInfoIDValue)
+	remoteAppInfoItems, err := fetchAppInfoLocalizations(ctx, client, appInfoIDValue)
 	if err != nil {
 		return PushPlanResult{}, nil, fmt.Errorf("%s: %w", errorPrefix, err)
 	}
-	remoteVersionItems, err := fetchVersionLocalizations(requestCtx, client, versionIDValue)
+	remoteVersionItems, err := fetchVersionLocalizations(ctx, client, versionIDValue)
 	if err != nil {
 		return PushPlanResult{}, nil, fmt.Errorf("%s: %w", errorPrefix, err)
 	}
@@ -136,13 +144,18 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 
 	localAppInfo := applyDefaultAppInfoFallback(localBundle.appInfo, localBundle.defaultAppInfo, remoteAppInfo, opts.AllowDeletes)
 	localVersion := applyDefaultVersionFallback(localBundle.version, localBundle.defaultVersion, remoteVersion, opts.AllowDeletes)
+	if err := validateMetadataCreatePrerequisites(localAppInfo, remoteAppInfo); err != nil {
+		return PushPlanResult{}, nil, shared.UsageError(err.Error())
+	}
 	warningMode := shared.SubmitReadinessCreateModePlanned
 	if !opts.DryRun {
 		warningMode = shared.SubmitReadinessCreateModeApplied
 	}
 	submitOpts := shared.SubmitReadinessOptions{}
 	if versionCreateWarningsNeedUpdateContext(localVersion, remoteVersion) {
-		submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(requestCtx, client, versionIDValue, resolvedAppID, platformValue)
+		readinessCtx, readinessCancel := shared.ContextWithTimeout(ctx)
+		submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(readinessCtx, client, versionIDValue, resolvedAppID, platformValue)
+		readinessCancel()
 	}
 	warnings := versionCreateWarningsForPatches(localVersion, remoteVersion, warningMode, submitOpts)
 
@@ -198,7 +211,7 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 	}
 
 	actions, applyErr := applyMetadataPlan(
-		requestCtx,
+		ctx,
 		client,
 		appInfoIDValue,
 		versionIDValue,
@@ -209,12 +222,32 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 		remoteVersionItems,
 		opts.AllowDeletes,
 	)
-	if applyErr != nil {
-		return PushPlanResult{}, nil, fmt.Errorf("%s: %w", errorPrefix, applyErr)
-	}
-	result.Applied = true
 	result.Actions = actions
+	result.Total = len(actions)
+	for _, action := range actions {
+		if action.Status == "failed" {
+			result.Failed++
+			continue
+		}
+		result.Succeeded++
+	}
+	result.Applied = applyErr == nil && result.Failed == 0
 
+	if result.Failed > 0 {
+		artifactPath, artifactErr := writeMetadataPushFailureArtifact(result, opts.CommandName)
+		if artifactErr != nil {
+			result.FailureArtifactError = artifactErr.Error()
+		} else {
+			result.FailureArtifactPath = artifactPath
+		}
+	}
+	if !opts.DryRun {
+		warnings = successfulVersionCreateWarnings(warnings, actions, remoteVersion)
+	}
+
+	if applyErr != nil {
+		return result, warnings, fmt.Errorf("%s: %w", errorPrefix, applyErr)
+	}
 	return result, warnings, nil
 }
 

--- a/internal/cli/metadata/keywords.go
+++ b/internal/cli/metadata/keywords.go
@@ -943,7 +943,7 @@ func executeMetadataKeywordsPlan(ctx context.Context, opts metadataKeywordsPlanO
 		return MetadataKeywordsPlanResult{}, err
 	}
 
-	remoteVersionItems, err := fetchVersionLocalizations(requestCtx, client, versionIDValue)
+	remoteVersionItems, err := fetchVersionLocalizations(ctx, client, versionIDValue)
 	if err != nil {
 		return MetadataKeywordsPlanResult{}, err
 	}
@@ -962,7 +962,9 @@ func executeMetadataKeywordsPlan(ctx context.Context, opts metadataKeywordsPlanO
 	sortPlanItems(updates)
 	submitOpts := shared.SubmitReadinessOptions{}
 	if versionCreateWarningsNeedUpdateContext(localPatches, remoteVersion) {
-		submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(requestCtx, client, versionIDValue, resolvedAppID, platformValue)
+		readinessCtx, readinessCancel := shared.ContextWithTimeout(ctx)
+		submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(readinessCtx, client, versionIDValue, resolvedAppID, platformValue)
+		readinessCancel()
 	}
 	warnings := buildMetadataKeywordWarnings(localState, remoteVersion, submitOpts)
 

--- a/internal/cli/metadata/keywords_audit.go
+++ b/internal/cli/metadata/keywords_audit.go
@@ -142,11 +142,11 @@ Examples:
 				return fmt.Errorf("metadata keywords audit: %w", err)
 			}
 
-			versionItems, err := fetchVersionLocalizations(requestCtx, client, versionIDValue)
+			versionItems, err := fetchVersionLocalizations(ctx, client, versionIDValue)
 			if err != nil {
 				return fmt.Errorf("metadata keywords audit: %w", err)
 			}
-			appInfoItems, err := fetchAppInfoLocalizations(requestCtx, client, appInfoIDValue)
+			appInfoItems, err := fetchAppInfoLocalizations(ctx, client, appInfoIDValue)
 			if err != nil {
 				return fmt.Errorf("metadata keywords audit: %w", err)
 			}

--- a/internal/cli/metadata/localization_fetch_timeout_test.go
+++ b/internal/cli/metadata/localization_fetch_timeout_test.go
@@ -1,0 +1,108 @@
+package metadata
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type metadataFetchRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn metadataFetchRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestLocalizationFetchesUseFreshDeadlinePerPage(t *testing.T) {
+	tests := []struct {
+		name      string
+		firstBody string
+		lastBody  string
+		fetch     func(context.Context, *asc.Client) (int, error)
+	}{
+		{
+			name:      "app info",
+			firstBody: `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}],"links":{"next":"/v1/appInfos/info-1/appInfoLocalizations?cursor=next"}}`,
+			lastBody:  `{"data":[{"type":"appInfoLocalizations","id":"loc-2","attributes":{"locale":"fr-FR"}}],"links":{"next":""}}`,
+			fetch: func(ctx context.Context, client *asc.Client) (int, error) {
+				items, err := fetchAppInfoLocalizations(ctx, client, "info-1")
+				return len(items), err
+			},
+		},
+		{
+			name:      "version",
+			firstBody: `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}],"links":{"next":"/v1/appStoreVersions/version-1/appStoreVersionLocalizations?cursor=next"}}`,
+			lastBody:  `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-2","attributes":{"locale":"fr-FR"}}],"links":{"next":""}}`,
+			fetch: func(ctx context.Context, client *asc.Client) (int, error) {
+				items, err := fetchVersionLocalizations(ctx, client, "version-1")
+				return len(items), err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_TIMEOUT", "100ms")
+			t.Setenv("ASC_MAX_RETRIES", "0")
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			calls := 0
+			http.DefaultTransport = metadataFetchRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					time.Sleep(60 * time.Millisecond)
+					return metadataFetchJSONResponse(test.firstBody), nil
+				}
+				deadline, ok := req.Context().Deadline()
+				if !ok || time.Until(deadline) < 70*time.Millisecond {
+					t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
+				}
+				return metadataFetchJSONResponse(test.lastBody), nil
+			})
+			client := newMetadataFetchClient(t)
+
+			count, err := test.fetch(context.Background(), client)
+			if err != nil {
+				t.Fatalf("fetch error: %v", err)
+			}
+			if calls != 2 || count != 2 {
+				t.Fatalf("unexpected pagination result: calls=%d count=%d", calls, count)
+			}
+		})
+	}
+}
+
+func newMetadataFetchClient(t *testing.T) *asc.Client {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	client, err := asc.NewClientFromPEM("KEY_ID", "ISSUER_ID", string(pemBytes))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client
+}
+
+func metadataFetchJSONResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}

--- a/internal/cli/metadata/pull.go
+++ b/internal/cli/metadata/pull.go
@@ -122,11 +122,11 @@ Examples:
 				return fmt.Errorf("metadata pull: %w", err)
 			}
 
-			appInfoItems, err := fetchAppInfoLocalizations(requestCtx, client, appInfoIDValue)
+			appInfoItems, err := fetchAppInfoLocalizations(ctx, client, appInfoIDValue)
 			if err != nil {
 				return fmt.Errorf("metadata pull: %w", err)
 			}
-			versionItems, err := fetchVersionLocalizations(requestCtx, client, versionIDValue)
+			versionItems, err := fetchVersionLocalizations(ctx, client, versionIDValue)
 			if err != nil {
 				return fmt.Errorf("metadata pull: %w", err)
 			}
@@ -291,7 +291,9 @@ func resolveMetadataPullAppInfoID(
 }
 
 func fetchAppInfoLocalizations(ctx context.Context, client *asc.Client, appInfoID string) ([]asc.Resource[asc.AppInfoLocalizationAttributes], error) {
-	firstPage, err := client.GetAppInfoLocalizations(ctx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	firstPage, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+		return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -302,8 +304,10 @@ func fetchAppInfoLocalizations(ctx context.Context, client *asc.Client, appInfoI
 		return firstPage.Data, nil
 	}
 
-	paginated, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		return client.GetAppInfoLocalizations(ctx, appInfoID, asc.WithAppInfoLocalizationsNextURL(nextURL))
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+			return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -316,7 +320,9 @@ func fetchAppInfoLocalizations(ctx context.Context, client *asc.Client, appInfoI
 }
 
 func fetchVersionLocalizations(ctx context.Context, client *asc.Client, versionID string) ([]asc.Resource[asc.AppStoreVersionLocalizationAttributes], error) {
-	firstPage, err := client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	firstPage, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+		return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -327,8 +333,10 @@ func fetchVersionLocalizations(ctx context.Context, client *asc.Client, versionI
 		return firstPage.Data, nil
 	}
 
-	paginated, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		return client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsNextURL(nextURL))
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+			return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -737,6 +737,9 @@ func applyAppInfoChanges(
 		}
 
 		if !localExists && remoteExists {
+			if !hasTrackedRemoteFields(appInfoPlanFields, remoteState.fields) {
+				continue
+			}
 			if !allowDeletes {
 				return actions, fmt.Errorf("delete operations require --allow-deletes")
 			}
@@ -870,6 +873,9 @@ func applyVersionChanges(
 		}
 
 		if !localExists && remoteExists {
+			if !hasTrackedRemoteFields(versionPlanFields, remoteState.fields) {
+				continue
+			}
 			if !allowDeletes {
 				return actions, fmt.Errorf("delete operations require --allow-deletes")
 			}
@@ -963,7 +969,7 @@ func canceledAppInfoAction(
 	err error,
 ) (ApplyAction, bool) {
 	if !localExists {
-		if remoteExists && allowDeletes {
+		if remoteExists && allowDeletes && hasTrackedRemoteFields(appInfoPlanFields, remoteState.fields) {
 			return failedMetadataAction(appInfoDirName, locale, "", "delete", remoteState.id, nil, err), true
 		}
 		return ApplyAction{}, false
@@ -989,7 +995,7 @@ func canceledVersionAction(
 	err error,
 ) (ApplyAction, bool) {
 	if !localExists {
-		if remoteExists && allowDeletes {
+		if remoteExists && allowDeletes && hasTrackedRemoteFields(versionPlanFields, remoteState.fields) {
 			return failedMetadataAction(versionDirName, locale, version, "delete", remoteState.id, nil, err), true
 		}
 		return ApplyAction{}, false
@@ -1002,6 +1008,15 @@ func canceledVersionAction(
 		return failedMetadataAction(versionDirName, locale, version, "create", "", versionFields(effectiveVersionCreateLocalization(localPatch)), err), true
 	}
 	return failedMetadataAction(versionDirName, locale, version, "update", remoteState.id, localPatch.setFields, err), true
+}
+
+func hasTrackedRemoteFields(fields []string, values map[string]string) bool {
+	for _, field := range fields {
+		if _, ok := values[field]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func runMetadataMutation(

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -56,28 +57,48 @@ type PlanAPICall struct {
 
 // ApplyAction represents one executed mutation action.
 type ApplyAction struct {
-	Scope          string `json:"scope"`
-	Locale         string `json:"locale"`
-	Version        string `json:"version,omitempty"`
-	Action         string `json:"action"`
-	LocalizationID string `json:"localizationId,omitempty"`
+	Scope          string            `json:"scope"`
+	Locale         string            `json:"locale"`
+	Version        string            `json:"version,omitempty"`
+	Action         string            `json:"action"`
+	Status         string            `json:"status,omitempty"`
+	LocalizationID string            `json:"localizationId,omitempty"`
+	Error          string            `json:"error,omitempty"`
+	DesiredFields  map[string]string `json:"desiredFields,omitempty"`
 }
 
 // PushPlanResult is the push dry-run output artifact.
 type PushPlanResult struct {
-	AppID     string        `json:"appId"`
-	AppInfoID string        `json:"appInfoId"`
-	Version   string        `json:"version"`
-	VersionID string        `json:"versionId"`
-	Dir       string        `json:"dir"`
-	DryRun    bool          `json:"dryRun"`
-	Applied   bool          `json:"applied,omitempty"`
-	Includes  []string      `json:"includes"`
-	Adds      []PlanItem    `json:"adds"`
-	Updates   []PlanItem    `json:"updates"`
-	Deletes   []PlanItem    `json:"deletes"`
-	APICalls  []PlanAPICall `json:"apiCalls,omitempty"`
-	Actions   []ApplyAction `json:"actions,omitempty"`
+	AppID                string        `json:"appId"`
+	AppInfoID            string        `json:"appInfoId"`
+	Version              string        `json:"version"`
+	VersionID            string        `json:"versionId"`
+	Dir                  string        `json:"dir"`
+	DryRun               bool          `json:"dryRun"`
+	Applied              bool          `json:"applied,omitempty"`
+	Includes             []string      `json:"includes"`
+	Adds                 []PlanItem    `json:"adds"`
+	Updates              []PlanItem    `json:"updates"`
+	Deletes              []PlanItem    `json:"deletes"`
+	APICalls             []PlanAPICall `json:"apiCalls,omitempty"`
+	Actions              []ApplyAction `json:"actions,omitempty"`
+	Total                int           `json:"total,omitempty"`
+	Succeeded            int           `json:"succeeded,omitempty"`
+	Failed               int           `json:"failed,omitempty"`
+	FailureArtifactPath  string        `json:"failureArtifactPath,omitempty"`
+	FailureArtifactError string        `json:"failureArtifactError,omitempty"`
+}
+
+type metadataPushFailureArtifact struct {
+	SchemaVersion int           `json:"schemaVersion"`
+	Command       string        `json:"command"`
+	AppID         string        `json:"appId"`
+	AppInfoID     string        `json:"appInfoId"`
+	Version       string        `json:"version"`
+	VersionID     string        `json:"versionId"`
+	Dir           string        `json:"dir"`
+	GeneratedAt   string        `json:"generatedAt"`
+	Failures      []ApplyAction `json:"failures"`
 }
 
 type scopeCallCounts struct {
@@ -170,7 +191,7 @@ Notes:
 				AllowDeletes: *allowDeletes,
 				Confirm:      *confirm,
 			})
-			if err != nil {
+			if err != nil && len(result.Actions) == 0 {
 				return err
 			}
 			if err := shared.PrintOutputWithRenderers(
@@ -182,7 +203,20 @@ Notes:
 			); err != nil {
 				return err
 			}
-			return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings)
+			if warningErr := shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings); warningErr != nil {
+				return warningErr
+			}
+			if err != nil || result.FailureArtifactError != "" {
+				message := fmt.Sprintf("metadata %s: %d localization(s) failed", cfg.name, result.Failed)
+				if result.Failed == 0 && err != nil {
+					message = fmt.Sprintf("metadata %s: operation incomplete: %v", cfg.name, err)
+				}
+				if result.FailureArtifactError != "" {
+					message += "; write failure artifact: " + result.FailureArtifactError
+				}
+				return shared.NewReportedError(fmt.Errorf("%s", message))
+			}
+			return nil
 		},
 	}
 }
@@ -578,6 +612,23 @@ func cloneVersionLocalPatch(patch versionLocalPatch) versionLocalPatch {
 	}
 }
 
+func validateMetadataCreatePrerequisites(local map[string]appInfoLocalPatch, remote map[string]AppInfoLocalization) error {
+	locales := make([]string, 0, len(local))
+	for locale := range local {
+		locales = append(locales, locale)
+	}
+	sort.Strings(locales)
+	for _, locale := range locales {
+		if _, exists := remote[locale]; exists {
+			continue
+		}
+		if strings.TrimSpace(local[locale].localization.Name) == "" {
+			return fmt.Errorf("app-info localization %q requires name when creating a new locale", locale)
+		}
+	}
+	return nil
+}
+
 func cloneStringMap(source map[string]string) map[string]string {
 	result := make(map[string]string, len(source))
 	for key, value := range source {
@@ -624,20 +675,21 @@ func applyMetadataPlan(
 	allowDeletes bool,
 ) ([]ApplyAction, error) {
 	actions := make([]ApplyAction, 0)
+	applyErrors := make([]error, 0)
 
 	appInfoActions, err := applyAppInfoChanges(ctx, client, appInfoID, localAppInfo, remoteAppInfoItems, allowDeletes)
-	if err != nil {
-		return nil, err
-	}
 	actions = append(actions, appInfoActions...)
+	if err != nil {
+		applyErrors = append(applyErrors, err)
+	}
 
 	versionActions, err := applyVersionChanges(ctx, client, versionID, version, localVersion, remoteVersionItems, allowDeletes)
-	if err != nil {
-		return nil, err
-	}
 	actions = append(actions, versionActions...)
+	if err != nil {
+		applyErrors = append(applyErrors, err)
+	}
 
-	return actions, nil
+	return actions, errors.Join(applyErrors...)
 }
 
 func applyAppInfoChanges(
@@ -667,25 +719,43 @@ func applyAppInfoChanges(
 	}
 
 	locales := sortedLocaleUnion(local, remoteByLocale)
-
 	actions := make([]ApplyAction, 0)
+	applyErrors := make([]error, 0)
+	contextErrorRecorded := false
 	for _, locale := range locales {
 		localPatch, localExists := local[locale]
 		remoteState, remoteExists := remoteByLocale[locale]
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if action, ok := canceledAppInfoAction(locale, localPatch, remoteState, localExists, remoteExists, allowDeletes, ctxErr); ok {
+				if !contextErrorRecorded {
+					applyErrors = append(applyErrors, ctxErr)
+					contextErrorRecorded = true
+				}
+				actions = append(actions, action)
+			}
+			continue
+		}
 
 		if !localExists && remoteExists {
 			if !allowDeletes {
-				return nil, fmt.Errorf("delete operations require --allow-deletes")
+				return actions, fmt.Errorf("delete operations require --allow-deletes")
 			}
-			if err := client.DeleteAppInfoLocalization(ctx, remoteState.id); err != nil {
-				return nil, fmt.Errorf("delete app-info localization %s: %w", locale, err)
+			id, action, err := runMetadataMutation(
+				ctx, "delete",
+				func(requestCtx context.Context) (string, error) {
+					return remoteState.id, client.DeleteAppInfoLocalization(requestCtx, remoteState.id)
+				},
+				func(readbackCtx context.Context) (string, bool, error) {
+					_, exists, readErr := readBackAppInfoLocalization(readbackCtx, client, appInfoID, locale, nil)
+					return remoteState.id, !exists, readErr
+				},
+			)
+			if err != nil {
+				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "delete", remoteState.id, nil, err))
+				applyErrors = append(applyErrors, fmt.Errorf("delete app-info localization %s: %w", locale, err))
+			} else {
+				actions = append(actions, successfulMetadataAction(appInfoDirName, locale, "", action, id))
 			}
-			actions = append(actions, ApplyAction{
-				Scope:          appInfoDirName,
-				Locale:         locale,
-				Action:         "delete",
-				LocalizationID: remoteState.id,
-			})
 			continue
 		}
 		if !localExists {
@@ -701,43 +771,55 @@ func applyAppInfoChanges(
 		switch {
 		case !remoteExists:
 			if strings.TrimSpace(localPatch.localization.Name) == "" {
-				return nil, fmt.Errorf("cannot create app-info localization %q without name", locale)
+				err := fmt.Errorf("cannot create app-info localization %q without name", locale)
+				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "create", "", localPatch.setFields, err))
+				applyErrors = append(applyErrors, err)
+				continue
 			}
-			resp, err := client.CreateAppInfoLocalization(ctx, appInfoID, appInfoAttributes(locale, localPatch.localization, true))
+			desired := appInfoFields(localPatch.localization)
+			id, action, err := runMetadataMutation(
+				ctx, "create",
+				func(requestCtx context.Context) (string, error) {
+					resp, mutationErr := client.CreateAppInfoLocalization(requestCtx, appInfoID, appInfoAttributes(locale, localPatch.localization, true))
+					if mutationErr != nil {
+						return "", mutationErr
+					}
+					return resp.Data.ID, nil
+				},
+				func(readbackCtx context.Context) (string, bool, error) {
+					return readBackAppInfoLocalization(readbackCtx, client, appInfoID, locale, desired)
+				},
+			)
 			if err != nil {
-				return nil, fmt.Errorf(
-					"create app-info localization %s (fields: %s): %w",
-					locale,
-					formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields),
-					err,
-				)
+				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "create", "", desired, err))
+				applyErrors = append(applyErrors, fmt.Errorf("create app-info localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields), err))
+			} else {
+				actions = append(actions, successfulMetadataAction(appInfoDirName, locale, "", action, id))
 			}
-			actions = append(actions, ApplyAction{
-				Scope:          appInfoDirName,
-				Locale:         locale,
-				Action:         "create",
-				LocalizationID: resp.Data.ID,
-			})
 		case remoteExists:
-			resp, err := client.UpdateAppInfoLocalization(ctx, remoteState.id, appInfoAttributes(locale, localPatch.localization, false))
+			id, action, err := runMetadataMutation(
+				ctx, "update",
+				func(requestCtx context.Context) (string, error) {
+					resp, mutationErr := client.UpdateAppInfoLocalizationFields(requestCtx, remoteState.id, cloneStringMap(localPatch.setFields))
+					if mutationErr != nil {
+						return "", mutationErr
+					}
+					return resp.Data.ID, nil
+				},
+				func(readbackCtx context.Context) (string, bool, error) {
+					return readBackAppInfoLocalization(readbackCtx, client, appInfoID, locale, localPatch.setFields)
+				},
+			)
 			if err != nil {
-				return nil, fmt.Errorf(
-					"update app-info localization %s (fields: %s): %w",
-					locale,
-					formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields),
-					err,
-				)
+				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "update", remoteState.id, localPatch.setFields, err))
+				applyErrors = append(applyErrors, fmt.Errorf("update app-info localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields), err))
+			} else {
+				actions = append(actions, successfulMetadataAction(appInfoDirName, locale, "", action, id))
 			}
-			actions = append(actions, ApplyAction{
-				Scope:          appInfoDirName,
-				Locale:         locale,
-				Action:         "update",
-				LocalizationID: resp.Data.ID,
-			})
 		}
 	}
 
-	return actions, nil
+	return actions, errors.Join(applyErrors...)
 }
 
 func applyVersionChanges(
@@ -771,24 +853,42 @@ func applyVersionChanges(
 	locales := sortedLocaleUnion(local, remoteByLocale)
 
 	actions := make([]ApplyAction, 0)
+	applyErrors := make([]error, 0)
+	contextErrorRecorded := false
 	for _, locale := range locales {
 		localPatch, localExists := local[locale]
 		remoteState, remoteExists := remoteByLocale[locale]
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if action, ok := canceledVersionAction(locale, version, localPatch, remoteState, localExists, remoteExists, allowDeletes, ctxErr); ok {
+				if !contextErrorRecorded {
+					applyErrors = append(applyErrors, ctxErr)
+					contextErrorRecorded = true
+				}
+				actions = append(actions, action)
+			}
+			continue
+		}
 
 		if !localExists && remoteExists {
 			if !allowDeletes {
-				return nil, fmt.Errorf("delete operations require --allow-deletes")
+				return actions, fmt.Errorf("delete operations require --allow-deletes")
 			}
-			if err := client.DeleteAppStoreVersionLocalization(ctx, remoteState.id); err != nil {
-				return nil, fmt.Errorf("delete version localization %s: %w", locale, err)
+			id, action, err := runMetadataMutation(
+				ctx, "delete",
+				func(requestCtx context.Context) (string, error) {
+					return remoteState.id, client.DeleteAppStoreVersionLocalization(requestCtx, remoteState.id)
+				},
+				func(readbackCtx context.Context) (string, bool, error) {
+					_, exists, readErr := readBackVersionLocalization(readbackCtx, client, versionID, locale, nil)
+					return remoteState.id, !exists, readErr
+				},
+			)
+			if err != nil {
+				actions = append(actions, failedMetadataAction(versionDirName, locale, version, "delete", remoteState.id, nil, err))
+				applyErrors = append(applyErrors, fmt.Errorf("delete version localization %s: %w", locale, err))
+			} else {
+				actions = append(actions, successfulMetadataAction(versionDirName, locale, version, action, id))
 			}
-			actions = append(actions, ApplyAction{
-				Scope:          versionDirName,
-				Locale:         locale,
-				Version:        version,
-				Action:         "delete",
-				LocalizationID: remoteState.id,
-			})
 			continue
 		}
 		if !localExists {
@@ -807,43 +907,244 @@ func applyVersionChanges(
 			if hasVersionContent(localPatch.createLocalization) {
 				createLoc = localPatch.createLocalization
 			}
-			resp, err := client.CreateAppStoreVersionLocalization(ctx, versionID, versionAttributes(locale, createLoc, true))
+			desired := versionFields(createLoc)
+			id, action, err := runMetadataMutation(
+				ctx, "create",
+				func(requestCtx context.Context) (string, error) {
+					resp, mutationErr := client.CreateAppStoreVersionLocalization(requestCtx, versionID, versionAttributes(locale, createLoc, true))
+					if mutationErr != nil {
+						return "", mutationErr
+					}
+					return resp.Data.ID, nil
+				},
+				func(readbackCtx context.Context) (string, bool, error) {
+					return readBackVersionLocalization(readbackCtx, client, versionID, locale, desired)
+				},
+			)
 			if err != nil {
-				return nil, fmt.Errorf(
-					"create version localization %s (fields: %s): %w",
-					locale,
-					formatAttemptedFieldMap(versionPlanFields, localPatch.setFields),
-					err,
-				)
+				actions = append(actions, failedMetadataAction(versionDirName, locale, version, "create", "", desired, err))
+				applyErrors = append(applyErrors, fmt.Errorf("create version localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(versionPlanFields, localPatch.setFields), err))
+			} else {
+				actions = append(actions, successfulMetadataAction(versionDirName, locale, version, action, id))
 			}
-			actions = append(actions, ApplyAction{
-				Scope:          versionDirName,
-				Locale:         locale,
-				Version:        version,
-				Action:         "create",
-				LocalizationID: resp.Data.ID,
-			})
 		case remoteExists:
-			resp, err := client.UpdateAppStoreVersionLocalization(ctx, remoteState.id, versionAttributes(locale, localPatch.localization, false))
+			id, action, err := runMetadataMutation(
+				ctx, "update",
+				func(requestCtx context.Context) (string, error) {
+					resp, mutationErr := client.UpdateAppStoreVersionLocalizationFields(requestCtx, remoteState.id, cloneStringMap(localPatch.setFields))
+					if mutationErr != nil {
+						return "", mutationErr
+					}
+					return resp.Data.ID, nil
+				},
+				func(readbackCtx context.Context) (string, bool, error) {
+					return readBackVersionLocalization(readbackCtx, client, versionID, locale, localPatch.setFields)
+				},
+			)
 			if err != nil {
-				return nil, fmt.Errorf(
-					"update version localization %s (fields: %s): %w",
-					locale,
-					formatAttemptedFieldMap(versionPlanFields, localPatch.setFields),
-					err,
-				)
+				actions = append(actions, failedMetadataAction(versionDirName, locale, version, "update", remoteState.id, localPatch.setFields, err))
+				applyErrors = append(applyErrors, fmt.Errorf("update version localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(versionPlanFields, localPatch.setFields), err))
+			} else {
+				actions = append(actions, successfulMetadataAction(versionDirName, locale, version, action, id))
 			}
-			actions = append(actions, ApplyAction{
-				Scope:          versionDirName,
-				Locale:         locale,
-				Version:        version,
-				Action:         "update",
-				LocalizationID: resp.Data.ID,
-			})
 		}
 	}
 
-	return actions, nil
+	return actions, errors.Join(applyErrors...)
+}
+
+func canceledAppInfoAction(
+	locale string,
+	localPatch appInfoLocalPatch,
+	remoteState remoteLocalizationState,
+	localExists bool,
+	remoteExists bool,
+	allowDeletes bool,
+	err error,
+) (ApplyAction, bool) {
+	if !localExists {
+		if remoteExists && allowDeletes {
+			return failedMetadataAction(appInfoDirName, locale, "", "delete", remoteState.id, nil, err), true
+		}
+		return ApplyAction{}, false
+	}
+	adds, updates := countIntentChanges(appInfoPlanFields, localPatch.setFields, remoteState.fields)
+	if adds == 0 && updates == 0 {
+		return ApplyAction{}, false
+	}
+	if !remoteExists {
+		return failedMetadataAction(appInfoDirName, locale, "", "create", "", appInfoFields(localPatch.localization), err), true
+	}
+	return failedMetadataAction(appInfoDirName, locale, "", "update", remoteState.id, localPatch.setFields, err), true
+}
+
+func canceledVersionAction(
+	locale string,
+	version string,
+	localPatch versionLocalPatch,
+	remoteState remoteLocalizationState,
+	localExists bool,
+	remoteExists bool,
+	allowDeletes bool,
+	err error,
+) (ApplyAction, bool) {
+	if !localExists {
+		if remoteExists && allowDeletes {
+			return failedMetadataAction(versionDirName, locale, version, "delete", remoteState.id, nil, err), true
+		}
+		return ApplyAction{}, false
+	}
+	adds, updates := countIntentChanges(versionPlanFields, localPatch.setFields, remoteState.fields)
+	if adds == 0 && updates == 0 {
+		return ApplyAction{}, false
+	}
+	if !remoteExists {
+		return failedMetadataAction(versionDirName, locale, version, "create", "", versionFields(effectiveVersionCreateLocalization(localPatch)), err), true
+	}
+	return failedMetadataAction(versionDirName, locale, version, "update", remoteState.id, localPatch.setFields, err), true
+}
+
+func runMetadataMutation(
+	ctx context.Context,
+	action string,
+	mutate func(context.Context) (string, error),
+	readback func(context.Context) (string, bool, error),
+) (string, string, error) {
+	id, status, err := shared.RunReconciledMutation(ctx, mutate, readback)
+	if err != nil {
+		return "", action, err
+	}
+	if status == shared.ReconciledMutationRecovered {
+		return id, "reconcile", nil
+	}
+	return id, action, nil
+}
+
+func successfulMetadataAction(scope, locale, version, action, id string) ApplyAction {
+	return ApplyAction{
+		Scope:          scope,
+		Locale:         locale,
+		Version:        version,
+		Action:         action,
+		Status:         "succeeded",
+		LocalizationID: id,
+	}
+}
+
+func failedMetadataAction(scope, locale, version, action, id string, desired map[string]string, err error) ApplyAction {
+	return ApplyAction{
+		Scope:          scope,
+		Locale:         locale,
+		Version:        version,
+		Action:         action,
+		Status:         "failed",
+		LocalizationID: id,
+		Error:          err.Error(),
+		DesiredFields:  cloneStringMap(desired),
+	}
+}
+
+func writeMetadataPushFailureArtifact(result PushPlanResult, commandName string) (string, error) {
+	failures := make([]ApplyAction, 0, result.Failed)
+	for _, action := range result.Actions {
+		if action.Status == "failed" {
+			failures = append(failures, action)
+		}
+	}
+
+	command := strings.TrimSpace(commandName)
+	switch command {
+	case "apply", "push":
+	default:
+		command = "push"
+	}
+	artifact := metadataPushFailureArtifact{
+		SchemaVersion: 1,
+		Command:       command,
+		AppID:         result.AppID,
+		AppInfoID:     result.AppInfoID,
+		Version:       result.Version,
+		VersionID:     result.VersionID,
+		Dir:           result.Dir,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Failures:      failures,
+	}
+	data, err := encodeCanonicalJSON(artifact)
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(
+		".asc",
+		"reports",
+		"metadata-"+command,
+		fmt.Sprintf("failures-%d.json", time.Now().UTC().UnixNano()),
+	)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := writeFileNoFollow(path, data); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func readBackAppInfoLocalization(ctx context.Context, client *asc.Client, appInfoID, locale string, desired map[string]string) (string, bool, error) {
+	items, err := fetchAppInfoLocalizations(ctx, client, appInfoID)
+	if err != nil {
+		return "", false, err
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.Attributes.Locale) != locale {
+			continue
+		}
+		if desired == nil {
+			return item.ID, true, nil
+		}
+		remote := appInfoFields(AppInfoLocalization{
+			Name:              item.Attributes.Name,
+			Subtitle:          item.Attributes.Subtitle,
+			PrivacyPolicyURL:  item.Attributes.PrivacyPolicyURL,
+			PrivacyChoicesURL: item.Attributes.PrivacyChoicesURL,
+			PrivacyPolicyText: item.Attributes.PrivacyPolicyText,
+		})
+		return item.ID, metadataFieldsMatch(remote, desired), nil
+	}
+	return "", false, nil
+}
+
+func readBackVersionLocalization(ctx context.Context, client *asc.Client, versionID, locale string, desired map[string]string) (string, bool, error) {
+	items, err := fetchVersionLocalizations(ctx, client, versionID)
+	if err != nil {
+		return "", false, err
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.Attributes.Locale) != locale {
+			continue
+		}
+		if desired == nil {
+			return item.ID, true, nil
+		}
+		remote := versionFields(VersionLocalization{
+			Description:     item.Attributes.Description,
+			Keywords:        item.Attributes.Keywords,
+			MarketingURL:    item.Attributes.MarketingURL,
+			PromotionalText: item.Attributes.PromotionalText,
+			SupportURL:      item.Attributes.SupportURL,
+			WhatsNew:        item.Attributes.WhatsNew,
+		})
+		return item.ID, metadataFieldsMatch(remote, desired), nil
+	}
+	return "", false, nil
+}
+
+func metadataFieldsMatch(remote, desired map[string]string) bool {
+	for field, value := range desired {
+		if remote[field] != value {
+			return false
+		}
+	}
+	return true
 }
 
 func countIntentChanges(fields []string, localSet map[string]string, remote map[string]string) (int, int) {
@@ -1166,6 +1467,18 @@ func printPushPlanTable(result PushPlanResult) error {
 	if result.Applied {
 		fmt.Printf("Applied: %t\n\n", result.Applied)
 	}
+	if len(result.Actions) > 0 || result.Failed > 0 || result.FailureArtifactError != "" {
+		fmt.Printf("Total: %d\n", result.Total)
+		fmt.Printf("Succeeded: %d\n", result.Succeeded)
+		fmt.Printf("Failed: %d\n", result.Failed)
+		if result.FailureArtifactPath != "" {
+			fmt.Printf("Failure Artifact: %s\n", result.FailureArtifactPath)
+		}
+		if result.FailureArtifactError != "" {
+			fmt.Printf("Failure Artifact Error: %s\n", result.FailureArtifactError)
+		}
+		fmt.Println()
+	}
 
 	headers := []string{"change", "key", "scope", "locale", "version", "field", "reason", "from", "to"}
 	rows := buildPlanRows(result)
@@ -1177,7 +1490,7 @@ func printPushPlanTable(result PushPlanResult) error {
 	}
 	if len(result.Actions) > 0 {
 		fmt.Println()
-		asc.RenderTable([]string{"scope", "locale", "version", "action", "localizationId"}, buildApplyActionRows(result.Actions))
+		asc.RenderTable([]string{"scope", "locale", "version", "action", "status", "localizationId", "error"}, buildApplyActionRows(result.Actions))
 	}
 	return nil
 }
@@ -1190,6 +1503,17 @@ func printPushPlanMarkdown(result PushPlanResult) error {
 	if result.Applied {
 		fmt.Printf("**Applied:** %t\n\n", result.Applied)
 	}
+	if len(result.Actions) > 0 || result.Failed > 0 || result.FailureArtifactError != "" {
+		fmt.Printf("**Total:** %d\n\n", result.Total)
+		fmt.Printf("**Succeeded:** %d\n\n", result.Succeeded)
+		fmt.Printf("**Failed:** %d\n\n", result.Failed)
+		if result.FailureArtifactPath != "" {
+			fmt.Printf("**Failure Artifact:** %s\n\n", result.FailureArtifactPath)
+		}
+		if result.FailureArtifactError != "" {
+			fmt.Printf("**Failure Artifact Error:** %s\n\n", result.FailureArtifactError)
+		}
+	}
 
 	headers := []string{"change", "key", "scope", "locale", "version", "field", "reason", "from", "to"}
 	rows := buildPlanRows(result)
@@ -1201,7 +1525,7 @@ func printPushPlanMarkdown(result PushPlanResult) error {
 	}
 	if len(result.Actions) > 0 {
 		fmt.Println()
-		asc.RenderMarkdown([]string{"scope", "locale", "version", "action", "localizationId"}, buildApplyActionRows(result.Actions))
+		asc.RenderMarkdown([]string{"scope", "locale", "version", "action", "status", "localizationId", "error"}, buildApplyActionRows(result.Actions))
 	}
 	return nil
 }
@@ -1269,7 +1593,9 @@ func buildApplyActionRows(actions []ApplyAction) [][]string {
 			action.Locale,
 			action.Version,
 			action.Action,
+			action.Status,
 			action.LocalizationID,
+			sanitizePlanCell(action.Error),
 		})
 	}
 	return rows

--- a/internal/cli/metadata/push_cancellation_test.go
+++ b/internal/cli/metadata/push_cancellation_test.go
@@ -1,0 +1,77 @@
+package metadata
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestApplyMetadataPlanDoesNotFailWhenCancellationFollowsFinalAction(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = metadataFetchRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appInfoLocalizations/loc-en" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: &metadataCancelOnEOFBody{
+				reader: strings.NewReader(`{"data":{"type":"appInfoLocalizations","id":"loc-en","attributes":{"name":"New name"}}}`),
+				cancel: cancel,
+			},
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	client := newMetadataFetchClient(t)
+
+	actions, err := applyMetadataPlan(
+		ctx,
+		client,
+		"appinfo-1",
+		"version-1",
+		"1.2.3",
+		map[string]appInfoLocalPatch{
+			"en-US": {
+				localization: AppInfoLocalization{Name: "New name"},
+				setFields:    map[string]string{"name": "New name"},
+			},
+		},
+		nil,
+		[]asc.Resource[asc.AppInfoLocalizationAttributes]{
+			{ID: "loc-en", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Old name"}},
+		},
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("final completed action should succeed despite trailing cancellation: %v", err)
+	}
+	if ctx.Err() != context.Canceled || len(actions) != 1 || actions[0].Status != "succeeded" {
+		t.Fatalf("unexpected final-action result: ctx=%v actions=%+v", ctx.Err(), actions)
+	}
+}
+
+type metadataCancelOnEOFBody struct {
+	reader io.Reader
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (b *metadataCancelOnEOFBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	if err == io.EOF {
+		b.once.Do(b.cancel)
+	}
+	return n, err
+}
+
+func (b *metadataCancelOnEOFBody) Close() error {
+	return nil
+}

--- a/internal/cli/metadata/push_test.go
+++ b/internal/cli/metadata/push_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestExecutePushPrefixesLocalMetadataReadErrors(t *testing.T) {
@@ -121,6 +123,23 @@ func TestBuildScopePlanTreatsMissingLocalFieldsAsNoOp(t *testing.T) {
 	}
 	if calls.create != 0 || calls.delete != 0 || calls.update != 1 {
 		t.Fatalf("unexpected call counts: %+v", calls)
+	}
+}
+
+func TestApplyAppInfoChangesIgnoresRemoteOnlyEmptyLocalization(t *testing.T) {
+	remote := []asc.Resource[asc.AppInfoLocalizationAttributes]{
+		{
+			ID: "loc-empty",
+			Attributes: asc.AppInfoLocalizationAttributes{
+				Locale: "en-US",
+			},
+		},
+	}
+	for _, allowDeletes := range []bool{false, true} {
+		actions, err := applyAppInfoChanges(context.Background(), nil, "appinfo-1", map[string]appInfoLocalPatch{}, remote, allowDeletes)
+		if err != nil || len(actions) != 0 {
+			t.Fatalf("allowDeletes=%t: expected empty remote locale no-op, actions=%+v err=%v", allowDeletes, actions, err)
+		}
 	}
 }
 

--- a/internal/cli/metadata/render_helpers_test.go
+++ b/internal/cli/metadata/render_helpers_test.go
@@ -115,6 +115,43 @@ func TestRenderHelpersProduceOutput(t *testing.T) {
 	}
 }
 
+func TestPushPlanPartialRenderersExposeRecoveryDetails(t *testing.T) {
+	result := PushPlanResult{
+		AppID:               "app-1",
+		Version:             "1.2.3",
+		Dir:                 "/tmp/meta",
+		Total:               2,
+		Succeeded:           1,
+		Failed:              1,
+		FailureArtifactPath: ".asc/reports/metadata-apply/failures-1.json",
+		Actions: []ApplyAction{
+			{Scope: appInfoDirName, Locale: "en-US", Action: "update", Status: "succeeded", LocalizationID: "loc-en"},
+			{Scope: versionDirName, Locale: "fr-FR", Action: "update", Status: "failed", LocalizationID: "loc-fr", Error: "rejected"},
+		},
+	}
+	tableOut := captureStdout(t, func() {
+		if err := printPushPlanTable(result); err != nil {
+			t.Fatalf("printPushPlanTable() error: %v", err)
+		}
+	})
+	for _, expected := range []string{"Total: 2", "Succeeded: 1", "Failed: 1", "Failure Artifact: .asc/reports/metadata-apply/", "rejected"} {
+		if !strings.Contains(tableOut, expected) {
+			t.Fatalf("table output missing %q: %s", expected, tableOut)
+		}
+	}
+
+	result.FailureArtifactPath = ""
+	result.FailureArtifactError = "mkdir .asc/reports: not a directory"
+	markdownOut := captureStdout(t, func() {
+		if err := printPushPlanMarkdown(result); err != nil {
+			t.Fatalf("printPushPlanMarkdown() error: %v", err)
+		}
+	})
+	if !strings.Contains(markdownOut, "**Failure Artifact Error:**") || !strings.Contains(markdownOut, "not a directory") {
+		t.Fatalf("markdown output missing artifact write failure: %s", markdownOut)
+	}
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/internal/cli/metadata/submit_warnings.go
+++ b/internal/cli/metadata/submit_warnings.go
@@ -38,6 +38,28 @@ func versionCreateWarningsForPatches(local map[string]versionLocalPatch, remote 
 	return shared.NormalizeSubmitReadinessCreateWarnings(warnings)
 }
 
+func successfulVersionCreateWarnings(
+	warnings []shared.SubmitReadinessCreateWarning,
+	actions []ApplyAction,
+	remote map[string]VersionLocalization,
+) []shared.SubmitReadinessCreateWarning {
+	succeeded := make(map[string]struct{})
+	for _, action := range actions {
+		if action.Scope != versionDirName || action.Status != "succeeded" || hasRemoteVersionLocalization(remote, action.Locale) {
+			continue
+		}
+		succeeded[action.Locale] = struct{}{}
+	}
+
+	filtered := make([]shared.SubmitReadinessCreateWarning, 0, len(warnings))
+	for _, warning := range warnings {
+		if _, ok := succeeded[warning.Locale]; ok {
+			filtered = append(filtered, warning)
+		}
+	}
+	return shared.NormalizeSubmitReadinessCreateWarnings(filtered)
+}
+
 func versionCreateWarningsNeedUpdateContext(local map[string]versionLocalPatch, remote map[string]VersionLocalization) bool {
 	for _, locale := range sortedKeys(local) {
 		if hasRemoteVersionLocalization(remote, locale) {

--- a/internal/cli/metadata/submit_warnings_test.go
+++ b/internal/cli/metadata/submit_warnings_test.go
@@ -131,3 +131,19 @@ func TestVersionCreateWarningsForPatches_RequiresWhatsNewForUpdates(t *testing.T
 		t.Fatalf("expected missing fields [whatsNew], got %+v", warnings[0].MissingFields)
 	}
 }
+
+func TestSuccessfulVersionCreateWarningsFiltersFailedCreates(t *testing.T) {
+	warnings := []shared.SubmitReadinessCreateWarning{
+		{Locale: "en-US", Mode: shared.SubmitReadinessCreateModeApplied, MissingFields: []string{"keywords"}},
+		{Locale: "fr-FR", Mode: shared.SubmitReadinessCreateModeApplied, MissingFields: []string{"supportUrl"}},
+	}
+	actions := []ApplyAction{
+		{Scope: versionDirName, Locale: "en-US", Action: "create", Status: "succeeded", LocalizationID: "en-id"},
+		{Scope: versionDirName, Locale: "fr-FR", Action: "create", Status: "failed", Error: "rejected"},
+	}
+
+	filtered := successfulVersionCreateWarnings(warnings, actions, nil)
+	if len(filtered) != 1 || filtered[0].Locale != "en-US" {
+		t.Fatalf("unexpected applied warnings: %+v", filtered)
+	}
+}

--- a/internal/cli/publish/group_resolver_test.go
+++ b/internal/cli/publish/group_resolver_test.go
@@ -40,6 +40,7 @@ func setupTestAuth(t *testing.T) {
 	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_MAX_RETRIES", "0")
 }
 
 func writeTestECDSAPEM(t *testing.T, path string) {

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -613,13 +613,16 @@ Examples:
 			}
 
 			if metadataDirValue != "" {
-				if _, err := applyPublishVersionMetadataFn(requestCtx, client, publishVersionMetadataOptions{
+				metadataCtx, metadataCancel := newPublishRequestCtx()
+				_, metadataErr := applyPublishVersionMetadataFn(metadataCtx, client, publishVersionMetadataOptions{
 					VersionID:      versionResp.Data.ID,
 					Version:        versionValue,
 					Dir:            metadataDirValue,
 					ValuesByLocale: metadataValuesByLocale,
-				}); err != nil {
-					return fmt.Errorf("publish appstore: apply metadata: %w", err)
+				})
+				metadataCancel()
+				if metadataErr != nil {
+					return fmt.Errorf("publish appstore: apply metadata: %w", metadataErr)
 				}
 			}
 

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -407,7 +407,7 @@ func PublishAppStoreCommand() *ffcli.Command {
 	dryRun := fs.Bool("dry-run", false, "Preview high-level publish plan without uploading or submitting")
 	wait := fs.Bool("wait", false, "Wait for build processing")
 	pollInterval := fs.Duration("poll-interval", shared.PublishDefaultPollInterval, "Polling interval for --wait and build discovery")
-	timeout := fs.Duration("timeout", 0, "Override upload + processing timeout (e.g., 30m)")
+	timeout := fs.Duration("timeout", 0, "Override upload + processing timeout; also applies to submission with --submit (e.g., 30m)")
 	localBuild := bindPublishLocalBuildFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
@@ -583,8 +583,6 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("publish appstore: %w", err)
 				}
-				requestCtx, cancel = newPublishRequestCtx()
-				defer cancel()
 				buildResp = localBuildResult.Build
 				versionValue = localBuildResult.Version
 				buildNumberValue = localBuildResult.BuildNumber
@@ -601,13 +599,16 @@ Examples:
 			}
 
 			if *wait {
+				cancel()
+				requestCtx, cancel = newPublishRequestCtx()
+				defer cancel()
 				buildResp, err = waitForPublishBuildProcessingFn(requestCtx, client, buildResp.Data.ID, *pollInterval)
 				if err != nil {
 					return fmt.Errorf("publish appstore: %w", err)
 				}
 			}
 
-			versionResp, err := client.FindOrCreateAppStoreVersion(requestCtx, resolvedPublishAppID, versionValue, platformValue)
+			versionResp, err := findOrCreatePublishAppStoreVersion(ctx, client, resolvedPublishAppID, versionValue, platformValue)
 			if err != nil {
 				return fmt.Errorf("publish appstore: %w", err)
 			}
@@ -625,10 +626,6 @@ Examples:
 					}
 					return fmt.Errorf("publish appstore: apply metadata: %w", metadataErr)
 				}
-
-				cancel()
-				requestCtx, cancel = newPublishRequestCtx()
-				defer cancel()
 			}
 
 			resolvedBuildNumberValue := firstNonEmpty(strings.TrimSpace(buildResp.Data.Attributes.Version), buildNumberValue)
@@ -662,6 +659,10 @@ Examples:
 				}
 			}
 
+			cancel()
+			requestCtx, cancel = newPublishRequestCtx()
+			defer cancel()
+
 			submitCtx := requestCtx
 			submitRequestTimeout := time.Duration(0)
 			if *submit && *timeout > 0 {
@@ -687,13 +688,19 @@ Examples:
 				}
 			}
 
-			attachResult, err := submitcli.EnsureBuildAttached(requestCtx, client, versionResp.Data.ID, buildResp.Data.ID, false)
+			attachResult, err := submitcli.EnsureBuildAttached(ctx, client, versionResp.Data.ID, buildResp.Data.ID, false)
 			if err != nil {
 				return fmt.Errorf("publish appstore: %w", err)
 			}
 			result.Attached = attachResult.Attached || attachResult.AlreadyAttached
 
 			if *submit {
+				if submitRequestTimeout == 0 {
+					cancel()
+					requestCtx, cancel = newPublishRequestCtx()
+					defer cancel()
+					submitCtx = requestCtx
+				}
 
 				localizationPreflight := func() error {
 					if submitRequestTimeout > 0 {

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -613,15 +613,16 @@ Examples:
 			}
 
 			if metadataDirValue != "" {
-				metadataCtx, metadataCancel := newPublishRequestCtx()
-				_, metadataErr := applyPublishVersionMetadataFn(metadataCtx, client, publishVersionMetadataOptions{
+				_, metadataErr := applyPublishVersionMetadataFn(ctx, client, publishVersionMetadataOptions{
 					VersionID:      versionResp.Data.ID,
 					Version:        versionValue,
 					Dir:            metadataDirValue,
 					ValuesByLocale: metadataValuesByLocale,
 				})
-				metadataCancel()
 				if metadataErr != nil {
+					if shared.IsLocalizationInputError(metadataErr) {
+						return shared.UsageErrorf("--metadata-dir %q: %v", metadataDirValue, metadataErr)
+					}
 					return fmt.Errorf("publish appstore: apply metadata: %w", metadataErr)
 				}
 			}

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -625,6 +625,10 @@ Examples:
 					}
 					return fmt.Errorf("publish appstore: apply metadata: %w", metadataErr)
 				}
+
+				cancel()
+				requestCtx, cancel = newPublishRequestCtx()
+				defer cancel()
 			}
 
 			resolvedBuildNumberValue := firstNonEmpty(strings.TrimSpace(buildResp.Data.Attributes.Version), buildNumberValue)

--- a/internal/cli/publish/publish_local_build_test.go
+++ b/internal/cli/publish/publish_local_build_test.go
@@ -858,7 +858,6 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 	metadataDir := t.TempDir()
 	writePublishVersionMetadataFixture(t, metadataDir, "1.2.3")
 	sequence := make([]string, 0, 4)
-	var uploadDeadline time.Time
 
 	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
 	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, appID string) (string, error) {
@@ -868,8 +867,7 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 		return newPublishTestFileInfo(t)
 	}
 	uploadBuildAndWaitForIDFn = func(stageCtx context.Context, _ *asc.Client, _ string, _ string, _ os.FileInfo, version, buildNumber string, _ asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
-		var ok bool
-		uploadDeadline, ok = stageCtx.Deadline()
+		_, ok := stageCtx.Deadline()
 		if !ok {
 			t.Fatal("expected upload stage deadline")
 		}
@@ -887,9 +885,11 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 	}
 	applyPublishVersionMetadataFn = func(metadataCtx context.Context, _ *asc.Client, opts publishVersionMetadataOptions) ([]asc.LocalizationUploadLocaleResult, error) {
 		sequence = append(sequence, "apply_metadata")
-		metadataDeadline, ok := metadataCtx.Deadline()
-		if !ok || !metadataDeadline.After(uploadDeadline.Add(150*time.Millisecond)) {
-			t.Fatalf("expected fresh metadata deadline after prior stage; upload=%v metadata=%v", uploadDeadline, metadataDeadline)
+		if _, ok := metadataCtx.Deadline(); ok {
+			t.Fatal("metadata batch should receive the healthy command parent without a batch-wide request deadline")
+		}
+		if err := metadataCtx.Err(); err != nil {
+			t.Fatalf("expected healthy metadata parent context: %v", err)
 		}
 		if opts.VersionID != "version-1" {
 			t.Fatalf("expected metadata version ID version-1, got %q", opts.VersionID)
@@ -954,6 +954,90 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 	wantSequence := strings.Join([]string{"ensure_version", "apply_metadata", "lookup_build", "attach_build"}, ",")
 	if gotSequence := strings.Join(sequence, ","); gotSequence != wantSequence {
 		t.Fatalf("expected sequence %s, got %s", wantSequence, gotSequence)
+	}
+}
+
+func TestPublishAppStoreMetadataInputFailureUsesUsageExit(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+
+	metadataDir := t.TempDir()
+	writePublishVersionMetadataFixture(t, metadataDir, "1.2.3")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+			t.Fatalf("unexpected input validation request: %s %s", req.Method, req.URL.Path)
+		}
+		return publishCommandJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+	})
+	inputClient := newPublishCommandTestClient(t)
+	_, _, inputErr := shared.UploadVersionLocalizationsWithWarnings(
+		context.Background(),
+		inputClient,
+		"version-1",
+		map[string]map[string]string{"en-US": {"promotionalText": ""}},
+		false,
+		shared.SubmitReadinessOptions{},
+	)
+	if inputErr == nil || !shared.IsLocalizationInputError(inputErr) {
+		t.Fatalf("failed to construct localization input error: %v", inputErr)
+	}
+
+	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
+	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, appID string) (string, error) {
+		return appID, nil
+	}
+	validatePublishIPAPathFn = func(string) (os.FileInfo, error) {
+		return newPublishTestFileInfo(t)
+	}
+	uploadBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, _ string, _ string, _ os.FileInfo, version, buildNumber string, _ asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		return &publishUploadResult{
+			Build: &asc.BuildResponse{Data: asc.Resource[asc.BuildAttributes]{
+				ID:         "build-42",
+				Attributes: asc.BuildAttributes{Version: buildNumber},
+			}},
+			Version:     version,
+			BuildNumber: buildNumber,
+		}, nil
+	}
+	applyPublishVersionMetadataFn = func(context.Context, *asc.Client, publishVersionMetadataOptions) ([]asc.LocalizationUploadLocaleResult, error) {
+		return nil, inputErr
+	}
+
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" {
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
+		}
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	cmd := PublishAppStoreCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "app-1",
+		"--ipa", "app.ipa",
+		"--version", "1.2.3",
+		"--build-number", "42",
+		"--metadata-dir", metadataDir,
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %T: %v", runErr, runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `Error: --metadata-dir "`+metadataDir+`"`) || strings.Contains(stderr, "0 locale(s) failed") {
+		t.Fatalf("unexpected stderr: %q", stderr)
 	}
 }
 

--- a/internal/cli/publish/publish_local_build_test.go
+++ b/internal/cli/publish/publish_local_build_test.go
@@ -903,6 +903,7 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 		if got := opts.ValuesByLocale["en-US"]["description"]; got != "Updated description" {
 			t.Fatalf("expected preflighted metadata values, got %+v", opts.ValuesByLocale)
 		}
+		time.Sleep(350 * time.Millisecond)
 		return nil, nil
 	}
 
@@ -915,6 +916,10 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
 			sequence = append(sequence, "lookup_build")
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected fresh post-metadata stage deadline, remaining=%s", time.Until(deadline))
+			}
 			return publishCommandJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/version-1/relationships/build":
 			sequence = append(sequence, "attach_build")

--- a/internal/cli/publish/publish_local_build_test.go
+++ b/internal/cli/publish/publish_local_build_test.go
@@ -372,6 +372,9 @@ func TestPublishTestFlightLocalBuildTableIncludesArchiveAndExportSections(t *tes
 		http.DefaultTransport = originalTransport
 	})
 	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if err := req.Context().Err(); err != nil {
+			t.Fatalf("expected healthy post-upload request context, got %v", err)
+		}
 		switch req.URL.Path {
 		case "/v1/apps/app-123/betaGroups":
 			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"group-1","isInternalGroup":false}}]}`)
@@ -854,6 +857,7 @@ func TestPublishAppStoreLocalBuildRequiresExportOptionsWhenDefaultMissing(t *tes
 func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *testing.T) {
 	restore := overridePublishCommandTestHooks(t)
 	defer restore()
+	t.Setenv("ASC_TIMEOUT", "500ms")
 
 	metadataDir := t.TempDir()
 	writePublishVersionMetadataFixture(t, metadataDir, "1.2.3")
@@ -871,7 +875,7 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 		if !ok {
 			t.Fatal("expected upload stage deadline")
 		}
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(550 * time.Millisecond)
 		return &publishUploadResult{
 			Build: &asc.BuildResponse{
 				Data: asc.Resource[asc.BuildAttributes]{
@@ -903,7 +907,7 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 		if got := opts.ValuesByLocale["en-US"]["description"]; got != "Updated description" {
 			t.Fatalf("expected preflighted metadata values, got %+v", opts.ValuesByLocale)
 		}
-		time.Sleep(350 * time.Millisecond)
+		time.Sleep(550 * time.Millisecond)
 		return nil, nil
 	}
 
@@ -913,6 +917,10 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
 			sequence = append(sequence, "ensure_version")
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected fresh post-upload stage deadline, remaining=%s", time.Until(deadline))
+			}
 			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
 			sequence = append(sequence, "lookup_build")
@@ -920,9 +928,14 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 			if !ok || time.Until(deadline) < 350*time.Millisecond {
 				t.Fatalf("expected fresh post-metadata stage deadline, remaining=%s", time.Until(deadline))
 			}
+			time.Sleep(450 * time.Millisecond)
 			return publishCommandJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/version-1/relationships/build":
 			sequence = append(sequence, "attach_build")
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected fresh attach deadline, remaining=%s", time.Until(deadline))
+			}
 			return publishCommandJSONResponse(http.StatusNoContent, "")
 		default:
 			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
@@ -1043,6 +1056,79 @@ func TestPublishAppStoreMetadataInputFailureUsesUsageExit(t *testing.T) {
 	}
 	if !strings.Contains(stderr, `Error: --metadata-dir "`+metadataDir+`"`) || strings.Contains(stderr, "0 locale(s) failed") {
 		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestPublishAppStoreRefreshesVersionContextAfterProcessingWait(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+	t.Setenv("ASC_TIMEOUT", "500ms")
+
+	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
+	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, appID string) (string, error) {
+		return appID, nil
+	}
+	validatePublishIPAPathFn = func(string) (os.FileInfo, error) {
+		return newPublishTestFileInfo(t)
+	}
+	uploadBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, _ string, _ string, _ os.FileInfo, version, buildNumber string, _ asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		return &publishUploadResult{
+			Build: &asc.BuildResponse{Data: asc.Resource[asc.BuildAttributes]{
+				ID:         "build-42",
+				Attributes: asc.BuildAttributes{Version: buildNumber},
+			}},
+			Version:     version,
+			BuildNumber: buildNumber,
+		}, nil
+	}
+	waitForPublishBuildProcessingFn = func(waitCtx context.Context, _ *asc.Client, _ string, _ time.Duration) (*asc.BuildResponse, error) {
+		if _, ok := waitCtx.Deadline(); !ok {
+			t.Fatal("expected processing wait stage deadline")
+		}
+		time.Sleep(550 * time.Millisecond)
+		return &asc.BuildResponse{Data: asc.Resource[asc.BuildAttributes]{
+			ID:         "build-42",
+			Attributes: asc.BuildAttributes{Version: "42"},
+		}}, nil
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected fresh post-wait version deadline, remaining=%s", time.Until(deadline))
+			}
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
+			return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-42","attributes":{"version":"42"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	cmd := PublishAppStoreCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "app-1",
+		"--ipa", "app.ipa",
+		"--version", "1.2.3",
+		"--build-number", "42",
+		"--wait",
+		"--timeout", "500ms",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if stderr != "" || !strings.Contains(stdout, `"attached":true`) {
+		t.Fatalf("unexpected publish result: stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 

--- a/internal/cli/publish/publish_local_build_test.go
+++ b/internal/cli/publish/publish_local_build_test.go
@@ -858,6 +858,7 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 	metadataDir := t.TempDir()
 	writePublishVersionMetadataFixture(t, metadataDir, "1.2.3")
 	sequence := make([]string, 0, 4)
+	var uploadDeadline time.Time
 
 	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
 	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, appID string) (string, error) {
@@ -866,7 +867,13 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 	validatePublishIPAPathFn = func(string) (os.FileInfo, error) {
 		return newPublishTestFileInfo(t)
 	}
-	uploadBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, _ string, _ string, _ os.FileInfo, version, buildNumber string, _ asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+	uploadBuildAndWaitForIDFn = func(stageCtx context.Context, _ *asc.Client, _ string, _ string, _ os.FileInfo, version, buildNumber string, _ asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		var ok bool
+		uploadDeadline, ok = stageCtx.Deadline()
+		if !ok {
+			t.Fatal("expected upload stage deadline")
+		}
+		time.Sleep(200 * time.Millisecond)
 		return &publishUploadResult{
 			Build: &asc.BuildResponse{
 				Data: asc.Resource[asc.BuildAttributes]{
@@ -878,8 +885,12 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 			BuildNumber: buildNumber,
 		}, nil
 	}
-	applyPublishVersionMetadataFn = func(_ context.Context, _ *asc.Client, opts publishVersionMetadataOptions) ([]asc.LocalizationUploadLocaleResult, error) {
+	applyPublishVersionMetadataFn = func(metadataCtx context.Context, _ *asc.Client, opts publishVersionMetadataOptions) ([]asc.LocalizationUploadLocaleResult, error) {
 		sequence = append(sequence, "apply_metadata")
+		metadataDeadline, ok := metadataCtx.Deadline()
+		if !ok || !metadataDeadline.After(uploadDeadline.Add(150*time.Millisecond)) {
+			t.Fatalf("expected fresh metadata deadline after prior stage; upload=%v metadata=%v", uploadDeadline, metadataDeadline)
+		}
 		if opts.VersionID != "version-1" {
 			t.Fatalf("expected metadata version ID version-1, got %q", opts.VersionID)
 		}
@@ -922,6 +933,7 @@ func TestPublishAppStoreMetadataDirAppliesAfterEnsureVersionBeforeAttach(t *test
 		"--version", "1.2.3",
 		"--build-number", "42",
 		"--metadata-dir", metadataDir,
+		"--timeout", "500ms",
 		"--output", "json",
 	}); err != nil {
 		t.Fatalf("parse flags: %v", err)

--- a/internal/cli/publish/publish_test.go
+++ b/internal/cli/publish/publish_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+func TestPublishAppStoreTimeoutHelpMatchesScope(t *testing.T) {
+	timeoutFlag := PublishAppStoreCommand().FlagSet.Lookup("timeout")
+	if timeoutFlag == nil {
+		t.Fatal("expected --timeout flag")
+	}
+	want := "Override upload + processing timeout; also applies to submission with --submit (e.g., 30m)"
+	if timeoutFlag.Usage != want {
+		t.Fatalf("expected timeout help %q, got %q", want, timeoutFlag.Usage)
+	}
+}
+
 func TestValidateIPAPathRejectsSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.ipa")

--- a/internal/cli/publish/version_metadata.go
+++ b/internal/cli/publish/version_metadata.go
@@ -36,6 +36,9 @@ func applyPublishVersionMetadata(ctx context.Context, client *asc.Client, opts p
 	}
 
 	results, warnings, err := shared.UploadVersionLocalizationsWithWarnings(ctx, client, versionID, valuesByLocale, false, shared.SubmitReadinessOptions{})
+	if err != nil && len(results) == 0 {
+		return nil, err
+	}
 	if len(warnings) > 0 {
 		if warnErr := shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings); warnErr != nil {
 			return nil, warnErr

--- a/internal/cli/publish/version_metadata.go
+++ b/internal/cli/publish/version_metadata.go
@@ -2,6 +2,7 @@ package publish
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,13 +36,27 @@ func applyPublishVersionMetadata(ctx context.Context, client *asc.Client, opts p
 	}
 
 	results, warnings, err := shared.UploadVersionLocalizationsWithWarnings(ctx, client, versionID, valuesByLocale, false, shared.SubmitReadinessOptions{})
-	if err != nil {
-		return nil, err
-	}
 	if len(warnings) > 0 {
 		if warnErr := shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings); warnErr != nil {
 			return nil, warnErr
 		}
+	}
+	if err != nil {
+		result := asc.LocalizationUploadResult{
+			Type:      shared.LocalizationTypeVersion,
+			VersionID: versionID,
+			InputPath: strings.TrimSpace(opts.Dir),
+			Results:   results,
+		}
+		shared.FinalizeLocalizationUploadResult(&result, "publish")
+		recoveryErr := fmt.Errorf("publish version metadata: %d locale(s) failed", result.Failed)
+		if result.FailureArtifactPath != "" {
+			recoveryErr = fmt.Errorf("%w; retry artifact: %s", recoveryErr, result.FailureArtifactPath)
+		}
+		if result.FailureArtifactError != "" {
+			recoveryErr = fmt.Errorf("%w; write retry artifact: %s", recoveryErr, result.FailureArtifactError)
+		}
+		return results, errors.Join(recoveryErr, err)
 	}
 	return results, nil
 }

--- a/internal/cli/publish/version_metadata_test.go
+++ b/internal/cli/publish/version_metadata_test.go
@@ -1,10 +1,16 @@
 package publish
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestLoadPublishVersionMetadataValuesReadsOnlyVersionLocalizationFields(t *testing.T) {
@@ -49,6 +55,65 @@ func TestLoadPublishVersionMetadataValuesReadsOnlyVersionLocalizationFields(t *t
 	}
 	if got := values["fr-FR"]["marketingUrl"]; got != "https://example.com/fr" {
 		t.Fatalf("expected fr-FR marketingUrl, got %q", got)
+	}
+}
+
+func TestApplyPublishVersionMetadataRetainsPartialResultsAndArtifact(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return publishJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"en-id","attributes":{"locale":"en-US","description":"Old English"}},{"type":"appStoreVersionLocalizations","id":"fr-id","attributes":{"locale":"fr-FR","description":"Old French"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/en-id":
+			patches++
+			return publishJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"en-id","attributes":{"locale":"en-US","description":"New English","whatsNew":"English notes"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/fr-id":
+			patches++
+			return publishJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"ENTITY_ERROR","detail":"French rejected"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	results, err := applyPublishVersionMetadata(context.Background(), client, publishVersionMetadataOptions{
+		VersionID: "version-1",
+		Dir:       "metadata",
+		ValuesByLocale: map[string]map[string]string{
+			"en-US": {"description": "New English", "whatsNew": "English notes"},
+			"fr-FR": {"description": "New French", "whatsNew": "French notes"},
+		},
+	})
+	if err == nil || patches != 2 || len(results) != 2 {
+		t.Fatalf("expected visible partial publish result, results=%+v patches=%d err=%v", results, patches, err)
+	}
+	if !strings.Contains(err.Error(), "retry artifact: .asc/reports/localizations-upload/") {
+		t.Fatalf("expected retry artifact in publish error: %v", err)
+	}
+	artifacts, globErr := filepath.Glob(filepath.Join(".asc", "reports", "localizations-upload", "failures-*.json"))
+	if globErr != nil || len(artifacts) != 1 {
+		t.Fatalf("expected one publish artifact, paths=%v err=%v", artifacts, globErr)
+	}
+	payload, readErr := os.ReadFile(artifacts[0])
+	if readErr != nil || !strings.Contains(string(payload), `"description": "New French"`) {
+		t.Fatalf("publish artifact is not resumable: payload=%s err=%v", payload, readErr)
+	}
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected underlying API failure to remain inspectable: %T %v", err, err)
+	}
+}
+
+func publishJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
 	}
 }
 

--- a/internal/cli/publish/version_metadata_test.go
+++ b/internal/cli/publish/version_metadata_test.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestLoadPublishVersionMetadataValuesReadsOnlyVersionLocalizationFields(t *testing.T) {
@@ -106,6 +108,116 @@ func TestApplyPublishVersionMetadataRetainsPartialResultsAndArtifact(t *testing.
 	var apiErr *asc.APIError
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected underlying API failure to remain inspectable: %T %v", err, err)
+	}
+}
+
+func TestApplyPublishVersionMetadataPreservesZeroResultInputError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return publishJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+	})
+	client := newPublishCommandTestClient(t)
+
+	results, err := applyPublishVersionMetadata(context.Background(), client, publishVersionMetadataOptions{
+		VersionID: "version-1",
+		Dir:       "metadata",
+		ValuesByLocale: map[string]map[string]string{
+			"en-US": {"promotionalText": ""},
+		},
+	})
+	if err == nil || !shared.IsLocalizationInputError(err) {
+		t.Fatalf("expected localization input error, got %T: %v", err, err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no mutation results, got %+v", results)
+	}
+	if _, statErr := os.Stat(filepath.Join(workDir, ".asc")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no bogus retry artifact, stat error=%v", statErr)
+	}
+}
+
+func TestApplyPublishVersionMetadataPreservesZeroResultAPIError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return publishJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"CONFLICT","detail":"snapshot conflict"}]}`), nil
+	})
+	client := newPublishCommandTestClient(t)
+
+	results, err := applyPublishVersionMetadata(context.Background(), client, publishVersionMetadataOptions{
+		VersionID: "version-1",
+		Dir:       "metadata",
+		ValuesByLocale: map[string]map[string]string{
+			"en-US": {"description": "Desired"},
+		},
+	})
+	if len(results) != 0 || err == nil {
+		t.Fatalf("expected zero-result API failure, results=%+v err=%v", results, err)
+	}
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict {
+		t.Fatalf("expected typed conflict, got %T: %v", err, err)
+	}
+	if strings.Contains(err.Error(), "0 locale(s) failed") {
+		t.Fatalf("unexpected zero-failure summary: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workDir, ".asc")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no retry artifact, stat error=%v", statErr)
+	}
+}
+
+func TestApplyPublishVersionMetadataUsesFreshDeadlinePerLocale(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return publishJSONResponse(http.StatusOK, `{"data":[
+				{"type":"appStoreVersionLocalizations","id":"en-id","attributes":{"locale":"en-US","description":"Old English"}},
+				{"type":"appStoreVersionLocalizations","id":"fr-id","attributes":{"locale":"fr-FR","description":"Old French"}}
+			],"links":{"next":""}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/en-id":
+			patches++
+			time.Sleep(60 * time.Millisecond)
+			return publishJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"en-id","attributes":{"description":"New English"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/fr-id":
+			patches++
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 70*time.Millisecond {
+				t.Fatalf("expected fresh second-locale deadline, remaining=%s", time.Until(deadline))
+			}
+			return publishJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"fr-id","attributes":{"description":"New French"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	results, err := applyPublishVersionMetadata(context.Background(), client, publishVersionMetadataOptions{
+		VersionID: "version-1",
+		ValuesByLocale: map[string]map[string]string{
+			"en-US": {"description": "New English"},
+			"fr-FR": {"description": "New French"},
+		},
+	})
+	if err != nil || patches != 2 || len(results) != 2 {
+		t.Fatalf("unexpected metadata batch: results=%+v patches=%d err=%v", results, patches, err)
 	}
 }
 

--- a/internal/cli/publish/version_recovery.go
+++ b/internal/cli/publish/version_recovery.go
@@ -1,0 +1,61 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func findOrCreatePublishAppStoreVersion(ctx context.Context, client *asc.Client, appID, version string, platform asc.Platform) (*asc.AppStoreVersionResponse, error) {
+	appID = strings.TrimSpace(appID)
+	version = strings.TrimSpace(version)
+	platformValue := strings.ToUpper(strings.TrimSpace(string(platform)))
+	if appID == "" || version == "" || platformValue == "" {
+		return nil, fmt.Errorf("app ID, version, and platform are required")
+	}
+
+	readVersion := func(parent context.Context) (*asc.AppStoreVersionResponse, bool, error) {
+		versions, err := shared.RetryReadWithFreshTimeout(parent, func(requestCtx context.Context) (*asc.AppStoreVersionsResponse, error) {
+			return client.GetAppStoreVersions(
+				requestCtx,
+				appID,
+				asc.WithAppStoreVersionsVersionStrings([]string{version}),
+				asc.WithAppStoreVersionsPlatforms([]string{platformValue}),
+				asc.WithAppStoreVersionsLimit(10),
+			)
+		})
+		if err != nil {
+			return nil, false, err
+		}
+
+		switch len(versions.Data) {
+		case 0:
+			return nil, false, nil
+		case 1:
+			return &asc.AppStoreVersionResponse{Data: versions.Data[0]}, true, nil
+		default:
+			return nil, false, fmt.Errorf("multiple app store versions found for version %q and platform %q", version, platformValue)
+		}
+	}
+
+	if existing, found, err := readVersion(ctx); err != nil || found {
+		return existing, err
+	}
+
+	created, _, err := shared.RunReconciledMutation(
+		ctx,
+		func(requestCtx context.Context) (*asc.AppStoreVersionResponse, error) {
+			return client.CreateAppStoreVersion(requestCtx, appID, asc.AppStoreVersionCreateAttributes{
+				Platform:      asc.Platform(platformValue),
+				VersionString: version,
+			})
+		},
+		func(readbackCtx context.Context) (*asc.AppStoreVersionResponse, bool, error) {
+			return readVersion(readbackCtx)
+		},
+	)
+	return created, err
+}

--- a/internal/cli/publish/version_recovery_test.go
+++ b/internal/cli/publish/version_recovery_test.go
@@ -1,0 +1,193 @@
+package publish
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestFindOrCreatePublishAppStoreVersionUsesFreshCreateDeadline(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected lookup request deadline, remaining=%s", time.Until(deadline))
+			}
+			time.Sleep(300 * time.Millisecond)
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appStoreVersions":
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected fresh create request deadline, remaining=%s", time.Until(deadline))
+			}
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	result, err := findOrCreatePublishAppStoreVersion(context.Background(), client, "app-1", "1.2.3", asc.PlatformIOS)
+	if err != nil || result.Data.ID != "version-1" {
+		t.Fatalf("unexpected version result: result=%+v err=%v", result, err)
+	}
+}
+
+func TestFindOrCreatePublishAppStoreVersionReadsTwiceBeforeReplay(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	sequence := make([]string, 0, 5)
+	reads := 0
+	creates := 0
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			reads++
+			sequence = append(sequence, "read")
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appStoreVersions":
+			creates++
+			sequence = append(sequence, "create")
+			if creates == 1 {
+				return publishCommandJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`)
+			}
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	result, err := findOrCreatePublishAppStoreVersion(context.Background(), client, "app-1", "1.2.3", asc.PlatformIOS)
+	if err != nil || result.Data.ID != "version-1" {
+		t.Fatalf("unexpected version result: result=%+v err=%v", result, err)
+	}
+	wantSequence := []string{"read", "create", "read", "read", "create"}
+	if !reflect.DeepEqual(sequence, wantSequence) {
+		t.Fatalf("expected bounded replay sequence %v, got %v", wantSequence, sequence)
+	}
+}
+
+func TestFindOrCreatePublishAppStoreVersionReconcilesAmbiguousCreate(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+
+	reads := 0
+	creates := 0
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			reads++
+			if reads == 1 {
+				return publishCommandJSONResponse(http.StatusOK, `{"data":[]}`)
+			}
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 350*time.Millisecond {
+				t.Fatalf("expected fresh readback deadline, remaining=%s", time.Until(deadline))
+			}
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appStoreVersions":
+			creates++
+			return publishCommandJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	result, err := findOrCreatePublishAppStoreVersion(context.Background(), client, "app-1", "1.2.3", asc.PlatformIOS)
+	if err != nil || result.Data.ID != "version-1" || reads != 2 || creates != 1 {
+		t.Fatalf("unexpected reconcile result: result=%+v reads=%d creates=%d err=%v", result, reads, creates, err)
+	}
+}
+
+func TestFindOrCreatePublishAppStoreVersionReturnsNormalizedExistingMatch(t *testing.T) {
+	requests := 0
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/appStoreVersions" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+		if got := req.URL.Query().Get("filter[versionString]"); got != "1.2.3" {
+			t.Fatalf("expected normalized version filter, got %q", got)
+		}
+		if got := req.URL.Query().Get("filter[platform]"); got != "IOS" {
+			t.Fatalf("expected normalized platform filter, got %q", got)
+		}
+		return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-existing","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
+	})
+	client := newPublishCommandTestClient(t)
+
+	result, err := findOrCreatePublishAppStoreVersion(context.Background(), client, " app-1 ", " 1.2.3 ", asc.Platform(" ios "))
+	if err != nil || result.Data.ID != "version-existing" || requests != 1 {
+		t.Fatalf("unexpected existing result: result=%+v requests=%d err=%v", result, requests, err)
+	}
+}
+
+func TestFindOrCreatePublishAppStoreVersionRejectsMultipleExactMatches(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			return nil, fmt.Errorf("unexpected mutation: %s %s", req.Method, req.URL.RequestURI())
+		}
+		return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1"},{"type":"appStoreVersions","id":"version-2"}]}`)
+	})
+	client := newPublishCommandTestClient(t)
+
+	_, err := findOrCreatePublishAppStoreVersion(context.Background(), client, "app-1", "1.2.3", asc.PlatformIOS)
+	if err == nil || !strings.Contains(err.Error(), "multiple app store versions found") {
+		t.Fatalf("expected multiple-match error, got %v", err)
+	}
+}
+
+func TestFindOrCreatePublishAppStoreVersionPreservesNonTransientCreateError(t *testing.T) {
+	reads := 0
+	creates := 0
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case http.MethodGet:
+			reads++
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[]}`)
+		case http.MethodPost:
+			creates++
+			return publishCommandJSONResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"invalid version"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	_, err := findOrCreatePublishAppStoreVersion(context.Background(), client, "app-1", "1.2.3", asc.PlatformIOS)
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("expected typed 422 error, got %T %v", err, err)
+	}
+	if reads != 2 || creates != 1 {
+		t.Fatalf("expected one readback and no replay, reads=%d creates=%d", reads, creates)
+	}
+}

--- a/internal/cli/shared/build_wait_test.go
+++ b/internal/cli/shared/build_wait_test.go
@@ -475,6 +475,7 @@ func TestWaitForBuildByNumberOrUploadFailureReturnsMalformedUploadRelationships(
 }
 
 func TestVerifyBuildUploadAfterCommitIgnoresRetryableLookupErrorsUntilBuildLinks(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "0")
 	lookupCalls := 0
 	client := newBuildWaitTestClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {

--- a/internal/cli/shared/localizations.go
+++ b/internal/cli/shared/localizations.go
@@ -25,6 +25,27 @@ const (
 	LocalizationTypeAppInfo = "app-info"
 )
 
+type localizationInputError struct {
+	err error
+}
+
+func (e localizationInputError) Error() string { return e.err.Error() }
+func (e localizationInputError) Unwrap() error { return e.err }
+
+func newLocalizationInputError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return localizationInputError{err: err}
+}
+
+// IsLocalizationInputError reports malformed locale/file input that should use
+// CLI usage exit semantics rather than a runtime failure.
+func IsLocalizationInputError(err error) bool {
+	_, ok := errors.AsType[localizationInputError](err)
+	return ok
+}
+
 var (
 	versionLocalizationKeys = []string{
 		"description",
@@ -80,6 +101,9 @@ func ValidateVersionLocalizationValueSet(valuesByLocale map[string]map[string]st
 	sort.Strings(locales)
 
 	for _, locale := range locales {
+		if err := validateLocalizationValuesForBatch(locale, valuesByLocale[locale]); err != nil {
+			return err
+		}
 		if err := ValidateVersionLocalizationValues(locale, valuesByLocale[locale]); err != nil {
 			return err
 		}
@@ -108,16 +132,36 @@ func ValidateAppInfoLocalizationKeys(locale string, values map[string]string) er
 	return validateLocalizationKeys(locale, values, appInfoLocalizationAllowedKeys)
 }
 
+// ValidateAppInfoLocalizationValueSet validates every locale before auth or
+// remote state is read.
+func ValidateAppInfoLocalizationValueSet(valuesByLocale map[string]map[string]string) error {
+	locales := make([]string, 0, len(valuesByLocale))
+	for locale := range valuesByLocale {
+		locales = append(locales, locale)
+	}
+	sort.Strings(locales)
+	for _, locale := range locales {
+		values := valuesByLocale[locale]
+		if err := validateLocalizationValuesForBatch(locale, values); err != nil {
+			return err
+		}
+		if err := ValidateAppInfoLocalizationKeys(locale, values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type versionLocalizationClient interface {
 	GetAppStoreVersionLocalizations(context.Context, string, ...asc.AppStoreVersionLocalizationsOption) (*asc.AppStoreVersionLocalizationsResponse, error)
 	CreateAppStoreVersionLocalization(context.Context, string, asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error)
-	UpdateAppStoreVersionLocalization(context.Context, string, asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error)
+	UpdateAppStoreVersionLocalizationFields(context.Context, string, map[string]string) (*asc.AppStoreVersionLocalizationResponse, error)
 }
 
 type appInfoLocalizationClient interface {
 	GetAppInfoLocalizations(context.Context, string, ...asc.AppInfoLocalizationsOption) (*asc.AppInfoLocalizationsResponse, error)
 	CreateAppInfoLocalization(context.Context, string, asc.AppInfoLocalizationAttributes) (*asc.AppInfoLocalizationResponse, error)
-	UpdateAppInfoLocalization(context.Context, string, asc.AppInfoLocalizationAttributes) (*asc.AppInfoLocalizationResponse, error)
+	UpdateAppInfoLocalizationFields(context.Context, string, map[string]string) (*asc.AppInfoLocalizationResponse, error)
 }
 
 func NormalizeLocalizationType(value string) (string, error) {
@@ -274,12 +318,19 @@ func ReadLocalizationStrings(inputPath string, locales []string) (map[string]map
 
 	filter := make(map[string]bool)
 	for _, locale := range locales {
-		filter[locale] = true
+		canonical, err := CanonicalizeAppStoreLocalizationLocale(locale)
+		if err != nil {
+			return nil, newLocalizationInputError(err)
+		}
+		if filter[canonical] {
+			return nil, newLocalizationInputError(fmt.Errorf("duplicate canonical locale %q in --locale", canonical))
+		}
+		filter[canonical] = true
 	}
 
 	if !info.IsDir() {
 		if len(locales) > 1 {
-			return nil, fmt.Errorf("single file input only supports one locale")
+			return nil, newLocalizationInputError(fmt.Errorf("single file input only supports one locale"))
 		}
 		locale := ""
 		if len(locales) == 1 {
@@ -287,8 +338,12 @@ func ReadLocalizationStrings(inputPath string, locales []string) (map[string]map
 		} else {
 			locale = strings.TrimSuffix(filepath.Base(inputPath), ".strings")
 			if locale == "" || locale == filepath.Base(inputPath) {
-				return nil, fmt.Errorf("cannot infer locale from %q (use --locale)", inputPath)
+				return nil, newLocalizationInputError(fmt.Errorf("cannot infer locale from %q (use --locale)", inputPath))
 			}
+		}
+		locale, err = CanonicalizeAppStoreLocalizationLocale(locale)
+		if err != nil {
+			return nil, newLocalizationInputError(err)
 		}
 
 		entries, err := readStringsFile(inputPath)
@@ -304,6 +359,7 @@ func ReadLocalizationStrings(inputPath string, locales []string) (map[string]map
 	}
 
 	values := make(map[string]map[string]string)
+	sources := make(map[string]string)
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -311,9 +367,13 @@ func ReadLocalizationStrings(inputPath string, locales []string) (map[string]map
 		if filepath.Ext(entry.Name()) != ".strings" {
 			continue
 		}
-		locale := strings.TrimSuffix(entry.Name(), ".strings")
-		if locale == "" {
+		rawLocale := strings.TrimSuffix(entry.Name(), ".strings")
+		if rawLocale == "" {
 			continue
+		}
+		locale, err := CanonicalizeAppStoreLocalizationLocale(rawLocale)
+		if err != nil {
+			return nil, newLocalizationInputError(fmt.Errorf("invalid localization file %q: %w", entry.Name(), err))
 		}
 		if len(filter) > 0 && !filter[locale] {
 			continue
@@ -324,13 +384,14 @@ func ReadLocalizationStrings(inputPath string, locales []string) (map[string]map
 			return nil, err
 		}
 		if _, exists := values[locale]; exists {
-			return nil, fmt.Errorf("duplicate locale %q in %s", locale, inputPath)
+			return nil, newLocalizationInputError(fmt.Errorf("duplicate canonical locale %q from files %q and %q", locale, sources[locale], entry.Name()))
 		}
 		values[locale] = parsed
+		sources[locale] = entry.Name()
 	}
 
 	if len(values) == 0 {
-		return nil, fmt.Errorf("no .strings files found in %q", inputPath)
+		return nil, newLocalizationInputError(fmt.Errorf("no .strings files found in %q", inputPath))
 	}
 	return values, nil
 }
@@ -378,10 +439,11 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "skip", LocalizationID: existing.ID}, nil
 		}
 		if existingID == "" {
-			if warning, ok := SubmitReadinessCreateWarningForLocaleWithOptions(locale, attributes, mode, submitOpts); ok {
-				warnings = append(warnings, warning)
-			}
+			warning, hasWarning := SubmitReadinessCreateWarningForLocaleWithOptions(locale, attributes, mode, submitOpts)
 			if dryRun {
+				if hasWarning {
+					warnings = append(warnings, warning)
+				}
 				return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "create"}, nil
 			}
 			id, reconciled, err := runLocalizationMutationWithReadback(
@@ -400,6 +462,9 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 			if err != nil {
 				return asc.LocalizationUploadLocaleResult{}, err
 			}
+			if hasWarning {
+				warnings = append(warnings, warning)
+			}
 			action := "create"
 			if reconciled {
 				action = "reconcile"
@@ -410,17 +475,18 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "update", LocalizationID: existingID}, nil
 		}
 		probeValues := cloneLocalizationValues(values)
+		updateFields := cloneLocalizationValues(values)
 		id, reconciled, err := runLocalizationMutationWithReadback(
 			ctx,
 			func(requestCtx context.Context) (string, error) {
-				resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, existingID, attributes)
+				resp, err := client.UpdateAppStoreVersionLocalizationFields(requestCtx, existingID, updateFields)
 				// A rejected whatsNew mutation is known not to have applied, so the
 				// documented initial-release fallback remains safe to send immediately.
-				if err != nil && strings.TrimSpace(attributes.WhatsNew) != "" && isWhatsNewUnsupportedError(err) {
+				if err != nil && strings.TrimSpace(updateFields["whatsNew"]) != "" && isWhatsNewUnsupportedError(err) {
 					fmt.Fprintln(os.Stderr, "Warning: 'whatsNew' cannot be set for this version (initial releases have no What's New section). Retrying without it.")
-					attributes.WhatsNew = ""
+					delete(updateFields, "whatsNew")
 					delete(probeValues, "whatsNew")
-					resp, err = client.UpdateAppStoreVersionLocalization(requestCtx, existingID, attributes)
+					resp, err = client.UpdateAppStoreVersionLocalizationFields(requestCtx, existingID, updateFields)
 				}
 				if err != nil {
 					return "", err
@@ -444,10 +510,8 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 }
 
 func UploadAppInfoLocalizations(ctx context.Context, client appInfoLocalizationClient, appInfoID string, valuesByLocale map[string]map[string]string, dryRun bool) ([]asc.LocalizationUploadLocaleResult, error) {
-	for locale, values := range valuesByLocale {
-		if err := ValidateAppInfoLocalizationKeys(locale, values); err != nil {
-			return nil, err
-		}
+	if err := ValidateAppInfoLocalizationValueSet(valuesByLocale); err != nil {
+		return nil, err
 	}
 
 	existing, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
@@ -503,7 +567,7 @@ func UploadAppInfoLocalizations(ctx context.Context, client appInfoLocalizationC
 		id, reconciled, err := runLocalizationMutationWithReadback(
 			ctx,
 			func(requestCtx context.Context) (string, error) {
-				resp, err := client.UpdateAppInfoLocalization(requestCtx, existingID, attributes)
+				resp, err := client.UpdateAppInfoLocalizationFields(requestCtx, existingID, cloneLocalizationValues(values))
 				if err != nil {
 					return "", err
 				}
@@ -534,7 +598,9 @@ func runLocalizationMutationWithReadback(
 }
 
 func findMatchingVersionLocalization(ctx context.Context, client versionLocalizationClient, versionID, locale string, values map[string]string) (string, bool, error) {
-	resp, err := client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	resp, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+		return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	})
 	if err != nil {
 		return "", false, err
 	}
@@ -547,7 +613,9 @@ func findMatchingVersionLocalization(ctx context.Context, client versionLocaliza
 }
 
 func findMatchingAppInfoLocalization(ctx context.Context, client appInfoLocalizationClient, appInfoID, locale string, values map[string]string) (string, bool, error) {
-	resp, err := client.GetAppInfoLocalizations(ctx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	resp, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+		return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	})
 	if err != nil {
 		return "", false, err
 	}
@@ -621,18 +689,6 @@ func uploadLocalizationValues(valuesByLocale map[string]map[string]string, exist
 	batchErrors := make([]error, 0)
 	for _, locale := range locales {
 		values := valuesByLocale[locale]
-		if len(values) == 0 {
-			err := fmt.Errorf("no localization values for locale %q", locale)
-			results = append(results, failedLocalizationUploadResult(locale, existing[locale], values, err))
-			batchErrors = append(batchErrors, err)
-			continue
-		}
-		if !hasNonEmptyLocalizationValues(values) {
-			err := fmt.Errorf("localization values for locale %q are empty", locale)
-			results = append(results, failedLocalizationUploadResult(locale, existing[locale], values, err))
-			batchErrors = append(batchErrors, err)
-			continue
-		}
 		result, err := handler(locale, values, existing[locale])
 		if err != nil {
 			if result.Locale == "" {
@@ -663,21 +719,21 @@ func uploadLocalizationValues(valuesByLocale map[string]map[string]string, exist
 	return results, errors.Join(batchErrors...)
 }
 
-func failedLocalizationUploadResult(locale, existingID string, values map[string]string, err error) asc.LocalizationUploadLocaleResult {
-	return asc.LocalizationUploadLocaleResult{
-		Locale:        locale,
-		Action:        localizationUploadMutationAction(existingID),
-		Status:        "failed",
-		Error:         err.Error(),
-		DesiredValues: cloneLocalizationValues(values),
-	}
-}
-
 func localizationUploadMutationAction(existingID string) string {
 	if existingID == "" {
 		return "create"
 	}
 	return "update"
+}
+
+func validateLocalizationValuesForBatch(locale string, values map[string]string) error {
+	if len(values) == 0 {
+		return fmt.Errorf("no localization values for locale %q", locale)
+	}
+	if !hasNonEmptyLocalizationValues(values) {
+		return fmt.Errorf("localization values for locale %q are empty", locale)
+	}
+	return nil
 }
 
 type localizationUploadFailureArtifact struct {
@@ -719,6 +775,37 @@ func FinalizeLocalizationUploadResult(result *asc.LocalizationUploadResult, comm
 		return
 	}
 	result.FailureArtifactPath = path
+}
+
+// RenderLocalizationUploadResult renders both the batch summary and per-locale
+// details so interactive output includes retry artifact information.
+func RenderLocalizationUploadResult(result *asc.LocalizationUploadResult, markdown bool) error {
+	if result == nil {
+		return fmt.Errorf("localization upload result is nil")
+	}
+	render := asc.RenderTable
+	if markdown {
+		render = asc.RenderMarkdown
+	}
+	render(
+		[]string{"Type", "Input Path", "Dry Run", "Total", "Succeeded", "Failed", "Failure Artifact", "Failure Artifact Error"},
+		[][]string{{
+			result.Type,
+			result.InputPath,
+			fmt.Sprintf("%t", result.DryRun),
+			strconv.Itoa(result.Total),
+			strconv.Itoa(result.Succeeded),
+			strconv.Itoa(result.Failed),
+			result.FailureArtifactPath,
+			result.FailureArtifactError,
+		}},
+	)
+	rows := make([][]string, 0, len(result.Results))
+	for _, item := range result.Results {
+		rows = append(rows, []string{item.Locale, item.Action, item.Status, item.LocalizationID, item.Error})
+	}
+	render([]string{"Locale", "Action", "Status", "Localization ID", "Error"}, rows)
+	return nil
 }
 
 func writeLocalizationUploadFailureArtifact(result *asc.LocalizationUploadResult, command string) (string, error) {
@@ -859,7 +946,11 @@ func readStringsFile(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseStringsContent(string(data))
+	values, err := parseStringsContent(string(data))
+	if err != nil {
+		return nil, newLocalizationInputError(err)
+	}
+	return values, nil
 }
 
 func parseStringsContent(content string) (map[string]string, error) {

--- a/internal/cli/shared/localizations.go
+++ b/internal/cli/shared/localizations.go
@@ -426,6 +426,9 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 		existingByLocale[item.Attributes.Locale] = item.ID
 		existingItems[item.Attributes.Locale] = item
 	}
+	if err := validateVersionLocalizationCreates(valuesByLocale, existingByLocale); err != nil {
+		return nil, nil, newLocalizationInputError(err)
+	}
 
 	mode := SubmitReadinessCreateModeApplied
 	if dryRun {
@@ -528,6 +531,9 @@ func UploadAppInfoLocalizations(ctx context.Context, client appInfoLocalizationC
 		}
 		existingByLocale[item.Attributes.Locale] = item.ID
 		existingItems[item.Attributes.Locale] = item
+	}
+	if err := validateAppInfoLocalizationCreates(valuesByLocale, existingByLocale); err != nil {
+		return nil, newLocalizationInputError(err)
 	}
 
 	return uploadLocalizationValues(valuesByLocale, existingByLocale, dryRun, func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error) {
@@ -730,8 +736,33 @@ func validateLocalizationValuesForBatch(locale string, values map[string]string)
 	if len(values) == 0 {
 		return fmt.Errorf("no localization values for locale %q", locale)
 	}
-	if !hasNonEmptyLocalizationValues(values) {
-		return fmt.Errorf("localization values for locale %q are empty", locale)
+	return nil
+}
+
+func validateVersionLocalizationCreates(valuesByLocale map[string]map[string]string, existing map[string]string) error {
+	locales := make([]string, 0, len(valuesByLocale))
+	for locale := range valuesByLocale {
+		locales = append(locales, locale)
+	}
+	sort.Strings(locales)
+	for _, locale := range locales {
+		if existing[locale] == "" && !hasNonEmptyLocalizationValues(valuesByLocale[locale]) {
+			return fmt.Errorf("cannot create version localization %q without a non-empty value", locale)
+		}
+	}
+	return nil
+}
+
+func validateAppInfoLocalizationCreates(valuesByLocale map[string]map[string]string, existing map[string]string) error {
+	locales := make([]string, 0, len(valuesByLocale))
+	for locale := range valuesByLocale {
+		locales = append(locales, locale)
+	}
+	sort.Strings(locales)
+	for _, locale := range locales {
+		if existing[locale] == "" && strings.TrimSpace(valuesByLocale[locale]["name"]) == "" {
+			return fmt.Errorf("cannot create app-info localization %q without a non-empty name", locale)
+		}
 	}
 	return nil
 }

--- a/internal/cli/shared/localizations.go
+++ b/internal/cli/shared/localizations.go
@@ -1,7 +1,9 @@
 package shared
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -347,16 +350,20 @@ func UploadVersionLocalizationsWithWarnings(ctx context.Context, client versionL
 // UploadPrevalidatedVersionLocalizationsWithWarnings uploads version localizations
 // after the caller has already validated the input value set.
 func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, client versionLocalizationClient, versionID string, valuesByLocale map[string]map[string]string, dryRun bool, submitOpts SubmitReadinessOptions) ([]asc.LocalizationUploadLocaleResult, []SubmitReadinessCreateWarning, error) {
-	existing, err := client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	existing, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+		return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	})
 	if err != nil {
 		return nil, nil, err
 	}
 	existingByLocale := make(map[string]string, len(existing.Data))
+	existingItems := make(map[string]asc.Resource[asc.AppStoreVersionLocalizationAttributes], len(existing.Data))
 	for _, item := range existing.Data {
 		if strings.TrimSpace(item.Attributes.Locale) == "" {
 			continue
 		}
 		existingByLocale[item.Attributes.Locale] = item.ID
+		existingItems[item.Attributes.Locale] = item
 	}
 
 	mode := SubmitReadinessCreateModeApplied
@@ -365,8 +372,11 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 	}
 	warnings := make([]SubmitReadinessCreateWarning, 0, len(valuesByLocale))
 
-	results, err := uploadLocalizationValues(valuesByLocale, existingByLocale, func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error) {
+	results, err := uploadLocalizationValues(valuesByLocale, existingByLocale, dryRun, func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error) {
 		attributes := buildVersionLocalizationAttributes(locale, values, existingID == "")
+		if existing, ok := existingItems[locale]; ok && versionLocalizationMatchesValues(existing.Attributes, values) {
+			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "skip", LocalizationID: existing.ID}, nil
+		}
 		if existingID == "" {
 			if warning, ok := SubmitReadinessCreateWarningForLocaleWithOptions(locale, attributes, mode, submitOpts); ok {
 				warnings = append(warnings, warning)
@@ -374,32 +384,63 @@ func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, cli
 			if dryRun {
 				return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "create"}, nil
 			}
-			resp, err := client.CreateAppStoreVersionLocalization(ctx, versionID, attributes)
+			id, reconciled, err := runLocalizationMutationWithReadback(
+				ctx,
+				func(requestCtx context.Context) (string, error) {
+					resp, err := client.CreateAppStoreVersionLocalization(requestCtx, versionID, attributes)
+					if err != nil {
+						return "", err
+					}
+					return resp.Data.ID, nil
+				},
+				func(requestCtx context.Context) (string, bool, error) {
+					return findMatchingVersionLocalization(requestCtx, client, versionID, locale, values)
+				},
+			)
 			if err != nil {
 				return asc.LocalizationUploadLocaleResult{}, err
 			}
-			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "create", LocalizationID: resp.Data.ID}, nil
+			action := "create"
+			if reconciled {
+				action = "reconcile"
+			}
+			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: action, LocalizationID: id}, nil
 		}
 		if dryRun {
 			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "update", LocalizationID: existingID}, nil
 		}
-		resp, err := client.UpdateAppStoreVersionLocalization(ctx, existingID, attributes)
-		// If the API rejects whatsNew (e.g. on an initial v1.0 release where
-		// there is no previous version), retry without it and warn the user.
-		if err != nil && strings.TrimSpace(attributes.WhatsNew) != "" && isWhatsNewUnsupportedError(err) {
-			fmt.Fprintln(os.Stderr, "Warning: 'whatsNew' cannot be set for this version (initial releases have no What's New section). Retrying without it.")
-			attributes.WhatsNew = ""
-			resp, err = client.UpdateAppStoreVersionLocalization(ctx, existingID, attributes)
-		}
+		probeValues := cloneLocalizationValues(values)
+		id, reconciled, err := runLocalizationMutationWithReadback(
+			ctx,
+			func(requestCtx context.Context) (string, error) {
+				resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, existingID, attributes)
+				// A rejected whatsNew mutation is known not to have applied, so the
+				// documented initial-release fallback remains safe to send immediately.
+				if err != nil && strings.TrimSpace(attributes.WhatsNew) != "" && isWhatsNewUnsupportedError(err) {
+					fmt.Fprintln(os.Stderr, "Warning: 'whatsNew' cannot be set for this version (initial releases have no What's New section). Retrying without it.")
+					attributes.WhatsNew = ""
+					delete(probeValues, "whatsNew")
+					resp, err = client.UpdateAppStoreVersionLocalization(requestCtx, existingID, attributes)
+				}
+				if err != nil {
+					return "", err
+				}
+				return resp.Data.ID, nil
+			},
+			func(requestCtx context.Context) (string, bool, error) {
+				return findMatchingVersionLocalization(requestCtx, client, versionID, locale, probeValues)
+			},
+		)
 		if err != nil {
 			return asc.LocalizationUploadLocaleResult{}, err
 		}
-		return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "update", LocalizationID: resp.Data.ID}, nil
+		action := "update"
+		if reconciled {
+			action = "reconcile"
+		}
+		return asc.LocalizationUploadLocaleResult{Locale: locale, Action: action, LocalizationID: id}, nil
 	})
-	if err != nil {
-		return nil, nil, err
-	}
-	return results, NormalizeSubmitReadinessCreateWarnings(warnings), nil
+	return results, NormalizeSubmitReadinessCreateWarnings(warnings), err
 }
 
 func UploadAppInfoLocalizations(ctx context.Context, client appInfoLocalizationClient, appInfoID string, valuesByLocale map[string]map[string]string, dryRun bool) ([]asc.LocalizationUploadLocaleResult, error) {
@@ -409,39 +450,140 @@ func UploadAppInfoLocalizations(ctx context.Context, client appInfoLocalizationC
 		}
 	}
 
-	existing, err := client.GetAppInfoLocalizations(ctx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	existing, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+		return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	})
 	if err != nil {
 		return nil, err
 	}
 	existingByLocale := make(map[string]string, len(existing.Data))
+	existingItems := make(map[string]asc.Resource[asc.AppInfoLocalizationAttributes], len(existing.Data))
 	for _, item := range existing.Data {
 		if strings.TrimSpace(item.Attributes.Locale) == "" {
 			continue
 		}
 		existingByLocale[item.Attributes.Locale] = item.ID
+		existingItems[item.Attributes.Locale] = item
 	}
 
-	return uploadLocalizationValues(valuesByLocale, existingByLocale, func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error) {
+	return uploadLocalizationValues(valuesByLocale, existingByLocale, dryRun, func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error) {
 		attributes := buildAppInfoLocalizationAttributes(locale, values, existingID == "")
+		if existing, ok := existingItems[locale]; ok && appInfoLocalizationMatchesValues(existing.Attributes, values) {
+			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "skip", LocalizationID: existing.ID}, nil
+		}
 		if existingID == "" {
 			if dryRun {
 				return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "create"}, nil
 			}
-			resp, err := client.CreateAppInfoLocalization(ctx, appInfoID, attributes)
+			id, reconciled, err := runLocalizationMutationWithReadback(
+				ctx,
+				func(requestCtx context.Context) (string, error) {
+					resp, err := client.CreateAppInfoLocalization(requestCtx, appInfoID, attributes)
+					if err != nil {
+						return "", err
+					}
+					return resp.Data.ID, nil
+				},
+				func(requestCtx context.Context) (string, bool, error) {
+					return findMatchingAppInfoLocalization(requestCtx, client, appInfoID, locale, values)
+				},
+			)
 			if err != nil {
 				return asc.LocalizationUploadLocaleResult{}, err
 			}
-			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "create", LocalizationID: resp.Data.ID}, nil
+			action := "create"
+			if reconciled {
+				action = "reconcile"
+			}
+			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: action, LocalizationID: id}, nil
 		}
 		if dryRun {
 			return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "update", LocalizationID: existingID}, nil
 		}
-		resp, err := client.UpdateAppInfoLocalization(ctx, existingID, attributes)
+		id, reconciled, err := runLocalizationMutationWithReadback(
+			ctx,
+			func(requestCtx context.Context) (string, error) {
+				resp, err := client.UpdateAppInfoLocalization(requestCtx, existingID, attributes)
+				if err != nil {
+					return "", err
+				}
+				return resp.Data.ID, nil
+			},
+			func(requestCtx context.Context) (string, bool, error) {
+				return findMatchingAppInfoLocalization(requestCtx, client, appInfoID, locale, values)
+			},
+		)
 		if err != nil {
 			return asc.LocalizationUploadLocaleResult{}, err
 		}
-		return asc.LocalizationUploadLocaleResult{Locale: locale, Action: "update", LocalizationID: resp.Data.ID}, nil
+		action := "update"
+		if reconciled {
+			action = "reconcile"
+		}
+		return asc.LocalizationUploadLocaleResult{Locale: locale, Action: action, LocalizationID: id}, nil
 	})
+}
+
+func runLocalizationMutationWithReadback(
+	ctx context.Context,
+	mutate func(context.Context) (string, error),
+	probe func(context.Context) (string, bool, error),
+) (string, bool, error) {
+	id, status, err := RunReconciledMutation(ctx, mutate, probe)
+	return id, status == ReconciledMutationRecovered, err
+}
+
+func findMatchingVersionLocalization(ctx context.Context, client versionLocalizationClient, versionID, locale string, values map[string]string) (string, bool, error) {
+	resp, err := client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	if err != nil {
+		return "", false, err
+	}
+	for _, item := range resp.Data {
+		if item.Attributes.Locale == locale && versionLocalizationMatchesValues(item.Attributes, values) {
+			return item.ID, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func findMatchingAppInfoLocalization(ctx context.Context, client appInfoLocalizationClient, appInfoID, locale string, values map[string]string) (string, bool, error) {
+	resp, err := client.GetAppInfoLocalizations(ctx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	if err != nil {
+		return "", false, err
+	}
+	for _, item := range resp.Data {
+		if item.Attributes.Locale == locale && appInfoLocalizationMatchesValues(item.Attributes, values) {
+			return item.ID, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func versionLocalizationMatchesValues(attrs asc.AppStoreVersionLocalizationAttributes, values map[string]string) bool {
+	remote := mapVersionLocalizationStrings(attrs)
+	return localizationValuesMatch(remote, values)
+}
+
+func appInfoLocalizationMatchesValues(attrs asc.AppInfoLocalizationAttributes, values map[string]string) bool {
+	remote := mapAppInfoLocalizationStrings(attrs)
+	return localizationValuesMatch(remote, values)
+}
+
+func localizationValuesMatch(remote, desired map[string]string) bool {
+	for key, value := range desired {
+		if remote[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneLocalizationValues(values map[string]string) map[string]string {
+	clone := make(map[string]string, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
 }
 
 func isWhatsNewUnsupportedError(err error) bool {
@@ -468,7 +610,7 @@ func containsWhatsNewToken(value string) bool {
 	return strings.Contains(normalized, "whatsnew")
 }
 
-func uploadLocalizationValues(valuesByLocale map[string]map[string]string, existing map[string]string, handler func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error)) ([]asc.LocalizationUploadLocaleResult, error) {
+func uploadLocalizationValues(valuesByLocale map[string]map[string]string, existing map[string]string, dryRun bool, handler func(locale string, values map[string]string, existingID string) (asc.LocalizationUploadLocaleResult, error)) ([]asc.LocalizationUploadLocaleResult, error) {
 	locales := make([]string, 0, len(valuesByLocale))
 	for locale := range valuesByLocale {
 		locales = append(locales, locale)
@@ -476,21 +618,137 @@ func uploadLocalizationValues(valuesByLocale map[string]map[string]string, exist
 	sort.Strings(locales)
 
 	results := make([]asc.LocalizationUploadLocaleResult, 0, len(locales))
+	batchErrors := make([]error, 0)
 	for _, locale := range locales {
 		values := valuesByLocale[locale]
 		if len(values) == 0 {
-			return nil, fmt.Errorf("no localization values for locale %q", locale)
+			err := fmt.Errorf("no localization values for locale %q", locale)
+			results = append(results, failedLocalizationUploadResult(locale, existing[locale], values, err))
+			batchErrors = append(batchErrors, err)
+			continue
 		}
 		if !hasNonEmptyLocalizationValues(values) {
-			return nil, fmt.Errorf("localization values for locale %q are empty", locale)
+			err := fmt.Errorf("localization values for locale %q are empty", locale)
+			results = append(results, failedLocalizationUploadResult(locale, existing[locale], values, err))
+			batchErrors = append(batchErrors, err)
+			continue
 		}
 		result, err := handler(locale, values, existing[locale])
 		if err != nil {
-			return nil, err
+			if result.Locale == "" {
+				result.Locale = locale
+			}
+			if result.Action == "" {
+				result.Action = localizationUploadMutationAction(existing[locale])
+			}
+			if result.LocalizationID == "" {
+				result.LocalizationID = existing[locale]
+			}
+			result.Status = "failed"
+			result.Error = err.Error()
+			result.DesiredValues = cloneLocalizationValues(values)
+			results = append(results, result)
+			batchErrors = append(batchErrors, fmt.Errorf("locale %q: %w", locale, err))
+			continue
+		}
+		if result.Status == "" {
+			if dryRun {
+				result.Status = "planned"
+			} else {
+				result.Status = "succeeded"
+			}
 		}
 		results = append(results, result)
 	}
-	return results, nil
+	return results, errors.Join(batchErrors...)
+}
+
+func failedLocalizationUploadResult(locale, existingID string, values map[string]string, err error) asc.LocalizationUploadLocaleResult {
+	return asc.LocalizationUploadLocaleResult{
+		Locale:        locale,
+		Action:        localizationUploadMutationAction(existingID),
+		Status:        "failed",
+		Error:         err.Error(),
+		DesiredValues: cloneLocalizationValues(values),
+	}
+}
+
+func localizationUploadMutationAction(existingID string) string {
+	if existingID == "" {
+		return "create"
+	}
+	return "update"
+}
+
+type localizationUploadFailureArtifact struct {
+	SchemaVersion int                                  `json:"schemaVersion"`
+	Command       string                               `json:"command"`
+	Type          string                               `json:"type"`
+	VersionID     string                               `json:"versionId,omitempty"`
+	AppID         string                               `json:"appId,omitempty"`
+	AppInfoID     string                               `json:"appInfoId,omitempty"`
+	InputPath     string                               `json:"inputPath,omitempty"`
+	Failed        int                                  `json:"failed"`
+	GeneratedAt   string                               `json:"generatedAt"`
+	Results       []asc.LocalizationUploadLocaleResult `json:"results"`
+}
+
+// FinalizeLocalizationUploadResult computes batch counts and writes a
+// versioned retry artifact for failed locales. Artifact failures are retained
+// in the result so callers can print the batch before returning an error.
+func FinalizeLocalizationUploadResult(result *asc.LocalizationUploadResult, command string) {
+	if result == nil {
+		return
+	}
+	result.Total = len(result.Results)
+	result.Succeeded = 0
+	result.Failed = 0
+	for _, item := range result.Results {
+		if item.Status == "failed" || item.Error != "" {
+			result.Failed++
+			continue
+		}
+		result.Succeeded++
+	}
+	if result.Failed == 0 {
+		return
+	}
+	path, err := writeLocalizationUploadFailureArtifact(result, command)
+	if err != nil {
+		result.FailureArtifactError = err.Error()
+		return
+	}
+	result.FailureArtifactPath = path
+}
+
+func writeLocalizationUploadFailureArtifact(result *asc.LocalizationUploadResult, command string) (string, error) {
+	failures := make([]asc.LocalizationUploadLocaleResult, 0, result.Failed)
+	for _, item := range result.Results {
+		if item.Status == "failed" || item.Error != "" {
+			failures = append(failures, item)
+		}
+	}
+	artifact := localizationUploadFailureArtifact{
+		SchemaVersion: 1,
+		Command:       strings.TrimSpace(command),
+		Type:          result.Type,
+		VersionID:     result.VersionID,
+		AppID:         result.AppID,
+		AppInfoID:     result.AppInfoID,
+		InputPath:     result.InputPath,
+		Failed:        result.Failed,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Results:       failures,
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(".asc", "reports", "localizations-upload", fmt.Sprintf("failures-%d.json", time.Now().UTC().UnixNano()))
+	if _, err := WriteStreamToFile(path, bytes.NewReader(data)); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 func hasNonEmptyLocalizationValues(values map[string]string) bool {

--- a/internal/cli/shared/localizations.go
+++ b/internal/cli/shared/localizations.go
@@ -411,15 +411,13 @@ func UploadVersionLocalizationsWithWarnings(ctx context.Context, client versionL
 // UploadPrevalidatedVersionLocalizationsWithWarnings uploads version localizations
 // after the caller has already validated the input value set.
 func UploadPrevalidatedVersionLocalizationsWithWarnings(ctx context.Context, client versionLocalizationClient, versionID string, valuesByLocale map[string]map[string]string, dryRun bool, submitOpts SubmitReadinessOptions) ([]asc.LocalizationUploadLocaleResult, []SubmitReadinessCreateWarning, error) {
-	existing, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
-		return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
-	})
+	existing, err := fetchAllVersionLocalizations(ctx, client, versionID)
 	if err != nil {
 		return nil, nil, err
 	}
-	existingByLocale := make(map[string]string, len(existing.Data))
-	existingItems := make(map[string]asc.Resource[asc.AppStoreVersionLocalizationAttributes], len(existing.Data))
-	for _, item := range existing.Data {
+	existingByLocale := make(map[string]string, len(existing))
+	existingItems := make(map[string]asc.Resource[asc.AppStoreVersionLocalizationAttributes], len(existing))
+	for _, item := range existing {
 		if strings.TrimSpace(item.Attributes.Locale) == "" {
 			continue
 		}
@@ -517,15 +515,13 @@ func UploadAppInfoLocalizations(ctx context.Context, client appInfoLocalizationC
 		return nil, err
 	}
 
-	existing, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
-		return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
-	})
+	existing, err := fetchAllAppInfoLocalizations(ctx, client, appInfoID)
 	if err != nil {
 		return nil, err
 	}
-	existingByLocale := make(map[string]string, len(existing.Data))
-	existingItems := make(map[string]asc.Resource[asc.AppInfoLocalizationAttributes], len(existing.Data))
-	for _, item := range existing.Data {
+	existingByLocale := make(map[string]string, len(existing))
+	existingItems := make(map[string]asc.Resource[asc.AppInfoLocalizationAttributes], len(existing))
+	for _, item := range existing {
 		if strings.TrimSpace(item.Attributes.Locale) == "" {
 			continue
 		}
@@ -604,13 +600,11 @@ func runLocalizationMutationWithReadback(
 }
 
 func findMatchingVersionLocalization(ctx context.Context, client versionLocalizationClient, versionID, locale string, values map[string]string) (string, bool, error) {
-	resp, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
-		return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
-	})
+	items, err := fetchAllVersionLocalizations(ctx, client, versionID)
 	if err != nil {
 		return "", false, err
 	}
-	for _, item := range resp.Data {
+	for _, item := range items {
 		if item.Attributes.Locale == locale && versionLocalizationMatchesValues(item.Attributes, values) {
 			return item.ID, true, nil
 		}
@@ -619,18 +613,88 @@ func findMatchingVersionLocalization(ctx context.Context, client versionLocaliza
 }
 
 func findMatchingAppInfoLocalization(ctx context.Context, client appInfoLocalizationClient, appInfoID, locale string, values map[string]string) (string, bool, error) {
-	resp, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
-		return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
-	})
+	items, err := fetchAllAppInfoLocalizations(ctx, client, appInfoID)
 	if err != nil {
 		return "", false, err
 	}
-	for _, item := range resp.Data {
+	for _, item := range items {
 		if item.Attributes.Locale == locale && appInfoLocalizationMatchesValues(item.Attributes, values) {
 			return item.ID, true, nil
 		}
 	}
 	return "", false, nil
+}
+
+func fetchAllVersionLocalizations(ctx context.Context, client versionLocalizationClient, versionID string) ([]asc.Resource[asc.AppStoreVersionLocalizationAttributes], error) {
+	firstPage, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+		return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	})
+	if err != nil {
+		return nil, err
+	}
+	if firstPage == nil {
+		return nil, fmt.Errorf("empty version localization response")
+	}
+	if strings.TrimSpace(firstPage.Links.Next) == "" {
+		return firstPage.Data, nil
+	}
+
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		nextPage, err := RetryReadWithFreshTimeout(pageCtx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+			return client.GetAppStoreVersionLocalizations(requestCtx, versionID, asc.WithAppStoreVersionLocalizationsNextURL(nextURL))
+		})
+		if err != nil {
+			return nil, err
+		}
+		if nextPage == nil {
+			return nil, fmt.Errorf("empty version localization response")
+		}
+		return nextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	allPages, ok := paginated.(*asc.AppStoreVersionLocalizationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected version localization pagination response type")
+	}
+	return allPages.Data, nil
+}
+
+func fetchAllAppInfoLocalizations(ctx context.Context, client appInfoLocalizationClient, appInfoID string) ([]asc.Resource[asc.AppInfoLocalizationAttributes], error) {
+	firstPage, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+		return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	})
+	if err != nil {
+		return nil, err
+	}
+	if firstPage == nil {
+		return nil, fmt.Errorf("empty app-info localization response")
+	}
+	if strings.TrimSpace(firstPage.Links.Next) == "" {
+		return firstPage.Data, nil
+	}
+
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		nextPage, err := RetryReadWithFreshTimeout(pageCtx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+			return client.GetAppInfoLocalizations(requestCtx, appInfoID, asc.WithAppInfoLocalizationsNextURL(nextURL))
+		})
+		if err != nil {
+			return nil, err
+		}
+		if nextPage == nil {
+			return nil, fmt.Errorf("empty app-info localization response")
+		}
+		return nextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	allPages, ok := paginated.(*asc.AppInfoLocalizationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected app-info localization pagination response type")
+	}
+	return allPages.Data, nil
 }
 
 func versionLocalizationMatchesValues(attrs asc.AppStoreVersionLocalizationAttributes, values map[string]string) bool {

--- a/internal/cli/shared/localizations_upload_test.go
+++ b/internal/cli/shared/localizations_upload_test.go
@@ -19,7 +19,9 @@ type stubVersionLocalizationClient struct {
 	getResp  *asc.AppStoreVersionLocalizationsResponse
 	getResps []*asc.AppStoreVersionLocalizationsResponse
 	getErr   error
+	getErrs  []error
 	getCalls int
+	onGet    func(context.Context, int)
 
 	createErrs        []error
 	createCalls       []asc.AppStoreVersionLocalizationAttributes
@@ -36,16 +38,25 @@ type expiringVersionLocalizationClient struct {
 type stubAppInfoLocalizationClient struct {
 	getResp     *asc.AppInfoLocalizationsResponse
 	getResps    []*asc.AppInfoLocalizationsResponse
+	getErrs     []error
 	getCalls    int
 	createErrs  []error
 	createCalls []asc.AppInfoLocalizationAttributes
 	updateErrs  []error
 	updateCalls []map[string]string
+	onGet       func(context.Context, int)
 }
 
-func (s *stubAppInfoLocalizationClient) GetAppInfoLocalizations(context.Context, string, ...asc.AppInfoLocalizationsOption) (*asc.AppInfoLocalizationsResponse, error) {
+func (s *stubAppInfoLocalizationClient) GetAppInfoLocalizations(ctx context.Context, _ string, _ ...asc.AppInfoLocalizationsOption) (*asc.AppInfoLocalizationsResponse, error) {
 	s.getCalls++
-	if index := s.getCalls - 1; index >= 0 && index < len(s.getResps) {
+	if s.onGet != nil {
+		s.onGet(ctx, s.getCalls)
+	}
+	index := s.getCalls - 1
+	if index >= 0 && index < len(s.getErrs) && s.getErrs[index] != nil {
+		return nil, s.getErrs[index]
+	}
+	if index >= 0 && index < len(s.getResps) {
 		return s.getResps[index], nil
 	}
 	return s.getResp, nil
@@ -93,12 +104,19 @@ func (c *expiringVersionLocalizationClient) UpdateAppStoreVersionLocalizationFie
 	return nil, &asc.RetryableError{Err: ctx.Err()}
 }
 
-func (s *stubVersionLocalizationClient) GetAppStoreVersionLocalizations(_ context.Context, _ string, _ ...asc.AppStoreVersionLocalizationsOption) (*asc.AppStoreVersionLocalizationsResponse, error) {
+func (s *stubVersionLocalizationClient) GetAppStoreVersionLocalizations(ctx context.Context, _ string, _ ...asc.AppStoreVersionLocalizationsOption) (*asc.AppStoreVersionLocalizationsResponse, error) {
 	s.getCalls++
+	if s.onGet != nil {
+		s.onGet(ctx, s.getCalls)
+	}
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
-	if index := s.getCalls - 1; index >= 0 && index < len(s.getResps) {
+	index := s.getCalls - 1
+	if index >= 0 && index < len(s.getErrs) && s.getErrs[index] != nil {
+		return nil, s.getErrs[index]
+	}
+	if index >= 0 && index < len(s.getResps) {
 		return s.getResps[index], nil
 	}
 	return s.getResp, nil
@@ -148,6 +166,47 @@ func TestUploadVersionLocalizations_SkipsExactExistingValues(t *testing.T) {
 	}
 }
 
+func TestUploadVersionLocalizations_SkipsExactExistingValuesOnSecondPage(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "150ms")
+	client := &stubVersionLocalizationClient{
+		getResps: []*asc.AppStoreVersionLocalizationsResponse{
+			{
+				Data:  []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{{ID: "first-page", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "de-DE"}}},
+				Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appStoreVersions/version-id/appStoreVersionLocalizations?cursor=page-2"},
+			},
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{{
+				ID: "existing-loc",
+				Attributes: asc.AppStoreVersionLocalizationAttributes{
+					Locale:      "en-US",
+					Description: "Existing description",
+				},
+			}}},
+		},
+	}
+	client.onGet = func(ctx context.Context, call int) {
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) < 100*time.Millisecond {
+			t.Fatalf("page %d did not receive a fresh timeout: %s", call, time.Until(deadline))
+		}
+		if call == 1 {
+			time.Sleep(75 * time.Millisecond)
+		}
+	}
+
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "Existing description"},
+	}, false)
+	if err != nil {
+		t.Fatalf("UploadVersionLocalizations() error: %v", err)
+	}
+	if client.getCalls != 2 || len(client.updateCalls) != 0 || len(client.createCalls) != 0 {
+		t.Fatalf("expected two-page skip without mutation, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+	}
+	if len(results) != 1 || results[0].Action != "skip" || results[0].LocalizationID != "existing-loc" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
 func TestUploadAppInfoLocalizations_SkipsExactExistingValues(t *testing.T) {
 	client := &stubAppInfoLocalizationClient{getResp: &asc.AppInfoLocalizationsResponse{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{
 		{ID: "loc-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Existing", Subtitle: "Subtitle"}},
@@ -157,6 +216,178 @@ func TestUploadAppInfoLocalizations_SkipsExactExistingValues(t *testing.T) {
 	}, false)
 	if err != nil || len(results) != 1 || results[0].Action != "skip" || len(client.updateCalls) != 0 {
 		t.Fatalf("expected exact app-info skip, results=%+v updates=%d err=%v", results, len(client.updateCalls), err)
+	}
+}
+
+func TestUploadAppInfoLocalizations_SkipsExactExistingValuesOnSecondPage(t *testing.T) {
+	client := &stubAppInfoLocalizationClient{getResps: []*asc.AppInfoLocalizationsResponse{
+		{
+			Data:  []asc.Resource[asc.AppInfoLocalizationAttributes]{{ID: "first-page", Attributes: asc.AppInfoLocalizationAttributes{Locale: "de-DE"}}},
+			Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appInfos/app-info-id/appInfoLocalizations?cursor=page-2"},
+		},
+		{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{{
+			ID:         "loc-id",
+			Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Existing", Subtitle: "Subtitle"},
+		}}},
+	}}
+	results, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+		"en-US": {"name": "Existing", "subtitle": "Subtitle"},
+	}, false)
+	if err != nil || client.getCalls != 2 || len(results) != 1 || results[0].Action != "skip" || len(client.updateCalls) != 0 || len(client.createCalls) != 0 {
+		t.Fatalf("expected page-two app-info skip, results=%+v gets=%d creates=%d updates=%d err=%v", results, client.getCalls, len(client.createCalls), len(client.updateCalls), err)
+	}
+}
+
+func TestUploadVersionLocalizations_StopsPaginationWhenParentCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &stubVersionLocalizationClient{getResps: []*asc.AppStoreVersionLocalizationsResponse{{
+		Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appStoreVersions/version-id/appStoreVersionLocalizations?cursor=page-2"},
+	}}}
+	client.onGet = func(_ context.Context, call int) {
+		if call == 1 {
+			cancel()
+		}
+	}
+
+	_, err := UploadVersionLocalizations(ctx, client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "English"},
+	}, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected parent cancellation, got %v", err)
+	}
+	if client.getCalls != 1 || len(client.createCalls) != 0 || len(client.updateCalls) != 0 {
+		t.Fatalf("expected pagination to stop before page two, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+	}
+}
+
+func TestUploadAppInfoLocalizations_ReturnsSecondPageError(t *testing.T) {
+	pageErr := errors.New("page two failed")
+	client := &stubAppInfoLocalizationClient{
+		getResps: []*asc.AppInfoLocalizationsResponse{{
+			Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appInfos/app-info-id/appInfoLocalizations?cursor=page-2"},
+		}},
+		getErrs: []error{nil, pageErr},
+	}
+	_, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+		"en-US": {"name": "English"},
+	}, false)
+	if !errors.Is(err, pageErr) || !strings.Contains(err.Error(), "page 2") {
+		t.Fatalf("expected page-two error, got %v", err)
+	}
+	if client.getCalls != 2 || len(client.createCalls) != 0 || len(client.updateCalls) != 0 {
+		t.Fatalf("expected pagination error before mutation, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+	}
+}
+
+func TestUploadVersionLocalizations_RejectsNilPaginationPage(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []*asc.AppStoreVersionLocalizationsResponse
+		wantReads int
+	}{
+		{name: "first page", responses: []*asc.AppStoreVersionLocalizationsResponse{nil}, wantReads: 1},
+		{
+			name: "later page",
+			responses: []*asc.AppStoreVersionLocalizationsResponse{
+				{Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appStoreVersions/version-id/appStoreVersionLocalizations?cursor=page-2"}},
+				nil,
+			},
+			wantReads: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &stubVersionLocalizationClient{getResps: test.responses}
+			_, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+				"en-US": {"description": "English"},
+			}, false)
+			if err == nil || !strings.Contains(err.Error(), "empty version localization response") {
+				t.Fatalf("expected empty page error, got %v", err)
+			}
+			if client.getCalls != test.wantReads || len(client.createCalls) != 0 || len(client.updateCalls) != 0 {
+				t.Fatalf("expected no mutation after empty page, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+			}
+		})
+	}
+}
+
+func TestUploadAppInfoLocalizations_RejectsNilPaginationPage(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []*asc.AppInfoLocalizationsResponse
+		wantReads int
+	}{
+		{name: "first page", responses: []*asc.AppInfoLocalizationsResponse{nil}, wantReads: 1},
+		{
+			name: "later page",
+			responses: []*asc.AppInfoLocalizationsResponse{
+				{Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appInfos/app-info-id/appInfoLocalizations?cursor=page-2"}},
+				nil,
+			},
+			wantReads: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &stubAppInfoLocalizationClient{getResps: test.responses}
+			_, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+				"en-US": {"name": "English"},
+			}, false)
+			if err == nil || !strings.Contains(err.Error(), "empty app-info localization response") {
+				t.Fatalf("expected empty page error, got %v", err)
+			}
+			if client.getCalls != test.wantReads || len(client.createCalls) != 0 || len(client.updateCalls) != 0 {
+				t.Fatalf("expected no mutation after empty page, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+			}
+		})
+	}
+}
+
+func TestUploadVersionLocalizations_ReconcilesAmbiguousCreateOnSecondReadbackPage(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	client := &stubVersionLocalizationClient{
+		getResps: []*asc.AppStoreVersionLocalizationsResponse{
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{}},
+			{
+				Data:  []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{{ID: "first-page", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "de-DE"}}},
+				Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appStoreVersions/version-id/appStoreVersionLocalizations?cursor=page-2"},
+			},
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{{
+				ID:         "created-loc",
+				Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "fr-FR", Description: "French"},
+			}}},
+		},
+		createErrs: []error{&asc.RetryableError{Err: errors.New("ambiguous create")}},
+	}
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"fr-FR": {"description": "French"},
+	}, false)
+	if err != nil || len(results) != 1 || results[0].Action != "reconcile" || len(client.createCalls) != 1 || client.getCalls != 3 {
+		t.Fatalf("unexpected page-two version recovery: results=%+v creates=%d reads=%d err=%v", results, len(client.createCalls), client.getCalls, err)
+	}
+}
+
+func TestUploadAppInfoLocalizations_ReconcilesAmbiguousCreateOnSecondReadbackPage(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	client := &stubAppInfoLocalizationClient{
+		getResps: []*asc.AppInfoLocalizationsResponse{
+			{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{}},
+			{
+				Data:  []asc.Resource[asc.AppInfoLocalizationAttributes]{{ID: "first-page", Attributes: asc.AppInfoLocalizationAttributes{Locale: "de-DE"}}},
+				Links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/appInfos/app-info-id/appInfoLocalizations?cursor=page-2"},
+			},
+			{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{{
+				ID:         "created-id",
+				Attributes: asc.AppInfoLocalizationAttributes{Locale: "fr-FR", Name: "French"},
+			}}},
+		},
+		createErrs: []error{&asc.RetryableError{Err: errors.New("ambiguous create")}},
+	}
+	results, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+		"fr-FR": {"name": "French"},
+	}, false)
+	if err != nil || len(results) != 1 || results[0].Action != "reconcile" || len(client.createCalls) != 1 || client.getCalls != 3 {
+		t.Fatalf("unexpected page-two app-info recovery: results=%+v creates=%d reads=%d err=%v", results, len(client.createCalls), client.getCalls, err)
 	}
 }
 

--- a/internal/cli/shared/localizations_upload_test.go
+++ b/internal/cli/shared/localizations_upload_test.go
@@ -306,13 +306,26 @@ func TestUploadVersionLocalizations_PreflightsAllLocalesBeforeFetch(t *testing.T
 	client := &stubVersionLocalizationClient{}
 	_, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
 		"en-US": {"description": "Valid"},
-		"fr-FR": {"promotionalText": ""},
+		"fr-FR": {},
 	}, false)
-	if err == nil || !strings.Contains(err.Error(), `locale "fr-FR" are empty`) {
+	if err == nil || !strings.Contains(err.Error(), `no localization values for locale "fr-FR"`) {
 		t.Fatalf("expected empty-locale validation error, got %v", err)
 	}
 	if client.getCalls != 0 || len(client.createCalls) != 0 || len(client.updateCalls) != 0 {
 		t.Fatalf("expected no requests before whole-batch validation, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+	}
+}
+
+func TestUploadVersionLocalizations_PreflightsEmptyCreateAfterSnapshot(t *testing.T) {
+	client := &stubVersionLocalizationClient{getResp: &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{}}}
+	_, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"fr-FR": {"promotionalText": ""},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), `cannot create version localization "fr-FR"`) {
+		t.Fatalf("expected remote-aware create validation, got %v", err)
+	}
+	if client.getCalls != 1 || len(client.createCalls) != 0 {
+		t.Fatalf("expected one snapshot and no mutation, gets=%d creates=%d", client.getCalls, len(client.createCalls))
 	}
 }
 
@@ -347,7 +360,7 @@ func TestUploadVersionLocalizations_PreservesExplicitEmptyUpdateField(t *testing
 		}},
 	}
 	values := map[string]map[string]string{
-		"en-US": {"description": "New", "promotionalText": ""},
+		"en-US": {"promotionalText": ""},
 	}
 	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", values, false)
 	if err != nil {
@@ -362,12 +375,34 @@ func TestUploadVersionLocalizations_PreservesExplicitEmptyUpdateField(t *testing
 
 	client = &stubVersionLocalizationClient{
 		getResp: &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
-			{ID: "loc-id", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "New", PromotionalText: ""}},
+			{ID: "loc-id", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old", PromotionalText: ""}},
 		}},
 	}
 	results, err = UploadVersionLocalizations(context.Background(), client, "version-id", values, false)
 	if err != nil || len(results) != 1 || results[0].Action != "skip" || len(client.updateFieldsCalls) != 0 {
 		t.Fatalf("expected identical rerun skip, results=%+v fields=%+v err=%v", results, client.updateFieldsCalls, err)
+	}
+}
+
+func TestUploadAppInfoLocalizations_ClearsOnlySuppliedFieldAndRerunSkips(t *testing.T) {
+	values := map[string]map[string]string{"en-US": {"subtitle": ""}}
+	client := &stubAppInfoLocalizationClient{getResp: &asc.AppInfoLocalizationsResponse{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{
+		{ID: "loc-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Name", Subtitle: "Old subtitle"}},
+	}}}
+	results, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", values, false)
+	if err != nil || len(results) != 1 || len(client.updateCalls) != 1 {
+		t.Fatalf("expected clear-only app-info update, results=%+v updates=%+v err=%v", results, client.updateCalls, err)
+	}
+	if value, ok := client.updateCalls[0]["subtitle"]; !ok || value != "" {
+		t.Fatalf("expected explicit empty subtitle field: %+v", client.updateCalls[0])
+	}
+
+	client = &stubAppInfoLocalizationClient{getResp: &asc.AppInfoLocalizationsResponse{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{
+		{ID: "loc-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Name", Subtitle: ""}},
+	}}}
+	results, err = UploadAppInfoLocalizations(context.Background(), client, "app-info-id", values, false)
+	if err != nil || len(results) != 1 || results[0].Action != "skip" || len(client.updateCalls) != 0 {
+		t.Fatalf("expected clear-only app-info rerun skip, results=%+v updates=%+v err=%v", results, client.updateCalls, err)
 	}
 }
 

--- a/internal/cli/shared/localizations_upload_test.go
+++ b/internal/cli/shared/localizations_upload_test.go
@@ -3,23 +3,56 @@ package shared
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 type stubVersionLocalizationClient struct {
 	getResp  *asc.AppStoreVersionLocalizationsResponse
+	getResps []*asc.AppStoreVersionLocalizationsResponse
 	getErr   error
 	getCalls int
 
+	createErrs  []error
 	createCalls []asc.AppStoreVersionLocalizationAttributes
 	updateErrs  []error
 	updateCalls []asc.AppStoreVersionLocalizationAttributes
+}
+
+type expiringVersionLocalizationClient struct {
+	getCalls    int
+	updateCalls int
+}
+
+func (c *expiringVersionLocalizationClient) GetAppStoreVersionLocalizations(ctx context.Context, _ string, _ ...asc.AppStoreVersionLocalizationsOption) (*asc.AppStoreVersionLocalizationsResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.getCalls++
+	description := "Old description"
+	if c.getCalls > 1 {
+		description = "New description"
+	}
+	return &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+		{ID: "existing-loc", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: description}},
+	}}, nil
+}
+
+func (c *expiringVersionLocalizationClient) CreateAppStoreVersionLocalization(context.Context, string, asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error) {
+	return nil, errors.New("unexpected create")
+}
+
+func (c *expiringVersionLocalizationClient) UpdateAppStoreVersionLocalization(ctx context.Context, _ string, _ asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error) {
+	c.updateCalls++
+	<-ctx.Done()
+	return nil, &asc.RetryableError{Err: ctx.Err()}
 }
 
 func (s *stubVersionLocalizationClient) GetAppStoreVersionLocalizations(_ context.Context, _ string, _ ...asc.AppStoreVersionLocalizationsOption) (*asc.AppStoreVersionLocalizationsResponse, error) {
@@ -27,16 +60,262 @@ func (s *stubVersionLocalizationClient) GetAppStoreVersionLocalizations(_ contex
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
+	if index := s.getCalls - 1; index >= 0 && index < len(s.getResps) {
+		return s.getResps[index], nil
+	}
 	return s.getResp, nil
 }
 
 func (s *stubVersionLocalizationClient) CreateAppStoreVersionLocalization(_ context.Context, _ string, attrs asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error) {
 	s.createCalls = append(s.createCalls, attrs)
+	callIndex := len(s.createCalls) - 1
+	if callIndex < len(s.createErrs) && s.createErrs[callIndex] != nil {
+		return nil, s.createErrs[callIndex]
+	}
 	return &asc.AppStoreVersionLocalizationResponse{
 		Data: asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
 			ID: "created-loc",
 		},
 	}, nil
+}
+
+func TestUploadVersionLocalizations_SkipsExactExistingValues(t *testing.T) {
+	client := &stubVersionLocalizationClient{
+		getResp: &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+			{
+				ID: "existing-loc",
+				Attributes: asc.AppStoreVersionLocalizationAttributes{
+					Locale:      "en-US",
+					Description: "Existing description",
+					Keywords:    "one,two",
+				},
+			},
+		}},
+	}
+
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"en-US": {
+			"description": "Existing description",
+			"keywords":    "one,two",
+		},
+	}, false)
+	if err != nil {
+		t.Fatalf("UploadVersionLocalizations() error: %v", err)
+	}
+	if len(client.updateCalls) != 0 || len(client.createCalls) != 0 {
+		t.Fatalf("expected exact state to skip mutation, creates=%d updates=%d", len(client.createCalls), len(client.updateCalls))
+	}
+	if len(results) != 1 || results[0].Action != "skip" || results[0].LocalizationID != "existing-loc" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestUploadVersionLocalizations_ReconcilesAmbiguousUpdateWithoutReplay(t *testing.T) {
+	client := &stubVersionLocalizationClient{
+		getResps: []*asc.AppStoreVersionLocalizationsResponse{
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+				{ID: "existing-loc", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old description"}},
+			}},
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+				{ID: "existing-loc", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "New description"}},
+			}},
+		},
+		updateErrs: []error{&asc.RetryableError{Err: errors.New("ambiguous timeout")}},
+	}
+
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "New description"},
+	}, false)
+	if err != nil {
+		t.Fatalf("UploadVersionLocalizations() error: %v", err)
+	}
+	if len(client.updateCalls) != 1 {
+		t.Fatalf("expected one update before readback, got %d", len(client.updateCalls))
+	}
+	if client.getCalls != 2 {
+		t.Fatalf("expected initial read and reconciliation read, got %d", client.getCalls)
+	}
+	if len(results) != 1 || results[0].Action != "reconcile" || results[0].LocalizationID != "existing-loc" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestUploadVersionLocalizations_UsesFreshContextForReadbackAfterRequestTimeout(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "20ms")
+	client := &expiringVersionLocalizationClient{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	results, err := UploadVersionLocalizations(ctx, client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "New description"},
+	}, false)
+	if err != nil {
+		t.Fatalf("UploadVersionLocalizations() error: %v", err)
+	}
+	if client.updateCalls != 1 || client.getCalls != 2 {
+		t.Fatalf("expected one timed-out update and a fresh readback, updates=%d reads=%d", client.updateCalls, client.getCalls)
+	}
+	if len(results) != 1 || results[0].Action != "reconcile" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestUploadVersionLocalizations_RetriesAfterNegativeReadback(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	client := &stubVersionLocalizationClient{
+		getResps: []*asc.AppStoreVersionLocalizationsResponse{
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+				{ID: "existing-loc", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old description"}},
+			}},
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+				{ID: "existing-loc", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old description"}},
+			}},
+			{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+				{ID: "existing-loc", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old description"}},
+			}},
+		},
+		updateErrs: []error{&asc.RetryableError{Err: errors.New("temporary failure")}},
+	}
+
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "New description"},
+	}, false)
+	if err != nil {
+		t.Fatalf("UploadVersionLocalizations() error: %v", err)
+	}
+	if len(client.updateCalls) != 2 || client.getCalls != 3 {
+		t.Fatalf("expected negative readback before one replay, updates=%d reads=%d", len(client.updateCalls), client.getCalls)
+	}
+	if len(results) != 1 || results[0].Action != "update" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestUploadVersionLocalizations_ContinuesAfterLocaleFailure(t *testing.T) {
+	client := &stubVersionLocalizationClient{
+		getResp: &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+			{ID: "en-id", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old English"}},
+			{ID: "fr-id", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "fr-FR", Description: "Old French"}},
+		}},
+		updateErrs: []error{errors.New("english update rejected")},
+	}
+
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "New English"},
+		"fr-FR": {"description": "New French"},
+	}, false)
+	if err == nil {
+		t.Fatal("expected partial batch error")
+	}
+	if len(results) != 2 || len(client.updateCalls) != 2 {
+		t.Fatalf("expected both locales to be attempted, results=%+v updates=%d", results, len(client.updateCalls))
+	}
+	if results[0].Locale != "en-US" || results[0].Status != "failed" || results[0].Error == "" || results[0].DesiredValues["description"] != "New English" {
+		t.Fatalf("unexpected failed result: %+v", results[0])
+	}
+	if results[1].Locale != "fr-FR" || results[1].Status != "succeeded" || results[1].Error != "" {
+		t.Fatalf("unexpected successful result: %+v", results[1])
+	}
+}
+
+func TestFinalizeLocalizationUploadResultWritesResumableArtifact(t *testing.T) {
+	t.Chdir(t.TempDir())
+	result := &asc.LocalizationUploadResult{
+		Type:      LocalizationTypeVersion,
+		VersionID: "version-id",
+		InputPath: "localizations",
+		Results: []asc.LocalizationUploadLocaleResult{
+			{Locale: "en-US", Action: "update", Status: "failed", LocalizationID: "loc-id", Error: "timeout", DesiredValues: map[string]string{"description": "Desired"}},
+			{Locale: "fr-FR", Action: "skip", Status: "succeeded", LocalizationID: "fr-id"},
+		},
+	}
+
+	FinalizeLocalizationUploadResult(result, "localizations upload")
+	if result.Total != 2 || result.Succeeded != 1 || result.Failed != 1 || result.FailureArtifactPath == "" || result.FailureArtifactError != "" {
+		t.Fatalf("unexpected finalized result: %+v", result)
+	}
+	payload, err := os.ReadFile(result.FailureArtifactPath)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	var artifact localizationUploadFailureArtifact
+	if err := json.Unmarshal(payload, &artifact); err != nil {
+		t.Fatalf("parse artifact: %v", err)
+	}
+	if artifact.SchemaVersion != 1 || artifact.InputPath != "localizations" || len(artifact.Results) != 1 || artifact.Results[0].DesiredValues["description"] != "Desired" {
+		t.Fatalf("artifact is not resumable: %+v", artifact)
+	}
+}
+
+func TestFinalizeLocalizationUploadResultRetainsArtifactWriteError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(".asc", []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	result := &asc.LocalizationUploadResult{
+		Results: []asc.LocalizationUploadLocaleResult{{Locale: "en-US", Action: "create", Status: "failed", Error: "timeout"}},
+	}
+
+	FinalizeLocalizationUploadResult(result, "localizations upload")
+	if result.Total != 1 || result.Failed != 1 || result.FailureArtifactPath != "" || result.FailureArtifactError == "" {
+		t.Fatalf("expected artifact write error in summary: %+v", result)
+	}
+}
+
+func TestRunLocalizationMutationWithReadbackRetriesChildDeadline(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	mutations := 0
+	readbacks := 0
+
+	id, reconciled, err := runLocalizationMutationWithReadback(
+		context.Background(),
+		func(context.Context) (string, error) {
+			mutations++
+			if mutations == 1 {
+				return "", context.DeadlineExceeded
+			}
+			return "existing-loc", nil
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "", false, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runLocalizationMutationWithReadback() error: %v", err)
+	}
+	if id != "existing-loc" || reconciled || mutations != 2 || readbacks != 2 {
+		t.Fatalf("unexpected recovery: id=%q reconciled=%t mutations=%d readbacks=%d", id, reconciled, mutations, readbacks)
+	}
+}
+
+func TestRunLocalizationMutationWithReadbackStopsOnParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	mutations := 0
+	readbacks := 0
+
+	_, _, err := runLocalizationMutationWithReadback(
+		ctx,
+		func(context.Context) (string, error) {
+			mutations++
+			return "", context.DeadlineExceeded
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "", false, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if mutations != 0 || readbacks != 0 {
+		t.Fatalf("expected no requests after parent cancellation, mutations=%d readbacks=%d", mutations, readbacks)
+	}
 }
 
 func (s *stubVersionLocalizationClient) UpdateAppStoreVersionLocalization(_ context.Context, _ string, attrs asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error) {

--- a/internal/cli/shared/localizations_upload_test.go
+++ b/internal/cli/shared/localizations_upload_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -20,15 +21,52 @@ type stubVersionLocalizationClient struct {
 	getErr   error
 	getCalls int
 
-	createErrs  []error
-	createCalls []asc.AppStoreVersionLocalizationAttributes
-	updateErrs  []error
-	updateCalls []asc.AppStoreVersionLocalizationAttributes
+	createErrs        []error
+	createCalls       []asc.AppStoreVersionLocalizationAttributes
+	updateErrs        []error
+	updateCalls       []asc.AppStoreVersionLocalizationAttributes
+	updateFieldsCalls []map[string]string
 }
 
 type expiringVersionLocalizationClient struct {
 	getCalls    int
 	updateCalls int
+}
+
+type stubAppInfoLocalizationClient struct {
+	getResp     *asc.AppInfoLocalizationsResponse
+	getResps    []*asc.AppInfoLocalizationsResponse
+	getCalls    int
+	createErrs  []error
+	createCalls []asc.AppInfoLocalizationAttributes
+	updateErrs  []error
+	updateCalls []map[string]string
+}
+
+func (s *stubAppInfoLocalizationClient) GetAppInfoLocalizations(context.Context, string, ...asc.AppInfoLocalizationsOption) (*asc.AppInfoLocalizationsResponse, error) {
+	s.getCalls++
+	if index := s.getCalls - 1; index >= 0 && index < len(s.getResps) {
+		return s.getResps[index], nil
+	}
+	return s.getResp, nil
+}
+
+func (s *stubAppInfoLocalizationClient) CreateAppInfoLocalization(_ context.Context, _ string, attrs asc.AppInfoLocalizationAttributes) (*asc.AppInfoLocalizationResponse, error) {
+	s.createCalls = append(s.createCalls, attrs)
+	index := len(s.createCalls) - 1
+	if index < len(s.createErrs) && s.createErrs[index] != nil {
+		return nil, s.createErrs[index]
+	}
+	return &asc.AppInfoLocalizationResponse{Data: asc.Resource[asc.AppInfoLocalizationAttributes]{ID: "created-id", Attributes: attrs}}, nil
+}
+
+func (s *stubAppInfoLocalizationClient) UpdateAppInfoLocalizationFields(_ context.Context, id string, fields map[string]string) (*asc.AppInfoLocalizationResponse, error) {
+	s.updateCalls = append(s.updateCalls, cloneLocalizationValues(fields))
+	index := len(s.updateCalls) - 1
+	if index < len(s.updateErrs) && s.updateErrs[index] != nil {
+		return nil, s.updateErrs[index]
+	}
+	return &asc.AppInfoLocalizationResponse{Data: asc.Resource[asc.AppInfoLocalizationAttributes]{ID: id}}, nil
 }
 
 func (c *expiringVersionLocalizationClient) GetAppStoreVersionLocalizations(ctx context.Context, _ string, _ ...asc.AppStoreVersionLocalizationsOption) (*asc.AppStoreVersionLocalizationsResponse, error) {
@@ -49,7 +87,7 @@ func (c *expiringVersionLocalizationClient) CreateAppStoreVersionLocalization(co
 	return nil, errors.New("unexpected create")
 }
 
-func (c *expiringVersionLocalizationClient) UpdateAppStoreVersionLocalization(ctx context.Context, _ string, _ asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error) {
+func (c *expiringVersionLocalizationClient) UpdateAppStoreVersionLocalizationFields(ctx context.Context, _ string, _ map[string]string) (*asc.AppStoreVersionLocalizationResponse, error) {
 	c.updateCalls++
 	<-ctx.Done()
 	return nil, &asc.RetryableError{Err: ctx.Err()}
@@ -107,6 +145,50 @@ func TestUploadVersionLocalizations_SkipsExactExistingValues(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Action != "skip" || results[0].LocalizationID != "existing-loc" {
 		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestUploadAppInfoLocalizations_SkipsExactExistingValues(t *testing.T) {
+	client := &stubAppInfoLocalizationClient{getResp: &asc.AppInfoLocalizationsResponse{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{
+		{ID: "loc-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Existing", Subtitle: "Subtitle"}},
+	}}}
+	results, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+		"en-US": {"name": "Existing", "subtitle": "Subtitle"},
+	}, false)
+	if err != nil || len(results) != 1 || results[0].Action != "skip" || len(client.updateCalls) != 0 {
+		t.Fatalf("expected exact app-info skip, results=%+v updates=%d err=%v", results, len(client.updateCalls), err)
+	}
+}
+
+func TestUploadAppInfoLocalizations_ReconcilesAmbiguousUpdate(t *testing.T) {
+	client := &stubAppInfoLocalizationClient{
+		getResps: []*asc.AppInfoLocalizationsResponse{
+			{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{{ID: "loc-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "Old"}}}},
+			{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{{ID: "loc-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "en-US", Name: "New"}}}},
+		},
+		updateErrs: []error{&asc.RetryableError{Err: errors.New("ambiguous update")}},
+	}
+	results, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+		"en-US": {"name": "New"},
+	}, false)
+	if err != nil || len(results) != 1 || results[0].Action != "reconcile" || len(client.updateCalls) != 1 || client.getCalls != 2 {
+		t.Fatalf("unexpected app-info update recovery: results=%+v updates=%d reads=%d err=%v", results, len(client.updateCalls), client.getCalls, err)
+	}
+}
+
+func TestUploadAppInfoLocalizations_ReconcilesAmbiguousCreate(t *testing.T) {
+	client := &stubAppInfoLocalizationClient{
+		getResps: []*asc.AppInfoLocalizationsResponse{
+			{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{}},
+			{Data: []asc.Resource[asc.AppInfoLocalizationAttributes]{{ID: "created-id", Attributes: asc.AppInfoLocalizationAttributes{Locale: "fr-FR", Name: "French"}}}},
+		},
+		createErrs: []error{&asc.RetryableError{Err: errors.New("ambiguous create")}},
+	}
+	results, err := UploadAppInfoLocalizations(context.Background(), client, "app-info-id", map[string]map[string]string{
+		"fr-FR": {"name": "French"},
+	}, false)
+	if err != nil || len(results) != 1 || results[0].Action != "reconcile" || len(client.createCalls) != 1 || client.getCalls != 2 {
+		t.Fatalf("unexpected app-info create recovery: results=%+v creates=%d reads=%d err=%v", results, len(client.createCalls), client.getCalls, err)
 	}
 }
 
@@ -220,6 +302,75 @@ func TestUploadVersionLocalizations_ContinuesAfterLocaleFailure(t *testing.T) {
 	}
 }
 
+func TestUploadVersionLocalizations_PreflightsAllLocalesBeforeFetch(t *testing.T) {
+	client := &stubVersionLocalizationClient{}
+	_, err := UploadVersionLocalizations(context.Background(), client, "version-id", map[string]map[string]string{
+		"en-US": {"description": "Valid"},
+		"fr-FR": {"promotionalText": ""},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), `locale "fr-FR" are empty`) {
+		t.Fatalf("expected empty-locale validation error, got %v", err)
+	}
+	if client.getCalls != 0 || len(client.createCalls) != 0 || len(client.updateCalls) != 0 {
+		t.Fatalf("expected no requests before whole-batch validation, gets=%d creates=%d updates=%d", client.getCalls, len(client.createCalls), len(client.updateCalls))
+	}
+}
+
+func TestReadLocalizationStringsCanonicalizesAndRejectsDuplicateLocales(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"en-US.strings", "en_us.strings"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("\"description\" = \"Value\";\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	_, err := ReadLocalizationStrings(dir, nil)
+	if err == nil || !strings.Contains(err.Error(), `duplicate canonical locale "en-US"`) {
+		t.Fatalf("expected canonical duplicate error, got %v", err)
+	}
+}
+
+func TestReadLocalizationStringsRejectsMalformedLocale(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.strings"), []byte("\"description\" = \"Value\";\n"), 0o644); err != nil {
+		t.Fatalf("write malformed locale: %v", err)
+	}
+	_, err := ReadLocalizationStrings(dir, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid locale") {
+		t.Fatalf("expected malformed locale error, got %v", err)
+	}
+}
+
+func TestUploadVersionLocalizations_PreservesExplicitEmptyUpdateField(t *testing.T) {
+	client := &stubVersionLocalizationClient{
+		getResp: &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+			{ID: "loc-id", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "Old", PromotionalText: "Old promo"}},
+		}},
+	}
+	values := map[string]map[string]string{
+		"en-US": {"description": "New", "promotionalText": ""},
+	}
+	results, err := UploadVersionLocalizations(context.Background(), client, "version-id", values, false)
+	if err != nil {
+		t.Fatalf("UploadVersionLocalizations() error: %v", err)
+	}
+	if len(results) != 1 || len(client.updateFieldsCalls) != 1 {
+		t.Fatalf("unexpected update result: results=%+v fields=%+v", results, client.updateFieldsCalls)
+	}
+	if value, ok := client.updateFieldsCalls[0]["promotionalText"]; !ok || value != "" {
+		t.Fatalf("expected explicit empty promotionalText in update fields: %+v", client.updateFieldsCalls[0])
+	}
+
+	client = &stubVersionLocalizationClient{
+		getResp: &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+			{ID: "loc-id", Attributes: asc.AppStoreVersionLocalizationAttributes{Locale: "en-US", Description: "New", PromotionalText: ""}},
+		}},
+	}
+	results, err = UploadVersionLocalizations(context.Background(), client, "version-id", values, false)
+	if err != nil || len(results) != 1 || results[0].Action != "skip" || len(client.updateFieldsCalls) != 0 {
+		t.Fatalf("expected identical rerun skip, results=%+v fields=%+v err=%v", results, client.updateFieldsCalls, err)
+	}
+}
+
 func TestFinalizeLocalizationUploadResultWritesResumableArtifact(t *testing.T) {
 	t.Chdir(t.TempDir())
 	result := &asc.LocalizationUploadResult{
@@ -318,8 +469,9 @@ func TestRunLocalizationMutationWithReadbackStopsOnParentCancellation(t *testing
 	}
 }
 
-func (s *stubVersionLocalizationClient) UpdateAppStoreVersionLocalization(_ context.Context, _ string, attrs asc.AppStoreVersionLocalizationAttributes) (*asc.AppStoreVersionLocalizationResponse, error) {
-	s.updateCalls = append(s.updateCalls, attrs)
+func (s *stubVersionLocalizationClient) UpdateAppStoreVersionLocalizationFields(_ context.Context, _ string, fields map[string]string) (*asc.AppStoreVersionLocalizationResponse, error) {
+	s.updateFieldsCalls = append(s.updateFieldsCalls, cloneLocalizationValues(fields))
+	s.updateCalls = append(s.updateCalls, buildVersionLocalizationAttributes("", fields, false))
 	callIndex := len(s.updateCalls) - 1
 	if callIndex < len(s.updateErrs) && s.updateErrs[callIndex] != nil {
 		return nil, s.updateErrs[callIndex]
@@ -329,6 +481,27 @@ func (s *stubVersionLocalizationClient) UpdateAppStoreVersionLocalization(_ cont
 			ID: "existing-loc",
 		},
 	}, nil
+}
+
+func TestUploadVersionLocalizationsWithWarnings_DoesNotWarnForFailedCreate(t *testing.T) {
+	client := &stubVersionLocalizationClient{
+		getResp:    &asc.AppStoreVersionLocalizationsResponse{Data: []asc.Resource[asc.AppStoreVersionLocalizationAttributes]{}},
+		createErrs: []error{errors.New("create rejected")},
+	}
+	results, warnings, err := UploadVersionLocalizationsWithWarnings(
+		context.Background(),
+		client,
+		"version-id",
+		map[string]map[string]string{"fr-FR": {"description": "French"}},
+		false,
+		SubmitReadinessOptions{},
+	)
+	if err == nil || len(results) != 1 || results[0].Status != "failed" {
+		t.Fatalf("expected failed create result, results=%+v err=%v", results, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("failed create must not emit applied warning: %+v", warnings)
+	}
 }
 
 func captureStderr(t *testing.T, fn func()) string {

--- a/internal/cli/shared/next_url_query.go
+++ b/internal/cli/shared/next_url_query.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -11,13 +12,17 @@ func MergeNextURLQuery(next string, additions url.Values) (string, error) {
 	if next == "" {
 		return "", nil
 	}
-	if err := validateNextURL(next); err != nil {
-		return "", err
-	}
 
 	parsed, err := url.Parse(next)
 	if err != nil {
 		return "", err
+	}
+	if parsed.IsAbs() {
+		if err := validateNextURL(next); err != nil {
+			return "", err
+		}
+	} else if parsed.Host != "" || strings.HasPrefix(next, "//") {
+		return "", fmt.Errorf("relative next URL must not specify a host")
 	}
 
 	query := parsed.Query()

--- a/internal/cli/shared/next_url_query_test.go
+++ b/internal/cli/shared/next_url_query_test.go
@@ -44,3 +44,29 @@ func TestMergeNextURLQueryRejectsInvalidURL(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+func TestMergeNextURLQueryPreservesRelativeURL(t *testing.T) {
+	merged, err := MergeNextURLQuery(
+		"/v1/subscriptions/sub-1/subscriptionLocalizations?cursor=Mg",
+		url.Values{"fields[subscriptionLocalizations]": []string{"description,locale,name"}},
+	)
+	if err != nil {
+		t.Fatalf("MergeNextURLQuery() error = %v", err)
+	}
+	parsed, err := url.Parse(merged)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	if parsed.Path != "/v1/subscriptions/sub-1/subscriptionLocalizations" || parsed.Query().Get("cursor") != "Mg" {
+		t.Fatalf("unexpected merged relative URL: %q", merged)
+	}
+	if got := parsed.Query().Get("fields[subscriptionLocalizations]"); got != "description,locale,name" {
+		t.Fatalf("unexpected merged fields: %q", got)
+	}
+}
+
+func TestMergeNextURLQueryRejectsSchemeRelativeHost(t *testing.T) {
+	if _, err := MergeNextURLQuery("//evil.example/v1/apps?cursor=Mg", url.Values{"limit": []string{"200"}}); err == nil {
+		t.Fatal("expected scheme-relative host rejection")
+	}
+}

--- a/internal/cli/shared/reconciled_mutation.go
+++ b/internal/cli/shared/reconciled_mutation.go
@@ -1,0 +1,121 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// ReconciledMutationStatus describes whether a mutation response was observed
+// directly or inferred from a matching readback after an ambiguous failure.
+type ReconciledMutationStatus string
+
+const (
+	ReconciledMutationApplied   ReconciledMutationStatus = "applied"
+	ReconciledMutationRecovered ReconciledMutationStatus = "reconciled"
+)
+
+// RunReconciledMutation executes a mutation with a fresh request deadline. If
+// the mutation fails ambiguously, it reads state immediately and once more
+// after backoff before replaying the mutation.
+func RunReconciledMutation[T any](
+	ctx context.Context,
+	mutate func(context.Context) (T, error),
+	readback func(context.Context) (T, bool, error),
+) (T, ReconciledMutationStatus, error) {
+	var zero T
+	if err := ctx.Err(); err != nil {
+		return zero, "", err
+	}
+
+	retryOpts := asc.ResolveRetryOptions()
+	for retry := 0; ; retry++ {
+		value, mutationErr := runMutationWithFreshTimeout(ctx, mutate)
+		if mutationErr == nil {
+			return value, ReconciledMutationApplied, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return zero, "", err
+		}
+
+		value, matches, readErr := runMutationReadback(ctx, readback)
+		if readErr != nil {
+			return zero, "", fmt.Errorf("mutation and readback failed: %w", errors.Join(mutationErr, readErr))
+		}
+		if matches {
+			return value, ReconciledMutationRecovered, nil
+		}
+		if !mutationErrorIsTransient(ctx, mutationErr) || retry >= retryOpts.MaxRetries {
+			return zero, "", mutationErr
+		}
+
+		if err := sleepForMutationRetry(ctx, mutationRetryDelay(retryOpts, retry, mutationErr)); err != nil {
+			return zero, "", err
+		}
+
+		value, matches, readErr = runMutationReadback(ctx, readback)
+		if readErr != nil {
+			return zero, "", fmt.Errorf("mutation and pre-retry readback failed: %w", errors.Join(mutationErr, readErr))
+		}
+		if matches {
+			return value, ReconciledMutationRecovered, nil
+		}
+	}
+}
+
+type mutationReadbackResult[T any] struct {
+	value   T
+	matches bool
+}
+
+func runMutationWithFreshTimeout[T any](ctx context.Context, mutate func(context.Context) (T, error)) (T, error) {
+	requestCtx, cancel := ContextWithTimeout(ctx)
+	defer cancel()
+	return mutate(requestCtx)
+}
+
+func runMutationReadback[T any](ctx context.Context, readback func(context.Context) (T, bool, error)) (T, bool, error) {
+	result, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (mutationReadbackResult[T], error) {
+		value, matches, readErr := readback(requestCtx)
+		return mutationReadbackResult[T]{value: value, matches: matches}, readErr
+	})
+	return result.value, result.matches, err
+}
+
+func mutationErrorIsTransient(parent context.Context, err error) bool {
+	if asc.IsRetryable(err) {
+		return true
+	}
+	return parent.Err() == nil && errors.Is(err, context.DeadlineExceeded)
+}
+
+func mutationRetryDelay(opts asc.RetryOptions, retry int, err error) time.Duration {
+	if delay := asc.GetRetryAfter(err); delay > 0 {
+		return delay
+	}
+	delay := opts.BaseDelay
+	if retry > 0 && retry < 31 {
+		delay *= time.Duration(1 << retry)
+	}
+	if opts.MaxDelay > 0 && (delay > opts.MaxDelay || delay <= 0) {
+		return opts.MaxDelay
+	}
+	return delay
+}
+
+func sleepForMutationRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/cli/shared/reconciled_mutation.go
+++ b/internal/cli/shared/reconciled_mutation.go
@@ -20,7 +20,8 @@ const (
 
 // RunReconciledMutation executes a mutation with a fresh request deadline. If
 // the mutation fails ambiguously, it reads state immediately and once more
-// after backoff before replaying the mutation.
+// after backoff before replaying the mutation. Readback callbacks may span
+// pagination and are responsible for fresh per-request deadlines.
 func RunReconciledMutation[T any](
 	ctx context.Context,
 	mutate func(context.Context) (T, error),
@@ -48,7 +49,7 @@ func RunReconciledMutation[T any](
 		if matches {
 			return value, ReconciledMutationRecovered, nil
 		}
-		if !mutationErrorIsTransient(ctx, mutationErr) || retry >= retryOpts.MaxRetries {
+		if !IsTransientMutationError(ctx, mutationErr) || retry >= retryOpts.MaxRetries {
 			return zero, "", mutationErr
 		}
 
@@ -66,11 +67,6 @@ func RunReconciledMutation[T any](
 	}
 }
 
-type mutationReadbackResult[T any] struct {
-	value   T
-	matches bool
-}
-
 func runMutationWithFreshTimeout[T any](ctx context.Context, mutate func(context.Context) (T, error)) (T, error) {
 	requestCtx, cancel := ContextWithTimeout(ctx)
 	defer cancel()
@@ -78,14 +74,12 @@ func runMutationWithFreshTimeout[T any](ctx context.Context, mutate func(context
 }
 
 func runMutationReadback[T any](ctx context.Context, readback func(context.Context) (T, bool, error)) (T, bool, error) {
-	result, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (mutationReadbackResult[T], error) {
-		value, matches, readErr := readback(requestCtx)
-		return mutationReadbackResult[T]{value: value, matches: matches}, readErr
-	})
-	return result.value, result.matches, err
+	return readback(ctx)
 }
 
-func mutationErrorIsTransient(parent context.Context, err error) bool {
+// IsTransientMutationError reports whether a mutation can be retried after
+// state readback while the parent operation remains healthy.
+func IsTransientMutationError(parent context.Context, err error) bool {
 	if asc.IsRetryable(err) {
 		return true
 	}

--- a/internal/cli/shared/reconciled_mutation_test.go
+++ b/internal/cli/shared/reconciled_mutation_test.go
@@ -1,0 +1,144 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestRunReconciledMutationReadsAgainBeforeReplay(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	mutations := 0
+	readbacks := 0
+
+	value, status, err := RunReconciledMutation(
+		context.Background(),
+		func(context.Context) (string, error) {
+			mutations++
+			return "", &asc.RetryableError{Err: errors.New("ambiguous timeout")}
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "localization-id", readbacks == 2, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("RunReconciledMutation() error: %v", err)
+	}
+	if value != "localization-id" || status != ReconciledMutationRecovered || mutations != 1 || readbacks != 2 {
+		t.Fatalf("unexpected recovery: value=%q status=%q mutations=%d readbacks=%d", value, status, mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationUsesFreshTimeoutForReplay(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "20ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	mutations := 0
+	readbacks := 0
+
+	value, status, err := RunReconciledMutation(
+		context.Background(),
+		func(ctx context.Context) (string, error) {
+			mutations++
+			if mutations == 1 {
+				<-ctx.Done()
+				return "", ctx.Err()
+			}
+			if err := ctx.Err(); err != nil {
+				t.Fatalf("replay received expired context: %v", err)
+			}
+			return "localization-id", nil
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "", false, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("RunReconciledMutation() error: %v", err)
+	}
+	if value != "localization-id" || status != ReconciledMutationApplied || mutations != 2 || readbacks != 2 {
+		t.Fatalf("unexpected replay: value=%q status=%q mutations=%d readbacks=%d", value, status, mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationStopsDuringBackoffCancellation(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1h")
+	t.Setenv("ASC_MAX_DELAY", "1h")
+	ctx, cancel := context.WithCancel(context.Background())
+	readbackDone := make(chan struct{})
+
+	go func() {
+		<-readbackDone
+		cancel()
+	}()
+	_, _, err := RunReconciledMutation(
+		ctx,
+		func(context.Context) (string, error) {
+			return "", &asc.RetryableError{Err: errors.New("temporary")}
+		},
+		func(context.Context) (string, bool, error) {
+			close(readbackDone)
+			return "", false, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
+func TestRunReconciledMutationRetriesReadbackChildDeadline(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "10ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	readbacks := 0
+
+	value, status, err := RunReconciledMutation(
+		context.Background(),
+		func(context.Context) (string, error) {
+			return "", &asc.RetryableError{Err: errors.New("ambiguous")}
+		},
+		func(ctx context.Context) (string, bool, error) {
+			readbacks++
+			if readbacks == 1 {
+				<-ctx.Done()
+				return "", false, ctx.Err()
+			}
+			return "localization-id", true, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("RunReconciledMutation() error: %v", err)
+	}
+	if value != "localization-id" || status != ReconciledMutationRecovered || readbacks != 2 {
+		t.Fatalf("unexpected recovery: value=%q status=%q readbacks=%d", value, status, readbacks)
+	}
+}
+
+func TestRunReconciledMutationDoesNotStartAfterParentDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+	mutations := 0
+
+	_, _, err := RunReconciledMutation(
+		ctx,
+		func(context.Context) (string, error) {
+			mutations++
+			return "", nil
+		},
+		func(context.Context) (string, bool, error) { return "", false, nil },
+	)
+	if !errors.Is(err, context.DeadlineExceeded) || mutations != 0 {
+		t.Fatalf("expected parent deadline before mutation, err=%v mutations=%d", err, mutations)
+	}
+}

--- a/internal/cli/shared/reconciled_mutation_test.go
+++ b/internal/cli/shared/reconciled_mutation_test.go
@@ -108,12 +108,15 @@ func TestRunReconciledMutationRetriesReadbackChildDeadline(t *testing.T) {
 			return "", &asc.RetryableError{Err: errors.New("ambiguous")}
 		},
 		func(ctx context.Context) (string, bool, error) {
-			readbacks++
-			if readbacks == 1 {
-				<-ctx.Done()
-				return "", false, ctx.Err()
-			}
-			return "localization-id", true, nil
+			value, readErr := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (string, error) {
+				readbacks++
+				if readbacks == 1 {
+					<-requestCtx.Done()
+					return "", requestCtx.Err()
+				}
+				return "localization-id", nil
+			})
+			return value, value != "", readErr
 		},
 	)
 	if err != nil {

--- a/internal/cli/shared/resilient_read.go
+++ b/internal/cli/shared/resilient_read.go
@@ -1,0 +1,61 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// RetryReadWithFreshTimeout retries child request deadlines with a fresh
+// timeout budget while the operation's parent context remains healthy.
+func RetryReadWithFreshTimeout[T any](ctx context.Context, read func(context.Context) (T, error)) (T, error) {
+	var zero T
+	if err := ctx.Err(); err != nil {
+		return zero, err
+	}
+
+	retryOpts := asc.ResolveRetryOptions()
+	for attempt := 0; ; attempt++ {
+		requestCtx, cancel := ContextWithTimeout(ctx)
+		value, err := read(requestCtx)
+		childTimedOut := err != nil && errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil
+		cancel()
+
+		if err == nil {
+			return value, nil
+		}
+		if !childTimedOut || attempt >= retryOpts.MaxRetries {
+			return zero, err
+		}
+		if err := sleepForReadRetry(ctx, readRetryDelay(retryOpts, attempt)); err != nil {
+			return zero, err
+		}
+	}
+}
+
+func readRetryDelay(opts asc.RetryOptions, attempt int) time.Duration {
+	delay := opts.BaseDelay
+	if attempt > 0 && attempt < 31 {
+		delay *= time.Duration(1 << attempt)
+	}
+	if opts.MaxDelay > 0 && (delay > opts.MaxDelay || delay <= 0) {
+		return opts.MaxDelay
+	}
+	return delay
+}
+
+func sleepForReadRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/cli/shared/resilient_read_test.go
+++ b/internal/cli/shared/resilient_read_test.go
@@ -1,0 +1,68 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRetryReadWithFreshTimeoutRetriesChildDeadline(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "1ms")
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	requests := 0
+	value, err := RetryReadWithFreshTimeout(context.Background(), func(ctx context.Context) (string, error) {
+		requests++
+		if requests == 1 {
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("expected a fresh request context, got %v", err)
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("RetryReadWithFreshTimeout() error: %v", err)
+	}
+	if value != "ok" || requests != 2 {
+		t.Fatalf("unexpected retry result: value=%q requests=%d", value, requests)
+	}
+}
+
+func TestRetryReadWithFreshTimeoutDoesNotRetryParentCancellation(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "3")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	requests := 0
+	_, err := RetryReadWithFreshTimeout(ctx, func(context.Context) (string, error) {
+		requests++
+		return "", context.Canceled
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected no request after parent cancellation, got %d", requests)
+	}
+}
+
+func TestRetryReadWithFreshTimeoutDoesNotAmplifyRetryableErrors(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "3")
+
+	requests := 0
+	wantErr := errors.New("server unavailable")
+	_, err := RetryReadWithFreshTimeout(context.Background(), func(context.Context) (string, error) {
+		requests++
+		return "", wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected server error, got %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one workflow read attempt, got %d", requests)
+	}
+}

--- a/internal/cli/shared/resilient_read_test.go
+++ b/internal/cli/shared/resilient_read_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRetryReadWithFreshTimeoutRetriesChildDeadline(t *testing.T) {
-	t.Setenv("ASC_TIMEOUT", "1ms")
+	t.Setenv("ASC_TIMEOUT", "100ms")
 	t.Setenv("ASC_MAX_RETRIES", "1")
 	t.Setenv("ASC_BASE_DELAY", "1ms")
 	t.Setenv("ASC_MAX_DELAY", "1ms")
@@ -29,6 +29,25 @@ func TestRetryReadWithFreshTimeoutRetriesChildDeadline(t *testing.T) {
 	}
 	if value != "ok" || requests != 2 {
 		t.Fatalf("unexpected retry result: value=%q requests=%d", value, requests)
+	}
+}
+
+func TestRetryReadWithFreshTimeoutDoesNotRetryInFlightParentCancellation(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "3")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requests := 0
+	_, err := RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (string, error) {
+		requests++
+		cancel()
+		<-requestCtx.Done()
+		return "", requestCtx.Err()
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one in-flight request, got %d", requests)
 	}
 }
 

--- a/internal/cli/shared/review_submissions_test.go
+++ b/internal/cli/shared/review_submissions_test.go
@@ -272,7 +272,7 @@ func TestFetchAllReviewSubmissions_ReturnsPaginationErrors(t *testing.T) {
 				"links": {"next":"`+nextURL+`"}
 			}`)
 		case 2:
-			return reviewSubmissionsSharedJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","detail":"boom"}]}`)
+			return reviewSubmissionsSharedJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","detail":"boom"}]}`)
 		default:
 			t.Fatalf("unexpected extra request #%d: %s %s", requestCount, req.Method, req.URL.RequestURI())
 			return nil, nil

--- a/internal/cli/submit/submit_flow.go
+++ b/internal/cli/submit/submit_flow.go
@@ -117,7 +117,9 @@ func EnsureBuildAttached(ctx context.Context, client *asc.Client, versionID, bui
 		return result, fmt.Errorf("attach build: build ID is required")
 	}
 
-	buildResp, err := client.GetAppStoreVersionBuild(ctx, result.VersionID)
+	buildResp, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.BuildResponse, error) {
+		return client.GetAppStoreVersionBuild(requestCtx, result.VersionID)
+	})
 	if err != nil {
 		if !asc.IsNotFound(err) {
 			return result, fmt.Errorf("attach build: failed to fetch current build: %w", err)
@@ -136,7 +138,27 @@ func EnsureBuildAttached(ctx context.Context, client *asc.Client, versionID, bui
 		return result, nil
 	}
 
-	if err := client.AttachBuildToVersion(ctx, result.VersionID, result.BuildID); err != nil {
+	_, _, err = shared.RunReconciledMutation(
+		ctx,
+		func(requestCtx context.Context) (string, error) {
+			attachErr := client.AttachBuildToVersion(requestCtx, result.VersionID, result.BuildID)
+			return result.BuildID, attachErr
+		},
+		func(readbackCtx context.Context) (string, bool, error) {
+			current, readErr := shared.RetryReadWithFreshTimeout(readbackCtx, func(requestCtx context.Context) (*asc.BuildResponse, error) {
+				return client.GetAppStoreVersionBuild(requestCtx, result.VersionID)
+			})
+			if readErr != nil {
+				if asc.IsNotFound(readErr) {
+					return "", false, nil
+				}
+				return "", false, readErr
+			}
+			currentID := strings.TrimSpace(current.Data.ID)
+			return currentID, currentID == result.BuildID, nil
+		},
+	)
+	if err != nil {
 		return result, fmt.Errorf("attach build: %w", err)
 	}
 	result.Attached = true

--- a/internal/cli/submit/submit_flow_test.go
+++ b/internal/cli/submit/submit_flow_test.go
@@ -3,11 +3,13 @@ package submit
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
@@ -277,6 +279,118 @@ func TestEnsureBuildAttachedAttachesWhenNoCurrentBuild(t *testing.T) {
 	}
 	if !buildAttach {
 		t.Fatal("expected attach request when no current build exists")
+	}
+}
+
+func TestEnsureBuildAttachedUsesFreshDeadlineForMutation(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
+			time.Sleep(60 * time.Millisecond)
+			return submitJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/version-1/relationships/build":
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 70*time.Millisecond {
+				t.Fatalf("expected fresh attach deadline, remaining=%s", time.Until(deadline))
+			}
+			return submitJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	result, err := EnsureBuildAttached(context.Background(), client, "version-1", "build-new", false)
+	if err != nil || !result.Attached {
+		t.Fatalf("unexpected attach result: result=%+v err=%v", result, err)
+	}
+}
+
+func TestEnsureBuildAttachedReconcilesAmbiguousMutation(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	reads := 0
+	patches := 0
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
+			reads++
+			if reads == 1 {
+				return submitJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+			}
+			deadline, ok := req.Context().Deadline()
+			if !ok || time.Until(deadline) < 70*time.Millisecond {
+				t.Fatalf("expected fresh readback deadline, remaining=%s", time.Until(deadline))
+			}
+			return submitJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-new"}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/version-1/relationships/build":
+			patches++
+			time.Sleep(60 * time.Millisecond)
+			return submitJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	result, err := EnsureBuildAttached(context.Background(), client, "version-1", "build-new", false)
+	if err != nil || !result.Attached || reads != 2 || patches != 1 {
+		t.Fatalf("unexpected reconcile result: result=%+v reads=%d patches=%d err=%v", result, reads, patches, err)
+	}
+}
+
+func TestEnsureBuildAttachedReplaysOnlyAfterTwoNegativeReadbacks(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+	reads := 0
+	patches := 0
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
+			reads++
+			return submitJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/version-1/relationships/build":
+			patches++
+			if patches == 1 {
+				return submitJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"temporary"}]}`)
+			}
+			return submitJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	result, err := EnsureBuildAttached(context.Background(), client, "version-1", "build-new", false)
+	if err != nil || !result.Attached || reads != 3 || patches != 2 {
+		t.Fatalf("unexpected bounded replay: result=%+v reads=%d patches=%d err=%v", result, reads, patches, err)
+	}
+}
+
+func TestEnsureBuildAttachedPreservesNonTransientFailure(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	reads := 0
+	patches := 0
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/build":
+			reads++
+			return submitJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/version-1/relationships/build":
+			patches++
+			return submitJSONResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"invalid build"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	result, err := EnsureBuildAttached(context.Background(), client, "version-1", "build-new", false)
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("expected typed non-transient error, result=%+v err=%T %v", result, err, err)
+	}
+	if reads != 2 || patches != 1 || result.Attached {
+		t.Fatalf("unexpected non-transient calls: result=%+v reads=%d patches=%d", result, reads, patches)
 	}
 }
 

--- a/internal/cli/submit/submit_test.go
+++ b/internal/cli/submit/submit_test.go
@@ -666,6 +666,7 @@ func setupSubmitAuth(t *testing.T) {
 	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
 	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
 }
 
 func writeSubmitECDSAPEM(t *testing.T, path string) {

--- a/internal/cli/subscriptions/group_localizations.go
+++ b/internal/cli/subscriptions/group_localizations.go
@@ -34,6 +34,7 @@ Examples:
 			SubscriptionsGroupsLocalizationsCreateCommand(),
 			SubscriptionsGroupsLocalizationsUpdateCommand(),
 			SubscriptionsGroupsLocalizationsDeleteCommand(),
+			SubscriptionsGroupsLocalizationsSyncCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/subscriptions/introductory_offers_import.go
+++ b/internal/cli/subscriptions/introductory_offers_import.go
@@ -1,12 +1,17 @@
 package subscriptions
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -60,9 +65,6 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			_ = ctx
-			_ = output
-
 			if strings.TrimSpace(*subscriptionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
 				return flag.ErrHelp
@@ -136,6 +138,20 @@ Examples:
 
 			if *dryRun {
 				summary.Created = len(resolvedRows)
+				for _, row := range resolvedRows {
+					summary.Results = append(summary.Results, subscriptionIntroductoryOfferImportResultItem{
+						Row:             row.row,
+						Territory:       row.territory,
+						OfferMode:       row.offerMode,
+						OfferDuration:   row.offerDuration,
+						NumberOfPeriods: row.numberOfPeriods,
+						StartDate:       row.startDate,
+						EndDate:         row.endDate,
+						PricePointID:    row.pricePointID,
+						TargetPlanType:  string(row.planType),
+						Status:          "planned",
+					})
+				}
 				return shared.PrintOutputWithRenderers(
 					summary,
 					*output.Output,
@@ -150,18 +166,24 @@ Examples:
 				return fmt.Errorf("subscriptions introductory-offers import: %w", err)
 			}
 
-			lookupCtx, lookupCancel := shared.ContextWithTimeout(ctx)
-			summary.SubscriptionID, err = resolveSubscriptionLookupID(lookupCtx, client, *appID, summary.SubscriptionID)
-			lookupCancel()
+			summary.SubscriptionID, err = shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (string, error) {
+				return resolveSubscriptionLookupID(requestCtx, client, *appID, summary.SubscriptionID)
+			})
 			if err != nil {
 				return err
+			}
+			operationNow := time.Now().UTC()
+			stateIndex, err := fetchSubscriptionIntroductoryOfferImportState(ctx, client, summary.SubscriptionID, operationNow)
+			if err != nil {
+				return fmt.Errorf("subscriptions introductory-offers import: fetch existing offers: %w", err)
 			}
 
 			for _, row := range resolvedRows {
 				attrs := asc.SubscriptionIntroductoryOfferCreateAttributes{
-					Duration:        asc.SubscriptionOfferDuration(row.offerDuration),
-					OfferMode:       asc.SubscriptionOfferMode(row.offerMode),
-					NumberOfPeriods: row.numberOfPeriods,
+					Duration:                   asc.SubscriptionOfferDuration(row.offerDuration),
+					OfferMode:                  asc.SubscriptionOfferMode(row.offerMode),
+					NumberOfPeriods:            row.numberOfPeriods,
+					TargetSubscriptionPlanType: row.planType,
 				}
 				if row.startDate != "" {
 					attrs.StartDate = row.startDate
@@ -170,18 +192,67 @@ Examples:
 					attrs.EndDate = row.endDate
 				}
 
-				createCtx, createCancel := shared.ContextWithTimeout(ctx)
-				_, err := client.CreateSubscriptionIntroductoryOffer(createCtx, summary.SubscriptionID, attrs, row.territory, row.pricePointID)
-				createCancel()
-				if err != nil {
-					appendSubscriptionIntroductoryOfferImportFailure(summary, row, err)
+				status := reconciledMutationSkipped
+				var rowErr error
+				if !stateIndex.matches(row) {
+					status, rowErr = runReconciledMutation(
+						ctx,
+						func(readbackCtx context.Context) (bool, error) {
+							refreshed, err := fetchSubscriptionIntroductoryOfferImportState(readbackCtx, client, summary.SubscriptionID, operationNow)
+							if err != nil {
+								return false, err
+							}
+							stateIndex = refreshed
+							return stateIndex.matches(row), nil
+						},
+						func(mutationCtx context.Context) error {
+							createCtx, createCancel := shared.ContextWithTimeout(mutationCtx)
+							defer createCancel()
+							_, err := client.CreateSubscriptionIntroductoryOffer(createCtx, summary.SubscriptionID, attrs, row.territory, row.pricePointID)
+							return err
+						},
+					)
+				}
+				if rowErr != nil {
+					appendSubscriptionIntroductoryOfferImportFailure(summary, row, rowErr)
 					if !*continueOnError {
 						break
 					}
 					continue
 				}
 
-				summary.Created++
+				summary.Results = append(summary.Results, subscriptionIntroductoryOfferImportResultItem{
+					Row:             row.row,
+					Territory:       row.territory,
+					OfferMode:       row.offerMode,
+					OfferDuration:   row.offerDuration,
+					NumberOfPeriods: row.numberOfPeriods,
+					StartDate:       row.startDate,
+					EndDate:         row.endDate,
+					PricePointID:    row.pricePointID,
+					TargetPlanType:  string(row.planType),
+					Status:          string(status),
+				})
+				if status != reconciledMutationSkipped {
+					stateIndex.add(row)
+				}
+				switch status {
+				case reconciledMutationCreated:
+					summary.Created++
+				case reconciledMutationSkipped:
+					summary.Skipped++
+				case reconciledMutationReconciled:
+					summary.Reconciled++
+				}
+			}
+
+			if summary.Failed > 0 {
+				artifactPath, artifactErr := writeSubscriptionIntroductoryOfferImportFailureArtifact(summary)
+				if artifactErr != nil {
+					summary.FailureArtifactError = artifactErr.Error()
+				} else {
+					summary.FailureArtifactPath = artifactPath
+				}
 			}
 
 			if err := shared.PrintOutputWithRenderers(
@@ -194,7 +265,11 @@ Examples:
 				return err
 			}
 			if summary.Failed > 0 {
-				return shared.NewReportedError(fmt.Errorf("subscriptions introductory-offers import: %d row(s) failed", summary.Failed))
+				rowErr := fmt.Errorf("subscriptions introductory-offers import: %d row(s) failed", summary.Failed)
+				if summary.FailureArtifactError != "" {
+					rowErr = errors.Join(rowErr, fmt.Errorf("write failure artifact: %s", summary.FailureArtifactError))
+				}
+				return shared.NewReportedError(rowErr)
 			}
 			return nil
 		},
@@ -202,20 +277,54 @@ Examples:
 }
 
 type subscriptionIntroductoryOfferImportSummary struct {
-	SubscriptionID  string                                              `json:"subscriptionId"`
-	InputFile       string                                              `json:"inputFile"`
-	DryRun          bool                                                `json:"dryRun"`
-	ContinueOnError bool                                                `json:"continueOnError"`
-	Total           int                                                 `json:"total"`
-	Created         int                                                 `json:"created"`
-	Failed          int                                                 `json:"failed"`
-	Failures        []subscriptionIntroductoryOfferImportSummaryFailure `json:"failures,omitempty"`
+	SubscriptionID       string                                              `json:"subscriptionId"`
+	InputFile            string                                              `json:"inputFile"`
+	DryRun               bool                                                `json:"dryRun"`
+	ContinueOnError      bool                                                `json:"continueOnError"`
+	Total                int                                                 `json:"total"`
+	Created              int                                                 `json:"created"`
+	Skipped              int                                                 `json:"skipped,omitempty"`
+	Reconciled           int                                                 `json:"reconciled,omitempty"`
+	Failed               int                                                 `json:"failed"`
+	Failures             []subscriptionIntroductoryOfferImportSummaryFailure `json:"failures,omitempty"`
+	FailureArtifactPath  string                                              `json:"failureArtifactPath,omitempty"`
+	FailureArtifactError string                                              `json:"failureArtifactError,omitempty"`
+	Results              []subscriptionIntroductoryOfferImportResultItem     `json:"results,omitempty"`
 }
 
 type subscriptionIntroductoryOfferImportSummaryFailure struct {
 	Row       int    `json:"row"`
 	Territory string `json:"territory,omitempty"`
 	Error     string `json:"error"`
+}
+
+type subscriptionIntroductoryOfferImportResultItem struct {
+	Row             int    `json:"row"`
+	Territory       string `json:"territory,omitempty"`
+	OfferMode       string `json:"offerMode,omitempty"`
+	OfferDuration   string `json:"offerDuration,omitempty"`
+	NumberOfPeriods int    `json:"numberOfPeriods"`
+	StartDate       string `json:"startDate,omitempty"`
+	EndDate         string `json:"endDate,omitempty"`
+	PricePointID    string `json:"pricePointId,omitempty"`
+	TargetPlanType  string `json:"targetSubscriptionPlanType"`
+	Status          string `json:"status"`
+	Error           string `json:"error,omitempty"`
+}
+
+type subscriptionIntroductoryOfferImportStateIndex struct {
+	offers []subscriptionIntroductoryOfferImportResolvedRow
+	now    time.Time
+}
+
+type subscriptionIntroductoryOfferImportFailureArtifact struct {
+	SchemaVersion  int                                             `json:"schemaVersion"`
+	Command        string                                          `json:"command"`
+	SubscriptionID string                                          `json:"subscriptionId"`
+	InputFile      string                                          `json:"inputFile"`
+	Failed         int                                             `json:"failed"`
+	GeneratedAt    string                                          `json:"generatedAt"`
+	Results        []subscriptionIntroductoryOfferImportResultItem `json:"results"`
 }
 
 func renderSubscriptionIntroductoryOfferImportSummary(summary *subscriptionIntroductoryOfferImportSummary, markdown bool) error {
@@ -229,14 +338,18 @@ func renderSubscriptionIntroductoryOfferImportSummary(summary *subscriptionIntro
 	}
 
 	render(
-		[]string{"Subscription ID", "Input File", "Dry Run", "Total", "Created", "Failed"},
+		[]string{"Subscription ID", "Input File", "Dry Run", "Total", "Created", "Skipped", "Reconciled", "Failed", "Failure Artifact", "Failure Artifact Error"},
 		[][]string{{
 			summary.SubscriptionID,
 			summary.InputFile,
 			fmt.Sprintf("%t", summary.DryRun),
 			fmt.Sprintf("%d", summary.Total),
 			fmt.Sprintf("%d", summary.Created),
+			fmt.Sprintf("%d", summary.Skipped),
+			fmt.Sprintf("%d", summary.Reconciled),
 			fmt.Sprintf("%d", summary.Failed),
+			summary.FailureArtifactPath,
+			summary.FailureArtifactError,
 		}},
 	)
 
@@ -265,4 +378,163 @@ func appendSubscriptionIntroductoryOfferImportFailure(summary *subscriptionIntro
 		Territory: row.territory,
 		Error:     err.Error(),
 	})
+	summary.Results = append(summary.Results, subscriptionIntroductoryOfferImportResultItem{
+		Row:             row.row,
+		Territory:       row.territory,
+		OfferMode:       row.offerMode,
+		OfferDuration:   row.offerDuration,
+		NumberOfPeriods: row.numberOfPeriods,
+		StartDate:       row.startDate,
+		EndDate:         row.endDate,
+		PricePointID:    row.pricePointID,
+		TargetPlanType:  string(row.planType),
+		Status:          "failed",
+		Error:           err.Error(),
+	})
+}
+
+func fetchSubscriptionIntroductoryOfferImportState(ctx context.Context, client *asc.Client, subscriptionID string, now time.Time) (*subscriptionIntroductoryOfferImportStateIndex, error) {
+	query := url.Values{
+		"fields[subscriptionIntroductoryOffers]": []string{"startDate,endDate,duration,offerMode,numberOfPeriods,targetSubscriptionPlanType,territory,subscriptionPricePoint"},
+		"include":                                []string{"territory,subscriptionPricePoint"},
+		"limit":                                  []string{"200"},
+	}
+	fetchPage := func(nextURL string) (*asc.SubscriptionIntroductoryOffersResponse, error) {
+		if nextURL != "" {
+			mergedNext, err := mergeSubscriptionPricesNextQuery(nextURL, query)
+			if err != nil {
+				return nil, err
+			}
+			return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionIntroductoryOffersResponse, error) {
+				return client.GetSubscriptionIntroductoryOffers(requestCtx, subscriptionID, asc.WithSubscriptionIntroductoryOffersNextURL(mergedNext))
+			})
+		}
+		return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionIntroductoryOffersResponse, error) {
+			return client.GetSubscriptionIntroductoryOffers(
+				requestCtx,
+				subscriptionID,
+				asc.WithSubscriptionIntroductoryOffersLimit(200),
+				asc.WithSubscriptionIntroductoryOffersFields([]string{"startDate", "endDate", "duration", "offerMode", "numberOfPeriods", "targetSubscriptionPlanType", "territory", "subscriptionPricePoint"}),
+				asc.WithSubscriptionIntroductoryOffersInclude([]string{"territory", "subscriptionPricePoint"}),
+			)
+		})
+	}
+
+	firstPage, err := fetchPage("")
+	if err != nil {
+		return nil, err
+	}
+	index := &subscriptionIntroductoryOfferImportStateIndex{now: now}
+	err = asc.PaginateEach(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return fetchPage(nextURL)
+	}, func(page asc.PaginatedResponse) error {
+		offers, ok := page.(*asc.SubscriptionIntroductoryOffersResponse)
+		if !ok {
+			return fmt.Errorf("unexpected introductory offers response type %T", page)
+		}
+		for _, offer := range offers.Data {
+			attrs := offer.Attributes
+			index.offers = append(index.offers, subscriptionIntroductoryOfferImportResolvedRow{
+				territory:       introductoryOfferTerritoryID(offer),
+				offerMode:       string(attrs.OfferMode),
+				offerDuration:   string(attrs.Duration),
+				numberOfPeriods: attrs.NumberOfPeriods,
+				startDate:       strings.TrimSpace(attrs.StartDate),
+				endDate:         strings.TrimSpace(attrs.EndDate),
+				pricePointID:    extractResourceRelationshipID(offer.Relationships, "subscriptionPricePoint"),
+				planType:        attrs.TargetSubscriptionPlanType,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func (index *subscriptionIntroductoryOfferImportStateIndex) matches(target subscriptionIntroductoryOfferImportResolvedRow) bool {
+	if index == nil {
+		return false
+	}
+	for _, offer := range index.offers {
+		if strings.EqualFold(offer.territory, target.territory) &&
+			offer.pricePointID == target.pricePointID &&
+			offer.planType == target.planType &&
+			offer.offerDuration == target.offerDuration &&
+			offer.offerMode == target.offerMode &&
+			offer.numberOfPeriods == target.numberOfPeriods &&
+			introductoryOfferStartDateMatches(offer.startDate, target.startDate, index.now) &&
+			offer.endDate == target.endDate {
+			return true
+		}
+	}
+	return false
+}
+
+func (index *subscriptionIntroductoryOfferImportStateIndex) add(target subscriptionIntroductoryOfferImportResolvedRow) {
+	if index == nil {
+		return
+	}
+	if strings.TrimSpace(target.startDate) == "" {
+		target.startDate = dateOnlyUTC(index.now).Format(equalizeDateLayout)
+	}
+	index.offers = append(index.offers, target)
+}
+
+func introductoryOfferStartDateMatches(actual, target string, now time.Time) bool {
+	actual = strings.TrimSpace(actual)
+	target = strings.TrimSpace(target)
+	if target != "" {
+		return actual == target
+	}
+	if actual == "" {
+		return true
+	}
+	parsed, err := time.Parse(equalizeDateLayout, actual)
+	return err == nil && !parsed.After(dateOnlyUTC(now))
+}
+
+func extractResourceRelationshipID(relationships json.RawMessage, key string) string {
+	if len(relationships) == 0 {
+		return ""
+	}
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(relationships, &values); err != nil {
+		return ""
+	}
+	var relationship struct {
+		Data asc.ResourceData `json:"data"`
+	}
+	if err := json.Unmarshal(values[key], &relationship); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(relationship.Data.ID)
+}
+
+func writeSubscriptionIntroductoryOfferImportFailureArtifact(summary *subscriptionIntroductoryOfferImportSummary) (string, error) {
+	failures := make([]subscriptionIntroductoryOfferImportResultItem, 0, summary.Failed)
+	for _, result := range summary.Results {
+		if result.Status == "failed" {
+			failures = append(failures, result)
+		}
+	}
+	artifact := subscriptionIntroductoryOfferImportFailureArtifact{
+		SchemaVersion:  1,
+		Command:        "subscriptions offers introductory import",
+		SubscriptionID: summary.SubscriptionID,
+		InputFile:      summary.InputFile,
+		Failed:         summary.Failed,
+		GeneratedAt:    time.Now().UTC().Format(time.RFC3339),
+		Results:        failures,
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(".asc", "reports", "subscription-introductory-offers-import", fmt.Sprintf("failures-%d.json", time.Now().UTC().UnixNano()))
+	if _, err := shared.WriteStreamToFile(path, bytes.NewReader(data)); err != nil {
+		return "", err
+	}
+	return path, nil
 }

--- a/internal/cli/subscriptions/introductory_offers_import.go
+++ b/internal/cli/subscriptions/introductory_offers_import.go
@@ -205,9 +205,7 @@ Examples:
 							return stateIndex.matches(row), nil
 						},
 						func(mutationCtx context.Context) error {
-							createCtx, createCancel := shared.ContextWithTimeout(mutationCtx)
-							defer createCancel()
-							_, err := client.CreateSubscriptionIntroductoryOffer(createCtx, summary.SubscriptionID, attrs, row.territory, row.pricePointID)
+							_, err := client.CreateSubscriptionIntroductoryOffer(mutationCtx, summary.SubscriptionID, attrs, row.territory, row.pricePointID)
 							return err
 						},
 					)

--- a/internal/cli/subscriptions/introductory_offers_import.go
+++ b/internal/cli/subscriptions/introductory_offers_import.go
@@ -172,8 +172,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			operationNow := time.Now().UTC()
-			stateIndex, err := fetchSubscriptionIntroductoryOfferImportState(ctx, client, summary.SubscriptionID, operationNow)
+			stateIndex, err := fetchSubscriptionIntroductoryOfferImportState(ctx, client, summary.SubscriptionID)
 			if err != nil {
 				return fmt.Errorf("subscriptions introductory-offers import: fetch existing offers: %w", err)
 			}
@@ -198,7 +197,7 @@ Examples:
 					status, rowErr = runReconciledMutation(
 						ctx,
 						func(readbackCtx context.Context) (bool, error) {
-							refreshed, err := fetchSubscriptionIntroductoryOfferImportState(readbackCtx, client, summary.SubscriptionID, operationNow)
+							refreshed, err := fetchSubscriptionIntroductoryOfferImportState(readbackCtx, client, summary.SubscriptionID)
 							if err != nil {
 								return false, err
 							}
@@ -393,7 +392,7 @@ func appendSubscriptionIntroductoryOfferImportFailure(summary *subscriptionIntro
 	})
 }
 
-func fetchSubscriptionIntroductoryOfferImportState(ctx context.Context, client *asc.Client, subscriptionID string, now time.Time) (*subscriptionIntroductoryOfferImportStateIndex, error) {
+func fetchSubscriptionIntroductoryOfferImportState(ctx context.Context, client *asc.Client, subscriptionID string) (*subscriptionIntroductoryOfferImportStateIndex, error) {
 	query := url.Values{
 		"fields[subscriptionIntroductoryOffers]": []string{"startDate,endDate,duration,offerMode,numberOfPeriods,targetSubscriptionPlanType,territory,subscriptionPricePoint"},
 		"include":                                []string{"territory,subscriptionPricePoint"},
@@ -424,7 +423,7 @@ func fetchSubscriptionIntroductoryOfferImportState(ctx context.Context, client *
 	if err != nil {
 		return nil, err
 	}
-	index := &subscriptionIntroductoryOfferImportStateIndex{now: now}
+	index := &subscriptionIntroductoryOfferImportStateIndex{}
 	err = asc.PaginateEach(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
 		return fetchPage(nextURL)
 	}, func(page asc.PaginatedResponse) error {
@@ -450,6 +449,7 @@ func fetchSubscriptionIntroductoryOfferImportState(ctx context.Context, client *
 	if err != nil {
 		return nil, err
 	}
+	index.now = subscriptionImportNow()
 	return index, nil
 }
 

--- a/internal/cli/subscriptions/introductory_offers_import_csv.go
+++ b/internal/cli/subscriptions/introductory_offers_import_csv.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -41,6 +42,7 @@ type subscriptionIntroductoryOfferImportResolvedRow struct {
 	startDate       string
 	endDate         string
 	pricePointID    string
+	planType        asc.SubscriptionPlanType
 }
 
 var subscriptionIntroductoryOffersImportKnownColumns = map[string]string{
@@ -285,6 +287,7 @@ func resolveSubscriptionIntroductoryOfferImportRows(
 			startDate:       startDate,
 			endDate:         endDate,
 			pricePointID:    row.pricePointID,
+			planType:        asc.SubscriptionPlanTypeUpfront,
 		})
 	}
 	return resolved, nil

--- a/internal/cli/subscriptions/introductory_offers_import_csv_test.go
+++ b/internal/cli/subscriptions/introductory_offers_import_csv_test.go
@@ -1,7 +1,17 @@
 package subscriptions
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,4 +79,73 @@ func TestSubscriptionIntroductoryOfferImportStateMatchesImmediateUpfrontOffer(t 
 	if index.matches(target) {
 		t.Fatal("expected a MONTHLY offer not to match an UPFRONT target")
 	}
+}
+
+func TestSubscriptionIntroductoryOfferImportReconcilesAcrossUTCMidnight(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	originalNow := subscriptionImportNow
+	t.Cleanup(func() { subscriptionImportNow = originalNow })
+	current := time.Date(2026, time.June, 24, 23, 59, 0, 0, time.UTC)
+	subscriptionImportNow = func() time.Time {
+		return current
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = introImportRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/introductoryOffers" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		current = time.Date(2026, time.June, 25, 0, 1, 0, 0, time.UTC)
+		body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1","attributes":{"startDate":"2026-06-25","duration":"ONE_WEEK","offerMode":"FREE_TRIAL","numberOfPeriods":1,"targetSubscriptionPlanType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: http.Header{"Content-Type": []string{"application/json"}}}, nil
+	})
+	client, err := asc.NewClientFromPEM("KEY123", "issuer", introImportTestPrivateKeyPEM(t))
+	if err != nil {
+		t.Fatalf("NewClientFromPEM() error: %v", err)
+	}
+
+	target := subscriptionIntroductoryOfferImportResolvedRow{
+		territory: "USA", offerMode: "FREE_TRIAL", offerDuration: "ONE_WEEK", numberOfPeriods: 1, planType: asc.SubscriptionPlanTypeUpfront,
+	}
+	mutations := 0
+	status, err := runReconciledMutation(
+		context.Background(),
+		func(readbackCtx context.Context) (bool, error) {
+			index, err := fetchSubscriptionIntroductoryOfferImportState(readbackCtx, client, "sub-1")
+			if err != nil {
+				return false, err
+			}
+			return index.matches(target), nil
+		},
+		func(context.Context) error {
+			mutations++
+			return &asc.RetryableError{Err: errors.New("ambiguous timeout")}
+		},
+	)
+	if err != nil {
+		t.Fatalf("runReconciledMutation() error: %v", err)
+	}
+	if status != reconciledMutationReconciled || mutations != 1 {
+		t.Fatalf("unexpected midnight recovery: status=%q mutations=%d", status, mutations)
+	}
+}
+
+type introImportRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn introImportRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func introImportTestPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
 }

--- a/internal/cli/subscriptions/introductory_offers_import_csv_test.go
+++ b/internal/cli/subscriptions/introductory_offers_import_csv_test.go
@@ -1,6 +1,12 @@
 package subscriptions
 
-import "testing"
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
 
 func TestParseSubscriptionIntroductoryOffersImportCSVHeader_StripsUTF8BOM(t *testing.T) {
 	got, err := parseSubscriptionIntroductoryOffersImportCSVHeader([]string{"\ufeffterritory", "offer_mode"})
@@ -12,5 +18,55 @@ func TestParseSubscriptionIntroductoryOffersImportCSVHeader_StripsUTF8BOM(t *tes
 	}
 	if got["offer_mode"] != 1 {
 		t.Fatalf("expected offer_mode column at index 1, got %d", got["offer_mode"])
+	}
+}
+
+func TestWriteSubscriptionIntroductoryOfferImportFailureArtifact_ReturnsWriteError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(".asc", []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	_, err := writeSubscriptionIntroductoryOfferImportFailureArtifact(&subscriptionIntroductoryOfferImportSummary{
+		Failed:  1,
+		Results: []subscriptionIntroductoryOfferImportResultItem{{Status: "failed"}},
+	})
+	if err == nil {
+		t.Fatal("expected write error, got nil")
+	}
+}
+
+func TestSubscriptionIntroductoryOfferImportStateMatchesImmediateUpfrontOffer(t *testing.T) {
+	index := &subscriptionIntroductoryOfferImportStateIndex{
+		now: time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC),
+		offers: []subscriptionIntroductoryOfferImportResolvedRow{{
+			territory:       "USA",
+			offerMode:       "FREE_TRIAL",
+			offerDuration:   "ONE_WEEK",
+			numberOfPeriods: 1,
+			startDate:       "2026-06-23",
+			planType:        asc.SubscriptionPlanTypeUpfront,
+		}},
+	}
+	target := subscriptionIntroductoryOfferImportResolvedRow{
+		territory:       "USA",
+		offerMode:       "FREE_TRIAL",
+		offerDuration:   "ONE_WEEK",
+		numberOfPeriods: 1,
+		planType:        asc.SubscriptionPlanTypeUpfront,
+	}
+	if !index.matches(target) {
+		t.Fatal("expected an already-active UPFRONT offer to match an immediate target")
+	}
+
+	index.offers[0].startDate = "2026-06-25"
+	if index.matches(target) {
+		t.Fatal("expected a future offer not to match an immediate target")
+	}
+
+	index.offers[0].startDate = "2026-06-23"
+	index.offers[0].planType = asc.SubscriptionPlanTypeMonthly
+	if index.matches(target) {
+		t.Fatal("expected a MONTHLY offer not to match an UPFRONT target")
 	}
 }

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -34,6 +34,7 @@ Examples:
 			SubscriptionsLocalizationsCreateCommand(),
 			SubscriptionsLocalizationsUpdateCommand(),
 			SubscriptionsLocalizationsDeleteCommand(),
+			SubscriptionsLocalizationsSyncCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/subscriptions/localizations_sync.go
+++ b/internal/cli/subscriptions/localizations_sync.go
@@ -1,0 +1,796 @@
+package subscriptions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const localizationSyncArtifactSchemaVersion = 1
+
+type localizationSyncEntry struct {
+	Locale string            `json:"locale"`
+	Fields map[string]string `json:"fields"`
+}
+
+type localizationSyncRemote struct {
+	ID     string
+	Locale string
+	Fields map[string]string
+}
+
+type localizationSyncResult struct {
+	Locale         string            `json:"locale"`
+	Action         string            `json:"action"`
+	Status         string            `json:"status"`
+	LocalizationID string            `json:"localizationId,omitempty"`
+	DesiredFields  map[string]string `json:"desiredFields,omitempty"`
+	Error          string            `json:"error,omitempty"`
+}
+
+type localizationSyncSummary struct {
+	Type                 string                   `json:"type"`
+	TargetID             string                   `json:"targetId"`
+	InputPath            string                   `json:"inputPath"`
+	DryRun               bool                     `json:"dryRun"`
+	Total                int                      `json:"total"`
+	Planned              int                      `json:"planned"`
+	Created              int                      `json:"created"`
+	Updated              int                      `json:"updated"`
+	Unchanged            int                      `json:"unchanged"`
+	Reconciled           int                      `json:"reconciled"`
+	Failed               int                      `json:"failed"`
+	FailureArtifactPath  string                   `json:"failureArtifactPath,omitempty"`
+	FailureArtifactError string                   `json:"failureArtifactError,omitempty"`
+	Results              []localizationSyncResult `json:"results"`
+}
+
+type localizationSyncFailureArtifact struct {
+	SchemaVersion int                          `json:"schemaVersion"`
+	Command       string                       `json:"command"`
+	Type          string                       `json:"type"`
+	TargetID      string                       `json:"targetId"`
+	InputPath     string                       `json:"inputPath"`
+	GeneratedAt   string                       `json:"generatedAt"`
+	Failures      []localizationSyncResult     `json:"failures"`
+	RetryInput    map[string]map[string]string `json:"retryInput"`
+}
+
+type localizationSyncAPI struct {
+	Type   string
+	List   func(context.Context) ([]localizationSyncRemote, error)
+	Create func(context.Context, localizationSyncEntry) (localizationSyncRemote, error)
+	Update func(context.Context, localizationSyncRemote, localizationSyncEntry) (localizationSyncRemote, error)
+}
+
+type localizationSyncInputError struct {
+	err error
+}
+
+func (e localizationSyncInputError) Error() string { return e.err.Error() }
+func (e localizationSyncInputError) Unwrap() error { return e.err }
+
+// SubscriptionsLocalizationsSyncCommand returns the experimental subscription localization sync command.
+func SubscriptionsLocalizationsSyncCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("localizations sync", flag.ExitOnError)
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	appID := addSubscriptionLookupAppFlag(fs)
+	inputPath := fs.String("input", "", "Locale-keyed JSON input file")
+	dryRun := fs.Bool("dry-run", false, "Preview changes without creating or updating localizations")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "sync",
+		ShortUsage: "asc subscriptions localizations sync --subscription-id \"SUB_ID\" --input \"./localizations.json\" [flags]",
+		ShortHelp:  "[experimental] Sync subscription localizations from JSON.",
+		LongHelp: `Sync subscription localizations from a locale-keyed JSON file.
+
+This command is experimental. It creates missing locales, updates only fields
+present in the input, and leaves omitted locales and fields unchanged. Name
+must be non-empty when present; an empty description clears that field.
+
+Input format:
+  {
+    "en-US": {"name": "Pro", "description": "Premium access"},
+    "de-DE": {"name": "Pro"}
+  }
+
+Examples:
+  asc subscriptions localizations sync --subscription-id "SUB_ID" --input "./localizations.json"
+  asc subscriptions localizations sync --subscription-id "SUB_ID" --input "./localizations.json" --dry-run`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("subscriptions localizations sync does not accept positional arguments: %s", strings.Join(args, " "))
+			}
+			id := strings.TrimSpace(*subscriptionID)
+			if id == "" {
+				return shared.UsageError("--subscription-id is required")
+			}
+			path := strings.TrimSpace(*inputPath)
+			if path == "" {
+				return shared.UsageError("--input is required")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			entries, err := readLocalizationSyncEntries(path, "description")
+			if err != nil {
+				return shared.UsageErrorf("subscriptions localizations sync: %v", err)
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("subscriptions localizations sync: %w", err)
+			}
+			id, err = shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (string, error) {
+				return resolveSubscriptionLookupID(requestCtx, client, *appID, id)
+			})
+			if err != nil {
+				return err
+			}
+
+			api := newSubscriptionLocalizationSyncAPI(client, id)
+			return runLocalizationSyncCommand(ctx, api, id, path, entries, *dryRun, "subscriptions localizations sync", output)
+		},
+	}
+}
+
+// SubscriptionsGroupsLocalizationsSyncCommand returns the experimental group localization sync command.
+func SubscriptionsGroupsLocalizationsSyncCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("groups localizations sync", flag.ExitOnError)
+	groupID := fs.String("group-id", "", "Subscription group ID")
+	inputPath := fs.String("input", "", "Locale-keyed JSON input file")
+	dryRun := fs.Bool("dry-run", false, "Preview changes without creating or updating localizations")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "sync",
+		ShortUsage: "asc subscriptions groups localizations sync --group-id \"GROUP_ID\" --input \"./localizations.json\" [flags]",
+		ShortHelp:  "[experimental] Sync subscription group localizations from JSON.",
+		LongHelp: `Sync subscription group localizations from a locale-keyed JSON file.
+
+This command is experimental. It creates missing locales, updates only fields
+present in the input, and leaves omitted locales and fields unchanged. Name
+must be non-empty when present; an empty customAppName clears that field.
+
+Input format:
+  {
+    "en-US": {"name": "Premium", "customAppName": "My App"},
+    "de-DE": {"name": "Premium"}
+  }
+
+Examples:
+  asc subscriptions groups localizations sync --group-id "GROUP_ID" --input "./localizations.json"
+  asc subscriptions groups localizations sync --group-id "GROUP_ID" --input "./localizations.json" --dry-run`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("subscriptions groups localizations sync does not accept positional arguments: %s", strings.Join(args, " "))
+			}
+			id := strings.TrimSpace(*groupID)
+			if id == "" {
+				return shared.UsageError("--group-id is required")
+			}
+			path := strings.TrimSpace(*inputPath)
+			if path == "" {
+				return shared.UsageError("--input is required")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			entries, err := readLocalizationSyncEntries(path, "customAppName")
+			if err != nil {
+				return shared.UsageErrorf("subscriptions groups localizations sync: %v", err)
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("subscriptions groups localizations sync: %w", err)
+			}
+			api := newSubscriptionGroupLocalizationSyncAPI(client, id)
+			return runLocalizationSyncCommand(ctx, api, id, path, entries, *dryRun, "subscriptions groups localizations sync", output)
+		},
+	}
+}
+
+func runLocalizationSyncCommand(ctx context.Context, api localizationSyncAPI, targetID, inputPath string, entries []localizationSyncEntry, dryRun bool, command string, output shared.OutputFlags) error {
+	summary, err := executeLocalizationSync(ctx, api, targetID, inputPath, entries, dryRun, command)
+	var inputErr localizationSyncInputError
+	if errors.As(err, &inputErr) {
+		return shared.UsageErrorf("%s: %v", command, inputErr)
+	}
+	if summary == nil {
+		if err != nil {
+			return fmt.Errorf("%s: %w", command, err)
+		}
+		return fmt.Errorf("%s: empty sync result", command)
+	}
+
+	if printErr := shared.PrintOutputWithRenderers(
+		summary,
+		*output.Output,
+		*output.Pretty,
+		func() error { return renderLocalizationSyncSummary(summary, false) },
+		func() error { return renderLocalizationSyncSummary(summary, true) },
+	); printErr != nil {
+		return printErr
+	}
+	if err != nil {
+		return shared.NewReportedError(err)
+	}
+	return nil
+}
+
+func executeLocalizationSync(ctx context.Context, api localizationSyncAPI, targetID, inputPath string, entries []localizationSyncEntry, dryRun bool, command string) (*localizationSyncSummary, error) {
+	remote, err := api.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch existing localizations: %w", err)
+	}
+	index, err := indexLocalizationSyncRemote(remote)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if _, exists := index[localizationSyncLocaleKey(entry.Locale)]; exists {
+			continue
+		}
+		name, present := entry.Fields["name"]
+		if !present || strings.TrimSpace(name) == "" {
+			return nil, localizationSyncInputError{err: fmt.Errorf("locale %q does not exist remotely and requires a non-empty name", entry.Locale)}
+		}
+	}
+
+	summary := &localizationSyncSummary{
+		Type:      api.Type,
+		TargetID:  strings.TrimSpace(targetID),
+		InputPath: filepath.Clean(strings.TrimSpace(inputPath)),
+		DryRun:    dryRun,
+		Total:     len(entries),
+		Results:   make([]localizationSyncResult, 0, len(entries)),
+	}
+
+	for i, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			appendLocalizationSyncCancellationFailures(summary, entries[i:], index, err)
+			break
+		}
+
+		key := localizationSyncLocaleKey(entry.Locale)
+		existing, exists := index[key]
+		action := "create"
+		if exists {
+			action = "update"
+			if localizationSyncFieldsMatch(existing.Fields, entry.Fields) {
+				summary.Unchanged++
+				summary.Results = append(summary.Results, localizationSyncResult{
+					Locale:         entry.Locale,
+					Action:         "none",
+					Status:         "unchanged",
+					LocalizationID: existing.ID,
+					DesiredFields:  cloneLocalizationSyncFields(entry.Fields),
+				})
+				continue
+			}
+		}
+
+		if dryRun {
+			summary.Planned++
+			summary.Results = append(summary.Results, localizationSyncResult{
+				Locale:         entry.Locale,
+				Action:         action,
+				Status:         "planned",
+				LocalizationID: existing.ID,
+				DesiredFields:  cloneLocalizationSyncFields(entry.Fields),
+			})
+			continue
+		}
+
+		value, mutationStatus, mutationErr := shared.RunReconciledMutation(
+			ctx,
+			func(requestCtx context.Context) (localizationSyncRemote, error) {
+				if exists {
+					return api.Update(requestCtx, existing, entry)
+				}
+				return api.Create(requestCtx, entry)
+			},
+			func(readbackCtx context.Context) (localizationSyncRemote, bool, error) {
+				refreshed, readErr := api.List(readbackCtx)
+				if readErr != nil {
+					return localizationSyncRemote{}, false, readErr
+				}
+				refreshedIndex, indexErr := indexLocalizationSyncRemote(refreshed)
+				if indexErr != nil {
+					return localizationSyncRemote{}, false, indexErr
+				}
+				candidate, found := refreshedIndex[key]
+				return candidate, found && localizationSyncFieldsMatch(candidate.Fields, entry.Fields), nil
+			},
+		)
+		if mutationErr != nil {
+			summary.Failed++
+			summary.Results = append(summary.Results, localizationSyncResult{
+				Locale:         entry.Locale,
+				Action:         action,
+				Status:         "failed",
+				LocalizationID: existing.ID,
+				DesiredFields:  cloneLocalizationSyncFields(entry.Fields),
+				Error:          mutationErr.Error(),
+			})
+			continue
+		}
+
+		if strings.TrimSpace(value.ID) == "" {
+			value.ID = existing.ID
+		}
+		if value.Fields == nil {
+			value.Fields = cloneLocalizationSyncFields(existing.Fields)
+		}
+		value.Locale = entry.Locale
+		for field, desired := range entry.Fields {
+			value.Fields[field] = desired
+		}
+		index[key] = value
+
+		status := "created"
+		if exists {
+			status = "updated"
+		}
+		if mutationStatus == shared.ReconciledMutationRecovered {
+			status = "reconciled"
+			summary.Reconciled++
+		} else if exists {
+			summary.Updated++
+		} else {
+			summary.Created++
+		}
+		summary.Results = append(summary.Results, localizationSyncResult{
+			Locale:         entry.Locale,
+			Action:         action,
+			Status:         status,
+			LocalizationID: value.ID,
+			DesiredFields:  cloneLocalizationSyncFields(entry.Fields),
+		})
+	}
+
+	if summary.Failed == 0 {
+		return summary, nil
+	}
+	path, artifactErr := writeLocalizationSyncFailureArtifact(summary, command)
+	if artifactErr != nil {
+		summary.FailureArtifactError = artifactErr.Error()
+	} else {
+		summary.FailureArtifactPath = path
+	}
+
+	runErr := fmt.Errorf("%s: %d locale(s) failed", command, summary.Failed)
+	if artifactErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("write failure artifact: %w", artifactErr))
+	}
+	return summary, runErr
+}
+
+func appendLocalizationSyncCancellationFailures(summary *localizationSyncSummary, entries []localizationSyncEntry, index map[string]localizationSyncRemote, err error) {
+	for _, entry := range entries {
+		existing, exists := index[localizationSyncLocaleKey(entry.Locale)]
+		action := "create"
+		if exists {
+			action = "update"
+		}
+		summary.Failed++
+		summary.Results = append(summary.Results, localizationSyncResult{
+			Locale:         entry.Locale,
+			Action:         action,
+			Status:         "failed",
+			LocalizationID: existing.ID,
+			DesiredFields:  cloneLocalizationSyncFields(entry.Fields),
+			Error:          err.Error(),
+		})
+	}
+}
+
+func readLocalizationSyncEntries(path, secondaryField string) ([]localizationSyncEntry, error) {
+	payload, err := shared.ReadJSONFilePayload(path)
+	if err != nil {
+		return nil, fmt.Errorf("read input %q: %w", path, err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	start, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("parse input %q: %w", path, err)
+	}
+	if delimiter, ok := start.(json.Delim); !ok || delimiter != '{' {
+		return nil, fmt.Errorf("input %q must be a JSON object", path)
+	}
+
+	entries := make([]localizationSyncEntry, 0)
+	seen := make(map[string]string)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("parse input %q: %w", path, err)
+		}
+		rawLocale, ok := token.(string)
+		if !ok {
+			return nil, fmt.Errorf("input %q contains a non-string locale key", path)
+		}
+		locale, err := shared.CanonicalizeAppStoreLocalizationLocale(rawLocale)
+		if err != nil {
+			return nil, err
+		}
+		key := localizationSyncLocaleKey(locale)
+		if previous, exists := seen[key]; exists {
+			return nil, fmt.Errorf("duplicate canonical locale %q conflicts with %q", locale, previous)
+		}
+		seen[key] = rawLocale
+
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("locale %q: %w", locale, err)
+		}
+		fields, err := readLocalizationSyncFields(raw, secondaryField)
+		if err != nil {
+			return nil, fmt.Errorf("locale %q: %w", locale, err)
+		}
+		entries = append(entries, localizationSyncEntry{Locale: locale, Fields: fields})
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("parse input %q: %w", path, err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("input %q must include at least one locale", path)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		left := localizationSyncLocaleKey(entries[i].Locale)
+		right := localizationSyncLocaleKey(entries[j].Locale)
+		if left == right {
+			return entries[i].Locale < entries[j].Locale
+		}
+		return left < right
+	})
+	return entries, nil
+}
+
+func readLocalizationSyncFields(payload json.RawMessage, secondaryField string) (map[string]string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	start, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delimiter, ok := start.(json.Delim); !ok || delimiter != '{' {
+		return nil, fmt.Errorf("value must be an object")
+	}
+
+	fields := make(map[string]string)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		field, ok := token.(string)
+		if !ok {
+			return nil, fmt.Errorf("field name must be a string")
+		}
+		if _, duplicate := fields[field]; duplicate {
+			return nil, fmt.Errorf("duplicate field %q", field)
+		}
+		if field != "name" && field != secondaryField {
+			return nil, fmt.Errorf("unknown field %q", field)
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, err
+		}
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return nil, fmt.Errorf("field %q must be a string, not null", field)
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, fmt.Errorf("field %q must be a string: %w", field, err)
+		}
+		fields[field] = value
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	if name, present := fields["name"]; present && strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("field %q must not be empty", "name")
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("at least one of name or %s is required", secondaryField)
+	}
+	return fields, nil
+}
+
+func newSubscriptionLocalizationSyncAPI(client *asc.Client, subscriptionID string) localizationSyncAPI {
+	return localizationSyncAPI{
+		Type: "subscriptionLocalizations",
+		List: func(ctx context.Context) ([]localizationSyncRemote, error) {
+			return fetchSubscriptionLocalizationSyncState(ctx, client, subscriptionID)
+		},
+		Create: func(ctx context.Context, entry localizationSyncEntry) (localizationSyncRemote, error) {
+			attrs := asc.SubscriptionLocalizationCreateAttributes{
+				Locale: entry.Locale,
+				Name:   entry.Fields["name"],
+			}
+			if description, ok := entry.Fields["description"]; ok {
+				attrs.Description = description
+			}
+			resp, err := client.CreateSubscriptionLocalization(ctx, subscriptionID, attrs)
+			if err != nil {
+				return localizationSyncRemote{}, err
+			}
+			return subscriptionLocalizationSyncRemote(resp.Data), nil
+		},
+		Update: func(ctx context.Context, existing localizationSyncRemote, entry localizationSyncEntry) (localizationSyncRemote, error) {
+			attrs := asc.SubscriptionLocalizationUpdateAttributes{}
+			if name, ok := entry.Fields["name"]; ok {
+				attrs.Name = &name
+			}
+			if description, ok := entry.Fields["description"]; ok {
+				attrs.Description = &description
+			}
+			resp, err := client.UpdateSubscriptionLocalization(ctx, existing.ID, attrs)
+			if err != nil {
+				return localizationSyncRemote{}, err
+			}
+			return subscriptionLocalizationSyncRemote(resp.Data), nil
+		},
+	}
+}
+
+func newSubscriptionGroupLocalizationSyncAPI(client *asc.Client, groupID string) localizationSyncAPI {
+	return localizationSyncAPI{
+		Type: "subscriptionGroupLocalizations",
+		List: func(ctx context.Context) ([]localizationSyncRemote, error) {
+			return fetchSubscriptionGroupLocalizationSyncState(ctx, client, groupID)
+		},
+		Create: func(ctx context.Context, entry localizationSyncEntry) (localizationSyncRemote, error) {
+			attrs := asc.SubscriptionGroupLocalizationCreateAttributes{
+				Locale: entry.Locale,
+				Name:   entry.Fields["name"],
+			}
+			if customAppName, ok := entry.Fields["customAppName"]; ok {
+				attrs.CustomAppName = customAppName
+			}
+			resp, err := client.CreateSubscriptionGroupLocalization(ctx, groupID, attrs)
+			if err != nil {
+				return localizationSyncRemote{}, err
+			}
+			return subscriptionGroupLocalizationSyncRemote(resp.Data), nil
+		},
+		Update: func(ctx context.Context, existing localizationSyncRemote, entry localizationSyncEntry) (localizationSyncRemote, error) {
+			attrs := asc.SubscriptionGroupLocalizationUpdateAttributes{}
+			if name, ok := entry.Fields["name"]; ok {
+				attrs.Name = &name
+			}
+			if customAppName, ok := entry.Fields["customAppName"]; ok {
+				attrs.CustomAppName = &customAppName
+			}
+			resp, err := client.UpdateSubscriptionGroupLocalization(ctx, existing.ID, attrs)
+			if err != nil {
+				return localizationSyncRemote{}, err
+			}
+			return subscriptionGroupLocalizationSyncRemote(resp.Data), nil
+		},
+	}
+}
+
+func fetchSubscriptionLocalizationSyncState(ctx context.Context, client *asc.Client, subscriptionID string) ([]localizationSyncRemote, error) {
+	first, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionLocalizationsResponse, error) {
+		return client.GetSubscriptionLocalizations(
+			requestCtx,
+			subscriptionID,
+			asc.WithSubscriptionLocalizationsFields([]string{"description", "locale", "name"}),
+			asc.WithSubscriptionLocalizationsLimit(200),
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+	aggregated, err := asc.PaginateAll(ctx, first, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		nextURL, mergeErr := shared.MergeNextURLQuery(nextURL, url.Values{
+			"fields[subscriptionLocalizations]": []string{"description,locale,name"},
+		})
+		if mergeErr != nil {
+			return nil, mergeErr
+		}
+		return shared.RetryReadWithFreshTimeout(pageCtx, func(requestCtx context.Context) (*asc.SubscriptionLocalizationsResponse, error) {
+			return client.GetSubscriptionLocalizations(requestCtx, subscriptionID, asc.WithSubscriptionLocalizationsNextURL(nextURL))
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	response, ok := aggregated.(*asc.SubscriptionLocalizationsResponse)
+	if !ok || response == nil {
+		return nil, fmt.Errorf("unexpected subscription localizations response type %T", aggregated)
+	}
+	result := make([]localizationSyncRemote, 0, len(response.Data))
+	for _, resource := range response.Data {
+		result = append(result, subscriptionLocalizationSyncRemote(resource))
+	}
+	return result, nil
+}
+
+func fetchSubscriptionGroupLocalizationSyncState(ctx context.Context, client *asc.Client, groupID string) ([]localizationSyncRemote, error) {
+	first, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionGroupLocalizationsResponse, error) {
+		return client.GetSubscriptionGroupLocalizations(
+			requestCtx,
+			groupID,
+			asc.WithSubscriptionGroupLocalizationsFields([]string{"customAppName", "locale", "name"}),
+			asc.WithSubscriptionGroupLocalizationsLimit(200),
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+	aggregated, err := asc.PaginateAll(ctx, first, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		nextURL, mergeErr := shared.MergeNextURLQuery(nextURL, url.Values{
+			"fields[subscriptionGroupLocalizations]": []string{"customAppName,locale,name"},
+		})
+		if mergeErr != nil {
+			return nil, mergeErr
+		}
+		return shared.RetryReadWithFreshTimeout(pageCtx, func(requestCtx context.Context) (*asc.SubscriptionGroupLocalizationsResponse, error) {
+			return client.GetSubscriptionGroupLocalizations(requestCtx, groupID, asc.WithSubscriptionGroupLocalizationsNextURL(nextURL))
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	response, ok := aggregated.(*asc.SubscriptionGroupLocalizationsResponse)
+	if !ok || response == nil {
+		return nil, fmt.Errorf("unexpected subscription group localizations response type %T", aggregated)
+	}
+	result := make([]localizationSyncRemote, 0, len(response.Data))
+	for _, resource := range response.Data {
+		result = append(result, subscriptionGroupLocalizationSyncRemote(resource))
+	}
+	return result, nil
+}
+
+func subscriptionLocalizationSyncRemote(resource asc.Resource[asc.SubscriptionLocalizationAttributes]) localizationSyncRemote {
+	return localizationSyncRemote{
+		ID:     strings.TrimSpace(resource.ID),
+		Locale: resource.Attributes.Locale,
+		Fields: map[string]string{
+			"name":        resource.Attributes.Name,
+			"description": resource.Attributes.Description,
+		},
+	}
+}
+
+func subscriptionGroupLocalizationSyncRemote(resource asc.Resource[asc.SubscriptionGroupLocalizationAttributes]) localizationSyncRemote {
+	return localizationSyncRemote{
+		ID:     strings.TrimSpace(resource.ID),
+		Locale: resource.Attributes.Locale,
+		Fields: map[string]string{
+			"name":          resource.Attributes.Name,
+			"customAppName": resource.Attributes.CustomAppName,
+		},
+	}
+}
+
+func indexLocalizationSyncRemote(remote []localizationSyncRemote) (map[string]localizationSyncRemote, error) {
+	index := make(map[string]localizationSyncRemote, len(remote))
+	for _, item := range remote {
+		locale, err := shared.CanonicalizeAppStoreLocalizationLocale(item.Locale)
+		if err != nil {
+			return nil, fmt.Errorf("remote localization %q: %w", item.ID, err)
+		}
+		key := localizationSyncLocaleKey(locale)
+		if previous, exists := index[key]; exists {
+			return nil, fmt.Errorf("duplicate remote locale %q for localizations %q and %q", locale, previous.ID, item.ID)
+		}
+		item.Locale = locale
+		if item.Fields == nil {
+			item.Fields = make(map[string]string)
+		}
+		index[key] = item
+	}
+	return index, nil
+}
+
+func localizationSyncLocaleKey(locale string) string {
+	return strings.ToLower(shared.NormalizeLocaleCode(locale))
+}
+
+func localizationSyncFieldsMatch(remote, desired map[string]string) bool {
+	for field, value := range desired {
+		if remote[field] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneLocalizationSyncFields(fields map[string]string) map[string]string {
+	result := make(map[string]string, len(fields))
+	for field, value := range fields {
+		result[field] = value
+	}
+	return result
+}
+
+func writeLocalizationSyncFailureArtifact(summary *localizationSyncSummary, command string) (string, error) {
+	failures := make([]localizationSyncResult, 0, summary.Failed)
+	for _, result := range summary.Results {
+		if result.Status == "failed" {
+			failures = append(failures, result)
+		}
+	}
+	artifact := localizationSyncFailureArtifact{
+		SchemaVersion: localizationSyncArtifactSchemaVersion,
+		Command:       command,
+		Type:          summary.Type,
+		TargetID:      summary.TargetID,
+		InputPath:     summary.InputPath,
+		GeneratedAt:   subscriptionImportNow().Format("2006-01-02T15:04:05Z07:00"),
+		Failures:      failures,
+		RetryInput:    make(map[string]map[string]string, len(failures)),
+	}
+	for _, failure := range failures {
+		artifact.RetryInput[failure.Locale] = cloneLocalizationSyncFields(failure.DesiredFields)
+	}
+	payload, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	directory := strings.ReplaceAll(strings.TrimSpace(command), " ", "-")
+	path := filepath.Join(".asc", "reports", directory, fmt.Sprintf("failures-%d.json", subscriptionImportNow().UnixNano()))
+	if _, err := shared.WriteStreamToFile(path, bytes.NewReader(payload)); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func renderLocalizationSyncSummary(summary *localizationSyncSummary, markdown bool) error {
+	render := asc.RenderTable
+	if markdown {
+		render = asc.RenderMarkdown
+	}
+	render(
+		[]string{"Type", "Target ID", "Input", "Dry Run", "Total", "Planned", "Created", "Updated", "Unchanged", "Reconciled", "Failed", "Failure Artifact", "Artifact Error"},
+		[][]string{{
+			summary.Type,
+			summary.TargetID,
+			summary.InputPath,
+			strconv.FormatBool(summary.DryRun),
+			strconv.Itoa(summary.Total),
+			strconv.Itoa(summary.Planned),
+			strconv.Itoa(summary.Created),
+			strconv.Itoa(summary.Updated),
+			strconv.Itoa(summary.Unchanged),
+			strconv.Itoa(summary.Reconciled),
+			strconv.Itoa(summary.Failed),
+			summary.FailureArtifactPath,
+			summary.FailureArtifactError,
+		}},
+	)
+	rows := make([][]string, 0, len(summary.Results))
+	for _, result := range summary.Results {
+		desired, _ := json.Marshal(result.DesiredFields)
+		rows = append(rows, []string{result.Locale, result.Action, result.Status, result.LocalizationID, string(desired), result.Error})
+	}
+	render([]string{"Locale", "Action", "Status", "Localization ID", "Desired Fields", "Error"}, rows)
+	return nil
+}

--- a/internal/cli/subscriptions/localizations_sync_test.go
+++ b/internal/cli/subscriptions/localizations_sync_test.go
@@ -1,0 +1,118 @@
+package subscriptions
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadLocalizationSyncEntriesRejectsStrictInputErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "unknown field", body: `{"en-US":{"name":"Pro","unexpected":"value"}}`, want: `unknown field "unexpected"`},
+		{name: "null field", body: `{"en-US":{"name":null}}`, want: `must be a string, not null`},
+		{name: "duplicate field", body: `{"en-US":{"name":"One","name":"Two"}}`, want: `duplicate field "name"`},
+		{name: "trailing document", body: `{"en-US":{"name":"Pro"}} {}`, want: `invalid JSON`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "input.json")
+			if err := os.WriteFile(path, []byte(tt.body), 0o600); err != nil {
+				t.Fatalf("write input: %v", err)
+			}
+			_, err := readLocalizationSyncEntries(path, "description")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestExecuteLocalizationSyncRejectsDuplicateRemoteLocaleBeforeMutation(t *testing.T) {
+	mutations := 0
+	api := localizationSyncAPI{
+		Type: "subscriptionLocalizations",
+		List: func(context.Context) ([]localizationSyncRemote, error) {
+			return []localizationSyncRemote{
+				{ID: "loc-1", Locale: "en_US", Fields: map[string]string{"name": "One"}},
+				{ID: "loc-2", Locale: "en-US", Fields: map[string]string{"name": "Two"}},
+			}, nil
+		},
+		Create: func(context.Context, localizationSyncEntry) (localizationSyncRemote, error) {
+			mutations++
+			return localizationSyncRemote{}, nil
+		},
+		Update: func(context.Context, localizationSyncRemote, localizationSyncEntry) (localizationSyncRemote, error) {
+			mutations++
+			return localizationSyncRemote{}, nil
+		},
+	}
+
+	_, err := executeLocalizationSync(
+		context.Background(),
+		api,
+		"sub-1",
+		"input.json",
+		[]localizationSyncEntry{{Locale: "en-US", Fields: map[string]string{"name": "Desired"}}},
+		false,
+		"subscriptions localizations sync",
+	)
+	if err == nil || !strings.Contains(err.Error(), `duplicate remote locale "en-US"`) {
+		t.Fatalf("expected duplicate remote locale error, got %v", err)
+	}
+	if mutations != 0 {
+		t.Fatalf("expected no mutations, got %d", mutations)
+	}
+}
+
+func TestExecuteLocalizationSyncCancellationArtifactsRemainingLocales(t *testing.T) {
+	t.Chdir(t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	mutations := 0
+	api := localizationSyncAPI{
+		Type: "subscriptionLocalizations",
+		List: func(context.Context) ([]localizationSyncRemote, error) {
+			return nil, nil
+		},
+		Create: func(context.Context, localizationSyncEntry) (localizationSyncRemote, error) {
+			mutations++
+			cancel()
+			return localizationSyncRemote{}, context.Canceled
+		},
+		Update: func(context.Context, localizationSyncRemote, localizationSyncEntry) (localizationSyncRemote, error) {
+			t.Fatal("unexpected update")
+			return localizationSyncRemote{}, nil
+		},
+	}
+	entries := []localizationSyncEntry{
+		{Locale: "de-DE", Fields: map[string]string{"name": "Deutsch"}},
+		{Locale: "en-US", Fields: map[string]string{"name": "English"}},
+		{Locale: "fr-FR", Fields: map[string]string{"name": "Francais"}},
+	}
+
+	summary, err := executeLocalizationSync(ctx, api, "sub-1", "input.json", entries, false, "subscriptions localizations sync")
+	if err == nil || summary == nil || summary.Failed != 3 || mutations != 1 {
+		t.Fatalf("unexpected cancellation result: summary=%+v mutations=%d err=%v", summary, mutations, err)
+	}
+	if summary.FailureArtifactPath == "" || len(summary.Results) != 3 {
+		t.Fatalf("expected all remaining locales in artifact summary: %+v", summary)
+	}
+	payload, readErr := os.ReadFile(summary.FailureArtifactPath)
+	if readErr != nil {
+		t.Fatalf("read artifact: %v", readErr)
+	}
+	var artifact localizationSyncFailureArtifact
+	if err := json.Unmarshal(payload, &artifact); err != nil {
+		t.Fatalf("decode artifact: %v", err)
+	}
+	if len(artifact.RetryInput) != 3 {
+		t.Fatalf("expected three replay locales, got %+v", artifact.RetryInput)
+	}
+}

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -502,11 +502,8 @@ func validateMonthlyCommitmentUpfrontPrices(
 	territoryIDs []string,
 	monthlyPrice string,
 ) error {
-	pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
-	defer pricesCancel()
-
 	resolved, err := fetchResolvedSubscriptionPrices(
-		pricesCtx,
+		ctx,
 		client,
 		subscriptionID,
 		200,
@@ -561,9 +558,8 @@ func prepareMonthlySubscriptionPrices(
 	monthlyPrice string,
 ) ([]monthlySubscriptionPriceCreate, error) {
 	now := time.Now().UTC()
-	pricesCtx, pricesCancel := shared.ContextWithTimeout(ctx)
 	resolvedPrices, err := fetchResolvedSubscriptionPrices(
-		pricesCtx,
+		ctx,
 		client,
 		subscriptionID,
 		200,
@@ -571,7 +567,6 @@ func prepareMonthlySubscriptionPrices(
 		now,
 		asc.SubscriptionPlanTypeMonthly,
 	)
-	pricesCancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch MONTHLY subscription prices: %w", err)
 	}

--- a/internal/cli/subscriptions/mutation_recovery.go
+++ b/internal/cli/subscriptions/mutation_recovery.go
@@ -1,0 +1,76 @@
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type reconciledMutationStatus string
+
+const (
+	reconciledMutationCreated    reconciledMutationStatus = "created"
+	reconciledMutationSkipped    reconciledMutationStatus = "skipped"
+	reconciledMutationReconciled reconciledMutationStatus = "reconciled"
+)
+
+func runReconciledMutation(
+	ctx context.Context,
+	readback func(context.Context) (bool, error),
+	mutate func(context.Context) error,
+) (reconciledMutationStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	retryOpts := asc.ResolveRetryOptions()
+	for retry := 0; ; retry++ {
+		mutationErr := mutate(ctx)
+		if mutationErr == nil {
+			return reconciledMutationCreated, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		exists, readErr := readback(ctx)
+		if readErr != nil {
+			return "", fmt.Errorf("mutation and readback failed: %w", errors.Join(mutationErr, readErr))
+		}
+		if exists {
+			return reconciledMutationReconciled, nil
+		}
+		if !reconciledMutationIsTransient(ctx, mutationErr) || retry >= retryOpts.MaxRetries {
+			return "", mutationErr
+		}
+
+		if err := sleepWithContext(ctx, reconciledMutationRetryDelay(retryOpts, retry, mutationErr)); err != nil {
+			return "", err
+		}
+	}
+}
+
+func reconciledMutationIsTransient(parent context.Context, err error) bool {
+	if asc.IsRetryable(err) {
+		return true
+	}
+	return parent.Err() == nil && errors.Is(err, context.DeadlineExceeded)
+}
+
+func reconciledMutationRetryDelay(opts asc.RetryOptions, retry int, err error) time.Duration {
+	if delay := asc.GetRetryAfter(err); delay > 0 {
+		return delay
+	}
+
+	delay := opts.BaseDelay
+	if retry > 0 && retry < 31 {
+		delay *= time.Duration(1 << retry)
+	}
+	if opts.MaxDelay > 0 && (delay > opts.MaxDelay || delay <= 0) {
+		return opts.MaxDelay
+	}
+	return delay
+}

--- a/internal/cli/subscriptions/mutation_recovery.go
+++ b/internal/cli/subscriptions/mutation_recovery.go
@@ -11,6 +11,8 @@ import (
 
 type reconciledMutationStatus string
 
+var subscriptionImportNow = func() time.Time { return time.Now().UTC() }
+
 const (
 	reconciledMutationCreated    reconciledMutationStatus = "created"
 	reconciledMutationSkipped    reconciledMutationStatus = "skipped"

--- a/internal/cli/subscriptions/mutation_recovery.go
+++ b/internal/cli/subscriptions/mutation_recovery.go
@@ -50,6 +50,17 @@ func runReconciledMutation(
 		if err := sleepWithContext(ctx, reconciledMutationRetryDelay(retryOpts, retry, mutationErr)); err != nil {
 			return "", err
 		}
+
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		exists, readErr = readback(ctx)
+		if readErr != nil {
+			return "", fmt.Errorf("mutation and pre-retry readback failed: %w", errors.Join(mutationErr, readErr))
+		}
+		if exists {
+			return reconciledMutationReconciled, nil
+		}
 	}
 }
 

--- a/internal/cli/subscriptions/mutation_recovery.go
+++ b/internal/cli/subscriptions/mutation_recovery.go
@@ -2,11 +2,9 @@ package subscriptions
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"time"
 
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 type reconciledMutationStatus string
@@ -24,66 +22,21 @@ func runReconciledMutation(
 	readback func(context.Context) (bool, error),
 	mutate func(context.Context) error,
 ) (reconciledMutationStatus, error) {
-	if err := ctx.Err(); err != nil {
+	_, status, err := shared.RunReconciledMutation(
+		ctx,
+		func(requestCtx context.Context) (struct{}, error) {
+			return struct{}{}, mutate(requestCtx)
+		},
+		func(readbackCtx context.Context) (struct{}, bool, error) {
+			exists, readErr := readback(readbackCtx)
+			return struct{}{}, exists, readErr
+		},
+	)
+	if err != nil {
 		return "", err
 	}
-
-	retryOpts := asc.ResolveRetryOptions()
-	for retry := 0; ; retry++ {
-		mutationErr := mutate(ctx)
-		if mutationErr == nil {
-			return reconciledMutationCreated, nil
-		}
-		if err := ctx.Err(); err != nil {
-			return "", err
-		}
-
-		exists, readErr := readback(ctx)
-		if readErr != nil {
-			return "", fmt.Errorf("mutation and readback failed: %w", errors.Join(mutationErr, readErr))
-		}
-		if exists {
-			return reconciledMutationReconciled, nil
-		}
-		if !reconciledMutationIsTransient(ctx, mutationErr) || retry >= retryOpts.MaxRetries {
-			return "", mutationErr
-		}
-
-		if err := sleepWithContext(ctx, reconciledMutationRetryDelay(retryOpts, retry, mutationErr)); err != nil {
-			return "", err
-		}
-
-		if err := ctx.Err(); err != nil {
-			return "", err
-		}
-		exists, readErr = readback(ctx)
-		if readErr != nil {
-			return "", fmt.Errorf("mutation and pre-retry readback failed: %w", errors.Join(mutationErr, readErr))
-		}
-		if exists {
-			return reconciledMutationReconciled, nil
-		}
+	if status == shared.ReconciledMutationRecovered {
+		return reconciledMutationReconciled, nil
 	}
-}
-
-func reconciledMutationIsTransient(parent context.Context, err error) bool {
-	if asc.IsRetryable(err) {
-		return true
-	}
-	return parent.Err() == nil && errors.Is(err, context.DeadlineExceeded)
-}
-
-func reconciledMutationRetryDelay(opts asc.RetryOptions, retry int, err error) time.Duration {
-	if delay := asc.GetRetryAfter(err); delay > 0 {
-		return delay
-	}
-
-	delay := opts.BaseDelay
-	if retry > 0 && retry < 31 {
-		delay *= time.Duration(1 << retry)
-	}
-	if opts.MaxDelay > 0 && (delay > opts.MaxDelay || delay <= 0) {
-		return opts.MaxDelay
-	}
-	return delay
+	return reconciledMutationCreated, nil
 }

--- a/internal/cli/subscriptions/mutation_recovery_test.go
+++ b/internal/cli/subscriptions/mutation_recovery_test.go
@@ -1,0 +1,113 @@
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestRunReconciledMutationRetriesOnlyAfterNegativeReadback(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	mutations := 0
+	readbacks := 0
+	status, err := runReconciledMutation(
+		context.Background(),
+		func(context.Context) (bool, error) {
+			readbacks++
+			return false, nil
+		},
+		func(context.Context) error {
+			mutations++
+			if mutations == 1 {
+				return &asc.RetryableError{Err: errors.New("temporary failure")}
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runReconciledMutation() error: %v", err)
+	}
+	if status != reconciledMutationCreated || mutations != 2 || readbacks != 1 {
+		t.Fatalf("unexpected recovery: status=%q mutations=%d readbacks=%d", status, mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationRetriesChildDeadlineAfterNegativeReadback(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	mutations := 0
+	readbacks := 0
+	status, err := runReconciledMutation(
+		context.Background(),
+		func(context.Context) (bool, error) {
+			readbacks++
+			return false, nil
+		},
+		func(context.Context) error {
+			mutations++
+			if mutations == 1 {
+				return context.DeadlineExceeded
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runReconciledMutation() error: %v", err)
+	}
+	if status != reconciledMutationCreated || mutations != 2 || readbacks != 1 {
+		t.Fatalf("unexpected recovery: status=%q mutations=%d readbacks=%d", status, mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationStopsWhenReadbackFails(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "3")
+	mutations := 0
+	_, err := runReconciledMutation(
+		context.Background(),
+		func(context.Context) (bool, error) {
+			return false, errors.New("readback unavailable")
+		},
+		func(context.Context) error {
+			mutations++
+			return &asc.RetryableError{Err: errors.New("ambiguous failure")}
+		},
+	)
+	if err == nil || mutations != 1 {
+		t.Fatalf("expected one mutation and a readback error, mutations=%d err=%v", mutations, err)
+	}
+}
+
+func TestRunReconciledMutationRespectsCancellationDuringBackoff(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1h")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mutations := 0
+	readbacks := 0
+	_, err := runReconciledMutation(
+		ctx,
+		func(context.Context) (bool, error) {
+			readbacks++
+			cancel()
+			return false, nil
+		},
+		func(context.Context) error {
+			mutations++
+			return &asc.RetryableError{Err: errors.New("temporary failure"), RetryAfter: time.Hour}
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if mutations != 1 || readbacks != 1 {
+		t.Fatalf("expected cancellation during first backoff, mutations=%d readbacks=%d", mutations, readbacks)
+	}
+}

--- a/internal/cli/subscriptions/mutation_recovery_test.go
+++ b/internal/cli/subscriptions/mutation_recovery_test.go
@@ -33,7 +33,7 @@ func TestRunReconciledMutationRetriesOnlyAfterNegativeReadback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runReconciledMutation() error: %v", err)
 	}
-	if status != reconciledMutationCreated || mutations != 2 || readbacks != 1 {
+	if status != reconciledMutationCreated || mutations != 2 || readbacks != 2 {
 		t.Fatalf("unexpected recovery: status=%q mutations=%d readbacks=%d", status, mutations, readbacks)
 	}
 }
@@ -62,7 +62,33 @@ func TestRunReconciledMutationRetriesChildDeadlineAfterNegativeReadback(t *testi
 	if err != nil {
 		t.Fatalf("runReconciledMutation() error: %v", err)
 	}
-	if status != reconciledMutationCreated || mutations != 2 || readbacks != 1 {
+	if status != reconciledMutationCreated || mutations != 2 || readbacks != 2 {
+		t.Fatalf("unexpected recovery: status=%q mutations=%d readbacks=%d", status, mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationReadsAgainBeforeReplay(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	mutations := 0
+	readbacks := 0
+	status, err := runReconciledMutation(
+		context.Background(),
+		func(context.Context) (bool, error) {
+			readbacks++
+			return readbacks == 2, nil
+		},
+		func(context.Context) error {
+			mutations++
+			return &asc.RetryableError{Err: errors.New("ambiguous failure")}
+		},
+	)
+	if err != nil {
+		t.Fatalf("runReconciledMutation() error: %v", err)
+	}
+	if status != reconciledMutationReconciled || mutations != 1 || readbacks != 2 {
 		t.Fatalf("unexpected recovery: status=%q mutations=%d readbacks=%d", status, mutations, readbacks)
 	}
 }

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,20 +27,21 @@ import (
 )
 
 type subscriptionPriceImportSummary struct {
-	SubscriptionID  string                                `json:"subscriptionId"`
-	InputFile       string                                `json:"inputFile"`
-	DryRun          bool                                  `json:"dryRun"`
-	ContinueOnError bool                                  `json:"continueOnError"`
-	DefaultStart    string                                `json:"defaultStartDate,omitempty"`
-	DefaultPreserve bool                                  `json:"defaultPreserved"`
-	Total           int                                   `json:"total"`
-	Created         int                                   `json:"created"`
-	Skipped         int                                   `json:"skipped,omitempty"`
-	Reconciled      int                                   `json:"reconciled,omitempty"`
-	Failed          int                                   `json:"failed"`
-	Failures        []subscriptionPriceImportSummaryError `json:"failures,omitempty"`
-	FailureArtifact string                                `json:"failureArtifactPath,omitempty"`
-	Results         []subscriptionPriceImportResultItem   `json:"results,omitempty"`
+	SubscriptionID       string                                `json:"subscriptionId"`
+	InputFile            string                                `json:"inputFile"`
+	DryRun               bool                                  `json:"dryRun"`
+	ContinueOnError      bool                                  `json:"continueOnError"`
+	DefaultStart         string                                `json:"defaultStartDate,omitempty"`
+	DefaultPreserve      bool                                  `json:"defaultPreserved"`
+	Total                int                                   `json:"total"`
+	Created              int                                   `json:"created"`
+	Skipped              int                                   `json:"skipped,omitempty"`
+	Reconciled           int                                   `json:"reconciled,omitempty"`
+	Failed               int                                   `json:"failed"`
+	Failures             []subscriptionPriceImportSummaryError `json:"failures,omitempty"`
+	FailureArtifact      string                                `json:"failureArtifactPath,omitempty"`
+	FailureArtifactError string                                `json:"failureArtifactError,omitempty"`
+	Results              []subscriptionPriceImportResultItem   `json:"results,omitempty"`
 }
 
 type subscriptionPriceImportSummaryError struct {
@@ -57,6 +59,7 @@ type subscriptionPriceImportResultItem struct {
 	StartDate            string `json:"startDate,omitempty"`
 	PreserveCurrentPrice bool   `json:"preserveCurrentPrice"`
 	PreserveCurrentSet   bool   `json:"preserveCurrentPriceSet"`
+	PlanType             string `json:"planType"`
 	Status               string `json:"status"`
 	Error                string `json:"error,omitempty"`
 }
@@ -91,6 +94,7 @@ type subscriptionPriceImportResolvedRow struct {
 	preserveSet          bool
 	preserveCurrentPrice bool
 	pricePointID         string
+	planType             asc.SubscriptionPlanType
 }
 
 type subscriptionPricePointLookupCache struct {
@@ -103,6 +107,7 @@ type subscriptionPriceImportState struct {
 	pricePointID         string
 	startDate            string
 	preserveCurrentPrice bool
+	planType             asc.SubscriptionPlanType
 }
 
 type subscriptionPriceImportStateIndex struct {
@@ -202,9 +207,9 @@ Examples:
 				Total:           len(rows),
 			}
 
-			resolveCtx, resolveCancel := shared.ContextWithTimeout(ctx)
-			summary.SubscriptionID, err = resolveSubscriptionLookupID(resolveCtx, client, *appID, summary.SubscriptionID)
-			resolveCancel()
+			summary.SubscriptionID, err = shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (string, error) {
+				return resolveSubscriptionLookupID(requestCtx, client, *appID, summary.SubscriptionID)
+			})
 			if err != nil {
 				return err
 			}
@@ -252,6 +257,7 @@ Examples:
 						StartDate:            resolvedRow.startDate,
 						PreserveCurrentPrice: resolvedRow.preserveCurrentPrice,
 						PreserveCurrentSet:   resolvedRow.preserveSet,
+						PlanType:             string(resolvedRow.planType),
 						Status:               "planned",
 					})
 					continue
@@ -259,6 +265,7 @@ Examples:
 
 				attrs := asc.SubscriptionPriceCreateAttributes{
 					StartDate: resolvedRow.startDate,
+					PlanType:  resolvedRow.planType,
 				}
 				if resolvedRow.preserveSet {
 					attrs.Preserved = &resolvedRow.preserveCurrentPrice
@@ -301,6 +308,7 @@ Examples:
 					StartDate:            resolvedRow.startDate,
 					PreserveCurrentPrice: resolvedRow.preserveCurrentPrice,
 					PreserveCurrentSet:   resolvedRow.preserveSet,
+					PlanType:             string(resolvedRow.planType),
 					Status:               string(status),
 				}
 				summary.Results = append(summary.Results, result)
@@ -320,9 +328,10 @@ Examples:
 			if summary.Failed > 0 {
 				artifactPath, artifactErr := writeSubscriptionPriceImportFailureArtifact(summary)
 				if artifactErr != nil {
-					return fmt.Errorf("subscriptions prices import: write failure artifact: %w", artifactErr)
+					summary.FailureArtifactError = artifactErr.Error()
+				} else {
+					summary.FailureArtifact = artifactPath
 				}
-				summary.FailureArtifact = artifactPath
 			}
 
 			if err := shared.PrintOutputWithRenderers(
@@ -336,7 +345,11 @@ Examples:
 			}
 
 			if summary.Failed > 0 {
-				return shared.NewReportedError(fmt.Errorf("subscriptions prices import: %d row(s) failed", summary.Failed))
+				rowErr := fmt.Errorf("subscriptions prices import: %d row(s) failed", summary.Failed)
+				if summary.FailureArtifactError != "" {
+					rowErr = errors.Join(rowErr, fmt.Errorf("write failure artifact: %s", summary.FailureArtifactError))
+				}
+				return shared.NewReportedError(rowErr)
 			}
 			return nil
 		},
@@ -354,7 +367,7 @@ func renderSubscriptionPriceImportSummaryTables(summary *subscriptionPriceImport
 	}
 
 	render(
-		[]string{"Subscription ID", "Input File", "Dry Run", "Total", "Created", "Skipped", "Reconciled", "Failed", "Failure Artifact"},
+		[]string{"Subscription ID", "Input File", "Dry Run", "Total", "Created", "Skipped", "Reconciled", "Failed", "Failure Artifact", "Failure Artifact Error"},
 		[][]string{{
 			summary.SubscriptionID,
 			summary.InputFile,
@@ -365,6 +378,7 @@ func renderSubscriptionPriceImportSummaryTables(summary *subscriptionPriceImport
 			fmt.Sprintf("%d", summary.Reconciled),
 			fmt.Sprintf("%d", summary.Failed),
 			summary.FailureArtifact,
+			summary.FailureArtifactError,
 		}},
 	)
 
@@ -403,26 +417,46 @@ func appendSubscriptionPriceImportFailure(summary *subscriptionPriceImportSummar
 		StartDate:            row.startDate,
 		PreserveCurrentPrice: row.preserveCurrentPrice,
 		PreserveCurrentSet:   row.preserveSet,
+		PlanType:             string(row.planType),
 		Status:               "failed",
 		Error:                err.Error(),
 	})
 }
 
 func fetchSubscriptionPriceImportState(ctx context.Context, client *asc.Client, subscriptionID string) (*subscriptionPriceImportStateIndex, error) {
+	query := url.Values{
+		"fields[subscriptionPrices]": []string{"startDate,preserved,planType,territory,subscriptionPricePoint"},
+		"filter[planType]":           []string{string(asc.SubscriptionPlanTypeUpfront)},
+		"include":                    []string{"territory,subscriptionPricePoint"},
+		"limit":                      []string{"200"},
+	}
 	fetchPage := func(nextURL string) (*asc.SubscriptionPricesResponse, error) {
-		requestCtx, cancel := shared.ContextWithTimeout(ctx)
-		defer cancel()
 		if nextURL != "" {
-			return client.GetSubscriptionPrices(requestCtx, subscriptionID, asc.WithSubscriptionPricesNextURL(nextURL))
+			mergedNext, err := mergeSubscriptionPricesNextQuery(nextURL, query)
+			if err != nil {
+				return nil, err
+			}
+			return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricesResponse, error) {
+				return client.GetSubscriptionPrices(requestCtx, subscriptionID, asc.WithSubscriptionPricesNextURL(mergedNext))
+			})
 		}
-		return client.GetSubscriptionPrices(requestCtx, subscriptionID, asc.WithSubscriptionPricesLimit(200))
+		return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricesResponse, error) {
+			return client.GetSubscriptionPrices(
+				requestCtx,
+				subscriptionID,
+				asc.WithSubscriptionPricesLimit(200),
+				asc.WithSubscriptionPricesPlanType(asc.SubscriptionPlanTypeUpfront),
+				asc.WithSubscriptionPricesFields([]string{"startDate", "preserved", "planType", "territory", "subscriptionPricePoint"}),
+				asc.WithSubscriptionPricesInclude([]string{"territory", "subscriptionPricePoint"}),
+			)
+		})
 	}
 
 	firstPage, err := fetchPage("")
 	if err != nil {
 		return nil, err
 	}
-	index := &subscriptionPriceImportStateIndex{now: time.Now().UTC()}
+	index := &subscriptionPriceImportStateIndex{}
 	err = asc.PaginateEach(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
 		return fetchPage(nextURL)
 	}, func(page asc.PaginatedResponse) error {
@@ -436,6 +470,7 @@ func fetchSubscriptionPriceImportState(ctx context.Context, client *asc.Client, 
 				pricePointID:         strings.TrimSpace(extractSubscriptionPriceRelationshipID(price, "subscriptionPricePoint")),
 				startDate:            strings.TrimSpace(price.Attributes.StartDate),
 				preserveCurrentPrice: price.Attributes.Preserved,
+				planType:             price.Attributes.PlanType,
 			})
 		}
 		return nil
@@ -443,6 +478,7 @@ func fetchSubscriptionPriceImportState(ctx context.Context, client *asc.Client, 
 	if err != nil {
 		return nil, err
 	}
+	index.now = subscriptionImportNow()
 	return index, nil
 }
 
@@ -455,6 +491,7 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 	if targetStart != "" {
 		for _, state := range index.states {
 			if state.territoryID == targetTerritory &&
+				state.planType == target.planType &&
 				state.pricePointID == target.pricePointID &&
 				state.startDate == targetStart &&
 				(!target.preserveSet || state.preserveCurrentPrice == target.preserveCurrentPrice) {
@@ -465,10 +502,11 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 	}
 
 	asOf := dateOnlyUTC(index.now)
-	latest := time.Time{}
-	matchingLatest := false
+	var selected *subscriptionPriceImportState
+	selectedStart := time.Time{}
 	for _, state := range index.states {
 		if state.territoryID != targetTerritory ||
+			state.planType != target.planType ||
 			(target.preserveSet && state.preserveCurrentPrice != target.preserveCurrentPrice) {
 			continue
 		}
@@ -480,14 +518,14 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 			}
 			start = parsed
 		}
-		if start.After(latest) {
-			latest = start
-			matchingLatest = state.pricePointID == target.pricePointID
-		} else if start.Equal(latest) && state.pricePointID == target.pricePointID {
-			matchingLatest = true
+		if selected == nil || start.After(selectedStart) ||
+			(start.Equal(selectedStart) && selected.preserveCurrentPrice && !state.preserveCurrentPrice) {
+			candidate := state
+			selected = &candidate
+			selectedStart = start
 		}
 	}
-	return matchingLatest
+	return selected != nil && selected.pricePointID == target.pricePointID
 }
 
 func (index *subscriptionPriceImportStateIndex) add(target subscriptionPriceImportResolvedRow) {
@@ -503,6 +541,7 @@ func (index *subscriptionPriceImportStateIndex) add(target subscriptionPriceImpo
 		pricePointID:         strings.TrimSpace(target.pricePointID),
 		startDate:            startDate,
 		preserveCurrentPrice: target.preserveCurrentPrice,
+		planType:             target.planType,
 	})
 }
 
@@ -672,6 +711,7 @@ func resolveSubscriptionPriceImportRow(
 		preserveSet:          row.preserveSet,
 		preserveCurrentPrice: row.preserveCurrentPrice,
 		pricePointID:         strings.TrimSpace(row.pricePointID),
+		planType:             asc.SubscriptionPlanTypeUpfront,
 	}
 
 	if resolved.startDate == "" {
@@ -738,24 +778,34 @@ func fetchSubscriptionPricePointsByTerritory(
 	territoryID string,
 ) (map[string][]string, error) {
 	priceByAmount := make(map[string][]string)
+	query := url.Values{
+		"fields[subscriptionPricePoints]": []string{"customerPrice"},
+		"filter[territory]":               []string{strings.ToUpper(strings.TrimSpace(territoryID))},
+		"limit":                           []string{"200"},
+	}
 	fetchPage := func(nextURL string) (*asc.SubscriptionPricePointsResponse, error) {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		defer pageCancel()
-
 		if nextURL == "" {
-			return client.GetSubscriptionPricePoints(
-				pageCtx,
-				subscriptionID,
-				asc.WithSubscriptionPricePointsTerritory(territoryID),
-				asc.WithSubscriptionPricePointsLimit(200),
-			)
-		} else {
-			return client.GetSubscriptionPricePoints(
-				pageCtx,
-				subscriptionID,
-				asc.WithSubscriptionPricePointsNextURL(nextURL),
-			)
+			return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricePointsResponse, error) {
+				return client.GetSubscriptionPricePoints(
+					requestCtx,
+					subscriptionID,
+					asc.WithSubscriptionPricePointsTerritory(territoryID),
+					asc.WithSubscriptionPricePointsFields([]string{"customerPrice"}),
+					asc.WithSubscriptionPricePointsLimit(200),
+				)
+			})
 		}
+		mergedNext, err := mergeSubscriptionPricesNextQuery(nextURL, query)
+		if err != nil {
+			return nil, err
+		}
+		return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricePointsResponse, error) {
+			return client.GetSubscriptionPricePoints(
+				requestCtx,
+				subscriptionID,
+				asc.WithSubscriptionPricePointsNextURL(mergedNext),
+			)
+		})
 	}
 
 	firstPage, err := fetchPage("")

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -506,8 +506,7 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 	selectedStart := time.Time{}
 	for _, state := range index.states {
 		if state.territoryID != targetTerritory ||
-			state.planType != target.planType ||
-			(target.preserveSet && state.preserveCurrentPrice != target.preserveCurrentPrice) {
+			state.planType != target.planType {
 			continue
 		}
 		start := time.Time{}
@@ -525,7 +524,9 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 			selectedStart = start
 		}
 	}
-	return selected != nil && selected.pricePointID == target.pricePointID
+	return selected != nil &&
+		selected.pricePointID == target.pricePointID &&
+		(!target.preserveSet || selected.preserveCurrentPrice == target.preserveCurrentPrice)
 }
 
 func (index *subscriptionPriceImportStateIndex) add(target subscriptionPriceImportResolvedRow) {

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -285,9 +285,7 @@ Examples:
 							return stateIndex.matches(resolvedRow), nil
 						},
 						func(mutationCtx context.Context) error {
-							createCtx, createCancel := shared.ContextWithTimeout(mutationCtx)
-							defer createCancel()
-							_, err := client.CreateSubscriptionPrice(createCtx, summary.SubscriptionID, pricePointID, resolvedRow.territoryID, attrs)
+							_, err := client.CreateSubscriptionPrice(mutationCtx, summary.SubscriptionID, pricePointID, resolvedRow.territoryID, attrs)
 							return err
 						},
 					)

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -493,8 +493,7 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 			if state.territoryID == targetTerritory &&
 				state.planType == target.planType &&
 				state.pricePointID == target.pricePointID &&
-				state.startDate == targetStart &&
-				(!target.preserveSet || state.preserveCurrentPrice == target.preserveCurrentPrice) {
+				state.startDate == targetStart {
 				return true
 			}
 		}
@@ -524,9 +523,7 @@ func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPrice
 			selectedStart = start
 		}
 	}
-	return selected != nil &&
-		selected.pricePointID == target.pricePointID &&
-		(!target.preserveSet || selected.preserveCurrentPrice == target.preserveCurrentPrice)
+	return selected != nil && selected.pricePointID == target.pricePointID
 }
 
 func (index *subscriptionPriceImportStateIndex) add(target subscriptionPriceImportResolvedRow) {

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -1,8 +1,10 @@
 package subscriptions
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -32,8 +34,12 @@ type subscriptionPriceImportSummary struct {
 	DefaultPreserve bool                                  `json:"defaultPreserved"`
 	Total           int                                   `json:"total"`
 	Created         int                                   `json:"created"`
+	Skipped         int                                   `json:"skipped,omitempty"`
+	Reconciled      int                                   `json:"reconciled,omitempty"`
 	Failed          int                                   `json:"failed"`
 	Failures        []subscriptionPriceImportSummaryError `json:"failures,omitempty"`
+	FailureArtifact string                                `json:"failureArtifactPath,omitempty"`
+	Results         []subscriptionPriceImportResultItem   `json:"results,omitempty"`
 }
 
 type subscriptionPriceImportSummaryError struct {
@@ -41,6 +47,28 @@ type subscriptionPriceImportSummaryError struct {
 	Territory string `json:"territory,omitempty"`
 	Price     string `json:"price,omitempty"`
 	Error     string `json:"error"`
+}
+
+type subscriptionPriceImportResultItem struct {
+	Row                  int    `json:"row"`
+	Territory            string `json:"territory,omitempty"`
+	Price                string `json:"price,omitempty"`
+	PricePointID         string `json:"pricePointId,omitempty"`
+	StartDate            string `json:"startDate,omitempty"`
+	PreserveCurrentPrice bool   `json:"preserveCurrentPrice"`
+	PreserveCurrentSet   bool   `json:"preserveCurrentPriceSet"`
+	Status               string `json:"status"`
+	Error                string `json:"error,omitempty"`
+}
+
+type subscriptionPriceImportFailureArtifact struct {
+	SchemaVersion  int                                 `json:"schemaVersion"`
+	Command        string                              `json:"command"`
+	SubscriptionID string                              `json:"subscriptionId"`
+	InputFile      string                              `json:"inputFile"`
+	Failed         int                                 `json:"failed"`
+	GeneratedAt    string                              `json:"generatedAt"`
+	Results        []subscriptionPriceImportResultItem `json:"results"`
 }
 
 type subscriptionPriceImportCSVRow struct {
@@ -68,6 +96,18 @@ type subscriptionPriceImportResolvedRow struct {
 type subscriptionPricePointLookupCache struct {
 	mu          sync.Mutex
 	byTerritory map[string]map[string][]string
+}
+
+type subscriptionPriceImportState struct {
+	territoryID          string
+	pricePointID         string
+	startDate            string
+	preserveCurrentPrice bool
+}
+
+type subscriptionPriceImportStateIndex struct {
+	now    time.Time
+	states []subscriptionPriceImportState
 }
 
 var subscriptionPricesImportKnownColumns = map[string]string{
@@ -172,6 +212,13 @@ Examples:
 			lookupCache := &subscriptionPricePointLookupCache{
 				byTerritory: make(map[string]map[string][]string),
 			}
+			var stateIndex *subscriptionPriceImportStateIndex
+			if !*dryRun {
+				stateIndex, err = fetchSubscriptionPriceImportState(ctx, client, summary.SubscriptionID)
+				if err != nil {
+					return fmt.Errorf("subscriptions prices import: fetch existing prices: %w", err)
+				}
+			}
 
 			for _, csvRow := range rows {
 				resolvedRow, rowErr := resolveSubscriptionPriceImportRow(csvRow, defaultStartDate, *preserved)
@@ -197,6 +244,16 @@ Examples:
 
 				if *dryRun {
 					summary.Created++
+					summary.Results = append(summary.Results, subscriptionPriceImportResultItem{
+						Row:                  resolvedRow.row,
+						Territory:            resolvedRow.territoryID,
+						Price:                resolvedRow.price,
+						PricePointID:         pricePointID,
+						StartDate:            resolvedRow.startDate,
+						PreserveCurrentPrice: resolvedRow.preserveCurrentPrice,
+						PreserveCurrentSet:   resolvedRow.preserveSet,
+						Status:               "planned",
+					})
 					continue
 				}
 
@@ -207,9 +264,27 @@ Examples:
 					attrs.Preserved = &resolvedRow.preserveCurrentPrice
 				}
 
-				createCtx, createCancel := shared.ContextWithTimeout(ctx)
-				_, rowErr = client.CreateSubscriptionPrice(createCtx, summary.SubscriptionID, pricePointID, resolvedRow.territoryID, attrs)
-				createCancel()
+				resolvedRow.pricePointID = pricePointID
+				status := reconciledMutationSkipped
+				if !stateIndex.matches(resolvedRow) {
+					status, rowErr = runReconciledMutation(
+						ctx,
+						func(readbackCtx context.Context) (bool, error) {
+							refreshed, err := fetchSubscriptionPriceImportState(readbackCtx, client, summary.SubscriptionID)
+							if err != nil {
+								return false, err
+							}
+							stateIndex = refreshed
+							return stateIndex.matches(resolvedRow), nil
+						},
+						func(mutationCtx context.Context) error {
+							createCtx, createCancel := shared.ContextWithTimeout(mutationCtx)
+							defer createCancel()
+							_, err := client.CreateSubscriptionPrice(createCtx, summary.SubscriptionID, pricePointID, resolvedRow.territoryID, attrs)
+							return err
+						},
+					)
+				}
 				if rowErr != nil {
 					appendSubscriptionPriceImportFailure(summary, resolvedRow, rowErr)
 					if !*continueOnError {
@@ -218,7 +293,36 @@ Examples:
 					continue
 				}
 
-				summary.Created++
+				result := subscriptionPriceImportResultItem{
+					Row:                  resolvedRow.row,
+					Territory:            resolvedRow.territoryID,
+					Price:                resolvedRow.price,
+					PricePointID:         pricePointID,
+					StartDate:            resolvedRow.startDate,
+					PreserveCurrentPrice: resolvedRow.preserveCurrentPrice,
+					PreserveCurrentSet:   resolvedRow.preserveSet,
+					Status:               string(status),
+				}
+				summary.Results = append(summary.Results, result)
+				if status != reconciledMutationSkipped {
+					stateIndex.add(resolvedRow)
+				}
+				switch status {
+				case reconciledMutationCreated:
+					summary.Created++
+				case reconciledMutationSkipped:
+					summary.Skipped++
+				case reconciledMutationReconciled:
+					summary.Reconciled++
+				}
+			}
+
+			if summary.Failed > 0 {
+				artifactPath, artifactErr := writeSubscriptionPriceImportFailureArtifact(summary)
+				if artifactErr != nil {
+					return fmt.Errorf("subscriptions prices import: write failure artifact: %w", artifactErr)
+				}
+				summary.FailureArtifact = artifactPath
 			}
 
 			if err := shared.PrintOutputWithRenderers(
@@ -250,14 +354,17 @@ func renderSubscriptionPriceImportSummaryTables(summary *subscriptionPriceImport
 	}
 
 	render(
-		[]string{"Subscription ID", "Input File", "Dry Run", "Total", "Created", "Failed"},
+		[]string{"Subscription ID", "Input File", "Dry Run", "Total", "Created", "Skipped", "Reconciled", "Failed", "Failure Artifact"},
 		[][]string{{
 			summary.SubscriptionID,
 			summary.InputFile,
 			fmt.Sprintf("%t", summary.DryRun),
 			fmt.Sprintf("%d", summary.Total),
 			fmt.Sprintf("%d", summary.Created),
+			fmt.Sprintf("%d", summary.Skipped),
+			fmt.Sprintf("%d", summary.Reconciled),
 			fmt.Sprintf("%d", summary.Failed),
+			summary.FailureArtifact,
 		}},
 	)
 
@@ -288,6 +395,142 @@ func appendSubscriptionPriceImportFailure(summary *subscriptionPriceImportSummar
 		Price:     row.price,
 		Error:     err.Error(),
 	})
+	summary.Results = append(summary.Results, subscriptionPriceImportResultItem{
+		Row:                  row.row,
+		Territory:            row.territoryID,
+		Price:                row.price,
+		PricePointID:         row.pricePointID,
+		StartDate:            row.startDate,
+		PreserveCurrentPrice: row.preserveCurrentPrice,
+		PreserveCurrentSet:   row.preserveSet,
+		Status:               "failed",
+		Error:                err.Error(),
+	})
+}
+
+func fetchSubscriptionPriceImportState(ctx context.Context, client *asc.Client, subscriptionID string) (*subscriptionPriceImportStateIndex, error) {
+	fetchPage := func(nextURL string) (*asc.SubscriptionPricesResponse, error) {
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		if nextURL != "" {
+			return client.GetSubscriptionPrices(requestCtx, subscriptionID, asc.WithSubscriptionPricesNextURL(nextURL))
+		}
+		return client.GetSubscriptionPrices(requestCtx, subscriptionID, asc.WithSubscriptionPricesLimit(200))
+	}
+
+	firstPage, err := fetchPage("")
+	if err != nil {
+		return nil, err
+	}
+	index := &subscriptionPriceImportStateIndex{now: time.Now().UTC()}
+	err = asc.PaginateEach(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return fetchPage(nextURL)
+	}, func(page asc.PaginatedResponse) error {
+		prices, ok := page.(*asc.SubscriptionPricesResponse)
+		if !ok {
+			return fmt.Errorf("unexpected subscription prices response type %T", page)
+		}
+		for _, price := range prices.Data {
+			index.states = append(index.states, subscriptionPriceImportState{
+				territoryID:          strings.ToUpper(strings.TrimSpace(extractSubscriptionPriceRelationshipID(price, "territory"))),
+				pricePointID:         strings.TrimSpace(extractSubscriptionPriceRelationshipID(price, "subscriptionPricePoint")),
+				startDate:            strings.TrimSpace(price.Attributes.StartDate),
+				preserveCurrentPrice: price.Attributes.Preserved,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func (index *subscriptionPriceImportStateIndex) matches(target subscriptionPriceImportResolvedRow) bool {
+	if index == nil {
+		return false
+	}
+	targetTerritory := strings.ToUpper(strings.TrimSpace(target.territoryID))
+	targetStart := strings.TrimSpace(target.startDate)
+	if targetStart != "" {
+		for _, state := range index.states {
+			if state.territoryID == targetTerritory &&
+				state.pricePointID == target.pricePointID &&
+				state.startDate == targetStart &&
+				(!target.preserveSet || state.preserveCurrentPrice == target.preserveCurrentPrice) {
+				return true
+			}
+		}
+		return false
+	}
+
+	asOf := dateOnlyUTC(index.now)
+	latest := time.Time{}
+	matchingLatest := false
+	for _, state := range index.states {
+		if state.territoryID != targetTerritory ||
+			(target.preserveSet && state.preserveCurrentPrice != target.preserveCurrentPrice) {
+			continue
+		}
+		start := time.Time{}
+		if state.startDate != "" {
+			parsed, err := time.Parse(equalizeDateLayout, state.startDate)
+			if err != nil || parsed.After(asOf) {
+				continue
+			}
+			start = parsed
+		}
+		if start.After(latest) {
+			latest = start
+			matchingLatest = state.pricePointID == target.pricePointID
+		} else if start.Equal(latest) && state.pricePointID == target.pricePointID {
+			matchingLatest = true
+		}
+	}
+	return matchingLatest
+}
+
+func (index *subscriptionPriceImportStateIndex) add(target subscriptionPriceImportResolvedRow) {
+	if index == nil {
+		return
+	}
+	startDate := strings.TrimSpace(target.startDate)
+	if startDate == "" {
+		startDate = dateOnlyUTC(index.now).Format(equalizeDateLayout)
+	}
+	index.states = append(index.states, subscriptionPriceImportState{
+		territoryID:          strings.ToUpper(strings.TrimSpace(target.territoryID)),
+		pricePointID:         strings.TrimSpace(target.pricePointID),
+		startDate:            startDate,
+		preserveCurrentPrice: target.preserveCurrentPrice,
+	})
+}
+
+func writeSubscriptionPriceImportFailureArtifact(summary *subscriptionPriceImportSummary) (string, error) {
+	failures := make([]subscriptionPriceImportResultItem, 0, summary.Failed)
+	for _, result := range summary.Results {
+		if result.Status == "failed" {
+			failures = append(failures, result)
+		}
+	}
+	artifact := subscriptionPriceImportFailureArtifact{
+		SchemaVersion:  1,
+		Command:        "subscriptions pricing prices import",
+		SubscriptionID: summary.SubscriptionID,
+		InputFile:      summary.InputFile,
+		Failed:         summary.Failed,
+		GeneratedAt:    time.Now().UTC().Format(time.RFC3339),
+		Results:        failures,
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(".asc", "reports", "subscription-prices-import", fmt.Sprintf("failures-%d.json", time.Now().UTC().UnixNano()))
+	if _, err := shared.WriteStreamToFile(path, bytes.NewReader(data)); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 func readSubscriptionPricesImportCSV(path string) ([]subscriptionPriceImportCSVRow, error) {

--- a/internal/cli/subscriptions/prices_import_test.go
+++ b/internal/cli/subscriptions/prices_import_test.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestReadSubscriptionPricesImportCSV_SupportsHeaderAliases(t *testing.T) {
@@ -140,6 +143,7 @@ func TestSubscriptionPriceImportStateMatchesIgnoresUnspecifiedPreservedValue(t *
 			pricePointID:         "pp-usa",
 			startDate:            "2026-07-01",
 			preserveCurrentPrice: true,
+			planType:             asc.SubscriptionPlanTypeUpfront,
 		}},
 	}
 	target := subscriptionPriceImportResolvedRow{
@@ -147,9 +151,63 @@ func TestSubscriptionPriceImportStateMatchesIgnoresUnspecifiedPreservedValue(t *
 		pricePointID: "pp-usa",
 		startDate:    "2026-07-01",
 		preserveSet:  false,
+		planType:     asc.SubscriptionPlanTypeUpfront,
 	}
 
 	if !index.matches(target) {
 		t.Fatal("expected omitted preserved value to match either remote state")
+	}
+}
+
+func TestSubscriptionPriceImportStateMatchesCanonicalSameDayPrice(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{
+		now: time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC),
+		states: []subscriptionPriceImportState{
+			{territoryID: "USA", pricePointID: "target", startDate: "2026-07-01", preserveCurrentPrice: true, planType: asc.SubscriptionPlanTypeUpfront},
+			{territoryID: "USA", pricePointID: "canonical", startDate: "2026-07-01", preserveCurrentPrice: false, planType: asc.SubscriptionPlanTypeUpfront},
+		},
+	}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID:  "USA",
+		pricePointID: "target",
+		planType:     asc.SubscriptionPlanTypeUpfront,
+	}
+	if index.matches(target) {
+		t.Fatal("expected the same-day non-preserved canonical price to win")
+	}
+
+	target.pricePointID = "canonical"
+	if !index.matches(target) {
+		t.Fatal("expected the canonical non-preserved price to match")
+	}
+}
+
+func TestSubscriptionPriceImportStateExplicitDateMatchesEitherPreservedValue(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{
+		states: []subscriptionPriceImportState{
+			{territoryID: "USA", pricePointID: "target", startDate: "2026-07-01", preserveCurrentPrice: true, planType: asc.SubscriptionPlanTypeUpfront},
+			{territoryID: "USA", pricePointID: "other", startDate: "2026-07-01", preserveCurrentPrice: false, planType: asc.SubscriptionPlanTypeUpfront},
+		},
+	}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID: "USA", pricePointID: "target", startDate: "2026-07-01", planType: asc.SubscriptionPlanTypeUpfront,
+	}
+	if !index.matches(target) {
+		t.Fatal("expected an explicit-date target with omitted preserve to match either preserved value")
+	}
+}
+
+func TestSubscriptionPriceImportStateRejectsMonthlyPrice(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{
+		now: time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC),
+		states: []subscriptionPriceImportState{{
+			territoryID: "USA", pricePointID: "pp-usa", startDate: "2026-07-01", planType: asc.SubscriptionPlanTypeMonthly,
+		}},
+	}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID: "USA", pricePointID: "pp-usa", planType: asc.SubscriptionPlanTypeUpfront,
+	}
+	if index.matches(target) {
+		t.Fatal("expected a MONTHLY price not to satisfy an UPFRONT import")
 	}
 }

--- a/internal/cli/subscriptions/prices_import_test.go
+++ b/internal/cli/subscriptions/prices_import_test.go
@@ -117,3 +117,39 @@ func TestResolveSubscriptionPriceImportTerritoryID_RejectsTerritoriesOutsideASCS
 		})
 	}
 }
+
+func TestWriteSubscriptionPriceImportFailureArtifact_ReturnsWriteError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(".asc", []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	_, err := writeSubscriptionPriceImportFailureArtifact(&subscriptionPriceImportSummary{
+		Failed:  1,
+		Results: []subscriptionPriceImportResultItem{{Status: "failed"}},
+	})
+	if err == nil {
+		t.Fatal("expected write error, got nil")
+	}
+}
+
+func TestSubscriptionPriceImportStateMatchesIgnoresUnspecifiedPreservedValue(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{
+		states: []subscriptionPriceImportState{{
+			territoryID:          "USA",
+			pricePointID:         "pp-usa",
+			startDate:            "2026-07-01",
+			preserveCurrentPrice: true,
+		}},
+	}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID:  "USA",
+		pricePointID: "pp-usa",
+		startDate:    "2026-07-01",
+		preserveSet:  false,
+	}
+
+	if !index.matches(target) {
+		t.Fatal("expected omitted preserved value to match either remote state")
+	}
+}

--- a/internal/cli/subscriptions/prices_import_test.go
+++ b/internal/cli/subscriptions/prices_import_test.go
@@ -182,6 +182,32 @@ func TestSubscriptionPriceImportStateMatchesCanonicalSameDayPrice(t *testing.T) 
 	}
 }
 
+func TestSubscriptionPriceImportStateSelectsCanonicalBeforeComparingExplicitPreservedValue(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{
+		now: time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC),
+		states: []subscriptionPriceImportState{
+			{territoryID: "USA", pricePointID: "target", startDate: "2026-07-01", preserveCurrentPrice: true, planType: asc.SubscriptionPlanTypeUpfront},
+			{territoryID: "USA", pricePointID: "canonical", startDate: "2026-07-01", preserveCurrentPrice: false, planType: asc.SubscriptionPlanTypeUpfront},
+		},
+	}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID:          "USA",
+		pricePointID:         "target",
+		preserveSet:          true,
+		preserveCurrentPrice: true,
+		planType:             asc.SubscriptionPlanTypeUpfront,
+	}
+	if index.matches(target) {
+		t.Fatal("expected explicit preserved matching to compare against the canonical row")
+	}
+
+	target.pricePointID = "canonical"
+	target.preserveCurrentPrice = false
+	if !index.matches(target) {
+		t.Fatal("expected the canonical row to match its explicit preserved value")
+	}
+}
+
 func TestSubscriptionPriceImportStateExplicitDateMatchesEitherPreservedValue(t *testing.T) {
 	index := &subscriptionPriceImportStateIndex{
 		states: []subscriptionPriceImportState{

--- a/internal/cli/subscriptions/prices_import_test.go
+++ b/internal/cli/subscriptions/prices_import_test.go
@@ -182,7 +182,7 @@ func TestSubscriptionPriceImportStateMatchesCanonicalSameDayPrice(t *testing.T) 
 	}
 }
 
-func TestSubscriptionPriceImportStateSelectsCanonicalBeforeComparingExplicitPreservedValue(t *testing.T) {
+func TestSubscriptionPriceImportStateSelectsCanonicalWhenPreserveIsExplicit(t *testing.T) {
 	index := &subscriptionPriceImportStateIndex{
 		now: time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC),
 		states: []subscriptionPriceImportState{
@@ -202,9 +202,8 @@ func TestSubscriptionPriceImportStateSelectsCanonicalBeforeComparingExplicitPres
 	}
 
 	target.pricePointID = "canonical"
-	target.preserveCurrentPrice = false
 	if !index.matches(target) {
-		t.Fatal("expected the canonical row to match its explicit preserved value")
+		t.Fatal("expected preserveCurrentPrice not to be compared with the canonical row's historical preserved state")
 	}
 }
 
@@ -220,6 +219,25 @@ func TestSubscriptionPriceImportStateExplicitDateMatchesEitherPreservedValue(t *
 	}
 	if !index.matches(target) {
 		t.Fatal("expected an explicit-date target with omitted preserve to match either preserved value")
+	}
+}
+
+func TestSubscriptionPriceImportStateExplicitDateIgnoresCreatePreserveOption(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{
+		states: []subscriptionPriceImportState{
+			{territoryID: "USA", pricePointID: "target", startDate: "2026-08-15", preserveCurrentPrice: false, planType: asc.SubscriptionPlanTypeUpfront},
+		},
+	}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID:          "USA",
+		pricePointID:         "target",
+		startDate:            "2026-08-15",
+		preserveSet:          true,
+		preserveCurrentPrice: true,
+		planType:             asc.SubscriptionPlanTypeUpfront,
+	}
+	if !index.matches(target) {
+		t.Fatal("expected preserveCurrentPrice create option not to be compared with response preserved state")
 	}
 }
 

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -539,10 +539,7 @@ func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID st
 
 	fmt.Fprintf(os.Stderr, "Verifying %d territory update(s) against current prices...\n", len(failures))
 
-	verifyCtx, verifyCancel := shared.ContextWithTimeout(ctx)
-	defer verifyCancel()
-
-	resolved, err := fetchResolvedSubscriptionPrices(verifyCtx, client, subID, 200, "", effectiveAt, "")
+	resolved, err := fetchResolvedSubscriptionPrices(ctx, client, subID, 200, "", effectiveAt, "")
 	if err != nil {
 		return 0, failures, err
 	}

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -228,9 +228,7 @@ Examples:
 						return reconciled == 1, readErr
 					},
 					func(mutationCtx context.Context) error {
-						initialCtx, initialCancel := shared.ContextWithTimeout(mutationCtx)
-						defer initialCancel()
-						_, mutationErr := client.SetSubscriptionInitialPrice(initialCtx, subID, baseTarget.PricePointID, baseTarget.Territory, priceAttrs)
+						_, mutationErr := client.SetSubscriptionInitialPrice(mutationCtx, subID, baseTarget.PricePointID, baseTarget.Territory, priceAttrs)
 						return mutationErr
 					},
 				)
@@ -447,7 +445,7 @@ func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string,
 
 func partitionEqualizeFailures(ctx context.Context, failures []equalizeAttemptFailure) (retryable []equalizeAttemptFailure, final []equalizeAttemptFailure) {
 	for _, failure := range failures {
-		if reconciledMutationIsTransient(ctx, failure.Err) {
+		if shared.IsTransientMutationError(ctx, failure.Err) {
 			retryable = append(retryable, failure)
 			continue
 		}

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -215,47 +215,52 @@ Examples:
 				fmt.Fprintf(os.Stderr, "Subscription has no prices; setting initial price in %s first...\n", territory)
 
 				baseTarget := allTerritories[0]
-				initialCtx, initialCancel := shared.ContextWithTimeout(ctx)
-				_, err := client.SetSubscriptionInitialPrice(initialCtx, subID, baseTarget.PricePointID, baseTarget.Territory, priceAttrs)
-				initialCancel()
+				_, err := runReconciledMutation(
+					ctx,
+					func(readbackCtx context.Context) (bool, error) {
+						reconciled, _, readErr := reconcileEqualizeFailures(
+							readbackCtx,
+							client,
+							subID,
+							[]equalizeAttemptFailure{{Target: baseTarget}},
+							effectiveAt,
+						)
+						return reconciled == 1, readErr
+					},
+					func(mutationCtx context.Context) error {
+						initialCtx, initialCancel := shared.ContextWithTimeout(mutationCtx)
+						defer initialCancel()
+						_, mutationErr := client.SetSubscriptionInitialPrice(initialCtx, subID, baseTarget.PricePointID, baseTarget.Territory, priceAttrs)
+						return mutationErr
+					},
+				)
 				if err != nil {
-					initialFailures := []equalizeAttemptFailure{{
+					failures = append(failures, equalizeAttemptFailure{
 						Target: baseTarget,
 						Err:    err,
-					}}
-					reconciled, remaining, verifyErr := reconcileEqualizeFailures(ctx, client, subID, initialFailures, effectiveAt)
-					if verifyErr != nil {
-						fmt.Fprintf(os.Stderr, "Warning: could not verify failed initial price update: %v\n", verifyErr)
+					})
+					result := &equalizeResult{
+						SubscriptionID:    subID,
+						BaseTerritory:     territory,
+						BasePrice:         price,
+						StartDate:         priceAttrs.StartDate,
+						AutoScheduled:     autoScheduled,
+						Preserved:         *preserved,
+						SubscriptionState: subscriptionState,
+						DryRun:            false,
+						Total:             len(allTerritories),
+						Succeeded:         succeeded,
+						Failed:            len(failures),
+						Failures:          renderEqualizeFailures(failures),
 					}
-					if len(remaining) == 0 {
-						succeeded += reconciled
-						remainingTerritories = allTerritories[1:]
-					} else {
-						failures = append(failures, remaining...)
-						result := &equalizeResult{
-							SubscriptionID:    subID,
-							BaseTerritory:     territory,
-							BasePrice:         price,
-							StartDate:         priceAttrs.StartDate,
-							AutoScheduled:     autoScheduled,
-							Preserved:         *preserved,
-							SubscriptionState: subscriptionState,
-							DryRun:            false,
-							Total:             len(allTerritories),
-							Succeeded:         succeeded,
-							Failed:            len(failures),
-							Failures:          renderEqualizeFailures(failures),
-						}
-						fmt.Fprintf(os.Stderr, "Done: %d succeeded, %d failed\n", result.Succeeded, result.Failed)
-						if err := printEqualizeResult(result, *output.Output, *output.Pretty); err != nil {
-							return err
-						}
-						return shared.NewReportedError(fmt.Errorf("equalize: failed to set initial price in %s", baseTarget.Territory))
+					fmt.Fprintf(os.Stderr, "Done: %d succeeded, %d failed\n", result.Succeeded, result.Failed)
+					if err := printEqualizeResult(result, *output.Output, *output.Pretty); err != nil {
+						return err
 					}
-				} else {
-					succeeded++
-					remainingTerritories = allTerritories[1:]
+					return shared.NewReportedError(fmt.Errorf("equalize: failed to set initial price in %s", baseTarget.Territory))
 				}
+				succeeded++
+				remainingTerritories = allTerritories[1:]
 			}
 
 			passSucceeded, passFailures := applyEqualizedPrices(ctx, client, subID, remainingTerritories, numWorkers, priceAttrs, effectiveAt)
@@ -327,9 +332,22 @@ type equalizeResult struct {
 
 func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string, targets []equalization, workers int, attrs asc.SubscriptionPriceCreateAttributes, effectiveAt time.Time) (int, []equalizeAttemptFailure) {
 	succeeded, failures := runEqualizePricePass(ctx, client, subID, targets, workers, attrs)
-	retryable, finalFailures := partitionEqualizeFailures(failures)
+	retryable, finalFailures := partitionEqualizeFailures(ctx, failures)
 
 	for pass := 1; len(retryable) > 0 && pass <= maxEqualizeRecoveryPasses; pass++ {
+		reconciled, unresolved, verifyErr := reconcileEqualizeFailures(ctx, client, subID, retryable, effectiveAt)
+		if verifyErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not verify %d retryable territory update(s) before replay: %v\n", len(retryable), verifyErr)
+			finalFailures = append(finalFailures, retryable...)
+			retryable = nil
+			break
+		}
+		succeeded += reconciled
+		retryable = unresolved
+		if len(retryable) == 0 {
+			break
+		}
+
 		if delay := maxEqualizeRetryAfter(retryable); delay > 0 {
 			fmt.Fprintf(os.Stderr, "Waiting %s before retrying %d retryable territory update(s)...\n", delay.Round(time.Second), len(retryable))
 			if err := sleepWithContext(ctx, delay); err != nil {
@@ -341,7 +359,7 @@ func applyEqualizedPrices(ctx context.Context, client *asc.Client, subID string,
 		retrySucceeded, retryFailures := runEqualizePricePass(ctx, client, subID, equalizeTargetsFromFailures(retryable), equalizeRecoveryWorkers, attrs)
 		succeeded += retrySucceeded
 
-		retryable, failures = partitionEqualizeFailures(retryFailures)
+		retryable, failures = partitionEqualizeFailures(ctx, retryFailures)
 		finalFailures = append(finalFailures, failures...)
 	}
 
@@ -427,9 +445,9 @@ func runEqualizePricePass(ctx context.Context, client *asc.Client, subID string,
 	return succeeded, failures
 }
 
-func partitionEqualizeFailures(failures []equalizeAttemptFailure) (retryable []equalizeAttemptFailure, final []equalizeAttemptFailure) {
+func partitionEqualizeFailures(ctx context.Context, failures []equalizeAttemptFailure) (retryable []equalizeAttemptFailure, final []equalizeAttemptFailure) {
 	for _, failure := range failures {
-		if asc.IsRetryable(failure.Err) {
+		if reconciledMutationIsTransient(ctx, failure.Err) {
 			retryable = append(retryable, failure)
 			continue
 		}

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -42,26 +42,30 @@ func fetchResolvedSubscriptionPrices(
 		opts = append(opts, asc.WithSubscriptionPricesPlanType(planType))
 	}
 
-	firstPage, err := client.GetSubscriptionPrices(ctx, subscriptionID, opts...)
+	firstPage, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricesResponse, error) {
+		return client.GetSubscriptionPrices(requestCtx, subscriptionID, opts...)
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := asc.PaginateEach(ctx, firstPage, func(ctx context.Context, next string) (asc.PaginatedResponse, error) {
+	if err := asc.PaginateEach(ctx, firstPage, func(_ context.Context, next string) (asc.PaginatedResponse, error) {
 		nextURL, err := mergeSubscriptionPricesNextQuery(next, resolvedSubscriptionPricesQuery(limit, planType))
 		if err != nil {
 			return nil, err
 		}
-		return client.GetSubscriptionPrices(
-			ctx,
-			subscriptionID,
-			asc.WithSubscriptionPricesNextURL(nextURL),
-			asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
-			asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
-			asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
-			asc.WithSubscriptionPricesPlanType(planType),
-		)
+		return shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricesResponse, error) {
+			return client.GetSubscriptionPrices(
+				requestCtx,
+				subscriptionID,
+				asc.WithSubscriptionPricesNextURL(nextURL),
+				asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
+				asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
+				asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
+				asc.WithSubscriptionPricesPlanType(planType),
+			)
+		})
 	}, func(page asc.PaginatedResponse) error {
 		resp, ok := page.(*asc.SubscriptionPricesResponse)
 		if !ok {

--- a/internal/cli/subscriptions/resolved_prices_timeout_test.go
+++ b/internal/cli/subscriptions/resolved_prices_timeout_test.go
@@ -27,13 +27,13 @@ func TestFetchResolvedSubscriptionPricesUsesFreshDeadlinePerPage(t *testing.T) {
 		calls++
 		if calls == 1 {
 			time.Sleep(60 * time.Millisecond)
-			return resolvedPricesJSONResponse(http.StatusOK, `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/prices?cursor=next"}}`), nil
+			return resolvedPricesJSONResponse(`{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/prices?cursor=next"}}`), nil
 		}
 		deadline, ok := req.Context().Deadline()
 		if !ok || time.Until(deadline) < 70*time.Millisecond {
 			t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
 		}
-		return resolvedPricesJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		return resolvedPricesJSONResponse(`{"data":[],"links":{"next":""}}`), nil
 	})
 	client, err := asc.NewClientFromPEM("KEY123", "issuer", introImportTestPrivateKeyPEM(t))
 	if err != nil {
@@ -49,9 +49,63 @@ func TestFetchResolvedSubscriptionPricesUsesFreshDeadlinePerPage(t *testing.T) {
 	}
 }
 
-func resolvedPricesJSONResponse(status int, body string) *http.Response {
+func TestMonthlyCommitmentResolvedPriceCallersUseFreshDeadlinePerPage(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *asc.Client) error
+	}{
+		{
+			name: "validate upfront prices",
+			run: func(ctx context.Context, client *asc.Client) error {
+				return validateMonthlyCommitmentUpfrontPrices(ctx, client, "sub-1", nil, "9.99")
+			},
+		},
+		{
+			name: "prepare monthly prices",
+			run: func(ctx context.Context, client *asc.Client) error {
+				_, err := prepareMonthlySubscriptionPrices(ctx, client, "sub-1", nil, "9.99")
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_TIMEOUT", "100ms")
+			t.Setenv("ASC_MAX_RETRIES", "0")
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			calls := 0
+			http.DefaultTransport = resolvedPricesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					time.Sleep(60 * time.Millisecond)
+					return resolvedPricesJSONResponse(`{"data":[],"links":{"next":"/v1/subscriptions/sub-1/prices?cursor=next"}}`), nil
+				}
+				deadline, ok := req.Context().Deadline()
+				if !ok || time.Until(deadline) < 70*time.Millisecond {
+					t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
+				}
+				return resolvedPricesJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+			})
+			client, err := asc.NewClientFromPEM("KEY123", "issuer", introImportTestPrivateKeyPEM(t))
+			if err != nil {
+				t.Fatalf("NewClientFromPEM() error: %v", err)
+			}
+
+			if err := test.run(context.Background(), client); err != nil {
+				t.Fatalf("caller error: %v", err)
+			}
+			if calls != 2 {
+				t.Fatalf("expected two page requests, got %d", calls)
+			}
+		})
+	}
+}
+
+func resolvedPricesJSONResponse(body string) *http.Response {
 	return &http.Response{
-		StatusCode: status,
+		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 	}

--- a/internal/cli/subscriptions/resolved_prices_timeout_test.go
+++ b/internal/cli/subscriptions/resolved_prices_timeout_test.go
@@ -1,0 +1,58 @@
+package subscriptions
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type resolvedPricesRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn resolvedPricesRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestFetchResolvedSubscriptionPricesUsesFreshDeadlinePerPage(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	calls := 0
+	http.DefaultTransport = resolvedPricesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			time.Sleep(60 * time.Millisecond)
+			return resolvedPricesJSONResponse(http.StatusOK, `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/prices?cursor=next"}}`), nil
+		}
+		deadline, ok := req.Context().Deadline()
+		if !ok || time.Until(deadline) < 70*time.Millisecond {
+			t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
+		}
+		return resolvedPricesJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+	})
+	client, err := asc.NewClientFromPEM("KEY123", "issuer", introImportTestPrivateKeyPEM(t))
+	if err != nil {
+		t.Fatalf("NewClientFromPEM() error: %v", err)
+	}
+
+	result, err := fetchResolvedSubscriptionPrices(context.Background(), client, "sub-1", 200, "", time.Now().UTC(), "")
+	if err != nil {
+		t.Fatalf("fetchResolvedSubscriptionPrices() error: %v", err)
+	}
+	if calls != 2 || len(result.Prices) != 0 {
+		t.Fatalf("unexpected pagination result: calls=%d result=%+v", calls, result)
+	}
+}
+
+func resolvedPricesJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}

--- a/internal/cli/subscriptions/review_screenshot_recovery.go
+++ b/internal/cli/subscriptions/review_screenshot_recovery.go
@@ -1,0 +1,233 @@
+package subscriptions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type subscriptionReviewScreenshotAction string
+
+const (
+	subscriptionReviewScreenshotSkip   subscriptionReviewScreenshotAction = "skip"
+	subscriptionReviewScreenshotPoll   subscriptionReviewScreenshotAction = "poll"
+	subscriptionReviewScreenshotResume subscriptionReviewScreenshotAction = "resume"
+)
+
+type subscriptionReviewScreenshotTarget struct {
+	FileName string
+	FileSize int64
+	Checksum string
+}
+
+var subscriptionReviewScreenshotFields = []string{
+	"fileName",
+	"fileSize",
+	"sourceFileChecksum",
+	"uploadOperations",
+	"assetDeliveryState",
+}
+
+func createOrResumeSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, subscriptionID, path string, info os.FileInfo, checksum string) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+	target := subscriptionReviewScreenshotTarget{
+		FileName: strings.TrimSpace(info.Name()),
+		FileSize: info.Size(),
+		Checksum: strings.TrimSpace(checksum),
+	}
+
+	reservation, found, err := readSubscriptionReviewScreenshot(ctx, client, subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect existing screenshot: %w", err)
+	}
+	if !found {
+		reservation, _, err = shared.RunReconciledMutation(
+			ctx,
+			func(requestCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+				return client.CreateSubscriptionAppStoreReviewScreenshot(requestCtx, subscriptionID, target.FileName, target.FileSize)
+			},
+			func(readbackCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, bool, error) {
+				candidate, exists, readErr := readSubscriptionReviewScreenshot(readbackCtx, client, subscriptionID)
+				if readErr != nil || !exists {
+					return candidate, false, readErr
+				}
+				matches, matchErr := subscriptionReviewScreenshotReservationMatches(candidate, target)
+				return candidate, matches, matchErr
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create upload reservation: %w", err)
+		}
+	}
+
+	action, err := classifySubscriptionReviewScreenshot(reservation, target)
+	if err != nil {
+		return nil, err
+	}
+	switch action {
+	case subscriptionReviewScreenshotSkip:
+		return pollSubscriptionReviewScreenshot(ctx, client, reservation.Data.ID, target.Checksum)
+	case subscriptionReviewScreenshotPoll:
+		return pollSubscriptionReviewScreenshot(ctx, client, reservation.Data.ID, target.Checksum)
+	case subscriptionReviewScreenshotResume:
+	default:
+		return nil, fmt.Errorf("unsupported screenshot recovery action %q", action)
+	}
+
+	err = asc.ExecuteUploadOperations(ctx, path, reservation.Data.Attributes.UploadOperations)
+	if err != nil {
+		return nil, fmt.Errorf("upload failed: %w", err)
+	}
+
+	uploaded := true
+	commitAttrs := asc.SubscriptionAppStoreReviewScreenshotUpdateAttributes{
+		SourceFileChecksum: &target.Checksum,
+		Uploaded:           &uploaded,
+	}
+	committed, _, err := shared.RunReconciledMutation(
+		ctx,
+		func(requestCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+			return client.UpdateSubscriptionAppStoreReviewScreenshot(requestCtx, reservation.Data.ID, commitAttrs)
+		},
+		func(readbackCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, bool, error) {
+			candidate, exists, readErr := readSubscriptionReviewScreenshot(readbackCtx, client, subscriptionID)
+			if readErr != nil || !exists {
+				return candidate, false, readErr
+			}
+			if strings.TrimSpace(candidate.Data.ID) != strings.TrimSpace(reservation.Data.ID) {
+				return candidate, false, fmt.Errorf("subscription now references screenshot %q instead of upload reservation %q", candidate.Data.ID, reservation.Data.ID)
+			}
+			remoteChecksum := strings.TrimSpace(candidate.Data.Attributes.SourceFileChecksum)
+			if remoteChecksum == "" {
+				return candidate, false, nil
+			}
+			if !strings.EqualFold(remoteChecksum, target.Checksum) {
+				return candidate, false, fmt.Errorf("subscription review screenshot checksum changed while committing upload")
+			}
+			return candidate, true, nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit upload: %w", err)
+	}
+	if committed != nil && strings.TrimSpace(committed.Data.ID) != "" {
+		if strings.TrimSpace(committed.Data.ID) != strings.TrimSpace(reservation.Data.ID) {
+			return nil, fmt.Errorf("upload commit returned screenshot %q instead of upload reservation %q", committed.Data.ID, reservation.Data.ID)
+		}
+		reservation = committed
+	}
+
+	return pollSubscriptionReviewScreenshot(ctx, client, reservation.Data.ID, target.Checksum)
+}
+
+func readSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, subscriptionID string) (*asc.SubscriptionAppStoreReviewScreenshotResponse, bool, error) {
+	resp, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+		return client.GetSubscriptionAppStoreReviewScreenshotForSubscription(
+			requestCtx,
+			subscriptionID,
+			asc.WithSubscriptionAppStoreReviewScreenshotFields(subscriptionReviewScreenshotFields),
+		)
+	})
+	if err != nil {
+		if asc.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if resp == nil {
+		return nil, false, fmt.Errorf("empty screenshot response")
+	}
+	if strings.TrimSpace(resp.Data.ID) == "" {
+		return nil, false, nil
+	}
+	return resp, true, nil
+}
+
+func subscriptionReviewScreenshotReservationMatches(resp *asc.SubscriptionAppStoreReviewScreenshotResponse, target subscriptionReviewScreenshotTarget) (bool, error) {
+	if resp == nil {
+		return false, nil
+	}
+	attrs := resp.Data.Attributes
+	remoteChecksum := strings.TrimSpace(attrs.SourceFileChecksum)
+	if remoteChecksum != "" {
+		if strings.EqualFold(remoteChecksum, target.Checksum) {
+			return true, nil
+		}
+		return false, fmt.Errorf("subscription already has a review screenshot with a different checksum")
+	}
+	if attrs.FileName == target.FileName && attrs.FileSize == target.FileSize {
+		return true, nil
+	}
+	return false, fmt.Errorf("subscription already has a different incomplete review screenshot reservation")
+}
+
+func classifySubscriptionReviewScreenshot(resp *asc.SubscriptionAppStoreReviewScreenshotResponse, target subscriptionReviewScreenshotTarget) (subscriptionReviewScreenshotAction, error) {
+	if resp == nil || strings.TrimSpace(resp.Data.ID) == "" {
+		return "", fmt.Errorf("empty screenshot response")
+	}
+	attrs := resp.Data.Attributes
+	state := subscriptionReviewScreenshotDeliveryState(resp)
+	if state == "FAILED" {
+		return "", subscriptionReviewScreenshotDeliveryError(resp)
+	}
+
+	remoteChecksum := strings.TrimSpace(attrs.SourceFileChecksum)
+	sameChecksum := remoteChecksum != "" && strings.EqualFold(remoteChecksum, target.Checksum)
+	if state == "COMPLETE" {
+		if sameChecksum {
+			return subscriptionReviewScreenshotSkip, nil
+		}
+		return "", fmt.Errorf("subscription already has a complete review screenshot with a different checksum")
+	}
+	if remoteChecksum != "" {
+		if !sameChecksum {
+			return "", fmt.Errorf("subscription already has a review screenshot with a different checksum")
+		}
+		return subscriptionReviewScreenshotPoll, nil
+	}
+	if attrs.FileName != target.FileName || attrs.FileSize != target.FileSize {
+		return "", fmt.Errorf("subscription already has a different incomplete review screenshot reservation")
+	}
+	if len(attrs.UploadOperations) == 0 {
+		return "", fmt.Errorf("matching incomplete review screenshot has no upload operations")
+	}
+	return subscriptionReviewScreenshotResume, nil
+}
+
+func subscriptionReviewScreenshotDeliveryState(resp *asc.SubscriptionAppStoreReviewScreenshotResponse) string {
+	if resp == nil || resp.Data.Attributes.AssetDeliveryState == nil || resp.Data.Attributes.AssetDeliveryState.State == nil {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(*resp.Data.Attributes.AssetDeliveryState.State))
+}
+
+func subscriptionReviewScreenshotDeliveryError(resp *asc.SubscriptionAppStoreReviewScreenshotResponse) error {
+	id := ""
+	var details []string
+	if resp != nil {
+		id = strings.TrimSpace(resp.Data.ID)
+		if state := resp.Data.Attributes.AssetDeliveryState; state != nil {
+			for _, item := range state.Errors {
+				if strings.TrimSpace(item.Code) != "" {
+					details = append(details, strings.TrimSpace(item.Code))
+				} else if strings.TrimSpace(item.Message) != "" {
+					details = append(details, strings.TrimSpace(item.Message))
+				}
+			}
+		}
+	}
+	detail := strings.Join(details, "; ")
+	if detail == "" {
+		detail = "unknown error"
+	}
+	return fmt.Errorf("screenshot %s delivery failed: %s", id, detail)
+}
+
+func pollSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, screenshotID, expectedChecksum string) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+	verifyCtx, verifyCancel := shared.ContextWithUploadTimeout(ctx)
+	defer verifyCancel()
+	return waitForSubscriptionReviewScreenshotDelivery(verifyCtx, client, screenshotID, expectedChecksum)
+}

--- a/internal/cli/subscriptions/review_screenshots.go
+++ b/internal/cli/subscriptions/review_screenshots.go
@@ -105,6 +105,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("subscriptions review screenshots create does not accept positional arguments: %s", strings.Join(args, " "))
+			}
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
@@ -116,12 +119,19 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
 				return flag.ErrHelp
 			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
 
 			file, info, err := openSubscriptionImageFile(pathValue)
 			if err != nil {
 				return fmt.Errorf("subscriptions review-screenshots create: %w", err)
 			}
 			defer file.Close()
+			checksum, err := asc.ComputeFileChecksum(pathValue, asc.ChecksumAlgorithmMD5)
+			if err != nil {
+				return fmt.Errorf("subscriptions review-screenshots create: checksum failed: %w", err)
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -133,43 +143,9 @@ Examples:
 				return err
 			}
 
-			requestCtx, cancel := shared.ContextWithUploadTimeout(ctx)
-			defer cancel()
-
-			resp, err := client.CreateSubscriptionAppStoreReviewScreenshot(requestCtx, id, info.Name(), info.Size())
+			finalResp, err := createOrResumeSubscriptionReviewScreenshot(ctx, client, id, pathValue, info, checksum.Hash)
 			if err != nil {
-				return fmt.Errorf("subscriptions review-screenshots create: failed to create: %w", err)
-			}
-			if resp == nil || len(resp.Data.Attributes.UploadOperations) == 0 {
-				return fmt.Errorf("subscriptions review-screenshots create: no upload operations returned")
-			}
-
-			if err := asc.UploadAssetFromFile(requestCtx, file, info.Size(), resp.Data.Attributes.UploadOperations); err != nil {
-				return fmt.Errorf("subscriptions review-screenshots create: upload failed: %w", err)
-			}
-
-			checksum, err := asc.ComputeFileChecksum(pathValue, asc.ChecksumAlgorithmMD5)
-			if err != nil {
-				return fmt.Errorf("subscriptions review-screenshots create: checksum failed: %w", err)
-			}
-
-			uploaded := true
-			updateAttrs := asc.SubscriptionAppStoreReviewScreenshotUpdateAttributes{
-				SourceFileChecksum: &checksum.Hash,
-				Uploaded:           &uploaded,
-			}
-
-			if _, err := client.UpdateSubscriptionAppStoreReviewScreenshot(requestCtx, resp.Data.ID, updateAttrs); err != nil {
-				return fmt.Errorf("subscriptions review-screenshots create: failed to commit upload: %w", err)
-			}
-
-			// Verify asset delivery — poll until COMPLETE or FAILED
-			screenshotID := resp.Data.ID
-			verifyCtx, verifyCancel := shared.ContextWithUploadTimeout(ctx)
-			defer verifyCancel()
-			finalResp, verifyErr := waitForSubscriptionReviewScreenshotDelivery(verifyCtx, client, screenshotID)
-			if verifyErr != nil {
-				return fmt.Errorf("subscriptions review-screenshots create: %w", verifyErr)
+				return fmt.Errorf("subscriptions review-screenshots create: %w", err)
 			}
 
 			return shared.PrintOutput(finalResp, *output.Output, *output.Pretty)
@@ -286,10 +262,12 @@ Examples:
 
 // waitForSubscriptionReviewScreenshotDelivery polls until the screenshot reaches
 // a terminal delivery state and returns the successful response for output.
-func waitForSubscriptionReviewScreenshotDelivery(ctx context.Context, client *asc.Client, screenshotID string) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+func waitForSubscriptionReviewScreenshotDelivery(ctx context.Context, client *asc.Client, screenshotID, expectedChecksum string) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
 	var verifiedResp *asc.SubscriptionAppStoreReviewScreenshotResponse
 	_, err := asc.PollUntil(ctx, reviewScreenshotPollInterval, func(ctx context.Context) (struct{}, bool, error) {
-		resp, err := client.GetSubscriptionAppStoreReviewScreenshot(ctx, screenshotID)
+		resp, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+			return client.GetSubscriptionAppStoreReviewScreenshot(requestCtx, screenshotID)
+		})
 		if err != nil {
 			return struct{}{}, false, err
 		}
@@ -297,6 +275,10 @@ func waitForSubscriptionReviewScreenshotDelivery(ctx context.Context, client *as
 		if state != nil && state.State != nil {
 			switch strings.ToUpper(*state.State) {
 			case "COMPLETE":
+				actualChecksum := strings.TrimSpace(resp.Data.Attributes.SourceFileChecksum)
+				if !strings.EqualFold(actualChecksum, strings.TrimSpace(expectedChecksum)) {
+					return struct{}{}, false, fmt.Errorf("screenshot %s checksum changed while waiting for delivery", screenshotID)
+				}
 				verifiedResp = resp
 				return struct{}{}, true, nil
 			case "FAILED":

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -847,16 +847,16 @@ Examples:
 				}
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
 			if *resolved {
-				resp, err := fetchResolvedSubscriptionPrices(requestCtx, client, id, *limit, *next, time.Now().UTC(), planTypeFilter)
+				resp, err := fetchResolvedSubscriptionPrices(ctx, client, id, *limit, *next, time.Now().UTC(), planTypeFilter)
 				if err != nil {
 					return fmt.Errorf("subscriptions prices list: failed to resolve: %w", err)
 				}
 				return shared.PrintResolvedPrices(resp, *output.Output, *output.Pretty)
 			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
 
 			nextURL := strings.TrimSpace(*next)
 			if nextURL != "" && planTypeFilter != "" {

--- a/internal/cli/validate/builds_test.go
+++ b/internal/cli/validate/builds_test.go
@@ -157,7 +157,7 @@ func TestFetchAppBuildCount_PropagatesCanceledContext(t *testing.T) {
 
 func TestFetchAppBuildCount_WrapsUnexpectedErrors(t *testing.T) {
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(*http.Request) (*http.Response, error) {
-		return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","title":"Internal Error","detail":"boom"}]}`)
+		return buildsJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"INVALID_REQUEST","title":"Invalid Request","detail":"boom"}]}`)
 	}))
 
 	_, _, err := fetchAppBuildCount(context.Background(), client, "app-1")
@@ -171,6 +171,7 @@ func TestFetchAppBuildCount_WrapsUnexpectedErrors(t *testing.T) {
 
 func newBuildsTestClient(t *testing.T, transport http.RoundTripper) *asc.Client {
 	t.Helper()
+	t.Setenv("ASC_MAX_RETRIES", "0")
 
 	tmpDir := t.TempDir()
 	keyPath := filepath.Join(tmpDir, "AuthKey.p8")

--- a/internal/cli/validate/subscription_fetch.go
+++ b/internal/cli/validate/subscription_fetch.go
@@ -511,17 +511,17 @@ func subscriptionHasImage(ctx context.Context, client *asc.Client, subscriptionI
 				SkipReason: "Image verification was skipped because this App Store Connect account cannot read subscription image assets",
 			}, nil
 		}
-		if asc.IsRetryable(err) {
-			return subscriptionImageStatus{
-				Verified:   false,
-				SkipReason: "Image verification was skipped because the App Store Connect image endpoint was temporarily unavailable or rate limited",
-			}, nil
-		}
 		var netErr net.Error
 		if errors.As(err, &netErr) {
 			return subscriptionImageStatus{
 				Verified:   false,
 				SkipReason: "Image verification was skipped because the App Store Connect image endpoint could not be reached",
+			}, nil
+		}
+		if asc.IsRetryable(err) {
+			return subscriptionImageStatus{
+				Verified:   false,
+				SkipReason: "Image verification was skipped because the App Store Connect image endpoint was temporarily unavailable or rate limited",
 			}, nil
 		}
 		return subscriptionImageStatus{}, err
@@ -540,15 +540,15 @@ func metadataCheckSkipReason(err error, resourceLabel string) (string, bool) {
 	if errors.Is(err, asc.ErrForbidden) || asc.IsUnauthorized(err) {
 		return fmt.Sprintf("Validation skipped %s because this App Store Connect account cannot read them", resourceLabel), true
 	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return fmt.Sprintf("Validation skipped %s because the App Store Connect endpoint could not be reached", resourceLabel), true
+	}
 	if asc.IsRetryable(err) {
 		return fmt.Sprintf("Validation skipped %s because the App Store Connect endpoint was temporarily unavailable or rate limited", resourceLabel), true
 	}
 	if asc.IsNotFound(err) {
 		return fmt.Sprintf("Validation skipped %s because the App Store Connect endpoint returned not found", resourceLabel), true
-	}
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return fmt.Sprintf("Validation skipped %s because the App Store Connect endpoint could not be reached", resourceLabel), true
 	}
 	return "", false
 }

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -217,7 +217,7 @@ Examples:
 					}
 				}
 			} else {
-				sourceRunResp, err := getCiBuildRunWithRetry(
+				sourceRunResp, err := getCiBuildRun(
 					requestCtx,
 					client,
 					resolvedSourceRunID,
@@ -363,7 +363,7 @@ Examples:
 			}
 
 			// Single status check
-			resp, err := getCiBuildRunWithRetry(requestCtx, client, strings.TrimSpace(*runID))
+			resp, err := getCiBuildRun(requestCtx, client, strings.TrimSpace(*runID))
 			if err != nil {
 				return fmt.Errorf("xcode-cloud status: %w", err)
 			}

--- a/internal/cli/xcodecloud/xcode_cloud_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_helpers.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
-	"syscall"
 	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -16,7 +14,7 @@ import (
 func waitForBuildCompletion(ctx context.Context, client *asc.Client, buildRunID string, pollInterval time.Duration, outputFormat string, pretty bool) error {
 	lastStatus := "unknown"
 	_, err := asc.PollUntil(ctx, pollInterval, func(ctx context.Context) (struct{}, bool, error) {
-		resp, err := getCiBuildRunWithRetry(ctx, client, buildRunID)
+		resp, err := getCiBuildRun(ctx, client, buildRunID)
 		if err != nil {
 			return struct{}{}, false, fmt.Errorf("xcode-cloud: failed to check status: %w", err)
 		}
@@ -84,31 +82,6 @@ func contextWithXcodeCloudTimeout(ctx context.Context, timeout time.Duration) (c
 	return context.WithTimeout(ctx, timeout)
 }
 
-func getCiBuildRunWithRetry(ctx context.Context, client *asc.Client, buildRunID string, opts ...asc.CiBuildRunGetOption) (*asc.CiBuildRunResponse, error) {
-	retryOpts := asc.ResolveRetryOptions()
-	return asc.WithRetry(ctx, func() (*asc.CiBuildRunResponse, error) {
-		resp, err := client.GetCiBuildRun(ctx, buildRunID, opts...)
-		if err != nil {
-			if isTransientNetworkError(err) {
-				return nil, &asc.RetryableError{Err: err}
-			}
-			return nil, err
-		}
-		return resp, nil
-	}, retryOpts)
-}
-
-func isTransientNetworkError(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		return false
-	}
-	if _, ok := errors.AsType[net.Error](err); ok {
-		return true
-	}
-	return errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, syscall.ECONNREFUSED)
+func getCiBuildRun(ctx context.Context, client *asc.Client, buildRunID string, opts ...asc.CiBuildRunGetOption) (*asc.CiBuildRunResponse, error) {
+	return client.GetCiBuildRun(ctx, buildRunID, opts...)
 }


### PR DESCRIPTION
## Summary

- broaden safe `GET`/`HEAD` recovery for transient transport failures and Apple 408/429/5xx responses while preserving caller cancellation
- add bounded mutation reconciliation that re-reads stable identity before replaying ambiguous creates and updates
- make subscription price and introductory-offer imports, metadata/localization batches, publish stages, and subscription review screenshots resume from current ASC state
- add experimental subscription and subscription-group localization `sync` commands with deterministic summaries and retry artifacts
- preserve exact rerun behavior: already-applied state is skipped, conflicts stop before mutation, and unresolved items remain explicit

## Why this approach

ASC can apply a mutation and still return a timeout or server error. Retrying every `POST`, `PATCH`, or `DELETE` at the HTTP layer can duplicate resources or overwrite newer state. These workflows instead use fresh bounded reads, compare canonical remote identity and payload, and replay only when two readbacks still prove the mutation unresolved.

The shared helpers keep cancellation and timeout ownership with the caller. Upload section `PUT`s are replay-safe and receive a fresh upload deadline per attempt; non-`PUT` upload operations are not replayed.

## UX and compatibility

Existing stable commands and flags remain available. The new localization sync commands are explicitly experimental.

```bash
asc subscriptions localizations sync --subscription-id "SUB_ID" --input "./localizations.json" --dry-run
asc subscriptions groups localizations sync --group-id "GROUP_ID" --input "./localizations.json"
asc subscriptions prices import --subscription-id "SUB_ID" --input "./prices.csv"
asc subscriptions introductory-offers import --subscription-id "SUB_ID" --input "./offers.csv"
asc subscriptions review screenshots create --subscription-id "SUB_ID" --file "./review.png"
```

Reruns report unchanged/skipped work instead of recreating it. Batch failures return nonzero with per-item results and a versioned retry input where applicable. Invalid CLI values and positional arguments remain usage errors with exit code 2.

## Alternatives considered

- **Generic mutation retries:** smaller implementation, but unsafe after ambiguous timeouts because ASC may already have committed the request.
- **Only increasing timeouts:** reduces some failures but does not recover partial batches, server errors, or interrupted cross-process reruns.
- **Separate retry flags on every command:** more visible, but fragments behavior and makes the safe reconciliation contract inconsistent.

## Verification

- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused stress and race runs for read retries, reconciliation, metadata apply, subscription imports/sync, and screenshot recovery
- Windows cross-compilation of the changed packages
- built-binary help plus success/error exit-code checks
- offline OpenAPI validation for every changed API-facing query/request shape

Live disposable-app verification covered localization create/update/clear/rerun/cleanup and review-screenshot first upload, byte-identical rerun, and delete. Temporary resources were removed and the screenshot relationship was restored to empty.

Addresses #1674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating only selected localization fields in App Store version and app info records.
  * Added richer upload/import output with success, failure, and recovery details.
  * Added new subscription localizations sync workflows and expanded subscription pricing/review screenshot commands.

* **Bug Fixes**
  * Improved retry and recovery behavior for uploads, pagination, and reconciliation after partial failures or ambiguous server responses.
  * Fixed several timeout-related issues so long-running paged requests and multi-step operations use fresh deadlines.
  * Improved error reporting and failure artifacts for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->