### PR TITLE
Converge apps info edit after localization conflicts

### DIFF
--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -554,15 +554,6 @@ func runAppInfoSetSingleLocale(
 				marketingURLValue = strings.TrimSpace(attrs.MarketingURL)
 				promotionalTextValue = strings.TrimSpace(attrs.PromotionalText)
 				whatsNewValue = strings.TrimSpace(attrs.WhatsNew)
-				if shouldBackfillAppInfoSetField(descriptionValue, true, targetLocalization.Attributes.Description) {
-					descriptionValue = strings.TrimSpace(sourceLocalization.Attributes.Description)
-				}
-				if shouldBackfillAppInfoSetField(keywordsValue, true, targetLocalization.Attributes.Keywords) {
-					keywordsValue = strings.TrimSpace(sourceLocalization.Attributes.Keywords)
-				}
-				if shouldBackfillAppInfoSetField(supportURLValue, true, targetLocalization.Attributes.SupportURL) {
-					supportURLValue = strings.TrimSpace(sourceLocalization.Attributes.SupportURL)
-				}
 			}
 			updateAttrs = applyAppInfoSetValues(
 				asc.AppStoreVersionLocalizationAttributes{},

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -750,7 +750,7 @@ func runAppInfoSetBatch(
 
 	warnings := make([]shared.SubmitReadinessCreateWarning, 0, len(locales))
 	for idx, locale := range locales {
-		if results[idx].Action != "create" || results[idx].Status != "success" {
+		if existingByLocale[strings.ToLower(locale)] != "" || results[idx].Status != "success" {
 			continue
 		}
 		if warning, ok := shared.SubmitReadinessCreateWarningForLocaleWithOptions(locale, valuesByLocale[locale], shared.SubmitReadinessCreateModeApplied, submitOpts); ok {

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -604,6 +604,12 @@ func runAppInfoSetSingleLocale(
 	if err := shared.PrintOutput(resp, *output.Output, *output.Pretty); err != nil {
 		return err
 	}
+	if !targetExists {
+		if warning, ok := shared.SubmitReadinessCreateWarningForLocaleWithOptions(locale, effectiveAttrs, shared.SubmitReadinessCreateModeApplied, submitOpts); ok {
+			return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, []shared.SubmitReadinessCreateWarning{warning})
+		}
+		return nil
+	}
 	warnAppInfoSetSubmitIncompleteLocale(locale, effectiveAttrs)
 	return nil
 }

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -681,6 +681,7 @@ func runAppInfoSetBatch(
 	}
 	sem := make(chan struct{}, workers)
 	var wg sync.WaitGroup
+	createWarningAttrs := make([]asc.AppStoreVersionLocalizationAttributes, len(locales))
 	for idx, locale := range locales {
 		idx := idx
 		locale := locale
@@ -702,6 +703,8 @@ func runAppInfoSetBatch(
 				Action: action,
 				Status: "success",
 			}
+			effectiveCreateAttrs := attrs
+			effectiveCreateAttrs.Locale = locale
 
 			if existingID == "" {
 				attrs.Locale = locale
@@ -729,8 +732,19 @@ func runAppInfoSetBatch(
 					existingID = strings.TrimSpace(refetchedLocalization.ID)
 					action = "update"
 					localeResult.Action = action
+					effectiveCreateAttrs = applyAppInfoSetValues(
+						refetchedLocalization.Attributes,
+						attrs.Description,
+						attrs.Keywords,
+						attrs.SupportURL,
+						attrs.MarketingURL,
+						attrs.PromotionalText,
+						attrs.WhatsNew,
+					)
+					effectiveCreateAttrs.Locale = locale
 				} else {
 					localeResult.LocalizationID = strings.TrimSpace(resp.Data.ID)
+					createWarningAttrs[idx] = effectiveCreateAttrs
 					results[idx] = localeResult
 					return
 				}
@@ -749,6 +763,9 @@ func runAppInfoSetBatch(
 				localizationID = existingID
 			}
 			localeResult.LocalizationID = localizationID
+			if existingByLocale[strings.ToLower(locale)] == "" {
+				createWarningAttrs[idx] = effectiveCreateAttrs
+			}
 			results[idx] = localeResult
 		}()
 	}
@@ -759,7 +776,7 @@ func runAppInfoSetBatch(
 		if existingByLocale[strings.ToLower(locale)] != "" || results[idx].Status != "success" {
 			continue
 		}
-		if warning, ok := shared.SubmitReadinessCreateWarningForLocaleWithOptions(locale, valuesByLocale[locale], shared.SubmitReadinessCreateModeApplied, submitOpts); ok {
+		if warning, ok := shared.SubmitReadinessCreateWarningForLocaleWithOptions(locale, createWarningAttrs[idx], shared.SubmitReadinessCreateModeApplied, submitOpts); ok {
 			warnings = append(warnings, warning)
 		}
 	}

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -554,6 +554,15 @@ func runAppInfoSetSingleLocale(
 				marketingURLValue = strings.TrimSpace(attrs.MarketingURL)
 				promotionalTextValue = strings.TrimSpace(attrs.PromotionalText)
 				whatsNewValue = strings.TrimSpace(attrs.WhatsNew)
+				if shouldBackfillAppInfoSetField(descriptionValue, true, targetLocalization.Attributes.Description) {
+					descriptionValue = strings.TrimSpace(sourceLocalization.Attributes.Description)
+				}
+				if shouldBackfillAppInfoSetField(keywordsValue, true, targetLocalization.Attributes.Keywords) {
+					keywordsValue = strings.TrimSpace(sourceLocalization.Attributes.Keywords)
+				}
+				if shouldBackfillAppInfoSetField(supportURLValue, true, targetLocalization.Attributes.SupportURL) {
+					supportURLValue = strings.TrimSpace(sourceLocalization.Attributes.SupportURL)
+				}
 			}
 			updateAttrs = applyAppInfoSetValues(
 				asc.AppStoreVersionLocalizationAttributes{},

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -3,9 +3,11 @@ package apps
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -530,15 +532,37 @@ func runAppInfoSetSingleLocale(
 		updateAttrs.Locale = locale
 		resp, createErr := client.CreateAppStoreVersionLocalization(ctx, versionID, updateAttrs)
 		if createErr != nil {
-			return fmt.Errorf("apps info edit: %w", createErr)
+			if !appInfoSetIsConflictError(createErr) {
+				return fmt.Errorf("apps info edit: %w", createErr)
+			}
+			refetchedLocalization, found, fetchErr := fetchAppInfoSetLocalizationByLocale(ctx, client, versionID, locale)
+			if fetchErr != nil {
+				return fmt.Errorf("apps info edit: create conflicted and failed to refetch localization: %w", fetchErr)
+			}
+			if !found {
+				return fmt.Errorf("apps info edit: %w", createErr)
+			}
+			targetLocalization = refetchedLocalization
+			effectiveAttrs = targetLocalization.Attributes
+			effectiveAttrs.Locale = locale
+			effectiveAttrs = applyAppInfoSetValues(
+				effectiveAttrs,
+				descriptionValue,
+				keywordsValue,
+				supportURLValue,
+				marketingURLValue,
+				promotionalTextValue,
+				whatsNewValue,
+			)
+		} else {
+			if err := shared.PrintOutput(resp, *output.Output, *output.Pretty); err != nil {
+				return err
+			}
+			if warning, ok := shared.SubmitReadinessCreateWarningForLocaleWithOptions(locale, effectiveAttrs, shared.SubmitReadinessCreateModeApplied, submitOpts); ok {
+				return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, []shared.SubmitReadinessCreateWarning{warning})
+			}
+			return nil
 		}
-		if err := shared.PrintOutput(resp, *output.Output, *output.Pretty); err != nil {
-			return err
-		}
-		if warning, ok := shared.SubmitReadinessCreateWarningForLocaleWithOptions(locale, effectiveAttrs, shared.SubmitReadinessCreateModeApplied, submitOpts); ok {
-			return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, []shared.SubmitReadinessCreateWarning{warning})
-		}
-		return nil
 	}
 
 	localizationID := strings.TrimSpace(targetLocalization.ID)
@@ -649,14 +673,33 @@ func runAppInfoSetBatch(
 				attrs.Locale = locale
 				resp, createErr := client.CreateAppStoreVersionLocalization(ctx, versionID, attrs)
 				if createErr != nil {
-					localeResult.Status = "failed"
-					localeResult.Error = createErr.Error()
+					if !appInfoSetIsConflictError(createErr) {
+						localeResult.Status = "failed"
+						localeResult.Error = createErr.Error()
+						results[idx] = localeResult
+						return
+					}
+					refetchedLocalization, found, fetchErr := fetchAppInfoSetLocalizationByLocale(ctx, client, versionID, locale)
+					if fetchErr != nil {
+						localeResult.Status = "failed"
+						localeResult.Error = fetchErr.Error()
+						results[idx] = localeResult
+						return
+					}
+					if !found {
+						localeResult.Status = "failed"
+						localeResult.Error = createErr.Error()
+						results[idx] = localeResult
+						return
+					}
+					existingID = strings.TrimSpace(refetchedLocalization.ID)
+					action = "update"
+					localeResult.Action = action
+				} else {
+					localeResult.LocalizationID = strings.TrimSpace(resp.Data.ID)
 					results[idx] = localeResult
 					return
 				}
-				localeResult.LocalizationID = strings.TrimSpace(resp.Data.ID)
-				results[idx] = localeResult
-				return
 			}
 
 			resp, updateErr := client.UpdateAppStoreVersionLocalization(ctx, existingID, attrs)
@@ -688,6 +731,25 @@ func runAppInfoSetBatch(
 	}
 
 	return buildAppInfoSetBatchResult(appID, versionID, false, results), shared.NormalizeSubmitReadinessCreateWarnings(warnings), nil
+}
+
+func fetchAppInfoSetLocalizationByLocale(ctx context.Context, client *asc.Client, versionID, locale string) (asc.Resource[asc.AppStoreVersionLocalizationAttributes], bool, error) {
+	localizations, err := client.GetAppStoreVersionLocalizations(
+		ctx,
+		versionID,
+		asc.WithAppStoreVersionLocalizationsLimit(200),
+		asc.WithAppStoreVersionLocalizationLocales([]string{locale}),
+	)
+	if err != nil {
+		return asc.Resource[asc.AppStoreVersionLocalizationAttributes]{}, false, err
+	}
+	localization, found := findAppInfoSetLocalizationByLocale(localizations.Data, locale)
+	return localization, found, nil
+}
+
+func appInfoSetIsConflictError(err error) bool {
+	var apiErr *asc.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict
 }
 
 func buildAppInfoSetBatchResult(appID string, versionID string, dryRun bool, results []asc.AppInfoSetLocaleResult) *asc.AppInfoSetBatchResult {

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -484,8 +484,10 @@ func runAppInfoSetSingleLocale(
 	promotionalTextValue := strings.TrimSpace(attrs.PromotionalText)
 	whatsNewValue := strings.TrimSpace(attrs.WhatsNew)
 
+	var sourceLocalization asc.Resource[asc.AppStoreVersionLocalizationAttributes]
 	if copyFromLocale != "" {
-		sourceLocalization, found := findAppInfoSetLocalizationByLocale(localizations.Data, copyFromLocale)
+		var found bool
+		sourceLocalization, found = findAppInfoSetLocalizationByLocale(localizations.Data, copyFromLocale)
 		if !found {
 			return fmt.Errorf("apps info edit: --copy-from-locale %q was not found for this app version", copyFromLocale)
 		}
@@ -545,6 +547,32 @@ func runAppInfoSetSingleLocale(
 			targetLocalization = refetchedLocalization
 			effectiveAttrs = targetLocalization.Attributes
 			effectiveAttrs.Locale = locale
+			if copyFromLocale != "" {
+				descriptionValue = strings.TrimSpace(attrs.Description)
+				keywordsValue = strings.TrimSpace(attrs.Keywords)
+				supportURLValue = strings.TrimSpace(attrs.SupportURL)
+				marketingURLValue = strings.TrimSpace(attrs.MarketingURL)
+				promotionalTextValue = strings.TrimSpace(attrs.PromotionalText)
+				whatsNewValue = strings.TrimSpace(attrs.WhatsNew)
+				if shouldBackfillAppInfoSetField(descriptionValue, true, targetLocalization.Attributes.Description) {
+					descriptionValue = strings.TrimSpace(sourceLocalization.Attributes.Description)
+				}
+				if shouldBackfillAppInfoSetField(keywordsValue, true, targetLocalization.Attributes.Keywords) {
+					keywordsValue = strings.TrimSpace(sourceLocalization.Attributes.Keywords)
+				}
+				if shouldBackfillAppInfoSetField(supportURLValue, true, targetLocalization.Attributes.SupportURL) {
+					supportURLValue = strings.TrimSpace(sourceLocalization.Attributes.SupportURL)
+				}
+			}
+			updateAttrs = applyAppInfoSetValues(
+				asc.AppStoreVersionLocalizationAttributes{},
+				descriptionValue,
+				keywordsValue,
+				supportURLValue,
+				marketingURLValue,
+				promotionalTextValue,
+				whatsNewValue,
+			)
 			effectiveAttrs = applyAppInfoSetValues(
 				effectiveAttrs,
 				descriptionValue,

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -210,7 +210,7 @@ func TestRunAppInfoSetSingleLocaleConflictRechecksCopyFromAfterRefetch(t *testin
 			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
 				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
 			}
-			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"","keywords":"","supportUrl":""}}]}`), nil
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Target description","keywords":"target,keywords","supportUrl":"https://example.com/target"}}]}`), nil
 		case 4:
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
 				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
@@ -227,6 +227,133 @@ func TestRunAppInfoSetSingleLocaleConflictRechecksCopyFromAfterRefetch(t *testin
 				t.Fatalf("copy-from values should not overwrite refetched target fields, got %s", bodyString)
 			}
 			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","whatsNew":"Bug fixes"}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	outputFormat := "json"
+	pretty := false
+	output := shared.OutputFlags{Output: &outputFormat, Pretty: &pretty}
+	captureAppsCreateOutput(t, func() {
+		err := runAppInfoSetSingleLocale(context.Background(), client, "version-1", "en-US", "fr-FR", asc.AppStoreVersionLocalizationAttributes{
+			WhatsNew: "Bug fixes",
+		}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, output)
+		if err != nil {
+			t.Fatalf("runAppInfoSetSingleLocale() error: %v", err)
+		}
+	})
+
+	if got, want := strings.Join(requests, ","), "GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,POST /v1/appStoreVersionLocalizations,GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,PATCH /v1/appStoreVersionLocalizations/loc-1"; got != want {
+		t.Fatalf("request sequence = %s, want %s", got, want)
+	}
+}
+
+func TestRunAppInfoSetSingleLocaleConflictBackfillsMissingRefetchedTarget(t *testing.T) {
+	requests := make([]string, 0)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch len(requests) {
+		case 1:
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US,fr-FR" {
+				t.Fatalf("expected initial filter[locale]=en-US,fr-FR, got %q", got)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-source","attributes":{"locale":"fr-FR","description":"Source description","keywords":"source,keywords","supportUrl":"https://example.com/source"}}]}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected create request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Conflict","detail":"localization already exists"}]}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
+				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}]}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			bodyString := string(body)
+			for _, want := range []string{`"description":"Source description"`, `"keywords":"source,keywords"`, `"supportUrl":"https://example.com/source"`, `"whatsNew":"Bug fixes"`} {
+				if !strings.Contains(bodyString, want) {
+					t.Fatalf("expected update body to contain %s, got %s", want, bodyString)
+				}
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Source description","keywords":"source,keywords","supportUrl":"https://example.com/source","whatsNew":"Bug fixes"}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	outputFormat := "json"
+	pretty := false
+	output := shared.OutputFlags{Output: &outputFormat, Pretty: &pretty}
+	captureAppsCreateOutput(t, func() {
+		err := runAppInfoSetSingleLocale(context.Background(), client, "version-1", "en-US", "fr-FR", asc.AppStoreVersionLocalizationAttributes{
+			WhatsNew: "Bug fixes",
+		}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, output)
+		if err != nil {
+			t.Fatalf("runAppInfoSetSingleLocale() error: %v", err)
+		}
+	})
+
+	if got, want := strings.Join(requests, ","), "GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,POST /v1/appStoreVersionLocalizations,GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,PATCH /v1/appStoreVersionLocalizations/loc-1"; got != want {
+		t.Fatalf("request sequence = %s, want %s", got, want)
+	}
+}
+
+func TestRunAppInfoSetSingleLocaleConflictBackfillsBlankRefetchedTarget(t *testing.T) {
+	requests := make([]string, 0)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch len(requests) {
+		case 1:
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US,fr-FR" {
+				t.Fatalf("expected initial filter[locale]=en-US,fr-FR, got %q", got)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-source","attributes":{"locale":"fr-FR","description":"Source description","keywords":"source,keywords","supportUrl":"https://example.com/source"}}]}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected create request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Conflict","detail":"localization already exists"}]}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
+				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"","keywords":"","supportUrl":""}}]}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			bodyString := string(body)
+			for _, want := range []string{
+				`"description":"Source description"`,
+				`"keywords":"source,keywords"`,
+				`"supportUrl":"https://example.com/source"`,
+				`"whatsNew":"Bug fixes"`,
+			} {
+				if !strings.Contains(bodyString, want) {
+					t.Fatalf("expected update body to contain %s, got %s", want, bodyString)
+				}
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Source description","keywords":"source,keywords","supportUrl":"https://example.com/source","whatsNew":"Bug fixes"}}}`), nil
 		default:
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 			return nil, nil

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -1,10 +1,21 @@
 package apps
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestSelectLatestAppStoreVersion(t *testing.T) {
@@ -62,4 +73,147 @@ func TestWarnAppInfoSetSubmitIncompleteLocaleMentionsCanonicalPublishFlow(t *tes
 	if strings.Contains(stderr, "release run") {
 		t.Fatalf("expected warning to avoid removed compatibility guidance, got %q", stderr)
 	}
+}
+
+func TestRunAppInfoSetSingleLocaleRefetchesAndUpdatesAfterCreateConflict(t *testing.T) {
+	requests := make([]string, 0)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch len(requests) {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected initial request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[]}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected create request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Conflict","detail":"localization already exists"}]}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Old description"}}]}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			if !strings.Contains(string(body), `"description":"New description"`) {
+				t.Fatalf("expected update body to contain new description, got %s", string(body))
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"New description"}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	outputFormat := "json"
+	pretty := false
+	output := shared.OutputFlags{Output: &outputFormat, Pretty: &pretty}
+	captureAppsCreateOutput(t, func() {
+		err := runAppInfoSetSingleLocale(context.Background(), client, "version-1", "en-US", "", asc.AppStoreVersionLocalizationAttributes{
+			Description: "New description",
+		}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, output)
+		if err != nil {
+			t.Fatalf("runAppInfoSetSingleLocale() error: %v", err)
+		}
+	})
+
+	if got, want := strings.Join(requests, ","), "GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,POST /v1/appStoreVersionLocalizations,GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,PATCH /v1/appStoreVersionLocalizations/loc-1"; got != want {
+		t.Fatalf("request sequence = %s, want %s", got, want)
+	}
+}
+
+func TestRunAppInfoSetBatchRefetchesAndUpdatesAfterCreateConflict(t *testing.T) {
+	requests := make([]string, 0)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch len(requests) {
+		case 1:
+			return appInfoJSONResponse(http.StatusOK, `{"data":[]}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected create request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Conflict","detail":"localization already exists"}]}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Old description"}}]}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			if !strings.Contains(string(body), `"description":"New description"`) {
+				t.Fatalf("expected update body to contain new description, got %s", string(body))
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"New description"}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	result, warnings, err := runAppInfoSetBatch(context.Background(), client, "app-1", "version-1", map[string]asc.AppStoreVersionLocalizationAttributes{
+		"en-US": {Description: "New description"},
+	}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, false)
+	if err != nil {
+		t.Fatalf("runAppInfoSetBatch() error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %+v", warnings)
+	}
+	if result == nil || result.Failed != 0 || result.Succeeded != 1 {
+		t.Fatalf("unexpected batch result: %+v", result)
+	}
+	if len(result.Results) != 1 || result.Results[0].Action != "update" || result.Results[0].LocalizationID != "loc-1" {
+		t.Fatalf("unexpected locale result: %+v", result.Results)
+	}
+}
+
+type appInfoRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn appInfoRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func appInfoJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func newAppInfoTestClient(t *testing.T, transport http.RoundTripper) *asc.Client {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
+	}
+	return client
 }

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -177,8 +178,14 @@ func TestRunAppInfoSetBatchRefetchesAndUpdatesAfterCreateConflict(t *testing.T) 
 	if err != nil {
 		t.Fatalf("runAppInfoSetBatch() error: %v", err)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("expected no warnings, got %+v", warnings)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %+v", warnings)
+	}
+	if warnings[0].Locale != "en-US" || warnings[0].Mode != shared.SubmitReadinessCreateModeApplied {
+		t.Fatalf("unexpected warning identity: %+v", warnings[0])
+	}
+	if !slices.Equal(warnings[0].MissingFields, []string{"keywords", "supportUrl", "whatsNew"}) {
+		t.Fatalf("unexpected warning missing fields: %+v", warnings[0].MissingFields)
 	}
 	if result == nil || result.Failed != 0 || result.Succeeded != 1 {
 		t.Fatalf("unexpected batch result: %+v", result)

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -210,7 +210,7 @@ func TestRunAppInfoSetSingleLocaleConflictRechecksCopyFromAfterRefetch(t *testin
 			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
 				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
 			}
-			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Target description","keywords":"target,keywords","supportUrl":"https://example.com/target"}}]}`), nil
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"","keywords":"","supportUrl":""}}]}`), nil
 		case 4:
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
 				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
@@ -226,7 +226,7 @@ func TestRunAppInfoSetSingleLocaleConflictRechecksCopyFromAfterRefetch(t *testin
 			if strings.Contains(bodyString, "Source description") || strings.Contains(bodyString, "source,keywords") || strings.Contains(bodyString, "https://example.com/source") {
 				t.Fatalf("copy-from values should not overwrite refetched target fields, got %s", bodyString)
 			}
-			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Target description","whatsNew":"Bug fixes"}}}`), nil
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","whatsNew":"Bug fixes"}}}`), nil
 		default:
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 			return nil, nil

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -94,6 +94,9 @@ func TestRunAppInfoSetSingleLocaleRefetchesAndUpdatesAfterCreateConflict(t *test
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
 				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
 			}
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
+				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
+			}
 			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Old description"}}]}`), nil
 		case 4:
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
@@ -146,6 +149,9 @@ func TestRunAppInfoSetBatchRefetchesAndUpdatesAfterCreateConflict(t *testing.T) 
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
 				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
 			}
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
+				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
+			}
 			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Old description"}}]}`), nil
 		case 4:
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
@@ -179,6 +185,68 @@ func TestRunAppInfoSetBatchRefetchesAndUpdatesAfterCreateConflict(t *testing.T) 
 	}
 	if len(result.Results) != 1 || result.Results[0].Action != "update" || result.Results[0].LocalizationID != "loc-1" {
 		t.Fatalf("unexpected locale result: %+v", result.Results)
+	}
+}
+
+func TestRunAppInfoSetSingleLocaleConflictRechecksCopyFromAfterRefetch(t *testing.T) {
+	requests := make([]string, 0)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch len(requests) {
+		case 1:
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US,fr-FR" {
+				t.Fatalf("expected initial filter[locale]=en-US,fr-FR, got %q", got)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-source","attributes":{"locale":"fr-FR","description":"Source description","keywords":"source,keywords","supportUrl":"https://example.com/source"}}]}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected create request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Conflict","detail":"localization already exists"}]}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
+				t.Fatalf("expected refetch filter[locale]=en-US, got %q", got)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Target description","keywords":"target,keywords","supportUrl":"https://example.com/target"}}]}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			bodyString := string(body)
+			if !strings.Contains(bodyString, `"whatsNew":"Bug fixes"`) {
+				t.Fatalf("expected update body to contain explicit whatsNew, got %s", bodyString)
+			}
+			if strings.Contains(bodyString, "Source description") || strings.Contains(bodyString, "source,keywords") || strings.Contains(bodyString, "https://example.com/source") {
+				t.Fatalf("copy-from values should not overwrite refetched target fields, got %s", bodyString)
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Target description","whatsNew":"Bug fixes"}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	outputFormat := "json"
+	pretty := false
+	output := shared.OutputFlags{Output: &outputFormat, Pretty: &pretty}
+	captureAppsCreateOutput(t, func() {
+		err := runAppInfoSetSingleLocale(context.Background(), client, "version-1", "en-US", "fr-FR", asc.AppStoreVersionLocalizationAttributes{
+			WhatsNew: "Bug fixes",
+		}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, output)
+		if err != nil {
+			t.Fatalf("runAppInfoSetSingleLocale() error: %v", err)
+		}
+	})
+
+	if got, want := strings.Join(requests, ","), "GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,POST /v1/appStoreVersionLocalizations,GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,PATCH /v1/appStoreVersionLocalizations/loc-1"; got != want {
+		t.Fatalf("request sequence = %s, want %s", got, want)
 	}
 }
 

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -198,6 +198,55 @@ func TestRunAppInfoSetBatchRefetchesAndUpdatesAfterCreateConflict(t *testing.T) 
 	}
 }
 
