### PR TITLE
Add nested review items commands

### DIFF
--- a/internal/cli/cmdtest/review_submissions_test.go
+++ b/internal/cli/cmdtest/review_submissions_test.go
@@ -224,15 +224,38 @@ func TestReviewCommandItemsInvalidItemType(t *testing.T) {
 }
 
 func TestReviewCommandItemsInvalidState(t *testing.T) {
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
+	tests := []struct {
+		name       string
+		args       []string
+		wantPrefix string
+	}{
+		{
+			name:       "legacy",
+			args:       []string{"review", "items-update", "--id", "ITEM_ID", "--state", "nope"},
+			wantPrefix: "review items-update:",
+		},
+		{
+			name:       "nested",
+			args:       []string{"review", "items", "update", "--id", "ITEM_ID", "--state", "nope"},
+			wantPrefix: "review items update:",
+		},
+	}
 
-	if err := root.Parse([]string{"review", "items-update", "--id", "ITEM_ID", "--state", "nope"}); err != nil {
-		t.Fatalf("parse error: %v", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			if err := root.Parse(test.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			err := root.Run(context.Background())
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.HasPrefix(err.Error(), test.wantPrefix) {
+				t.Fatalf("expected error prefix %q, got %v", test.wantPrefix, err)
+			}
+		})
 	}
-	err := root.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	t.Logf("got expected error: %v", err)
 }

--- a/internal/cli/cmdtest/review_submissions_test.go
+++ b/internal/cli/cmdtest/review_submissions_test.go
@@ -137,6 +137,26 @@ func TestReviewCommandItemsValidationErrors(t *testing.T) {
 			args:    []string{"review", "items-remove", "--id", "ITEM_ID"},
 			wantErr: "--confirm is required to remove",
 		},
