### PR TITLE
apps wall: add AnLi Kids

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -55,6 +55,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/00/14/93/0014939d-ce61-2386-0bf3-b79c4dd678c4/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "AnLi Kids",
+    "link": "https://apps.apple.com/us/app/anli-kids/id6759224873?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5d/44/9e/5d449e83-d5d6-3221-eba4-1bf12165d42f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "App Time Limit: Screen Leech",
     "link": "https://apps.apple.com/us/app/app-time-limit-screen-leech/id6743212513?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f5/a4/6e/f5a46e54-20c9-8a3f-69d0-df232214a7fc/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -57,7 +57,7 @@
   {
     "app": "AnLi Kids",
     "link": "https://apps.apple.com/us/app/anli-kids/id6759224873?uo=4",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5d/44/9e/5d449e83-d5d6-3221-eba4-1bf12165d42f/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/32/55/ba/3255ba71-f714-8d4c-b0b2-2dadd0a9fe26/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
     "app": "App Time Limit: Screen Leech",


### PR DESCRIPTION
## Summary

- add `AnLi Kids` to the Wall of Apps

## Entry

- App ID: 6759224873
- App: AnLi Kids
- Link: https://apps.apple.com/us/app/anli-kids/id6759224873?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new app listing for **AnLi Kids** to the app directory, including its Apple App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->