### PR TITLE
[codex] Migrate maintainer workflows to agent skills

### DIFF
--- a/.agents/skills/audit-asc-pr/SKILL.md
+++ b/.agents/skills/audit-asc-pr/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: audit-asc-pr
+description: Audit App-Store-Connect-CLI pull requests end to end and fix concrete defects. Use when the user asks to audit or review a PR, decide whether a PR is valuable or slop, verify that a PR truly solves its issue, assess blast radius, or make a PR code-ready before merge.
+---
+
+# Audit an ASC CLI pull request
+
+Perform an evidence-first review of the entire pull request. Default to fix-forward work unless the user explicitly requests review-only.
+
+## Establish the contract
+
+1. Read `AGENTS.md` and resolve the repository, PR number, base branch, head branch, and exact head SHA.
+2. Read the PR body, every commit, linked issues, current checks, reviews, and comments.
+3. Fetch thread-aware review state with GitHub GraphQL. Do not treat a flat comment list as proof that all review threads are resolved.
+4. State the behavior the PR claims to change and the evidence needed to prove it.
+5. Confirm whether the user authorized fixes, pushes, approval, or merge. An audit authorizes fix-forward changes in this repository, but approval and merge still require explicit user intent.
+
+## Isolate and inspect
+
+1. Use a dedicated worktree and local branch for the PR. Preserve the user's main checkout and unrelated worktrees.
+2. Inspect the full merge-base diff and all PR commits, not only the latest commit.
+3. Compare the implementation with the linked issue and current product behavior. Check architecture fit, compatibility, error paths, permissions, destructive operations, output contracts, and missing cleanup.
+4. Verify claims from bots or reviewers against code, schemas, and tests before editing.
+5. Identify the blast radius: commands, shared helpers, API resources, output formats, auth modes, and release surfaces affected.
+
+## Verify behavior
+
+1. Run the relevant current `--help` paths before judging command shape.
+2. Build a binary when CLI behavior, flags, output, or exit codes changed. Exercise realistic invocations against the built binary.
+3. For API-facing changes, verify the exact endpoint and method in `docs/openapi/latest.json`, including create-versus-update attributes and endpoint-specific query parameters.
+4. Run focused tests first, then the broader checks proportional to the diff.
+5. Prefer read-only live App Store Connect verification. When mutation is necessary, use the disposable app `6759231657`, clean up temporary resources, and record anything that could not be removed. Never mutate another app without explicit approval.
+6. Preserve uncertainty when live state cannot reproduce an edge case; use deterministic fixtures or tests instead of claiming success.
+
+## Fix forward
+
+1. Reproduce each defect before changing code.
+2. Add or adjust a failing regression test, confirm the failure, implement the smallest coherent fix, and rerun the focused test.
+3. Keep commits logical and traceable to findings or review threads.
+4. Push to the PR head when permitted. If the contributor branch cannot accept maintainer pushes, report the exact limitation and prepare a separate fix PR only when authorized.
+5. Reply to and resolve only threads fully addressed by the pushed change.
+6. Re-fetch the head SHA, checks, reviews, and GraphQL threads after every push.
+
+## Apply the merge gate
+
+Do not call the PR ready until all of the following are true:
+
+- The latest head was audited and is based on an acceptable current `main`.
+- Relevant focused and repository checks pass.
+- No actionable unresolved review thread remains.
+- Required reviews are satisfied.
+- GitHub reports the PR mergeable with a clean merge state.
+- Live or deterministic verification supports the claimed behavior.
+
+Use `$watch-asc-pr` after the first push when checks or reviewers are still pending. Approve or merge only when the user asked for that action.
+
+## Hand off
+
+Report findings, fixes, commits, pushes, commands and tests run, live ASC mutations and cleanup, unresolved risks, check state, thread state, and the final merge recommendation.

--- a/.agents/skills/audit-asc-pr/agents/openai.yaml
+++ b/.agents/skills/audit-asc-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit ASC Pull Request"
+  short_description: "Audit and fix-forward an ASC CLI pull request"
+  default_prompt: "Use $audit-asc-pr to audit this ASC CLI pull request end to end."

--- a/.agents/skills/develop-asc-change/SKILL.md
+++ b/.agents/skills/develop-asc-change/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: develop-asc-change
+description: Design, implement, and verify behavior changes in App-Store-Connect-CLI. Use when adding or changing a command, flag, API endpoint, output format, exit code, shared CLI behavior, or when fixing or refactoring behavior that requires code and tests.
+---
+
+# Develop an ASC CLI change
+
+Deliver one complete, reviewable behavior change through architecture, RED-GREEN implementation, realistic CLI verification, and PR-ready validation.
+
+## Write the design note
+
+Before implementation, record:
+
+1. Placement in the existing command taxonomy and registry.
+2. Current `--help` behavior and expected invocation shape.
+3. Exact OpenAPI endpoint, method, request schema, query parameters, and response shape when API-facing.
+4. Flags, output formats, stdout/stderr behavior, and exit codes.
+5. Compatibility, lifecycle, migration, and deprecation impact.
+6. RED-GREEN tests, black-box checks, live verification, edge cases, and failure modes.
+7. One or two credible alternatives and why this shape is preferable.
+
+Stop and align before coding if the public command shape or compatibility decision remains materially ambiguous.
+
+## Establish RED
+
+- For a bug, reproduce it first and add the smallest regression test that fails for the expected reason.
+- For a feature, start with CLI-level tests for flags, output, errors, and exit behavior, then add unit or HTTP tests for core logic.
+- For a behavior-changing refactor, add characterization coverage before moving code.
+- Run the focused test and record the expected failure before implementation.
+
+Read [references/test-matrix.md](references/test-matrix.md) for mandatory CLI, output, artifact, and auth cases.
+
+## Validate API support
+
+1. Search `docs/openapi/paths.txt`, then inspect the exact operation in `docs/openapi/latest.json`.
+2. Validate attributes against the correct create or update request schema.
+3. Validate filters and includes against the specific endpoint, not a related top-level or relationship endpoint.
+4. If the API does not support the proposed behavior, do not ship a misleading flag. Use explicit client-side behavior or document the limitation.
+5. Prefer the `sosumi.ai` mirror when explanatory App Store Connect API documentation is required.
+
+## Implement narrowly
+
+- Extend the correct `internal/cli/<domain>` package and register new top-level commands in `internal/cli/registry/registry.go`.
+- Set `UsageFunc: shared.DefaultUsageFunc` for command groups and subcommands.
+- Use `shared.ContextWithTimeout` or `shared.ContextWithUploadTimeout` for outbound HTTP.
+- Validate required flags before side effects and return usage errors with exit code `2`.
+- Write data to stdout and diagnostics to stderr. Never silently ignore accepted flags.
+- Use long-form flags in documentation, tests, and examples.
+- Require `--confirm` for destructive operations; do not add interactive prompts.
+- Keep one logical change per commit and remove helpers made obsolete by the change.
+- Deprecate stable commands or flags before removal, with warning text, transition tests, and an upgrade path.
+
+## Reach GREEN and verify
+
+1. Rerun the focused failing test after each small fix.
+2. Run adjacent package and command tests.
+3. Build `/tmp/asc` and verify realistic invocations, output streams, and exit codes against the built binary.
+4. Run a minimal live smoke test when behavior depends on App Store Connect quirks. Prefer read-only calls; use disposable resources and clean them up for mutations.
+5. Run the repository gate before opening or updating a PR:
+
+```bash
+make format
+make check-docs
+make lint
+ASC_BYPASS_KEYCHAIN=1 make test
+```
+
+If command help changed, run `make generate-command-docs` and commit the resulting `docs/COMMANDS.md` update before the gate.
+
+## Hand off
+
+Explain the chosen approach, alternatives, expected invocations and outputs, compatibility impact, tests and live checks, commands run, and remaining limitations. Be explicit about pre-existing failures and anything not reproduced.

--- a/.agents/skills/develop-asc-change/agents/openai.yaml
+++ b/.agents/skills/develop-asc-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Develop ASC Change"
+  short_description: "Design, implement, and verify ASC CLI changes"
+  default_prompt: "Use $develop-asc-change to implement this ASC CLI behavior change completely."

