### PR TITLE
Shard Go tests across CI runners

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -120,7 +120,11 @@ jobs:
       matrix:
         include:
           - name: packages
-            command: go test -v ./cmd && python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -v
+            command: go test -v ./cmd && python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --exclude ./internal/cli/web --shard-index 0 --shard-total 1 -- -v
+          - name: web 1/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/web --shard-index 0 --shard-total 2 -- -v
+          - name: web 2/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/web --shard-index 1 --shard-total 2 -- -v
           - name: cmdtest 1/2
             command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -v
           - name: cmdtest 2/2

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -121,14 +121,10 @@ jobs:
         include:
           - name: packages
             command: python3 scripts/go_test_shard.py packages --packages ./... --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -v
-          - name: cmdtest 1/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 4 -- -v
-          - name: cmdtest 2/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 4 -- -v
-          - name: cmdtest 3/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 2 --shard-total 4 -- -v
-          - name: cmdtest 4/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 3 --shard-total 4 -- -v
+          - name: cmdtest 1/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -v
+          - name: cmdtest 2/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 2 -- -v
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -110,10 +110,25 @@ jobs:
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint
 
-  test:
+  test-shards:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
+    name: test shard (${{ matrix.name }})
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: packages
+            command: python3 scripts/go_test_shard.py packages --packages ./... --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -v
+          - name: cmdtest 1/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 4 -- -v
+          - name: cmdtest 2/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 4 -- -v
+          - name: cmdtest 3/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 2 --shard-total 4 -- -v
+          - name: cmdtest 4/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 3 --shard-total 4 -- -v
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -124,8 +139,20 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
-      - name: Run all tests
-        run: ASC_BYPASS_KEYCHAIN=1 make test
+      - name: Run Go test shard
+        run: ASC_BYPASS_KEYCHAIN=1 ${{ matrix.command }}
+
+  test:
+    needs: [changes, test-shards]
+    if: always() && needs.changes.outputs.wall_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify test shards
+        run: |
+          if [ "${{ needs.test-shards.result }}" != "success" ]; then
+            echo "test-shards result: ${{ needs.test-shards.result }}"
+            exit 1
+          fi
 
   build:
     needs: changes

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -120,7 +120,7 @@ jobs:
       matrix:
         include:
           - name: packages
-            command: python3 scripts/go_test_shard.py packages --packages ./... --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -v
+            command: go test -v ./cmd && python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -v
           - name: cmdtest 1/2
             command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -v
           - name: cmdtest 2/2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -124,14 +124,10 @@ jobs:
         include:
           - name: packages
             command: python3 scripts/go_test_shard.py packages --packages ./... --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -short
-          - name: cmdtest 1/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 4 -- -short
-          - name: cmdtest 2/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 4 -- -short
-          - name: cmdtest 3/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 2 --shard-total 4 -- -short
-          - name: cmdtest 4/4
-            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 3 --shard-total 4 -- -short
+          - name: cmdtest 1/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -short
+          - name: cmdtest 2/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 2 -- -short
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -123,7 +123,11 @@ jobs:
       matrix:
         include:
           - name: packages
-            command: go test -short ./cmd && python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -short
+            command: go test -short ./cmd && python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --exclude ./internal/cli/web --shard-index 0 --shard-total 1 -- -short
+          - name: web 1/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/web --shard-index 0 --shard-total 2 -- -short
+          - name: web 2/2
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/web --shard-index 1 --shard-total 2 -- -short
           - name: cmdtest 1/2
             command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -short
           - name: cmdtest 2/2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -113,10 +113,25 @@ jobs:
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint
 
-  unit-tests:
+  unit-test-shards:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
+    name: unit-test shard (${{ matrix.name }})
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: packages
+            command: python3 scripts/go_test_shard.py packages --packages ./... --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -short
+          - name: cmdtest 1/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 4 -- -short
+          - name: cmdtest 2/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 4 -- -short
+          - name: cmdtest 3/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 2 --shard-total 4 -- -short
+          - name: cmdtest 4/4
+            command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 3 --shard-total 4 -- -short
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -127,8 +142,20 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
-      - name: Run unit tests
-        run: ASC_BYPASS_KEYCHAIN=1 go test -short ./...
+      - name: Run Go test shard
+        run: ASC_BYPASS_KEYCHAIN=1 ${{ matrix.command }}
+
+  unit-tests:
+    needs: [changes, unit-test-shards]
+    if: always() && needs.changes.outputs.wall_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify unit test shards
+        run: |
+          if [ "${{ needs.unit-test-shards.result }}" != "success" ]; then
+            echo "unit-test-shards result: ${{ needs.unit-test-shards.result }}"
+            exit 1
+          fi
 
   telemetry-windows-tests:
     needs: changes

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -123,7 +123,7 @@ jobs:
       matrix:
         include:
           - name: packages
