### PR TITLE
[codex] Fix integration key file permissions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,7 @@ jobs:
           # Write key from base64 secret to temp file
           if [ -n "$ASC_PRIVATE_KEY_B64" ]; then
             echo "$ASC_PRIVATE_KEY_B64" | base64 -d > /tmp/AuthKey.p8
+            chmod 600 /tmp/AuthKey.p8
             export ASC_PRIVATE_KEY_PATH=/tmp/AuthKey.p8
           fi
 


### PR DESCRIPTION
## Summary

Fixes the scheduled/manual integration workflow's decoded App Store Connect private key file permissions by running `chmod 600 /tmp/AuthKey.p8` before exposing it via `ASC_PRIVATE_KEY_PATH`.

## Why

The integration run failed before any Apple API call because the CLI rejects private key files with permissive permissions:

```text
invalid private key: private key file is too permissive; run: chmod 600 "/tmp/AuthKey.p8"
```

## Validation

- `actionlint .github/workflows/integration.yml`
- local shell check confirming the decoded key path ends with mode `600`
- pre-commit hook: format checks, lint checks, short Go test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened permissions on a temporary authentication key file used during integration testing, reducing the risk of unintended access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->