--- a/.agents/skills/develop-asc-change/references/test-matrix.md
+++ b/.agents/skills/develop-asc-change/references/test-matrix.md
@@ -1,0 +1,41 @@
+# ASC CLI behavior test matrix
+
+Apply the sections relevant to the changed behavior. Prefer a small number of high-signal tests over broad repetitive matrices.
+
+## Flags and parsing
+
+- Add one valid-path test for every new or changed flag.
+- Add one invalid-value test that asserts stderr and exit code `2`.
+- Test flags before subcommands, mixed flag ordering, multiple flags with values, and values that look like subcommand names.
+- Assert required-flag errors on stderr; do not test only for `flag.ErrHelp`.
+- Never accept and silently ignore an unsupported flag or value.
+
+## Output and exit behavior
+
+- Parse JSON or XML and assert fields instead of relying only on substring matching.
+- Assert representative table or Markdown structure and headers.
+- Verify stdout, stderr, and exit code with a built binary for changed CLI behavior.
+- Test successful artifact/report writes and write failures.
+- Prevent duplicate usage or duplicate error output.
+
+## HTTP and API behavior
+
+- Use `httptest` to assert method, path, query, headers, and request body.
+- Cover a realistic non-empty response, validation failure, and API error.
+- Keep representative response-decoding assertions when consolidating table-driven tests.
+- Test pagination and empty responses where applicable.
+
+## Auth and process isolation
+
+- Run repository tests with `ASC_BYPASS_KEYCHAIN=1`.
+- Use `t.Setenv` and a temporary `ASC_CONFIG_PATH` for auth-sensitive tests.
+- Set or clear `ASC_PROFILE`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64`, and `ASC_STRICT_AUTH` locally when relevant.
+- Restore exact process state when a test cannot use `t.Setenv`.
+- Allow `t.Skip` only for a specific documented and reproducible condition; never use a broad error-string skip.
+
+## Live verification
+
+- Prefer read-only calls first.
+- For mutations, use a disposable resource, record its ID, and delete or cancel it afterward.
+- Assert the externally visible result, not only a successful HTTP status.
+- Report any state that could not be cleaned up.

--- a/.agents/skills/release-asc-cli/SKILL.md
+++ b/.agents/skills/release-asc-cli/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: release-asc-cli
+description: Publish and verify a new release of the App-Store-Connect-CLI repository. Use only when the user explicitly asks to release, tag, or publish a specific ASC CLI version, including the full GitHub release, artifact, Homebrew, WinGet, cleanup, and release-announcement workflow.
+---
+
+# Release the ASC CLI
+
+Treat a release request as an end-to-end publishing operation, not merely a tag push.
+
+## Prove the release target
+
+1. Resolve the requested plain semantic version without a `v` prefix.
+2. Fetch `origin`, verify the tag does not already exist locally or remotely, and inspect the release-worthy delta since the previous tag.
+3. Query open PRs and confirm the intended changes are already merged.
+4. Create a clean detached worktree from the exact current `origin/main` commit. Do not release from a dirty user checkout or an unmerged branch.
+5. Inspect `.github/workflows/release.yml` and current repository guidance instead of assuming an older release procedure still applies.
+
+## Run the release gate
+
+Run and record:
+
+```bash
+make format
+make check-docs
+make check-wall-of-apps
+make lint
+ASC_BYPASS_KEYCHAIN=1 make test
+make build
+./asc version
+```
+
+If formatting changes files, inspect and commit only intentional release-related changes before continuing. Stop on unexplained failures; do not tag around a broken gate.
+
+## Publish
+
+1. Reconfirm the worktree HEAD equals the intended `origin/main` commit.
+2. Create an annotated tag using the exact requested version and push that tag explicitly.
+3. Locate the tag-triggered GitHub Actions run and watch it through completion.
+4. Do not retry by silently moving or recreating a published tag. Diagnose failures and preserve the immutable release history.
+
+## Verify consumer-visible state
+
+Do not declare success from CI alone. Verify:
+
+- The GitHub release is published, not draft or prerelease unless requested.
+- Expected macOS, Linux, Windows, and checksum assets exist.
+- A downloaded macOS binary reports the requested version and passes `codesign --verify`.
+- Downloaded artifact hashes match the published checksum file.
+- The Homebrew formula points to the new version and hashes.
+- The expected WinGet submission or PR exists and references the new version.
+- Any notarization step required by the current workflow succeeded.
+
+## Draft the announcement
+
+Read [references/release-announcement.md](references/release-announcement.md). Create the Typefully draft only after the release is visibly published. Never schedule or publish the post unless the user explicitly asks.
+
+## Clean up and hand off
+
+Remove only the temporary release worktree created by this run. Report the released commit and tag, workflow run, release URL, artifact verification, Homebrew state, WinGet state, Typefully review URL or connector blocker, commands run, and any residual state.
+
+## Automation boundary
+
+Do not schedule unattended releases. After an explicitly initiated tag push, a thread heartbeat may reuse this skill to watch the release run and finish downstream verification.

--- a/.agents/skills/release-asc-cli/agents/openai.yaml
+++ b/.agents/skills/release-asc-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release ASC CLI"
+  short_description: "Publish and verify an ASC CLI repository release"
+  default_prompt: "Use $release-asc-cli to publish and verify the requested ASC CLI release."

--- a/.agents/skills/release-asc-cli/references/release-announcement.md
+++ b/.agents/skills/release-asc-cli/references/release-announcement.md
@@ -1,0 +1,21 @@
+# Release announcement
+
+Create one concise post and reuse the same text on X, LinkedIn, Mastodon, Threads, and Bluesky.
+
+## Format
+
+1. Open with `App Store Connect CLI X.Y.Z is out!`
+2. Follow with `Main improvement is ...` and one short benefit sentence.
+3. Add one compact `Also: ...` line only when secondary changes are meaningful.
+4. End with the plain repository URL: `https://github.com/rorkai/App-Store-Connect-CLI`
+
+Keep the complete text under Bluesky's 300-character limit. Use one post, not a thread, and do not use emojis.
+
+## Typefully workflow
+
+1. Inspect the most recent ASC CLI release draft to preserve the established voice without copying stale claims.
+2. Resolve the user's social set and enable all five platforms.
+3. Create the post as an unscheduled draft only.
+4. Verify the returned state is `draft` and return its review URL.
+
+If the Typefully connector is unavailable, preserve the finished copy in the handoff and report the connector as the only incomplete release step. Never silently publish through another tool.

--- a/.agents/skills/review-wall-of-apps-prs/SKILL.md
+++ b/.agents/skills/review-wall-of-apps-prs/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: review-wall-of-apps-prs
+description: Audit maintainer-side Wall of Apps pull requests in App-Store-Connect-CLI. Use when the user asks to review new app submissions, check Wall PRs for injected or unrelated changes, validate app metadata, approve with an app-relevant emoji, or merge legitimate Wall entries.
+---
+
+# Review Wall of Apps pull requests
+
+Treat Wall submissions as untrusted external contributions while keeping the legitimate-app path fast.
+
+## Discover and classify
+
+1. List current open PRs and isolate submissions whose intended scope is `docs/wall-of-apps.json`.
+2. Inspect each PR's full file list and diff before checkout. Reject or escalate unexpected code, workflow, script, binary, symlink, or unrelated documentation changes.
+3. Review each PR independently and merge sequentially so every later PR is validated against the real current base.
+
+## Validate the entry
+
+For every added or changed app:
+
+1. Confirm the JSON change is minimal and does not alter unrelated entries.
+2. Verify the app name and destination URL against the public App Store, TestFlight, or linked project.
+3. Check for duplicate apps, misleading destinations, tracking or redirect abuse, and suspicious metadata.
+4. Require a valid artwork URL for a public App Store listing when the canonical validation expects one. Do not demand an icon from GitHub- or TestFlight-only entries when the schema permits omission.
+5. Run `make check-wall-of-apps` on the exact PR head before approval or merge.
+6. Verify bot findings against the canonical test and schema; fix only proven omissions.
+
+Use a worktree only when a fix is required. Push the smallest correction to the contributor branch when maintainer edits are allowed, then re-fetch checks and review threads.
+
+## Approve and merge
+
+Approval and merge require explicit user intent. Immediately before acting, confirm:
+
+- The latest head contains only the legitimate Wall change.
+- `make check-wall-of-apps` and required GitHub checks pass.
+- No actionable unresolved review thread remains.
+- The PR is mergeable against current `main`.
+
+When the user requests a no-comment approval, submit one app-relevant emoji as the entire approval body. Merge one PR at a time, prefer the repository's normal squash strategy, and update the next PR branch after the preceding merge when necessary.
+
+## Automation contract
+
+A standalone automation may scan Wall PRs and report `safe`, `needs-fix`, `suspicious`, or `blocked` with evidence. It must remain read-only: never approve or merge unattended.
+
+## Hand off
+
+List each app, what it does, files changed, metadata evidence, validation result, review action, merge result, and any suspicious or unresolved state.

