### PR TITLE
[codex] Remove weekly integration test schedule

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,6 @@
 name: Integration Tests
 
 on:
-  schedule:
-    # Run weekly on Mondays at 06:00 UTC
-    - cron: '0 6 * * 1'
   workflow_dispatch:
     # Allow manual trigger from GitHub UI
 


### PR DESCRIPTION
## Summary

Removes the Monday cron trigger from the `Integration Tests` workflow.

The workflow remains available through `workflow_dispatch` for manual integration runs when we actually want to exercise live App Store Connect credentials.

## Why

The weekly run has been noisy and is no longer needed as an automatic scheduled check.

## Validation

- `actionlint .github/workflows/integration.yml`
- `git diff --check`
- pre-commit hook: format checks, lint checks, short Go test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the weekly scheduled execution from the integration workflow.
  * The integration checks now run only when explicitly started, rather than on an automated weekly cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->