### PR TITLE
Make subscription price set converge on existing prices

### DIFF
--- a/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
@@ -5,12 +5,35 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 )
+
+func subscriptionPriceListFixture(pricePointID, territoryID, attrs string) string {
+	if strings.TrimSpace(attrs) == "" {
+		attrs = "{}"
+	}
+
+	territoryRelationship := ""
+	if territoryID != "" {
+		territoryRelationship = fmt.Sprintf(
+			`,"territory":{"data":{"type":"territories","id":%q}}`,
+			territoryID,
+		)
+	}
+
+	return fmt.Sprintf(
+		`{"data":[{"type":"subscriptionPrices","id":%q,"attributes":%s,"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":%q}}%s}}],"links":{"next":""}}`,
+		"existing-price-1",
+		attrs,
+		pricePointID,
+		territoryRelationship,
+	)
+}
 
 func TestSubscriptionsPricesAdd_TierAndPricePointMutualExclusion(t *testing.T) {
 	root := RootCommand("1.2.3")
@@ -69,6 +92,13 @@ func TestSubscriptionsPricesAdd_TierUsesSubscriptionPricePoints(t *testing.T) {
 		case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/apps/"):
 			t.Fatalf("unexpected app price points request: %s", req.URL.Path)
 			return nil, nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/prices"):
+			body := subscriptionPriceListFixture("sub-pp-1", "USA", "")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
 		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/subscriptionPrices"):
 			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyStr := string(bodyBytes)
@@ -141,6 +171,13 @@ func TestSubscriptionsPricesAdd_NormalizesTerritory(t *testing.T) {
 				],
 				"links":{"next":""}
 			}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/prices"):
+			body := subscriptionPriceListFixture("different-pp", "FRA", "")
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -341,6 +378,13 @@ func TestSubscriptionsPricesAdd_ExistingPriceForwardsTerritoryOverridePayload(t 
 				Body:       io.NopCloser(strings.NewReader(body)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/prices"):
+			body := subscriptionPriceListFixture("different-pp", "NOR", `{"startDate":"2026-05-01","preserved":true}`)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
 			var payload map[string]any
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
@@ -442,6 +486,76 @@ func TestSubscriptionsPricesAdd_ExistingPriceForwardsTerritoryOverridePayload(t 
 	}
 	if !strings.Contains(stdout, `"id":"sub-price-1"`) {
 		t.Fatalf("expected subscription price response in stdout, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsPricesAdd_ExistingMatchingPriceSkipsCreate(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var posted bool
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/relationships/prices"):
+			body := `{"data":[{"type":"subscriptionPrices","id":"existing-price-1"}],"links":{}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/prices"):
+			query := req.URL.Query()
+			if got := query.Get("filter[territory]"); got != "USA" {
+				t.Fatalf("expected filter[territory]=USA, got %q", got)
+			}
+			if got := query.Get("include"); got != "subscriptionPricePoint,territory" {
+				t.Fatalf("expected relationship include query, got %q", got)
+			}
+			body := subscriptionPriceListFixture("PP_ID", "USA", `{"startDate":"2026-05-01","preserved":true}`)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			posted = true
+			t.Fatalf("unexpected POST request for already matching price")
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "set",
+			"--subscription-id", "8000000003",
+			"--price-point", "PP_ID",
+			"--territory", "USA",
+			"--start-date", "2026-05-01",
+			"--preserved",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if posted {
+		t.Fatal("did not expect create request")
+	}
+	if !strings.Contains(stdout, `"id":"existing-price-1"`) {
+		t.Fatalf("expected existing subscription price response in stdout, got %q", stdout)
 	}
 }
 
@@ -555,6 +669,13 @@ func TestSubscriptionsPricesAddRefreshesContextAfterTierResolution(t *testing.T)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/prices"):
+			resp := subscriptionPriceListFixture("sub-pp-1", "USA", "")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(resp)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
 		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/subscriptionPrices"):

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1004,10 +1004,11 @@ func subscriptionPriceMatchesTarget(price asc.Resource[asc.SubscriptionPriceAttr
 		return false
 	}
 
-	if attrs.StartDate != "" && price.Attributes.StartDate != attrs.StartDate {
+	if strings.TrimSpace(price.Attributes.StartDate) != strings.TrimSpace(attrs.StartDate) {
 		return false
 	}
-	if attrs.Preserved != nil && *attrs.Preserved && !price.Attributes.Preserved {
+	targetPreserved := attrs.Preserved != nil && *attrs.Preserved
+	if price.Attributes.Preserved != targetPreserved {
 		return false
 	}
 	if attrs.PlanType != "" && price.Attributes.PlanType != attrs.PlanType {

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -2,6 +2,7 @@ package subscriptions
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/url"
@@ -943,6 +944,79 @@ func mergeSubscriptionPricesNextQuery(next string, additions url.Values) (string
 	return parsed.String(), nil
 }
 
+type subscriptionPriceRelationshipData struct {
+	SubscriptionPricePoint *asc.Relationship `json:"subscriptionPricePoint"`
+	Territory              *asc.Relationship `json:"territory"`
+}
+
+func findMatchingSubscriptionPrice(ctx context.Context, client *asc.Client, subID, pricePointID, territoryID string, attrs asc.SubscriptionPriceCreateAttributes) (*asc.SubscriptionPriceResponse, error) {
+	pricePointID = strings.TrimSpace(pricePointID)
+	territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
+
+	opts := []asc.SubscriptionPricesOption{
+		asc.WithSubscriptionPricesLimit(200),
+		asc.WithSubscriptionPricesInclude([]string{"subscriptionPricePoint", "territory"}),
+	}
+	if territoryID != "" {
+		opts = append(opts, asc.WithSubscriptionPricesTerritory(territoryID))
+	}
+
+	for {
+		resp, err := client.GetSubscriptionPrices(ctx, subID, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, price := range resp.Data {
+			if subscriptionPriceMatchesTarget(price, pricePointID, territoryID, attrs) {
+				return &asc.SubscriptionPriceResponse{Data: price}, nil
+			}
+		}
+
+		next := strings.TrimSpace(resp.Links.Next)
+		if next == "" {
+			return nil, nil
+		}
+		opts = []asc.SubscriptionPricesOption{asc.WithSubscriptionPricesNextURL(next)}
+	}
+}
+
+func subscriptionPriceMatchesTarget(price asc.Resource[asc.SubscriptionPriceAttributes], pricePointID, territoryID string, attrs asc.SubscriptionPriceCreateAttributes) bool {
+	if strings.TrimSpace(pricePointID) == "" {
+		return false
+	}
+
+	var relationships subscriptionPriceRelationshipData
+	if len(price.Relationships) > 0 {
+		if err := json.Unmarshal(price.Relationships, &relationships); err != nil {
+			return false
+		}
+	}
+	if relationships.SubscriptionPricePoint == nil || relationships.SubscriptionPricePoint.Data.ID != pricePointID {
+		return false
+	}
+
+	actualTerritory := ""
+	if relationships.Territory != nil {
+		actualTerritory = strings.ToUpper(strings.TrimSpace(relationships.Territory.Data.ID))
+	}
+	if strings.ToUpper(strings.TrimSpace(territoryID)) != actualTerritory {
+		return false
+	}
+
+	if attrs.StartDate != "" && price.Attributes.StartDate != attrs.StartDate {
+		return false
+	}
+	if attrs.Preserved != nil && *attrs.Preserved && !price.Attributes.Preserved {
+		return false
+	}
+	if attrs.PlanType != "" && price.Attributes.PlanType != attrs.PlanType {
+		return false
+	}
+
+	return true
+}
+
 // SubscriptionsPricesAddCommand returns the subscriptions prices add subcommand.
 func SubscriptionsPricesAddCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("prices add", flag.ExitOnError)
@@ -1061,6 +1135,14 @@ Examples:
 					return fmt.Errorf("subscriptions prices add: failed to set initial price: %w", err)
 				}
 				return shared.PrintOutput(subResp, *output.Output, *output.Pretty)
+			}
+
+			matchingPrice, err := findMatchingSubscriptionPrice(requestCtx, client, id, pricePoint, territoryID, attrs)
+			if err != nil {
+				return fmt.Errorf("subscriptions prices add: failed to check matching price: %w", err)
+			}
+			if matchingPrice != nil {
+				return shared.PrintOutput(matchingPrice, *output.Output, *output.Pretty)
 			}
 
 			// Existing prices: use POST /v1/subscriptionPrices for a price change

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1011,7 +1011,15 @@ func subscriptionPriceMatchesTarget(price asc.Resource[asc.SubscriptionPriceAttr
 	if price.Attributes.Preserved != targetPreserved {
 		return false
 	}
-	if attrs.PlanType != "" && price.Attributes.PlanType != attrs.PlanType {
+	targetPlanType := attrs.PlanType
+	if targetPlanType == "" {
+		targetPlanType = asc.SubscriptionPlanTypeUpfront
+	}
+	actualPlanType := price.Attributes.PlanType
+	if actualPlanType == "" {
+		actualPlanType = asc.SubscriptionPlanTypeUpfront
+	}
+	if actualPlanType != targetPlanType {
 		return false
 	}
 

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -960,6 +960,9 @@ func findMatchingSubscriptionPrice(ctx context.Context, client *asc.Client, subI
 	if territoryID != "" {
 		opts = append(opts, asc.WithSubscriptionPricesTerritory(territoryID))
 	}
+	if attrs.PlanType != "" {
+		opts = append(opts, asc.WithSubscriptionPricesPlanType(attrs.PlanType))
+	}
 
 	for {
 		resp, err := client.GetSubscriptionPrices(ctx, subID, opts...)
@@ -977,7 +980,11 @@ func findMatchingSubscriptionPrice(ctx context.Context, client *asc.Client, subI
 		if next == "" {
 			return nil, nil
 		}
-		opts = []asc.SubscriptionPricesOption{asc.WithSubscriptionPricesNextURL(next)}
+		nextURL, err := mergeSubscriptionPricesPlanType(next, attrs.PlanType)
+		if err != nil {
+			return nil, err
+		}
+		opts = []asc.SubscriptionPricesOption{asc.WithSubscriptionPricesNextURL(nextURL)}
 	}
 }
 

--- a/internal/cli/subscriptions/subscriptions_command_test.go
+++ b/internal/cli/subscriptions/subscriptions_command_test.go
@@ -74,4 +74,14 @@ func TestSubscriptionPriceMatchesTargetComparesDefaultScheduleAndPreserved(t *te
 	if subscriptionPriceMatchesTarget(price, "PP_ID", "USA", asc.SubscriptionPriceCreateAttributes{}) {
 		t.Fatal("expected preserved price not to match omitted preserved flag")
 	}
+	price.Attributes.Preserved = false
+
+	price.Attributes.PlanType = asc.SubscriptionPlanTypeMonthly
+	if subscriptionPriceMatchesTarget(price, "PP_ID", "USA", asc.SubscriptionPriceCreateAttributes{}) {
+		t.Fatal("expected monthly plan price not to match omitted upfront plan type")
+	}
+	price.Attributes.PlanType = asc.SubscriptionPlanTypeUpfront
+	if !subscriptionPriceMatchesTarget(price, "PP_ID", "USA", asc.SubscriptionPriceCreateAttributes{}) {
+		t.Fatal("expected upfront plan price to match omitted plan type")
+	}
 }

--- a/internal/cli/subscriptions/subscriptions_command_test.go
+++ b/internal/cli/subscriptions/subscriptions_command_test.go
@@ -1,6 +1,7 @@
 package subscriptions
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 	"testing"
@@ -45,5 +46,32 @@ func TestMergeSubscriptionPricesPlanTypeLeavesUnfilteredRelativeNextURLUntouched
 	}
 	if merged != next {
 		t.Fatalf("expected unfiltered relative next URL to be unchanged, got %q", merged)
+	}
+}
+
+func TestSubscriptionPriceMatchesTargetComparesDefaultScheduleAndPreserved(t *testing.T) {
+	price := asc.Resource[asc.SubscriptionPriceAttributes]{
+		ID:         "existing-price-1",
+		Type:       "subscriptionPrices",
+		Attributes: asc.SubscriptionPriceAttributes{},
+		Relationships: json.RawMessage(`{
+			"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"PP_ID"}},
+			"territory":{"data":{"type":"territories","id":"USA"}}
+		}`),
+	}
+
+	if !subscriptionPriceMatchesTarget(price, "PP_ID", "USA", asc.SubscriptionPriceCreateAttributes{}) {
+		t.Fatal("expected default price to match default requested state")
+	}
+
+	price.Attributes.StartDate = "2026-05-01"
+	if subscriptionPriceMatchesTarget(price, "PP_ID", "USA", asc.SubscriptionPriceCreateAttributes{}) {
+		t.Fatal("expected scheduled price not to match omitted start date")
+	}
+	price.Attributes.StartDate = ""
+
+	price.Attributes.Preserved = true
+	if subscriptionPriceMatchesTarget(price, "PP_ID", "USA", asc.SubscriptionPriceCreateAttributes{}) {
+		t.Fatal("expected preserved price not to match omitted preserved flag")
 	}
 }


### PR DESCRIPTION
## Summary
- make `subscriptions pricing prices set` check existing subscription prices before creating a new price
- return the matching existing price and exit 0 when the requested price point/territory/schedule already exists
- keep the telemetry surface unchanged; this fixes the local CLI behavior that was producing `api_conflict` events without adding raw stderr or high-cardinality values

## Why
Production v2 telemetry showed Claude Code repeatedly failing on `asc subscriptions pricing prices set` with `api_conflict`. The command is named `set`, but for subscriptions with existing prices it previously issued a blind `POST /v1/subscriptionPrices`, so an already-achieved desired state still failed with conflict.

## Validation
- RED: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestSubscriptionsPricesAdd_ExistingMatchingPriceSkipsCreate -count=1` failed on the old blind POST path
- GREEN: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestSubscriptionsPricesAdd -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/subscriptions ./internal/asc ./internal/cli/cmdtest -run 'TestSubscriptionsPricesAdd|TestCreateSubscriptionPrice|TestSubscriptionPrices' -count=1`
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook reran command-doc checks, format, lint, and the short test suite

Note: golangci printed a non-fatal stale external worktree cache warning while reporting 0 issues.

## Scope
This intentionally does not add new telemetry fields or transmit stderr. It only makes the highest-volume `api_conflict` command convergent when the requested target already exists. Structured local error envelopes, unknown-flag suggestions, and broader idempotency for setup/equalize should be follow-up PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced **subscriptions prices add** to reuse an existing matching subscription price when one is already present, avoiding unnecessary creation.
  * When a match is found, the command outputs the existing price ID and skips creating a new one.

* **Bug Fixes**
  * Improved match accuracy using subscription price point, normalized territory, start date, preserved flag, and plan type (with sensible defaults when optional values are omitted).

* **Tests**
  * Centralized consistent mock `/prices` responses for subscription-price CLI tests.
  * Added coverage to ensure no create request is made when an existing match exists, and expanded matching-logic scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->