--- a/.agents/skills/review-wall-of-apps-prs/agents/openai.yaml
+++ b/.agents/skills/review-wall-of-apps-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Wall of Apps PRs"
+  short_description: "Validate and safely review Wall of Apps PRs"
+  default_prompt: "Use $review-wall-of-apps-prs to audit the open Wall of Apps pull requests."

--- a/.agents/skills/sync-asc-skills/SKILL.md
+++ b/.agents/skills/sync-asc-skills/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sync-asc-skills
+description: Audit and update rorkai/app-store-connect-cli-skills against the current ASC CLI surface. Use when the user asks whether ASC agent skills need updates, requests a post-release skills sync, or wants command, flag, output, auth, or workflow examples checked for drift.
+---
+
+# Synchronize ASC workflow skills
+
+Compare the external workflow-skill repository with live CLI behavior and make only proven, minimal corrections.
+
+## Establish both sources
+
+1. Resolve the current App-Store-Connect-CLI source commit and latest released version relevant to the request.
+2. Resolve a clean checkout of `rorkai/app-store-connect-cli-skills` and read its repository guidance.
+3. Inventory every skill and identify which commands, flags, environment variables, outputs, or workflows it claims to use.
+4. Run the current CLI's `--help` at each relevant command path. Use `asc search`, `asc schema`, or `asc capabilities` only when their own current help confirms they are appropriate.
+
+## Prove drift
+
+Check for:
+
+- Renamed, moved, deprecated, or removed commands.
+- Added, removed, or changed flags and accepted values.
+- Incorrect long-form examples, pagination, output, confirmation, or pretty-print behavior.
+- Auth, environment-variable, timeout, and default-output changes.
+- Workflow ordering changes that affect builds, TestFlight, metadata, review, signing, or release operations.
+- Examples that parse but no longer perform the claimed workflow.
+
+Do not update skills merely because a newer CLI version exists. Record exact help or runtime evidence for every edit.
+
+## Update minimally
+
+1. Change only affected skills and examples; avoid release-number churn and speculative prose.
+2. Keep each `SKILL.md` concise and move lengthy reference material behind progressive disclosure.
+3. Preserve the skills repository's naming, metadata, validation, and style conventions.
+4. Validate every changed command example against a current built or released `asc` binary.
+5. Run the skills repository's validators and the current skill-creator validator when available.
+6. Open a separate draft PR in the skills repository with the CLI commit or release used as evidence and a command-by-command validation summary.
+
+Never modify the CLI merely to make stale skill documentation pass.
+
+## Automation contract
+
+A weekly or post-release automation may run a read-only drift audit and report proven mismatches. It may open a draft PR only when the automation has explicit write authorization and every change is deterministic; otherwise leave a precise change plan.
+
+## Hand off
+
+Report the CLI version and commit, skills commit, drift found, files changed, commands verified, validators run, PR URL, and any workflow that could not be tested safely.

--- a/.agents/skills/sync-asc-skills/agents/openai.yaml
+++ b/.agents/skills/sync-asc-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sync ASC Skills"
+  short_description: "Audit ASC workflow skills for CLI surface drift"
+  default_prompt: "Use $sync-asc-skills to compare ASC workflow skills with the current CLI and fix proven drift."

--- a/.agents/skills/triage-asc-issue/SKILL.md
+++ b/.agents/skills/triage-asc-issue/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: triage-asc-issue
+description: Triage App-Store-Connect-CLI GitHub issues against current code, CLI behavior, and App Store Connect API support. Use when the user asks to audit, reproduce, classify, label, scope, prioritize, or decide whether an ASC CLI issue should be fixed or implemented.
+---
+
+# Triage an ASC CLI issue
+
+Produce a current, evidence-backed verdict and leave the issue with complete repository labels.
+
+## Read current evidence
+
+1. Fetch the live issue body, comments, labels, linked PRs, and referenced documentation.
+2. Resolve the affected command through current `--help`, source, tests, and recent history. Do not infer support from an old command name.
+3. Reproduce reported behavior with the current built or installed CLI when safe.
+4. For API claims, verify the exact method and endpoint in `docs/openapi/latest.json`; use the `sosumi.ai` documentation mirror for explanatory context.
+5. Check whether the report is already fixed on current `origin/main`, duplicated, unsupported by the public API, or blocked by Apple/platform behavior.
+
+## Classify the outcome
+
+Choose one primary verdict:
+
+- Confirmed bug with a reproducible expected-versus-actual mismatch.
+- Valid enhancement with a supported and coherent API or client-side design.
+- Question requiring clarification or support guidance.
+- Already fixed, duplicate, not reproducible, unsupported, or platform-limited.
+
+Separate urgency from implementation size. Explain user impact, blast radius, workaround, compatibility risk, and the smallest proof needed for completion.
+
+## Apply labels
+
+Follow `CONTRIBUTING.md` and leave exactly one label from each bucket:
+
+- Type: `bug`, `enhancement`, or `question`.
+- Priority: `p0`, `p1`, `p2`, or `p3`.
+- Difficulty: `easy`, `medium`, or `hard`.
+
+Remove conflicting labels before adding replacements. If evidence is ambiguous, choose the lower priority or difficulty and state the assumption.
+
+## Define implementation readiness
+
+When the issue is actionable, provide:
+
+1. Proposed command and UX shape.
+2. API endpoint or explicit client-side behavior.
+3. Files and shared surfaces likely affected.
+4. RED-GREEN test plan and black-box exit/output cases.
+5. Safe live verification and cleanup plan.
+6. Compatibility or deprecation requirements.
+
+If the user asks to implement the issue, hand the validated contract to `$develop-asc-change` in an isolated branch or worktree. Do not close the issue or claim completion before the implementation is merged and verified.
+
+## Automation contract
+
+A recurring issue-triage automation may classify new or incompletely labeled issues and report actionable findings. It must not implement code, close issues, or make speculative high-priority labels without explicit authorization.

--- a/.agents/skills/triage-asc-issue/agents/openai.yaml
+++ b/.agents/skills/triage-asc-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Triage ASC Issue"
+  short_description: "Reproduce, classify, and scope an ASC CLI issue"
+  default_prompt: "Use $triage-asc-issue to triage this ASC CLI issue against the code and API."

--- a/.agents/skills/watch-asc-pr/SKILL.md
+++ b/.agents/skills/watch-asc-pr/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: watch-asc-pr
+description: Recheck an in-progress App-Store-Connect-CLI pull request for new review feedback, CI results, head changes, and merge readiness. Use when the user says to check for new PR comments, continue polling, fix and loop, babysit a PR, or keep working until the PR is clean.
+---
+
+# Watch an ASC CLI pull request
+
+Run one idempotent follow-up pass. Preserve the existing PR context instead of restarting the full audit.
+
+## Recheck current state
+
+1. Resolve the exact PR and compare its current head SHA with the last audited or pushed SHA.
+2. Fetch checks, reviews, top-level comments, and GraphQL review threads.
+3. Separate new actionable feedback from resolved, outdated, informational, duplicate, or bot-noise comments.
+4. If the head changed outside this workflow, inspect the new diff before relying on prior conclusions.
+
+## Address actionable feedback
+
+1. Verify every new claim against the codebase, API schema, and existing behavior. Do not follow automated feedback blindly.
+2. Reproduce a valid defect and add or update a focused test before changing behavior.
+3. Implement the smallest coherent fix, run the focused check, commit, and push.
+4. Reply to and resolve only the threads fully addressed by that push.
+5. Re-fetch the PR after pushing and confirm the live head, checks, and thread state.
+
+## Return one state
+
+- `changed`: pushed a fix; include commit and validation.
+- `pending`: checks or reviews are still running; identify exactly what remains.
+- `clean`: latest head is green, mergeable, and has no actionable unresolved threads.
+- `blocked`: user input, permissions, an external outage, or an unsafe product decision prevents progress.
+
+Do not approve or merge unless the user explicitly requested it. If merge was requested, reapply the complete merge gate from `$audit-asc-pr` immediately before merging.
+
+## Automation contract
+
+Use this skill from a thread heartbeat when the same PR conversation should continue every few minutes. Each wake-up must run one pass, report only changes or blockers, and stop the loop when the PR is clean, merged, closed, superseded, or awaiting a material user decision. Do not create an unattended auto-merge loop.

