### PR TITLE
[codex] Add structured telemetry error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ or machine identifier.
 
 Telemetry includes the CLI version, operating system and architecture,
 registered command path, duration and exit outcome, runtime context, invocation
-source, and random event and session IDs. It does **not** include raw arguments
+source, low-cardinality invocation shape and failure classifications, and random
+event and session IDs. It does **not** include raw arguments, stderr, error messages,
 or flag values, credentials, private keys, Apple account, team, or issuer IDs,
 app or bundle IDs, API responses, usernames, hostnames, repository names, or
 file paths.

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -27,7 +27,7 @@ func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 	sawFlag := false
 
 	for i := 0; i < len(args); {
-		token := strings.TrimSpace(args[i])
+		token := args[i]
 		if token == "" {
 			i++
 			continue
@@ -67,6 +67,23 @@ func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 	}
 
 	return invocationAnalysis{command: current, shape: shapeForCommand(current, sawFlag)}
+}
+
+func rejectUnexpectedHybridArgs(command *ffcli.Command) {
+	for _, subcommand := range command.Subcommands {
+		rejectUnexpectedHybridArgs(subcommand)
+		if subcommand.Exec == nil || len(subcommand.Subcommands) == 0 {
+			continue
+		}
+
+		exec := subcommand.Exec
+		subcommand.Exec = func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			return exec(ctx, args)
+		}
+	}
 }
 
 func shapeForCommand(command *ffcli.Command, sawFlag bool) telemetry.InvocationShape {
@@ -116,7 +133,7 @@ func validationFailureContext(analysis invocationAnalysis, err error) telemetry.
 }
 
 func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int) telemetry.EventContext {
-	if errors.Is(err, flag.ErrHelp) {
+	if errors.Is(err, flag.ErrHelp) || analysis.shape == telemetry.InvocationShapeUnknownChild {
 		return validationFailureContext(analysis, err)
 	}
 
@@ -133,7 +150,7 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 	case exitCode == ExitConflict:
 		eventContext.ErrorKind = telemetry.ErrorKindAPIConflict
 		eventContext.FailureStage = telemetry.FailureStageRequest
-	case exitCode >= 60 && exitCode <= 69:
+	case exitCode >= 60 && exitCode <= 99:
 		eventContext.ErrorKind = telemetry.ErrorKindAPI5xx
 		eventContext.FailureStage = telemetry.FailureStageRequest
 	case exitCode == ExitAuth || exitCode == ExitNotFound || (exitCode >= 10 && exitCode <= 59):

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -144,11 +144,20 @@ func shouldRenderGroupHelp(analysis invocationAnalysis, err error) bool {
 	if !errors.Is(err, flag.ErrHelp) || shared.ClassifyUsageError(err) != "" || analysis.command == nil {
 		return false
 	}
-	if analysis.unknownToken != "" || len(analysis.command.Subcommands) == 0 {
+	if analysis.unknownToken != "" || len(analysis.command.Subcommands) == 0 || hasDefinedFlags(analysis.command.FlagSet) {
 		return false
 	}
 	return analysis.shape == telemetry.InvocationShapeBareGroup ||
 		analysis.shape == telemetry.InvocationShapeGroupWithFlags
+}
+
+func hasDefinedFlags(flagSet *flag.FlagSet) bool {
+	if flagSet == nil {
+		return false
+	}
+	found := false
+	flagSet.VisitAll(func(*flag.Flag) { found = true })
+	return found
 }
 
 func printUnknownFlagSuggestion(analysis invocationAnalysis) {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -85,9 +85,28 @@ func shouldRejectUnknownChild(root *ffcli.Command, analysis invocationAnalysis, 
 	}
 
 	// Snitch intentionally accepts a positional report description before its
-	// optional flush subcommand. Other command groups treat unmatched children
-	// as usage errors before their default action can run.
-	return commandName != "asc snitch"
+	// optional flush subcommand. Normalized view/edit commands and a few removed
+	// commands also handle legacy children to print precise migration guidance.
+	return commandName != "asc snitch" && !preservesLegacyChild(analysis, commandName)
+}
+
+func preservesLegacyChild(analysis invocationAnalysis, commandName string) bool {
+	token := strings.TrimSpace(analysis.unknownToken)
+	if token == "get" && findDirectSubcommand(analysis.command, "view") != nil {
+		return true
+	}
+	if token == "set" && findDirectSubcommand(analysis.command, "edit") != nil {
+		return true
+	}
+
+	switch commandName {
+	case "asc apps":
+		return token == "create"
+	case "asc submit":
+		return token == "create" || token == "preflight"
+	default:
+		return false
+	}
 }
 
 func isHelpToken(token string) bool {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -87,6 +87,8 @@ func parseFailureContext(analysis invocationAnalysis) telemetry.EventContext {
 	kind := telemetry.ErrorKindInvalidValue
 	if analysis.unknownFlag {
 		kind = telemetry.ErrorKindUnknownFlag
+	} else if analysis.shape == telemetry.InvocationShapeUnknownChild {
+		kind = telemetry.ErrorKindOther
 	}
 	return telemetry.EventContext{
 		InvocationShape: analysis.shape,

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -79,6 +79,17 @@ func shapeForCommand(command *ffcli.Command, sawFlag bool) telemetry.InvocationS
 	return telemetry.InvocationShapeBareGroup
 }
 
+func shouldRejectUnknownChild(root *ffcli.Command, analysis invocationAnalysis, commandName string) bool {
+	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil || analysis.command == root {
+		return false
+	}
+
+	// Snitch intentionally accepts a positional report description before its
+	// optional flush subcommand. Other command groups treat unmatched children
+	// as usage errors before their default action can run.
+	return commandName != "asc snitch"
+}
+
 func isHelpToken(token string) bool {
 	return token == "-h" || token == "--help" || strings.HasPrefix(token, "--help=")
 }

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared/suggest"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+)
+
+type invocationAnalysis struct {
+	command      *ffcli.Command
+	shape        telemetry.InvocationShape
+	unknownToken string
+	unknownFlag  bool
+}
+
+func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
+	current := root
+	sawFlag := false
+
+	for i := 0; i < len(args); {
+		token := strings.TrimSpace(args[i])
+		if token == "" {
+			i++
+			continue
+		}
+		if sub := findDirectSubcommand(current, token); sub != nil {
+			current = sub
+			i++
+			continue
+		}
+		if isHelpToken(token) {
+			sawFlag = true
+			i++
+			continue
+		}
+		if strings.HasPrefix(token, "-") && token != "-" {
+			next, consumed := consumeFlagToken(current.FlagSet, token, args, i)
+			if consumed {
+				sawFlag = true
+				i = next
+				continue
+			}
+			return invocationAnalysis{
+				command:      current,
+				shape:        shapeForCommand(current, true),
+				unknownToken: token,
+				unknownFlag:  true,
+			}
+		}
+		if len(current.Subcommands) > 0 {
+			return invocationAnalysis{
+				command:      current,
+				shape:        telemetry.InvocationShapeUnknownChild,
+				unknownToken: token,
+			}
+		}
+		return invocationAnalysis{command: current, shape: telemetry.InvocationShapeLeaf}
+	}
+
+	return invocationAnalysis{command: current, shape: shapeForCommand(current, sawFlag)}
+}
+
+func shapeForCommand(command *ffcli.Command, sawFlag bool) telemetry.InvocationShape {
+	if command == nil || len(command.Subcommands) == 0 {
+		return telemetry.InvocationShapeLeaf
+	}
+	if sawFlag {
+		return telemetry.InvocationShapeGroupWithFlags
+	}
+	return telemetry.InvocationShapeBareGroup
+}
+
+func isHelpToken(token string) bool {
+	return token == "-h" || token == "--help" || strings.HasPrefix(token, "--help=")
+}
+
+func parseFailureContext(analysis invocationAnalysis) telemetry.EventContext {
+	kind := telemetry.ErrorKindInvalidValue
+	if analysis.unknownFlag {
+		kind = telemetry.ErrorKindUnknownFlag
+	}
+	return telemetry.EventContext{
+		InvocationShape: analysis.shape,
+		ErrorKind:       kind,
+		FailureStage:    telemetry.FailureStageParse,
+	}
+}
+
+func validationFailureContext(analysis invocationAnalysis, err error) telemetry.EventContext {
+	kind := telemetry.ErrorKindOther
+	switch shared.ClassifyUsageError(err) {
+	case shared.UsageErrorMissingRequired:
+		kind = telemetry.ErrorKindMissingRequired
+	case shared.UsageErrorInvalidValue:
+		kind = telemetry.ErrorKindInvalidValue
+	}
+	if analysis.shape == telemetry.InvocationShapeUnknownChild {
+		kind = telemetry.ErrorKindOther
+	}
+	return telemetry.EventContext{
+		InvocationShape: analysis.shape,
+		ErrorKind:       kind,
+		FailureStage:    telemetry.FailureStageValidation,
+	}
+}
+
+func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int) telemetry.EventContext {
+	if errors.Is(err, flag.ErrHelp) {
+		return validationFailureContext(analysis, err)
+	}
+
+	eventContext := telemetry.EventContext{
+		InvocationShape: analysis.shape,
+		ErrorKind:       telemetry.ErrorKindOther,
+		FailureStage:    telemetry.FailureStageExecution,
+	}
+	switch {
+	case errors.Is(err, shared.ErrMissingAuth):
+		eventContext.FailureStage = telemetry.FailureStageValidation
+	case errors.Is(err, context.DeadlineExceeded):
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	case exitCode == ExitConflict:
+		eventContext.ErrorKind = telemetry.ErrorKindAPIConflict
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	case exitCode >= 60 && exitCode <= 69:
+		eventContext.ErrorKind = telemetry.ErrorKindAPI5xx
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	case exitCode == ExitAuth || exitCode == ExitNotFound || (exitCode >= 10 && exitCode <= 59):
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	}
+	return eventContext
+}
+
+func shouldRenderGroupHelp(analysis invocationAnalysis, err error) bool {
+	if !errors.Is(err, flag.ErrHelp) || shared.ClassifyUsageError(err) != "" || analysis.command == nil {
+		return false
+	}
+	if analysis.unknownToken != "" || len(analysis.command.Subcommands) == 0 {
+		return false
+	}
+	return analysis.shape == telemetry.InvocationShapeBareGroup ||
+		analysis.shape == telemetry.InvocationShapeGroupWithFlags
+}
+
+func printUnknownFlagSuggestion(analysis invocationAnalysis) {
+	if !analysis.unknownFlag || analysis.command == nil || analysis.command.FlagSet == nil {
+		return
+	}
+	input := strings.TrimLeft(strings.SplitN(analysis.unknownToken, "=", 2)[0], "-")
+	candidates := make([]string, 0)
+	analysis.command.FlagSet.VisitAll(func(f *flag.Flag) {
+		candidates = append(candidates, f.Name)
+	})
+	suggestions := suggest.Commands(input, candidates)
+	if len(suggestions) == 0 {
+		return
+	}
+	for i, item := range suggestions {
+		suggestions[i] = "--" + shared.SanitizeTerminal(item)
+	}
+	fmt.Fprintf(os.Stderr, "Did you mean: %s?\n", strings.Join(suggestions, ", "))
+}
+
+func printUnknownSubcommandSuggestion(analysis invocationAnalysis) {
+	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil || analysis.command.Name == "asc" {
+		return
+	}
+	candidates := make([]string, 0, len(analysis.command.Subcommands))
+	for _, sub := range analysis.command.Subcommands {
+		candidates = append(candidates, sub.Name)
+	}
+	suggestions := suggest.Commands(analysis.unknownToken, candidates)
+	if len(suggestions) == 0 {
+		return
+	}
+	for i, item := range suggestions {
+		suggestions[i] = shared.SanitizeTerminal(item)
+	}
+	fmt.Fprintf(os.Stderr, "Did you mean: %s?\n", strings.Join(suggestions, ", "))
+}

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -171,14 +171,7 @@ func printUnknownFlagSuggestion(analysis invocationAnalysis) {
 	analysis.command.FlagSet.VisitAll(func(f *flag.Flag) {
 		candidates = append(candidates, f.Name)
 	})
-	suggestions := suggest.Commands(input, candidates)
-	if len(suggestions) == 0 {
-		return
-	}
-	for i, item := range suggestions {
-		suggestions[i] = "--" + shared.SanitizeTerminal(item)
-	}
-	fmt.Fprintf(os.Stderr, "Did you mean: %s?\n", strings.Join(suggestions, ", "))
+	printSuggestions(input, candidates, "--")
 }
 
 func printUnknownSubcommandSuggestion(analysis invocationAnalysis) {
@@ -189,12 +182,16 @@ func printUnknownSubcommandSuggestion(analysis invocationAnalysis) {
 	for _, sub := range analysis.command.Subcommands {
 		candidates = append(candidates, sub.Name)
 	}
-	suggestions := suggest.Commands(analysis.unknownToken, candidates)
+	printSuggestions(analysis.unknownToken, candidates, "")
+}
+
+func printSuggestions(input string, candidates []string, prefix string) {
+	suggestions := suggest.Commands(input, candidates)
 	if len(suggestions) == 0 {
 		return
 	}
 	for i, item := range suggestions {
-		suggestions[i] = shared.SanitizeTerminal(item)
+		suggestions[i] = prefix + shared.SanitizeTerminal(item)
 	}
 	fmt.Fprintf(os.Stderr, "Did you mean: %s?\n", strings.Join(suggestions, ", "))
 }

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -69,23 +69,6 @@ func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 	return invocationAnalysis{command: current, shape: shapeForCommand(current, sawFlag)}
 }
 
-func rejectUnexpectedHybridArgs(command *ffcli.Command) {
-	for _, subcommand := range command.Subcommands {
-		rejectUnexpectedHybridArgs(subcommand)
-		if subcommand.Exec == nil || len(subcommand.Subcommands) == 0 {
-			continue
-		}
-
-		exec := subcommand.Exec
-		subcommand.Exec = func(ctx context.Context, args []string) error {
-			if len(args) > 0 {
-				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
-			}
-			return exec(ctx, args)
-		}
-	}
-}
-
 func shapeForCommand(command *ffcli.Command, sawFlag bool) telemetry.InvocationShape {
 	if command == nil || len(command.Subcommands) == 0 {
 		return telemetry.InvocationShapeLeaf

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -38,6 +38,13 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 			wantKind:  telemetry.ErrorKindAPI5xx,
 			wantStage: telemetry.FailureStageRequest,
 		},
+		{
+			name:      "API server failure at upper exit code boundary",
+			err:       errors.New("server failure"),
+			exitCode:  HTTPStatusToExitCode(599),
+			wantKind:  telemetry.ErrorKindAPI5xx,
+			wantStage: telemetry.FailureStageRequest,
+		},
 	}
 
 	for _, test := range tests {
@@ -47,6 +54,16 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 				t.Fatalf("runtimeFailureContext() = %+v, want kind=%q stage=%q", got, test.wantKind, test.wantStage)
 			}
 		})
+	}
+}
+
+func TestAnalyzeInvocationPreservesRawTokens(t *testing.T) {
+	root := RootCommand("1.0.0")
+
+	got := analyzeInvocation(root, []string{" builds "})
+
+	if got.command != root || got.shape != telemetry.InvocationShapeUnknownChild || got.unknownToken != " builds " {
+		t.Fatalf("analyzeInvocation() = %+v, want root unknown child with raw token", got)
 	}
 }
 

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -49,3 +49,11 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFailureContextClassifiesUnknownChildAsOther(t *testing.T) {
+	got := parseFailureContext(invocationAnalysis{shape: telemetry.InvocationShapeUnknownChild})
+
+	if got.ErrorKind != telemetry.ErrorKindOther || got.FailureStage != telemetry.FailureStageParse {
+		t.Fatalf("parseFailureContext() = %+v, want kind=%q stage=%q", got, telemetry.ErrorKindOther, telemetry.FailureStageParse)
+	}
+}

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+)
+
+func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
+	analysis := invocationAnalysis{shape: telemetry.InvocationShapeLeaf}
+	tests := []struct {
+		name      string
+		err       error
+		exitCode  int
+		wantKind  telemetry.ErrorKind
+		wantStage telemetry.FailureStage
+	}{
+		{
+			name:      "missing auth is local validation",
+			err:       shared.ErrMissingAuth,
+			exitCode:  ExitAuth,
+			wantKind:  telemetry.ErrorKindOther,
+			wantStage: telemetry.FailureStageValidation,
+		},
+		{
+			name:      "API conflict",
+			err:       errors.New("conflict"),
+			exitCode:  ExitConflict,
+			wantKind:  telemetry.ErrorKindAPIConflict,
+			wantStage: telemetry.FailureStageRequest,
+		},
+		{
+			name:      "API server failure",
+			err:       errors.New("server failure"),
+			exitCode:  ExitHTTPInternalServer,
+			wantKind:  telemetry.ErrorKindAPI5xx,
+			wantStage: telemetry.FailureStageRequest,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := runtimeFailureContext(analysis, test.err, test.exitCode)
+			if got.ErrorKind != test.wantKind || got.FailureStage != test.wantStage {
+				t.Fatalf("runtimeFailureContext() = %+v, want kind=%q stage=%q", got, test.wantKind, test.wantStage)
+			}
+		})
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -94,6 +94,13 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	commandName := getCommandName(root, args)
+	if shouldRejectUnknownChild(root, analysis, commandName) {
+		runErr := shared.UsageErrorf("unexpected argument(s): %s", shared.SanitizeTerminal(analysis.unknownToken))
+		fmt.Fprint(os.Stderr, analysis.command.UsageFunc(analysis.command))
+		printUnknownSubcommandSuggestion(analysis)
+		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, runErr))
+		return ExitUsage
+	}
 
 	runUsageOutput := &bytes.Buffer{}
 	restoreRunUsageOutput := redirectCommandFlagOutput(analysis.command, runUsageOutput)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -105,28 +105,28 @@ func Run(args []string, versionInfo string) int {
 	if shouldCancelRunContextAfterError(runErr) {
 		stopSignals()
 	}
-	if shouldRenderGroupHelp(analysis, runErr) {
+	renderGroupHelp := shouldRenderGroupHelp(analysis, runErr)
+	if renderGroupHelp {
 		fmt.Fprint(os.Stdout, runUsageOutput.String())
-		emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, telemetry.EventContext{
-			InvocationShape: analysis.shape,
-		})
-		return ExitSuccess
-	}
-	if runUsageOutput.Len() > 0 {
+	} else if runUsageOutput.Len() > 0 {
 		fmt.Fprint(os.Stderr, runUsageOutput.String())
 	}
 
-	if shouldRunSkillsUpdateCheck(commandName, runCtx, runErr) {
+	if !renderGroupHelp && shouldRunSkillsUpdateCheck(commandName, runCtx, runErr) {
 		maybeCheckForSkillUpdates(runCtx)
 	}
 
 	// Write JUnit report if requested
 	if shared.ReportFormat() == shared.ReportFormatJUnit && shared.ReportFile() != "" {
-		reportErr := writeJUnitReport(commandName, runErr, elapsed)
+		reportRunErr := runErr
+		if renderGroupHelp {
+			reportRunErr = nil
+		}
+		reportErr := writeJUnitReport(commandName, reportRunErr, elapsed)
 		if reportErr != nil {
 			// Report write failure is a hard error - CI depends on it
 			fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", reportErr)
-			if runErr == nil {
+			if reportRunErr == nil {
 				emitTelemetry(commandName, versionInfo, elapsed, ExitError, telemetry.EventContext{
 					InvocationShape: analysis.shape,
 					ErrorKind:       telemetry.ErrorKindOther,
@@ -135,6 +135,13 @@ func Run(args []string, versionInfo string) int {
 				return ExitError
 			}
 		}
+	}
+
+	if renderGroupHelp {
+		emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, telemetry.EventContext{
+			InvocationShape: analysis.shape,
+		})
+		return ExitSuccess
 	}
 
 	if runErr != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,6 +38,7 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	root := RootCommand(versionInfo)
+	rejectUnexpectedHybridArgs(root)
 	analysis := analyzeInvocation(root, args)
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
@@ -155,6 +156,7 @@ func Run(args []string, versionInfo string) int {
 			emitTelemetry(commandName, versionInfo, elapsed, ExitUsage, validationFailureContext(analysis, runErr))
 			return ExitUsage
 		}
+		printUnknownSubcommandSuggestion(analysis)
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(runErr))
 		exitCode := ExitCodeFromError(runErr)
 		emitTelemetry(commandName, versionInfo, elapsed, exitCode, runtimeFailureContext(analysis, runErr, exitCode))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,7 +38,6 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	root := RootCommand(versionInfo)
-	rejectUnexpectedHybridArgs(root)
 	analysis := analyzeInvocation(root, args)
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	maybeCheckForSkillUpdates = install.MaybeCheckForSkillUpdates
-	emitTelemetry             = telemetry.Emit
+	emitTelemetry             = telemetry.EmitWithContext
 )
 
 // Run executes the CLI using the provided args (not including argv[0]) and version string.
@@ -38,6 +38,7 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	root := RootCommand(versionInfo)
+	analysis := analyzeInvocation(root, args)
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
 
@@ -50,7 +51,9 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 		}
 		if errors.Is(parseErr, flag.ErrHelp) {
-			emitImmediateTelemetry(args, root, versionInfo, ExitSuccess)
+			emitImmediateTelemetry(args, root, versionInfo, ExitSuccess, telemetry.EventContext{
+				InvocationShape: analysis.shape,
+			})
 			return ExitSuccess
 		}
 		if parseOutput.Len() == 0 {
@@ -60,14 +63,15 @@ func Run(args []string, versionInfo string) int {
 		if parseOutput.Len() > 0 {
 			exitCode = ExitUsage
 		}
-		emitImmediateTelemetry(args, root, versionInfo, exitCode)
+		printUnknownFlagSuggestion(analysis)
+		emitImmediateTelemetry(args, root, versionInfo, exitCode, parseFailureContext(analysis))
 		return exitCode
 	}
 
 	// Validate CI report flags after parsing
 	if err := shared.ValidateReportFlags(); err != nil {
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
-		emitImmediateTelemetry(args, root, versionInfo, ExitUsage)
+		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, err))
 		return ExitUsage
 	}
 
@@ -91,12 +95,25 @@ func Run(args []string, versionInfo string) int {
 
 	commandName := getCommandName(root, args)
 
+	runUsageOutput := &bytes.Buffer{}
+	restoreRunUsageOutput := redirectCommandFlagOutput(analysis.command, runUsageOutput)
 	start := time.Now()
 	runErr := root.Run(runCtx)
 	elapsed := time.Since(start)
+	restoreRunUsageOutput()
 
 	if shouldCancelRunContextAfterError(runErr) {
 		stopSignals()
+	}
+	if shouldRenderGroupHelp(analysis, runErr) {
+		fmt.Fprint(os.Stdout, runUsageOutput.String())
+		emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, telemetry.EventContext{
+			InvocationShape: analysis.shape,
+		})
+		return ExitSuccess
+	}
+	if runUsageOutput.Len() > 0 {
+		fmt.Fprint(os.Stderr, runUsageOutput.String())
 	}
 
 	if shouldRunSkillsUpdateCheck(commandName, runCtx, runErr) {
@@ -110,7 +127,11 @@ func Run(args []string, versionInfo string) int {
 			// Report write failure is a hard error - CI depends on it
 			fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", reportErr)
 			if runErr == nil {
-				emitTelemetry(commandName, versionInfo, elapsed, ExitError)
+				emitTelemetry(commandName, versionInfo, elapsed, ExitError, telemetry.EventContext{
+					InvocationShape: analysis.shape,
+					ErrorKind:       telemetry.ErrorKindOther,
+					FailureStage:    telemetry.FailureStageExecution,
+				})
 				return ExitError
 			}
 		}
@@ -119,25 +140,43 @@ func Run(args []string, versionInfo string) int {
 	if runErr != nil {
 		if _, ok := errors.AsType[shared.ReportedError](runErr); ok {
 			exitCode := ExitCodeFromError(runErr)
-			emitTelemetry(commandName, versionInfo, elapsed, exitCode)
+			emitTelemetry(commandName, versionInfo, elapsed, exitCode, runtimeFailureContext(analysis, runErr, exitCode))
 			return exitCode
 		}
 		if errors.Is(runErr, flag.ErrHelp) {
-			emitTelemetry(commandName, versionInfo, elapsed, ExitUsage)
+			printUnknownSubcommandSuggestion(analysis)
+			emitTelemetry(commandName, versionInfo, elapsed, ExitUsage, validationFailureContext(analysis, runErr))
 			return ExitUsage
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(runErr))
 		exitCode := ExitCodeFromError(runErr)
-		emitTelemetry(commandName, versionInfo, elapsed, exitCode)
+		emitTelemetry(commandName, versionInfo, elapsed, exitCode, runtimeFailureContext(analysis, runErr, exitCode))
 		return exitCode
 	}
 
-	emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess)
+	emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, telemetry.EventContext{
+		InvocationShape: analysis.shape,
+	})
 	return ExitSuccess
 }
 