-            command: python3 scripts/go_test_shard.py packages --packages ./... --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -short
+            command: go test -short ./cmd && python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --shard-index 0 --shard-total 1 -- -short
           - name: cmdtest 1/2
             command: python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -short
           - name: cmdtest 2/2

--- a/cmd/ads_blackbox_test.go
+++ b/cmd/ads_blackbox_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAdsUsageErrorsExitTwoWithBuiltBinary(t *testing.T) {
-	binaryPath := buildAdsBlackboxBinary(t)
+	binaryPath := buildASCBlackboxBinary(t)
 
 	tests := []struct {
 		name       string
@@ -65,19 +65,6 @@ func TestAdsUsageErrorsExitTwoWithBuiltBinary(t *testing.T) {
 			}
 		})
 	}
-}
-
-func buildAdsBlackboxBinary(t *testing.T) string {
-	t.Helper()
-
-	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc")
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, output)
-	}
-	return binaryPath
 }
 
 func isolatedAdsBlackboxEnv(configPath string) []string {

--- a/cmd/blackbox_test.go
+++ b/cmd/blackbox_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+var (
+	ascBlackboxBinaryOnce   sync.Once
+	ascBlackboxBinaryPath   string
+	ascBlackboxBinaryOutput []byte
+	ascBlackboxBinaryErr    error
+)
+
+func buildASCBlackboxBinary(t *testing.T) string {
+	t.Helper()
+
+	ascBlackboxBinaryOnce.Do(func() {
+		ascBlackboxBinaryPath = filepath.Join(testTempDir, "asc-test")
+
+		build := exec.Command("go", "build", "-o", ascBlackboxBinaryPath, ".")
+		build.Dir = ".."
+		ascBlackboxBinaryOutput, ascBlackboxBinaryErr = build.CombinedOutput()
+	})
+	if ascBlackboxBinaryErr != nil {
+		t.Fatalf("failed to build binary: %v\n%s", ascBlackboxBinaryErr, ascBlackboxBinaryOutput)
+	}
+
+	return ascBlackboxBinaryPath
+}

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -205,12 +205,7 @@ func TestGetCommandName(t *testing.T) {
 func TestJUnitReportNameWithRootFlags(t *testing.T) {
 	// Build the binary
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	cmd.Dir = ".." // Go up from cmd/ to project root
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("Failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	reportFile := filepath.Join(tmpDir, "junit.xml")
 	// Run with root flags before subcommand
@@ -247,12 +242,7 @@ func TestJUnitReportNameWithRootFlags(t *testing.T) {
 func TestJUnitReportEndToEnd(t *testing.T) {
 	// Build the binary
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	cmd.Dir = ".." // Go up from cmd/ to project root
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("Failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	tests := []struct {
 		name       string
@@ -334,13 +324,7 @@ func TestJUnitReportEndToEnd(t *testing.T) {
 
 func TestBuildsListMissingAppExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(binaryPath, "builds", "list", "--version", "1.2.3")
 	runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
@@ -364,13 +348,7 @@ func TestBuildsListMissingAppExitCode(t *testing.T) {
 
 func TestScreenshotsUploadResumeMissingValueExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(binaryPath, "screenshots", "upload", "--resume")
 	runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
@@ -395,13 +373,7 @@ func TestScreenshotsUploadResumeMissingValueExitCode(t *testing.T) {
 
 func TestBuildsTestNotesUpdateConflictingFlagsExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(binaryPath, "builds", "test-notes", "update",
 		"--id", "loc-1", "--build", "build-1", "--whats-new", "test")
@@ -433,13 +405,7 @@ func TestBuildsTestNotesUpdateConflictingFlagsExitCode(t *testing.T) {
 
 func TestBuildsExpiredFlagsInvalidBooleanExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".." // Go up from cmd/ to project root
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	tests := []struct {
 		name string
@@ -498,13 +464,7 @@ func TestBuildsExpiredFlagsInvalidBooleanExitCode(t *testing.T) {
 
 func TestPublishAppStoreDryRunInvalidBooleanExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(
 		binaryPath,
@@ -539,13 +499,7 @@ func TestPublishAppStoreDryRunInvalidBooleanExitCode(t *testing.T) {
 
 func TestPublishAppStoreEmptyMetadataDirExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(
 		binaryPath,
@@ -580,13 +534,7 @@ func TestPublishAppStoreEmptyMetadataDirExitCode(t *testing.T) {
 
 func TestPublishAppStoreMissingMetadataDirExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	missingMetadataDir := filepath.Join(tmpDir, "missing-metadata")
 	runCmd := exec.Command(
@@ -625,13 +573,7 @@ func TestPublishAppStoreMissingMetadataDirExitCode(t *testing.T) {
 
 func TestWebAuthLoginLegacyTwoFactorFlagExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(
 		binaryPath,
@@ -666,13 +608,7 @@ func TestWebAuthLoginLegacyTwoFactorFlagExitCode(t *testing.T) {
 
 func TestAuthTokenConfirmInvalidBooleanExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".." // Go up from cmd/ to project root
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(binaryPath, "auth", "token", "--confirm=maybe")
 	runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
@@ -700,13 +636,7 @@ func TestAuthTokenConfirmInvalidBooleanExitCode(t *testing.T) {
 
 func TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	runCmd := exec.Command(binaryPath, "web", "auth", "login", "--apple-id", "user@example.com")
 	runCmd.Env = append(
@@ -780,13 +710,7 @@ func TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError(t *testing.T) {
 
 func TestWebAuthLoginPromptInterruptSkipsSkillsAutoCheck(t *testing.T) {
 	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "asc-test")
-
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = ".."
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build binary: %v\n%s", err, out)
-	}
+	binaryPath := buildASCBlackboxBinary(t)
 
 	configPath := filepath.Join(tmpDir, "config.json")
 	if err := os.WriteFile(configPath, []byte(`{"skills_checked_at":"2000-01-01T00:00:00Z"}`), 0o600); err != nil {

--- a/cmd/test_main_test.go
+++ b/cmd/test_main_test.go
@@ -5,7 +5,18 @@ import (
 	"testing"
 )
 
+var testTempDir string
+
 func TestMain(m *testing.M) {
+	tempDir, err := os.MkdirTemp("", "asc-cmd-*")
+	if err != nil {
+		panic(err)
+	}
+	testTempDir = tempDir
+
 	_ = os.Setenv("ASC_TELEMETRY_DISABLED", "1")
-	os.Exit(m.Run())
+	code := m.Run()
+
+	_ = os.RemoveAll(tempDir)
+	os.Exit(code)
 }

--- a/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
+++ b/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
@@ -1,17 +1,17 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"io"
 	"net/http"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestAnalyticsRequestReuseExistingRejectsInvalidAccessType(t *testing.T) {
@@ -46,8 +46,6 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidAccessType(t *testing.T) {
 }
 
 func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		args    []string
@@ -87,26 +85,16 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, test.args...)
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(test.args, "1.2.3"); code != rootcmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", rootcmd.ExitUsage, code)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected invalid bool error, got %q", stderr.String())
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected invalid bool error, got %q", stderr)
 			}
 		})
 	}

--- a/internal/cli/cmdtest/apps_registry_pull_test.go
+++ b/internal/cli/cmdtest/apps_registry_pull_test.go
@@ -1,7 +1,6 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -695,8 +693,6 @@ func TestAppsRegistryPullInvalidFlagValues(t *testing.T) {
 }
 
 func TestAppsRegistryPullInvalidFlagExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		args    []string
@@ -751,27 +747,7 @@ func TestAppsRegistryPullInvalidFlagExitCode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, test.args...)
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
-			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected stderr %q, got %q", test.wantErr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantErr)
 		})
 	}
 }

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3971,37 +3971,10 @@ func TestPublishValidationErrors(t *testing.T) {
 		},
 	}
 
-	parentT := t
-	var binaryPath string
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.wantExit != 0 {
-				if binaryPath == "" {
-					binaryPath = buildASCBlackBoxBinary(parentT)
-				}
-				command := exec.Command(binaryPath, test.args...)
-
-				var stdout strings.Builder
-				var stderr strings.Builder
-				command.Stdout = &stdout
-				command.Stderr = &stderr
-
-				err := command.Run()
-				var exitErr *exec.ExitError
-				if !errors.As(err, &exitErr) {
-					t.Fatalf("expected process exit error, got %v", err)
-				}
-				if exitErr.ExitCode() != test.wantExit {
-					t.Fatalf("expected exit code %d, got %d", test.wantExit, exitErr.ExitCode())
-				}
-
-				if stdout.String() != "" {
-					t.Fatalf("expected empty stdout, got %q", stdout.String())
-				}
-				if !strings.Contains(stderr.String(), test.wantErr) {
-					t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
-				}
+				assertUsageExit(t, test.args, test.wantErr)
 				return
 			}
 

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -643,7 +643,8 @@ func TestMigrateImportDryRunSkipScreenshotsFlag(t *testing.T) {
 }
 
 func TestMigrateImportSkipScreenshotsRejectsInvalidBooleanExitCode(t *testing.T) {
-	assertUsageExit(t,
+	assertUsageExit(
+		t,
 		[]string{"migrate", "import", "--app", "APP_ID", "--version-id", "VERSION_ID", "--skip-screenshots=maybe"},
 		"invalid boolean value",
 	)

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -3,7 +3,6 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -11,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -645,28 +643,10 @@ func TestMigrateImportDryRunSkipScreenshotsFlag(t *testing.T) {
 }
 
 func TestMigrateImportSkipScreenshotsRejectsInvalidBooleanExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-	cmd := exec.Command(binaryPath, "migrate", "import", "--app", "APP_ID", "--version-id", "VERSION_ID", "--skip-screenshots=maybe")
-
-	var stdout strings.Builder
-	var stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected process exit error, got %v", err)
-	}
-	if exitErr.ExitCode() != 2 {
-		t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-	}
-	if stdout.String() != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "invalid boolean value") {
-		t.Fatalf("expected invalid boolean error, got %q", stderr.String())
-	}
+	assertUsageExit(t,
+		[]string{"migrate", "import", "--app", "APP_ID", "--version-id", "VERSION_ID", "--skip-screenshots=maybe"},
+		"invalid boolean value",
+	)
 }
 
 func TestMigrateImportDryRunSkipScreenshotsAllowsMissingFastlaneScreenshotsDir(t *testing.T) {

--- a/internal/cli/cmdtest/run_helpers_test.go
+++ b/internal/cli/cmdtest/run_helpers_test.go
@@ -1,0 +1,24 @@
+package cmdtest
+
+import (
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func assertUsageExit(t *testing.T, args []string, wantErr string) {
+	t.Helper()
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := rootcmd.Run(args, "1.2.3"); code != rootcmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", rootcmd.ExitUsage, code)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, wantErr) {
+		t.Fatalf("expected stderr to contain %q, got %q", wantErr, stderr)
+	}
+}

--- a/internal/cli/cmdtest/storekit_retention_test.go
+++ b/internal/cli/cmdtest/storekit_retention_test.go
@@ -1,7 +1,6 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -361,20 +359,14 @@ func TestStoreKitInvalidValuesAreUsageErrors(t *testing.T) {
 }
 
 func TestStoreKitBuiltBinaryUsageExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-	cmd := exec.Command(binaryPath, "storekit", "retention-messaging", "messages", "list")
-	cmd.Env = append(os.Environ(), "ASC_STOREKIT_ENVIRONMENT=", "ASC_STOREKIT_KEY_ID=", "ASC_STOREKIT_ISSUER_ID=")
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
-		t.Fatalf("error = %v, want exit code 2", err)
-	}
-	if stdout.String() != "" || !strings.Contains(stderr.String(), "--environment is required") {
-		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
-	}
+	t.Setenv("ASC_STOREKIT_ENVIRONMENT", "")
+	t.Setenv("ASC_STOREKIT_KEY_ID", "")
+	t.Setenv("ASC_STOREKIT_ISSUER_ID", "")
+
+	assertUsageExit(t,
+		[]string{"storekit", "retention-messaging", "messages", "list"},
+		"--environment is required",
+	)
 }
 
 func setupStoreKitAuth(t *testing.T) {

--- a/internal/cli/cmdtest/storekit_retention_test.go
+++ b/internal/cli/cmdtest/storekit_retention_test.go
@@ -363,7 +363,8 @@ func TestStoreKitBuiltBinaryUsageExitCode(t *testing.T) {
 	t.Setenv("ASC_STOREKIT_KEY_ID", "")
 	t.Setenv("ASC_STOREKIT_ISSUER_ID", "")
 
-	assertUsageExit(t,
+	assertUsageExit(
+		t,
 		[]string{"storekit", "retention-messaging", "messages", "list"},
 		"--environment is required",
 	)

--- a/internal/cli/cmdtest/subscriptions_localizations_sync_test.go
+++ b/internal/cli/cmdtest/subscriptions_localizations_sync_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -549,29 +548,13 @@ func TestRunSubscriptionsLocalizationsSyncExitCodes(t *testing.T) {
 }
 
 func TestSubscriptionsLocalizationsSyncBuiltBinaryInvalidOutputExitUsage(t *testing.T) {
-	bin := buildCLIBinary(t)
 	input := writeLocalizationSyncInput(t, `{"en-US":{"name":"English"}}`)
-	cmd := exec.Command(
-		bin,
+	assertUsageExit(t, []string{
 		"subscriptions", "localizations", "sync",
 		"--subscription-id", "8000000001",
 		"--input", input,
 		"--output", "yaml",
-	)
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) || exitErr.ExitCode() != rootcmd.ExitUsage {
-		t.Fatalf("expected exit %d, got %v", rootcmd.ExitUsage, err)
-	}
-	if stdout.String() != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "unsupported format: yaml") {
-		t.Fatalf("unexpected stderr: %q", stderr.String())
-	}
+	}, "unsupported format: yaml")
 }
 
 func TestSubscriptionsLocalizationSyncPreflightsEveryCreateBeforeMutating(t *testing.T) {

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -1,14 +1,12 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -121,8 +119,6 @@ func TestSubscriptionsPricingMonthlyCommitmentValidationErrors(t *testing.T) {
 }
 
 func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		args    []string
@@ -167,27 +163,7 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, test.args...)
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
-			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantErr)
 		})
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
@@ -1,14 +1,12 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"testing"
 )
@@ -261,8 +259,6 @@ func TestSubscriptionsPricingPricesListPlanTypeValidationErrors(t *testing.T) {
 }
 
 func TestSubscriptionsPricingPricesListPlanTypeUsageExitCodes(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		value   string
@@ -282,32 +278,11 @@ func TestSubscriptionsPricingPricesListPlanTypeUsageExitCodes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(
-				binaryPath,
+			assertUsageExit(t, []string{
 				"subscriptions", "pricing", "prices", "list",
 				"--subscription-id", "8000000001",
 				"--plan-type", test.value,
-			)
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
-			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
-			}
+			}, test.wantErr)
 		})
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
+++ b/internal/cli/cmdtest/subscriptions_pricing_equalize_test.go
@@ -8,12 +8,9 @@ import (
 	"flag"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
-
-	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
@@ -70,8 +67,6 @@ func TestSubscriptionsPricingEqualizeValidationErrors(t *testing.T) {
 }
 
 func TestSubscriptionsPricingEqualizeBooleanFlagExitCodes(t *testing.T) {
-	bin := buildCLIBinary(t)
-
 	tests := []struct {
 		name       string
 		args       []string
@@ -103,39 +98,9 @@ func TestSubscriptionsPricingEqualizeBooleanFlagExitCodes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(bin, test.args...)
-			var stdout, stderr strings.Builder
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-			err := cmd.Run()
-
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected exit error, got %v", err)
-			}
-			if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
-				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantStderr) {
-				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantStderr)
 		})
 	}
-}
-
-func buildCLIBinary(t *testing.T) string {
-	t.Helper()
-
-	bin := t.TempDir() + "/asc"
-	cmd := exec.Command("go", "build", "-o", bin, "../../..")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, output)
-	}
-	return bin
 }
 
 func TestSubscriptionsPricingEqualize_RequiresConfirmUnlessDryRun(t *testing.T) {

--- a/internal/cli/cmdtest/subscriptions_update_review_note_test.go
+++ b/internal/cli/cmdtest/subscriptions_update_review_note_test.go
@@ -1,13 +1,10 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,27 +71,8 @@ func TestSubscriptionsUpdateSendsReviewNote(t *testing.T) {
 }
 
 func TestSubscriptionsUpdateRejectsEmptyReviewNoteExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
-	cmd := exec.Command(binaryPath, "subscriptions", "update", "--id", "sub-1", "--review-note", "")
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected process exit error, got %v", err)
-	}
-	if exitErr.ExitCode() != 2 {
-		t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-	}
-	if stdout.String() != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "--review-note cannot be empty") {
-		t.Fatalf("expected empty review note error, got %q", stderr.String())
-	}
+	assertUsageExit(t,
+		[]string{"subscriptions", "update", "--id", "sub-1", "--review-note", ""},
+		"--review-note cannot be empty",
+	)
 }

