### PR TITLE
Allow subscriptions list to resolve app scope

### DIFF
--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1525,6 +1525,16 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 			wantErr: "--group-id or --app is required",
 		},
 		{
+			name:    "subscriptions list rejects app with group",
+			args:    []string{"subscriptions", "list", "--group-id", "GROUP_ID", "--app", "APP_ID"},
+			wantErr: "--group-id and --app are mutually exclusive",
+		},
+		{
+			name:    "subscriptions list rejects app with next",
+			args:    []string{"subscriptions", "list", "--app", "APP_ID", "--next", "https://api.appstoreconnect.apple.com/v1/subscriptionGroups/GROUP_ID/subscriptions?cursor=NEXT"},
+			wantErr: "--next cannot be combined with --app",
+		},
+		{
 			name:    "subscriptions create missing group",
 			args:    []string{"subscriptions", "create", "--reference-name", "Monthly", "--product-id", "com.example.sub"},
 			wantErr: "--group-id is required",

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1522,7 +1522,7 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 		{
 			name:    "subscriptions list missing group",
 			args:    []string{"subscriptions", "list"},
-			wantErr: "--group-id is required",
+			wantErr: "--group-id or --app is required",
 		},
 		{
 			name:    "subscriptions create missing group",

--- a/internal/cli/cmdtest/subscriptions_list_app_test.go
+++ b/internal/cli/cmdtest/subscriptions_list_app_test.go
@@ -1,0 +1,58 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
+			body := `{"data":[{"type":"subscriptionGroups","id":"group-1"},{"type":"subscriptionGroups","id":"group-2"}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
+			body := `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-2/subscriptions":
+			body := `{"data":[{"type":"subscriptions","id":"sub-2","attributes":{"name":"Yearly","productId":"com.example.yearly"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "list",
+			"--app", "app-1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-1"`) || !strings.Contains(stdout, `"id":"sub-2"`) {
+		t.Fatalf("expected subscriptions from both groups, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_list_app_test.go
+++ b/internal/cli/cmdtest/subscriptions_list_app_test.go
@@ -11,18 +11,19 @@ import (
 func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
-			body := `{"data":[{"type":"subscriptionGroups","id":"group-1"},{"type":"subscriptionGroups","id":"group-2"}],"links":{}}`
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups" && req.URL.Query().Get("cursor") == "":
+			body := `{"data":[{"type":"subscriptionGroups","id":"group-1"}],"links":{"next":"/v1/apps/app-1/subscriptionGroups?cursor=group-page-2"}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
-			body := `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{}}`
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups" && req.URL.Query().Get("cursor") == "group-page-2":
+			body := `{"data":[{"type":"subscriptionGroups","id":"group-2"}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions" && req.URL.Query().Get("cursor") == "":
+			body := `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":"/v1/subscriptionGroups/group-1/subscriptions?cursor=sub-page-2"}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions" && req.URL.Query().Get("cursor") == "sub-page-2":
+			body := `{"data":[{"type":"subscriptions","id":"sub-1b","attributes":{"name":"Weekly","productId":"com.example.weekly"}}],"links":{}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-2/subscriptions":
 			body := `{"data":[{"type":"subscriptions","id":"sub-2","attributes":{"name":"Yearly","productId":"com.example.yearly"}}],"links":{}}`
@@ -31,7 +32,7 @@ func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
 		}
-	})
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -52,7 +53,43 @@ func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"sub-1"`) || !strings.Contains(stdout, `"id":"sub-2"`) {
-		t.Fatalf("expected subscriptions from both groups, got %q", stdout)
+	if !strings.Contains(stdout, `"id":"sub-1"`) || !strings.Contains(stdout, `"id":"sub-1b"`) || !strings.Contains(stdout, `"id":"sub-2"`) {
+		t.Fatalf("expected subscriptions from every group and subscription page, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsListGroupIDIgnoresDefaultAppEnv(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "app-default")
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionGroups/group-1/subscriptions" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		body := `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{}}`
+		return jsonHTTPResponse(http.StatusOK, body), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "list",
+			"--group-id", "group-1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-1"`) {
+		t.Fatalf("expected group-scoped subscription response, got %q", stdout)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_list_app_test.go
+++ b/internal/cli/cmdtest/subscriptions_list_app_test.go
@@ -41,6 +41,7 @@ func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 		if err := root.Parse([]string{
 			"subscriptions", "list",
 			"--app", "app-1",
+			"--paginate",
 			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -55,6 +56,47 @@ func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"sub-1"`) || !strings.Contains(stdout, `"id":"sub-1b"`) || !strings.Contains(stdout, `"id":"sub-2"`) {
 		t.Fatalf("expected subscriptions from every group and subscription page, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsListAppDoesNotPaginateByDefault(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups" && req.URL.Query().Get("cursor") == "":
+			body := `{"data":[{"type":"subscriptionGroups","id":"group-1"}],"links":{"next":"/v1/apps/app-1/subscriptionGroups?cursor=group-page-2"}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions" && req.URL.Query().Get("cursor") == "":
+			body := `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":"/v1/subscriptionGroups/group-1/subscriptions?cursor=sub-page-2"}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected paginated request without --paginate: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "list",
+			"--app", "app-1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"sub-1"`) {
+		t.Fatalf("expected first page subscription, got %q", stdout)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_list_app_test.go
+++ b/internal/cli/cmdtest/subscriptions_list_app_test.go
@@ -59,7 +59,7 @@ func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 	}
 }
 
-func TestSubscriptionsListAppDoesNotPaginateByDefault(t *testing.T) {
+func TestSubscriptionsListAppPaginatesByDefault(t *testing.T) {
 	setupAuth(t)
 
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -67,11 +67,20 @@ func TestSubscriptionsListAppDoesNotPaginateByDefault(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups" && req.URL.Query().Get("cursor") == "":
 			body := `{"data":[{"type":"subscriptionGroups","id":"group-1"}],"links":{"next":"/v1/apps/app-1/subscriptionGroups?cursor=group-page-2"}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups" && req.URL.Query().Get("cursor") == "group-page-2":
+			body := `{"data":[{"type":"subscriptionGroups","id":"group-2"}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions" && req.URL.Query().Get("cursor") == "":
 			body := `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":"/v1/subscriptionGroups/group-1/subscriptions?cursor=sub-page-2"}}`
 			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions" && req.URL.Query().Get("cursor") == "sub-page-2":
+			body := `{"data":[{"type":"subscriptions","id":"sub-1b","attributes":{"name":"Weekly","productId":"com.example.weekly"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-2/subscriptions":
+			body := `{"data":[{"type":"subscriptions","id":"sub-2","attributes":{"name":"Yearly","productId":"com.example.yearly"}}],"links":{}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
 		default:
-			t.Fatalf("unexpected paginated request without --paginate: %s %s", req.Method, req.URL.String())
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
 		}
 	}))
@@ -95,8 +104,8 @@ func TestSubscriptionsListAppDoesNotPaginateByDefault(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"sub-1"`) {
-		t.Fatalf("expected first page subscription, got %q", stdout)
+	if !strings.Contains(stdout, `"id":"sub-1"`) || !strings.Contains(stdout, `"id":"sub-1b"`) || !strings.Contains(stdout, `"id":"sub-2"`) {
+		t.Fatalf("expected subscriptions from every group and subscription page, got %q", stdout)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_list_app_test.go
+++ b/internal/cli/cmdtest/subscriptions_list_app_test.go
@@ -58,6 +58,41 @@ func TestSubscriptionsListAppAggregatesGroups(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsListAppPreservesEmptyDataArray(t *testing.T) {
+	setupAuth(t)
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/subscriptionGroups" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		body := `{"data":[],"links":{}}`
+		return jsonHTTPResponse(http.StatusOK, body), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "list",
+			"--app", "app-1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"data":[]`) {
+		t.Fatalf("expected empty data array, got %q", stdout)
+	}
+}
+
 func TestSubscriptionsListGroupIDIgnoresDefaultAppEnv(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_APP_ID", "app-default")

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -401,13 +401,17 @@ Examples:
 			}
 
 			id := strings.TrimSpace(*groupID)
-			resolvedAppID := shared.ResolveAppID(*appID)
+			appFlag := strings.TrimSpace(*appID)
 			nextURL := strings.TrimSpace(*next)
-			if id != "" && resolvedAppID != "" {
+			if id != "" && appFlag != "" {
 				return shared.UsageError("--group-id and --app are mutually exclusive")
 			}
-			if resolvedAppID != "" && nextURL != "" {
+			if appFlag != "" && nextURL != "" {
 				return shared.UsageError("--next cannot be combined with --app; use --group-id with the group-scoped next URL")
+			}
+			resolvedAppID := ""
+			if appFlag != "" || (id == "" && nextURL == "") {
+				resolvedAppID = shared.ResolveAppID(*appID)
 			}
 			if id == "" && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id or --app is required (or set ASC_APP_ID)")
@@ -423,7 +427,7 @@ Examples:
 			defer cancel()
 
 			if resolvedAppID != "" {
-				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit, *paginate)
+				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit)
 				if err != nil {
 					return fmt.Errorf("subscriptions list: %w", err)
 				}
@@ -462,53 +466,44 @@ Examples:
 	}
 }
 
-func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID string, limit int, paginate bool) (*asc.SubscriptionsResponse, error) {
-	groupLimit := limit
-	if paginate {
-		groupLimit = 200
+func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID string, limit int) (*asc.SubscriptionsResponse, error) {
+	pageLimit := limit
+	if pageLimit == 0 {
+		pageLimit = 200
 	}
-	groupsResp, err := client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsLimit(groupLimit))
+	groupsResp, err := client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsLimit(pageLimit))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch groups: %w", err)
 	}
 
-	if paginate {
-		paginatedGroups, err := asc.PaginateAll(ctx, groupsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			return client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
-		})
-		if err != nil {
-			return nil, fmt.Errorf("paginate groups: %w", err)
-		}
-		var ok bool
-		groupsResp, ok = paginatedGroups.(*asc.SubscriptionGroupsResponse)
-		if !ok {
-			return nil, fmt.Errorf("unexpected groups response type %T", paginatedGroups)
-		}
+	paginatedGroups, err := asc.PaginateAll(ctx, groupsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate groups: %w", err)
+	}
+	var ok bool
+	groupsResp, ok = paginatedGroups.(*asc.SubscriptionGroupsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected groups response type %T", paginatedGroups)
 	}
 
 	result := &asc.SubscriptionsResponse{}
 	for _, group := range groupsResp.Data {
-		subLimit := limit
-		if paginate {
-			subLimit = 200
-		}
-		subsResp, err := client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsLimit(subLimit))
+		subsResp, err := client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsLimit(pageLimit))
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch subscriptions for group %s: %w", group.ID, err)
 		}
 