-func emitImmediateTelemetry(args []string, root *ffcli.Command, versionInfo string, exitCode int) {
-	emitTelemetry(getCommandName(root, args), versionInfo, 0, exitCode)
+func redirectCommandFlagOutput(command *ffcli.Command, output io.Writer) func() {
+	if command == nil || command.FlagSet == nil {
+		return func() {}
+	}
+	original := command.FlagSet.Output()
+	command.FlagSet.SetOutput(output)
+	return func() { command.FlagSet.SetOutput(original) }
+}
+
+func emitImmediateTelemetry(
+	args []string,
+	root *ffcli.Command,
+	versionInfo string,
+	exitCode int,
+	eventContext telemetry.EventContext,
+) {
+	emitTelemetry(getCommandName(root, args), versionInfo, 0, exitCode, eventContext)
 }
 
 func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buffer) func() {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -255,20 +255,34 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 }
 
 func TestRun_ReviewsMissingRequiredFlagsReturnsUsage(t *testing.T) {
-	resetReportFlags(t)
-	t.Setenv("ASC_APP_ID", "")
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
-	stdout, stderr := captureCommandOutput(t, func() {
-		if code := Run([]string{"reviews"}, "1.0.0"); code != ExitUsage {
-			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
-		}
-	})
+	for _, args := range [][]string{{"reviews"}, {"reviews", "list"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			resetReportFlags(t)
+			t.Setenv("ASC_APP_ID", "")
+			var gotContext telemetry.EventContext
+			emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+				gotContext = eventContext
+			}
 
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if !strings.Contains(stderr, "--app is required") {
-		t.Fatalf("expected missing app error, got %q", stderr)
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "--app is required") {
+				t.Fatalf("expected missing app error, got %q", stderr)
+			}
+			if gotContext.ErrorKind != telemetry.ErrorKindMissingRequired || gotContext.FailureStage != telemetry.FailureStageValidation {
+				t.Fatalf("unexpected telemetry context: %+v", gotContext)
+			}
+		})
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
 
 func TestRun_VersionFlag(t *testing.T) {
@@ -67,7 +68,7 @@ func TestRun_ReportFlagValidationErrorEmitsTelemetry(t *testing.T) {
 	var commandName string
 	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(command, _ string, elapsed time.Duration, code int) {
+	emitTelemetry = func(command, _ string, elapsed time.Duration, code int, _ telemetry.EventContext) {
 		calls++
 		commandName = command
 		duration = elapsed
@@ -101,7 +102,7 @@ func TestRun_ParseErrorEmitsTelemetry(t *testing.T) {
 	var commandName string
 	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(command, _ string, elapsed time.Duration, code int) {
+	emitTelemetry = func(command, _ string, elapsed time.Duration, code int, _ telemetry.EventContext) {
 		calls++
 		commandName = command
 		duration = elapsed
@@ -156,6 +157,105 @@ func TestRun_UnknownCommandReturnsUsage(t *testing.T) {
 	code := Run([]string{"unknown-command"}, "1.0.0")
 	if code != ExitUsage {
 		t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"builds"}, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
+		}
+	})
+
+	if !strings.Contains(stdout, "asc builds list") {
+		t.Fatalf("expected builds help on stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if gotContext.InvocationShape != telemetry.InvocationShapeBareGroup {
+		t.Fatalf("InvocationShape = %q, want %q", gotContext.InvocationShape, telemetry.InvocationShapeBareGroup)
+	}
+	if gotContext.ErrorKind != "" || gotContext.FailureStage != "" {
+		t.Fatalf("successful help should not carry failure context: %+v", gotContext)
+	}
+}
+
+func TestRun_UnknownNestedSubcommandSuggestsRealSubcommand(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "lsit"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Did you mean: list") {
+		t.Fatalf("expected list suggestion, got %q", stderr)
+	}
+}
+
+func TestRun_UnknownFlagSuggestsRealFlagAndEmitsContext(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"versions", "attach-build", "--version-id", "VERSION_ID", "--build-id", "BUILD_ID"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Did you mean: --build") {
+		t.Fatalf("expected --build suggestion, got %q", stderr)
+	}
+	if gotContext.InvocationShape != telemetry.InvocationShapeLeaf ||
+		gotContext.ErrorKind != telemetry.ErrorKindUnknownFlag ||
+		gotContext.FailureStage != telemetry.FailureStageParse {
+		t.Fatalf("unexpected telemetry context: %+v", gotContext)
+	}
+}
+
+func TestRun_UnknownGroupFlagIsNotClassifiedAsBareGroup(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
+
+	captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "--definitely-invalid"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if gotContext.InvocationShape != telemetry.InvocationShapeGroupWithFlags ||
+		gotContext.ErrorKind != telemetry.ErrorKindUnknownFlag ||
+		gotContext.FailureStage != telemetry.FailureStageParse {
+		t.Fatalf("unexpected telemetry context: %+v", gotContext)
 	}
 }
 
@@ -440,7 +540,7 @@ func TestRun_HelpEmitsTelemetry(t *testing.T) {
 	var commandName string
 	var duration time.Duration
 	var exitCode int
-	emitTelemetry = func(command, _ string, elapsed time.Duration, code int) {
+	emitTelemetry = func(command, _ string, elapsed time.Duration, code int, _ telemetry.EventContext) {
 		commandName = command
 		duration = elapsed
 		exitCode = code
@@ -451,6 +551,7 @@ func TestRun_HelpEmitsTelemetry(t *testing.T) {
 		RootCommand("1.0.0"),
 		"1.0.0",
 		ExitSuccess,
+		telemetry.EventContext{InvocationShape: telemetry.InvocationShapeGroupWithFlags},
 	)
 	if commandName != "asc builds" {
 		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -331,6 +331,39 @@ func TestRun_UnknownHybridSubcommandReturnsUsageBeforeAuth(t *testing.T) {
 	}
 }
 
+func TestRun_RemovedSubcommandsPreserveMigrationGuidance(t *testing.T) {
+	resetReportFlags(t)
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "normalized get", args: []string{"builds", "app", "get"}, wantStderr: "Use `asc builds app view` instead."},
+		{name: "normalized set", args: []string{"age-rating", "set"}, wantStderr: "Use `asc age-rating edit` instead."},
+		{name: "apps create", args: []string{"apps", "create"}, wantStderr: "Use `asc web apps create` instead."},
+		{name: "submit create", args: []string{"submit", "create"}, wantStderr: "Use `asc review submit`"},
+		{name: "submit preflight", args: []string{"submit", "preflight"}, wantStderr: "Use `asc validate` instead."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Fatalf("expected migration guidance %q, got %q", test.wantStderr, stderr)
+			}
+		})
+	}
+}
+
 func TestRun_SnitchPreservesPositionalDescription(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("GITHUB_TOKEN", "")

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -254,12 +254,20 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	}
 }
 
-func TestRun_ReviewsMissingRequiredFlagsReturnsUsage(t *testing.T) {
+func TestRun_MissingRequiredFlagsEmitContext(t *testing.T) {
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
-	for _, args := range [][]string{{"reviews"}, {"reviews", "list"}} {
-		t.Run(strings.Join(args, " "), func(t *testing.T) {
+	tests := []struct {
+		args       []string
+		wantStderr string
+	}{
+		{args: []string{"reviews"}, wantStderr: "--app is required"},
+		{args: []string{"reviews", "list"}, wantStderr: "--app is required"},
+		{args: []string{"screenshots", "plan", "--version", "1.0"}, wantStderr: "--app is required"},
+	}
+	for _, test := range tests {
+		t.Run(strings.Join(test.args, " "), func(t *testing.T) {
 			resetReportFlags(t)
 			t.Setenv("ASC_APP_ID", "")
 			var gotContext telemetry.EventContext
@@ -268,7 +276,7 @@ func TestRun_ReviewsMissingRequiredFlagsReturnsUsage(t *testing.T) {
 			}
 
 			stdout, stderr := captureCommandOutput(t, func() {
-				if code := Run(args, "1.0.0"); code != ExitUsage {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
 					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
 				}
 			})
@@ -276,8 +284,8 @@ func TestRun_ReviewsMissingRequiredFlagsReturnsUsage(t *testing.T) {
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if !strings.Contains(stderr, "--app is required") {
-				t.Fatalf("expected missing app error, got %q", stderr)
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Fatalf("expected %q, got %q", test.wantStderr, stderr)
 			}
 			if gotContext.ErrorKind != telemetry.ErrorKindMissingRequired || gotContext.FailureStage != telemetry.FailureStageValidation {
 				t.Fatalf("unexpected telemetry context: %+v", gotContext)

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -303,20 +303,31 @@ func TestRun_UnknownHybridSubcommandReturnsUsageBeforeAuth(t *testing.T) {
 	t.Setenv("ASC_PRIVATE_KEY_B64", "")
 	t.Setenv("ASC_STRICT_AUTH", "")
 
-	stdout, stderr := captureCommandOutput(t, func() {
-		if code := Run([]string{"reviews", "lsti", "--app", "APP_ID"}, "1.0.0"); code != ExitUsage {
-			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
-		}
-	})
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "reviews", args: []string{"reviews", "lsti", "--app", "APP_ID"}},
+		{name: "xcode cloud workflows", args: []string{"xcode-cloud", "workflows", "lsti", "--app", "APP_ID"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
 
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if !strings.Contains(stderr, "SUBCOMMANDS") {
-		t.Fatalf("expected reviews help, got %q", stderr)
-	}
-	if strings.Contains(stderr, "missing authentication") {
-		t.Fatalf("expected unknown child validation before auth resolution, got %q", stderr)
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "SUBCOMMANDS") {
+				t.Fatalf("expected command help, got %q", stderr)
+			}
+			if strings.Contains(stderr, "missing authentication") {
+				t.Fatalf("expected unknown child validation before auth resolution, got %q", stderr)
+			}
+		})
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -279,6 +279,37 @@ func TestRun_UnknownNestedSubcommandSuggestsRealSubcommand(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownHybridSubcommandReturnsUsageBeforeAuth(t *testing.T) {
+	resetReportFlags(t)
+
+	tempDir := t.TempDir()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(tempDir, "missing.json"))
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"reviews", "lsti", "--app", "APP_ID"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "SUBCOMMANDS") {
+		t.Fatalf("expected reviews help, got %q", stderr)
+	}
+	if strings.Contains(stderr, "missing authentication") {
+		t.Fatalf("expected unknown child validation before auth resolution, got %q", stderr)
+	}
+}
+
 func TestRun_UnknownFlagSuggestsRealFlagAndEmitsContext(t *testing.T) {
 	resetReportFlags(t)
 	originalEmitTelemetry := emitTelemetry

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -190,6 +190,42 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	}
 }
 
+func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
+	resetReportFlags(t)
+	t.Setenv("ASC_APP_ID", "")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"validate"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--version or --version-id is required") {
+		t.Fatalf("expected missing version error, got %q", stderr)
+	}
+}
+
+func TestRun_ReviewsMissingRequiredFlagsReturnsUsage(t *testing.T) {
+	resetReportFlags(t)
+	t.Setenv("ASC_APP_ID", "")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"reviews"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--app is required") {
+		t.Fatalf("expected missing app error, got %q", stderr)
+	}
+}
+
 func TestRun_UnknownNestedSubcommandSuggestsRealSubcommand(t *testing.T) {
 	resetReportFlags(t)
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -190,6 +190,42 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	}
 }
 
+func TestRun_BareGroupWritesJUnitReport(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "junit.xml")
+
+	captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--report", "junit",
+			"--report-file", reportPath,
+			"builds",
+		}, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
+		}
+	})
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+
+	var suite struct {
+		Failures  int `xml:"failures,attr"`
+		TestCases []struct {
+			Name string `xml:"name,attr"`
+		} `xml:"testcase"`
+	}
+	if err := xml.Unmarshal(data, &suite); err != nil {
+		t.Fatalf("xml.Unmarshal() error: %v", err)
+	}
+	if suite.Failures != 0 {
+		t.Fatalf("failures = %d, want 0", suite.Failures)
+	}
+	if len(suite.TestCases) != 1 || suite.TestCases[0].Name != "asc builds" {
+		t.Fatalf("unexpected testcase payload: %+v", suite.TestCases)
+	}
+}
+
 func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("ASC_APP_ID", "")

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -229,6 +229,13 @@ func TestRun_BareGroupWritesJUnitReport(t *testing.T) {
 func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("ASC_APP_ID", "")
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
 
 	stdout, stderr := captureCommandOutput(t, func() {
 		if code := Run([]string{"validate"}, "1.0.0"); code != ExitUsage {
@@ -241,6 +248,9 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "--version or --version-id is required") {
 		t.Fatalf("expected missing version error, got %q", stderr)
+	}
+	if gotContext.ErrorKind != telemetry.ErrorKindMissingRequired || gotContext.FailureStage != telemetry.FailureStageValidation {
+		t.Fatalf("unexpected telemetry context: %+v", gotContext)
 	}
 }
 
@@ -307,6 +317,22 @@ func TestRun_UnknownHybridSubcommandReturnsUsageBeforeAuth(t *testing.T) {
 	}
 	if strings.Contains(stderr, "missing authentication") {
 		t.Fatalf("expected unknown child validation before auth resolution, got %q", stderr)
+	}
+}
+
+func TestRun_SnitchPreservesPositionalDescription(t *testing.T) {
+	resetReportFlags(t)
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	_, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"snitch", "--dry-run", "status command needs bundle ID support"}, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
+		}
+	})
+
+	if !strings.Contains(stderr, "status command needs bundle ID support") {
+		t.Fatalf("expected snitch preview to preserve description, got %q", stderr)
 	}
 }
 

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -17,7 +17,7 @@ Rork sandboxes, Rork GitHub workflows, and explicitly ephemeral environments;
 events from those disposable runtimes omit the durable local install ID. Use
 `asc telemetry disable`, `ASC_TELEMETRY_DISABLED`, or `DO_NOT_TRACK` to opt out.
 
-The CLI payload does **not** include raw arguments, Apple account identifiers,
+The CLI payload does **not** include raw arguments, stderr, error messages, Apple account identifiers,
 team IDs, issuer IDs, key IDs, app IDs, bundle IDs, usernames, hostnames,
 repository names, IP addresses, user-agent strings, or file paths. As with any
 HTTPS service, the collector's edge provider sees the connection address; the
@@ -88,7 +88,7 @@ The CLI sends a single best-effort JSON event after command completion:
 ```json
 {
   "event_id": "2d2f86dd-6d75-4a6f-b97f-a6ce15d4bc79",
-  "schema_version": 1,
+  "schema_version": 2,
   "asc_version": "1.13.0",
   "os": "darwin",
   "arch": "arm64",
@@ -101,7 +101,10 @@ The CLI sends a single best-effort JSON event after command completion:
   "runtime_context": "local",
   "invocation_source": "codex_desktop",
   "install_id": "5fd9bf39-2e0d-45c1-8e4a-b65a58159ed7",
-  "session_id": "ac8062e3-e6d2-4301-8d08-bb444cd55004"
+  "session_id": "ac8062e3-e6d2-4301-8d08-bb444cd55004",
+  "invocation_shape": "leaf",
+  "error_kind": null,
+  "failure_stage": null
 }
 ```
 
@@ -109,6 +112,12 @@ Raw command arguments never enter event construction. `command_path` comes only
 from the CLI's registered command tree, so flag values and positional values
 cannot become telemetry dimensions. `session_id` is reused only within one CLI
 process and changes the next time `asc` starts.
+
+`invocation_shape` is one of `leaf`, `bare_group`, `group_with_flags`, or
+`unknown_child`. Failed schema-v2 events also include an allowlisted
+`error_kind` and `failure_stage`; successful events set both fields to `null`.
+These fields are derived inside the CLI and never contain stderr, error text,
+flag values, or positional values.
 
 `runtime_context` describes where the command runs, independently from
 `invocation_source`, which describes what launched it. A command launched by
@@ -164,6 +173,9 @@ CREATE TABLE asc_cli_events
   invocation_source LowCardinality(String),
   install_id Nullable(UUID),
   session_id UUID,
+  invocation_shape Nullable(LowCardinality(String)),
+  error_kind Nullable(LowCardinality(String)),
+  failure_stage Nullable(LowCardinality(String)),
   source LowCardinality(String),
   collector_version LowCardinality(String)
 )

--- a/internal/cli/accessibility/accessibility.go
+++ b/internal/cli/accessibility/accessibility.go
@@ -97,7 +97,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -166,7 +166,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeAccessibilityDeclarationFields(*fields)
@@ -224,13 +224,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			deviceFamilyValue := strings.TrimSpace(*deviceFamily)
 			if deviceFamilyValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --device-family is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedDeviceFamily, err := normalizeAccessibilityDeviceFamily(deviceFamilyValue)
