### PR TITLE
Make IAP localization create idempotent

### DIFF
--- a/internal/cli/cmdtest/iap_localizations_create_test.go
+++ b/internal/cli/cmdtest/iap_localizations_create_test.go
@@ -1,0 +1,129 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIAPLocalizationsCreateReusesMatchingLocale(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method == http.MethodPost {
+			t.Fatalf("create should reuse matching localization, got POST %s", req.URL.Path)
+		}
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v2/inAppPurchases/123456789/inAppPurchaseLocalizations" {
+				t.Fatalf("unexpected lookup request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected limit=200 lookup, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"inAppPurchaseLocalizations","id":"loc-1","attributes":{"name":"Coins","locale":"en-US","description":"Pack of coins."}}],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var result struct {
+		Data struct {
+			ID         string `json:"id"`
+			Attributes struct {
+				Name        string `json:"name"`
+				Locale      string `json:"locale"`
+				Description string `json:"description"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"iap", "localizations", "create",
+			"--iap-id", "123456789",
+			"--locale", "en-US",
+			"--name", "Coins",
+			"--description", "Pack of coins.",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected only localization lookup request, got %d", requestCount)
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%q", err, stdout)
+	}
+	if result.Data.ID != "loc-1" || result.Data.Attributes.Locale != "en-US" || result.Data.Attributes.Name != "Coins" {
+		t.Fatalf("unexpected reused localization output: %+v", result)
+	}
+}
+
+func TestIAPLocalizationsCreateRejectsDifferentExistingLocale(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPost {
+			t.Fatalf("create should reject mismatched existing localization before POST")
+		}
+		if req.Method != http.MethodGet || req.URL.Path != "/v2/inAppPurchases/123456789/inAppPurchaseLocalizations" {
+			t.Fatalf("unexpected lookup request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"inAppPurchaseLocalizations","id":"loc-1","attributes":{"name":"Old Coins","locale":"en-US","description":"Old description."}}],"links":{"next":""}}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"iap", "localizations", "create",
+			"--iap-id", "123456789",
+			"--locale", "en-US",
+			"--name", "Coins",
+			"--description", "Pack of coins.",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected existing localization mismatch error")
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `localization for locale "en-US" already exists as loc-1`) {
+		t.Fatalf("expected existing localization guidance, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "iap localizations update --localization-id loc-1") {
+		t.Fatalf("expected update guidance, got %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/iap_localizations_create_test.go
+++ b/internal/cli/cmdtest/iap_localizations_create_test.go
@@ -55,7 +55,7 @@ func TestIAPLocalizationsCreateReusesMatchingLocale(t *testing.T) {
 		if err := root.Parse([]string{
 			"iap", "localizations", "create",
 			"--iap-id", "123456789",
-			"--locale", "en-US",
+			"--locale", "en-us",
 			"--name", "Coins",
 			"--description", "Pack of coins.",
 			"--output", "json",

--- a/internal/cli/iap/localizations.go
+++ b/internal/cli/iap/localizations.go
@@ -2,6 +2,7 @@ package iap
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+var errIAPLocalizationFound = errors.New("iap localization found")
 
 // IAPLocalizationsCreateCommand returns the localizations create subcommand.
 func IAPLocalizationsCreateCommand() *ffcli.Command {
@@ -65,11 +68,30 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.CreateInAppPurchaseLocalization(requestCtx, iapValue, asc.InAppPurchaseLocalizationCreateAttributes{
+			attrs := asc.InAppPurchaseLocalizationCreateAttributes{
 				Name:        nameValue,
 				Locale:      localeValue,
 				Description: strings.TrimSpace(*description),
-			})
+			}
+
+			existing, found, err := findIAPLocalizationByLocale(requestCtx, client, iapValue, localeValue)
+			if err != nil {
+				return fmt.Errorf("iap localizations create: failed to check existing localizations: %w", err)
+			}
+			if found {
+				if iapLocalizationMatchesCreateAttributes(existing, attrs) {
+					resp := &asc.InAppPurchaseLocalizationResponse{Data: existing}
+					return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+				}
+				return shared.UsageError(fmt.Sprintf(
+					"localization for locale %q already exists as %s; use iap localizations update --localization-id %s to change it",
+					localeValue,
+					strings.TrimSpace(existing.ID),
+					strings.TrimSpace(existing.ID),
+				))
+			}
+
+			resp, err := client.CreateInAppPurchaseLocalization(requestCtx, iapValue, attrs)
 			if err != nil {
 				return fmt.Errorf("iap localizations create: failed to create: %w", err)
 			}
@@ -77,6 +99,53 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func findIAPLocalizationByLocale(ctx context.Context, client *asc.Client, iapID, locale string) (asc.Resource[asc.InAppPurchaseLocalizationAttributes], bool, error) {
+	locale = strings.TrimSpace(locale)
+	if locale == "" {
+		return asc.Resource[asc.InAppPurchaseLocalizationAttributes]{}, false, nil
+	}
+	firstPage, err := client.GetInAppPurchaseLocalizations(ctx, iapID, asc.WithIAPLocalizationsLimit(200))
+	if err != nil {
+		return asc.Resource[asc.InAppPurchaseLocalizationAttributes]{}, false, err
+	}
+	if firstPage == nil {
+		return asc.Resource[asc.InAppPurchaseLocalizationAttributes]{}, false, nil
+	}
+
+	var found asc.Resource[asc.InAppPurchaseLocalizationAttributes]
+	if err := asc.PaginateEach(
+		ctx,
+		firstPage,
+		func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetInAppPurchaseLocalizations(ctx, iapID, asc.WithIAPLocalizationsNextURL(nextURL))
+		},
+		func(page asc.PaginatedResponse) error {
+			resp, ok := page.(*asc.InAppPurchaseLocalizationsResponse)
+			if !ok {
+				return fmt.Errorf("unexpected in-app purchase localizations pagination type %T", page)
+			}
+			for _, localization := range resp.Data {
+				if strings.TrimSpace(localization.Attributes.Locale) != locale {
+					continue
+				}
+				found = localization
+				return errIAPLocalizationFound
+			}
+			return nil
+		},
+	); err != nil && !errors.Is(err, errIAPLocalizationFound) {
+		return asc.Resource[asc.InAppPurchaseLocalizationAttributes]{}, false, err
+	}
+
+	return found, strings.TrimSpace(found.ID) != "", nil
+}
+
+func iapLocalizationMatchesCreateAttributes(localization asc.Resource[asc.InAppPurchaseLocalizationAttributes], attrs asc.InAppPurchaseLocalizationCreateAttributes) bool {
+	return strings.TrimSpace(localization.Attributes.Locale) == strings.TrimSpace(attrs.Locale) &&
+		strings.TrimSpace(localization.Attributes.Name) == strings.TrimSpace(attrs.Name) &&
+		strings.TrimSpace(localization.Attributes.Description) == strings.TrimSpace(attrs.Description)
 }
 
 // IAPLocalizationsUpdateCommand returns the localizations update subcommand.

--- a/internal/cli/iap/localizations.go
+++ b/internal/cli/iap/localizations.go
@@ -127,7 +127,7 @@ func findIAPLocalizationByLocale(ctx context.Context, client *asc.Client, iapID,
 				return fmt.Errorf("unexpected in-app purchase localizations pagination type %T", page)
 			}
 			for _, localization := range resp.Data {
-				if strings.TrimSpace(localization.Attributes.Locale) != locale {
+				if !strings.EqualFold(strings.TrimSpace(localization.Attributes.Locale), locale) {
 					continue
 				}
 				found = localization
@@ -143,7 +143,7 @@ func findIAPLocalizationByLocale(ctx context.Context, client *asc.Client, iapID,
 }
 
 func iapLocalizationMatchesCreateAttributes(localization asc.Resource[asc.InAppPurchaseLocalizationAttributes], attrs asc.InAppPurchaseLocalizationCreateAttributes) bool {
-	return strings.TrimSpace(localization.Attributes.Locale) == strings.TrimSpace(attrs.Locale) &&
+	return strings.EqualFold(strings.TrimSpace(localization.Attributes.Locale), strings.TrimSpace(attrs.Locale)) &&
 		strings.TrimSpace(localization.Attributes.Name) == strings.TrimSpace(attrs.Name) &&
 		strings.TrimSpace(localization.Attributes.Description) == strings.TrimSpace(attrs.Description)
 }


### PR DESCRIPTION
## Summary
- check existing IAP localizations by locale before creating
- return the existing localization when locale/name/description already match the request
- fail before POST with update guidance when the locale exists with different content
- add CLI regression coverage for matching and mismatched existing locales

## Validation
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/iap ./internal/cli/cmdtest -run 'TestIAPLocalizationsCreate|TestUsageErrors|TestIAP' -count=1
- commit hook: command docs, format, lint, short test suite

Note: lint still prints the pre-existing stale worktree cache warning for /Users/rudrank/.codex/worktrees/asc-release-2.3.0, but reports 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `iap localizations create` command now avoids creating duplicate in-app purchase localizations when one already exists for the same (trimmed, case-insensitive) locale.
  * If an existing localization matches the requested values, the command reuses and returns it instead of creating a new entry.
  * If the locale exists but details differ, the command fails with guidance to use `iap localizations update --localization-id`.
* **Tests**
  * Added CLI tests covering both the reuse and conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->