### PR TITLE
Fix resolved subscription price listing

### DIFF
--- a/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_plan_type_test.go
@@ -231,6 +231,15 @@ func TestSubscriptionsPricingPricesListPlanTypeValidationErrors(t *testing.T) {
 			},
 			wantErr: "invalid value for --plan-type: cannot be empty",
 		},
+		{
+			name: "empty territory",
+			args: []string{
+				"subscriptions", "pricing", "prices", "list",
+				"--subscription-id", "8000000001",
+				"--territory", "",
+			},
+			wantErr: "invalid value for --territory: cannot be empty",
+		},
 	}
 
 	for _, test := range tests {
@@ -285,4 +294,12 @@ func TestSubscriptionsPricingPricesListPlanTypeUsageExitCodes(t *testing.T) {
 			}, test.wantErr)
 		})
 	}
+}
+
+func TestSubscriptionsPricingPricesListTerritoryUsageExitCodes(t *testing.T) {
+	assertUsageExit(t, []string{
+		"subscriptions", "pricing", "prices", "list",
+		"--subscription-id", "8000000001",
+		"--territory", "",
+	}, "invalid value for --territory: cannot be empty")
 }

--- a/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
@@ -195,14 +195,156 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v, stdout = %q", err, stdout)
 	}
-	if len(result.Prices) != 2 {
-		t.Fatalf("expected 2 resolved prices, got %+v", result.Prices)
+	if len(result.Prices) != 3 {
+		t.Fatalf("expected 3 resolved prices, got %+v", result.Prices)
 	}
-	if result.Prices[0].Territory != "GBR" || result.Prices[0].CustomerPrice != "7.99" {
+	if result.Prices[0].Territory != "FRA" || result.Prices[0].CustomerPrice != "6.99" {
 		t.Fatalf("unexpected first resolved row: %+v", result.Prices[0])
 	}
-	if result.Prices[1].Territory != "USA" || result.Prices[1].CustomerPrice != "9.99" {
+	if result.Prices[1].Territory != "GBR" || result.Prices[1].CustomerPrice != "7.99" {
 		t.Fatalf("unexpected second resolved row: %+v", result.Prices[1])
+	}
+	if result.Prices[2].Territory != "USA" || result.Prices[2].CustomerPrice != "9.99" {
+		t.Fatalf("unexpected third resolved row: %+v", result.Prices[2])
+	}
+}
+
+func TestSubscriptionsPricingPricesListResolvedIncludesUndatedCurrentPrices(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		query := req.URL.Query()
+		if query.Get("include") != "subscriptionPricePoint,territory" {
+			t.Fatalf("expected include query, got %q", query.Get("include"))
+		}
+
+		return jsonResponse(http.StatusOK, `{
+			"data":[
+				{
+					"type":"subscriptionPrices",
+					"id":"price-usa",
+					"attributes":{"preserved":false},
+					"relationships":{
+						"territory":{"data":{"type":"territories","id":"USA"}},
+						"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}
+					}
+				},
+				{
+					"type":"subscriptionPrices",
+					"id":"price-nor",
+					"attributes":{"preserved":false},
+					"relationships":{
+						"territory":{"data":{"type":"territories","id":"NOR"}},
+						"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-nor"}}
+					}
+				}
+			],
+			"included":[
+				{"type":"subscriptionPricePoints","id":"pp-usa","attributes":{"customerPrice":"4.99","proceeds":"3.49"}},
+				{"type":"subscriptionPricePoints","id":"pp-nor","attributes":{"customerPrice":"59.00","proceeds":"41.00"}},
+				{"type":"territories","id":"USA","attributes":{"currency":"USD"}},
+				{"type":"territories","id":"NOR","attributes":{"currency":"NOK"}}
+			],
+			"links":{"next":""}
+		}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--resolved",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result shared.ResolvedPricesResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if len(result.Prices) != 2 {
+		t.Fatalf("expected undated resolved prices, got %+v", result.Prices)
+	}
+	if result.Prices[0].Territory != "NOR" || result.Prices[0].CustomerPrice != "59.00" || result.Prices[0].Currency != "NOK" {
+		t.Fatalf("unexpected first resolved row: %+v", result.Prices[0])
+	}
+	if result.Prices[1].Territory != "USA" || result.Prices[1].CustomerPrice != "4.99" || result.Prices[1].Currency != "USD" {
+		t.Fatalf("unexpected second resolved row: %+v", result.Prices[1])
+	}
+}
+
+func TestSubscriptionsPricingPricesListResolvedTerritoryFilter(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/prices" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		query := req.URL.Query()
+		if got := query.Get("filter[territory]"); got != "USA" {
+			t.Fatalf("expected filter[territory]=USA, got %q", got)
+		}
+		if got := query.Get("include"); got != "subscriptionPricePoint,territory" {
+			t.Fatalf("expected resolved includes, got %q", got)
+		}
+
+		return jsonResponse(http.StatusOK, `{
+			"data":[{
+				"type":"subscriptionPrices",
+				"id":"price-usa",
+				"relationships":{
+					"territory":{"data":{"type":"territories","id":"USA"}},
+					"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}
+				}
+			}],
+			"included":[
+				{"type":"subscriptionPricePoints","id":"pp-usa","attributes":{"customerPrice":"4.99"}},
+				{"type":"territories","id":"USA","attributes":{"currency":"USD"}}
+			],
+			"links":{"next":""}
+		}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "list",
+			"--subscription-id", "8000000001",
+			"--resolved",
+			"--territory", "US",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result shared.ResolvedPricesResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if len(result.Prices) != 1 || result.Prices[0].Territory != "USA" {
+		t.Fatalf("expected one USA resolved price, got %+v", result.Prices)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
@@ -195,21 +195,18 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v, stdout = %q", err, stdout)
 	}
-	if len(result.Prices) != 3 {
-		t.Fatalf("expected 3 resolved prices, got %+v", result.Prices)
+	if len(result.Prices) != 2 {
+		t.Fatalf("expected 2 resolved prices, got %+v", result.Prices)
 	}
-	if result.Prices[0].Territory != "FRA" || result.Prices[0].CustomerPrice != "6.99" {
+	if result.Prices[0].Territory != "GBR" || result.Prices[0].CustomerPrice != "7.99" {
 		t.Fatalf("unexpected first resolved row: %+v", result.Prices[0])
 	}
-	if result.Prices[1].Territory != "GBR" || result.Prices[1].CustomerPrice != "7.99" {
+	if result.Prices[1].Territory != "USA" || result.Prices[1].CustomerPrice != "9.99" {
 		t.Fatalf("unexpected second resolved row: %+v", result.Prices[1])
-	}
-	if result.Prices[2].Territory != "USA" || result.Prices[2].CustomerPrice != "9.99" {
-		t.Fatalf("unexpected third resolved row: %+v", result.Prices[2])
 	}
 }
 
-func TestSubscriptionsPricingPricesListResolvedIncludesUndatedCurrentPrices(t *testing.T) {
+func TestSubscriptionsPricingPricesListResolvedPlanTypeIncludesUndatedCurrentPrices(t *testing.T) {
 	setupAuth(t)
 
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -219,6 +216,9 @@ func TestSubscriptionsPricingPricesListResolvedIncludesUndatedCurrentPrices(t *t
 		query := req.URL.Query()
 		if query.Get("include") != "subscriptionPricePoint,territory" {
 			t.Fatalf("expected include query, got %q", query.Get("include"))
+		}
+		if got := query.Get("filter[planType]"); got != "MONTHLY" {
+			t.Fatalf("expected filter[planType]=MONTHLY, got %q", got)
 		}
 
 		return jsonResponse(http.StatusOK, `{
@@ -260,6 +260,7 @@ func TestSubscriptionsPricingPricesListResolvedIncludesUndatedCurrentPrices(t *t
 			"subscriptions", "pricing", "prices", "list",
 			"--subscription-id", "8000000001",
 			"--resolved",
+			"--plan-type", "MONTHLY",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -306,6 +307,7 @@ func TestSubscriptionsPricingPricesListResolvedTerritoryFilter(t *testing.T) {
 			"data":[{
 				"type":"subscriptionPrices",
 				"id":"price-usa",
+				"attributes":{"startDate":"2026-01-01"},
 				"relationships":{
 					"territory":{"data":{"type":"territories","id":"USA"}},
 					"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}

--- a/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_resolved_test.go
@@ -73,6 +73,9 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 			if query.Get("fields[subscriptionPricePoints]") != "customerPrice,proceeds,proceedsYear2" {
 				t.Fatalf("unexpected price point fields: %q", query.Get("fields[subscriptionPricePoints]"))
 			}
+			if query.Get("fields[subscriptionPrices]") != "startDate,preserved,planType,territory,subscriptionPricePoint" {
+				t.Fatalf("unexpected subscription price fields: %q", query.Get("fields[subscriptionPrices]"))
+			}
 			if query.Get("fields[territories]") != "currency" {
 				t.Fatalf("unexpected territory fields: %q", query.Get("fields[territories]"))
 			}
@@ -85,7 +88,7 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 					{
 						"type":"subscriptionPrices",
 						"id":"price-current-usa",
-						"attributes":{"startDate":"2025-01-01","preserved":false},
+						"attributes":{"startDate":"2025-01-01","preserved":false,"planType":"UPFRONT"},
 						"relationships":{
 							"territory":{"data":{"type":"territories","id":"USA"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-current-usa"}}
@@ -94,7 +97,7 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 					{
 						"type":"subscriptionPrices",
 						"id":"price-future-usa",
-						"attributes":{"startDate":"2030-01-01","preserved":false},
+						"attributes":{"startDate":"2030-01-01","preserved":false,"planType":"UPFRONT"},
 						"relationships":{
 							"territory":{"data":{"type":"territories","id":"USA"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-future-usa"}}
@@ -127,6 +130,9 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 			if query.Get("fields[subscriptionPricePoints]") != "customerPrice,proceeds,proceedsYear2" {
 				t.Fatalf("unexpected paginated price point fields: %q", query.Get("fields[subscriptionPricePoints]"))
 			}
+			if query.Get("fields[subscriptionPrices]") != "startDate,preserved,planType,territory,subscriptionPricePoint" {
+				t.Fatalf("unexpected paginated subscription price fields: %q", query.Get("fields[subscriptionPrices]"))
+			}
 			if query.Get("fields[territories]") != "currency" {
 				t.Fatalf("unexpected paginated territory fields: %q", query.Get("fields[territories]"))
 			}
@@ -136,7 +142,7 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 					{
 						"type":"subscriptionPrices",
 						"id":"price-current-gbr",
-						"attributes":{"startDate":"2024-06-01","preserved":false},
+						"attributes":{"startDate":"2024-06-01","preserved":false,"planType":"UPFRONT"},
 						"relationships":{
 							"territory":{"data":{"type":"territories","id":"GBR"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-current-gbr"}}
@@ -145,7 +151,7 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 					{
 						"type":"subscriptionPrices",
 						"id":"price-undated-fra",
-						"attributes":{"preserved":false},
+						"attributes":{"preserved":false,"planType":"UPFRONT"},
 						"relationships":{
 							"territory":{"data":{"type":"territories","id":"FRA"}},
 							"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-undated-fra"}}
@@ -195,14 +201,17 @@ func TestSubscriptionsPricingPricesListResolvedJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v, stdout = %q", err, stdout)
 	}
-	if len(result.Prices) != 2 {
-		t.Fatalf("expected 2 resolved prices, got %+v", result.Prices)
+	if len(result.Prices) != 3 {
+		t.Fatalf("expected 3 resolved prices, got %+v", result.Prices)
 	}
-	if result.Prices[0].Territory != "GBR" || result.Prices[0].CustomerPrice != "7.99" {
+	if result.Prices[0].Territory != "FRA" || result.Prices[0].CustomerPrice != "6.99" || result.Prices[0].PlanType != "UPFRONT" {
 		t.Fatalf("unexpected first resolved row: %+v", result.Prices[0])
 	}
-	if result.Prices[1].Territory != "USA" || result.Prices[1].CustomerPrice != "9.99" {
+	if result.Prices[1].Territory != "GBR" || result.Prices[1].CustomerPrice != "7.99" || result.Prices[1].PlanType != "UPFRONT" {
 		t.Fatalf("unexpected second resolved row: %+v", result.Prices[1])
+	}
+	if result.Prices[2].Territory != "USA" || result.Prices[2].CustomerPrice != "9.99" || result.Prices[2].PlanType != "UPFRONT" {
+		t.Fatalf("unexpected third resolved row: %+v", result.Prices[2])
 	}
 }
 

--- a/internal/cli/shared/resolved_prices.go
+++ b/internal/cli/shared/resolved_prices.go
@@ -11,6 +11,7 @@ import (
 // ResolvedPriceRow represents the currently effective price for a territory.
 type ResolvedPriceRow struct {
 	Territory     string `json:"territory"`
+	PlanType      string `json:"planType,omitempty"`
 	PriceID       string `json:"priceId"`
 	PricePointID  string `json:"pricePointId"`
 	CustomerPrice string `json:"customerPrice,omitempty"`
@@ -35,6 +36,9 @@ func SortResolvedPrices(rows []ResolvedPriceRow) {
 		right := rows[j]
 		if left.Territory != right.Territory {
 			return left.Territory < right.Territory
+		}
+		if left.PlanType != right.PlanType {
+			return left.PlanType < right.PlanType
 		}
 		if left.StartDate != right.StartDate {
 			return left.StartDate < right.StartDate
@@ -68,6 +72,7 @@ func printResolvedPricesTable(result *ResolvedPricesResult, markdown bool) error
 
 	headers := []string{
 		"Territory",
+		"Plan Type",
 		"Price ID",
 		"Price Point ID",
 		"Customer Price",
@@ -84,6 +89,7 @@ func printResolvedPricesTable(result *ResolvedPricesResult, markdown bool) error
 	for _, row := range rows {
 		values = append(values, []string{
 			row.Territory,
+			row.PlanType,
 			row.PriceID,
 			row.PricePointID,
 			row.CustomerPrice,

--- a/internal/cli/shared/resolved_prices_output_test.go
+++ b/internal/cli/shared/resolved_prices_output_test.go
@@ -39,10 +39,10 @@ func TestPrintResolvedPrices_TableAndMarkdown(t *testing.T) {
 			t.Fatalf("PrintResolvedPrices(markdown) error = %v", err)
 		}
 	})
-	if !strings.Contains(markdownOut, "| Territory | Price ID |") {
+	if !strings.Contains(markdownOut, "| Territory | Plan Type | Price ID |") {
 		t.Fatalf("expected markdown header row, got %q", markdownOut)
 	}
-	if !strings.Contains(markdownOut, "| USA       | price-1  | pp-1           | 9.99") || !strings.Contains(markdownOut, "true") {
+	if !strings.Contains(markdownOut, "| USA       |           | price-1  | pp-1") || !strings.Contains(markdownOut, "true") {
 		t.Fatalf("expected markdown value row, got %q", markdownOut)
 	}
 }

--- a/internal/cli/subscriptions/monthly_commitment.go
+++ b/internal/cli/subscriptions/monthly_commitment.go
@@ -510,6 +510,7 @@ func validateMonthlyCommitmentUpfrontPrices(
 		"",
 		time.Now().UTC(),
 		asc.SubscriptionPlanTypeUpfront,
+		"",
 	)
 	if err != nil {
 		return fmt.Errorf("failed to fetch UPFRONT subscription prices: %w", err)
@@ -566,6 +567,7 @@ func prepareMonthlySubscriptionPrices(
 		"",
 		now,
 		asc.SubscriptionPlanTypeMonthly,
+		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch MONTHLY subscription prices: %w", err)

--- a/internal/cli/subscriptions/pricing_equalize.go
+++ b/internal/cli/subscriptions/pricing_equalize.go
@@ -539,7 +539,7 @@ func reconcileEqualizeFailures(ctx context.Context, client *asc.Client, subID st
 
 	fmt.Fprintf(os.Stderr, "Verifying %d territory update(s) against current prices...\n", len(failures))
 
-	resolved, err := fetchResolvedSubscriptionPrices(ctx, client, subID, 200, "", effectiveAt, "")
+	resolved, err := fetchResolvedSubscriptionPrices(ctx, client, subID, 200, "", effectiveAt, "", "")
 	if err != nil {
 		return 0, failures, err
 	}

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -26,6 +26,7 @@ func fetchResolvedSubscriptionPrices(
 	nextURL string,
 	now time.Time,
 	planType asc.SubscriptionPlanType,
+	territory string,
 ) (*shared.ResolvedPricesResult, error) {
 	if limit <= 0 {
 		limit = 200
@@ -41,6 +42,9 @@ func fetchResolvedSubscriptionPrices(
 	if planType != "" {
 		opts = append(opts, asc.WithSubscriptionPricesPlanType(planType))
 	}
+	if strings.TrimSpace(territory) != "" {
+		opts = append(opts, asc.WithSubscriptionPricesTerritory(territory))
+	}
 
 	firstPage, err := shared.RetryReadWithFreshTimeout(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricesResponse, error) {
 		return client.GetSubscriptionPrices(requestCtx, subscriptionID, opts...)
@@ -51,7 +55,7 @@ func fetchResolvedSubscriptionPrices(
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
 	if err := asc.PaginateEach(ctx, firstPage, func(_ context.Context, next string) (asc.PaginatedResponse, error) {
-		nextURL, err := mergeSubscriptionPricesNextQuery(next, resolvedSubscriptionPricesQuery(limit, planType))
+		nextURL, err := mergeSubscriptionPricesNextQuery(next, resolvedSubscriptionPricesQuery(limit, planType, territory))
 		if err != nil {
 			return nil, err
 		}
@@ -64,6 +68,7 @@ func fetchResolvedSubscriptionPrices(
 				asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
 				asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
 				asc.WithSubscriptionPricesPlanType(planType),
+				asc.WithSubscriptionPricesTerritory(territory),
 			)
 		})
 	}, func(page asc.PaginatedResponse) error {
@@ -84,7 +89,7 @@ func fetchResolvedSubscriptionPrices(
 	return &shared.ResolvedPricesResult{Prices: rows}, nil
 }
 
-func resolvedSubscriptionPricesQuery(limit int, planType asc.SubscriptionPlanType) url.Values {
+func resolvedSubscriptionPricesQuery(limit int, planType asc.SubscriptionPlanType, territory string) url.Values {
 	values := url.Values{}
 	values.Set("include", "subscriptionPricePoint,territory")
 	values.Set("fields[subscriptionPricePoints]", "customerPrice,proceeds,proceedsYear2")
@@ -94,6 +99,9 @@ func resolvedSubscriptionPricesQuery(limit int, planType asc.SubscriptionPlanTyp
 	}
 	if planType != "" {
 		values.Set("filter[planType]", string(planType))
+	}
+	if strings.TrimSpace(territory) != "" {
+		values.Set("filter[territory]", strings.ToUpper(strings.TrimSpace(territory)))
 	}
 	return values
 }
@@ -136,12 +144,6 @@ func consumeResolvedSubscriptionPricePageForPlanType(
 		}
 
 		startAt := parseSubscriptionPricingDate(price.Attributes.StartDate)
-		// Preserve the legacy undated-price skip unless a plan-specific view was requested.
-		if startAt == nil {
-			if planType == "" {
-				continue
-			}
-		}
 		if startAt != nil && startAt.After(asOf) {
 			continue
 		}

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -35,6 +35,7 @@ func fetchResolvedSubscriptionPrices(
 	opts := []asc.SubscriptionPricesOption{
 		asc.WithSubscriptionPricesLimit(limit),
 		asc.WithSubscriptionPricesNextURL(nextURL),
+		asc.WithSubscriptionPricesFields([]string{"startDate", "preserved", "planType", "territory", "subscriptionPricePoint"}),
 		asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
 		asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
 		asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
@@ -64,6 +65,7 @@ func fetchResolvedSubscriptionPrices(
 				requestCtx,
 				subscriptionID,
 				asc.WithSubscriptionPricesNextURL(nextURL),
+				asc.WithSubscriptionPricesFields([]string{"startDate", "preserved", "planType", "territory", "subscriptionPricePoint"}),
 				asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
 				asc.WithSubscriptionPricesPricePointFields([]string{"customerPrice", "proceeds", "proceedsYear2"}),
 				asc.WithSubscriptionPricesTerritoryFields([]string{"currency"}),
@@ -92,6 +94,7 @@ func fetchResolvedSubscriptionPrices(
 func resolvedSubscriptionPricesQuery(limit int, planType asc.SubscriptionPlanType, territory string) url.Values {
 	values := url.Values{}
 	values.Set("include", "subscriptionPricePoint,territory")
+	values.Set("fields[subscriptionPrices]", "startDate,preserved,planType,territory,subscriptionPricePoint")
 	values.Set("fields[subscriptionPricePoints]", "customerPrice,proceeds,proceedsYear2")
 	values.Set("fields[territories]", "currency")
 	if limit > 0 {
@@ -136,14 +139,15 @@ func consumeResolvedSubscriptionPricePage(
 		}
 
 		startAt := parseSubscriptionPricingDate(price.Attributes.StartDate)
-		if startAt == nil && planType == "" {
-			continue
-		}
 		if startAt != nil && startAt.After(asOf) {
 			continue
 		}
 
 		territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
+		rowPlanType := strings.TrimSpace(string(price.Attributes.PlanType))
+		if rowPlanType == "" {
+			rowPlanType = strings.TrimSpace(string(planType))
+		}
 		currency := currencies[territoryID]
 		if currency == "" {
 			currency = territoryToCurrency(territoryID)
@@ -152,6 +156,7 @@ func consumeResolvedSubscriptionPricePage(
 		candidate := resolvedSubscriptionPriceCandidate{
 			row: shared.ResolvedPriceRow{
 				Territory:     territoryID,
+				PlanType:      rowPlanType,
 				PriceID:       strings.TrimSpace(price.ID),
 				PricePointID:  strings.TrimSpace(pricePointID),
 				CustomerPrice: value.CustomerPrice,
@@ -165,13 +170,22 @@ func consumeResolvedSubscriptionPricePage(
 			preserved: price.Attributes.Preserved,
 		}
 
-		existing, ok := candidates[territoryID]
+		candidateKey := resolvedSubscriptionPriceCandidateKey(territoryID, rowPlanType)
+		existing, ok := candidates[candidateKey]
 		if !ok || subscriptionResolvedCandidateIsNewer(candidate, existing) {
-			candidates[territoryID] = candidate
+			candidates[candidateKey] = candidate
 		}
 	}
 
 	return nil
+}
+
+func resolvedSubscriptionPriceCandidateKey(territoryID, planType string) string {
+	normalizedPlanType := strings.ToUpper(strings.TrimSpace(planType))
+	if normalizedPlanType == "" {
+		return territoryID
+	}
+	return territoryID + "\x00" + normalizedPlanType
 }
 
 func subscriptionResolvedCandidateIsNewer(candidate, existing resolvedSubscriptionPriceCandidate) bool {

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -76,7 +76,7 @@ func fetchResolvedSubscriptionPrices(
 		if !ok {
 			return fmt.Errorf("unexpected subscription prices response type %T", page)
 		}
-		return consumeResolvedSubscriptionPricePageForPlanType(candidates, resp, now, planType)
+		return consumeResolvedSubscriptionPricePage(candidates, resp, now)
 	}); err != nil {
 		return nil, err
 	}
@@ -110,15 +110,6 @@ func consumeResolvedSubscriptionPricePage(
 	candidates map[string]resolvedSubscriptionPriceCandidate,
 	page *asc.SubscriptionPricesResponse,
 	now time.Time,
-) error {
-	return consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, "")
-}
-
-func consumeResolvedSubscriptionPricePageForPlanType(
-	candidates map[string]resolvedSubscriptionPriceCandidate,
-	page *asc.SubscriptionPricesResponse,
-	now time.Time,
-	planType asc.SubscriptionPlanType,
 ) error {
 	if page == nil {
 		return nil

--- a/internal/cli/subscriptions/resolved_prices.go
+++ b/internal/cli/subscriptions/resolved_prices.go
@@ -76,7 +76,7 @@ func fetchResolvedSubscriptionPrices(
 		if !ok {
 			return fmt.Errorf("unexpected subscription prices response type %T", page)
 		}
-		return consumeResolvedSubscriptionPricePage(candidates, resp, now)
+		return consumeResolvedSubscriptionPricePage(candidates, resp, now, planType)
 	}); err != nil {
 		return nil, err
 	}
@@ -110,6 +110,7 @@ func consumeResolvedSubscriptionPricePage(
 	candidates map[string]resolvedSubscriptionPriceCandidate,
 	page *asc.SubscriptionPricesResponse,
 	now time.Time,
+	planType asc.SubscriptionPlanType,
 ) error {
 	if page == nil {
 		return nil
@@ -135,6 +136,9 @@ func consumeResolvedSubscriptionPricePage(
 		}
 
 		startAt := parseSubscriptionPricingDate(price.Attributes.StartDate)
+		if startAt == nil && planType == "" {
+			continue
+		}
 		if startAt != nil && startAt.After(asOf) {
 			continue
 		}

--- a/internal/cli/subscriptions/resolved_prices_test.go
+++ b/internal/cli/subscriptions/resolved_prices_test.go
@@ -30,7 +30,7 @@ func TestConsumeResolvedSubscriptionPricePage_SelectsLatestActivePerTerritory(t 
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now, ""); err != nil {
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
@@ -64,7 +64,7 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersNonPreservedSameDay(t *test
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now, ""); err != nil {
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
@@ -77,7 +77,7 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersNonPreservedSameDay(t *test
 	}
 }
 
-func TestConsumeResolvedSubscriptionPricePage_UsesUndatedCurrentPriceAndSkipsFuture(t *testing.T) {
+func TestConsumeResolvedSubscriptionPricePage_SkipsUndatedCurrentPriceWithoutPlanType(t *testing.T) {
 	now := time.Date(2026, time.March, 29, 12, 0, 0, 0, time.UTC)
 
 	page := &asc.SubscriptionPricesResponse{
@@ -93,16 +93,12 @@ func TestConsumeResolvedSubscriptionPricePage_UsesUndatedCurrentPriceAndSkipsFut
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now, ""); err != nil {
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
-	row, ok := candidates["USA"]
-	if !ok {
-		t.Fatalf("expected undated current row, got %+v", candidates)
-	}
-	if row.row.PriceID != "price-undated" || row.row.CustomerPrice != "8.99" {
-		t.Fatalf("expected undated current price to resolve, got %+v", row.row)
+	if len(candidates) != 0 {
+		t.Fatalf("expected no resolved rows, got %+v", candidates)
 	}
 }
 
@@ -120,7 +116,7 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedMonthlyPrice(t *test
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now, asc.SubscriptionPlanTypeMonthly); err != nil {
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
@@ -147,7 +143,7 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedUpfrontPrice(t *test
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now, asc.SubscriptionPlanTypeUpfront); err != nil {
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
@@ -176,7 +172,7 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersDatedCurrentOverUndatedFall
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now, asc.SubscriptionPlanTypeUpfront); err != nil {
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 

--- a/internal/cli/subscriptions/resolved_prices_test.go
+++ b/internal/cli/subscriptions/resolved_prices_test.go
@@ -77,7 +77,7 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersNonPreservedSameDay(t *test
 	}
 }
 
-func TestConsumeResolvedSubscriptionPricePage_DoesNotFallbackToFutureOrUndated(t *testing.T) {
+func TestConsumeResolvedSubscriptionPricePage_UsesUndatedCurrentPriceAndSkipsFuture(t *testing.T) {
 	now := time.Date(2026, time.March, 29, 12, 0, 0, 0, time.UTC)
 
 	page := &asc.SubscriptionPricesResponse{
@@ -97,8 +97,12 @@ func TestConsumeResolvedSubscriptionPricePage_DoesNotFallbackToFutureOrUndated(t
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
-	if len(candidates) != 0 {
-		t.Fatalf("expected no resolved rows, got %+v", candidates)
+	row, ok := candidates["USA"]
+	if !ok {
+		t.Fatalf("expected undated current row, got %+v", candidates)
+	}
+	if row.row.PriceID != "price-undated" || row.row.CustomerPrice != "8.99" {
+		t.Fatalf("expected undated current price to resolve, got %+v", row.row)
 	}
 }
 

--- a/internal/cli/subscriptions/resolved_prices_test.go
+++ b/internal/cli/subscriptions/resolved_prices_test.go
@@ -77,17 +77,24 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersNonPreservedSameDay(t *test
 	}
 }
 
-func TestConsumeResolvedSubscriptionPricePage_SkipsUndatedCurrentPriceWithoutPlanType(t *testing.T) {
+func TestConsumeResolvedSubscriptionPricePage_UsesUndatedCurrentPricesPerPlanType(t *testing.T) {
 	now := time.Date(2026, time.March, 29, 12, 0, 0, 0, time.UTC)
+
+	monthly := newResolvedSubscriptionPriceResource("price-monthly", "USA", "pp-monthly", "", false)
+	monthly.Attributes.PlanType = asc.SubscriptionPlanTypeMonthly
+	upfront := newResolvedSubscriptionPriceResource("price-upfront", "USA", "pp-upfront", "", false)
+	upfront.Attributes.PlanType = asc.SubscriptionPlanTypeUpfront
 
 	page := &asc.SubscriptionPricesResponse{
 		Data: []asc.Resource[asc.SubscriptionPriceAttributes]{
 			newResolvedSubscriptionPriceResource("price-future", "USA", "pp-future", "2030-01-01", false),
-			newResolvedSubscriptionPriceResource("price-undated", "USA", "pp-undated", "", false),
+			monthly,
+			upfront,
 		},
 		Included: mustMarshalJSON(t, []map[string]any{
 			subscriptionPricePointIncluded("pp-future", "12.99", "10.00", "11.00"),
-			subscriptionPricePointIncluded("pp-undated", "8.99", "6.20", "7.10"),
+			subscriptionPricePointIncluded("pp-monthly", "8.99", "6.20", "7.10"),
+			subscriptionPricePointIncluded("pp-upfront", "49.99", "34.90", "39.90"),
 			territoryIncluded("USA", "USD"),
 		}),
 	}
@@ -97,8 +104,17 @@ func TestConsumeResolvedSubscriptionPricePage_SkipsUndatedCurrentPriceWithoutPla
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
-	if len(candidates) != 0 {
-		t.Fatalf("expected no resolved rows, got %+v", candidates)
+	rows := resolvedSubscriptionRows(candidates)
+	shared.SortResolvedPrices(rows)
+
+	if len(rows) != 2 {
+		t.Fatalf("expected one row per plan type, got %+v", rows)
+	}
+	if rows[0].PlanType != "MONTHLY" || rows[0].PriceID != "price-monthly" || rows[0].CustomerPrice != "8.99" {
+		t.Fatalf("unexpected monthly row: %+v", rows[0])
+	}
+	if rows[1].PlanType != "UPFRONT" || rows[1].PriceID != "price-upfront" || rows[1].CustomerPrice != "49.99" {
+		t.Fatalf("unexpected upfront row: %+v", rows[1])
 	}
 }
 
@@ -120,12 +136,16 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedMonthlyPrice(t *test
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
-	row, ok := candidates["NOR"]
-	if !ok {
+	rows := resolvedSubscriptionRows(candidates)
+	if len(rows) != 1 {
 		t.Fatal("expected undated MONTHLY price to resolve as the active price")
 	}
-	if row.row.CustomerPrice != "5.0" {
-		t.Fatalf("expected MONTHLY customer price 5.0, got %+v", row.row)
+	row := rows[0]
+	if row.CustomerPrice != "5.0" {
+		t.Fatalf("expected MONTHLY customer price 5.0, got %+v", row)
+	}
+	if row.PlanType != "MONTHLY" {
+		t.Fatalf("expected MONTHLY plan type, got %+v", row)
 	}
 }
 
@@ -147,12 +167,16 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedUpfrontPrice(t *test
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
-	row, ok := candidates["NOR"]
-	if !ok {
+	rows := resolvedSubscriptionRows(candidates)
+	if len(rows) != 1 {
 		t.Fatal("expected undated UPFRONT price to resolve as the active price")
 	}
-	if row.row.CustomerPrice != "49.0" {
-		t.Fatalf("expected UPFRONT customer price 49.0, got %+v", row.row)
+	row := rows[0]
+	if row.CustomerPrice != "49.0" {
+		t.Fatalf("expected UPFRONT customer price 49.0, got %+v", row)
+	}
+	if row.PlanType != "UPFRONT" {
+		t.Fatalf("expected UPFRONT plan type, got %+v", row)
 	}
 }
 
@@ -176,12 +200,13 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersDatedCurrentOverUndatedFall
 		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
-	row, ok := candidates["NOR"]
-	if !ok {
+	rows := resolvedSubscriptionRows(candidates)
+	if len(rows) != 1 {
 		t.Fatal("expected a resolved UPFRONT price")
 	}
-	if row.row.PriceID != "price-current" || row.row.CustomerPrice != "59.0" {
-		t.Fatalf("expected latest dated price to beat the undated initial fallback, got %+v", row.row)
+	row := rows[0]
+	if row.PriceID != "price-current" || row.CustomerPrice != "59.0" {
+		t.Fatalf("expected latest dated price to beat the undated initial fallback, got %+v", row)
 	}
 }
 

--- a/internal/cli/subscriptions/resolved_prices_test.go
+++ b/internal/cli/subscriptions/resolved_prices_test.go
@@ -120,8 +120,8 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedMonthlyPrice(t *test
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, asc.SubscriptionPlanTypeMonthly); err != nil {
-		t.Fatalf("consumeResolvedSubscriptionPricePageForPlanType() error = %v", err)
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
 	row, ok := candidates["NOR"]
@@ -147,8 +147,8 @@ func TestConsumeResolvedSubscriptionPricePage_AcceptsUndatedUpfrontPrice(t *test
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, asc.SubscriptionPlanTypeUpfront); err != nil {
-		t.Fatalf("consumeResolvedSubscriptionPricePageForPlanType() error = %v", err)
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
 	row, ok := candidates["NOR"]
@@ -176,8 +176,8 @@ func TestConsumeResolvedSubscriptionPricePage_PrefersDatedCurrentOverUndatedFall
 	}
 
 	candidates := make(map[string]resolvedSubscriptionPriceCandidate)
-	if err := consumeResolvedSubscriptionPricePageForPlanType(candidates, page, now, asc.SubscriptionPlanTypeUpfront); err != nil {
-		t.Fatalf("consumeResolvedSubscriptionPricePageForPlanType() error = %v", err)
+	if err := consumeResolvedSubscriptionPricePage(candidates, page, now); err != nil {
+		t.Fatalf("consumeResolvedSubscriptionPricePage() error = %v", err)
 	}
 
 	row, ok := candidates["NOR"]

--- a/internal/cli/subscriptions/resolved_prices_timeout_test.go
+++ b/internal/cli/subscriptions/resolved_prices_timeout_test.go
@@ -40,7 +40,7 @@ func TestFetchResolvedSubscriptionPricesUsesFreshDeadlinePerPage(t *testing.T) {
 		t.Fatalf("NewClientFromPEM() error: %v", err)
 	}
 
-	result, err := fetchResolvedSubscriptionPrices(context.Background(), client, "sub-1", 200, "", time.Now().UTC(), "")
+	result, err := fetchResolvedSubscriptionPrices(context.Background(), client, "sub-1", 200, "", time.Now().UTC(), "", "")
 	if err != nil {
 		t.Fatalf("fetchResolvedSubscriptionPrices() error: %v", err)
 	}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -778,6 +778,7 @@ func SubscriptionsPricesListCommand() *ffcli.Command {
 	subID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
 	appID := addSubscriptionLookupAppFlag(fs)
 	planType := fs.String("plan-type", "", "Filter by plan type: MONTHLY or UPFRONT")
+	territory := fs.String("territory", "", "Filter by territory (accepts alpha-2, alpha-3, or exact English country name; e.g., US, USA, United States)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -786,16 +787,18 @@ func SubscriptionsPricesListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc subscriptions prices list --subscription-id \"SUB_ID\" [--plan-type MONTHLY|UPFRONT]",
+		ShortUsage: "asc subscriptions prices list --subscription-id \"SUB_ID\" [--plan-type MONTHLY|UPFRONT] [--territory USA]",
 		ShortHelp:  "List prices for a subscription.",
 		LongHelp: `List prices for a subscription.
 
 Use --plan-type to filter by MONTHLY or UPFRONT billing plan prices.
+Use --territory to filter by a single territory.
 
 Examples:
   asc subscriptions prices list --subscription-id "SUB_ID"
   asc subscriptions prices list --subscription-id "SUB_ID" --paginate
   asc subscriptions prices list --subscription-id "SUB_ID" --resolved
+  asc subscriptions prices list --subscription-id "SUB_ID" --resolved --territory USA
   asc subscriptions prices list --subscription-id "SUB_ID" --plan-type MONTHLY`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -835,6 +838,15 @@ Examples:
 				planTypeFilter = normalized
 			}
 
+			territoryFilter := strings.TrimSpace(*territory)
+			if territoryFilter != "" {
+				normalizedTerritory, normalizeErr := ascterritory.Normalize(territoryFilter)
+				if normalizeErr != nil {
+					return shared.UsageError(normalizeErr.Error())
+				}
+				territoryFilter = normalizedTerritory
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("subscriptions prices list: %w", err)
@@ -848,7 +860,7 @@ Examples:
 			}
 
 			if *resolved {
-				resp, err := fetchResolvedSubscriptionPrices(ctx, client, id, *limit, *next, time.Now().UTC(), planTypeFilter)
+				resp, err := fetchResolvedSubscriptionPrices(ctx, client, id, *limit, *next, time.Now().UTC(), planTypeFilter, territoryFilter)
 				if err != nil {
 					return fmt.Errorf("subscriptions prices list: failed to resolve: %w", err)
 				}
@@ -859,8 +871,8 @@ Examples:
 			defer cancel()
 
 			nextURL := strings.TrimSpace(*next)
-			if nextURL != "" && planTypeFilter != "" {
-				nextURL, err = mergeSubscriptionPricesPlanType(nextURL, planTypeFilter)
+			if nextURL != "" && (planTypeFilter != "" || territoryFilter != "") {
+				nextURL, err = mergeSubscriptionPricesListFilters(nextURL, planTypeFilter, territoryFilter)
 				if err != nil {
 					return fmt.Errorf("subscriptions prices list: %w", err)
 				}
@@ -872,6 +884,9 @@ Examples:
 			if planTypeFilter != "" && nextURL == "" {
 				opts = append(opts, asc.WithSubscriptionPricesPlanType(planTypeFilter))
 			}
+			if territoryFilter != "" && nextURL == "" {
+				opts = append(opts, asc.WithSubscriptionPricesTerritory(territoryFilter))
+			}
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithSubscriptionPricesLimit(200))
@@ -881,7 +896,7 @@ Examples:
 				}
 
 				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-					nextURL, err := mergeSubscriptionPricesPlanType(nextURL, planTypeFilter)
+					nextURL, err := mergeSubscriptionPricesListFilters(nextURL, planTypeFilter, territoryFilter)
 					if err != nil {
 						return nil, err
 					}
@@ -905,14 +920,23 @@ Examples:
 }
 
 func mergeSubscriptionPricesPlanType(next string, planType asc.SubscriptionPlanType) (string, error) {
-	if planType == "" {
+	return mergeSubscriptionPricesListFilters(next, planType, "")
+}
+
+func mergeSubscriptionPricesListFilters(next string, planType asc.SubscriptionPlanType, territory string) (string, error) {
+	if planType == "" && strings.TrimSpace(territory) == "" {
 		return next, nil
 	}
 
-	return mergeSubscriptionPricesNextQuery(
-		next,
-		url.Values{"filter[planType]": []string{string(planType)}},
-	)
+	additions := url.Values{}
+	if planType != "" {
+		additions.Set("filter[planType]", string(planType))
+	}
+	if strings.TrimSpace(territory) != "" {
+		additions.Set("filter[territory]", strings.ToUpper(strings.TrimSpace(territory)))
+	}
+
+	return mergeSubscriptionPricesNextQuery(next, additions)
 }
 
 func mergeSubscriptionPricesNextQuery(next string, additions url.Values) (string, error) {

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -839,7 +839,16 @@ Examples:
 			}
 
 			territoryFilter := strings.TrimSpace(*territory)
-			if territoryFilter != "" {
+			territoryProvided := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "territory" {
+					territoryProvided = true
+				}
+			})
+			if territoryProvided {
+				if territoryFilter == "" {
+					return shared.UsageError("invalid value for --territory: cannot be empty")
+				}
 				normalizedTerritory, normalizeErr := ascterritory.Normalize(territoryFilter)
 				if normalizeErr != nil {
 					return shared.UsageError(normalizeErr.Error())


### PR DESCRIPTION
## Summary
- Treat undated subscription price records as current base prices in `subscriptions pricing prices list --resolved`
- Keep future scheduled prices excluded and preserve existing latest-active selection rules
- Add `--territory` to `subscriptions pricing prices list` so resolved output can be filtered to one territory

## Root cause
The resolved subscription price path fetched `GET /v1/subscriptions/{id}/prices?include=subscriptionPricePoint,territory&fields[subscriptionPricePoints]=customerPrice,proceeds,proceedsYear2&fields[territories]=currency&limit=200`, but then skipped every row whose `attributes.startDate` was empty unless a plan-type filter was set. App Store Connect can return current/base per-territory subscription prices without `startDate`; the summary command already accepts those as current. When all current territory prices are undated, the CLI reduced a non-empty API response to `{"prices":[]}`.

Request diff from the reported reproduction:
- Raw list: `GET /v1/subscriptions/<SUB_ID>/prices` returned `subscriptionPrices` data.
- Resolved list: `GET /v1/subscriptions/<SUB_ID>/prices?include=subscriptionPricePoint,territory&fields[subscriptionPricePoints]=customerPrice,proceeds,proceedsYear2&fields[territories]=currency&limit=200` returned data plus included price points/territories, but the CLI dropped undated rows during response mapping.
- With this fix, `--resolved --territory USA` adds `filter[territory]=USA` to the same resolved request shape.

## Tests
- `go test ./internal/cli/cmdtest -run 'TestSubscriptionsPricingPricesListResolved|TestSubscriptionsPricingPricesListRawOutputUnchanged'`
- `go test ./internal/cli/subscriptions`
- `go test ./internal/asc/...`
- `env -u ASC_KEY_ID -u ASC_ISSUER_ID -u ASC_KEY_PATH -u ASC_PRIVATE_KEY -u ASC_PROFILE go test ./internal/cli/shared`

Note: `go test ./internal/cli/...` passed all affected packages but failed in `internal/cli/shared` when local ASC credential/keychain state leaked into `TestResolveAuthCredentialsMetadata_FallsBackToEnvKeyID`; rerunning that package with ASC credential env cleared passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--territory` filtering to `asc subscriptions prices list`, including resolved-price views, with pagination-aware filtering.
  * Resolved pricing output now includes **Plan Type** (new table column).

* **Bug Fixes**
  * Resolved pricing now returns undated “current” prices per plan type when a plan type is provided.
  * Resolved pricing honors the requested territory filter during retrieval and resolution.

* **Tests**
  * Expanded CLI and resolved-pricing tests for territory handling, plan-type behavior, updated resolution consumption, and output changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->