### PR TITLE
fix(subscriptions): report missing review screenshot

### DIFF
--- a/internal/cli/cmdtest/subscriptions_app_store_review_screenshot_test.go
+++ b/internal/cli/cmdtest/subscriptions_app_store_review_screenshot_test.go
@@ -1,0 +1,90 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestSubscriptionsReviewAppStoreScreenshotViewNullRelationshipReturnsNotFound(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/6759789602/appStoreReviewScreenshot" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":null,"links":{"self":"https://api.appstoreconnect.apple.com/v1/subscriptions/6759789602/appStoreReviewScreenshot"}}`), nil
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"subscriptions", "review", "app-store-screenshot", "view",
+			"--subscription-id", "6759789602",
+			"--output", "json",
+		}, "1.2.3")
+		if code != cmd.ExitNotFound {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitNotFound, code)
+		}
+	})
+
+	if requests != 1 {
+		t.Fatalf("expected one request, got %d", requests)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `subscriptions review app-store-screenshot view: no App Store review screenshot found for subscription "6759789602"`) {
+		t.Fatalf("expected clear not-found stderr, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsReviewAppStoreScreenshotViewPrintsPopulatedRelationship(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/6759789602/appStoreReviewScreenshot" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}},"links":{"self":"https://api.appstoreconnect.apple.com/v1/subscriptions/6759789602/appStoreReviewScreenshot"}}`), nil
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"subscriptions", "review", "app-store-screenshot", "view",
+			"--subscription-id", "6759789602",
+			"--output", "json",
+		}, "1.2.3")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitSuccess, code)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var output struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nstdout: %s", err, stdout)
+	}
+	if output.Data.ID != "shot-1" {
+		t.Fatalf("expected screenshot id shot-1, got %q", output.Data.ID)
+	}
+}

--- a/internal/cli/subscriptions/app_store_review_screenshot.go
+++ b/internal/cli/subscriptions/app_store_review_screenshot.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -75,6 +76,9 @@ Examples:
 			resp, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(requestCtx, id)
 			if err != nil {
 				return fmt.Errorf("subscriptions app-store-review-screenshot get: failed to fetch: %w", err)
+			}
+			if resp == nil || strings.TrimSpace(resp.Data.ID) == "" {
+				return fmt.Errorf("subscriptions app-store-review-screenshot get: no App Store review screenshot found for subscription %q: %w", id, asc.ErrNotFound)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)


### PR DESCRIPTION
## Summary
- treat an HTTP 200 `data: null` subscription review-screenshot relationship as absent
- return the existing not-found exit contract instead of rendering a zero-valued resource
- preserve populated relationship JSON output

Fixes #1681

## Why this approach
The live endpoint returns `data: null` despite the offline OpenAPI snapshot describing a required single resource. The command now validates the decoded resource ID and wraps `asc.ErrNotFound`, which keeps the fix local to the affected CLI behavior and preserves the shared generic response type.

Alternatives considered:
- changing generic single-resource responses to pointer data, which would create broad API compatibility churn
- changing the ASC client method, which would alter behavior for all callers and overlap the independent screenshot-recovery work

Expected absent-resource behavior:
```text
$ asc subscriptions review app-store-screenshot view --subscription-id 6759789602 --output json
Error: subscriptions review app-store-screenshot view: no App Store review screenshot found for subscription "6759789602": resource not found
# exit 4; stdout empty
```

## Verification
- RED: live-shaped cmdtest expected exit 4 and observed exit 0 before the fix
- GREEN: null and populated CLI cases, including stdout, stderr, parsed JSON, and exit codes
- `make format`
- `make check-command-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run 'TestSubscriptionsReviewAppStoreScreenshotView' -count=10`
- built `/tmp/asc-1681-fixed`; live read-only smoke against subscription `6759789602` returned exit 4, empty stdout, and the canonical not-found stderr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app store review screenshot command to handle missing or incomplete responses more gracefully.
  * When a screenshot isn’t found, the command now returns a clear not-found result instead of continuing with empty data.
  * Verified the command returns the expected JSON output when a screenshot is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->