--- a/internal/cli/cmdtest/subscriptions_update_review_note_test.go
+++ b/internal/cli/cmdtest/subscriptions_update_review_note_test.go
@@ -71,7 +71,8 @@ func TestSubscriptionsUpdateSendsReviewNote(t *testing.T) {
 }
 
 func TestSubscriptionsUpdateRejectsEmptyReviewNoteExitCode(t *testing.T) {
-	assertUsageExit(t,
+	assertUsageExit(
+		t,
 		[]string{"subscriptions", "update", "--id", "sub-1", "--review-note", ""},
 		"--review-note cannot be empty",
 	)

--- a/internal/cli/cmdtest/validate_blackbox_test.go
+++ b/internal/cli/cmdtest/validate_blackbox_test.go
@@ -1,32 +1,8 @@
 package cmdtest
 
-import (
-	"bytes"
-	"errors"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"testing"
-)
-
-func buildASCBlackBoxBinary(t *testing.T) string {
-	t.Helper()
-
-	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
-	binaryPath := filepath.Join(t.TempDir(), "asc")
-
-	build := exec.Command("go", "build", "-o", binaryPath, ".")
-	build.Dir = repoRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build asc binary: %v\n%s", err, string(output))
-	}
-
-	return binaryPath
-}
+import "testing"
 
 func TestValidateRemovedRemediationFlagsReturnUsageExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		args    []string
@@ -46,34 +22,12 @@ func TestValidateRemovedRemediationFlagsReturnUsageExitCode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, test.args...)
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
-			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantErr)
 		})
 	}
 }
 
 func TestValidateSubcommandsRejectParentValidateFlagsExitCode(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		args    []string
@@ -93,27 +47,7 @@ func TestValidateSubcommandsRejectParentValidateFlagsExitCode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, test.args...)
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
-			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected error %q, got %q", test.wantErr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantErr)
 		})
 	}
 }

