### PR TITLE
apps wall: add Rote.ink

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1192,6 +1192,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/50/64/bd/5064bd5c-0e6c-4b46-dd11-c3c7848c845a/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Rote.ink",
+    "link": "https://apps.apple.com/us/app/rote-ink/id6755513897?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/20/6e/3f/206e3fdc-5999-43aa-d7b3-123de15f0c9a/Rote-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Ryform Golf",
     "link": "https://apps.apple.com/us/app/id6746525972",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/63/a9/01/63a90152-943b-ba07-d666-402df1f9694e/AppIcon-0-0-1x_U007epad-0-1-85-220.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Rote.ink` to the Wall of Apps

## Entry

- App ID: 6755513897
- App: Rote.ink
- Link: https://apps.apple.com/us/app/rote-ink/id6755513897?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added **Rote.ink** to the wall of apps listing with its name, link, and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->