-		if paginate {
-			paginatedSubs, err := asc.PaginateAll(ctx, subsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-				return client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsNextURL(nextURL))
-			})
-			if err != nil {
-				return nil, fmt.Errorf("paginate subscriptions for group %s: %w", group.ID, err)
-			}
-			var ok bool
-			subsResp, ok = paginatedSubs.(*asc.SubscriptionsResponse)
-			if !ok {
-				return nil, fmt.Errorf("unexpected subscriptions response type %T", paginatedSubs)
-			}
+		paginatedSubs, err := asc.PaginateAll(ctx, subsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsNextURL(nextURL))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("paginate subscriptions for group %s: %w", group.ID, err)
+		}
+		subsResp, ok = paginatedSubs.(*asc.SubscriptionsResponse)
+		if !ok {
+			return nil, fmt.Errorf("unexpected subscriptions response type %T", paginatedSubs)
 		}
 
 		result.Data = append(result.Data, subsResp.Data...)

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -427,7 +427,7 @@ Examples:
 			defer cancel()
 
 			if resolvedAppID != "" {
-				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit, *paginate)
+				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit, true)
 				if err != nil {
 					return fmt.Errorf("subscriptions list: %w", err)
 				}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -374,6 +374,7 @@ func SubscriptionsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	groupID := fs.String("group-id", "", "Subscription group ID")
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env); lists subscriptions across all groups")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -381,13 +382,14 @@ func SubscriptionsListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc subscriptions list --group-id \"GROUP_ID\" [flags]",
-		ShortHelp:  "List subscriptions in a group.",
-		LongHelp: `List subscriptions in a group.
+		ShortUsage: "asc subscriptions list (--group-id \"GROUP_ID\" | --app \"APP_ID\") [flags]",
+		ShortHelp:  "List subscriptions in a group or app.",
+		LongHelp: `List subscriptions in a group or across all groups in an app.
 
 Examples:
   asc subscriptions list --group-id "GROUP_ID"