+func TestRunAppInfoSetBatchConflictWarningsUseRefetchedFields(t *testing.T) {
+	requests := make([]string, 0)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch len(requests) {
+		case 1:
+			return appInfoJSONResponse(http.StatusOK, `{"data":[]}`), nil
+		case 2:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected create request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Conflict","detail":"localization already exists"}]}`), nil
+		case 3:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/appStoreVersionLocalizations" {
+				t.Fatalf("unexpected refetch request: %s %s", req.Method, req.URL.String())
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Existing description","keywords":"existing,keywords","supportUrl":"https://example.com/support"}}]}`), nil
+		case 4:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+				t.Fatalf("unexpected update request: %s %s", req.Method, req.URL.String())
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			if !strings.Contains(string(body), `"whatsNew":"Bug fixes"`) {
+				t.Fatalf("expected update body to contain whatsNew, got %s", string(body))
+			}
+			return appInfoJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","whatsNew":"Bug fixes"}}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	result, warnings, err := runAppInfoSetBatch(context.Background(), client, "app-1", "version-1", map[string]asc.AppStoreVersionLocalizationAttributes{
+		"en-US": {WhatsNew: "Bug fixes"},
+	}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, false)
+	if err != nil {
+		t.Fatalf("runAppInfoSetBatch() error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings from refetched complete fields, got %+v", warnings)
+	}
+	if result == nil || result.Failed != 0 || result.Succeeded != 1 {
+		t.Fatalf("unexpected batch result: %+v", result)
+	}
+}
+
 func TestRunAppInfoSetSingleLocaleConflictRechecksCopyFromAfterRefetch(t *testing.T) {
 	requests := make([]string, 0)
 	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -120,7 +120,7 @@ func TestRunAppInfoSetSingleLocaleRefetchesAndUpdatesAfterCreateConflict(t *test
 	outputFormat := "json"
 	pretty := false
 	output := shared.OutputFlags{Output: &outputFormat, Pretty: &pretty}
-	captureAppsCreateOutput(t, func() {
+	stderr := captureAppsCreateOutput(t, func() {
 		err := runAppInfoSetSingleLocale(context.Background(), client, "version-1", "en-US", "", asc.AppStoreVersionLocalizationAttributes{
 			Description: "New description",
 		}, shared.SubmitReadinessOptions{RequireWhatsNew: true}, output)
@@ -129,6 +129,9 @@ func TestRunAppInfoSetSingleLocaleRefetchesAndUpdatesAfterCreateConflict(t *test
 		}
 	})
 
+	if !strings.Contains(stderr, "whatsNew") {
+		t.Fatalf("expected RequireWhatsNew warning after conflict fallback, got %q", stderr)
+	}
 	if got, want := strings.Join(requests, ","), "GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,POST /v1/appStoreVersionLocalizations,GET /v1/appStoreVersions/version-1/appStoreVersionLocalizations,PATCH /v1/appStoreVersionLocalizations/loc-1"; got != want {
 		t.Fatalf("request sequence = %s, want %s", got, want)
 	}


### PR DESCRIPTION
## Summary
- recover from app version localization create conflicts in `apps info edit`
- refetch the target locale after a 409 and update the existing localization instead of failing
- apply the convergence path to both inline single-locale edits and batched `--from-dir` edits

## Telemetry basis
- v1 aggregate telemetry showed `asc apps info edit` conflict exits over the last 7 days
- v2 aggregate telemetry showed `asc apps info edit` as `api_conflict/request` in the last 48 hours
- no raw stderr, IDs, args, hashes, or user values were queried or added

## Tests
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/apps`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/apps ./internal/cli/cmdtest`
- pre-commit hook: command docs check, gofmt/gofumpt, lint, short test suite

Note: lint emitted the existing stale generated_file_filter warning for `/Users/rudrank/.codex/worktrees/asc-release-2.3.0/...`, then reported `0 issues`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved App Store Connect app version localization editing to recover from “already exists” (HTTP 409) by refetching the existing locale and switching from create to update.
  * Applied the same conflict recovery in batch edits, updating the locale action after refetch and marking locales as failed only when the refetch can’t locate the localization.
  * Copy-from locale conflict recovery now preserves copied target fields correctly while ensuring “what’s new” is applied as expected.
  * When refetched target fields are missing or blank, the follow-up update now backfills description/keywords/support URL from the source.
* **Tests**
  * Added targeted tests covering single-locale and batch 409 → refetch → update flows, including backfill and copy-from behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->