### PR TITLE
Classify validation failures in telemetry

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -158,6 +158,8 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 	switch {
 	case errors.Is(err, shared.ErrMissingAuth):
 		eventContext.FailureStage = telemetry.FailureStageValidation
+	case shared.IsValidationError(err):
+		eventContext.FailureStage = telemetry.FailureStageValidation
 	case errors.Is(err, context.DeadlineExceeded):
 		eventContext.FailureStage = telemetry.FailureStageRequest
 	case exitCode == ExitConflict:

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -25,6 +25,13 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 			wantStage: telemetry.FailureStageValidation,
 		},
 		{
+			name:      "reported validation failure",
+			err:       shared.NewValidationReportedError(errors.New("found blocking issues")),
+			exitCode:  ExitError,
+			wantKind:  telemetry.ErrorKindOther,
+			wantStage: telemetry.FailureStageValidation,
+		},
+		{
 			name:      "API conflict",
 			err:       errors.New("conflict"),
 			exitCode:  ExitConflict,

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -597,10 +597,10 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 	if locID != "" {
 		files, err := collectScreenshotUploadFiles(pathValue, opts.MaxScreenshots)
 		if err != nil {
-			return nil, err
+			return nil, shared.NewValidationError(err)
 		}
 		if err := validateScreenshotDimensions(files, apiDisplayType); err != nil {
-			return nil, err
+			return nil, shared.NewValidationError(err)
 		}
 		client, err := deps.GetClient()
 		if err != nil {
@@ -629,11 +629,11 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 
 	localeAssets, err := collectLocaleAssetFilesWithLimit(pathValue, apiDisplayType, opts.MaxScreenshots)
 	if err != nil {
-		return nil, err
+		return nil, shared.NewValidationError(err)
 	}
 	localeAssets, err = limitScreenshotFanoutUploadFiles(localeAssets, opts.MaxScreenshots)
 	if err != nil {
-		return nil, err
+		return nil, shared.NewValidationError(err)
 	}
 
 	client, err := deps.GetClient()

--- a/internal/cli/assets/assets_screenshots_fanout_test.go
+++ b/internal/cli/assets/assets_screenshots_fanout_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestUploadScreenshotsFanoutUsesLocaleDirectoriesForResolvedVersion(t *testing.T) {
@@ -591,6 +592,9 @@ func TestExecuteScreenshotUploadCommandValidatesFanoutFilesBeforeClientCreation(
 	})
 	if err == nil {
 		t.Fatal("expected local validation error")
+	}
+	if !shared.IsValidationError(err) {
+		t.Fatalf("expected shared validation error, got %T: %v", err, err)
 	}
 	if clientCalled {
 		t.Fatal("expected client creation to be skipped on local validation failure")

--- a/internal/cli/assets/assets_screenshots_review_plan.go
+++ b/internal/cli/assets/assets_screenshots_review_plan.go
@@ -136,7 +136,7 @@ Examples:
 				return err
 			}
 			if result.ErrorCount > 0 {
-				return shared.NewReportedError(fmt.Errorf("screenshots plan: found %d blocking issue(s)", result.ErrorCount))
+				return shared.NewValidationReportedError(fmt.Errorf("screenshots plan: found %d blocking issue(s)", result.ErrorCount))
 			}
 			return nil
 		},
@@ -205,7 +205,7 @@ Examples:
 				return err
 			}
 			if result.ErrorCount > 0 {
-				return shared.NewReportedError(fmt.Errorf("screenshots apply: found %d blocking issue(s)", result.ErrorCount))
+				return shared.NewValidationReportedError(fmt.Errorf("screenshots apply: found %d blocking issue(s)", result.ErrorCount))
 			}
 			return nil
 		},

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestAssetsScreenshotsSizesCommandDefaultFocused(t *testing.T) {
@@ -289,6 +290,9 @@ func TestExecuteScreenshotUploadCommandRejectsMoreThanTenScreenshotsBeforeAuth(t
 
 	if err == nil {
 		t.Fatal("expected screenshot-count error")
+	}
+	if !shared.IsValidationError(err) {
+		t.Fatalf("expected shared validation error, got %T: %v", err, err)
 	}
 	if !strings.Contains(err.Error(), "allow at most 10 images") {
 		t.Fatalf("expected max screenshot guidance, got %v", err)

--- a/internal/cli/assets/assets_screenshots_validate.go
+++ b/internal/cli/assets/assets_screenshots_validate.go
@@ -112,7 +112,7 @@ Examples:
 			}
 
 			if result.ErrorCount > 0 {
-				return shared.NewReportedError(fmt.Errorf("screenshots validate: found %d error(s)", result.ErrorCount))
+				return shared.NewValidationReportedError(fmt.Errorf("screenshots validate: found %d error(s)", result.ErrorCount))
 			}
 
 			return nil

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -15,7 +15,19 @@ type ReportedError interface {
 	Reported() bool
 }
 
+// ValidationFailure marks an error as a command/domain validation result rather
+// than a generic runtime failure. It intentionally carries no command-specific
+// value so telemetry can classify the stage without increasing cardinality.
+type ValidationFailure interface {
+	error
+	ValidationFailure() bool
+}
+
 type reportedError struct {
+	err error
+}
+
+type validationError struct {
 	err error
 }
 
@@ -52,12 +64,45 @@ func (e reportedError) Reported() bool {
 	return true
 }
 
+func (e validationError) Error() string {
+	return e.err.Error()
+}
+
+func (e validationError) Unwrap() error {
+	return e.err
+}
+
+func (e validationError) ValidationFailure() bool {
+	return true
+}
+
 // NewReportedError wraps an error that has already been printed.
 func NewReportedError(err error) error {
 	if err == nil {
 		return nil
 	}
 	return reportedError{err: err}
+}
+
+// NewValidationError wraps an error that represents local/domain validation.
+func NewValidationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return validationError{err: err}
+}
+
+// NewValidationReportedError wraps an already printed validation result.
+func NewValidationReportedError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return NewReportedError(NewValidationError(err))
+}
+
+func IsValidationError(err error) bool {
+	var validationErr ValidationFailure
+	return errors.As(err, &validationErr) && validationErr.ValidationFailure()
 }
 
 // UsageError prints a CLI validation error and returns flag.ErrHelp so callers