--- a/internal/cli/cmdtest/web_apps_compatibility_test.go
+++ b/internal/cli/cmdtest/web_apps_compatibility_test.go
@@ -1,14 +1,6 @@
 package cmdtest
 
-import (
-	"bytes"
-	"errors"
-	"os/exec"
-	"strings"
-	"testing"
-
-	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
-)
+import "testing"
 
 func TestWebAppsCompatibilityCommandSurface(t *testing.T) {
 	root := RootCommand("1.2.3")
@@ -26,8 +18,6 @@ func TestWebAppsCompatibilityCommandSurface(t *testing.T) {
 }
 
 func TestWebAppsCompatibilityInvalidBooleanExitCodes(t *testing.T) {
-	bin := buildCLIBinary(t)
-
 	tests := []struct {
 		name       string
 		args       []string
@@ -82,25 +72,7 @@ func TestWebAppsCompatibilityInvalidBooleanExitCodes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(bin, test.args...)
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected exit error, got %v", err)
-			}
-			if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
-				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantStderr) {
-				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantStderr)
 		})
 	}
 }

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -289,7 +288,6 @@ func TestWebReviewIAPsAttachArgumentParsingEdges(t *testing.T) {
 }
 
 func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
-	bin := buildCLIBinary(t)
 	tests := []struct {
 		name       string
 		args       []string
@@ -319,25 +317,7 @@ func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(bin, test.args...)
-			var stdout, stderr strings.Builder
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected exit error, got %v", err)
-			}
-			if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
-				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantStderr) {
-				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantStderr)
 		})
 	}
 }

