### PR TITLE
apps wall: add Vibe Check: Selfie Score

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1542,6 +1542,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3f/90/6f/3f906ff7-be78-e596-b72c-c5dee3bb0b7c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Vibe Check: Selfie Score",
+    "link": "https://apps.apple.com/us/app/vibe-check-selfie-score/id6784058417?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/bd/7f/8e/bd7f8e20-c7c8-97df-21ba-ffc60eea1ae9/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Video Annotation",
     "link": "https://apps.apple.com/us/app/video-annotation/id6758316355",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/c3/a9/43c3a9e9-e32b-081c-8a8b-a4f401846771/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Vibe Check: Selfie Score` to the Wall of Apps

## Entry

- App ID: 6784058417
- App: Vibe Check: Selfie Score
- Link: https://apps.apple.com/us/app/vibe-check-selfie-score/id6784058417?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new app listing, **“Vibe Check: Selfie Score,”** to the apps directory with its store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->