--- a/.agents/skills/watch-asc-pr/agents/openai.yaml
+++ b/.agents/skills/watch-asc-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Watch ASC Pull Request"
+  short_description: "Recheck ASC PR feedback, checks, and readiness"
+  default_prompt: "Use $watch-asc-pr to check this ASC CLI pull request for new actionable feedback."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,248 +2,110 @@
 
 Unofficial, fast, lightweight, agent-assisted, reviewer-owned CLI for the App Store Connect API. Built in Go with [ffcli](https://github.com/peterbourgon/ff).
 
-## asc skills
+## Skills
 
-Agent Skills for automating `asc` workflows including builds, TestFlight, metadata sync, submissions, and signing. https://github.com/rorkai/app-store-connect-cli-skills
+Skills for using `asc` in app workflows live at https://github.com/rorkai/app-store-connect-cli-skills.
 
-## Core Principles
+Repository-maintainer workflows live under `.agents/skills/`:
 
-- **Explicit flags**: Use long-form flags in docs/tests/examples (`--app`, `--output`) for clarity
-- **TTY-aware output defaults**: `table` in interactive terminals, `json` for pipes/CI; use `--output` for explicit formats
-- **No interactive prompts**: Use `--confirm` flags for destructive operations
-- **Pagination**: `--paginate` fetches all pages automatically
+- `$develop-asc-change`: design, implement, and verify commands, flags, endpoints, bug fixes, and behavior-changing refactors.
+- `$audit-asc-pr`: audit a complete PR and fix proven defects.
+- `$watch-asc-pr`: recheck PR comments, checks, head changes, and merge readiness.
+- `$triage-asc-issue`: reproduce, classify, label, and scope an issue.
+- `$review-wall-of-apps-prs`: validate, approve, and merge Wall of Apps submissions safely.
+- `$release-asc-cli`: publish and verify an end-to-end CLI repository release.
+- `$sync-asc-skills`: check the external ASC workflow skills for CLI-surface drift.
 
-## Discovering Commands
+Use these skills for their matching workflows instead of expanding this always-loaded file with task-specific procedures.
 
-**Before implementing or testing any command, run `--help` to confirm the exact interface.** The CLI is self-documenting:
+## Core CLI contract
 
-```bash
-asc --help                    # List all commands
-asc builds --help             # List builds subcommands
-asc builds list --help        # Show all flags for a command
-```
+- Use long-form flags in docs, tests, and examples (`--app`, `--output`).
+- Output defaults are TTY-aware: `table` in terminals and minified `json` for pipes or CI. Explicit `--output` wins.
+- Do not add interactive prompts. Require `--confirm` for destructive operations.
+- Use `--paginate` when callers request every page.
+- Write data to stdout and errors or diagnostics to stderr.
+- Never accept and silently ignore an unsupported flag or value.
 
-Do not memorize commands. Always check `--help` for the current interface.
+## Discover current behavior
 
-## Documentation
-
-When looking up App Store Connect API docs, prefer the `sosumi.ai` mirror instead of `developer.apple.com`.
-Replace `https://developer.apple.com/documentation/appstoreconnectapi/...` with `https://sosumi.ai/documentation/appstoreconnectapi/...`.
-
-## OpenAPI (offline)
-
-For endpoint existence and request/response schemas, use the offline snapshot:
-`docs/openapi/latest.json` and the quick index `docs/openapi/paths.txt`.
-Update instructions live in `docs/openapi/README.md`.
-
-Notes:
-- Validate flags against the *request* schema for the method you're implementing (create vs update often differ).
-- Validate query params against the specific endpoint (top-level vs relationship endpoints may allow different filters).
-
-## Build & Test
+Never rely on memorized command shapes. Before implementing, testing, or documenting a command, inspect its current help:
 
 ```bash
-make build      # Build binary
-ASC_BYPASS_KEYCHAIN=1 make test  # Run tests with keychain bypass (always run before committing)
-make lint       # Lint code
-make format     # Format code
-make install-hooks  # Install local pre-commit hook (.githooks/pre-commit)
+asc --help
+asc builds --help
+asc builds list --help
 ```
 
-Canonical test rule: all test runs must use `ASC_BYPASS_KEYCHAIN=1` to avoid host keychain prompts and profile bleed-through.
+For App Store Connect API documentation, prefer the `sosumi.ai` mirror over `developer.apple.com`.
 
-## PR Guardrails
+Use the offline OpenAPI snapshot for endpoint and schema truth:
 
-- Before opening or merging a PR, run `make format`, `make check-command-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`.
-- If command/help text changed, run `make generate-command-docs` and commit `docs/COMMANDS.md` before running checks.
-- Use `make install-hooks` once per clone to enforce local pre-commit checks.
-- CI must enforce formatting + lint + tests on both PR and `main` workflows.
-- Remove unused shared wrappers/helpers when commands are refactored.
+- `docs/openapi/latest.json`: complete snapshot.
+- `docs/openapi/paths.txt`: quick endpoint index.
+- `docs/openapi/README.md`: update procedure.
 
-## PR Audit Workflow
+Validate attributes against the exact create or update request schema. Validate filters and includes against the specific endpoint; related top-level and relationship endpoints often differ.
 
-- When the user says `audit the PR`, treat it as a standing workflow; do not wait for them to restate the same instructions.
-- Check the PR out in an isolated git worktree (preferred) with its own local branch so the user's main checkout stays untouched.
-- Audit the full PR, not just the latest commit: inspect the branch diff, review all commits on the PR, and run the relevant tests/checks.
-- PR audits are fix-forward by default in this repo: if you find concrete issues, fix them, add/update tests, create a new commit, and push to the PR branch unless the user explicitly asks for review-only.
-- After pushing audit fixes, inspect GitHub PR review comments/threads with `gh`, address actionable feedback, commit and push follow-up fixes, and resolve threads you fully handled.
-- After the first push, keep checking for new PR comments/review threads about every minute for 5-10 minutes total, fixing and pushing follow-up changes if needed unless the user tells you to stop.
-- Assume `gh` auth is already available for PR audit tasks; use `gh` directly and only stop to ask if auth actually fails.
-- For all PR-audit test runs and live CLI/API verification, use `ASC_BYPASS_KEYCHAIN=1` so auth resolves from config/env instead of the macOS keychain.
-- Prefer the throwaway App Store Connect app `ASC Test 20260216074703` (`6759231657`) for live mutating verification during PR audits.
-- The `ASC Test` app is disposable: it is acceptable to create/cancel submissions and mutate resources there for validation, but still clean up temporary artifacts when possible.
-- Avoid mutating non-throwaway apps during PR audits unless the user explicitly approves it or there is no safer way to validate the change.
-- In the PR audit handoff, include the audit findings, fixes made, commits/pushes performed, commands run, test results, and any live ASC state that could not be cleaned up.
+## Development workflow
 
-## Issue Triage & Labeling
+- Work on a branch and use an isolated worktree when the main checkout is dirty or other work is in progress.
+- Do not push directly to `main`, bypass hooks, use `--no-verify`, or skip checks to force a result.
+- Use TDD for behavior changes: reproduce or establish RED, implement the smallest coherent change, then reach GREEN.
+- Keep one logical change per commit. Do not mix unrelated refactors, fixes, and test rewrites.
+- Re-run the focused failing test after each fix before broad validation.
+- Preserve and report pre-existing failures honestly.
+- Parallel exploration is allowed, but do not concurrently edit the same command group; integrate final changes in one coherent pass.
 
-- When creating or triaging a GitHub issue, ensure it ends the task with exactly one label
-  from each of these buckets:
-  - type: `bug`, `enhancement`, or `question`
-  - priority: `p0`, `p1`, `p2`, or `p3`
-  - difficulty: `easy`, `medium`, or `hard`
-- If an issue is created without labels, add the missing labels immediately as part of the
-  same task.
-- Use priority for urgency and user impact, not implementation size.
-- Use difficulty for implementation scope/risk, not urgency.
-- Do not leave newly created issues without a type, priority, and difficulty label.
-- If the exact label is ambiguous, prefer the lower priority/difficulty and note the
-  assumption in the handoff.
+User-facing commands and flags follow `experimental` -> `stable` -> `deprecated` -> `removed`. Do not delete stable behavior directly. Deprecations require warning text, transition tests, migration guidance, and a release-note entry.
 
-## Release Announcements
+## Implementation invariants
 
-- When the user asks for a new release (e.g., "do a new release of X.Y.Z"), after the release
-  is tagged/published also create a social announcement **draft** via the Typefully MCP
-  (`TypefullyMCP`, configured in the user's Claude config). Match the user's established
-  release-post format.
-- **One post, no emojis** — never a thread.
-- **All five platforms enabled**: X, LinkedIn, Mastodon, Threads, Bluesky (the "five-platform"
-  release draft). Discover the user's social set via `typefully_list_social_sets`; send the same
-  text to every platform.
-- **Structure** (model on the most recent prior release draft via `typefully_list_drafts` ->
-  `typefully_get_draft`):
-  - Opener: `App Store Connect CLI X.Y.Z is out!`
-  - `Main improvement is <command/feature>` + one short benefit line
-  - A compact `Also: ...` line for secondary changes
-  - Plain repo link: `https://github.com/rorkai/App-Store-Connect-CLI`
-- Keep the text under Bluesky's 300-character limit.
-- **Save as a draft only** — do not schedule or publish unless the user explicitly asks. Share
-  the draft's review URL in the handoff.
+- Put command implementations in `internal/cli/<domain>` and register new top-level commands in `internal/cli/registry/registry.go`.
+- Set `UsageFunc: shared.DefaultUsageFunc` on command groups and subcommands.
+- Use `shared.ContextWithTimeout` or `shared.ContextWithUploadTimeout` for outbound HTTP.
+- Validate required flags before side effects and assert stderr messages in tests.
+- Use `internal/cli/cmdtest` for CLI-level coverage and `httptest` for HTTP payload coverage.
+- Remove shared wrappers or helpers made obsolete by a refactor.
 
-## Testing Discipline
+## Build and validation
 
-- Use TDD for behavior changes: bugs, refactors that alter behavior, and new features.
-- Start with a failing test that captures the expected behavior and edge cases.
-- For new features, begin with CLI-level tests (flags, output, errors) and add unit tests for core logic.
-- Verify the test fails for the right reason before implementing; keep tests green incrementally.
-- **Test realistic CLI invocation patterns**, not invented happy paths. For example, when testing argument parsing, always consider:
-  - Flags before subcommands: `asc --flag subcmd` vs `asc subcmd --flag`
-  - Flag values that look like subcommands: `asc --report junit completion`
-  - Multiple flags with values: `asc -a val1 -b val2 subcmd`
-- **Model tests on actual CLI usage**, not assumed patterns. Check `--help` output to understand real command structure before writing tests.
+```bash
+make build
+make format
+make check-docs
+make lint
+ASC_BYPASS_KEYCHAIN=1 make test
+make install-hooks
+```
 
-## Debugging & Bug Fixing
+Every manual test command must use `ASC_BYPASS_KEYCHAIN=1` to prevent host keychain prompts and profile bleed-through. The `make test` target enforces the same environment internally.
 
-- **Reproduce first**: Before fixing, run the failing test locally to confirm the issue. Don't assume you understand the bug.
-- **One change at a time**: Make one small fix, verify it works, then move to the next. Don't batch multiple changes.
-- **Re-run after each fix**: Re-run the specific failing test after each fix before running the full suite.
-- **One logical change per commit**: Keep commits narrowly scoped and reviewable. Avoid mixing refactor + bug fix + test rewrites in a single commit.
-- **Never bypass checks**: Don't use `--no-verify`, don't push directly to `main`, don't skip tests to "get around" failures.
-- **Be honest about pre-existing issues**: If a test was failing before your changes, say so. Don't claim credit for "fixing" something you didn't break.
-- **Verify before claiming done**: Run the specific failing test again to confirm it's fixed, not just "all tests pass".
-- **Avoid broad skip logic**: Don't skip tests with generic string matches (e.g., "Keychain Error") that can hide regressions. Match specific error codes instead.
-- **Isolate test auth/env state**: Tests that touch auth must set/clear relevant env vars (`ASC_BYPASS_KEYCHAIN`, `ASC_PROFILE`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64`, `ASC_STRICT_AUTH`) locally and restore exact original state.
-- **Local test command**: When running repository tests manually, use `ASC_BYPASS_KEYCHAIN=1 make test` to prevent macOS keychain profile prompts from host environment bleed-through.
-- **Strict skip policy**: `t.Skip` is allowed only for specific, documented, reproducible conditions (exact error code/condition). Generic skip patterns are not allowed.
-- **Use proper workflow**: Branch → change → test → PR. Not: main → change → push.
+Before opening or merging a PR, run `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`. If command help changed, run `make generate-command-docs` and commit `docs/COMMANDS.md` before those checks. Run `make check-wall-of-apps` for Wall changes.
 
-## Definition of Done (Single-Pass)
+Do not weaken CI: formatting, documentation, lint, and tests must run on PR and `main` workflows.
 
-- Done means checks pass, key exit-code scenarios are validated, and commands run are recorded in handoff.
-- For CLI behavior changes (flags, exit codes, output/reporting), follow this sequence:
-  - Add/adjust failing tests first (RED), then implement (GREEN).
-  - Do not add placeholder tests; every new test must assert exit code, stderr/stdout, and/or parsed structured output.
-  - For every new or changed flag, add:
-    - one valid-path test
-    - one invalid-value test that asserts stderr and exit code `2`
-  - For argument/subcommand parsing, test edge cases: flags before subcommands, flag values that match subcommand names, mixed flag order.
-  - Never silently ignore accepted flags; unsupported values must return an error.
-  - For JSON/XML output tests, parse output (`json.Unmarshal`/`xml.Unmarshal`) instead of relying only on string matching.
-  - For report/artifact file outputs, test both successful write and write-failure behavior.
-  - Verify CLI exit behavior using a built binary (not only `go run`) for black-box checks:
-    - `go build -o /tmp/asc .`
-    - run `/tmp/asc ...` and assert exit code + stderr/stdout
-  - For any new/changed API-facing flag (query params or request attributes), cross-check `docs/openapi/latest.json` to ensure:
-    - the attribute exists in the correct request schema (create-only vs update-only is common)
-    - the query parameter is permitted for that endpoint (top-level vs relationship endpoints can differ)
-    - if the API doesn't support it, don't ship a flag; implement client-side behavior or document the limitation explicitly
-  - If the change depends on ASC API quirks and you have credentials available locally, run a minimal live smoke test with a built binary (`/tmp/asc`).
-    - Prefer read-only commands first; for write operations, use a throwaway app/resource and clean up (create-then-delete).
-- Before opening/updating a PR, always run:
-  - `make format`
-  - `make check-command-docs`
-  - `make lint`
-  - `ASC_BYPASS_KEYCHAIN=1 make test`
-- In the PR description or handoff, include:
-  - commands run
-  - key exit-code scenarios validated
+## GitHub and issue guardrails
 
-## Operating Mode: Architecture-First Agent Engineering
+- Inspect thread-aware GitHub review state before declaring a PR clean; flat comments do not prove every thread is resolved.
+- A PR is ready only when the latest head was reviewed, required checks pass, actionable threads are resolved, and GitHub reports it mergeable.
+- Fix-forward is the default for `$audit-asc-pr`; approval and merge still require explicit user intent.
+- Every newly created or triaged issue must end with exactly one type (`bug`, `enhancement`, `question`), one priority (`p0`-`p3`), and one difficulty (`easy`, `medium`, `hard`) label.
 
-- Default mode is architecture-first, not vibe-first.
-- Before implementing any new command/flag, produce a short design note covering:
-  1) command placement in existing taxonomy,
-  2) OpenAPI endpoint/schema validation,
-  3) UX shape (flags/output/exit codes),
-  4) backward-compatibility and deprecation impact,
-  5) RED -> GREEN test plan.
-- If command shape is ambiguous, stop and align before coding.
+## Authentication and live testing
 
-## Command Lifecycle & Compatibility
+App Store Connect API keys come from https://appstoreconnect.apple.com/access/integrations/api and must never be committed.
 
-- User-facing commands/flags must follow lifecycle states: `experimental`, `stable`, `deprecated`, `removed`.
-- Do not delete stable commands directly; deprecate first with migration guidance.
-- Deprecations must include:
-  - warning text in help/output,
-  - tests covering old and new behavior during transition,
-  - release notes entry with upgrade path.
+Tests touching auth must isolate relevant environment and config state. For live verification, prefer read-only calls. When mutation is necessary during PR audits, prefer disposable app `6759231657`, clean up temporary resources, and record anything left behind. Never mutate a non-disposable app without explicit approval.
 
-## Agent Explainability Contract
+## Handoff contract
 
-For each substantial change, include:
-- why this approach was chosen,
-- one to two alternatives considered and trade-offs,
-- expected invocation examples and outputs,
-- edge cases and failure modes tested.
-
-A change is not done if the reviewer cannot explain command behavior and trade-offs from the handoff.
-
-## Parallel Agent Policy
-
-- Parallel agents are allowed for independent exploration or test drafting.
-- Final implementation integration must be done in a single coherent pass.
-- Avoid concurrent edits to the same command group.
-
-## CLI Implementation Checklist
-
-- Register new commands in `internal/cli/registry/registry.go`.
-- Always set `UsageFunc: shared.DefaultUsageFunc` for command groups and subcommands.
-- For outbound HTTP, use `shared.ContextWithTimeout` (or `shared.ContextWithUploadTimeout`) so `ASC_TIMEOUT` applies.
-- Validate required flags and assert stderr error messages in tests (not just `flag.ErrHelp`).
-- Add `internal/cli/cmdtest` coverage for new commands; use `httptest` for network payload tests.
-
-## Authentication
-
-API keys are generated at https://appstoreconnect.apple.com/access/integrations/api and stored in the system keychain (with local config fallback). Never commit keys to version control.
-
-## Environment Variables
-
-| Variable | Purpose |
-|----------|---------|
-| `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64` | Auth fallback |
-| `ASC_BYPASS_KEYCHAIN` | Ignore keychain and use config/env auth |
-| `ASC_STRICT_AUTH` | Fail when credentials resolve from multiple sources (`true/false`, `1/0`, `yes/no`, `y/n`, `on/off`) |
-| `ASC_APP_ID` | Default app ID |
-| `ASC_VENDOR_NUMBER` | Sales/finance reports |
-| `ASC_TIMEOUT` | Request timeout (e.g., `90s`, `2m`) |
-| `ASC_TIMEOUT_SECONDS` | Timeout in seconds (alternative) |
-| `ASC_UPLOAD_TIMEOUT` | Upload timeout (e.g., `60s`, `2m`) |
-| `ASC_UPLOAD_TIMEOUT_SECONDS` | Upload timeout in seconds (alternative) |
-| `ASC_DEBUG` | Enable debug logging (set to `api` for HTTP requests/responses) |
-| `ASC_DEFAULT_OUTPUT` | Default output format: `json`, `table`, `markdown`, or `md` |
-| `ASC_TELEMETRY_DISABLED` | Disable default-on anonymous command telemetry |
-| `ASC_TELEMETRY_EPHEMERAL` | Send telemetry without a local install ID for disposable runtimes |
-| `ASC_TELEMETRY_ENDPOINT` | Override the HTTPS telemetry collector endpoint |
-
-When `ASC_DEFAULT_OUTPUT` is unset, defaults are TTY-aware (`table` in terminals, `json` for non-interactive output).
-Explicit `--output` flags always override `ASC_DEFAULT_OUTPUT` and TTY-aware defaults.
+For substantial changes, explain the chosen approach, alternatives and trade-offs, expected invocations and outputs, compatibility impact, edge cases, failure modes, commands run, tests, live verification, commits or pushes, and unresolved risks.
 
 ## References
 
-Detailed guidance on specific topics (only read when needed):
-
-- **Go coding standards**: `docs/GO_STANDARDS.md`
-- **Testing patterns**: `docs/TESTING.md`
-- **Git workflow, CLI structure, adding features**: `docs/CONTRIBUTING.md`
-- **API quirks (analytics, finance, sandbox)**: `docs/API_NOTES.md`
-- **Development setup, PRs**: `CONTRIBUTING.md` (root)
+- Go standards: `docs/GO_STANDARDS.md`
+- Testing patterns: `docs/TESTING.md`
+- Git workflow and CLI structure: `docs/CONTRIBUTING.md`
+- API quirks: `docs/API_NOTES.md`
+- Development setup, PRs, labels, and Wall submissions: `CONTRIBUTING.md`

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,14 @@ check-website-docs:
 	python3 ./scripts/check_website_docs.py
 	python3 ./scripts/check_website_commands.py
 
+.PHONY: check-agent-skills
+check-agent-skills:
+	@echo "$(BLUE)Checking repository agent skills...$(NC)"
+	python3 ./scripts/test_check_agent_skills.py
+	python3 ./scripts/check_agent_skills.py
+
 .PHONY: check-docs
-check-docs: check-command-docs check-repo-docs check-website-docs
+check-docs: check-command-docs check-repo-docs check-website-docs check-agent-skills
 
 .PHONY: check-wall-of-apps
 check-wall-of-apps:
@@ -294,6 +300,7 @@ help:
 	@echo "  check-command-docs Validate docs command lists against live CLI help"
 	@echo "  check-repo-docs Validate local links in repository markdown docs"
 	@echo "  check-website-docs Validate Mintlify website navigation, links, and CLI examples"
+	@echo "  check-agent-skills Validate repository-scoped Codex skills"
 	@echo "  check-docs     Run all documentation checks"
 	@echo "  clean          Clean build artifacts"
 	@echo "  install        Install binary"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,6 +30,18 @@ If `docs/wall-of-apps.json` is the only staged change, the local hook skips the 
 make check-wall-of-apps
 ```
 
+## Repository Agent Skills
+
+Keep always-on repository invariants in `AGENTS.md` and task-specific maintainer workflows in `.agents/skills/<skill-name>/`.
+
+Each skill must contain a `SKILL.md` with only `name` and `description` frontmatter plus matching `agents/openai.yaml` UI metadata. Keep trigger descriptions specific, link detailed references through progressive disclosure, and run:
+
+```bash
+make check-agent-skills
+```
+
+`make check-docs` includes this validation.
+
 ## CLI Structure
 
 - Command implementations live in `internal/cli/<domain>` packages

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,7 +68,9 @@ func TestSomething(t *testing.T) {
 ## Running Tests
 
 ```bash
-make test       # Run all tests
-go test -v ./...  # Verbose output
-go test -run TestName ./pkg  # Run specific test
+ASC_BYPASS_KEYCHAIN=1 make test  # Run all tests
+ASC_BYPASS_KEYCHAIN=1 go test -v ./...  # Verbose output
+ASC_BYPASS_KEYCHAIN=1 go test -run TestName ./pkg  # Run specific test
 ```
+
+Always set `ASC_BYPASS_KEYCHAIN=1` for manual test commands so host keychain profiles cannot affect results. The `make test` target also sets it internally.

--- a/scripts/check_agent_skills.py
+++ b/scripts/check_agent_skills.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate repository-scoped Codex skills and their UI metadata."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_ROOT = ROOT / ".agents" / "skills"
+AGENTS_PATH = ROOT / "AGENTS.md"
+EXPECTED_SKILLS = {
+    "audit-asc-pr",
+    "develop-asc-change",
+    "release-asc-cli",
+    "review-wall-of-apps-prs",
+    "sync-asc-skills",
+    "triage-asc-issue",
+    "watch-asc-pr",
+}
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def parse_frontmatter(text: str, path: Path) -> tuple[dict[str, str], str]:
+    if not text.startswith("---\n"):
+        raise ValueError(f"{path}: missing YAML frontmatter")
+
+    try:
+        raw_frontmatter, body = text[4:].split("\n---\n", 1)
+    except ValueError as exc:
+        raise ValueError(f"{path}: unterminated YAML frontmatter") from exc
+
+    values: dict[str, str] = {}
+    for line in raw_frontmatter.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith((" ", "\t")) or ":" not in line:
+            raise ValueError(f"{path}: unsupported frontmatter line: {line!r}")
+        key, value = line.split(":", 1)
+        values[key.strip()] = value.strip().strip('"')
+    return values, body
+
+
+def yaml_string(text: str, key: str) -> str | None:
+    match = re.search(rf'^\s+{re.escape(key)}:\s+"([^"]*)"\s*$', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def validate_skill(skill_dir: Path, agents_text: str) -> list[str]:
+    errors: list[str] = []
+    skill_path = skill_dir / "SKILL.md"
+    metadata_path = skill_dir / "agents" / "openai.yaml"
+
+    if not skill_path.is_file():
+        return [f"{skill_dir}: missing SKILL.md"]
+    if not metadata_path.is_file():
+        return [f"{skill_dir}: missing agents/openai.yaml"]
+
+    text = skill_path.read_text(encoding="utf-8")
+    try:
+        frontmatter, body = parse_frontmatter(text, skill_path)
+    except ValueError as exc:
+        return [str(exc)]
+
+    if set(frontmatter) != {"name", "description"}:
+        errors.append(f"{skill_path}: frontmatter must contain only name and description")
+    if frontmatter.get("name") != skill_dir.name:
+        errors.append(f"{skill_path}: name must match directory {skill_dir.name!r}")
+    if len(frontmatter.get("description", "")) < 50:
+        errors.append(f"{skill_path}: description is too short for reliable triggering")
+    if not body.strip():
+        errors.append(f"{skill_path}: instructions are empty")
+    if "TODO" in text:
+        errors.append(f"{skill_path}: unresolved TODO placeholder")
+
+    for raw_target in MARKDOWN_LINK.findall(body):
+        target = raw_target.split("#", 1)[0].strip()
+        if not target or target.startswith(("http://", "https://")):
+            continue
+        resolved = (skill_path.parent / target).resolve()
+        if not resolved.is_relative_to(ROOT):
+            errors.append(f"{skill_path}: local link escapes repository: {target}")
+        elif not resolved.exists():
+            errors.append(f"{skill_path}: missing local link target: {target}")
+
+    metadata = metadata_path.read_text(encoding="utf-8")
+    display_name = yaml_string(metadata, "display_name")
+    short_description = yaml_string(metadata, "short_description")
+    default_prompt = yaml_string(metadata, "default_prompt")
+    if not display_name:
+        errors.append(f"{metadata_path}: missing quoted display_name")
+    if not short_description or not 25 <= len(short_description) <= 64:
+        errors.append(f"{metadata_path}: short_description must be 25-64 characters")
+    if not default_prompt or f"${skill_dir.name}" not in default_prompt:
+        errors.append(f"{metadata_path}: default_prompt must mention ${skill_dir.name}")
+
+    if f"${skill_dir.name}" not in agents_text:
+        errors.append(f"{AGENTS_PATH}: missing workflow route for ${skill_dir.name}")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not SKILLS_ROOT.is_dir():
+        errors.append(f"{SKILLS_ROOT}: skills directory is missing")
+        skill_dirs: list[Path] = []
+    else:
+        skill_dirs = sorted(path for path in SKILLS_ROOT.iterdir() if path.is_dir())
+
+    actual_names = {path.name for path in skill_dirs}
+    for missing in sorted(EXPECTED_SKILLS - actual_names):
+        errors.append(f"{SKILLS_ROOT}: missing expected skill {missing}")
+
+    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+    for skill_dir in skill_dirs:
+        errors.extend(validate_skill(skill_dir, agents_text))
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(skill_dirs)} repository agent skills.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_agent_skills.py
+++ b/scripts/check_agent_skills.py
@@ -48,6 +48,19 @@ def yaml_string(text: str, key: str) -> str | None:
     return match.group(1) if match else None
 
 
+def yaml_mapping(text: str, key: str) -> str | None:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line == f"{key}:":
+            nested: list[str] = []
+            for candidate in lines[index + 1 :]:
+                if candidate and not candidate.startswith((" ", "\t")):
+                    break
+                nested.append(candidate)
+            return "\n".join(nested)
+    return None
+
+
 def validate_skill(skill_dir: Path, agents_text: str) -> list[str]:
     errors: list[str] = []
     skill_path = skill_dir / "SKILL.md"
@@ -86,9 +99,13 @@ def validate_skill(skill_dir: Path, agents_text: str) -> list[str]:
             errors.append(f"{skill_path}: missing local link target: {target}")
 
     metadata = metadata_path.read_text(encoding="utf-8")
-    display_name = yaml_string(metadata, "display_name")
-    short_description = yaml_string(metadata, "short_description")
-    default_prompt = yaml_string(metadata, "default_prompt")
+    interface = yaml_mapping(metadata, "interface")
+    if interface is None:
+        errors.append(f"{metadata_path}: missing interface mapping")
+        interface = ""
+    display_name = yaml_string(interface, "display_name")
+    short_description = yaml_string(interface, "short_description")
+    default_prompt = yaml_string(interface, "default_prompt")
     if not display_name:
         errors.append(f"{metadata_path}: missing quoted display_name")
     if not short_description or not 25 <= len(short_description) <= 64:
@@ -113,7 +130,11 @@ def main() -> int:
     for missing in sorted(EXPECTED_SKILLS - actual_names):
         errors.append(f"{SKILLS_ROOT}: missing expected skill {missing}")
 
-    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+    if AGENTS_PATH.is_file():
+        agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+    else:
+        errors.append(f"{AGENTS_PATH}: file is missing")
+        agents_text = ""
     for skill_dir in skill_dirs:
         errors.extend(validate_skill(skill_dir, agents_text))
 

--- a/scripts/test_check_agent_skills.py
+++ b/scripts/test_check_agent_skills.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import check_agent_skills
+
+
+class CheckAgentSkillsTests(unittest.TestCase):
+    def make_skill(self, root: Path, *, link: str = "references/details.md") -> Path:
+        skill_dir = root / ".agents" / "skills" / "sample-skill"
+        (skill_dir / "agents").mkdir(parents=True)
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "details.md").write_text("# Details\n")
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: sample-skill\n"
+            "description: Validate a representative skill when its workflow is requested.\n"
+            "---\n\n"
+            "# Sample\n\n"
+            f"Read [details]({link}).\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "agents" / "openai.yaml").write_text(
+            'interface:\n'
+            '  display_name: "Sample Skill"\n'
+            '  short_description: "Validate a representative skill"\n'
+            '  default_prompt: "Use $sample-skill for this workflow."\n',
+            encoding="utf-8",
+        )
+        return skill_dir
+
+    def test_validate_skill_accepts_complete_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            skill_dir = self.make_skill(root)
+            with (
+                mock.patch.object(check_agent_skills, "ROOT", root),
+                mock.patch.object(check_agent_skills, "AGENTS_PATH", root / "AGENTS.md"),
+            ):
+                errors = check_agent_skills.validate_skill(skill_dir, "$sample-skill")
+        self.assertEqual(errors, [])
+
+    def test_validate_skill_rejects_missing_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            skill_dir = self.make_skill(root, link="references/missing.md")
+            with (
+                mock.patch.object(check_agent_skills, "ROOT", root),
+                mock.patch.object(check_agent_skills, "AGENTS_PATH", root / "AGENTS.md"),
+            ):
+                errors = check_agent_skills.validate_skill(skill_dir, "$sample-skill")
+        self.assertTrue(any("missing local link target" in error for error in errors))
+
+    def test_parse_frontmatter_rejects_extra_nested_fields(self) -> None:
+        text = "---\nname: sample\nmetadata:\n  owner: team\n---\nbody\n"
+        with self.assertRaisesRegex(ValueError, "unsupported frontmatter line"):
+            check_agent_skills.parse_frontmatter(text, Path("SKILL.md"))
+
+    def test_yaml_string_requires_quoted_value(self) -> None:
+        self.assertEqual(
+            check_agent_skills.yaml_string('  display_name: "Sample"\n', "display_name"),
+            "Sample",
+        )
+        self.assertIsNone(
+            check_agent_skills.yaml_string("  display_name: Sample\n", "display_name")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_agent_skills.py
+++ b/scripts/test_check_agent_skills.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from contextlib import redirect_stderr
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
@@ -10,7 +12,13 @@ import check_agent_skills
 
 
 class CheckAgentSkillsTests(unittest.TestCase):
-    def make_skill(self, root: Path, *, link: str = "references/details.md") -> Path:
+    def make_skill(
+        self,
+        root: Path,
+        *,
+        link: str = "references/details.md",
+        metadata: str | None = None,
+    ) -> Path:
         skill_dir = root / ".agents" / "skills" / "sample-skill"
         (skill_dir / "agents").mkdir(parents=True)
         (skill_dir / "references").mkdir()
@@ -25,10 +33,13 @@ class CheckAgentSkillsTests(unittest.TestCase):
             encoding="utf-8",
         )
         (skill_dir / "agents" / "openai.yaml").write_text(
-            'interface:\n'
-            '  display_name: "Sample Skill"\n'
-            '  short_description: "Validate a representative skill"\n'
-            '  default_prompt: "Use $sample-skill for this workflow."\n',
+            metadata
+            or (
+                'interface:\n'
+                '  display_name: "Sample Skill"\n'
+                '  short_description: "Validate a representative skill"\n'
+                '  default_prompt: "Use $sample-skill for this workflow."\n'
+            ),
             encoding="utf-8",
         )
         return skill_dir
@@ -54,6 +65,43 @@ class CheckAgentSkillsTests(unittest.TestCase):
             ):
                 errors = check_agent_skills.validate_skill(skill_dir, "$sample-skill")
         self.assertTrue(any("missing local link target" in error for error in errors))
+
+    def test_validate_skill_rejects_interface_fields_in_another_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            skill_dir = self.make_skill(
+                root,
+                metadata=(
+                    "dependencies:\n"
+                    '  display_name: "Sample Skill"\n'
+                    '  short_description: "Validate a representative skill"\n'
+                    '  default_prompt: "Use $sample-skill for this workflow."\n'
+                    "interface:\n"
+                ),
+            )
+            with (
+                mock.patch.object(check_agent_skills, "ROOT", root),
+                mock.patch.object(check_agent_skills, "AGENTS_PATH", root / "AGENTS.md"),
+            ):
+                errors = check_agent_skills.validate_skill(skill_dir, "$sample-skill")
+        self.assertTrue(any("missing quoted display_name" in error for error in errors))
+
+    def test_main_reports_missing_agents_file_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            skills_root = root / ".agents" / "skills"
+            skills_root.mkdir(parents=True)
+            stderr = StringIO()
+            with (
+                mock.patch.object(check_agent_skills, "ROOT", root),
+                mock.patch.object(check_agent_skills, "SKILLS_ROOT", skills_root),
+                mock.patch.object(check_agent_skills, "AGENTS_PATH", root / "AGENTS.md"),
+                mock.patch.object(check_agent_skills, "EXPECTED_SKILLS", set()),
+                redirect_stderr(stderr),
+            ):
+                exit_code = check_agent_skills.main()
+        self.assertEqual(exit_code, 1)
+        self.assertIn("AGENTS.md: file is missing", stderr.getvalue())
 
     def test_parse_frontmatter_rejects_extra_nested_fields(self) -> None:
         text = "---\nname: sample\nmetadata:\n  owner: team\n---\nbody\n"

--- a/scripts/test_check_agent_skills.py
+++ b/scripts/test_check_agent_skills.py
@@ -34,7 +34,8 @@ class CheckAgentSkillsTests(unittest.TestCase):
         )
         (skill_dir / "agents" / "openai.yaml").write_text(
             metadata
-            or (
+            if metadata is not None
+            else (
                 'interface:\n'
                 '  display_name: "Sample Skill"\n'
                 '  short_description: "Validate a representative skill"\n'
@@ -85,6 +86,17 @@ class CheckAgentSkillsTests(unittest.TestCase):
             ):
                 errors = check_agent_skills.validate_skill(skill_dir, "$sample-skill")
         self.assertTrue(any("missing quoted display_name" in error for error in errors))
+
+    def test_validate_skill_rejects_empty_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            skill_dir = self.make_skill(root, metadata="")
+            with (
+                mock.patch.object(check_agent_skills, "ROOT", root),
+                mock.patch.object(check_agent_skills, "AGENTS_PATH", root / "AGENTS.md"),
+            ):
+                errors = check_agent_skills.validate_skill(skill_dir, "$sample-skill")
+        self.assertTrue(any("missing interface mapping" in error for error in errors))
 
     def test_main_reports_missing_agents_file_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- reduce `AGENTS.md` from 249 lines / 15.3 KB to 111 lines / 6.1 KB of always-on repository invariants
- add seven focused repo-scoped maintainer skills under `.agents/skills/`
- add UI metadata and progressive-disclosure references for release and behavior-change workflows
- add a dependency-free skill validator, four validator tests, and `make check-agent-skills`
- include skill validation in `make check-docs` and align manual test examples with `ASC_BYPASS_KEYCHAIN=1`

## Why this shape

The previous `AGENTS.md` combined repository invariants with long PR-audit, release, issue-triage, testing, and automation runbooks. Those task-specific procedures now load only when their skill triggers, while the rules that must apply to every change remain in `AGENTS.md`.

The skills are intentionally separate:

- `audit-asc-pr` performs the full evidence-first audit and fix-forward pass
- `watch-asc-pr` performs one idempotent PR follow-up suitable for thread heartbeats
- `release-asc-cli` owns the explicit, end-to-end repository release
- `develop-asc-change` owns architecture-first RED-GREEN implementation
- `triage-asc-issue` owns reproduction, labels, and implementation readiness
- `review-wall-of-apps-prs` owns the untrusted Wall contribution path
- `sync-asc-skills` owns drift checks against the external workflow-skill repository

This is one atomic PR because `AGENTS.md` routing and the validator depend on all seven skills being present together.

## Automation boundaries

The automation-facing skills define idempotent, conservative contracts. PR watching can continue in a thread heartbeat; recurring issue, Wall, and skill-drift sweeps are read-only by default. Releases, approvals, and merges remain explicitly initiated actions.

## Validation

- RED: `python3 scripts/check_agent_skills.py` rejected all seven generated placeholders and missing `AGENTS.md` routes
- GREEN: `make check-agent-skills` validates seven skills and runs four validator tests
- official skill-creator `quick_validate.py` passed for all seven skills
- `make format`
- `make check-docs`
- `make lint` (0 issues; the local linter emitted a stale external-cache path warning)
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make check-wall-of-apps`
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 ./asc --help` (exit 0)
- `ASC_BYPASS_KEYCHAIN=1 ./asc version` (exit 0)
- `git diff --check`

## Reviewer notes

The validator checks required skills, exact frontmatter fields, folder/name consistency, trigger-description length, unresolved placeholders, local reference targets, quoted UI metadata, default prompts, and `AGENTS.md` workflow routes. It intentionally avoids a runtime PyYAML dependency so CI can run it with the standard library.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added multiple new “agent skill” playbooks covering auditing ASC PRs, developing ASC changes, triaging issues, reviewing Wall of Apps PRs, syncing skills, watching PR feedback, and running ASC CLI releases.
  * Reworked contributor/testing guidance to document the required skill structure and standardized manual-test keychain handling.

* **Chores**
  * Added a new `check-agent-skills` validation and integrated it into the existing docs checks and `make help`.

* **Tests**
  * Expanded automated coverage for skill validation rules, including frontmatter, OpenAI interface metadata, local link targets, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->