--- a/internal/cli/cmdtest/web_subscriptions_test.go
+++ b/internal/cli/cmdtest/web_subscriptions_test.go
@@ -1,13 +1,10 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -432,8 +429,6 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapRunUsageErrors(t *test
 }
 
 func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapUsageExitCodes(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-
 	tests := []struct {
 		name    string
 		args    []string
@@ -498,26 +493,7 @@ func TestWebSubscriptionsPricingMonthlyCommitmentBootstrapUsageExitCodes(t *test
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, test.args...)
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected process exit error, got %v", err)
-			}
-			if exitErr.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantErr) {
-				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantErr)
 		})
 	}
 }
@@ -579,32 +555,11 @@ func TestWebSubscriptionsPricingAdjustedEqualizationsViewRun(t *testing.T) {
 }
 
 func TestWebSubscriptionsPricingAdjustedEqualizationsRejectsUpfrontPlanType(t *testing.T) {
-	binaryPath := buildASCBlackBoxBinary(t)
-	command := exec.Command(
-		binaryPath,
+	assertUsageExit(t, []string{
 		"web", "subscriptions", "pricing", "adjusted-equalizations", "view",
 		"--price-point-id", "upfront-point",
 		"--plan-type", "UPFRONT",
-	)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-
-	err := command.Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected process exit error, got %v", err)
-	}
-	if exitErr.ExitCode() != 2 {
-		t.Fatalf("expected exit code 2, got %d", exitErr.ExitCode())
-	}
-	if stdout.String() != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), `--plan-type only supports "MONTHLY"`) {
-		t.Fatalf("expected MONTHLY-only error, got %q", stderr.String())
-	}
+	}, `--plan-type only supports "MONTHLY"`)
 }
 
 func webSubscriptionsAvailabilityResponse(t *testing.T, req *http.Request, availabilityListCalls *int, patchCalls *int, postPatchRemoved ...bool) (*http.Response, error) {

--- a/internal/cli/cmdtest/win_back_offers_create_test.go
+++ b/internal/cli/cmdtest/win_back_offers_create_test.go
@@ -1,20 +1,9 @@
 package cmdtest
 
-import (
-	"bytes"
-	"errors"
-	"os/exec"
-	"strings"
-	"testing"
-
-	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
-)
+import "testing"
 
 func TestWinBackOffersCreateInvalidPricePointExitUsage(t *testing.T) {
-	bin := buildCLIBinary(t)
-
-	cmd := exec.Command(
-		bin,
+	assertUsageExit(t, []string{
 		"subscriptions", "offers", "win-back", "create",
 		"--subscription-id", "sub-1",
 		"--reference-name", "spring-2026",
@@ -27,23 +16,5 @@ func TestWinBackOffersCreateInvalidPricePointExitUsage(t *testing.T) {
 		"--start-date", "2026-02-01",
 		"--priority", "HIGH",
 		"--price", "not-a-price-point!!",
-	)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected exit error, got %v", err)
-	}
-	if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
-		t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
-	}
-	if stdout.String() != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "is not a subscription price point ID") {
-		t.Fatalf("expected invalid price point error, got %q", stderr.String())
-	}
+	}, "is not a subscription price point ID")
 }

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -1,18 +1,14 @@
 package cmdtest
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestXcodeCommandExists(t *testing.T) {
@@ -137,7 +133,6 @@ func TestXcodeExportHelpMentionsDirectUploadMode(t *testing.T) {
 }
 
 func TestXcodeInjectInvalidFlagValuesExitUsage(t *testing.T) {
-	bin := buildCLIBinary(t)
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "deployment.json")
 	if err := os.WriteFile(manifestPath, []byte(`{
@@ -172,25 +167,7 @@ func TestXcodeInjectInvalidFlagValuesExitUsage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd := exec.Command(bin, test.args...)
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			err := cmd.Run()
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				t.Fatalf("expected exit error, got %v", err)
-			}
-			if code := exitErr.ExitCode(); code != rootcmd.ExitUsage {
-				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
-			}
-			if stdout.String() != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout.String())
-			}
-			if !strings.Contains(stderr.String(), test.wantStderr) {
-				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr.String())
-			}
+			assertUsageExit(t, test.args, test.wantStderr)
 		})
 	}
 }

--- a/scripts/go_test_shard.py
+++ b/scripts/go_test_shard.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run deterministic Go test shards for CI.
+
+The script supports two sharding levels:
+
+* package mode: list packages with `go list`, optionally exclude packages, and
+  run a stable subset of packages for the requested shard.
+* tests mode: list top-level tests in a single package and run a stable subset
+  through one `go test -run` regex.
+
+It intentionally keeps selection deterministic from repository contents only so
+CI does not depend on checked-in timing data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+def run_capture(command: list[str]) -> list[str]:
+    result = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def go_list(patterns: list[str]) -> list[str]:
+    return run_capture(["go", "list", *patterns])
+
+
+def normalize_packages(patterns: list[str]) -> set[str]:
+    if not patterns:
+        return set()
+    return set(go_list(patterns))
+
+
+def select_shard(items: list[str], shard_index: int, shard_total: int) -> list[str]:
+    return [item for index, item in enumerate(sorted(items)) if index % shard_total == shard_index]
+
+
+def run_package_shard(args: argparse.Namespace) -> int:
+    packages = go_list(args.packages)
+    excluded = normalize_packages(args.exclude)
+    selected = select_shard(
+        [package for package in packages if package not in excluded],
+        args.shard_index,
+        args.shard_total,
+    )
+    print(
+        f"Selected {len(selected)} package(s) for shard "
+        f"{args.shard_index + 1}/{args.shard_total}",
+        flush=True,
+    )
+    for package in selected:
+        print(f"  {package}", flush=True)
+    if not selected:
+        return 0
+    return subprocess.run(["go", "test", *args.go_test_args, *selected]).returncode
+
+
+def run_test_shard(args: argparse.Namespace) -> int:
+    tests = run_capture(["go", "test", "-list", "^Test", args.package])
+    tests = [test for test in tests if test.startswith("Test")]
+    selected = select_shard(tests, args.shard_index, args.shard_total)
+    print(
+        f"Selected {len(selected)} test(s) from {args.package} for shard "
+        f"{args.shard_index + 1}/{args.shard_total}",
+        flush=True,
+    )
+    if not selected:
+        return 0
+    pattern = "^(?:" + "|".join(re.escape(test) for test in selected) + ")$"
+    return subprocess.run(
+        ["go", "test", *args.go_test_args, "-run", pattern, args.package],
+    ).returncode
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    package_parser = subparsers.add_parser("packages")
+    package_parser.add_argument("--packages", nargs="+", default=["./..."])
+    package_parser.add_argument("--exclude", action="append", default=[])
+    package_parser.add_argument("--shard-index", type=int, required=True)
+    package_parser.add_argument("--shard-total", type=int, required=True)
+    package_parser.add_argument("go_test_args", nargs=argparse.REMAINDER)
+
+    test_parser = subparsers.add_parser("tests")
+    test_parser.add_argument("--package", required=True)
+    test_parser.add_argument("--shard-index", type=int, required=True)
+    test_parser.add_argument("--shard-total", type=int, required=True)
+    test_parser.add_argument("go_test_args", nargs=argparse.REMAINDER)
+
+    args = parser.parse_args()
+    if args.shard_total < 1:
+        parser.error("--shard-total must be at least 1")
+    if args.shard_index < 0 or args.shard_index >= args.shard_total:
+        parser.error("--shard-index must be between 0 and shard-total - 1")
+    if args.go_test_args and args.go_test_args[0] == "--":
+        args.go_test_args = args.go_test_args[1:]
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    if args.mode == "packages":
+        return run_package_shard(args)
+    if args.mode == "tests":
+        return run_test_shard(args)
+    raise AssertionError(f"unknown mode {args.mode}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/go_test_shard.py
+++ b/scripts/go_test_shard.py
@@ -70,7 +70,7 @@ def run_test_shard(args: argparse.Namespace) -> int:
     )
     if not selected:
         return 0
-    pattern = "^(?:" + "|".join(re.escape(test) for test in selected) + ")$"
+    pattern = "^(?:" + "|".join(re.escape(test) for test in selected) + ")(?:/.*)?$"
     return subprocess.run(
         ["go", "test", *args.go_test_args, "-run", pattern, args.package],
     ).returncode


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Split Go unit tests into deterministic CI shards:
  - generic package shard runs `./cmd` first, then all packages except `./cmd`, `./internal/cli/cmdtest`, and `./internal/cli/web`
  - two `internal/cli/web` shards split top-level web tests while preserving selected subtests
  - two `internal/cli/cmdtest` shards split top-level cmdtest tests while preserving selected subtests
- Keep aggregate `test` / `unit-tests` jobs so the old check names remain visible after shard completion.
- Add reusable `scripts/go_test_shard.py` for package and test-name sharding.
- Preserve black-box process coverage in `cmd`, but build the CLI binary once per package instead of rebuilding it per test.
- Convert cmdtest usage-exit checks from process-level binary execution to the in-process CLI runner via `assertUsageExit`, removing cmdtest package binary builds without dropping exit-code/stderr assertions.

## Measured impact

Latest successful PR Checks run on this head: https://github.com/rorkai/App-Store-Connect-CLI/actions/runs/28277562142

- PR Checks workflow wall time: ~7m55s before test sharding -> 3m38s now, about 54% faster in this sample
- Earlier sharded PR Checks wall time was ~4m09s; this follow-up saves another ~31s, about 12% on the full workflow sample
- Old `unit-tests`: 7m22s wall, with `Run unit tests` step 7m04s
- Latest unit-test shard max duration: 1m51s (`packages`), with cmdtest/web shards below that
- Unit-test shard duration improvement vs old `unit-tests`: about 75% in this sample

Latest PR shard timings:

- `unit-test shard (packages)`: 1m51s
- `unit-test shard (web 1/2)`: 1m04s
- `unit-test shard (web 2/2)`: 44s
- `unit-test shard (cmdtest 1/2)`: 1m33s
- `unit-test shard (cmdtest 2/2)`: 1m44s
- `build`: 3m26s, now the longest PR Checks job

Additional local no-cache timing after this refactor:

- `./cmd`: ~2.5s Go test time after cached black-box binary helper
- full `./internal/cli/cmdtest`: ~82s after removing cmdtest binary builds, down from ~116s after binary caching and ~146s in the earlier baseline profile
- package shard excluding web/cmdtest: ~36s
- `internal/cli/web` shard 1/2: ~37s Go test time (~38s wall)
- `internal/cli/web` shard 2/2: ~24s Go test time (~25s wall)
- `internal/cli/cmdtest` shard 1/2: ~38s Go test time
- `internal/cli/cmdtest` shard 2/2: ~46s Go test time (~48s wall)

## Validation

- [x] `python3 -m py_compile scripts/go_test_shard.py`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test -short ./cmd`
- [x] `ASC_BYPASS_KEYCHAIN=1 python3 scripts/go_test_shard.py tests --package ./internal/cli/web --shard-index 0 --shard-total 2 -- -short`
- [x] `ASC_BYPASS_KEYCHAIN=1 python3 scripts/go_test_shard.py tests --package ./internal/cli/web --shard-index 1 --shard-total 2 -- -short`
- [x] `ASC_BYPASS_KEYCHAIN=1 python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 0 --shard-total 2 -- -short`
- [x] `ASC_BYPASS_KEYCHAIN=1 python3 scripts/go_test_shard.py tests --package ./internal/cli/cmdtest --shard-index 1 --shard-total 2 -- -short`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test -short ./cmd && ASC_BYPASS_KEYCHAIN=1 python3 scripts/go_test_shard.py packages --packages ./... --exclude ./cmd --exclude ./internal/cli/cmdtest --exclude ./internal/cli/web --shard-index 0 --shard-total 1 -- -short`
- [x] `make format`
- [x] `make check-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] Latest PR Checks passed on the pushed head
- [x] CodeQL and Govulncheck passed on the pushed head

If this PR only updates `docs/wall-of-apps.json`, use `make check-wall-of-apps` instead of the full checklist above.

## Wall of Apps (only if this PR adds/updates a Wall app)

- [ ] I used `asc apps wall submit --app "1234567890" --confirm` (or made the equivalent single-file update manually)
- [ ] This PR only updates `docs/wall-of-apps.json`
- [ ] I ran `make check-wall-of-apps`

Entry template:

```json
{
  "app": "Your App Name",
  "link": "https://apps.apple.com/app/id1234567890",
  "creator": "your-github-handle",
  "platform": ["iOS"]
}
```

Common Apple labels: `iOS`, `macOS`, `watchOS`, `tvOS`, `visionOS`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f06c5-84ae-7daf-a69e-a100fec5af44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f06c5-84ae-7daf-a69e-a100fec5af44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage and made CLI validation tests run more consistently in-process.

* **Chores**
  * Reworked CI to run tests in parallel shards, which should improve feedback speed and reliability.
  * Added shared test helpers to reduce repeated setup across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->