-  asc subscriptions list --group-id "GROUP_ID" --paginate`,
+  asc subscriptions list --group-id "GROUP_ID" --paginate
+  asc subscriptions list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -399,8 +401,16 @@ Examples:
 			}
 
 			id := strings.TrimSpace(*groupID)
-			if id == "" && strings.TrimSpace(*next) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
+			resolvedAppID := shared.ResolveAppID(*appID)
+			nextURL := strings.TrimSpace(*next)
+			if id != "" && resolvedAppID != "" {
+				return shared.UsageError("--group-id and --app are mutually exclusive")
+			}
+			if resolvedAppID != "" && nextURL != "" {
+				return shared.UsageError("--next cannot be combined with --app; use --group-id with the group-scoped next URL")
+			}
+			if id == "" && resolvedAppID == "" && nextURL == "" {
+				fmt.Fprintln(os.Stderr, "Error: --group-id or --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()
 			}
 
@@ -412,9 +422,17 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
+			if resolvedAppID != "" {
+				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit, *paginate)
+				if err != nil {
+					return fmt.Errorf("subscriptions list: %w", err)
+				}
+				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			}
+
 			opts := []asc.SubscriptionsOption{
 				asc.WithSubscriptionsLimit(*limit),
-				asc.WithSubscriptionsNextURL(*next),
+				asc.WithSubscriptionsNextURL(nextURL),
 			}
 
 			if *paginate {
@@ -442,6 +460,60 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID string, limit int, paginate bool) (*asc.SubscriptionsResponse, error) {
+	groupLimit := limit
+	if paginate {
+		groupLimit = 200
+	}
+	groupsResp, err := client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsLimit(groupLimit))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch groups: %w", err)
+	}
+
+	if paginate {
+		paginatedGroups, err := asc.PaginateAll(ctx, groupsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("paginate groups: %w", err)
+		}
+		var ok bool
+		groupsResp, ok = paginatedGroups.(*asc.SubscriptionGroupsResponse)
+		if !ok {
+			return nil, fmt.Errorf("unexpected groups response type %T", paginatedGroups)
+		}
+	}
+
+	result := &asc.SubscriptionsResponse{}
+	for _, group := range groupsResp.Data {
+		subLimit := limit
+		if paginate {
+			subLimit = 200
+		}
+		subsResp, err := client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsLimit(subLimit))
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch subscriptions for group %s: %w", group.ID, err)
+		}
+
+		if paginate {
+			paginatedSubs, err := asc.PaginateAll(ctx, subsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+				return client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsNextURL(nextURL))
+			})
+			if err != nil {
+				return nil, fmt.Errorf("paginate subscriptions for group %s: %w", group.ID, err)
+			}
+			var ok bool
+			subsResp, ok = paginatedSubs.(*asc.SubscriptionsResponse)
+			if !ok {
+				return nil, fmt.Errorf("unexpected subscriptions response type %T", paginatedSubs)
+			}
+		}
+
+		result.Data = append(result.Data, subsResp.Data...)
+	}
+	return result, nil
 }
 
 // SubscriptionsCreateCommand returns the subscriptions create subcommand.

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -427,7 +427,7 @@ Examples:
 			defer cancel()
 
 			if resolvedAppID != "" {
-				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit)
+				resp, err := listSubscriptionsForApp(requestCtx, client, resolvedAppID, *limit, *paginate)
 				if err != nil {
 					return fmt.Errorf("subscriptions list: %w", err)
 				}
@@ -466,7 +466,7 @@ Examples:
 	}
 }
 
-func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID string, limit int) (*asc.SubscriptionsResponse, error) {
+func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID string, limit int, paginate bool) (*asc.SubscriptionsResponse, error) {
 	pageLimit := limit
 	if pageLimit == 0 {
 		pageLimit = 200
@@ -476,16 +476,18 @@ func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID stri
 		return nil, fmt.Errorf("failed to fetch groups: %w", err)
 	}
 
-	paginatedGroups, err := asc.PaginateAll(ctx, groupsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		return client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
-	})
-	if err != nil {
-		return nil, fmt.Errorf("paginate groups: %w", err)
-	}
-	var ok bool
-	groupsResp, ok = paginatedGroups.(*asc.SubscriptionGroupsResponse)
-	if !ok {
-		return nil, fmt.Errorf("unexpected groups response type %T", paginatedGroups)
+	if paginate {
+		paginatedGroups, err := asc.PaginateAll(ctx, groupsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionGroups(ctx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("paginate groups: %w", err)
+		}
+		var ok bool
+		groupsResp, ok = paginatedGroups.(*asc.SubscriptionGroupsResponse)
+		if !ok {
+			return nil, fmt.Errorf("unexpected groups response type %T", paginatedGroups)
+		}
 	}
 
 	result := &asc.SubscriptionsResponse{Data: []asc.Resource[asc.SubscriptionAttributes]{}}
@@ -495,15 +497,18 @@ func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID stri
 			return nil, fmt.Errorf("failed to fetch subscriptions for group %s: %w", group.ID, err)
 		}
 
-		paginatedSubs, err := asc.PaginateAll(ctx, subsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			return client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsNextURL(nextURL))
-		})
-		if err != nil {
-			return nil, fmt.Errorf("paginate subscriptions for group %s: %w", group.ID, err)
-		}
-		subsResp, ok = paginatedSubs.(*asc.SubscriptionsResponse)
-		if !ok {
-			return nil, fmt.Errorf("unexpected subscriptions response type %T", paginatedSubs)
+		if paginate {
+			paginatedSubs, err := asc.PaginateAll(ctx, subsResp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+				return client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsNextURL(nextURL))
+			})
+			if err != nil {
+				return nil, fmt.Errorf("paginate subscriptions for group %s: %w", group.ID, err)
+			}
+			var ok bool
+			subsResp, ok = paginatedSubs.(*asc.SubscriptionsResponse)
+			if !ok {
+				return nil, fmt.Errorf("unexpected subscriptions response type %T", paginatedSubs)
+			}
 		}
 
 		result.Data = append(result.Data, subsResp.Data...)

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -488,7 +488,7 @@ func listSubscriptionsForApp(ctx context.Context, client *asc.Client, appID stri
 		return nil, fmt.Errorf("unexpected groups response type %T", paginatedGroups)
 	}
 
-	result := &asc.SubscriptionsResponse{}
+	result := &asc.SubscriptionsResponse{Data: []asc.Resource[asc.SubscriptionAttributes]{}}
 	for _, group := range groupsResp.Data {
 		subsResp, err := client.GetSubscriptions(ctx, group.ID, asc.WithSubscriptionsLimit(pageLimit))
 		if err != nil {


### PR DESCRIPTION
## Summary
- add `--app` to `asc subscriptions list` as an alternative to `--group-id`
- aggregate subscriptions across all subscription groups for the app
- keep `--next` group-scoped and reject `--app` + `--next` to avoid ambiguous pagination

## Why
Telemetry showed agents, especially Claude Code, trying app-level subscription listing. The previous surface only accepted `--group-id`, so `asc subscriptions list --app ...` failed before the CLI could help. This preserves the existing group-scoped command and adds the app-scoped shape agents naturally reach for.

## Validation
- RED: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestSubscriptionsListAppAggregatesGroups -count=1` failed before implementation because `--app` was unknown
- GREEN: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestSubscriptionsListAppAggregatesGroups -count=1`
- `make generate-command-docs`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/subscriptions ./internal/cli/cmdtest -run 'TestSubscriptionsList|TestSubscriptionsGroupsList' -count=1`
- commit hook reran command docs, format, lint, and short test suite

Note: golangci printed a non-fatal stale external worktree cache warning while reporting 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--app` mode to `subscriptions list` to list subscriptions across all groups in an app, aggregating results into a single output.
* **Bug Fixes**
  * Improved CLI validation and error messaging: `--group-id` and `--app` are mutually exclusive; `--next` can’t be used with `--app`; and input is required as `--group-id or --app` (including via default app settings when applicable).
  * Ensures group-scoped listing ignores any default app environment value.
* **Tests**
  * Added CLI integration tests covering app aggregation, empty app results, pagination behavior (including default), and updated validation text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->