@@ -303,7 +303,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs, err := buildAccessibilityDeclarationUpdateAttributes(map[string]string{
@@ -366,11 +366,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/actors/actors.go
+++ b/internal/cli/actors/actors.go
@@ -70,7 +70,7 @@ Examples:
 			}
 			if strings.TrimSpace(*ids) == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeActorFields(*fields)
@@ -145,7 +145,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeActorFields(*fields)

--- a/internal/cli/ads/api.go
+++ b/internal/cli/ads/api.go
@@ -72,7 +72,7 @@ Examples:
 			pathValue := strings.TrimSpace(*path)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if methodValue == http.MethodDelete && !*confirm {
 				return shared.UsageError("--confirm is required")

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -80,23 +80,23 @@ Examples:
 			}
 			if strings.TrimSpace(*name) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*clientID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --client-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*teamID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --team-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*keyID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --key-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*privateKey) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --private-key is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *skipValidation && *network {
 				return shared.UsageError("--skip-validation and --network are mutually exclusive")
@@ -666,7 +666,7 @@ Examples:
 			}
 			if strings.TrimSpace(*name) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := appleads.SetDefaultCredentials(*name); err != nil {
 				return fmt.Errorf("ads auth switch: %w", err)

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -405,7 +405,7 @@ func readBody(spec appleads.EndpointSpec, flags endpointFlagValues) (json.RawMes
 	fileValue := value(flags.file)
 	if fileValue == "" {
 		fmt.Fprintln(os.Stderr, "Error: --file is required")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 	kind := shared.JSONPayloadObject
 	if spec.BodyKind == appleads.BodyArray {

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -110,7 +110,7 @@ Examples:
 			}
 			if appInfoValue == "" && versionValue == "" && appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -208,7 +208,7 @@ Examples:
 				}
 				if appInfoValue == "" && versionValue == "" && appValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id or --app is required (or set ASC_APP_ID)")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 

--- a/internal/cli/agreements/agreements.go
+++ b/internal/cli/agreements/agreements.go
@@ -85,7 +85,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("agreements territories list: --limit must be between 1 and 200")
@@ -117,7 +117,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithEndUserLicenseAgreementTerritoriesLimit(200))
 				firstPage, err := client.GetEndUserLicenseAgreementTerritories(requestCtx, idValue, paginateOpts...)

--- a/internal/cli/alternativedistribution/alternative_distribution_domains.go
+++ b/internal/cli/alternativedistribution/alternative_distribution_domains.go
@@ -132,7 +132,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*domainID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --domain-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -175,13 +175,13 @@ Examples:
 			domainValue := strings.TrimSpace(*domain)
 			if domainValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --domain is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			referenceValue := strings.TrimSpace(*referenceName)
 			if referenceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -224,11 +224,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*domainID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --domain-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/alternativedistribution/alternative_distribution_keys.go
+++ b/internal/cli/alternativedistribution/alternative_distribution_keys.go
@@ -134,7 +134,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*keyID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --key-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -179,7 +179,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			keyValue := strings.TrimSpace(*publicKey)
@@ -189,7 +189,7 @@ Examples:
 			}
 			if keyValue == "" && keyPath == "" {
 				fmt.Fprintln(os.Stderr, "Error: --public-key or --public-key-path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if keyValue == "" && keyPath != "" {
 				var err error
@@ -239,11 +239,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*keyID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --key-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -289,7 +289,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/alternativedistribution/alternative_distribution_package_versions.go
+++ b/internal/cli/alternativedistribution/alternative_distribution_package_versions.go
@@ -67,7 +67,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*packageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --package-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > alternativeDistributionMaxLimit) {
 				return fmt.Errorf("alternative-distribution packages versions list: --limit must be between 1 and %d", alternativeDistributionMaxLimit)
@@ -137,7 +137,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -183,7 +183,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > alternativeDistributionMaxLimit) {
 				return fmt.Errorf("alternative-distribution packages versions deltas: --limit must be between 1 and %d", alternativeDistributionMaxLimit)
@@ -257,7 +257,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > alternativeDistributionMaxLimit) {
 				return fmt.Errorf("alternative-distribution packages versions variants: --limit must be between 1 and %d", alternativeDistributionMaxLimit)

--- a/internal/cli/alternativedistribution/alternative_distribution_packages.go
+++ b/internal/cli/alternativedistribution/alternative_distribution_packages.go
@@ -68,7 +68,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*packageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --package-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -110,7 +110,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*appStoreVersionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-store-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -152,7 +152,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*appStoreVersionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-store-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -194,7 +194,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*variantID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --variant-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -236,7 +236,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*deltaID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --delta-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/analytics/analytics_instances.go
+++ b/internal/cli/analytics/analytics_instances.go
@@ -59,7 +59,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*instanceID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -117,7 +117,7 @@ Examples:
 			}
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/analytics/analytics_reports.go
+++ b/internal/cli/analytics/analytics_reports.go
@@ -59,7 +59,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*reportID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --report-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -112,7 +112,7 @@ Examples:
 			id := strings.TrimSpace(*reportID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --report-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -40,11 +40,11 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*accessType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --access-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedAccessType, err := normalizeAnalyticsAccessType(*accessType)
 			if err != nil {
@@ -144,7 +144,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" && strings.TrimSpace(*requestID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -318,14 +318,14 @@ Examples:
 			id := strings.TrimSpace(*requestID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --request-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := validateUUIDFlag("--request-id", id); err != nil {
 				return fmt.Errorf("analytics requests delete: %w", err)
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -379,7 +379,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*requestID) == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --request-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*requestID) != "" {
 				if err := validateUUIDFlag("--request-id", *requestID); err != nil {
@@ -528,11 +528,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*requestID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --request-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*instanceID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := validateUUIDFlag("--request-id", *requestID); err != nil {
 				return fmt.Errorf("analytics download: %w", err)

--- a/internal/cli/analytics/analytics_sales.go
+++ b/internal/cli/analytics/analytics_sales.go
@@ -45,23 +45,23 @@ Examples:
 			vendorNumber := shared.ResolveVendorNumber(*vendor)
 			if vendorNumber == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor is required (or set ASC_VENDOR_NUMBER/ASC_ANALYTICS_VENDOR_NUMBER)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*reportType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*reportSubType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subtype is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*frequency) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --frequency is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*date) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --date is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			salesType, err := normalizeSalesReportType(*reportType)

--- a/internal/cli/analytics/analytics_segments.go
+++ b/internal/cli/analytics/analytics_segments.go
@@ -54,7 +54,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*segmentID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --segment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/androidiosmapping/android_ios_mapping.go
+++ b/internal/cli/androidiosmapping/android_ios_mapping.go
@@ -70,7 +70,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("android-ios-mapping list: --limit must be between 1 and 200")
@@ -145,7 +145,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*id) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --mapping-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			fieldValues, err := normalizeAndroidIosMappingFields(*fields)
 			if err != nil {
@@ -196,17 +196,17 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			packageValue := strings.TrimSpace(*packageName)
 			if packageValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --android-package-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			fingerprintValues := shared.SplitCSV(*fingerprints)
 			if len(fingerprintValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --fingerprints is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -258,7 +258,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --mapping-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			seen := map[string]bool{}
@@ -337,11 +337,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --mapping-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -84,7 +84,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appEventsClientFactory()
@@ -147,7 +147,7 @@ Examples:
 			id := strings.TrimSpace(*eventID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appEventsClientFactory()
@@ -202,13 +202,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedBadge, err := normalizeAppEventBadge(*eventType, true)
@@ -343,7 +343,7 @@ Examples:
 			id := strings.TrimSpace(*eventID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var (
@@ -432,7 +432,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appEventsClientFactory()
@@ -475,11 +475,11 @@ Examples:
 			id := strings.TrimSpace(*eventID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appEventsClientFactory()

--- a/internal/cli/app_events/localization_media.go
+++ b/internal/cli/app_events/localization_media.go
@@ -68,7 +68,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -166,7 +166,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -241,7 +241,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -316,7 +316,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/app_events/localizations.go
+++ b/internal/cli/app_events/localizations.go
@@ -71,7 +71,7 @@ Examples:
 			id := strings.TrimSpace(*eventID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("app-events localizations list: --limit must be between 1 and 200")
@@ -141,7 +141,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -188,13 +188,13 @@ Examples:
 			id := strings.TrimSpace(*eventID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.AppEventLocalizationCreateAttributes{
@@ -247,7 +247,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var (
@@ -273,7 +273,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -316,11 +316,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/app_events/relationships.go
+++ b/internal/cli/app_events/relationships.go
@@ -45,7 +45,7 @@ Examples:
 			id := strings.TrimSpace(*eventID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/app_events/screenshots.go
+++ b/internal/cli/app_events/screenshots.go
@@ -76,7 +76,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedNext == "" && strings.TrimSpace(*localizationID) == "" && strings.TrimSpace(*eventID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -159,7 +159,7 @@ Examples:
 			}
 			if strings.TrimSpace(*next) == "" && strings.TrimSpace(*localizationID) == "" && strings.TrimSpace(*eventID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -232,7 +232,7 @@ Examples:
 			id := strings.TrimSpace(*screenshotID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -279,11 +279,11 @@ Examples:
 			pathValue := strings.TrimSpace(*path)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*localizationID) == "" && strings.TrimSpace(*eventID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedAssetType, err := normalizeAppEventAssetType(*assetType)
@@ -364,11 +364,11 @@ Examples:
 			id := strings.TrimSpace(*screenshotID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/app_events/submit.go
+++ b/internal/cli/app_events/submit.go
@@ -37,19 +37,19 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to submit for review")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			id := strings.TrimSpace(*eventID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)

--- a/internal/cli/app_events/video_clips.go
+++ b/internal/cli/app_events/video_clips.go
@@ -76,7 +76,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedNext == "" && strings.TrimSpace(*localizationID) == "" && strings.TrimSpace(*eventID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -159,7 +159,7 @@ Examples:
 			}
 			if strings.TrimSpace(*next) == "" && strings.TrimSpace(*localizationID) == "" && strings.TrimSpace(*eventID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -232,7 +232,7 @@ Examples:
 			id := strings.TrimSpace(*clipID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -280,11 +280,11 @@ Examples:
 			pathValue := strings.TrimSpace(*path)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*localizationID) == "" && strings.TrimSpace(*eventID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --event-id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedAssetType, err := normalizeAppEventAssetType(*assetType)
@@ -369,11 +369,11 @@ Examples:
 			id := strings.TrimSpace(*clipID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/advanced_experience_images.go
+++ b/internal/cli/appclips/advanced_experience_images.go
@@ -61,7 +61,7 @@ Examples:
 			idValue := strings.TrimSpace(*imageID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -107,13 +107,13 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fileValue := strings.TrimSpace(*filePath)
 			if fileValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -161,11 +161,11 @@ Examples:
 			idValue := strings.TrimSpace(*imageID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/advanced_experiences.go
+++ b/internal/cli/appclips/advanced_experiences.go
@@ -82,7 +82,7 @@ Examples:
 			appClipValue := strings.TrimSpace(*appClipID)
 			if appClipValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -157,7 +157,7 @@ Examples:
 			idValue := strings.TrimSpace(*experienceID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -209,12 +209,12 @@ Examples:
 			linkValue := strings.TrimSpace(*link)
 			if linkValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --link is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*defaultLanguage) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --default-language is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			langValue, err := normalizeAppClipLanguage(*defaultLanguage)
@@ -228,7 +228,7 @@ Examples:
 			})
 			if !visited["is-powered-by"] {
 				fmt.Fprintln(os.Stderr, "Error: --is-powered-by is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var actionValue *asc.AppClipAction
@@ -262,11 +262,11 @@ Examples:
 			appValue := strings.TrimSpace(shared.ResolveAppID(*appID))
 			if appClipValue == "" && bundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-clip-id or --bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if appClipValue == "" && appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required with --bundle-id")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			appClipValue, err = resolveAppClipID(requestCtx, client, appValue, appClipValue, bundleValue)
@@ -322,7 +322,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -333,7 +333,7 @@ Examples:
 			hasUpdate := visited["action"] || visited["category"] || visited["default-language"] || visited["is-powered-by"] || visited["removed"] || visited["header-image-id"] || visited["localization-id"] || visited["app-clip-id"]
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var attrs *asc.AppClipAdvancedExperienceUpdateAttributes
@@ -411,11 +411,11 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/app_clips.go
+++ b/internal/cli/appclips/app_clips.go
@@ -84,7 +84,7 @@ Examples:
 			appValue := strings.TrimSpace(shared.ResolveAppID(*appID))
 			if appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -157,7 +157,7 @@ Examples:
 			idValue := strings.TrimSpace(*appClipID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/default_experience_header_image.go
+++ b/internal/cli/appclips/default_experience_header_image.go
@@ -55,7 +55,7 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/default_experience_localizations.go
+++ b/internal/cli/appclips/default_experience_localizations.go
@@ -75,7 +75,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -148,7 +148,7 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -192,13 +192,13 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var subtitleValue *string
@@ -252,7 +252,7 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -262,7 +262,7 @@ Examples:
 
 			if !visited["subtitle"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var attrs *asc.AppClipDefaultExperienceLocalizationUpdateAttributes
@@ -313,11 +313,11 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -363,7 +363,7 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/default_experience_relationships.go
+++ b/internal/cli/appclips/default_experience_relationships.go
@@ -57,7 +57,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -99,7 +99,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/default_experiences.go
+++ b/internal/cli/appclips/default_experiences.go
@@ -80,7 +80,7 @@ Examples:
 			appClipValue := strings.TrimSpace(*appClipID)
 			if appClipValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -153,7 +153,7 @@ Examples:
 			idValue := strings.TrimSpace(*experienceID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			includeValue, err := normalizeAppClipDefaultExperienceInclude(*include)
@@ -203,7 +203,7 @@ Examples:
 			appClipValue := strings.TrimSpace(*appClipID)
 			if appClipValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var attrs *asc.AppClipDefaultExperienceCreateAttributes
@@ -259,7 +259,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -269,7 +269,7 @@ Examples:
 
 			if !visited["action"] && !visited["release-version-id"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var attrs *asc.AppClipDefaultExperienceUpdateAttributes
@@ -323,11 +323,11 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -373,7 +373,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -415,7 +415,7 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/domain_status.go
+++ b/internal/cli/appclips/domain_status.go
@@ -59,7 +59,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -106,7 +106,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/header_images.go
+++ b/internal/cli/appclips/header_images.go
@@ -61,7 +61,7 @@ Examples:
 			idValue := strings.TrimSpace(*imageID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -106,13 +106,13 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fileValue := strings.TrimSpace(*filePath)
 			if fileValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -155,11 +155,11 @@ Examples:
 			idValue := strings.TrimSpace(*imageID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/invocation_localizations.go
+++ b/internal/cli/appclips/invocation_localizations.go
@@ -66,7 +66,7 @@ Examples:
 			invocationValue := strings.TrimSpace(*invocationID)
 			if invocationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --invocation-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -114,19 +114,19 @@ Examples:
 			invocationValue := strings.TrimSpace(*invocationID)
 			if invocationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --invocation-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			titleValue := strings.TrimSpace(*title)
 			if titleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --title is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -174,7 +174,7 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -183,7 +183,7 @@ Examples:
 			})
 			if !visited["title"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			titleValue := strings.TrimSpace(*title)
@@ -229,11 +229,11 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/invocations.go
+++ b/internal/cli/appclips/invocations.go
@@ -76,7 +76,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appClipsClientFactory()
@@ -150,7 +150,7 @@ Examples:
 			invocationValue := strings.TrimSpace(*invocationID)
 			if invocationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --invocation-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appClipsClientFactory()
@@ -199,13 +199,13 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			urlValue := strings.TrimSpace(*url)
 			if urlValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --url is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localizationValues := shared.SplitCSV(*localizationIDs)
@@ -213,11 +213,11 @@ Examples:
 			titleValue := strings.TrimSpace(*title)
 			if titleValue != "" && localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required when --title is set")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if localeValue != "" && titleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --title is required when --locale is set")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			inlineLocalizations := make([]asc.BetaAppClipInvocationLocalizationCreateAttributes, 0, 1)
@@ -273,7 +273,7 @@ Examples:
 			invocationValue := strings.TrimSpace(*invocationID)
 			if invocationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --invocation-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -282,7 +282,7 @@ Examples:
 			})
 			if !visited["url"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			urlValue := strings.TrimSpace(*url)
@@ -328,11 +328,11 @@ Examples:
 			invocationValue := strings.TrimSpace(*invocationID)
 			if invocationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --invocation-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := appClipsClientFactory()

--- a/internal/cli/appclips/relationships.go
+++ b/internal/cli/appclips/relationships.go
@@ -45,7 +45,7 @@ Examples:
 			appClipValue := strings.TrimSpace(*appClipID)
 			if appClipValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -120,7 +120,7 @@ Examples:
 			appClipValue := strings.TrimSpace(*appClipID)
 			if appClipValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-clip-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/appclips/review_details.go
+++ b/internal/cli/appclips/review_details.go
@@ -61,7 +61,7 @@ Examples:
 			detailValue := strings.TrimSpace(*detailID)
 			if detailValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -104,13 +104,13 @@ Examples:
 			experienceValue := strings.TrimSpace(*experienceID)
 			if experienceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experience-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			urlValues := shared.SplitCSV(*urls)
 			if len(urlValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --url is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -154,7 +154,7 @@ Examples:
 			detailValue := strings.TrimSpace(*detailID)
 			if detailValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -163,7 +163,7 @@ Examples:
 			})
 			if !visited["url"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			urlValues := shared.SplitCSV(*urls)

--- a/internal/cli/apps/app_encryption_declarations.go
+++ b/internal/cli/apps/app_encryption_declarations.go
@@ -88,7 +88,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			buildIDs := shared.SplitCSV(*builds)

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -103,7 +103,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if strings.TrimSpace(*versionID) == "" && resolvedAppID == "" && infoIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --info-id is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			includeValues, err := normalizeAppInfoInclude(*include)
@@ -128,7 +128,7 @@ Examples:
 			}
 			if strings.TrimSpace(*version) != "" && len(platforms) != 1 {
 				fmt.Fprintln(os.Stderr, "Error: --platform is required with --version")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if len(includeValues) > 0 {
@@ -260,7 +260,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if strings.TrimSpace(*versionID) == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platforms, err := shared.NormalizeAppStoreVersionPlatforms(shared.SplitCSVUpper(*platform))
@@ -276,7 +276,7 @@ Examples:
 			}
 			if strings.TrimSpace(*version) != "" && len(platforms) != 1 {
 				fmt.Fprintln(os.Stderr, "Error: --platform is required with --version")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
@@ -292,7 +292,7 @@ Examples:
 			}
 			if fromDirValue == "" && localeValue == "" && len(localesValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if localeValue != "" {
 				if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
@@ -331,7 +331,7 @@ Examples:
 			}
 			if fromDirValue == "" && !hasInlineUpdates && copyFromLocaleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := shared.ValidateVersionLocalizationAttributes(inlineAttrs); err != nil {
 				return shared.UsageError(err.Error())

--- a/internal/cli/apps/app_info_relationships.go
+++ b/internal/cli/apps/app_info_relationships.go
@@ -106,7 +106,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && infoIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --info-id is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/app_info_territory_age_ratings.go
+++ b/internal/cli/apps/app_info_territory_age_ratings.go
@@ -80,7 +80,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && infoIDValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --info-id is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeTerritoryAgeRatingFields(*fields)

--- a/internal/cli/apps/app_infos.go
+++ b/internal/cli/apps/app_infos.go
@@ -38,7 +38,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if strings.TrimSpace(resolvedAppID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -103,7 +103,7 @@ Examples:
 			appIDValue := strings.TrimSpace(*appID)
 			if appIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			bundleIDValue := strings.TrimSpace(*bundleID)
@@ -139,7 +139,7 @@ Examples:
 			}
 			if hasLocalization && localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required for app info localization updates")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if localeValue != "" {
 				if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
@@ -421,7 +421,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*path) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedType, err := shared.NormalizeLocalizationType(*locType)
@@ -435,7 +435,7 @@ Examples:
 			case shared.LocalizationTypeVersion:
 				if strings.TrimSpace(*versionID) == "" {
 					fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
@@ -487,7 +487,7 @@ Examples:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {

--- a/internal/cli/apps/app_tags.go
+++ b/internal/cli/apps/app_tags.go
@@ -134,7 +134,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -221,13 +221,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*tagID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if *territoryLimit != 0 && (*territoryLimit < 1 || *territoryLimit > 50) {
@@ -339,7 +339,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*tagID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -348,11 +348,11 @@ Examples:
 			})
 			if !visited["visible-in-app-store"] {
 				fmt.Fprintln(os.Stderr, "Error: --visible-in-app-store is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -405,7 +405,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*tagID)
 			if trimmedID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("app-tags territories: --limit must be between 1 and 200")
@@ -487,7 +487,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*tagID)
 			if trimmedID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("app-tags territories-links: --limit must be between 1 and 200")
@@ -571,7 +571,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -143,7 +143,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -190,7 +190,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.AppUpdateAttributes{}
@@ -213,7 +213,7 @@ Examples:
 			}
 			if attrs.BundleID == nil && attrs.PrimaryLocale == nil && attrs.ContentRightsDeclaration == nil {
 				fmt.Fprintln(os.Stderr, "Error: --bundle-id, --primary-locale, or --content-rights is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/apps_beta_testers.go
+++ b/internal/cli/apps/apps_beta_testers.go
@@ -36,17 +36,17 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			testerIDs := shared.SplitCSV(*testers)
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/apps_ci_product.go
+++ b/internal/cli/apps/apps_ci_product.go
@@ -55,7 +55,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/community_wall_submit.go
+++ b/internal/cli/apps/community_wall_submit.go
@@ -192,7 +192,7 @@ Examples:
 			}
 			if !*dryRun && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required unless --dry-run is set")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			input, err := collectCommunityWallSubmitInput(*appID, *name, *link, *country)

--- a/internal/cli/apps/content_rights.go
+++ b/internal/cli/apps/content_rights.go
@@ -71,7 +71,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -140,12 +140,12 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*usesThirdParty) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --uses-third-party-content is required (true or false)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			declaration, err := parseContentRightsValue(*usesThirdParty)

--- a/internal/cli/apps/public.go
+++ b/internal/cli/apps/public.go
@@ -170,7 +170,7 @@ Examples:
 			termValue := strings.TrimSpace(*term)
 			if termValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --term is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit < 1 || *limit > 200 {
 				fmt.Fprintln(os.Stderr, "Error: --limit must be between 1 and 200")

--- a/internal/cli/apps/search_keywords.go
+++ b/internal/cli/apps/search_keywords.go
@@ -79,7 +79,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platforms, err := shared.NormalizeAppStoreVersionPlatforms(shared.SplitCSVUpper(*platform))
@@ -160,17 +160,17 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			keywordValues := shared.SplitCSV(*keywords)
 			if len(keywordValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/subscription_grace_period.go
+++ b/internal/cli/apps/subscription_grace_period.go
@@ -54,7 +54,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/assets/assets_previews.go
+++ b/internal/cli/assets/assets_previews.go
@@ -42,7 +42,7 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-localization is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -114,17 +114,17 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-localization is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*path)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			deviceValue := strings.TrimSpace(*deviceType)
 			if deviceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --device-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *skipExisting && *replace {
 				fmt.Fprintln(os.Stderr, "Error: --skip-existing and --replace are mutually exclusive")
@@ -222,7 +222,7 @@ Examples:
 
 			if idValue == "" && locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --version-localization is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if idValue != "" && locID != "" {
 				return shared.UsageError("--id and --version-localization are mutually exclusive")
@@ -233,7 +233,7 @@ Examples:
 			if idValue != "" {
 				if outputFile == "" {
 					fmt.Fprintln(os.Stderr, "Error: --output is required with --id")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				if strings.HasSuffix(outputFile, string(filepath.Separator)) {
 					return shared.UsageError("--output must be a file path")
@@ -242,7 +242,7 @@ Examples:
 			if locID != "" {
 				if outputDirValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --output-dir is required with --version-localization")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 
@@ -516,11 +516,11 @@ Examples:
 			assetID := strings.TrimSpace(*id)
 			if assetID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -576,12 +576,12 @@ Examples:
 			previewID := strings.TrimSpace(*id)
 			if previewID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			tc := strings.TrimSpace(*timeCode)
 			if tc == "" {
 				fmt.Fprintln(os.Stderr, "Error: --time-code is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !isValidPreviewFrameTimeCode(tc) {
 				fmt.Fprintln(os.Stderr, "Error: --time-code must be in HH:MM:SS:FF or HH:MM:SS.mmm format (e.g., 00:00:05:00 or 00:00:05.000)")

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -226,17 +226,17 @@ func ExecuteScreenshotSetUpload[T any](ctx context.Context, opts ScreenshotSetUp
 	trimmedLocalizationID := strings.TrimSpace(opts.LocalizationID)
 	if trimmedLocalizationID == "" {
 		fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-		return zero, flag.ErrHelp
+		return zero, shared.MissingRequiredUsageError()
 	}
 	trimmedPath := strings.TrimSpace(opts.Path)
 	if trimmedPath == "" {
 		fmt.Fprintln(os.Stderr, "Error: --path is required")
-		return zero, flag.ErrHelp
+		return zero, shared.MissingRequiredUsageError()
 	}
 	trimmedDeviceType := strings.TrimSpace(opts.DeviceType)
 	if trimmedDeviceType == "" {
 		fmt.Fprintln(os.Stderr, "Error: --device-type is required")
-		return zero, flag.ErrHelp
+		return zero, shared.MissingRequiredUsageError()
 	}
 	if opts.ClientFactory == nil {
 		return zero, fmt.Errorf("client factory is required")
@@ -543,7 +543,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 	if locID == "" {
 		if !appModeRequested {
 			fmt.Fprintln(os.Stderr, "Error: --version-localization is required")
-			return nil, flag.ErrHelp
+			return nil, shared.MissingRequiredUsageError()
 		}
 	} else if appModeRequested {
 		fmt.Fprintln(os.Stderr, "Error: --version-localization cannot be combined with --app, --version, --version-id, or --platform")
@@ -554,11 +554,11 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 		resolvedAppValue := shared.ResolveAppID(appFlagValue)
 		if resolvedAppValue == "" {
 			fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-			return nil, flag.ErrHelp
+			return nil, shared.MissingRequiredUsageError()
 		}
 		if versionValue == "" && versionIDValue == "" {
 			fmt.Fprintln(os.Stderr, "Error: --version or --version-id is required with --app")
-			return nil, flag.ErrHelp
+			return nil, shared.MissingRequiredUsageError()
 		}
 		if versionValue != "" && versionIDValue != "" {
 			fmt.Fprintln(os.Stderr, "Error: --version and --version-id are mutually exclusive")
@@ -570,12 +570,12 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 	pathValue := strings.TrimSpace(opts.Path)
 	if pathValue == "" {
 		fmt.Fprintln(os.Stderr, "Error: --path is required")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 	deviceValue := strings.TrimSpace(opts.DeviceType)
 	if deviceValue == "" {
 		fmt.Fprintln(os.Stderr, "Error: --device-type is required")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 	if opts.SkipExisting && opts.Replace {
 		fmt.Fprintln(os.Stderr, "Error: --skip-existing and --replace are mutually exclusive")

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -307,7 +307,7 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-localization is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1279,7 +1279,7 @@ Examples:
 
 			if idValue == "" && locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --version-localization is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if idValue != "" && locID != "" {
 				return shared.UsageError("--id and --version-localization are mutually exclusive")
@@ -1290,7 +1290,7 @@ Examples:
 			if idValue != "" {
 				if outputFile == "" {
 					fmt.Fprintln(os.Stderr, "Error: --output is required with --id")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				if strings.HasSuffix(outputFile, string(filepath.Separator)) {
 					return shared.UsageError("--output must be a file path")
@@ -1299,7 +1299,7 @@ Examples:
 			if locID != "" {
 				if outputDirValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --output-dir is required with --version-localization")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 
@@ -1608,11 +1608,11 @@ Examples:
 			assetID := strings.TrimSpace(*id)
 			if assetID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/assets/assets_screenshots_review_plan.go
+++ b/internal/cli/assets/assets_screenshots_review_plan.go
@@ -216,7 +216,7 @@ func executeScreenshotReviewPlan(ctx context.Context, opts screenshotReviewPlanO
 	resolvedAppID := shared.ResolveAppID(opts.AppID)
 	if strings.TrimSpace(resolvedAppID) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 
 	versionValue := strings.TrimSpace(opts.Version)

--- a/internal/cli/assets/assets_screenshots_review_plan.go
+++ b/internal/cli/assets/assets_screenshots_review_plan.go
@@ -177,7 +177,7 @@ Examples:
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to apply screenshot uploads")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := executeScreenshotReviewPlan(ctx, screenshotReviewPlanOptions{

--- a/internal/cli/assets/assets_screenshots_validate.go
+++ b/internal/cli/assets/assets_screenshots_validate.go
@@ -83,12 +83,12 @@ Examples:
 			pathValue := strings.TrimSpace(*path)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			deviceValue := strings.TrimSpace(*deviceType)
 			if deviceValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --device-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			displayType, err := normalizeScreenshotDisplayType(deviceValue)

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -480,11 +480,11 @@ so commands continue to work even if the original .p8 file is removed.`,
 			}
 			if *name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *keyID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --key-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedKeyType := config.NormalizeCredentialKeyType(*keyType)
 			if !config.IsValidCredentialKeyType(normalizedKeyType) {
@@ -492,14 +492,14 @@ so commands continue to work even if the original .p8 file is removed.`,
 			}
 			if normalizedKeyType == config.CredentialKeyTypeTeam && *issuerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --issuer-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if normalizedKeyType == config.CredentialKeyTypeIndividual && strings.TrimSpace(*issuerID) != "" {
 				return shared.UsageError("--issuer-id must be omitted when --key-type individual")
 			}
 			if *keyPath == "" {
 				fmt.Fprintln(os.Stderr, "Error: --private-key is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *skipValidation && *network {
 				return shared.UsageError("--skip-validation and --network are mutually exclusive")
@@ -703,7 +703,7 @@ Examples:
 			trimmedName := strings.TrimSpace(*name)
 			if trimmedName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			credentials, err := listCredentialSummaries()

--- a/internal/cli/backgroundassets/background_assets.go
+++ b/internal/cli/backgroundassets/background_assets.go
@@ -83,7 +83,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > backgroundAssetsMaxLimit) {
 				return fmt.Errorf("background-assets list: --limit must be between 1 and %d", backgroundAssetsMaxLimit)
@@ -174,7 +174,7 @@ Examples:
 			assetIDValue := strings.TrimSpace(*assetID)
 			if assetIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -217,13 +217,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			assetPackIdentifierValue := strings.TrimSpace(*assetPackIdentifier)
 			if assetPackIdentifierValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --asset-pack-identifier is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -266,12 +266,12 @@ Examples:
 			assetIDValue := strings.TrimSpace(*assetID)
 			if assetIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*archived) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --archived is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			archivedValue, err := shared.ParseBoolFlag(*archived, "--archived")
 			if err != nil {

--- a/internal/cli/backgroundassets/background_assets_releases.go
+++ b/internal/cli/backgroundassets/background_assets_releases.go
@@ -55,7 +55,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -120,7 +120,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -185,7 +185,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/backgroundassets/background_assets_submit.go
+++ b/internal/cli/backgroundassets/background_assets_submit.go
@@ -61,7 +61,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
 			if err != nil {
@@ -93,7 +93,7 @@ Examples:
 			}
 			if !*confirm && !*dryRun {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required unless --dry-run is set")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *noSubmit && *dryRun {
 				return shared.UsageError("--no-submit and --dry-run are mutually exclusive")

--- a/internal/cli/backgroundassets/background_assets_upload_files.go
+++ b/internal/cli/backgroundassets/background_assets_upload_files.go
@@ -68,7 +68,7 @@ Examples:
 			versionIDValue := strings.TrimSpace(*versionID)
 			if versionIDValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > backgroundAssetsMaxLimit) {
 				return fmt.Errorf("background-assets upload-files list: --limit must be between 1 and %d", backgroundAssetsMaxLimit)
@@ -138,7 +138,7 @@ Examples:
 			uploadFileIDValue := strings.TrimSpace(*uploadFileID)
 			if uploadFileIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --upload-file-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -184,18 +184,18 @@ Examples:
 			versionIDValue := strings.TrimSpace(*versionID)
 			if versionIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*assetType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --asset-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			typeValue, err := normalizeBackgroundAssetUploadFileAssetType(*assetType)
@@ -299,13 +299,13 @@ Examples:
 			uploadFileIDValue := strings.TrimSpace(*uploadFileID)
 			if uploadFileIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --upload-file-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			uploadedValue := strings.TrimSpace(*uploaded)
 			if uploadedValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --uploaded is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			uploadedBool, err := shared.ParseBoolFlag(uploadedValue, "--uploaded")
 			if err != nil {

--- a/internal/cli/backgroundassets/background_assets_versions.go
+++ b/internal/cli/backgroundassets/background_assets_versions.go
@@ -67,7 +67,7 @@ Examples:
 			assetIDValue := strings.TrimSpace(*assetID)
 			if assetIDValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --background-asset-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > backgroundAssetsMaxLimit) {
 				return fmt.Errorf("background-assets versions list: --limit must be between 1 and %d", backgroundAssetsMaxLimit)
@@ -140,7 +140,7 @@ Examples:
 			versionIDValue := strings.TrimSpace(*versionID)
 			if versionIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -182,7 +182,7 @@ Examples:
 			assetIDValue := strings.TrimSpace(*assetID)
 			if assetIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --background-asset-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/betaapplocalizations/beta_app_localizations.go
+++ b/internal/cli/betaapplocalizations/beta_app_localizations.go
@@ -76,7 +76,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			locales := shared.SplitCSV(*locale)
@@ -150,7 +150,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -199,13 +199,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
 				return fmt.Errorf("beta-app-localizations create: %w", err)
@@ -276,7 +276,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -291,7 +291,7 @@ Examples:
 				visited["tv-os-privacy-policy"]
 			if !hasUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.BetaAppLocalizationUpdateAttributes{}
@@ -356,11 +356,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/betaapplocalizations/beta_app_localizations_app.go
+++ b/internal/cli/betaapplocalizations/beta_app_localizations_app.go
@@ -55,7 +55,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/buildbundles/build_bundles.go
+++ b/internal/cli/buildbundles/build_bundles.go
@@ -69,7 +69,7 @@ Examples:
 			buildValue := strings.TrimSpace(*buildID)
 			if buildValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -152,7 +152,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -266,7 +266,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -336,7 +336,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -419,7 +419,7 @@ Examples:
 			buildBundleValue := strings.TrimSpace(*buildBundleID)
 			if buildBundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/buildlocalizations/build_localizations.go
+++ b/internal/cli/buildlocalizations/build_localizations.go
@@ -78,7 +78,7 @@ Examples:
 			build := strings.TrimSpace(*buildID)
 			if build == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			locales := shared.SplitCSV(*locale)
@@ -153,7 +153,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -198,13 +198,13 @@ Examples:
 			build := strings.TrimSpace(*buildID)
 			if build == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
 				return fmt.Errorf("build-localizations create: %w", err)
@@ -276,13 +276,13 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			whatsNewValue := strings.TrimSpace(*whatsNew)
 			if whatsNewValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -329,11 +329,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/build_test_notes.go
+++ b/internal/cli/builds/build_test_notes.go
@@ -260,7 +260,7 @@ Examples:
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
 				return fmt.Errorf("builds test-notes create: %w", err)
@@ -272,7 +272,7 @@ Examples:
 			whatsNewValue := strings.TrimSpace(*whatsNew)
 			if whatsNewValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --whats-new is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -348,7 +348,7 @@ Examples:
 			whatsNewValue := strings.TrimSpace(*whatsNew)
 			if whatsNewValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -425,7 +425,7 @@ Examples:
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -50,11 +50,11 @@ Examples:
 			groupInputs := shared.SplitCSV(*groups)
 			if len(groupInputs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *submit && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --submit")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *confirm && !*submit {
 				fmt.Fprintln(os.Stderr, "Error: --confirm requires --submit")
@@ -197,7 +197,7 @@ Examples:
 			trimmedEncryption := strings.TrimSpace(strings.ToLower(*usesNonExemptEncryption))
 			if trimmedEncryption == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required (e.g. --uses-non-exempt-encryption)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.BuildUpdateAttributes{}
@@ -268,11 +268,11 @@ Examples:
 			groupIDs := shared.SplitCSV(*groups)
 			if len(groupIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -67,7 +67,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			// Validate that exactly one of --ipa or --pkg is provided
@@ -75,7 +75,7 @@ Examples:
 			hasPKG := *pkgPath != ""
 			if !hasIPA && !hasPKG {
 				fmt.Fprintf(os.Stderr, "Error: --ipa or --pkg is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if hasIPA && hasPKG {
 				fmt.Fprintf(os.Stderr, "Error: --ipa and --pkg are mutually exclusive\n\n")
@@ -160,11 +160,11 @@ Examples:
 			localeValue := strings.TrimSpace(*locale)
 			if testNotesValue != "" && localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required with --test-notes")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if testNotesValue == "" && localeValue != "" {
 				fmt.Fprintln(os.Stderr, "Error: --test-notes is required with --locale")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if testNotesValue != "" {
 				if *dryRun {
@@ -472,7 +472,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && nextValue == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -800,7 +800,7 @@ Examples:
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to expire build")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_count.go
+++ b/internal/cli/builds/builds_count.go
@@ -54,7 +54,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platformValue := ""

--- a/internal/cli/builds/builds_expire_all.go
+++ b/internal/cli/builds/builds_expire_all.go
@@ -54,20 +54,20 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			olderThanValue := strings.TrimSpace(*olderThan)
 			if olderThanValue == "" && *keepLatest == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --older-than or --keep-latest is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *keepLatest < 0 {
 				return fmt.Errorf("builds expire-all: --keep-latest must be greater than or equal to 0")
 			}
 			if !*dryRun && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to expire builds")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			now := time.Now().UTC()

--- a/internal/cli/builds/builds_individual_testers.go
+++ b/internal/cli/builds/builds_individual_testers.go
@@ -164,7 +164,7 @@ Examples:
 			testerIDs := shared.SplitCSV(*testers)
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -227,11 +227,11 @@ Examples:
 			testerIDs := shared.SplitCSV(*testers)
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/builds/builds_relationships.go
+++ b/internal/cli/builds/builds_relationships.go
@@ -94,7 +94,7 @@ Examples:
 			relationshipType := strings.TrimSpace(*relType)
 			if relationshipType == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			kind, ok := buildRelationshipKinds[relationshipType]

--- a/internal/cli/builds/builds_uploads.go
+++ b/internal/cli/builds/builds_uploads.go
@@ -87,7 +87,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platforms, err := shared.NormalizeAppStoreVersionPlatforms(shared.SplitCSVUpper(*platform))
@@ -163,7 +163,7 @@ Examples:
 			uploadID := strings.TrimSpace(*id)
 			if uploadID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -206,11 +206,11 @@ Examples:
 			uploadID := strings.TrimSpace(*id)
 			if uploadID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -293,7 +293,7 @@ Examples:
 			uploadValue := strings.TrimSpace(*uploadID)
 			if uploadValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --upload is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -312,7 +312,7 @@ Examples:
 			if *paginate {
 				if uploadValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --upload is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				paginateOpts := append(opts, asc.WithBuildUploadFilesLimit(200))
@@ -363,7 +363,7 @@ Examples:
 			fileID := strings.TrimSpace(*id)
 			if fileID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/bundleids/bundle_ids.go
+++ b/internal/cli/bundleids/bundle_ids.go
@@ -139,7 +139,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*id) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -183,12 +183,12 @@ Examples:
 			identifierValue := strings.TrimSpace(*identifier)
 			if identifierValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --identifier is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			platformValue, err := shared.NormalizePlatform(*platform)
 			if err != nil {
@@ -240,12 +240,12 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -289,11 +289,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/bundleids/bundle_ids_capabilities.go
+++ b/internal/cli/bundleids/bundle_ids_capabilities.go
@@ -70,7 +70,7 @@ Examples:
 			bundleValue := strings.TrimSpace(*bundleID)
 			if bundleValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -135,12 +135,12 @@ Examples:
 			bundleValue := strings.TrimSpace(*bundleID)
 			if bundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			capabilityValue := strings.ToUpper(strings.TrimSpace(*capability))
 			if capabilityValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --capability is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			settingsValue, err := parseCapabilitySettings(*settings)
@@ -195,7 +195,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			capabilityValue := strings.ToUpper(strings.TrimSpace(*capabilityType))
@@ -208,7 +208,7 @@ Examples:
 			// Treat empty settings arrays as no-op updates.
 			if capabilityValue == "" && len(settingsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: at least one update field is required (--capability or --settings)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -255,11 +255,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/bundleids/bundle_ids_relationships.go
+++ b/internal/cli/bundleids/bundle_ids_relationships.go
@@ -58,7 +58,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -127,7 +127,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("bundle-ids profiles list: --limit must be between 1 and 200")
@@ -159,7 +159,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithBundleIDProfilesLimit(200))
 				firstPage, err := client.GetBundleIDProfiles(requestCtx, idValue, paginateOpts...)

--- a/internal/cli/categories/category_detail.go
+++ b/internal/cli/categories/category_detail.go
@@ -34,7 +34,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*categoryID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --category-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -76,7 +76,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*categoryID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --category-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -131,7 +131,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --category-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/certificates/certificates.go
+++ b/internal/cli/certificates/certificates.go
@@ -153,7 +153,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			includeValues, err := normalizeCertificatesInclude(*include)
@@ -218,7 +218,7 @@ Examples:
 			certificateValue := strings.ToUpper(strings.TrimSpace(*certificateType))
 			if certificateValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --certificate-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			csrValue := strings.TrimSpace(*csrPath)
 
@@ -230,12 +230,12 @@ Examples:
 				keyOutValue := strings.TrimSpace(*keyOut)
 				if keyOutValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --key-out is required with --generate-csr")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				csrOutValue := strings.TrimSpace(*csrOut)
 				if csrOutValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --csr-out is required with --generate-csr")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				_, csrPEM, err := generateCSRFiles(csrGenerateOptions{
@@ -263,7 +263,7 @@ Examples:
 				}
 				if csrValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --csr is required (or use --generate-csr with --key-out and --csr-out)")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				var err error
@@ -325,7 +325,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			activatedValue, err := shared.ParseOptionalBoolFlag("--activated", *activated)
@@ -334,7 +334,7 @@ Examples:
 			}
 			if activatedValue == nil {
 				fmt.Fprintln(os.Stderr, "Error: --activated is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -379,11 +379,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -107,12 +107,12 @@ Examples:
 			keyOutValue := strings.TrimSpace(*keyOut)
 			if keyOutValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --key-out is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			csrOutValue := strings.TrimSpace(*csrOut)
 			if csrOutValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --csr-out is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
 				return shared.UsageError("--key-out and --csr-out must be different paths")

--- a/internal/cli/certificates/relationships.go
+++ b/internal/cli/certificates/relationships.go
@@ -55,7 +55,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/completion/completion.go
+++ b/internal/cli/completion/completion.go
@@ -34,7 +34,7 @@ func CompletionCommand(rootSubcommands []*ffcli.Command) *ffcli.Command {
 		s := strings.ToLower(strings.TrimSpace(*shell))
 		if s == "" {
 			fmt.Fprintln(os.Stderr, "Error: --shell is required")
-			return flag.ErrHelp
+			return shared.MissingRequiredUsageError()
 		}
 
 		names := rootCommandNames(rootSubcommands)

--- a/internal/cli/crashes/crashes.go
+++ b/internal/cli/crashes/crashes.go
@@ -102,7 +102,7 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 	resolvedAppID := shared.ResolveAppID(*flags.appID)
 	if resolvedAppID == "" && strings.TrimSpace(*flags.next) == "" {
 		fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	client, err := shared.GetASCClient()

--- a/internal/cli/devices/devices.go
+++ b/internal/cli/devices/devices.go
@@ -197,7 +197,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeDeviceFields(*fields)
@@ -281,7 +281,7 @@ Examples:
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			udidValue := strings.TrimSpace(*udid)
@@ -298,7 +298,7 @@ Examples:
 			}
 			if udidValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --udid is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platformValue := strings.TrimSpace(*platform)
@@ -307,7 +307,7 @@ Examples:
 			}
 			if platformValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --platform is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *udidFromSystem && strings.ToUpper(platformValue) != "MAC_OS" {
 				fmt.Fprintln(os.Stderr, "Error: --udid-from-system requires --platform MAC_OS")
@@ -420,14 +420,14 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			statusRaw := strings.TrimSpace(*status)
 			if nameValue == "" && statusRaw == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			statusValue, err := normalizeDeviceStatus(statusRaw)

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -129,7 +129,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			buildIDs := shared.SplitCSV(*builds)
@@ -205,7 +205,7 @@ Examples:
 			declarationValue := strings.TrimSpace(*declarationID)
 			if declarationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *buildLimit != 0 && (*buildLimit < 1 || *buildLimit > 50) {
 				return fmt.Errorf("encryption declarations get: --build-limit must be between 1 and 50")
@@ -273,7 +273,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -284,19 +284,19 @@ Examples:
 			descriptionValue := strings.TrimSpace(*appDescription)
 			if descriptionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !visited["contains-proprietary-cryptography"] {
 				fmt.Fprintln(os.Stderr, "Error: --contains-proprietary-cryptography is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !visited["contains-third-party-cryptography"] {
 				fmt.Fprintln(os.Stderr, "Error: --contains-third-party-cryptography is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !visited["available-on-french-store"] {
 				fmt.Fprintln(os.Stderr, "Error: --available-on-french-store is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -559,13 +559,13 @@ Examples:
 			declarationValue := strings.TrimSpace(*declarationID)
 			if declarationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			buildIDs := shared.SplitCSV(*builds)
 			if len(buildIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -636,7 +636,7 @@ Examples:
 			documentValue := strings.TrimSpace(*documentID)
 			if documentValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeEncryptionDocumentFields(*fields, "--fields")
@@ -684,13 +684,13 @@ Examples:
 			declarationValue := strings.TrimSpace(*declarationID)
 			if declarationValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --declaration is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			info, err := os.Lstat(pathValue)

--- a/internal/cli/encryption/encryption_declaration_relationships.go
+++ b/internal/cli/encryption/encryption_declaration_relationships.go
@@ -55,7 +55,7 @@ Examples:
 			idValue := strings.TrimSpace(*declarationID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -120,7 +120,7 @@ Examples:
 			idValue := strings.TrimSpace(*declarationID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/eula/eula.go
+++ b/internal/cli/eula/eula.go
@@ -73,7 +73,7 @@ Examples:
 			}
 			if idValue == "" && appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if idValue != "" && strings.TrimSpace(*appID) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id and --app are mutually exclusive")
@@ -124,7 +124,7 @@ Examples:
 			appValue := shared.ResolveAppID(*appID)
 			if appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -168,12 +168,12 @@ Examples:
 			appValue := shared.ResolveAppID(*appID)
 			if appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			agreementValue := strings.TrimSpace(*agreementText)
 			if agreementValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --agreement-text is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
@@ -182,7 +182,7 @@ Examples:
 			}
 			if len(territoryIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --territory is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -227,7 +227,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var agreementValue *string
@@ -242,7 +242,7 @@ Examples:
 			}
 			if agreementValue == nil && len(territoryIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --agreement-text or --territory is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -285,11 +285,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/feedback/feedback.go
+++ b/internal/cli/feedback/feedback.go
@@ -104,7 +104,7 @@ func runListCommand(ctx context.Context, config shared.ListCommandConfig, flags 
 	resolvedAppID := shared.ResolveAppID(*flags.appID)
 	if resolvedAppID == "" && strings.TrimSpace(*flags.next) == "" {
 		fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	client, err := shared.GetASCClient()

--- a/internal/cli/finance/finance.go
+++ b/internal/cli/finance/finance.go
@@ -106,19 +106,19 @@ Examples:
 			vendorNumber := shared.ResolveVendorNumber(*vendor)
 			if vendorNumber == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor is required (or set ASC_VENDOR_NUMBER)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*reportType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --report-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*region) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --region is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*date) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --date is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedReportType, err := normalizeFinanceReportType(*reportType)

--- a/internal/cli/gamecenter/game_center_achievements.go
+++ b/internal/cli/gamecenter/game_center_achievements.go
@@ -94,7 +94,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -179,7 +179,7 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -241,19 +241,19 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if group == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			vendor := strings.TrimSpace(*vendorID)
 			if vendor == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if group != "" && !strings.HasPrefix(vendor, "grp.") {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id must start with \"grp.\" when using --group-id")
@@ -337,7 +337,7 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterAchievementUpdateAttributes{}
@@ -390,7 +390,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -440,11 +440,11 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -505,21 +505,21 @@ Examples:
 			vendorValue := strings.TrimSpace(*vendorID)
 			if vendorValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *percentage < 0 {
 				fmt.Fprintln(os.Stderr, "Error: --percentage is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			bundleValue := strings.TrimSpace(*bundleID)
 			if bundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			playerValue := strings.TrimSpace(*scopedPlayerID)
 			if playerValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --scoped-player-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var preReleasedValue *bool
@@ -630,7 +630,7 @@ Examples:
 			achID := strings.TrimSpace(*achievementID)
 			if achID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --achievement-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -694,7 +694,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -741,31 +741,31 @@ Examples:
 			achID := strings.TrimSpace(*achievementID)
 			if achID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --achievement-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeVal := strings.TrimSpace(*locale)
 			if localeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			beforeVal := strings.TrimSpace(*beforeEarnedDescription)
 			if beforeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --before-earned-description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			afterVal := strings.TrimSpace(*afterEarnedDescription)
 			if afterVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --after-earned-description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -818,7 +818,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterAchievementLocalizationUpdateAttributes{}
@@ -844,7 +844,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -887,11 +887,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -976,7 +976,7 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --achievement-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1041,13 +1041,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			id := strings.TrimSpace(*achievementID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --achievement-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1096,11 +1096,11 @@ Examples:
 			id := strings.TrimSpace(*releaseID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1176,13 +1176,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			path := strings.TrimSpace(*filePath)
 			if path == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1224,7 +1224,7 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1267,11 +1267,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1340,7 +1340,7 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1405,7 +1405,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1470,7 +1470,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_achievements_v2.go
+++ b/internal/cli/gamecenter/game_center_achievements_v2.go
@@ -83,7 +83,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if group == "" && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -194,7 +194,7 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --achievement-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -258,7 +258,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -300,7 +300,7 @@ Examples:
 			id := strings.TrimSpace(*achievementID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --achievement-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -381,7 +381,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -445,7 +445,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -491,31 +491,31 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			loc := strings.TrimSpace(*locale)
 			if loc == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localizedName := strings.TrimSpace(*name)
 			if localizedName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			before := strings.TrimSpace(*beforeEarned)
 			if before == "" {
 				fmt.Fprintln(os.Stderr, "Error: --before-earned-description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			after := strings.TrimSpace(*afterEarned)
 			if after == "" {
 				fmt.Fprintln(os.Stderr, "Error: --after-earned-description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterAchievementLocalizationCreateAttributes{
@@ -567,7 +567,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterAchievementLocalizationUpdateAttributes{}
@@ -591,7 +591,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -634,11 +634,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -715,13 +715,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			path := strings.TrimSpace(*filePath)
 			if path == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -766,7 +766,7 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if id == "" && locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if id != "" && locID != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id cannot be used with --localization-id")
@@ -821,11 +821,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_activities.go
+++ b/internal/cli/gamecenter/game_center_activities.go
@@ -92,7 +92,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -165,7 +165,7 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -225,19 +225,19 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if group == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			vendor := strings.TrimSpace(*vendorID)
 			if vendor == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if group != "" && !strings.HasPrefix(vendor, "grp.") {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id must start with \"grp.\" when using --group-id")
@@ -347,7 +347,7 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterActivityUpdateAttributes{}
@@ -394,7 +394,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -437,11 +437,11 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -516,12 +516,12 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --activity-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			idsValue := shared.SplitCSV(*ids)
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -598,12 +598,12 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --activity-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			idsValue := shared.SplitCSV(*ids)
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -694,7 +694,7 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --activity-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -758,7 +758,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -802,7 +802,7 @@ Examples:
 			id := strings.TrimSpace(*activityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --activity-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -845,12 +845,12 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*fallbackURL) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --fallback-url is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			value := strings.TrimSpace(*fallbackURL)
@@ -938,7 +938,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1002,7 +1002,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1047,22 +1047,22 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			loc := strings.TrimSpace(*locale)
 			if loc == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			descriptionValue := strings.TrimSpace(*description)
 			if descriptionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterActivityLocalizationCreateAttributes{
@@ -1112,7 +1112,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterActivityLocalizationUpdateAttributes{}
@@ -1131,7 +1131,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1174,11 +1174,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1254,13 +1254,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file := strings.TrimSpace(*filePath)
 			if file == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1302,7 +1302,7 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1345,11 +1345,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1435,7 +1435,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1508,7 +1508,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1551,11 +1551,11 @@ Examples:
 			id := strings.TrimSpace(*releaseID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1624,7 +1624,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1689,7 +1689,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_app_versions.go
+++ b/internal/cli/gamecenter/game_center_app_versions.go
@@ -80,7 +80,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -156,7 +156,7 @@ Examples:
 			id := strings.TrimSpace(*appVersionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -198,7 +198,7 @@ Examples:
 			id := strings.TrimSpace(*appStoreVersionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app-store-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -242,7 +242,7 @@ Examples:
 			id := strings.TrimSpace(*appVersionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterAppVersionUpdateAttributes{}
@@ -261,7 +261,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required (--enabled)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -339,7 +339,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if id == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -429,7 +429,7 @@ Examples:
 			id := strings.TrimSpace(*appVersionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_challenges.go
+++ b/internal/cli/gamecenter/game_center_challenges.go
@@ -88,7 +88,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -161,7 +161,7 @@ Examples:
 			id := strings.TrimSpace(*challengeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -217,19 +217,19 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if group == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			vendor := strings.TrimSpace(*vendorID)
 			if vendor == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if group != "" && !strings.HasPrefix(vendor, "grp.") {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id must start with \"grp.\" when using --group-id")
@@ -314,7 +314,7 @@ Examples:
 			id := strings.TrimSpace(*challengeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterChallengeUpdateAttributes{}
@@ -348,7 +348,7 @@ Examples:
 
 			if !hasUpdate && strings.TrimSpace(*leaderboardID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -391,11 +391,11 @@ Examples:
 			id := strings.TrimSpace(*challengeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -482,7 +482,7 @@ Examples:
 			id := strings.TrimSpace(*challengeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --challenge-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -546,7 +546,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -588,7 +588,7 @@ Examples:
 			id := strings.TrimSpace(*challengeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --challenge-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -674,7 +674,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -738,7 +738,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -783,22 +783,22 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			loc := strings.TrimSpace(*locale)
 			if loc == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			descriptionValue := strings.TrimSpace(*description)
 			if descriptionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterChallengeLocalizationCreateAttributes{
@@ -848,7 +848,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterChallengeLocalizationUpdateAttributes{}
@@ -867,7 +867,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -910,11 +910,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -990,13 +990,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file := strings.TrimSpace(*filePath)
 			if file == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1038,7 +1038,7 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1081,11 +1081,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1171,7 +1171,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1244,7 +1244,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1287,11 +1287,11 @@ Examples:
 			id := strings.TrimSpace(*releaseID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1360,7 +1360,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1425,7 +1425,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_details.go
+++ b/internal/cli/gamecenter/game_center_details.go
@@ -92,7 +92,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -157,7 +157,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -200,7 +200,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			ceVal := strings.TrimSpace(*challengeEnabled)
@@ -252,7 +252,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var rels *asc.GameCenterDetailUpdateRelationships
@@ -294,7 +294,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required (--game-center-group-id, --default-leaderboard-id)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -372,7 +372,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if id == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -462,7 +462,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -539,7 +539,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -638,7 +638,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -737,7 +737,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -836,7 +836,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -935,7 +935,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1034,7 +1034,7 @@ Examples:
 			id := strings.TrimSpace(*detailID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1168,12 +1168,12 @@ func runDetailsMetrics(ctx context.Context, name string, detailID *string, granu
 	id := strings.TrimSpace(*detailID)
 	if id == "" && strings.TrimSpace(*next) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --id is required")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 	gran := strings.TrimSpace(*granularity)
 	if gran == "" && strings.TrimSpace(*next) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --granularity is required")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)

--- a/internal/cli/gamecenter/game_center_enabled_versions.go
+++ b/internal/cli/gamecenter/game_center_enabled_versions.go
@@ -71,7 +71,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -150,7 +150,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if id == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_groups.go
+++ b/internal/cli/gamecenter/game_center_groups.go
@@ -92,7 +92,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -168,7 +168,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -253,12 +253,12 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*referenceName) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			value := strings.TrimSpace(*referenceName)
 
@@ -302,11 +302,11 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -391,7 +391,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -473,12 +473,12 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			idsValue := shared.SplitCSV(*ids)
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -565,7 +565,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -647,12 +647,12 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			idsValue := shared.SplitCSV(*ids)
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -737,7 +737,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -851,7 +851,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -952,7 +952,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1017,12 +1017,12 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			idsValue := shared.SplitCSV(*ids)
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1100,7 +1100,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if id == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboard_localizations.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_localizations.go
@@ -79,7 +79,7 @@ Examples:
 			lbID := strings.TrimSpace(*leaderboardID)
 			if lbID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -143,7 +143,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -192,19 +192,19 @@ Examples:
 			lbID := strings.TrimSpace(*leaderboardID)
 			if lbID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeVal := strings.TrimSpace(*locale)
 			if localeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -281,7 +281,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardLocalizationUpdateAttributes{}
@@ -319,7 +319,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -362,11 +362,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -435,7 +435,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboard_set_images.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_images.go
@@ -62,13 +62,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file := strings.TrimSpace(*filePath)
 			if file == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -111,11 +111,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members.go
@@ -71,7 +71,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -140,7 +140,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			ids := shared.SplitUniqueCSV(*leaderboardIDs)

--- a/internal/cli/gamecenter/game_center_leaderboard_sets.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets.go
@@ -129,7 +129,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -193,7 +193,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -238,19 +238,19 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeVal := strings.TrimSpace(*locale)
 			if localeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -298,7 +298,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardSetLocalizationUpdateAttributes{}
@@ -312,7 +312,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required (--name)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -355,11 +355,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -418,7 +418,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -492,7 +492,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -537,19 +537,19 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			vendor := strings.TrimSpace(*vendorID)
 			if vendor == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -603,7 +603,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardSetUpdateAttributes{}
@@ -617,7 +617,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -660,11 +660,11 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -751,7 +751,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -818,13 +818,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -873,11 +873,11 @@ Examples:
 			id := strings.TrimSpace(*releaseID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -946,7 +946,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1011,7 +1011,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1103,11 +1103,11 @@ Examples:
 			if strings.TrimSpace(*next) == "" {
 				if set == "" {
 					fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				if leaderboard == "" {
 					fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 
@@ -1178,7 +1178,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1224,25 +1224,25 @@ Examples:
 			setID := strings.TrimSpace(*leaderboardSetID)
 			if setID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			lbID := strings.TrimSpace(*leaderboardID)
 			if lbID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeVal := strings.TrimSpace(*locale)
 			if localeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1290,7 +1290,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardSetMemberLocalizationUpdateAttributes{}
@@ -1304,7 +1304,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required (--name)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1347,11 +1347,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1420,7 +1420,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1485,7 +1485,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
@@ -90,7 +90,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if group == "" && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -163,7 +163,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -215,19 +215,19 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if group == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			vendor := strings.TrimSpace(*vendorID)
 			if vendor == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if group != "" && !strings.HasPrefix(vendor, "grp.") {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id must start with \"grp.\" when using --group-id")
@@ -288,7 +288,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardSetUpdateAttributes{}
@@ -302,7 +302,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -345,11 +345,11 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -431,7 +431,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -497,7 +497,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			ids := shared.SplitUniqueCSV(*leaderboardIDs)
@@ -584,7 +584,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -648,7 +648,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -690,7 +690,7 @@ Examples:
 			id := strings.TrimSpace(*setID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -771,7 +771,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -835,7 +835,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -879,19 +879,19 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeVal := strings.TrimSpace(*locale)
 			if localeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardSetLocalizationCreateAttributes{
@@ -939,13 +939,13 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardSetLocalizationUpdateAttributes{
@@ -992,11 +992,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1073,13 +1073,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file := strings.TrimSpace(*filePath)
 			if file == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1124,7 +1124,7 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if id == "" && locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if id != "" && locID != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id cannot be used with --localization-id")
@@ -1179,11 +1179,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboards.go
+++ b/internal/cli/gamecenter/game_center_leaderboards.go
@@ -108,13 +108,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file := strings.TrimSpace(*filePath)
 			if file == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -157,11 +157,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -220,7 +220,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -305,7 +305,7 @@ Examples:
 			id := strings.TrimSpace(*leaderboardID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -369,19 +369,19 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if group == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			vendor := strings.TrimSpace(*vendorID)
 			if vendor == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if group != "" && !strings.HasPrefix(vendor, "grp.") {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id must start with \"grp.\" when using --group-id")
@@ -391,7 +391,7 @@ Examples:
 			formatterVal := strings.TrimSpace(strings.ToUpper(*formatter))
 			if formatterVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --formatter is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !isValidLeaderboardFormatter(formatterVal) {
 				fmt.Fprintf(os.Stderr, "Error: --formatter must be one of: %s\n", strings.Join(asc.ValidLeaderboardFormatters, ", "))
@@ -401,7 +401,7 @@ Examples:
 			sortVal := strings.TrimSpace(strings.ToUpper(*sortType))
 			if sortVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --sort is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !isValidScoreSortType(sortVal) {
 				fmt.Fprintf(os.Stderr, "Error: --sort must be one of: %s\n", strings.Join(asc.ValidScoreSortTypes, ", "))
@@ -411,7 +411,7 @@ Examples:
 			submissionVal := strings.TrimSpace(strings.ToUpper(*submissionType))
 			if submissionVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !isValidSubmissionType(submissionVal) {
 				fmt.Fprintf(os.Stderr, "Error: --submission-type must be one of: %s\n", strings.Join(asc.ValidSubmissionTypes, ", "))
@@ -488,7 +488,7 @@ Examples:
 			id := strings.TrimSpace(*leaderboardID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardUpdateAttributes{}
@@ -512,7 +512,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -562,11 +562,11 @@ Examples:
 			id := strings.TrimSpace(*leaderboardID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -628,22 +628,22 @@ Examples:
 			vendorValue := strings.TrimSpace(*vendorID)
 			if vendorValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --vendor-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			scoreValue := strings.TrimSpace(*score)
 			if scoreValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --score is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			bundleValue := strings.TrimSpace(*bundleID)
 			if bundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			playerValue := strings.TrimSpace(*scopedPlayerID)
 			if playerValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --scoped-player-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var preReleasedValue *bool
@@ -733,7 +733,7 @@ Examples:
 			id := strings.TrimSpace(*leaderboardID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -814,7 +814,7 @@ Examples:
 			lbID := strings.TrimSpace(*leaderboardID)
 			if lbID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -881,13 +881,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			lbID := strings.TrimSpace(*leaderboardID)
 			if lbID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -936,11 +936,11 @@ Examples:
 			id := strings.TrimSpace(*releaseID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboards_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboards_v2.go
@@ -83,7 +83,7 @@ Examples:
 			nextURL := strings.TrimSpace(*next)
 			if group == "" && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -194,7 +194,7 @@ Examples:
 			id := strings.TrimSpace(*leaderboardID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -258,7 +258,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -300,7 +300,7 @@ Examples:
 			id := strings.TrimSpace(*leaderboardID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --leaderboard-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -381,7 +381,7 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -445,7 +445,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -494,19 +494,19 @@ Examples:
 			id := strings.TrimSpace(*versionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeVal := strings.TrimSpace(*locale)
 			if localeVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var formatterOverrideVal *string
@@ -583,7 +583,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterLeaderboardLocalizationUpdateAttributes{}
@@ -621,7 +621,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -664,11 +664,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -745,13 +745,13 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file := strings.TrimSpace(*filePath)
 			if file == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -796,7 +796,7 @@ Examples:
 			locID := strings.TrimSpace(*localizationID)
 			if id == "" && locID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if id != "" && locID != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id cannot be used with --localization-id")
@@ -851,11 +851,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_matchmaking.go
+++ b/internal/cli/gamecenter/game_center_matchmaking.go
@@ -167,7 +167,7 @@ Examples:
 			id := strings.TrimSpace(*queueID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -213,12 +213,12 @@ Examples:
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			ruleSet := strings.TrimSpace(*ruleSetID)
 			if ruleSet == "" {
 				fmt.Fprintln(os.Stderr, "Error: --rule-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingQueueCreateAttributes{
@@ -269,7 +269,7 @@ Examples:
 			id := strings.TrimSpace(*queueID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			hasUpdate := false
@@ -281,7 +281,7 @@ Examples:
 
 			if !hasUpdate && strings.TrimSpace(*ruleSetID) == "" && strings.TrimSpace(*experimentRuleSetID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -324,11 +324,11 @@ Examples:
 			id := strings.TrimSpace(*queueID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -476,7 +476,7 @@ Examples:
 			id := strings.TrimSpace(*ruleSetID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -521,15 +521,15 @@ Examples:
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *ruleLanguageVersion == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --rule-language-version is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *minPlayers == 0 || *maxPlayers == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --min-players and --max-players are required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingRuleSetCreateAttributes{
@@ -581,7 +581,7 @@ Examples:
 			id := strings.TrimSpace(*ruleSetID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingRuleSetUpdateAttributes{}
@@ -600,7 +600,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -643,11 +643,11 @@ Examples:
 			id := strings.TrimSpace(*ruleSetID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -728,7 +728,7 @@ Examples:
 			id := strings.TrimSpace(*ruleSetID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --rule-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -833,7 +833,7 @@ Examples:
 			id := strings.TrimSpace(*ruleSetID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --rule-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -902,27 +902,27 @@ Examples:
 			ruleSet := strings.TrimSpace(*ruleSetID)
 			if ruleSet == "" {
 				fmt.Fprintln(os.Stderr, "Error: --rule-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			desc := strings.TrimSpace(*description)
 			if desc == "" {
 				fmt.Fprintln(os.Stderr, "Error: --description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			rtype := strings.TrimSpace(*ruleType)
 			if rtype == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			expr := strings.TrimSpace(*expression)
 			if expr == "" {
 				fmt.Fprintln(os.Stderr, "Error: --expression is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingRuleCreateAttributes{
@@ -984,7 +984,7 @@ Examples:
 			id := strings.TrimSpace(*ruleID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingRuleUpdateAttributes{}
@@ -1012,7 +1012,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1055,11 +1055,11 @@ Examples:
 			id := strings.TrimSpace(*ruleID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1146,7 +1146,7 @@ Examples:
 			id := strings.TrimSpace(*ruleSetID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --rule-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1213,16 +1213,16 @@ Examples:
 			ruleSet := strings.TrimSpace(*ruleSetID)
 			if ruleSet == "" {
 				fmt.Fprintln(os.Stderr, "Error: --rule-set-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *minPlayers == 0 || *maxPlayers == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --min-players and --max-players are required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingTeamCreateAttributes{
@@ -1273,7 +1273,7 @@ Examples:
 			id := strings.TrimSpace(*teamID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.GameCenterMatchmakingTeamUpdateAttributes{}
@@ -1290,7 +1290,7 @@ Examples:
 			}
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1333,11 +1333,11 @@ Examples:
 			id := strings.TrimSpace(*teamID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1607,12 +1607,12 @@ func runMetricsQueue(ctx context.Context, name string, queueID *string, granular
 	id := strings.TrimSpace(*queueID)
 	if id == "" && strings.TrimSpace(*next) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --queue-id is required")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 	gran := strings.TrimSpace(*granularity)
 	if gran == "" && strings.TrimSpace(*next) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --granularity is required")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	var err error
@@ -1685,12 +1685,12 @@ func runMetricsRule(ctx context.Context, name string, ruleID *string, granularit
 	id := strings.TrimSpace(*ruleID)
 	if id == "" && strings.TrimSpace(*next) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --rule-id is required")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 	gran := strings.TrimSpace(*granularity)
 	if gran == "" && strings.TrimSpace(*next) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --granularity is required")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -1775,7 +1775,7 @@ Examples:
 			path := strings.TrimSpace(*filePath)
 			if path == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			payload, err := shared.ReadJSONFilePayload(path)

--- a/internal/cli/iap/availabilities.go
+++ b/internal/cli/iap/availabilities.go
@@ -59,7 +59,7 @@ Examples:
 			id := strings.TrimSpace(*availabilityID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -112,7 +112,7 @@ Examples:
 			id := strings.TrimSpace(*availabilityID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/availability.go
+++ b/internal/cli/iap/availability.go
@@ -58,7 +58,7 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -112,7 +112,7 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
@@ -121,7 +121,7 @@ Examples:
 			}
 			if len(territoryIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --territories is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/content.go
+++ b/internal/cli/iap/content.go
@@ -58,7 +58,7 @@ Examples:
 			contentValue := strings.TrimSpace(*contentID)
 			if iapValue == "" && contentValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id or --content-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if iapValue != "" && contentValue != "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id and --content-id are mutually exclusive")

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -96,7 +96,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -187,7 +187,7 @@ Examples:
 			id := strings.TrimSpace(*iapID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -243,7 +243,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedType, err := normalizeIAPType(*iapType)
@@ -255,13 +255,13 @@ Examples:
 			name := strings.TrimSpace(*refName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --ref-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			product := strings.TrimSpace(*productID)
 			if product == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -315,13 +315,13 @@ Examples:
 			id := strings.TrimSpace(*iapID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*refName)
 			if name == "" && !*familySharable {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -373,11 +373,11 @@ Examples:
 			id := strings.TrimSpace(*iapID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -458,7 +458,7 @@ Examples:
 			}
 			if resolvedID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("iap localizations list: --limit must be between 1 and 200")

--- a/internal/cli/iap/images.go
+++ b/internal/cli/iap/images.go
@@ -77,7 +77,7 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -148,7 +148,7 @@ Examples:
 			imageValue := strings.TrimSpace(*imageID)
 			if imageValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --image-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -192,12 +192,12 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file, info, err := openImageFile(pathValue)
@@ -276,12 +276,12 @@ Examples:
 			imageValue := strings.TrimSpace(*imageID)
 			if imageValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --image-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file, info, err := openImageFile(pathValue)
@@ -379,11 +379,11 @@ Examples:
 			imageValue := strings.TrimSpace(*imageID)
 			if imageValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --image-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/localizations.go
+++ b/internal/cli/iap/localizations.go
@@ -39,17 +39,17 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -103,13 +103,13 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			descriptionValue := strings.TrimSpace(*description)
 			if nameValue == "" && descriptionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -160,11 +160,11 @@ Examples:
 			locValue := strings.TrimSpace(*localizationID)
 			if locValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/offer_code_codes.go
+++ b/internal/cli/iap/offer_code_codes.go
@@ -72,7 +72,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -136,7 +136,7 @@ Examples:
 			id := strings.TrimSpace(*customCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -182,13 +182,13 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			code := strings.TrimSpace(*customCode)
 			if code == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-code is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if *quantity <= 0 {
@@ -304,7 +304,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -368,7 +368,7 @@ Examples:
 			id := strings.TrimSpace(*oneTimeCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --one-time-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -415,7 +415,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if *quantity <= 0 {
@@ -506,7 +506,7 @@ Examples:
 			id := strings.TrimSpace(*oneTimeCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --one-time-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/offer_code_prices.go
+++ b/internal/cli/iap/offer_code_prices.go
@@ -45,7 +45,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/offer_codes.go
+++ b/internal/cli/iap/offer_codes.go
@@ -84,7 +84,7 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -155,7 +155,7 @@ Examples:
 			offerCodeValue := strings.TrimSpace(*offerCodeID)
 			if offerCodeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -202,13 +202,13 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			parsedEligibilities, err := parseOfferCodeEligibilities(*eligibilities)
@@ -227,7 +227,7 @@ Examples:
 			}
 			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -280,11 +280,11 @@ Examples:
 			offerCodeValue := strings.TrimSpace(*offerCodeID)
 			if offerCodeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !active.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --active is required (true or false)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/price_points.go
+++ b/internal/cli/iap/price_points.go
@@ -90,7 +90,7 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/price_schedules.go
+++ b/internal/cli/iap/price_schedules.go
@@ -75,7 +75,7 @@ Examples:
 			scheduleValue := strings.TrimSpace(*scheduleID)
 			if iapValue == "" && scheduleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id or --schedule-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if iapValue != "" && scheduleValue != "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id and --schedule-id are mutually exclusive")
@@ -199,7 +199,7 @@ Examples:
 			id := strings.TrimSpace(*scheduleID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --schedule-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -250,12 +250,12 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			baseTerritoryValue := strings.TrimSpace(*baseTerritory)
 			if baseTerritoryValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --base-territory is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			tierValue := *tier
@@ -287,7 +287,7 @@ Examples:
 				}
 				if len(parsedPrices) == 0 {
 					fmt.Fprintln(os.Stderr, "Error: --prices (or --tier/--price) is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 
@@ -397,7 +397,7 @@ Examples:
 			id := strings.TrimSpace(*scheduleID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --schedule-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -486,7 +486,7 @@ Examples:
 			id := strings.TrimSpace(*scheduleID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --schedule-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/prices.go
+++ b/internal/cli/iap/prices.go
@@ -95,7 +95,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(requestedAppID)
 			if requestedIAPID == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/review_screenshots.go
+++ b/internal/cli/iap/review_screenshots.go
@@ -70,7 +70,7 @@ Examples:
 			screenshotValue := strings.TrimSpace(*screenshotID)
 			if iapValue == "" && screenshotValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id or --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -130,12 +130,12 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file, info, err := openImageFile(pathValue)
@@ -218,12 +218,12 @@ Examples:
 			screenshotValue := strings.TrimSpace(*screenshotID)
 			if screenshotValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file, info, err := openImageFile(pathValue)
@@ -321,11 +321,11 @@ Examples:
 			screenshotValue := strings.TrimSpace(*screenshotID)
 			if screenshotValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/iap/submissions.go
+++ b/internal/cli/iap/submissions.go
@@ -34,11 +34,11 @@ Examples:
 			iapValue := strings.TrimSpace(*iapID)
 			if iapValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --iap-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/localizations/create.go
+++ b/internal/cli/localizations/create.go
@@ -59,13 +59,13 @@ Examples:
 			vid := strings.TrimSpace(*versionID)
 			if vid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedLocale, err := shared.CanonicalizeAppStoreLocalizationLocale(localeValue)
 			if err != nil {

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -98,7 +98,7 @@ Examples:
 			case shared.LocalizationTypeVersion:
 				if strings.TrimSpace(*versionID) == "" {
 					fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				client, err := shared.GetASCClient()
@@ -144,7 +144,7 @@ Examples:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				client, err := shared.GetASCClient()
 				if err != nil {
@@ -244,7 +244,7 @@ Examples:
 			case shared.LocalizationTypeVersion:
 				if strings.TrimSpace(*versionID) == "" {
 					fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				client, err := shared.GetASCClient()
@@ -319,7 +319,7 @@ Examples:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				client, err := shared.GetASCClient()
 				if err != nil {
@@ -432,7 +432,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*path) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedType, err := shared.NormalizeLocalizationType(*locType)
@@ -446,7 +446,7 @@ Examples:
 			case shared.LocalizationTypeVersion:
 				if strings.TrimSpace(*versionID) == "" {
 					fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
@@ -507,7 +507,7 @@ Examples:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				valuesByLocale, err := shared.ReadLocalizationStrings(*path, locales)
 				if err != nil {

--- a/internal/cli/localizations/media_sets.go
+++ b/internal/cli/localizations/media_sets.go
@@ -189,11 +189,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*setID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/localizations/search_keywords.go
+++ b/internal/cli/localizations/search_keywords.go
@@ -66,7 +66,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -109,13 +109,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			keywordValues := shared.SplitCSV(*keywords)
 			if len(keywordValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -158,17 +158,17 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			keywordValues := shared.SplitCSV(*keywords)
 			if len(keywordValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/localizations/supported_locales.go
+++ b/internal/cli/localizations/supported_locales.go
@@ -55,7 +55,7 @@ Examples:
 			vid := strings.TrimSpace(*versionID)
 			if vid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/localizations/update.go
+++ b/internal/cli/localizations/update.go
@@ -80,7 +80,7 @@ At least one field flag must be provided.`,
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			localeValue, err = shared.CanonicalizeAppStoreLocalizationLocale(localeValue)
 			if err != nil {
@@ -128,13 +128,13 @@ type updateAppInfoParams struct {
 func updateAppInfoLocalization(ctx context.Context, p updateAppInfoParams) error {
 	if !hasAnyAppInfoField(p) {
 		fmt.Fprintln(os.Stderr, "Error: at least one app-info field is required (--name, --subtitle, --privacy-policy-url, --privacy-choices-url, --privacy-policy-text)")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	resolvedAppID := shared.ResolveAppID(p.appID)
 	if resolvedAppID == "" {
 		fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations (or set ASC_APP_ID)")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	client, err := shared.GetASCClient()
@@ -202,13 +202,13 @@ type updateVersionParams struct {
 func updateVersionLocalization(ctx context.Context, p updateVersionParams) error {
 	if !hasAnyVersionField(p) {
 		fmt.Fprintln(os.Stderr, "Error: at least one version field is required (--description, --keywords, --whats-new, --promotional-text, --support-url, --marketing-url)")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	vid := strings.TrimSpace(p.versionID)
 	if vid == "" {
 		fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 	if err := shared.ValidateVersionLocalizationAttributes(asc.AppStoreVersionLocalizationAttributes{Keywords: p.keywords}); err != nil {
 		return shared.UsageError(err.Error())

--- a/internal/cli/marketplace/marketplace_search_details.go
+++ b/internal/cli/marketplace/marketplace_search_details.go
@@ -64,7 +64,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeMarketplaceSearchDetailFields(*fields)
@@ -112,13 +112,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			catalogURLValue := strings.TrimSpace(*catalogURL)
 			if catalogURLValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --catalog-url is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -161,7 +161,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*detailID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --search-detail-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -171,7 +171,7 @@ Examples:
 
 			if !visited["catalog-url"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.MarketplaceSearchDetailUpdateAttributes{}
@@ -220,11 +220,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*detailID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --search-detail-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/marketplace/marketplace_webhooks.go
+++ b/internal/cli/marketplace/marketplace_webhooks.go
@@ -144,7 +144,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -189,12 +189,12 @@ Examples:
 			endpointURL := strings.TrimSpace(*url)
 			if endpointURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --url is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			secretValue := strings.TrimSpace(*secret)
 			if secretValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --secret is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -241,7 +241,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -251,7 +251,7 @@ Examples:
 
 			if !visited["url"] && !visited["secret"] {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.MarketplaceWebhookUpdateAttributes{}
@@ -306,11 +306,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/merchantids/merchant_ids.go
+++ b/internal/cli/merchantids/merchant_ids.go
@@ -186,7 +186,7 @@ Examples:
 			merchantIDValue := strings.TrimSpace(*merchantID)
 			if merchantIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --merchant-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *certificatesLimit != 0 && (*certificatesLimit < 1 || *certificatesLimit > 50) {
 				return fmt.Errorf("merchant-ids get: --certificates-limit must be between 1 and 50")
@@ -260,12 +260,12 @@ Examples:
 			identifierValue := strings.TrimSpace(*identifier)
 			if identifierValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --identifier is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -313,12 +313,12 @@ Examples:
 			merchantIDValue := strings.TrimSpace(*merchantID)
 			if merchantIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --merchant-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" && !*clearName {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if nameValue != "" && *clearName {
 				fmt.Fprintln(os.Stderr, "Error: --name cannot be used with --clear-name")
@@ -370,11 +370,11 @@ Examples:
 			merchantIDValue := strings.TrimSpace(*merchantID)
 			if merchantIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --merchant-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/merchantids/merchant_ids_certificates.go
+++ b/internal/cli/merchantids/merchant_ids_certificates.go
@@ -71,7 +71,7 @@ Examples:
 			merchantIDValue := strings.TrimSpace(*merchantID)
 			if merchantIDValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --merchant-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("merchant-ids certificates list: --limit must be between 1 and 200")
@@ -173,7 +173,7 @@ Examples:
 			merchantIDValue := strings.TrimSpace(*merchantID)
 			if merchantIDValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --merchant-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("merchant-ids certificates get: --limit must be between 1 and 200")

--- a/internal/cli/metadata/keywords_push.go
+++ b/internal/cli/metadata/keywords_push.go
@@ -91,13 +91,13 @@ Examples:
 			vid := strings.TrimSpace(*versionID)
 			if vid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			inputValue := strings.TrimSpace(*inputPath)
 			if inputValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --input is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			entries, err := readMetadataKeywordsPushEntries(inputValue)

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -172,11 +172,11 @@ Examples:
 
 			if strings.TrimSpace(*versionID) == "" && (strings.TrimSpace(inputs.DeliverfileConfig.AppVersion) == "" || strings.TrimSpace(inputs.DeliverfileConfig.Platform) == "") {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required (or set Deliverfile app_version and platform)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*appID) == "" && strings.TrimSpace(inputs.DeliverfileConfig.AppIdentifier) == "" && shared.ResolveAppID("") == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID or Deliverfile app_identifier)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var client *asc.Client
@@ -318,17 +318,17 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*outputDir) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --output-dir is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -757,7 +757,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*fastlaneDir) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --fastlane-dir is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			metadataDir := filepath.Join(*fastlaneDir, "metadata")

--- a/internal/cli/nominations/nominations.go
+++ b/internal/cli/nominations/nominations.go
@@ -102,7 +102,7 @@ Examples:
 			}
 			if len(statusValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --status is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			typeValues, err := normalizeNominationTypes(shared.SplitCSVUpper(*nomType))
@@ -221,7 +221,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*nominationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *inAppEventsLimit != 0 && (*inAppEventsLimit < 1 || *inAppEventsLimit > 50) {
 				return fmt.Errorf("nominations get: --in-app-events-limit must be between 1 and 50")
@@ -333,29 +333,29 @@ Examples:
 			relatedApps := shared.SplitCSV(shared.ResolveAppID(*appID))
 			if len(relatedApps) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			trimmedName := strings.TrimSpace(*name)
 			if trimmedName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			trimmedDescription := strings.TrimSpace(*description)
 			if trimmedDescription == "" {
 				fmt.Fprintln(os.Stderr, "Error: --description is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if !visited["submitted"] {
 				fmt.Fprintln(os.Stderr, "Error: --submitted is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*nomType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedType, err := normalizeNominationType(*nomType)
@@ -488,7 +488,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*nominationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -514,11 +514,11 @@ Examples:
 
 			if !hasAttributeUpdates && !hasRelationshipUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !visited["submitted"] && !visited["archived"] {
 				fmt.Fprintln(os.Stderr, "Error: --submitted or --archived is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var attrs *asc.NominationUpdateAttributes
@@ -531,7 +531,7 @@ Examples:
 				if visited["type"] {
 					if strings.TrimSpace(*nomType) == "" {
 						fmt.Fprintln(os.Stderr, "Error: --type is required")
-						return flag.ErrHelp
+						return shared.MissingRequiredUsageError()
 					}
 					normalized, err := normalizeNominationType(*nomType)
 					if err != nil {
@@ -680,11 +680,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*nominationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/notarization/notarization.go
+++ b/internal/cli/notarization/notarization.go
@@ -78,7 +78,7 @@ Examples:
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			interval, err := time.ParseDuration(strings.TrimSpace(*pollInterval))
@@ -254,7 +254,7 @@ Examples:
 			idValue := strings.TrimSpace(*submissionID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -300,7 +300,7 @@ Examples:
 			idValue := strings.TrimSpace(*submissionID)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/notify/notify.go
+++ b/internal/cli/notify/notify.go
@@ -116,7 +116,7 @@ Examples:
 			webhookURL := resolveWebhook(*webhook)
 			if webhookURL == "" {
 				fmt.Fprintf(os.Stderr, "Error: --webhook is required or set %s env var\n", slackWebhookEnvVar)
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := validateSlackWebhookURL(webhookURL); err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
@@ -126,7 +126,7 @@ Examples:
 			msg := strings.TrimSpace(*message)
 			if msg == "" {
 				fmt.Fprintln(os.Stderr, "Error: --message is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			blocks, err := parseSlackBlocks(*blocksJSON, *blocksFile)

--- a/internal/cli/offercodes/custom_codes.go
+++ b/internal/cli/offercodes/custom_codes.go
@@ -118,18 +118,18 @@ Examples:
 			trimmedOfferCodeID := strings.TrimSpace(*offerCodeID)
 			if trimmedOfferCodeID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			trimmedCode := strings.TrimSpace(*code)
 			if trimmedCode == "" {
 				fmt.Fprintln(os.Stderr, "Error: --code is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if *quantity <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --quantity is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var normalizedExpiration *string

--- a/internal/cli/offercodes/offer_codes.go
+++ b/internal/cli/offercodes/offer_codes.go
@@ -43,11 +43,11 @@ Examples:
 			trimmedOfferCodeID := strings.TrimSpace(*offerCodeID)
 			if trimmedOfferCodeID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --offer-code-id is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *quantity <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --quantity is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedExpirationDate, err := normalizeOfferCodeExpirationDate(*expirationDate)
 			if err != nil {
@@ -138,7 +138,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --batch-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			format, err := normalizeOfferCodeValuesFormat(*outputFormat)
 			if err != nil {

--- a/internal/cli/offercodes/subscription_offer_codes.go
+++ b/internal/cli/offercodes/subscription_offer_codes.go
@@ -158,18 +158,18 @@ Examples:
 			subscription := strings.TrimSpace(*subscriptionID)
 			if subscription == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			trimmedName := strings.TrimSpace(*name)
 			if trimmedName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*customerEligibilities) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --customer-eligibilities is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			customerEligibilityValues, err := normalizeOfferCodeCustomerEligibilities(*customerEligibilities)
 			if err != nil {
@@ -178,7 +178,7 @@ Examples:
 
 			if strings.TrimSpace(*offerEligibility) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-eligibility is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			offerEligibilityValue, err := normalizeOfferCodeEligibility(*offerEligibility)
 			if err != nil {
@@ -187,7 +187,7 @@ Examples:
 
 			if strings.TrimSpace(*duration) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --duration is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			durationValue, err := normalizeOfferCodeDuration(*duration)
 			if err != nil {
@@ -196,7 +196,7 @@ Examples:
 
 			if strings.TrimSpace(*offerMode) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-mode is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			offerModeValue, err := normalizeOfferCodeMode(*offerMode)
 			if err != nil {
@@ -205,7 +205,7 @@ Examples:
 
 			if !numberOfPeriods.set {
 				fmt.Fprintln(os.Stderr, "Error: --number-of-periods is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if numberOfPeriods.value <= 0 {
 				return fmt.Errorf("offer-codes create: --number-of-periods must be greater than 0")
@@ -222,7 +222,7 @@ Examples:
 			}
 			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			autoRenewEnabledValue, err := shared.ParseOptionalBoolFlag("--auto-renew-enabled", *autoRenewEnabled)

--- a/internal/cli/offercodes/update_helpers.go
+++ b/internal/cli/offercodes/update_helpers.go
@@ -43,7 +43,7 @@ func newActiveUpdateCommand(config activeUpdateCommandConfig) *ffcli.Command {
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --%s is required\n", config.IDFlag)
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			activeValue, err := shared.ParseOptionalBoolFlag("--active", *active)
@@ -52,7 +52,7 @@ func newActiveUpdateCommand(config activeUpdateCommandConfig) *ffcli.Command {
 			}
 			if activeValue == nil {
 				fmt.Fprintln(os.Stderr, "Error: --active is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/passtypeids/certificates.go
+++ b/internal/cli/passtypeids/certificates.go
@@ -69,7 +69,7 @@ Examples:
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
 			if passTypeIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("pass-type-ids certificates list: --limit must be between 1 and 200")
@@ -173,7 +173,7 @@ Examples:
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
 			if passTypeIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("pass-type-ids certificates get: --limit must be between 1 and 200")

--- a/internal/cli/passtypeids/pass_type_ids.go
+++ b/internal/cli/passtypeids/pass_type_ids.go
@@ -194,7 +194,7 @@ Examples:
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
 			if passTypeIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *certificatesLimit != 0 && (*certificatesLimit < 1 || *certificatesLimit > 50) {
 				return fmt.Errorf("pass-type-ids get: --limit-certificates must be between 1 and 50")
@@ -267,12 +267,12 @@ Examples:
 			identifierValue := strings.TrimSpace(*identifier)
 			if identifierValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --identifier is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -319,12 +319,12 @@ Examples:
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
 			if passTypeIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -370,11 +370,11 @@ Examples:
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
 			if passTypeIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/performance/performance_diagnostics.go
+++ b/internal/cli/performance/performance_diagnostics.go
@@ -65,7 +65,7 @@ Examples:
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("performance diagnostics list: --limit must be between 1 and 200")
@@ -145,7 +145,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*signatureID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("performance diagnostics get: --limit must be between 1 and 200")

--- a/internal/cli/performance/performance_download.go
+++ b/internal/cli/performance/performance_download.go
@@ -62,7 +62,7 @@ Examples:
 				appFlag = shared.ResolveAppID(*appID)
 				if appFlag == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app, --build, or --diagnostic-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				selectionCount = 1
 			}

--- a/internal/cli/performance/performance_metrics.go
+++ b/internal/cli/performance/performance_metrics.go
@@ -63,7 +63,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platforms, err := normalizePerfPowerMetricPlatforms(shared.SplitCSVUpper(*platform), "--platform")
@@ -123,7 +123,7 @@ Examples:
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			platforms, err := normalizePerfPowerMetricPlatforms(shared.SplitCSVUpper(*platform), "--platform")

--- a/internal/cli/preorders/pre_orders.go
+++ b/internal/cli/preorders/pre_orders.go
@@ -65,7 +65,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -169,15 +169,15 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*territory) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --territory is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*releaseDate) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --release-date is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if availableInNewTerritories.IsSet() {
@@ -300,7 +300,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*territoryAvailabilityID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --territory-availability is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.TerritoryAvailabilityUpdateAttributes{}
@@ -332,7 +332,7 @@ Examples:
 			}
 			if !hasAttr {
 				fmt.Fprintln(os.Stderr, "Error: at least one of --release-date, --pre-order-enabled, or --available is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -374,7 +374,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*territoryAvailabilityID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --territory-availability is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			preOrderEnabled := false
@@ -420,7 +420,7 @@ Examples:
 			ids := shared.SplitCSV(*territoryAvailabilityIDs)
 			if len(ids) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --territory-availability is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/prerelease/prerelease.go
+++ b/internal/cli/prerelease/prerelease.go
@@ -80,7 +80,7 @@ Examples:
 			nextValue := strings.TrimSpace(*next)
 			if resolvedAppID == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -153,7 +153,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/prerelease/prerelease_related.go
+++ b/internal/cli/prerelease/prerelease_related.go
@@ -57,7 +57,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -133,7 +133,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -152,7 +152,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithPreReleaseVersionBuildsLimit(200))
 				firstPage, err := client.GetPreReleaseVersionBuilds(requestCtx, idValue, paginateOpts...)

--- a/internal/cli/prerelease/relationships.go
+++ b/internal/cli/prerelease/relationships.go
@@ -83,7 +83,7 @@ Examples:
 			relationshipType := strings.TrimSpace(*relType)
 			if relationshipType == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			kind, ok := preReleaseRelationshipKinds[relationshipType]
@@ -96,7 +96,7 @@ Examples:
 			nextValue := strings.TrimSpace(*next)
 			if versionValue == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if kind == relationshipSingle && (nextValue != "" || *paginate || *limit != 0) {

--- a/internal/cli/pricing/current.go
+++ b/internal/cli/pricing/current.go
@@ -74,7 +74,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if *allTerritories && strings.TrimSpace(*territory) != "" {

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -186,7 +186,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -259,7 +259,7 @@ Examples:
 			trimmedPricePointID := strings.TrimSpace(*pricePointID)
 			if trimmedPricePointID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --price-point is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -357,7 +357,7 @@ Examples:
 			}
 			if idValue == "" && appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --id is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if idValue != "" && strings.TrimSpace(*appID) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id and --app are mutually exclusive")
@@ -444,7 +444,7 @@ Examples:
 			trimmedScheduleID := strings.TrimSpace(*scheduleID)
 			if trimmedScheduleID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --schedule is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -534,7 +534,7 @@ Examples:
 			trimmedScheduleID := strings.TrimSpace(*scheduleID)
 			if trimmedScheduleID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --schedule is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -643,7 +643,7 @@ Examples:
 			}
 			if idValue == "" && appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --id is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if idValue != "" && strings.TrimSpace(*appID) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id and --app are mutually exclusive")

--- a/internal/cli/pricing/tiers.go
+++ b/internal/cli/pricing/tiers.go
@@ -45,7 +45,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			territoryInput := strings.TrimSpace(*territory)

--- a/internal/cli/productpages/custom_page_localization_media_sets.go
+++ b/internal/cli/productpages/custom_page_localization_media_sets.go
@@ -65,7 +65,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
 				return fmt.Errorf("custom-pages localizations preview-sets list: --limit must be between 1 and %d", productPagesMaxLimit)
@@ -164,7 +164,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
 				return fmt.Errorf("custom-pages localizations screenshot-sets list: --limit must be between 1 and %d", productPagesMaxLimit)

--- a/internal/cli/productpages/custom_page_localization_media_upload.go
+++ b/internal/cli/productpages/custom_page_localization_media_upload.go
@@ -71,7 +71,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to sync")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := executeCustomPageScreenshotUpload(ctx, *localizationID, *path, *deviceType, true)
@@ -138,7 +138,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to sync")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := executeCustomPagePreviewUpload(ctx, *localizationID, *path, *deviceType, true)

--- a/internal/cli/productpages/custom_page_localization_media_upload.go
+++ b/internal/cli/productpages/custom_page_localization_media_upload.go
@@ -190,17 +190,17 @@ func executeCustomPagePreviewUpload(
 	trimmedLocalizationID := strings.TrimSpace(localizationID)
 	if trimmedLocalizationID == "" {
 		fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
 		fmt.Fprintln(os.Stderr, "Error: --path is required")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 	trimmedDeviceType := strings.TrimSpace(deviceType)
 	if trimmedDeviceType == "" {
 		fmt.Fprintln(os.Stderr, "Error: --device-type is required")
-		return nil, flag.ErrHelp
+		return nil, shared.MissingRequiredUsageError()
 	}
 
 	previewType, err := assets.NormalizePreviewType(trimmedDeviceType)

--- a/internal/cli/productpages/custom_page_localization_search_keywords.go
+++ b/internal/cli/productpages/custom_page_localization_search_keywords.go
@@ -60,7 +60,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -103,13 +103,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			keywordValues := shared.SplitCSV(*keywords)
 			if len(keywordValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -152,17 +152,17 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			keywordValues := shared.SplitCSV(*keywords)
 			if len(keywordValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/productpages/custom_page_localizations.go
+++ b/internal/cli/productpages/custom_page_localizations.go
@@ -79,7 +79,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -143,7 +143,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -188,13 +188,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -237,13 +237,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			promoValue := strings.TrimSpace(*promotionalText)
 			if promoValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --promotional-text is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.AppCustomProductPageLocalizationUpdateAttributes{
@@ -290,11 +290,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/productpages/custom_page_versions.go
+++ b/internal/cli/productpages/custom_page_versions.go
@@ -72,7 +72,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*customPageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -136,7 +136,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -180,7 +180,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*customPageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -223,13 +223,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			deepLinkValue := strings.TrimSpace(*deepLink)
 			if deepLinkValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --deep-link is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.AppCustomProductPageVersionUpdateAttributes{

--- a/internal/cli/productpages/custom_pages.go
+++ b/internal/cli/productpages/custom_pages.go
@@ -79,7 +79,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -143,7 +143,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*customPageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -186,13 +186,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -238,7 +238,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*customPageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.AppCustomProductPageUpdateAttributes{}
@@ -251,7 +251,7 @@ Examples:
 			}
 			if attrs.Name == nil && attrs.Visible == nil {
 				fmt.Fprintln(os.Stderr, "Error: --name or --visible is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -294,11 +294,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*customPageID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --custom-page-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/productpages/experiment_treatment_localization_media_sets.go
+++ b/internal/cli/productpages/experiment_treatment_localization_media_sets.go
@@ -64,7 +64,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
 				return fmt.Errorf("experiments treatments localizations preview-sets list: --limit must be between 1 and %d", productPagesMaxLimit)
@@ -165,7 +165,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
 				return fmt.Errorf("experiments treatments localizations screenshot-sets list: --limit must be between 1 and %d", productPagesMaxLimit)
@@ -269,7 +269,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to sync")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := executeExperimentTreatmentLocalizationScreenshotUpload(ctx, *localizationID, *path, *deviceType, true)

--- a/internal/cli/productpages/experiment_treatment_localizations.go
+++ b/internal/cli/productpages/experiment_treatment_localizations.go
@@ -75,7 +75,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*treatmentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --treatment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -139,7 +139,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -182,13 +182,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*treatmentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --treatment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -231,11 +231,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*localizationID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --localization-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/productpages/experiment_treatments.go
+++ b/internal/cli/productpages/experiment_treatments.go
@@ -77,7 +77,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*experimentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experiment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -154,7 +154,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*treatmentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --treatment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -199,13 +199,13 @@ Examples:
 			trimmedID := strings.TrimSpace(*experimentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experiment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -250,14 +250,14 @@ Examples:
 			trimmedID := strings.TrimSpace(*treatmentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --treatment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			appIconValue := strings.TrimSpace(*appIconName)
 			if nameValue == "" && appIconValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name or --app-icon-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.AppStoreVersionExperimentTreatmentUpdateAttributes{}
@@ -308,11 +308,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*treatmentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --treatment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/productpages/experiments.go
+++ b/internal/cli/productpages/experiments.go
@@ -89,7 +89,7 @@ Examples:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				client, err := shared.GetASCClient()
@@ -134,7 +134,7 @@ Examples:
 			trimmedVersionID := strings.TrimSpace(*versionID)
 			if trimmedVersionID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -201,7 +201,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*experimentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experiment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -257,7 +257,7 @@ Examples:
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			trafficValue, err := parseTrafficProportion(*trafficProportion)
@@ -270,7 +270,7 @@ Examples:
 				resolvedAppID := shared.ResolveAppID(*appID)
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 
 				platformValue, err := shared.NormalizePlatform(*platform)
@@ -298,7 +298,7 @@ Examples:
 			trimmedVersionID := strings.TrimSpace(*versionID)
 			if trimmedVersionID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -348,7 +348,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*experimentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experiment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrsName := strings.TrimSpace(*name)
@@ -364,7 +364,7 @@ Examples:
 
 			if attrsName == "" && trafficPtr == nil && !started.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --name, --traffic-proportion, or --started is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -442,11 +442,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*experimentID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --experiment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/profiles/inspect.go
+++ b/internal/cli/profiles/inspect.go
@@ -76,7 +76,7 @@ Examples:
 			pathValue := strings.TrimSpace(*sourcePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file, err := shared.OpenExistingNoFollow(pathValue)

--- a/internal/cli/profiles/local.go
+++ b/internal/cli/profiles/local.go
@@ -144,7 +144,7 @@ Examples:
 			idValue := strings.TrimSpace(*profileID)
 			if pathValue == "" && idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path or --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if pathValue != "" && idValue != "" {
 				return shared.UsageError("--path and --id are mutually exclusive")
@@ -360,7 +360,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*dryRun && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*expiredOnly {
 				// At least one clean mode is required; currently only --expired exists.

--- a/internal/cli/profiles/profiles.go
+++ b/internal/cli/profiles/profiles.go
@@ -160,7 +160,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			includeValues, err := normalizeProfileInclude(*include)
@@ -217,22 +217,22 @@ Examples:
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			profileTypeValue := strings.ToUpper(strings.TrimSpace(*profileType))
 			if profileTypeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --profile-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			bundleValue := strings.TrimSpace(*bundleID)
 			if bundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			certificateIDs := shared.SplitCSV(*certificates)
 			if len(certificateIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --certificate is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			deviceIDs := shared.SplitCSV(*devices)
 
@@ -280,11 +280,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -331,12 +331,12 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*outputPath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --output is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/profiles/relationships.go
+++ b/internal/cli/profiles/relationships.go
@@ -62,7 +62,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -108,7 +108,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("profiles links certificates: --limit must be between 1 and 200")
@@ -140,7 +140,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
 				firstPage, err := client.GetProfileCertificatesRelationships(requestCtx, idValue, paginateOpts...)
@@ -193,7 +193,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("profiles links devices: --limit must be between 1 and 200")
@@ -225,7 +225,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
 				firstPage, err := client.GetProfileDevicesRelationships(requestCtx, idValue, paginateOpts...)

--- a/internal/cli/promotedpurchases/promoted_purchases.go
+++ b/internal/cli/promotedpurchases/promoted_purchases.go
@@ -80,7 +80,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -144,7 +144,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -193,18 +193,18 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			productIDValue := strings.TrimSpace(*productID)
 			if productIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*productType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			productTypeValue, err := normalizePromotedPurchaseProductType(*productType)
@@ -215,7 +215,7 @@ Examples:
 
 			if !visibleForAllUsers.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --visible-for-all-users is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -297,11 +297,11 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !visibleForAllUsers.IsSet() && !enabled.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -353,13 +353,13 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -410,7 +410,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var promotedPurchaseIDs []string
@@ -421,14 +421,14 @@ Examples:
 				}
 				if !*confirm {
 					fmt.Fprintln(os.Stderr, "Error: --confirm is required with --clear")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				promotedPurchaseIDs = nil
 			} else {
 				promotedPurchaseIDs = shared.SplitCSV(*promotedIDs)
 				if len(promotedPurchaseIDs) == 0 {
 					fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -97,7 +97,7 @@ Examples:
 		}
 		if appID == "" && strings.TrimSpace(next) == "" {
 			fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-			return flag.ErrHelp
+			return shared.MissingRequiredUsageError()
 		}
 
 		client, err := shared.GetASCClient()
@@ -202,7 +202,7 @@ Examples:
 
 		if appID == "" {
 			fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-			return flag.ErrHelp
+			return shared.MissingRequiredUsageError()
 		}
 
 		var scopedIDs []string
@@ -213,13 +213,13 @@ Examples:
 			}
 			if !confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --clear")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 		} else {
 			scopedIDs = shared.SplitCSV(promotedIDs)
 			if len(scopedIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 		}
 

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -107,7 +107,7 @@ Examples:
 			resolvedAppInput := shared.ResolveAppID(*appID)
 			if resolvedAppInput == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			setFlags := collectSetFlags(fs)
@@ -154,11 +154,11 @@ Examples:
 			parsedGroupIDs := shared.SplitCSV(*groupIDs)
 			if len(parsedGroupIDs) == 0 {
 				fmt.Fprintf(os.Stderr, "Error: --group is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *submit && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --submit")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *confirm && !*submit {
 				fmt.Fprintln(os.Stderr, "Error: --confirm requires --submit")
@@ -169,11 +169,11 @@ Examples:
 			localeValue := strings.TrimSpace(*locale)
 			if testNotesValue != "" && localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required with --test-notes")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if testNotesValue == "" && localeValue != "" {
 				fmt.Fprintln(os.Stderr, "Error: --test-notes is required with --locale")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if testNotesValue != "" {
 				if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
@@ -441,13 +441,13 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if *submit && !*confirm && !*dryRun {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --submit")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			resolvedAppInput := shared.ResolveAppID(*appID)
 			if resolvedAppInput == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			setFlags := collectSetFlags(fs)
@@ -475,7 +475,7 @@ Examples:
 				}
 			case ipaValue == "":
 				fmt.Fprintf(os.Stderr, "Error: --ipa is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")

--- a/internal/cli/releasenotes/release_notes.go
+++ b/internal/cli/releasenotes/release_notes.go
@@ -91,13 +91,13 @@ Examples:
 			}
 			if sinceTagValue == "" && sinceRefValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: one of --since-tag or --since-ref is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			until := strings.TrimSpace(*untilRef)
 			if until == "" {
 				fmt.Fprintln(os.Stderr, "Error: --until-ref is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			formatValue := strings.ToLower(strings.TrimSpace(*format))

--- a/internal/cli/reviews/review_attachments.go
+++ b/internal/cli/reviews/review_attachments.go
@@ -63,7 +63,7 @@ Examples:
 			reviewDetailValue := strings.TrimSpace(*reviewDetailID)
 			if reviewDetailValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --review-detail is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -135,7 +135,7 @@ Examples:
 			attachmentValue := strings.TrimSpace(*attachmentID)
 			if attachmentValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeReviewAttachmentFields(*fields)
@@ -196,13 +196,13 @@ Examples:
 			reviewDetailValue := strings.TrimSpace(*reviewDetailID)
 			if reviewDetailValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --review-detail is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			info, err := os.Lstat(pathValue)
@@ -287,11 +287,11 @@ Examples:
 			attachmentValue := strings.TrimSpace(*attachmentID)
 			if attachmentValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/reviews/review_details.go
+++ b/internal/cli/reviews/review_details.go
@@ -45,7 +45,7 @@ Examples:
 			detailValue := strings.TrimSpace(*detailID)
 			if detailValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -87,7 +87,7 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -167,7 +167,7 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -275,7 +275,7 @@ Examples:
 			detailValue := strings.TrimSpace(*detailID)
 			if detailValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -285,7 +285,7 @@ Examples:
 
 			if !hasReviewDetailUpdates(visited) {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if visited["demo-account-password"] {
 				if err := validateReviewDetailDemoPasswordLength(strings.TrimSpace(*demoAccountPassword)); err != nil {

--- a/internal/cli/reviews/review_items.go
+++ b/internal/cli/reviews/review_items.go
@@ -34,7 +34,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*itemID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -85,7 +85,7 @@ Examples:
 			}
 			if strings.TrimSpace(*submissionID) == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -153,15 +153,15 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*submissionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*itemType) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --item-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*itemID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --item-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedType, err := normalizeReviewSubmissionItemType(*itemType)
@@ -209,11 +209,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*itemID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*state) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --state is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedState, err := normalizeReviewSubmissionItemState(*state)
@@ -263,11 +263,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to remove")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*itemID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/reviews/review_overview.go
+++ b/internal/cli/reviews/review_overview.go
@@ -212,7 +212,7 @@ func resolveReviewOverviewFlags(appID, version, versionID, platform string) (str
 	resolvedAppID := shared.ResolveAppID(appID)
 	if strings.TrimSpace(resolvedAppID) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-		return "", "", "", "", flag.ErrHelp
+		return "", "", "", "", shared.MissingRequiredUsageError()
 	}
 
 	versionValue := strings.TrimSpace(version)

--- a/internal/cli/reviews/review_submissions.go
+++ b/internal/cli/reviews/review_submissions.go
@@ -63,12 +63,12 @@ Examples:
 			// Require one of --app or --global (unless --next is provided)
 			if !*global && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --global is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			// Top-level /v1/reviewSubmissions requires filter[app].
 			if *global && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required with --global (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -164,7 +164,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*submissionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -207,7 +207,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
@@ -255,7 +255,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*submissionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -264,7 +264,7 @@ Examples:
 			})
 			if !visited["canceled"] {
 				fmt.Fprintln(os.Stderr, "Error: --canceled is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.ReviewSubmissionUpdateAttributes{
@@ -310,11 +310,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to submit")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*submissionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -356,11 +356,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to cancel")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*submissionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -406,7 +406,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*submissionID)
 			if trimmedID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("review submissions-items-ids: --limit must be between 1 and 200")

--- a/internal/cli/reviews/review_submit.go
+++ b/internal/cli/reviews/review_submit.go
@@ -62,23 +62,23 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*buildID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*version) == "" && strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version or --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*version) != "" && strings.TrimSpace(*versionID) != "" {
 				return shared.UsageError("--version and --version-id are mutually exclusive")
 			}
 			if !*confirm && !*dryRun {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required unless --dry-run is set")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}

--- a/internal/cli/reviews/reviews.go
+++ b/internal/cli/reviews/reviews.go
@@ -122,7 +122,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *onlyUnresponded, *includeResponse, *responseFields)

--- a/internal/cli/reviews/reviews.go
+++ b/internal/cli/reviews/reviews.go
@@ -70,11 +70,13 @@ Examples:
 			ReviewsResponseCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
-			// If no flags are set and no args, show help
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
-				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.UsageError("--app is required (or set ASC_APP_ID)")
 			}
 
 			// Execute the list functionality directly

--- a/internal/cli/reviews/reviews_get.go
+++ b/internal/cli/reviews/reviews_get.go
@@ -32,7 +32,7 @@ Examples:
 			reviewValue := strings.TrimSpace(*reviewID)
 			if reviewValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/reviews/reviews_ratings.go
+++ b/internal/cli/reviews/reviews_ratings.go
@@ -52,7 +52,7 @@ Examples:
 
 			if strings.TrimSpace(*appID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if *workers < 1 {

--- a/internal/cli/reviews/reviews_responses.go
+++ b/internal/cli/reviews/reviews_responses.go
@@ -38,11 +38,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*reviewID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --review-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*response) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --response is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -111,7 +111,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*responseID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -155,11 +155,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*responseID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -207,7 +207,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*reviewID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --review-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/reviews/reviews_summarizations.go
+++ b/internal/cli/reviews/reviews_summarizations.go
@@ -52,7 +52,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeReviewSummarizationFields(*fields)

--- a/internal/cli/reviews/submissions_history.go
+++ b/internal/cli/reviews/submissions_history.go
@@ -84,7 +84,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/routingcoverage/routing_coverage.go
+++ b/internal/cli/routingcoverage/routing_coverage.go
@@ -61,7 +61,7 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -103,7 +103,7 @@ Examples:
 			coverageValue := strings.TrimSpace(*coverageID)
 			if coverageValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -146,13 +146,13 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			info, err := os.Lstat(pathValue)
@@ -237,11 +237,11 @@ Examples:
 			coverageValue := strings.TrimSpace(*coverageID)
 			if coverageValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/sandbox/sandbox_manage.go
+++ b/internal/cli/sandbox/sandbox_manage.go
@@ -35,7 +35,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*testerID) == "" && strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*email) != "" {
 				if err := validateSandboxEmail(*email); err != nil {
@@ -93,7 +93,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*testerID) == "" && strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*email) != "" {
 				if err := validateSandboxEmail(*email); err != nil {
@@ -112,7 +112,7 @@ Examples:
 
 			if !interruptPurchases.IsSet() && normalizedTerritory == "" && normalizedRate == "" {
 				fmt.Fprintln(os.Stderr, "Error: --territory, --interrupt-purchases, or --subscription-renewal-rate is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -181,11 +181,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*testerID) == "" && strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*email) != "" {
 				if err := validateSandboxEmail(*email); err != nil {

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -90,7 +90,7 @@ Examples:
 			}
 			if len(args) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: search query is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --limit must be greater than 0")
@@ -100,7 +100,7 @@ Examples:
 			query := strings.Join(args, " ")
 			if strings.TrimSpace(query) == "" {
 				fmt.Fprintln(os.Stderr, "Error: search query is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			selectedOutput := *output.Output
 			selectedPretty := *output.Pretty

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -54,19 +54,19 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 			resolvedAppID := resolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return MissingRequiredUsageError()
 			}
 			if !*allTerritories && strings.TrimSpace(*territory) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --territory or --all-territories is required")
-				return flag.ErrHelp
+				return MissingRequiredUsageError()
 			}
 			if !available.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --available is required (true or false)")
-				return flag.ErrHelp
+				return MissingRequiredUsageError()
 			}
 			if config.IncludeAvailableInNewTerritories && !availableInNewTerritories.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --available-in-new-territories is required (true or false)")
-				return flag.ErrHelp
+				return MissingRequiredUsageError()
 			}
 
 			var territories []string

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -28,10 +28,16 @@ const (
 )
 
 type classifiedUsageError struct {
-	kind UsageErrorKind
+	kind    UsageErrorKind
+	message string
 }
 
-func (e classifiedUsageError) Error() string { return flag.ErrHelp.Error() }
+func (e classifiedUsageError) Error() string {
+	if e.message == "" {
+		return flag.ErrHelp.Error()
+	}
+	return e.message
+}
 func (e classifiedUsageError) Unwrap() error { return flag.ErrHelp }
 
 func (e reportedError) Error() string {
@@ -61,7 +67,7 @@ func UsageError(message string) error {
 	if trimmed != "" {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", trimmed)
 	}
-	return classifiedUsageError{kind: classifyUsageMessage(trimmed)}
+	return classifiedUsageError{kind: classifyUsageMessage(trimmed), message: trimmed}
 }
 
 // UsageErrorf formats and returns a usage-class validation error.

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -75,6 +75,12 @@ func UsageErrorf(format string, args ...any) error {
 	return UsageError(fmt.Sprintf(format, args...))
 }
 
+// MissingRequiredUsageError classifies a required-input failure after the
+// command has already written its diagnostic to stderr.
+func MissingRequiredUsageError() error {
+	return classifiedUsageError{kind: UsageErrorMissingRequired}
+}
+
 func ClassifyUsageError(err error) UsageErrorKind {
 	var classified classifiedUsageError
 	if errors.As(err, &classified) {

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -17,6 +18,21 @@ type ReportedError interface {
 type reportedError struct {
 	err error
 }
+
+type UsageErrorKind string
+
+const (
+	UsageErrorMissingRequired UsageErrorKind = "missing_required"
+	UsageErrorInvalidValue    UsageErrorKind = "invalid_value"
+	UsageErrorOther           UsageErrorKind = "other"
+)
+
+type classifiedUsageError struct {
+	kind UsageErrorKind
+}
+
+func (e classifiedUsageError) Error() string { return flag.ErrHelp.Error() }
+func (e classifiedUsageError) Unwrap() error { return flag.ErrHelp }
 
 func (e reportedError) Error() string {
 	return e.err.Error()
@@ -45,10 +61,29 @@ func UsageError(message string) error {
 	if trimmed != "" {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", trimmed)
 	}
-	return flag.ErrHelp
+	return classifiedUsageError{kind: classifyUsageMessage(trimmed)}
 }
 
 // UsageErrorf formats and returns a usage-class validation error.
 func UsageErrorf(format string, args ...any) error {
 	return UsageError(fmt.Sprintf(format, args...))
+}
+
+func ClassifyUsageError(err error) UsageErrorKind {
+	var classified classifiedUsageError
+	if errors.As(err, &classified) {
+		return classified.kind
+	}
+	return ""
+}
+
+func classifyUsageMessage(message string) UsageErrorKind {
+	lower := strings.ToLower(message)
+	if strings.Contains(lower, "required") {
+		return UsageErrorMissingRequired
+	}
+	if strings.Contains(lower, "invalid") || strings.Contains(lower, "unsupported") || strings.Contains(lower, "must be") {
+		return UsageErrorInvalidValue
+	}
+	return UsageErrorOther
 }

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -1,0 +1,28 @@
+package shared
+
+import (
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestUsageErrorPreservesValidationMessage(t *testing.T) {
+	var usageErr error
+	_, stderr := captureOutput(t, func() {
+		usageErr = UsageError("--app is required")
+	})
+
+	if usageErr.Error() != "--app is required" {
+		t.Fatalf("UsageError().Error() = %q, want %q", usageErr.Error(), "--app is required")
+	}
+	if !errors.Is(usageErr, flag.ErrHelp) {
+		t.Fatalf("UsageError() should unwrap to flag.ErrHelp, got %v", usageErr)
+	}
+	if got := ClassifyUsageError(usageErr); got != UsageErrorMissingRequired {
+		t.Fatalf("ClassifyUsageError() = %q, want %q", got, UsageErrorMissingRequired)
+	}
+	if !strings.Contains(stderr, "Error: --app is required") {
+		t.Fatalf("UsageError() stderr = %q", stderr)
+	}
+}

--- a/internal/cli/shared/pricing_command.go
+++ b/internal/cli/shared/pricing_command.go
@@ -53,7 +53,7 @@ func NewPricingSetCommand(config PricingSetCommandConfig) *ffcli.Command {
 			resolvedAppID := resolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return MissingRequiredUsageError()
 			}
 			pricePointValue := strings.TrimSpace(*pricePointID)
 			tierValue := *tier
@@ -72,7 +72,7 @@ func NewPricingSetCommand(config PricingSetCommandConfig) *ffcli.Command {
 			baseTerritoryInput := strings.TrimSpace(*baseTerritory)
 			if requiresExplicitBaseTerritory(config, baseTerritoryInput, tierValue, priceValue, freeValue) {
 				fmt.Fprintln(os.Stderr, "Error: --base-territory is required")
-				return flag.ErrHelp
+				return MissingRequiredUsageError()
 			}
 			baseTerritoryValue := baseTerritoryInput
 			if baseTerritoryInput != "" {
@@ -89,7 +89,7 @@ func NewPricingSetCommand(config PricingSetCommandConfig) *ffcli.Command {
 					startDateValue = time.Now().Format("2006-01-02")
 				} else {
 					fmt.Fprintln(os.Stderr, "Error: --start-date is required")
-					return flag.ErrHelp
+					return MissingRequiredUsageError()
 				}
 			}
 

--- a/internal/cli/shared/suggest/suggest.go
+++ b/internal/cli/shared/suggest/suggest.go
@@ -33,7 +33,7 @@ func Commands(input string, candidates []string) []string {
 		}
 
 		d := levenshtein(in, name)
-		if !withinThreshold(in, d) {
+		if !withinThreshold(in, d) && !isAdjacentTransposition(in, name) {
 			continue
 		}
 		collected = append(collected, candidate{name: name, score: 1, dist: d})
@@ -67,6 +67,24 @@ func Commands(input string, candidates []string) []string {
 		}
 	}
 	return out
+}
+
+func isAdjacentTransposition(a, b string) bool {
+	if len(a) != len(b) || len(a) < 2 {
+		return false
+	}
+	first := -1
+	for i := range len(a) {
+		if a[i] == b[i] {
+			continue
+		}
+		if first == -1 {
+			first = i
+			continue
+		}
+		return i == first+1 && a[first] == b[i] && a[i] == b[first] && a[i+1:] == b[i+1:]
+	}
+	return false
 }
 
 func withinThreshold(input string, dist int) bool {

--- a/internal/cli/shared/suggest/suggest_test.go
+++ b/internal/cli/shared/suggest/suggest_test.go
@@ -25,6 +25,13 @@ func TestCommandsConservativeBehavior(t *testing.T) {
 	}
 }
 
+func TestCommandsAdjacentTransposition(t *testing.T) {
+	got := Commands("lsit", []string{"list", "view", "update"})
+	if len(got) == 0 || got[0] != "list" {
+		t.Fatalf("expected adjacent transposition suggestion, got %v", got)
+	}
+}
+
 func TestLevenshteinAndThresholdHelpers(t *testing.T) {
 	if d := levenshtein("apps", "apps"); d != 0 {
 		t.Fatalf("expected equal strings distance 0, got %d", d)

--- a/internal/cli/shots/shots_capture.go
+++ b/internal/cli/shots/shots_capture.go
@@ -40,12 +40,12 @@ macOS: app must be running. Captures the frontmost visible window by bundle ID.
 			bundleIDVal := strings.TrimSpace(*bundleID)
 			if bundleIDVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			nameVal := strings.TrimSpace(*name)
 			if nameVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if nameVal == "." || nameVal == ".." || strings.ContainsAny(nameVal, `/\`) {
 				fmt.Fprintln(os.Stderr, "Error: --name must be a file name without path separators")

--- a/internal/cli/shots/shots_frame.go
+++ b/internal/cli/shots/shots_frame.go
@@ -62,7 +62,7 @@ framed screenshots whenever the YAML config or referenced raw assets change.`,
 			inputVal := strings.TrimSpace(*inputPath)
 			if configVal == "" && inputVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --input is required when --config is not set")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if configVal != "" && inputVal != "" {
 				fmt.Fprintln(os.Stderr, "Error: use either --input or --config, not both")

--- a/internal/cli/shots/shots_review_generate.go
+++ b/internal/cli/shots/shots_review_generate.go
@@ -41,7 +41,7 @@ func ShotsReviewGenerateCommand() *ffcli.Command {
 			framed := strings.TrimSpace(*framedDir)
 			if framed == "" {
 				fmt.Fprintln(os.Stderr, "Error: --framed-dir is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := screenshots.GenerateReview(ctx, screenshots.ReviewRequest{

--- a/internal/cli/shots/shots_review_open.go
+++ b/internal/cli/shots/shots_review_open.go
@@ -29,7 +29,7 @@ func ShotsReviewOpenCommand() *ffcli.Command {
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*outputDir) == "" && strings.TrimSpace(*htmlPath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --output-dir or --html-path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := screenshots.OpenReview(ctx, screenshots.ReviewOpenRequest{

--- a/internal/cli/shots/shots_run.go
+++ b/internal/cli/shots/shots_run.go
@@ -36,7 +36,7 @@ Supported actions: launch, tap, type, wait, wait_for (polling), screenshot.`,
 			planPathVal := strings.TrimSpace(*planPath)
 			if planPathVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --plan is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			absPlanPath, err := filepath.Abs(planPathVal)

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -52,18 +52,18 @@ Examples:
 			bundle := strings.TrimSpace(*bundleID)
 			if bundle == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			profType := strings.TrimSpace(*profileType)
 			if profType == "" {
 				fmt.Fprintln(os.Stderr, "Error: --profile-type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			profType = strings.ToUpper(profType)
 			if *createMissing && isDevelopmentProfile(profType) && strings.TrimSpace(*deviceIDs) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --device is required for development profiles")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			outputDir := strings.TrimSpace(*outputPath)

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -169,7 +169,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			includes, err := parseInclude(*include)

--- a/internal/cli/submit/submit.go
+++ b/internal/cli/submit/submit.go
@@ -122,7 +122,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*submissionID) == "" && strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*submissionID) != "" && strings.TrimSpace(*versionID) != "" {
 				return shared.UsageError("--id and --version-id are mutually exclusive")
@@ -486,11 +486,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to cancel a submission")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*submissionID) == "" && strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*submissionID) != "" && strings.TrimSpace(*versionID) != "" {
 				return shared.UsageError("--id and --version-id are mutually exclusive")

--- a/internal/cli/subscriptions/app_store_review_screenshot.go
+++ b/internal/cli/subscriptions/app_store_review_screenshot.go
@@ -57,7 +57,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/grace_periods.go
+++ b/internal/cli/subscriptions/grace_periods.go
@@ -59,7 +59,7 @@ Examples:
 			id := strings.TrimSpace(*gracePeriodID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -107,7 +107,7 @@ Examples:
 			id := strings.TrimSpace(*gracePeriodID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			durationValue, err := normalizeSubscriptionGracePeriodDuration(*duration, false)
@@ -122,7 +122,7 @@ Examples:
 			}
 			if !optIn.IsSet() && !sandboxOptIn.IsSet() && durationValue == "" && renewalTypeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/group_localizations.go
+++ b/internal/cli/subscriptions/group_localizations.go
@@ -74,7 +74,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -138,7 +138,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -183,19 +183,19 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -247,14 +247,14 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			customValue := strings.TrimSpace(*customAppName)
 			if nameValue == "" && customValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -305,11 +305,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/images.go
+++ b/internal/cli/subscriptions/images.go
@@ -74,7 +74,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -145,7 +145,7 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -189,13 +189,13 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			file, info, err := openSubscriptionImageFile(pathValue)
@@ -277,13 +277,13 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			checksumValue := strings.TrimSpace(*checksum)
 			if checksumValue == "" && !uploaded.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -335,11 +335,11 @@ Examples:
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -82,7 +82,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -153,7 +153,7 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -211,7 +211,7 @@ Timeouts:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			duration, err := normalizeSubscriptionOfferDuration(*offerDuration)
@@ -228,7 +228,7 @@ Timeouts:
 
 			if *numberOfPeriods <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --number-of-periods is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var normalizedStartDate string
@@ -662,11 +662,11 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*endDate) == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedEndDate, err := shared.NormalizeDate(*endDate, "--end-date")
@@ -719,11 +719,11 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/introductory_offers_import.go
+++ b/internal/cli/subscriptions/introductory_offers_import.go
@@ -67,11 +67,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*subscriptionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*inputPath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --input is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedOfferDuration := ""
 			if strings.TrimSpace(*offerDuration) != "" {

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -75,7 +75,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -146,7 +146,7 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -192,19 +192,19 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			localeValue := strings.TrimSpace(*locale)
 			if localeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -261,14 +261,14 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			descriptionValue := strings.TrimSpace(*description)
 			if nameValue == "" && descriptionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -319,11 +319,11 @@ Examples:
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -85,7 +85,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -192,7 +192,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -245,13 +245,13 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			eligibility, err := normalizeSubscriptionOfferEligibility(*offerEligibility, true)
@@ -280,7 +280,7 @@ Examples:
 
 			if *numberOfPeriods <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --number-of-periods is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			priceEntries, err := parseSubscriptionOfferCodePrices(*prices, mode)
@@ -290,7 +290,7 @@ Examples:
 			}
 			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -352,11 +352,11 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !active.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --active is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -448,7 +448,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -512,7 +512,7 @@ Examples:
 			id := strings.TrimSpace(*oneTimeCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --batch-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -564,7 +564,7 @@ Examples:
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -245,7 +245,7 @@ Examples:
 			id := strings.TrimSpace(*pricePointID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --price-point-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/prices_import.go
+++ b/internal/cli/subscriptions/prices_import.go
@@ -169,13 +169,13 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			inputValue := strings.TrimSpace(*inputPath)
 			if inputValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --input is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			defaultStartDate := ""

--- a/internal/cli/subscriptions/pricing.go
+++ b/internal/cli/subscriptions/pricing.go
@@ -93,7 +93,7 @@ func buildSubscriptionsPricingSummaryCommand(
 			resolvedAppID := shared.ResolveAppID(requestedAppID)
 			if requestedSubID == "" && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app or --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			territoryInput := strings.TrimSpace(*territory)

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -72,12 +72,12 @@ Examples:
 			subID := strings.TrimSpace(*subscriptionID)
 			if subID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			price := strings.TrimSpace(*basePrice)
 			if price == "" {
 				fmt.Fprintln(os.Stderr, "Error: --base-price is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := shared.ValidateFinitePriceFlag("--base-price", price); err != nil {
 				return shared.UsageError(err.Error())

--- a/internal/cli/subscriptions/promotional_offers.go
+++ b/internal/cli/subscriptions/promotional_offers.go
@@ -75,7 +75,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -146,7 +146,7 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -195,19 +195,19 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			offerCodeValue := strings.TrimSpace(*offerCode)
 			if offerCodeValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			nameValue := strings.TrimSpace(*name)
 			if nameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			duration, err := normalizeSubscriptionOfferDuration(*offerDuration)
@@ -224,13 +224,13 @@ Examples:
 
 			if *numberOfPeriods <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --number-of-periods is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			priceIDs := shared.SplitCSV(*prices)
 			if len(priceIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -286,13 +286,13 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			priceIDs := shared.SplitCSV(*prices)
 			if len(priceIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -335,11 +335,11 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -392,7 +392,7 @@ Examples:
 			id := strings.TrimSpace(*offerID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/review_screenshots.go
+++ b/internal/cli/subscriptions/review_screenshots.go
@@ -64,7 +64,7 @@ Examples:
 			id := strings.TrimSpace(*screenshotID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -111,13 +111,13 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
 				return shared.UsageError(err.Error())
@@ -177,13 +177,13 @@ Examples:
 			id := strings.TrimSpace(*screenshotID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			checksumValue := strings.TrimSpace(*checksum)
 			if checksumValue == "" && !uploaded.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -235,11 +235,11 @@ Examples:
 			id := strings.TrimSpace(*screenshotID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/submit.go
+++ b/internal/cli/subscriptions/submit.go
@@ -34,11 +34,11 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -86,11 +86,11 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -127,7 +127,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -192,13 +192,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -244,7 +244,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -287,13 +287,13 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -340,11 +340,11 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -401,7 +401,7 @@ Examples:
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -471,19 +471,19 @@ Examples:
 			group := strings.TrimSpace(*groupID)
 			if group == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			product := strings.TrimSpace(*productID)
 			if product == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			period, err := normalizeSubscriptionPeriod(*subscriptionPeriod, false)
@@ -543,7 +543,7 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -595,7 +595,7 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
@@ -620,7 +620,7 @@ Examples:
 
 			if name == "" && note == "" && period == "" && !*familySharable && !groupLevel.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -713,11 +713,11 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -814,7 +814,7 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var planTypeFilter asc.SubscriptionPlanType
@@ -975,7 +975,7 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			pricePoint := strings.TrimSpace(*pricePointID)
@@ -1002,7 +1002,7 @@ Examples:
 			if tierValue > 0 || priceValue != "" {
 				if territoryID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --territory is required when using --tier or --price")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 
@@ -1096,11 +1096,11 @@ Examples:
 			id := strings.TrimSpace(*priceID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --price-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1182,7 +1182,7 @@ Examples:
 			subscriptionValue := strings.TrimSpace(*subscriptionID)
 			if availabilityValue == "" && subscriptionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --availability-id or --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if availabilityValue != "" && subscriptionValue != "" {
 				fmt.Fprintln(os.Stderr, "Error: --availability-id and --subscription-id are mutually exclusive")
@@ -1255,7 +1255,7 @@ Examples:
 			id := strings.TrimSpace(*availabilityID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --availability-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1328,7 +1328,7 @@ Examples:
 			id := strings.TrimSpace(*subID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
@@ -1337,7 +1337,7 @@ Examples:
 			}
 			if len(territoryIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --territories is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedBillingMode, err := normalizeSubscriptionBillingMode(*billingMode)
 			if err != nil {

--- a/internal/cli/testflight/beta_crash_logs.go
+++ b/internal/cli/testflight/beta_crash_logs.go
@@ -55,7 +55,7 @@ func deprecatedBetaCrashLogsGetAliasCommand() *ffcli.Command {
 			}
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --crash-log-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runCrashLogByCrashLogID(ctx, idValue, output)
 		},

--- a/internal/cli/testflight/beta_feedback.go
+++ b/internal/cli/testflight/beta_feedback.go
@@ -78,7 +78,7 @@ Examples:
 			submissionIDValue := strings.TrimSpace(*submissionID)
 			if submissionIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runFeedbackSubmissionView(ctx, submissionIDValue, output)
 		},
@@ -106,11 +106,11 @@ Examples:
 			submissionIDValue := strings.TrimSpace(*submissionID)
 			if submissionIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runFeedbackSubmissionDelete(ctx, submissionIDValue, output)
 		},
@@ -182,7 +182,7 @@ Examples:
 			submissionIDValue := strings.TrimSpace(*submissionID)
 			if submissionIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runCrashSubmissionView(ctx, submissionIDValue, output)
 		},
@@ -210,11 +210,11 @@ Examples:
 			submissionIDValue := strings.TrimSpace(*submissionID)
 			if submissionIDValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runCrashSubmissionDelete(ctx, submissionIDValue, output)
 		},
@@ -244,7 +244,7 @@ Examples:
 			crashLogIDValue := strings.TrimSpace(*crashLogID)
 			if (submissionIDValue == "" && crashLogIDValue == "") || (submissionIDValue != "" && crashLogIDValue != "") {
 				fmt.Fprintln(os.Stderr, "Error: exactly one of --submission-id or --crash-log-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if submissionIDValue != "" {
 				return runCrashLogBySubmissionID(ctx, submissionIDValue, output)
@@ -323,7 +323,7 @@ func deprecatedBetaFeedbackCrashSubmissionsGetAliasCommand() *ffcli.Command {
 			}
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runCrashSubmissionView(ctx, idValue, output)
 		},
@@ -353,11 +353,11 @@ func deprecatedBetaFeedbackCrashSubmissionsDeleteAliasCommand() *ffcli.Command {
 			}
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runCrashSubmissionDelete(ctx, idValue, output)
 		},
@@ -406,7 +406,7 @@ func deprecatedBetaFeedbackScreenshotSubmissionsGetAliasCommand() *ffcli.Command
 			}
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runFeedbackSubmissionView(ctx, idValue, output)
 		},
@@ -436,11 +436,11 @@ func deprecatedBetaFeedbackScreenshotSubmissionsDeleteAliasCommand() *ffcli.Comm
 			}
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runFeedbackSubmissionDelete(ctx, idValue, output)
 		},
@@ -488,7 +488,7 @@ func deprecatedBetaFeedbackCrashLogGetAliasCommand() *ffcli.Command {
 			}
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			return runCrashLogBySubmissionID(ctx, idValue, output)
 		},

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -107,7 +107,7 @@ Examples:
 			// Require one of --app or --global (unless --next is provided)
 			if !*global && resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app or --global is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -273,11 +273,11 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*name) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -325,7 +325,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*id) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -374,7 +374,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -394,12 +394,12 @@ Examples:
 				visited["feedback-enabled"]
 			if !hasUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if visited["public-link-limit-enabled"] && *publicLinkLimitEnabled && !visited["public-link-limit"] {
 				fmt.Fprintln(os.Stderr, "Error: --public-link-limit is required when enabling public link limit")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -468,11 +468,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*id) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -517,14 +517,14 @@ Examples:
 			groupID := strings.TrimSpace(*group)
 			if groupID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			testerIDs := shared.SplitCSV(*tester)
 			testerEmails := shared.SplitCSV(*email)
 			if len(testerIDs) == 0 && len(testerEmails) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester or --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -616,17 +616,17 @@ Examples:
 			groupID := strings.TrimSpace(*group)
 			if groupID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			testerIDs := shared.SplitCSV(*tester)
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_groups_related.go
+++ b/internal/cli/testflight/beta_groups_related.go
@@ -62,7 +62,7 @@ Examples:
 			}
 			if groupValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -134,7 +134,7 @@ Examples:
 			}
 			if groupValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -206,7 +206,7 @@ Examples:
 			}
 			if groupValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_groups_relationships.go
+++ b/internal/cli/testflight/beta_groups_relationships.go
@@ -76,7 +76,7 @@ Examples:
 			relationshipType := strings.TrimSpace(*relType)
 			if relationshipType == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			kind, ok := betaGroupRelationshipKinds[relationshipType]
@@ -96,7 +96,7 @@ Examples:
 			nextValue := strings.TrimSpace(*next)
 			if groupValue == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if kind == relationshipSingle && (nextValue != "" || *paginate || *limit != 0) {

--- a/internal/cli/testflight/beta_license_agreements.go
+++ b/internal/cli/testflight/beta_license_agreements.go
@@ -147,7 +147,7 @@ Examples:
 			}
 			if idValue == "" && appValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id or --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if idValue != "" && strings.TrimSpace(*appID) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id and --app are mutually exclusive")
@@ -211,12 +211,12 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			textValue := strings.TrimSpace(*agreementText)
 			if textValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --agreement-text is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_notifications.go
+++ b/internal/cli/testflight/beta_notifications.go
@@ -58,7 +58,7 @@ Examples:
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -109,7 +109,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -190,7 +190,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -236,15 +236,15 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*group) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -292,11 +292,11 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -353,13 +353,13 @@ Examples:
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			groupIDs := shared.SplitCSV(*groups)
 			if len(groupIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -414,17 +414,17 @@ Examples:
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			groupIDs := shared.SplitCSV(*groups)
 			if len(groupIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -481,13 +481,13 @@ Examples:
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			parsedBuildIDs := shared.SplitCSV(*buildIDs)
 			if len(parsedBuildIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -545,17 +545,17 @@ Examples:
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			parsedBuildIDs := shared.SplitCSV(*buildIDs)
 			if len(parsedBuildIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -610,17 +610,17 @@ Examples:
 			testerID := strings.TrimSpace(*id)
 			if testerID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			appIDs := shared.SplitCSV(*apps)
 			if len(appIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --app is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -675,11 +675,11 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -96,13 +96,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			outputValue := strings.TrimSpace(*outputPath)
 			if outputValue == "" {
 				fmt.Fprintf(os.Stderr, "Error: --output is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.HasSuffix(outputValue, string(filepath.Separator)) {
 				return shared.UsageError("--output must be a file path")
@@ -289,13 +289,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			inputValue := strings.TrimSpace(*inputPath)
 			if inputValue == "" {
 				fmt.Fprintf(os.Stderr, "Error: --input is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_testers_metrics.go
+++ b/internal/cli/testflight/beta_testers_metrics.go
@@ -70,11 +70,11 @@ Examples:
 			nextValue := strings.TrimSpace(*next)
 			if nextValue == "" && testerValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if nextValue == "" && resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_testers_related.go
+++ b/internal/cli/testflight/beta_testers_related.go
@@ -75,7 +75,7 @@ Examples:
 			}
 			if testerValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -94,7 +94,7 @@ Examples:
 			if *paginate {
 				if testerValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithBetaTesterAppsLimit(200))
 				resp, err := shared.PaginateWithSpinner(
@@ -184,7 +184,7 @@ Examples:
 			}
 			if testerValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -203,7 +203,7 @@ Examples:
 			if *paginate {
 				if testerValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithBetaTesterBetaGroupsLimit(200))
 				resp, err := shared.PaginateWithSpinner(
@@ -293,7 +293,7 @@ Examples:
 			}
 			if testerValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -312,7 +312,7 @@ Examples:
 			if *paginate {
 				if testerValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithBetaTesterBuildsLimit(200))
 				resp, err := shared.PaginateWithSpinner(

--- a/internal/cli/testflight/beta_testers_relationships.go
+++ b/internal/cli/testflight/beta_testers_relationships.go
@@ -77,7 +77,7 @@ Examples:
 			relationshipType := strings.TrimSpace(*relType)
 			if relationshipType == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			kind, ok := betaTesterRelationshipKinds[relationshipType]
@@ -97,7 +97,7 @@ Examples:
 			nextValue := strings.TrimSpace(*next)
 			if testerValue == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if kind == relationshipSingle && (nextValue != "" || *paginate || *limit != 0) {

--- a/internal/cli/testflight/metrics_beta_tester_usages.go
+++ b/internal/cli/testflight/metrics_beta_tester_usages.go
@@ -146,7 +146,7 @@ Examples:
 			nextValue := strings.TrimSpace(*next)
 			if nextValue == "" && resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -76,7 +76,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -132,7 +132,7 @@ Examples:
 			detailID := strings.TrimSpace(*id)
 			if detailID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -150,7 +150,7 @@ Examples:
 				visited["notes"]
 			if !hasUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.BetaAppReviewDetailUpdateAttributes{}
@@ -229,11 +229,11 @@ Examples:
 			}
 			if strings.TrimSpace(*buildID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -298,7 +298,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -374,7 +374,7 @@ Examples:
 			buildValue := strings.TrimSpace(*buildID)
 			if buildValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("testflight review submissions list: --limit must be between 1 and 200")
@@ -447,7 +447,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -489,7 +489,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -569,7 +569,7 @@ Examples:
 			trimmedBuildID := strings.TrimSpace(*buildID)
 			if trimmedBuildID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -640,7 +640,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -690,7 +690,7 @@ Examples:
 			detailID := strings.TrimSpace(*id)
 			if detailID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			visited := map[string]bool{}
@@ -701,7 +701,7 @@ Examples:
 			hasUpdates := visited["auto-notify"] || visited["external-testing"]
 			if !hasUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.BuildBetaDetailUpdateAttributes{}
@@ -783,11 +783,11 @@ Examples:
 			criteriaID := strings.TrimSpace(*id)
 			if criteriaID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -890,7 +890,7 @@ Examples:
 			trimmedGroupID := strings.TrimSpace(*groupID)
 			if trimmedGroupID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			filterValues, err := parseDeviceFamilyOsVersionFilters(*filters)
@@ -899,7 +899,7 @@ Examples:
 			}
 			if len(filterValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --os-version-filter is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1063,7 +1063,7 @@ Examples:
 			trimmedGroupID := strings.TrimSpace(*groupID)
 			if trimmedGroupID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1105,7 +1105,7 @@ Examples:
 			trimmedGroupID := strings.TrimSpace(*groupID)
 			if trimmedGroupID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/testflight_sync.go
+++ b/internal/cli/testflight/testflight_sync.go
@@ -147,13 +147,13 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			outputValue := strings.TrimSpace(*output)
 			if outputValue == "" {
 				fmt.Fprintf(os.Stderr, "Error: --output is required\n\n")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			buildFilters := shared.SplitCSV(*buildFilter)

--- a/internal/cli/users/invites_visible_apps.go
+++ b/internal/cli/users/invites_visible_apps.go
@@ -62,7 +62,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("users invites visible-apps list: --limit must be between 1 and 200")
@@ -94,7 +94,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithUserInvitationVisibleAppsLimit(200))
 				firstPage, err := client.GetUserInvitationVisibleApps(requestCtx, idValue, paginateOpts...)

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -150,7 +150,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			includeValues, err := normalizeUsersInclude(*include)
@@ -205,13 +205,13 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			roleValues := shared.SplitCSV(*roles)
 			if len(roleValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			warnDeprecatedUserRoles(roleValues)
 
@@ -270,13 +270,13 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -328,25 +328,25 @@ Examples:
 			emailValue := strings.TrimSpace(*email)
 			if emailValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			firstNameValue := strings.TrimSpace(*firstName)
 			if firstNameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --first-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			lastNameValue := strings.TrimSpace(*lastName)
 			if lastNameValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --last-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			roleValues := shared.SplitCSV(*roles)
 			if len(roleValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			warnDeprecatedUserRoles(roleValues)
 
@@ -359,7 +359,7 @@ Examples:
 
 			if !*allApps && len(visibleAppIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --all-apps or --visible-app is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -513,7 +513,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -555,13 +555,13 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/users/visible_apps.go
+++ b/internal/cli/users/visible_apps.go
@@ -64,7 +64,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("users visible-apps list: --limit must be between 1 and 200")
@@ -96,7 +96,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithUserVisibleAppsLimit(200))
 				firstPage, err := client.GetUserVisibleApps(requestCtx, idValue, paginateOpts...)
@@ -149,7 +149,7 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("users visible-apps get: --limit must be between 1 and 200")
@@ -181,7 +181,7 @@ Examples:
 			if *paginate {
 				if idValue == "" {
 					fmt.Fprintln(os.Stderr, "Error: --id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithLinkagesLimit(200))
 				firstPage, err := client.GetUserVisibleAppsRelationships(requestCtx, idValue, paginateOpts...)

--- a/internal/cli/validate/iap.go
+++ b/internal/cli/validate/iap.go
@@ -47,7 +47,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			return runValidateIAP(ctx, validateIAPOptions{

--- a/internal/cli/validate/subscriptions.go
+++ b/internal/cli/validate/subscriptions.go
@@ -50,7 +50,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			return runValidateSubscriptions(ctx, validateSubscriptionsOptions{

--- a/internal/cli/validate/testflight.go
+++ b/internal/cli/validate/testflight.go
@@ -52,13 +52,13 @@ Examples:
 			buildValue := strings.TrimSpace(*buildID)
 			if buildValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			return runValidateTestFlight(ctx, validateTestFlightOptions{

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -97,8 +97,7 @@ Subscriptions:
 			trimmedVersion := strings.TrimSpace(*version)
 			trimmedVersionID := strings.TrimSpace(*versionID)
 			if trimmedVersion == "" && trimmedVersionID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --version or --version-id is required")
-				return flag.ErrHelp
+				return shared.UsageError("--version or --version-id is required")
 			}
 			if trimmedVersion != "" && trimmedVersionID != "" {
 				return shared.UsageError("--version and --version-id are mutually exclusive")
@@ -106,8 +105,7 @@ Subscriptions:
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.UsageError("--app is required (or set ASC_APP_ID)")
 			}
 
 			var normalizedPlatform string

--- a/internal/cli/versions/app_clip_default_experience.go
+++ b/internal/cli/versions/app_clip_default_experience.go
@@ -55,7 +55,7 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/versions/customer_reviews.go
+++ b/internal/cli/versions/customer_reviews.go
@@ -68,7 +68,7 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/versions/experiments_v2.go
+++ b/internal/cli/versions/experiments_v2.go
@@ -68,7 +68,7 @@ Examples:
 			versionValue := strings.TrimSpace(*versionID)
 			if versionValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/versions/phased_release.go
+++ b/internal/cli/versions/phased_release.go
@@ -78,7 +78,7 @@ Examples:
 			version := strings.TrimSpace(*versionID)
 			if version == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -125,7 +125,7 @@ Examples:
 			version := strings.TrimSpace(*versionID)
 			if version == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var phasedState asc.PhasedReleaseState
@@ -186,13 +186,13 @@ Examples:
 			id := strings.TrimSpace(*phasedID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			stateValue := strings.TrimSpace(strings.ToUpper(*state))
 			if stateValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --state is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			phasedState, ok := validPhasedReleaseStates[stateValue]
@@ -244,12 +244,12 @@ Examples:
 			id := strings.TrimSpace(*phasedID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/versions/relationships.go
+++ b/internal/cli/versions/relationships.go
@@ -67,7 +67,7 @@ Examples:
 			relationshipType := strings.TrimSpace(*relType)
 			if relationshipType == "" {
 				fmt.Fprintln(os.Stderr, "Error: --type is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			kind, ok := appStoreVersionRelationshipKinds[relationshipType]
@@ -80,7 +80,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if kind == relationshipSingle && (trimmedNext != "" || *paginate || *limit != 0) {

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -92,7 +92,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -165,7 +165,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*versionID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -278,7 +278,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*versionString) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
@@ -289,7 +289,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			copyMetadataFromValue := strings.TrimSpace(*copyMetadataFrom)
@@ -305,7 +305,7 @@ Examples:
 			}
 			if copyMetadataFromValue == "" && (len(copyFieldsValue) > 0 || len(excludeFieldsValue) > 0) {
 				fmt.Fprintln(os.Stderr, "Error: --copy-metadata-from is required when using --copy-fields or --exclude-fields")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			selectedCopyFields := []string(nil)
@@ -397,13 +397,13 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			// Check that at least one update field is provided
 			if *copyright == "" && *releaseType == "" && *earliestReleaseDate == "" && *versionString == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one of --copyright, --release-type, --earliest-release-date, or --version is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -468,11 +468,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to delete a version")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -517,11 +517,11 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*versionID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*buildID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/versions/versions_promotions.go
+++ b/internal/cli/versions/versions_promotions.go
@@ -58,12 +58,12 @@ Examples:
 			version := strings.TrimSpace(*versionID)
 			if version == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			treatment := strings.TrimSpace(*treatmentID)
 			if treatment == "" {
 				fmt.Fprintln(os.Stderr, "Error: --treatment-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/versions/versions_release.go
+++ b/internal/cli/versions/versions_release.go
@@ -35,11 +35,11 @@ Examples:
 			version := strings.TrimSpace(*versionID)
 			if version == "" {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required to release a version")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/web/web_apps_compatibility.go
+++ b/internal/cli/web/web_apps_compatibility.go
@@ -71,7 +71,7 @@ func WebAppsCompatibilityViewCommand() *ffcli.Command {
 			resolvedAppID := strings.TrimSpace(shared.ResolveAppID(*appID))
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			session, err := resolveWebSessionForCommand(ctx, authFlags)
@@ -123,11 +123,11 @@ func WebAppsCompatibilityEditCommand() *ffcli.Command {
 			resolvedAppID := strings.TrimSpace(shared.ResolveAppID(*appID))
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !iosAppOnMac.IsSet() && !iosAppOnVisionPro.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: at least one of --ios-app-on-mac or --ios-app-on-vision-pro is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			var macValue *bool

--- a/internal/cli/web/web_xcode_cloud.go
+++ b/internal/cli/web/web_xcode_cloud.go
@@ -277,7 +277,7 @@ Examples:
 			}
 			if len(requestedProductIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --product-ids is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			primaryProductID := requestedProductIDs[0]
 			if err := validateDateFlag("--start", *start); err != nil {
@@ -401,7 +401,7 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if err := validateDateFlag("--start", *start); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err)

--- a/internal/cli/web/web_xcode_cloud_envvars.go
+++ b/internal/cli/web/web_xcode_cloud_envvars.go
@@ -104,12 +104,12 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -188,22 +188,22 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			varName := strings.TrimSpace(*name)
 			if varName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			varValue := *value
 			if varValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --value is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -329,21 +329,21 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			varName := strings.TrimSpace(*name)
 			if varName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)

--- a/internal/cli/web/web_xcode_cloud_shared_envvars.go
+++ b/internal/cli/web/web_xcode_cloud_shared_envvars.go
@@ -96,7 +96,7 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -175,17 +175,17 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			varName := strings.TrimSpace(*name)
 			if varName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			varValue := *value
 			if varValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --value is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -310,16 +310,16 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			varName := strings.TrimSpace(*name)
 			if varName == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)

--- a/internal/cli/web/web_xcode_cloud_workflow_options.go
+++ b/internal/cli/web/web_xcode_cloud_workflow_options.go
@@ -157,7 +157,7 @@ and container file path recommendations. JSON output only.
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			return executeWorkflowOptionsFetch(
@@ -199,7 +199,7 @@ JSON output only.
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if flagProvided(fs, "limit") && *limit <= 0 {
 				fmt.Fprintln(os.Stderr, "Error: --limit must be greater than 0 when provided")
@@ -241,7 +241,7 @@ Show workflow test destination options for a given Xcode version. JSON output on
 			version := strings.TrimSpace(*xcodeVersion)
 			if version == "" {
 				fmt.Fprintln(os.Stderr, "Error: --xcode-version is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			return executeWorkflowOptionsFetch(

--- a/internal/cli/web/web_xcode_cloud_workflows.go
+++ b/internal/cli/web/web_xcode_cloud_workflows.go
@@ -130,12 +130,12 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -212,12 +212,12 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			fileValue := strings.TrimSpace(*file)
 			if fileValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			payload, err := shared.ReadJSONFilePayload(fileValue)
@@ -317,17 +317,17 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			patchFileValue := strings.TrimSpace(*patchFile)
 			if patchFileValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --patch-file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			patchPayload, err := shared.ReadJSONFilePayload(patchFileValue)
@@ -423,12 +423,12 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := executeWorkflowToggle(ctx, sessionFlags, pid, wfID, false, "xcode-cloud workflows enable")
@@ -476,16 +476,16 @@ Examples:
 			pid := strings.TrimSpace(*productID)
 			if pid == "" {
 				fmt.Fprintln(os.Stderr, "Error: --product-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			wfID := strings.TrimSpace(*workflowID)
 			if wfID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --workflow-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := executeWorkflowToggle(ctx, sessionFlags, pid, wfID, true, "xcode-cloud workflows disable")

--- a/internal/cli/webhooks/webhooks.go
+++ b/internal/cli/webhooks/webhooks.go
@@ -80,7 +80,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > webhooksMaxLimit) {
 				return fmt.Errorf("webhooks list: --limit must be between 1 and %d", webhooksMaxLimit)
@@ -105,7 +105,7 @@ Examples:
 			if *paginate {
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithWebhooksLimit(webhooksMaxLimit))
 				firstPage, err := client.GetAppWebhooks(requestCtx, resolvedAppID, paginateOpts...)
@@ -152,7 +152,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -200,27 +200,27 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*name) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*url) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --url is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*secret) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --secret is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*events) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --events is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !enabled.IsSet() {
 				fmt.Fprintln(os.Stderr, "Error: --enabled is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			eventTypes, err := normalizeWebhookEvents(*events)
@@ -282,7 +282,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			attrs := asc.WebhookUpdateAttributes{}
@@ -319,7 +319,7 @@ Examples:
 
 			if !hasUpdate {
 				fmt.Fprintln(os.Stderr, "Error: --name, --url, --secret, --events, or --enabled is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -361,12 +361,12 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -420,7 +420,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			filterCount := 0
 			if strings.TrimSpace(*createdAfter) != "" {
@@ -432,7 +432,7 @@ Examples:
 			if trimmedNext == "" {
 				if filterCount == 0 {
 					fmt.Fprintln(os.Stderr, "Error: --created-after or --created-before is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				if filterCount > 1 {
 					fmt.Fprintln(os.Stderr, "Error: only one of --created-after or --created-before can be used")
@@ -478,7 +478,7 @@ Examples:
 			if *paginate {
 				if trimmedID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithWebhookDeliveriesLimit(webhooksMaxLimit))
 				firstPage, err := client.GetWebhookDeliveries(requestCtx, trimmedID, paginateOpts...)
@@ -530,7 +530,7 @@ Examples:
 			trimmedNext := strings.TrimSpace(*next)
 			if trimmedID == "" && trimmedNext == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *limit != 0 && (*limit < 1 || *limit > webhooksMaxLimit) {
 				return fmt.Errorf("webhooks deliveries links: --limit must be between 1 and %d", webhooksMaxLimit)
@@ -562,7 +562,7 @@ Examples:
 			if *paginate {
 				if trimmedID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				paginateOpts := append(opts, asc.WithLinkagesLimit(webhooksMaxLimit))
 				firstPage, err := client.GetWebhookDeliveriesRelationships(requestCtx, trimmedID, paginateOpts...)
@@ -609,7 +609,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*deliveryID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --delivery-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -651,7 +651,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*webhookID)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --webhook-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/webhooks/webhooks_serve.go
+++ b/internal/cli/webhooks/webhooks_serve.go
@@ -106,7 +106,7 @@ Examples:
 			bindHost := strings.TrimSpace(*host)
 			if bindHost == "" {
 				fmt.Fprintln(os.Stderr, "Error: --host is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*allowRemote && !isLoopbackWebhookBindHost(bindHost) {
 				return shared.UsageErrorf("binding to non-loopback host %q requires --allow-remote", bindHost)

--- a/internal/cli/winbackoffers/win_back_offers.go
+++ b/internal/cli/winbackoffers/win_back_offers.go
@@ -171,7 +171,7 @@ Examples:
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -292,24 +292,24 @@ Examples:
 			subscription := strings.TrimSpace(*subscriptionID)
 			if subscription == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			name := strings.TrimSpace(*referenceName)
 			if name == "" {
 				fmt.Fprintln(os.Stderr, "Error: --reference-name is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			offer := strings.TrimSpace(*offerID)
 			if offer == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if strings.TrimSpace(*duration) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --duration is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			durationValue, err := normalizeWinBackOfferDuration(*duration)
 			if err != nil {
@@ -318,7 +318,7 @@ Examples:
 
 			if strings.TrimSpace(*offerMode) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-mode is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			offerModeValue, err := normalizeWinBackOfferMode(*offerMode)
 			if err != nil {
@@ -327,7 +327,7 @@ Examples:
 
 			if !periodCount.set {
 				fmt.Fprintln(os.Stderr, "Error: --period-count is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if periodCount.value <= 0 {
 				return fmt.Errorf("win-back-offers create: --period-count must be greater than 0")
@@ -335,7 +335,7 @@ Examples:
 
 			if !eligibilityPaidMonths.set {
 				fmt.Fprintln(os.Stderr, "Error: --eligibility-paid-months is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if eligibilityPaidMonths.value < 0 {
 				return fmt.Errorf("win-back-offers create: --eligibility-paid-months must be 0 or greater")
@@ -343,7 +343,7 @@ Examples:
 
 			if !eligibilityLastSubscribedMin.set && !eligibilityLastSubscribedMax.set {
 				fmt.Fprintln(os.Stderr, "Error: --eligibility-last-subscribed-min or --eligibility-last-subscribed-max is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if eligibilityLastSubscribedMin.set && eligibilityLastSubscribedMin.value < 0 {
 				return fmt.Errorf("win-back-offers create: eligibility last subscribed min must be 0 or greater")
@@ -365,7 +365,7 @@ Examples:
 
 			if strings.TrimSpace(*startDate) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --start-date is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			normalizedStartDate, err := shared.NormalizeDate(*startDate, "--start-date")
 			if err != nil {
@@ -374,7 +374,7 @@ Examples:
 
 			if strings.TrimSpace(*priority) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --priority is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			priorityValue, err := normalizeWinBackOfferPriority(*priority)
 			if err != nil {
@@ -384,7 +384,7 @@ Examples:
 			prices := shared.SplitCSV(*priceIDs)
 			if len(prices) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --price is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			if eligibilityWaitMonths.set && eligibilityWaitMonths.value < 0 {
@@ -548,7 +548,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			hasUpdates := false
@@ -629,7 +629,7 @@ Examples:
 
 			if !hasUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -672,11 +672,11 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -738,7 +738,7 @@ Examples:
 			trimmedID := strings.TrimSpace(*id)
 			if trimmedID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			fieldsValue, err := normalizeWinBackOfferPriceFields(*fields, "--fields")

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -118,19 +118,19 @@ Examples:
 			}
 			if strings.TrimSpace(*workspacePath) == "" && strings.TrimSpace(*projectPath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: exactly one of --workspace or --project is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*workspacePath) != "" && strings.TrimSpace(*projectPath) != "" {
 				fmt.Fprintln(os.Stderr, "Error: exactly one of --workspace or --project is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*scheme) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --scheme is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*archivePath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --archive-path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			result, err := runArchive(ctx, localxcode.ArchiveOptions{
@@ -207,15 +207,15 @@ Examples:
 			}
 			if strings.TrimSpace(*archivePath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --archive-path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*exportOptions) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --export-options is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*ipaPath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --ipa-path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *wait && *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
@@ -363,7 +363,7 @@ Examples:
 			}
 			if trimmedIPAPath == "" {
 				fmt.Fprintln(os.Stderr, "Error: --ipa is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if !strings.EqualFold(filepath.Ext(trimmedIPAPath), ".ipa") {
 				return shared.UsageError("--ipa must end with .ipa")

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -136,11 +136,11 @@ Examples:
 			} else {
 				if !hasWorkflowName && !hasWorkflowID {
 					fmt.Fprintln(os.Stderr, "Error: --workflow or --workflow-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 				if !hasBranch && !hasGitRefID && !hasPullRequestID {
 					fmt.Fprintln(os.Stderr, "Error: --branch, --git-reference-id, or --pull-request-id is required")
-					return flag.ErrHelp
+					return shared.MissingRequiredUsageError()
 				}
 			}
 			if *timeout < 0 {
@@ -153,7 +153,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if hasWorkflowName && !hasSourceRunID && resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required when using --workflow (or set ASC_APP_ID)")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -341,7 +341,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if strings.TrimSpace(*runID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --run-id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			if *timeout < 0 {
 				return shared.UsageError("--timeout must be greater than or equal to 0")

--- a/internal/cli/xcodecloud/xcode_cloud_artifacts.go
+++ b/internal/cli/xcodecloud/xcode_cloud_artifacts.go
@@ -141,12 +141,12 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			pathValue := strings.TrimSpace(*path)
 			if pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/xcodecloud/xcode_cloud_list_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_list_helpers.go
@@ -2,7 +2,6 @@ package xcodecloud
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -79,7 +78,7 @@ func runXcodeCloudPaginatedParentList(
 	resolvedParentID := strings.TrimSpace(parentID)
 	if resolvedParentID == "" && strings.TrimSpace(next) == "" {
 		fmt.Fprintf(os.Stderr, "Error: --%s is required\n", parentFlag)
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	return runXcodeCloudPaginatedList(

--- a/internal/cli/xcodecloud/xcode_cloud_workflows.go
+++ b/internal/cli/xcodecloud/xcode_cloud_workflows.go
@@ -152,7 +152,7 @@ Examples:
 			fileValue := strings.TrimSpace(*file)
 			if fileValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			payload, err := shared.ReadJSONFilePayload(fileValue)
@@ -199,12 +199,12 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 			fileValue := strings.TrimSpace(*file)
 			if fileValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --file is required")
-				return flag.ErrHelp
+				return shared.MissingRequiredUsageError()
 			}
 
 			payload, err := shared.ReadJSONFilePayload(fileValue)
@@ -270,7 +270,7 @@ func xcodeCloudWorkflowsList(ctx context.Context, appID string, limit int, next 
 	resolvedAppID := shared.ResolveAppID(appID)
 	if resolvedAppID == "" && nextURL == "" {
 		fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-		return flag.ErrHelp
+		return shared.MissingRequiredUsageError()
 	}
 
 	client, err := shared.GetASCClient()

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -23,6 +23,15 @@ const (
 var sendHTTP = sendHTTPEvent
 
 func Emit(commandName, version string, duration time.Duration, exitCode int) {
+	EmitWithContext(commandName, version, duration, exitCode, EventContext{InvocationShape: InvocationShapeLeaf})
+}
+
+func EmitWithContext(
+	commandName, version string,
+	duration time.Duration,
+	exitCode int,
+	eventContext EventContext,
+) {
 	commandPath := sanitizeCommandName(commandName)
 	if shouldSkipCommand(commandPath) {
 		return
@@ -44,7 +53,7 @@ func Emit(commandName, version string, duration time.Duration, exitCode int) {
 		return
 	}
 
-	ev, ok := BuildEvent(commandPath, version, duration, exitCode)
+	ev, ok := BuildEventWithContext(commandPath, version, duration, exitCode, eventContext)
 	if !ok {
 		return
 	}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -25,6 +25,45 @@ type Event struct {
 	InvocationSource InvocationSource `json:"invocation_source"`
 	InstallID        *string          `json:"install_id"`
 	SessionID        string           `json:"session_id"`
+	InvocationShape  InvocationShape  `json:"invocation_shape"`
+	ErrorKind        *ErrorKind       `json:"error_kind"`
+	FailureStage     *FailureStage    `json:"failure_stage"`
+}
+
+type InvocationShape string
+
+const (
+	InvocationShapeLeaf           InvocationShape = "leaf"
+	InvocationShapeBareGroup      InvocationShape = "bare_group"
+	InvocationShapeGroupWithFlags InvocationShape = "group_with_flags"
+	InvocationShapeUnknownChild   InvocationShape = "unknown_child"
+)
+
+type ErrorKind string
+
+const (
+	ErrorKindUnknownFlag     ErrorKind = "unknown_flag"
+	ErrorKindMissingRequired ErrorKind = "missing_required"
+	ErrorKindInvalidValue    ErrorKind = "invalid_value"
+	ErrorKindBareGroup       ErrorKind = "bare_group"
+	ErrorKindAPIConflict     ErrorKind = "api_conflict"
+	ErrorKindAPI5xx          ErrorKind = "api_5xx"
+	ErrorKindOther           ErrorKind = "other"
+)
+
+type FailureStage string
+
+const (
+	FailureStageParse      FailureStage = "parse"
+	FailureStageValidation FailureStage = "validation"
+	FailureStageRequest    FailureStage = "request"
+	FailureStageExecution  FailureStage = "execution"
+)
+
+type EventContext struct {
+	InvocationShape InvocationShape
+	ErrorKind       ErrorKind
+	FailureStage    FailureStage
 }
 
 // processSessionID groups events from one CLI process without linking separate
@@ -32,6 +71,17 @@ type Event struct {
 var processSessionID = uuid.NewString()
 
 func BuildEvent(commandName, version string, duration time.Duration, exitCode int) (Event, bool) {
+	return BuildEventWithContext(commandName, version, duration, exitCode, EventContext{
+		InvocationShape: InvocationShapeLeaf,
+	})
+}
+
+func BuildEventWithContext(
+	commandName, version string,
+	duration time.Duration,
+	exitCode int,
+	eventContext EventContext,
+) (Event, bool) {
 	commandPath := sanitizeCommandName(commandName)
 	if commandPath == "" {
 		return Event{}, false
@@ -50,9 +100,11 @@ func BuildEvent(commandName, version string, duration time.Duration, exitCode in
 		}
 	}
 
+	eventContext = normalizeEventContext(eventContext, exitCode)
+
 	return Event{
 		EventID:          uuid.NewString(),
-		SchemaVersion:    1,
+		SchemaVersion:    2,
 		ASCVersion:       strings.TrimSpace(version),
 		OS:               runtime.GOOS,
 		Arch:             runtime.GOARCH,
@@ -66,7 +118,59 @@ func BuildEvent(commandName, version string, duration time.Duration, exitCode in
 		InvocationSource: invocationSource,
 		InstallID:        installID,
 		SessionID:        processSessionID,
+		InvocationShape:  eventContext.InvocationShape,
+		ErrorKind:        optionalErrorKind(eventContext.ErrorKind),
+		FailureStage:     optionalFailureStage(eventContext.FailureStage),
 	}, true
+}
+
+func normalizeEventContext(eventContext EventContext, exitCode int) EventContext {
+	switch eventContext.InvocationShape {
+	case InvocationShapeLeaf, InvocationShapeBareGroup, InvocationShapeGroupWithFlags, InvocationShapeUnknownChild:
+	default:
+		eventContext.InvocationShape = InvocationShapeLeaf
+	}
+
+	if exitCode == 0 {
+		eventContext.ErrorKind = ""
+		eventContext.FailureStage = ""
+		return eventContext
+	}
+	if eventContext.ErrorKind == "" {
+		eventContext.ErrorKind = ErrorKindOther
+	}
+	switch eventContext.ErrorKind {
+	case ErrorKindUnknownFlag:
+		eventContext.FailureStage = FailureStageParse
+	case ErrorKindMissingRequired, ErrorKindInvalidValue, ErrorKindBareGroup:
+		eventContext.FailureStage = FailureStageValidation
+	case ErrorKindAPIConflict, ErrorKindAPI5xx:
+		eventContext.FailureStage = FailureStageRequest
+	case ErrorKindOther:
+		switch eventContext.FailureStage {
+		case FailureStageParse, FailureStageValidation, FailureStageRequest, FailureStageExecution:
+		default:
+			eventContext.FailureStage = FailureStageExecution
+		}
+	default:
+		eventContext.ErrorKind = ErrorKindOther
+		eventContext.FailureStage = FailureStageExecution
+	}
+	return eventContext
+}
+
+func optionalErrorKind(kind ErrorKind) *ErrorKind {
+	if kind == "" {
+		return nil
+	}
+	return &kind
+}
+
+func optionalFailureStage(stage FailureStage) *FailureStage {
+	if stage == "" {
+		return nil
+	}
+	return &stage
 }
 
 func sanitizeCommandName(commandName string) string {

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -51,6 +52,66 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 		if _, exists := payload[forbiddenField]; exists {
 			t.Fatalf("event contains forbidden raw-argument field %q", forbiddenField)
 		}
+	}
+}
+
+func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc versions attach-build",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			InvocationShape: InvocationShapeLeaf,
+			ErrorKind:       ErrorKindUnknownFlag,
+			FailureStage:    FailureStageParse,
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.SchemaVersion != 2 {
+		t.Fatalf("SchemaVersion = %d, want 2", ev.SchemaVersion)
+	}
+	if ev.InvocationShape != InvocationShapeLeaf || ev.ErrorKind == nil || *ev.ErrorKind != ErrorKindUnknownFlag ||
+		ev.FailureStage == nil || *ev.FailureStage != FailureStageParse {
+		t.Fatalf("unexpected classifications: %+v", ev)
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	for _, forbidden := range []string{"stderr", "error_message", "args", "argv"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("payload contains forbidden field %q: %s", forbidden, data)
+		}
+	}
+}
+
+func TestBuildEventWithContextCanonicalizesFailureStage(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc versions attach-build",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			InvocationShape: InvocationShapeLeaf,
+			ErrorKind:       ErrorKindUnknownFlag,
+			FailureStage:    FailureStageRequest,
+		},
+	)
+	if !ok || ev.FailureStage == nil {
+		t.Fatal("expected classified event")
+	}
+	if *ev.FailureStage != FailureStageParse {
+		t.Fatalf("FailureStage = %q, want %q", *ev.FailureStage, FailureStageParse)
 	}
 }
 

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -115,6 +115,39 @@ func TestBuildEventWithContextCanonicalizesFailureStage(t *testing.T) {
 	}
 }
 
+func TestBuildEventWithContextRejectsUnboundedContextValues(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc builds",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			InvocationShape: InvocationShape("unknown_child:private-app-name"),
+			ErrorKind:       ErrorKind("unknown_flag:--private-value"),
+			FailureStage:    FailureStage("stderr:private-error"),
+		},
+	)
+	if !ok || ev.ErrorKind == nil || ev.FailureStage == nil {
+		t.Fatal("expected canonicalized event")
+	}
+	if ev.InvocationShape != InvocationShapeLeaf || *ev.ErrorKind != ErrorKindOther || *ev.FailureStage != FailureStageExecution {
+		t.Fatalf("unexpected canonicalized context: %+v", ev)
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	for _, privateValue := range []string{"private-app-name", "private-value", "private-error"} {
+		if strings.Contains(string(data), privateValue) {
+			t.Fatalf("payload leaked unbounded context %q: %s", privateValue, data)
+		}
+	}
+}
+
 func TestBuildEventReusesProcessSessionID(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)


### PR DESCRIPTION
## What changed

- emit schema-v2 telemetry with allowlisted invocation shape, error kind, and failure stage
- keep stderr, error messages, raw arguments, and flag values out of telemetry
- print help to stdout and exit 0 when a non-default command group is invoked without a subcommand
- preserve exit 2 for unknown children, unknown flags, missing required flags, and invalid values
- suggest real nested subcommands and flags from the live command tree
- document the exact schema-v2 payload and privacy boundary

Telemetry remains pseudonymous, not anonymous: the existing random local installation ID is unchanged. The new fields are closed enums and cannot contain stderr, raw arguments, flag values, account identifiers, or app identifiers.

## Root cause

The previous telemetry path retained only recognized command tokens. `asc builds`, `asc builds --bad-flag`, and `asc builds unknown-child` could therefore collapse to the same `command_path`, preventing reliable attribution of usage errors. Most command groups also rendered discovery help on stderr with exit 2, while a few default-action groups exited successfully.

## Behavior and compatibility

- Existing default-action commands such as `asc apps` keep their current behavior.
- Explicit `--help` remains successful.
- Only groups whose execution returns unclassified `flag.ErrHelp` with no unknown token are normalized to successful help.
- Validation errors wrapped by `shared.UsageError` retain exit 2 and gain low-cardinality classification.
- Schema-v2 events require the coordinated Rork collector in https://github.com/rorkai/rorkai/pull/3377 to be deployed first.

## Validation

- RED/GREEN focused tests for bare groups, nested/flag suggestions, event normalization, and request classifications
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- built-binary checks:
  - `asc builds`: exit 0, help on stdout, empty stderr
  - `asc builds lsit`: exit 2 with `Did you mean: list?`
  - `asc versions attach-build ... --build-id ...`: exit 2 with `Did you mean: --build?`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware CLI telemetry with `invocation_shape`, `error_kind`, and `failure_stage` (schema v2).
  * Improved “Did you mean” suggestions for unknown flags/subcommands, including adjacent-transposition typos.
* **Bug Fixes**
  * Refined help, parse/validation, and runtime failure classification and telemetry.
  * Improved bare-group help behavior and added telemetry for JUnit-report write failures.
* **Documentation**
  * Updated telemetry privacy and payload schema guidance (excludes stderr and error text).
* **Tests**
  * Added/updated coverage for telemetry classification, suggestions, and usage-error categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->