### PR TITLE
Make subscription localization create idempotent

### DIFF
--- a/internal/cli/cmdtest/subscriptions_localizations_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_localizations_create_test.go
@@ -1,0 +1,129 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionsLocalizationsCreateReusesMatchingLocale(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method == http.MethodPost {
+			t.Fatalf("create should reuse matching localization, got POST %s", req.URL.Path)
+		}
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/123456789/subscriptionLocalizations" {
+				t.Fatalf("unexpected lookup request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected limit=200 lookup, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-1","attributes":{"name":"Pro","locale":"en-US","description":"Premium features."}}],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var result struct {
+		Data struct {
+			ID         string `json:"id"`
+			Attributes struct {
+				Name        string `json:"name"`
+				Locale      string `json:"locale"`
+				Description string `json:"description"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "localizations", "create",
+			"--subscription-id", "123456789",
+			"--locale", "en-US",
+			"--name", "Pro",
+			"--description", "Premium features.",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected only localization lookup request, got %d", requestCount)
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%q", err, stdout)
+	}
+	if result.Data.ID != "loc-1" || result.Data.Attributes.Locale != "en-US" || result.Data.Attributes.Name != "Pro" {
+		t.Fatalf("unexpected reused localization output: %+v", result)
+	}
+}
+
+func TestSubscriptionsLocalizationsCreateRejectsDifferentExistingLocale(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPost {
+			t.Fatalf("create should reject mismatched existing localization before POST")
+		}
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/123456789/subscriptionLocalizations" {
+			t.Fatalf("unexpected lookup request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-1","attributes":{"name":"Old Pro","locale":"en-US","description":"Old description."}}],"links":{"next":""}}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "localizations", "create",
+			"--subscription-id", "123456789",
+			"--locale", "en-US",
+			"--name", "Pro",
+			"--description", "Premium features.",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected existing localization mismatch error")
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `localization for locale "en-US" already exists as loc-1`) {
+		t.Fatalf("expected existing localization guidance, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "subscriptions localizations update --id loc-1") {
+		t.Fatalf("expected update guidance, got %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_localizations_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_localizations_create_test.go
@@ -55,7 +55,7 @@ func TestSubscriptionsLocalizationsCreateReusesMatchingLocale(t *testing.T) {
 		if err := root.Parse([]string{
 			"subscriptions", "localizations", "create",
 			"--subscription-id", "123456789",
-			"--locale", "en-US",
+			"--locale", "en-us",
 			"--name", "Pro",
 			"--description", "Premium features.",
 			"--output", "json",

--- a/internal/cli/cmdtest/subscriptions_localizations_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_localizations_create_test.go
@@ -3,11 +3,14 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestSubscriptionsLocalizationsCreateReusesMatchingLocale(t *testing.T) {
@@ -101,6 +104,7 @@ func TestSubscriptionsLocalizationsCreateRejectsDifferentExistingLocale(t *testi
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
+	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"subscriptions", "localizations", "create",
@@ -111,19 +115,25 @@ func TestSubscriptionsLocalizationsCreateRejectsDifferentExistingLocale(t *testi
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
-		err := root.Run(context.Background())
-		if err == nil {
-			t.Fatal("expected existing localization mismatch error")
-		}
+		runErr = root.Run(context.Background())
 	})
+	if runErr == nil {
+		t.Fatal("expected existing localization mismatch error")
+	}
+	if !errors.Is(runErr, asc.ErrConflict) {
+		t.Fatalf("expected conflict error, got %v", runErr)
+	}
 
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, `localization for locale "en-US" already exists as loc-1`) {
-		t.Fatalf("expected existing localization guidance, got %q", stderr)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stderr, "subscriptions localizations update --id loc-1") {
-		t.Fatalf("expected update guidance, got %q", stderr)
+	if !strings.Contains(runErr.Error(), `localization for locale "en-US" already exists as loc-1`) {
+		t.Fatalf("expected existing localization guidance, got %v", runErr)
+	}
+	if !strings.Contains(runErr.Error(), "subscriptions localizations update --id loc-1") {
+		t.Fatalf("expected update guidance, got %v", runErr)
 	}
 }

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -2,6 +2,7 @@ package subscriptions
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+var errSubscriptionLocalizationFound = errors.New("subscription localization found")
 
 // SubscriptionsLocalizationsCommand returns the subscription localizations command group.
 func SubscriptionsLocalizationsCommand() *ffcli.Command {
@@ -228,6 +231,23 @@ Examples:
 				attrs.Description = desc
 			}
 
+			existing, found, err := findSubscriptionLocalizationByLocale(requestCtx, client, id, localeValue)
+			if err != nil {
+				return fmt.Errorf("subscriptions localizations create: failed to check existing localizations: %w", err)
+			}
+			if found {
+				if subscriptionLocalizationMatchesCreateAttributes(existing, attrs) {
+					resp := &asc.SubscriptionLocalizationResponse{Data: existing}
+					return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+				}
+				return shared.UsageError(fmt.Sprintf(
+					"localization for locale %q already exists as %s; use subscriptions localizations update --id %s to change it",
+					localeValue,
+					strings.TrimSpace(existing.ID),
+					strings.TrimSpace(existing.ID),
+				))
+			}
+
 			resp, err := client.CreateSubscriptionLocalization(requestCtx, id, attrs)
 			if err != nil {
 				return fmt.Errorf("subscriptions localizations create: failed to create: %w", err)
@@ -236,6 +256,53 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func findSubscriptionLocalizationByLocale(ctx context.Context, client *asc.Client, subscriptionID, locale string) (asc.Resource[asc.SubscriptionLocalizationAttributes], bool, error) {
+	locale = strings.TrimSpace(locale)
+	if locale == "" {
+		return asc.Resource[asc.SubscriptionLocalizationAttributes]{}, false, nil
+	}
+	firstPage, err := client.GetSubscriptionLocalizations(ctx, subscriptionID, asc.WithSubscriptionLocalizationsLimit(200))
+	if err != nil {
+		return asc.Resource[asc.SubscriptionLocalizationAttributes]{}, false, err
+	}
+	if firstPage == nil {
+		return asc.Resource[asc.SubscriptionLocalizationAttributes]{}, false, nil
+	}
+
+	var found asc.Resource[asc.SubscriptionLocalizationAttributes]
+	if err := asc.PaginateEach(
+		ctx,
+		firstPage,
+		func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionLocalizations(ctx, subscriptionID, asc.WithSubscriptionLocalizationsNextURL(nextURL))
+		},
+		func(page asc.PaginatedResponse) error {
+			resp, ok := page.(*asc.SubscriptionLocalizationsResponse)
+			if !ok {
+				return fmt.Errorf("unexpected subscription localizations pagination type %T", page)
+			}
+			for _, localization := range resp.Data {
+				if strings.TrimSpace(localization.Attributes.Locale) != locale {
+					continue
+				}
+				found = localization
+				return errSubscriptionLocalizationFound
+			}
+			return nil
+		},
+	); err != nil && !errors.Is(err, errSubscriptionLocalizationFound) {
+		return asc.Resource[asc.SubscriptionLocalizationAttributes]{}, false, err
+	}
+
+	return found, strings.TrimSpace(found.ID) != "", nil
+}
+
+func subscriptionLocalizationMatchesCreateAttributes(localization asc.Resource[asc.SubscriptionLocalizationAttributes], attrs asc.SubscriptionLocalizationCreateAttributes) bool {
+	return strings.TrimSpace(localization.Attributes.Locale) == strings.TrimSpace(attrs.Locale) &&
+		strings.TrimSpace(localization.Attributes.Name) == strings.TrimSpace(attrs.Name) &&
+		strings.TrimSpace(localization.Attributes.Description) == strings.TrimSpace(attrs.Description)
 }
 
 // SubscriptionsLocalizationsUpdateCommand returns the localizations update subcommand.

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -240,12 +241,18 @@ Examples:
 					resp := &asc.SubscriptionLocalizationResponse{Data: existing}
 					return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 				}
-				return shared.UsageError(fmt.Sprintf(
+				message := fmt.Sprintf(
 					"localization for locale %q already exists as %s; use subscriptions localizations update --id %s to change it",
 					localeValue,
 					strings.TrimSpace(existing.ID),
 					strings.TrimSpace(existing.ID),
-				))
+				)
+				return fmt.Errorf("subscriptions localizations create: %w", &asc.APIError{
+					Code:       "CONFLICT",
+					Title:      "Conflict",
+					Detail:     message,
+					StatusCode: http.StatusConflict,
+				})
 			}
 
 			resp, err := client.CreateSubscriptionLocalization(requestCtx, id, attrs)

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -284,7 +284,7 @@ func findSubscriptionLocalizationByLocale(ctx context.Context, client *asc.Clien
 				return fmt.Errorf("unexpected subscription localizations pagination type %T", page)
 			}
 			for _, localization := range resp.Data {
-				if strings.TrimSpace(localization.Attributes.Locale) != locale {
+				if !strings.EqualFold(strings.TrimSpace(localization.Attributes.Locale), locale) {
 					continue
 				}
 				found = localization
@@ -300,7 +300,7 @@ func findSubscriptionLocalizationByLocale(ctx context.Context, client *asc.Clien
 }
 
 func subscriptionLocalizationMatchesCreateAttributes(localization asc.Resource[asc.SubscriptionLocalizationAttributes], attrs asc.SubscriptionLocalizationCreateAttributes) bool {
-	return strings.TrimSpace(localization.Attributes.Locale) == strings.TrimSpace(attrs.Locale) &&
+	return strings.EqualFold(strings.TrimSpace(localization.Attributes.Locale), strings.TrimSpace(attrs.Locale)) &&
 		strings.TrimSpace(localization.Attributes.Name) == strings.TrimSpace(attrs.Name) &&
 		strings.TrimSpace(localization.Attributes.Description) == strings.TrimSpace(attrs.Description)
 }


### PR DESCRIPTION
## Summary
- check existing subscription localizations by locale before creating
- return the existing localization when locale/name/description already match the request
- fail before POST with update guidance when the locale exists with different content
- add CLI regression coverage for both matching and mismatched existing locales

## Validation
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/subscriptions ./internal/cli/cmdtest -run 'TestSubscriptionsLocalizationsCreate|TestSubscriptionsSetup|TestUsageErrors' -count=1
- commit hook: command docs, format, lint, short test suite

Note: lint still prints the pre-existing stale worktree cache warning for /Users/rudrank/.codex/worktrees/asc-release-2.3.0, but reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `subscriptions localizations create` now looks for an existing localization with the requested locale (case-insensitive).
  * If the existing locale’s locale, name, and description match, the command reuses it instead of creating a duplicate.
  * If the locale exists but details differ, the command fails with a conflict message and instructs you to use `subscriptions localizations update --id ...`.
* **Tests**
  * Added integration tests covering locale reuse vs conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->