+		{
+			name:    "nested review items list missing submission",
+			args:    []string{"review", "items", "list"},
+			wantErr: "--submission is required",
+		},
+		{
+			name:    "nested review items add missing item-id",
+			args:    []string{"review", "items", "add", "--submission", "SUBMISSION_ID", "--item-type", "appStoreVersions"},
+			wantErr: "--item-id is required",
+		},
+		{
+			name:    "nested review items update missing state",
+			args:    []string{"review", "items", "update", "--id", "ITEM_ID"},
+			wantErr: "--state is required",
+		},
+		{
+			name:    "nested review items remove missing confirm",
+			args:    []string{"review", "items", "remove", "--id", "ITEM_ID"},
+			wantErr: "--confirm is required to remove",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/reviews/review.go
+++ b/internal/cli/reviews/review.go
@@ -32,9 +32,9 @@ Examples:
   asc review submissions-submit --id "SUBMISSION_ID" --confirm
   asc review submissions-update --id "SUBMISSION_ID" --canceled=true
   asc review submissions-items-ids --id "SUBMISSION_ID"
-  asc review items-get --id "ITEM_ID"
-  asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-  asc review items-update --id "ITEM_ID" --state READY_FOR_REVIEW
+  asc review items list --submission "SUBMISSION_ID"
+  asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+  asc review items update --id "ITEM_ID" --state READY_FOR_REVIEW
   asc review history --app "123456789"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -58,6 +58,7 @@ Examples:
 			ReviewSubmissionsCancelCommand(),
 			ReviewSubmissionsUpdateCommand(),
 			ReviewSubmissionsItemsIDsCommand(),
+			ReviewItemsCommand(),
 			ReviewItemsGetCommand(),
 			ReviewItemsListCommand(),
 			ReviewItemsAddCommand(),

--- a/internal/cli/reviews/review_items.go
+++ b/internal/cli/reviews/review_items.go
@@ -13,21 +13,58 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+// ReviewItemsCommand returns the nested review items command group.
+func ReviewItemsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("items", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "items",
+		ShortUsage: "asc review items <subcommand> [flags]",
+		ShortHelp:  "Manage review submission items.",
+		LongHelp: `Manage review submission items.
+
+Examples:
+  asc review items get --id "ITEM_ID"
+  asc review items list --submission "SUBMISSION_ID"
+  asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+  asc review items update --id "ITEM_ID" --state READY_FOR_REVIEW
+  asc review items remove --id "ITEM_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			reviewItemsGetCommand("get", "review items get", `asc review items get --id "ITEM_ID"`),
+			reviewItemsListCommand("list", "review items list", `asc review items list [flags]`, `asc review items list --submission "SUBMISSION_ID"
+  asc review items list --submission "SUBMISSION_ID" --paginate`),
+			reviewItemsAddCommand("add", "review items add", `asc review items add [flags]`, `asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+  asc review items add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "VERSION_ID"`),
+			reviewItemsUpdateCommand("update", "review items update", `asc review items update --id "ITEM_ID" --state READY_FOR_REVIEW [flags]`, `asc review items update --id "ITEM_ID" --state READY_FOR_REVIEW`),
+			reviewItemsRemoveCommand("remove", "review items remove", `asc review items remove [flags]`, `asc review items remove --id "ITEM_ID" --confirm`),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
 // ReviewItemsGetCommand returns the review items get subcommand.
 func ReviewItemsGetCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("items-get", flag.ExitOnError)
+	return reviewItemsGetCommand("items-get", "review items-get", `asc review items-get --id "ITEM_ID"`)
+}
+
+func reviewItemsGetCommand(name, errorPrefix, example string) *ffcli.Command {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
 
 	itemID := fs.String("id", "", "Review submission item ID (required)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "items-get",
-		ShortUsage: "asc review items-get --id \"ITEM_ID\" [flags]",
+		Name:       name,
+		ShortUsage: example + " [flags]",
 		ShortHelp:  "Get a review submission item by ID.",
 		LongHelp: `Get a review submission item by ID.
 
 Examples:
-  asc review items-get --id "ITEM_ID"`,
+  ` + example,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -39,7 +76,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("review items-get: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -47,7 +84,7 @@ Examples:
 
 			resp, err := client.GetReviewSubmissionItem(requestCtx, trimmedID)
 			if err != nil {
-				return fmt.Errorf("review items-get: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -57,7 +94,12 @@ Examples:
 
 // ReviewItemsListCommand returns the review items list subcommand.
 func ReviewItemsListCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("items-list", flag.ExitOnError)
+	return reviewItemsListCommand("items-list", "review items-list", `asc review items-list [flags]`, `asc review items-list --submission "SUBMISSION_ID"
+  asc review items-list --submission "SUBMISSION_ID" --paginate`)
+}
+
+func reviewItemsListCommand(name, errorPrefix, shortUsage, examples string) *ffcli.Command {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
 
 	submissionID := fs.String("submission", "", "Review submission ID (required)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
@@ -66,22 +108,21 @@ func ReviewItemsListCommand() *ffcli.Command {
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "items-list",
-		ShortUsage: "asc review items-list [flags]",
+		Name:       name,
+		ShortUsage: shortUsage,
 		ShortHelp:  "List items in a review submission.",
 		LongHelp: `List items in a review submission.
 
 Examples:
-  asc review items-list --submission "SUBMISSION_ID"
-  asc review items-list --submission "SUBMISSION_ID" --paginate`,
+  ` + examples,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("review items-list: --limit must be between 1 and 200")
+				return fmt.Errorf("%s: --limit must be between 1 and 200", errorPrefix)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
-				return fmt.Errorf("review items-list: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 			if strings.TrimSpace(*submissionID) == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --submission is required")
@@ -113,7 +154,7 @@ Examples:
 					},
 				)
 				if err != nil {
-					return fmt.Errorf("review items-list: %w", err)
+					return fmt.Errorf("%s: %w", errorPrefix, err)
 				}
 
 				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -121,7 +162,7 @@ Examples:
 
 			resp, err := client.GetReviewSubmissionItems(requestCtx, strings.TrimSpace(*submissionID), opts...)
 			if err != nil {
-				return fmt.Errorf("review items-list: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -131,7 +172,12 @@ Examples:
 
 // ReviewItemsAddCommand returns the review items add subcommand.
 func ReviewItemsAddCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("items-add", flag.ExitOnError)
+	return reviewItemsAddCommand("items-add", "review items-add", `asc review items-add [flags]`, `asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+  asc review items-add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "VERSION_ID"`)
+}
+
+func reviewItemsAddCommand(name, errorPrefix, shortUsage, examples string) *ffcli.Command {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
 
 	submissionID := fs.String("submission", "", "Review submission ID (required)")
 	itemTypeValues := strings.Join(reviewSubmissionItemTypeList(), ", ")
@@ -140,14 +186,13 @@ func ReviewItemsAddCommand() *ffcli.Command {
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "items-add",
-		ShortUsage: "asc review items-add [flags]",
+		Name:       name,
+		ShortUsage: shortUsage,
 		ShortHelp:  "Add an item to a review submission.",
 		LongHelp: `Add an item to a review submission.
 
 Examples:
-  asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-  asc review items-add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "VERSION_ID"`,
+  ` + examples,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -171,7 +216,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("review items-add: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -179,7 +224,7 @@ Examples:
 
 			resp, err := client.CreateReviewSubmissionItem(requestCtx, strings.TrimSpace(*submissionID), normalizedType, strings.TrimSpace(*itemID))
 			if err != nil {
-				return fmt.Errorf("review items-add: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -189,20 +234,24 @@ Examples:
 
 // ReviewItemsUpdateCommand returns the review items update subcommand.
 func ReviewItemsUpdateCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("items-update", flag.ExitOnError)
+	return reviewItemsUpdateCommand("items-update", "review items-update", `asc review items-update --id "ITEM_ID" --state READY_FOR_REVIEW [flags]`, `asc review items-update --id "ITEM_ID" --state READY_FOR_REVIEW`)
+}
+
+func reviewItemsUpdateCommand(name, errorPrefix, shortUsage, examples string) *ffcli.Command {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
 
 	itemID := fs.String("id", "", "Review submission item ID (required)")
 	state := fs.String("state", "", "Item state: READY_FOR_REVIEW, ACCEPTED, APPROVED, REJECTED, REMOVED (required)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "items-update",
-		ShortUsage: "asc review items-update --id \"ITEM_ID\" --state READY_FOR_REVIEW [flags]",
+		Name:       name,
+		ShortUsage: shortUsage,
 		ShortHelp:  "Update a review submission item.",
 		LongHelp: `Update a review submission item.
 
 Examples:
-  asc review items-update --id "ITEM_ID" --state READY_FOR_REVIEW`,
+  ` + examples,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -223,7 +272,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("review items-update: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -234,7 +283,7 @@ Examples:
 			}
 			resp, err := client.UpdateReviewSubmissionItem(requestCtx, trimmedID, attrs)
 			if err != nil {
-				return fmt.Errorf("review items-update: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -244,20 +293,24 @@ Examples:
 
 // ReviewItemsRemoveCommand returns the review items remove subcommand.
 func ReviewItemsRemoveCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("items-remove", flag.ExitOnError)
+	return reviewItemsRemoveCommand("items-remove", "review items-remove", `asc review items-remove [flags]`, `asc review items-remove --id "ITEM_ID" --confirm`)
+}
+
+func reviewItemsRemoveCommand(name, errorPrefix, shortUsage, examples string) *ffcli.Command {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
 
 	itemID := fs.String("id", "", "Review submission item ID (required)")
 	confirm := fs.Bool("confirm", false, "Confirm removal (required)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
-		Name:       "items-remove",
-		ShortUsage: "asc review items-remove [flags]",
+		Name:       name,
+		ShortUsage: shortUsage,
 		ShortHelp:  "Remove an item from a review submission.",
 		LongHelp: `Remove an item from a review submission.
 
 Examples:
-  asc review items-remove --id "ITEM_ID" --confirm`,
+  ` + examples,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -272,14 +325,14 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("review items-remove: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
 			if err := client.DeleteReviewSubmissionItem(requestCtx, strings.TrimSpace(*itemID)); err != nil {
-				return fmt.Errorf("review items-remove: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			result := &asc.ReviewSubmissionItemDeleteResult{

--- a/internal/cli/reviews/review_items.go
+++ b/internal/cli/reviews/review_items.go
@@ -131,7 +131,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("review items-list: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -267,7 +267,7 @@ Examples:
 
 			normalizedState, err := normalizeReviewSubmissionItemState(*state)
 			if err != nil {
-				return fmt.Errorf("review items-update: %w", err)
+				return fmt.Errorf("%s: %w", errorPrefix, err)
 			}
 
 			client, err := shared.GetASCClient()


### PR DESCRIPTION
## Summary
- add `asc review items <subcommand>` alongside the existing dashed `items-*` commands
- keep existing dashed commands working for compatibility
- share implementations so nested and dashed forms stay behavior-identical
- add validation coverage for nested list/add/update/remove forms

## Validation
- make generate-command-docs
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/reviews ./internal/cli/cmdtest -run 'TestReviewCommandItemsValidationErrors|TestReviewItems|TestReviewCommand' -count=1
- commit hook: command docs, format, lint, short test suite

Note: lint still prints the pre-existing stale worktree cache warning for /Users/rudrank/.codex/worktrees/asc-release-2.3.0, but reports 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level “review items” command group to make nested review-item actions easier to find and use.
  * Updated “review” command help examples to match the current workflow.

* **Bug Fixes**
  * Improved validation for nested review-item subcommands, including clearer errors when required flags are missing.
  * Extended invalid-state handling to cover both legacy and nested “review items update” forms.

* **Tests**
  * Expanded table-driven test coverage for nested review-item command validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->