--- a/internal/cli/validate/iap.go
+++ b/internal/cli/validate/iap.go
@@ -110,7 +110,7 @@ func runValidateIAP(ctx context.Context, opts validateIAPOptions) error {
 	}
 
 	if report.Summary.Blocking > 0 {
-		return shared.NewReportedError(fmt.Errorf("validate iap: found %d blocking issue(s)", report.Summary.Blocking))
+		return shared.NewValidationReportedError(fmt.Errorf("validate iap: found %d blocking issue(s)", report.Summary.Blocking))
 	}
 
 	return nil

--- a/internal/cli/validate/subscriptions.go
+++ b/internal/cli/validate/subscriptions.go
@@ -133,7 +133,7 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 	}
 
 	if report.Summary.Blocking > 0 {
-		return shared.NewReportedError(fmt.Errorf("validate subscriptions: found %d blocking issue(s)", report.Summary.Blocking))
+		return shared.NewValidationReportedError(fmt.Errorf("validate subscriptions: found %d blocking issue(s)", report.Summary.Blocking))
 	}
 
 	return nil

--- a/internal/cli/validate/testflight.go
+++ b/internal/cli/validate/testflight.go
@@ -164,7 +164,7 @@ func runValidateTestFlight(ctx context.Context, opts validateTestFlightOptions) 
 	}
 
 	if report.Summary.Blocking > 0 {
-		return shared.NewReportedError(fmt.Errorf("validate testflight: found %d blocking issue(s)", report.Summary.Blocking))
+		return shared.NewValidationReportedError(fmt.Errorf("validate testflight: found %d blocking issue(s)", report.Summary.Blocking))
 	}
 
 	return nil

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -213,7 +213,7 @@ func runValidate(ctx context.Context, opts validateOptions) error {
 	}
 
 	if report.Summary.Blocking > 0 {
-		return shared.NewReportedError(fmt.Errorf("validate: found %d blocking issue(s)", report.Summary.Blocking))
+		return shared.NewValidationReportedError(fmt.Errorf("validate: found %d blocking issue(s)", report.Summary.Blocking))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- mark reported/domain validation failures separately from generic execution errors
- classify validate and screenshot validation/report blockers as `failure_stage=validation` without adding high-cardinality fields
- wrap screenshot upload local preflight errors as validation failures

## Telemetry basis
- v1 aggregate failures showed `asc validate`, `asc screenshots upload`, and `asc screenshots validate` as recurring exit-1 clusters without error context
- v2 aggregate failures confirmed `asc validate`, `asc validate subscriptions`, and `asc screenshots upload` still appeared as `other/execution` even when the command was reporting validation/preflight blockers
- this keeps telemetry pseudoanonymous: no stderr, raw args, IDs, hashes, or value payloads are transmitted

## Tests
- `ASC_BYPASS_KEYCHAIN=1 go test ./cmd ./internal/cli/shared ./internal/cli/validate ./internal/cli/assets`
- pre-commit hook: command docs check, gofmt/gofumpt, lint, short test suite

Note: lint emitted the existing stale generated_file_filter warning for `/Users/rudrank/.codex/worktrees/asc-release-2.3.0/...`, then reported `0 issues`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how validation-related command failures are classified, so blocking issues are reported more consistently.
  * Screenshot upload and validation commands now return clearer validation-style errors when inputs or checks fail.
  * Updated telemetry/error handling to better recognize validation failures during execution.
* **Tests**
  * Added coverage for validation failure classification across CLI and runtime flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->