### PR TITLE
[codex] Promote web session commands

### DIFF
--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -22,7 +22,7 @@ var rootUsageGroups = []rootCommandGroup{
 		commands: []string{"auth", "doctor", "install-skills", "init", "docs"},
 	},
 	{
-		title:    "EXPERIMENTAL COMMANDS",
+		title:    "WEB SESSION COMMANDS",
 		commands: []string{"web"},
 	},
 	{

--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -7,7 +7,7 @@
 The `apps` command is the main app-management surface for App Store Connect.
 
 App creation no longer lives under `asc apps` in 1.0. Use `asc web apps create`
-for the unofficial web-session creation flow, and see the
+for the web-session creation flow, and see the
 [Migrate to 1.0](/migrate-to-1-0) guide if you are updating older scripts.
 
 ## Commands

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -48,9 +48,9 @@ Commands are organized into logical families based on functionality:
 * `init` - Initialize asc helper docs in the current repo
 * `docs` - Access embedded documentation guides and reference helpers
 
-### Experimental and Unofficial
+### Web Session
 
-* `web` - Unofficial Apple web-session workflows. Experimental, unofficial, and discouraged.
+* `web` - Apple web-session workflows.
 
 ### Analytics and Finance
 

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -1,12 +1,8 @@
 # web
 
-> Unofficial Apple web-session workflows for App Store Connect. Experimental, unofficial, and discouraged.
+> Apple web-session workflows for App Store Connect.
 
-The `asc web` command family automates workflows that rely on Apple's private App Store Connect web endpoints instead of the public App Store Connect API. Use this surface only when no supported API flow exists and you accept the risk that Apple can change or block these endpoints at any time.
-
-<Warning>
-  `asc web` is experimental, unofficial, and discouraged. These commands use private Apple web-session endpoints, are not sanctioned for third-party automation, can break without notice, and may put your account at risk. Prefer the public App Store Connect API and the non-`web` `asc` commands whenever those can do the job.
-</Warning>
+The `asc web` command family automates App Store Connect workflows through Apple web-session endpoints.
 
 ## Quick start
 
@@ -38,17 +34,11 @@ asc web analytics overview --app "123456789" --start 2026-01-01 --end 2026-03-31
 
 ## When to use `asc web`
 
-Use `asc web` only when one of these is true:
+Use `asc web` when one of these is true:
 
 * Apple exposes the workflow only in the App Store Connect web UI
 * the public App Store Connect API is missing the specific mutation or report you need
-* you are doing one-off or reviewer-owned operations where breakage risk is acceptable
-
-Avoid `asc web` when:
-
-* an official `asc` command already exists for the workflow
-* you need stable CI or production-critical automation
-* you need guarantees that the endpoint contract will stay consistent over time
+* you need workflows that are available in the `asc web` command family
 
 ## Session model
 
@@ -76,7 +66,7 @@ Available commands:
 
 ### `asc web apps`
 
-App management workflows over private web endpoints.
+App management workflows over Apple web-session endpoints.
 
 Available commands:
 
@@ -88,7 +78,6 @@ Notes:
 
 * `asc web apps create` is the canonical app-creation path in the `web` family
 * `asc web apps medical-device set` currently supports only `--declared false`
-* all commands in this group remain experimental and discouraged
 
 ### `asc web sandbox`
 
@@ -131,8 +120,8 @@ Available commands:
 
 ### `asc web subscriptions`
 
-Subscription sale availability and private pricing workflows over Apple
-web-session `/iris` endpoints.
+Subscription sale availability and pricing workflows over Apple web-session
+`/iris` endpoints.
 
 Available commands:
 
@@ -140,16 +129,10 @@ Available commands:
 * `asc web subscriptions pricing monthly-commitment bootstrap` - create or reuse MONTHLY availability and attach paired UPFRONT/MONTHLY prices
 * `asc web subscriptions pricing adjusted-equalizations view` - inspect Apple's adjusted price matrix for a MONTHLY subscription price point
 
-<Warning>
-  Removing an approved auto-renewable subscription from sale requires an Account Holder web session. App Store Connect rejects Admin and App Manager users for this action.
-</Warning>
+Role requirement: removing an approved auto-renewable subscription from sale requires an Account Holder web session. App Store Connect rejects Admin and App Manager users for this action.
 
-<Warning>
-  Prefer `asc subscriptions pricing monthly-commitment enable` for normal
-  monthly-commitment setup. The `asc web subscriptions pricing` commands are
-  private-endpoint escape hatches for App Store Connect's paired pricing and
-  adjusted-equalization workflows.
-</Warning>
+For standard monthly-commitment setup, use `asc subscriptions pricing monthly-commitment enable`.
+Use `asc web subscriptions pricing` for App Store Connect paired pricing and adjusted-equalization workflows.
 
 Example:
 
@@ -191,7 +174,7 @@ asc web subscriptions pricing adjusted-equalizations view \
 
 ### `asc web analytics`
 
-Recreates App Store Connect analytics dashboards using private web analytics endpoints.
+Recreates App Store Connect analytics dashboards using Apple web analytics endpoints.
 
 Available commands:
 
@@ -217,7 +200,7 @@ asc web analytics sales --app "123456789" --start 2026-01-01 --end 2026-03-31 --
 
 ### `asc web xcode-cloud`
 
-Private Xcode Cloud usage, workflow, and environment-variable management.
+Xcode Cloud usage, workflow, and environment-variable management.
 
 Available command groups:
 
@@ -233,13 +216,9 @@ asc web xcode-cloud usage summary --apple-id "user@example.com"
 asc web xcode-cloud workflows create --product-id "UUID" --file ./workflow.json --apple-id "user@example.com"
 ```
 
-## Safety notes
+## Session upkeep
 
-* Expect authentication churn; cached web sessions expire
-* prefer one-off human-driven usage over unattended automation
-* expect contract drift in request/response bodies
-* do not treat `asc web` output or behavior as stable API guarantees
-* when an official non-`web` command exists, prefer that command instead
+Cached web sessions expire. Use `asc web auth status` to inspect the current session and `asc web auth login` to refresh it.
 
 ## Discoverability
 
@@ -259,18 +238,18 @@ asc web xcode-cloud --help
 
 <CardGroup cols={2}>
   <Card title="Apps command" icon="boxes-stacked" href="/commands/apps">
-    Prefer the supported app-management surface when it can do the job
+    Browse the main app-management command family
   </Card>
 
   <Card title="Sandbox command" icon="flask" href="/commands/sandbox">
-    Compare the official sandbox command family with the web-only creation flow
+    Browse sandbox tester commands
   </Card>
 
   <Card title="Analytics command" icon="chart-line" href="/commands/analytics">
-    Use official analytics and report workflows when those meet your needs
+    Browse analytics and report workflows
   </Card>
 
   <Card title="Xcode Cloud command" icon="cloud" href="/commands/xcode-cloud">
-    Prefer the supported Xcode Cloud command family when possible
+    Browse Xcode Cloud commands
   </Card>
 </CardGroup>

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -42,9 +42,9 @@ asc <subcommand> [flags]
 - `init` - Initialize asc helper docs in the current repo.
 - `docs` - Access embedded documentation guides and reference helpers.
 
-### Experimental Commands
+### Web Session Commands
 
-- `web` - [experimental] Unofficial web-session workflows (discouraged).
+- `web` - Apple web-session workflows.
 
 ### Analytics and Finance
 

--- a/guides/agent-ios-release.mdx
+++ b/guides/agent-ios-release.mdx
@@ -13,7 +13,7 @@ state before reporting success.
 * Run `--help` for every command before using it.
 * Resolve the app ID and version target before changing anything. Resolve the
   build ID before staging or submitting.
-* Use public App Store Connect API commands before experimental web commands.
+* Use the most specific `asc` command for the workflow, including `asc web` when the operation lives there.
 * Preview supported workflows with `--dry-run`. Use `--confirm` only after
   checking every identifier available at that stage.
 * Never print credentials or personal identity values in logs or handoffs.
@@ -261,7 +261,7 @@ a review state such as `WAITING_FOR_REVIEW`, `IN_REVIEW`, or
 
 ## Web fallback
 
-Use an explicit `asc web` command only when the public API cannot perform the
-operation and the user accepts its experimental status. `asc web auth login`
-supports interactive two-factor authentication, but account-holder agreements,
+Use an explicit `asc web` command when the operation lives in the web-session
+command family. `asc web auth login` supports interactive two-factor authentication,
+but account-holder agreements,
 payment issues, CAPTCHA, and unsupported surfaces may still require the browser.

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -19,7 +19,7 @@ const (
 	statusCLISupported = "cli-supported"
 	statusPartial      = "partial"
 	statusClientOnly   = "client-only"
-	statusExperimental = "experimental-web"
+	statusWebSession   = "web-session"
 	statusNotPublicAPI = "not-public-api"
 )
 
@@ -27,7 +27,7 @@ var allowedCapabilityStatuses = []string{
 	statusCLISupported,
 	statusPartial,
 	statusClientOnly,
-	statusExperimental,
+	statusWebSession,
 	statusNotPublicAPI,
 }
 
@@ -65,7 +65,7 @@ type capabilityFilter struct {
 // Command returns the capabilities command.
 func Command() *ffcli.Command {
 	fs := flag.NewFlagSet("capabilities", flag.ExitOnError)
-	status := fs.String("status", "", "Filter by status: cli-supported, partial, client-only, experimental-web, not-public-api")
+	status := fs.String("status", "", "Filter by status: cli-supported, partial, client-only, web-session, not-public-api")
 	area := fs.String("area", "", "Filter by area (comma-separated, e.g. release,monetization)")
 	output := shared.BindOutputFlags(fs)
 
@@ -77,7 +77,7 @@ func Command() *ffcli.Command {
 
 This command answers whether high-value App Store Connect workflows are first-class
 CLI commands, partially covered, available only through internal client code, routed
-through experimental web-session commands, or blocked by Apple's public API.
+through web-session commands, or blocked by Apple's public API.
 
 Examples:
   asc capabilities
@@ -191,7 +191,7 @@ func buildReport(filter capabilityFilter) (Report, error) {
 		Sources: []string{
 			"registered CLI command surface",
 			"embedded App Store Connect OpenAPI schema index",
-			"curated public-API limitations and experimental web-session surfaces",
+			"curated public-API limitations and web-session surfaces",
 		},
 	}, nil
 }
@@ -265,11 +265,11 @@ func capabilityRows() []Capability {
 		{
 			Area:         "app-management",
 			Capability:   "App creation",
-			Status:       statusExperimental,
+			Status:       statusWebSession,
 			Commands:     []string{"asc web apps create"},
 			APIResources: []string{"apps"},
 			Notes:        []string{"The public apps API manages existing apps; creating app records is not exposed as a public REST operation."},
-			NextAction:   "Use App Store Connect web UI, or experimental asc web apps create at your own risk.",
+			NextAction:   "Use App Store Connect web UI, or asc web apps create.",
 		},
 		{
 			Area:         "app-management",
@@ -330,10 +330,10 @@ func capabilityRows() []Capability {
 		{
 			Area:       "privacy",
 			Capability: "App privacy data-use declarations",
-			Status:     statusExperimental,
+			Status:     statusWebSession,
 			Commands:   []string{"asc web privacy"},
 			Notes:      []string{"App privacy data-use resources are not present in the embedded public OpenAPI snapshot."},
-			NextAction: "Use App Store Connect web UI, or experimental asc web privacy when web-session risk is acceptable.",
+			NextAction: "Use App Store Connect web UI, or asc web privacy.",
 		},
 		{
 			Area:       "monetization",
@@ -381,7 +381,7 @@ func capabilityRows() []Capability {
 				"sandboxTesters",
 				"sandboxTestersClearPurchaseHistoryRequest",
 			},
-			Notes: []string{"Public API support varies by operation and account; web-session creation exists as an experimental fallback."},
+			Notes: []string{"Public API support varies by operation and account; web-session creation exists as a fallback."},
 		},
 		{
 			Area:       "analytics",
@@ -466,7 +466,7 @@ func capabilityRows() []Capability {
 		{
 			Area:       "review",
 			Capability: "Web-only review rejection inspection",
-			Status:     statusExperimental,
+			Status:     statusWebSession,
 			Commands:   []string{"asc web review"},
 			Notes:      []string{"Some reviewer-message and rejection-detail surfaces are richer in App Store Connect web-session flows than in public API responses."},
 		},

--- a/internal/cli/cmdtest/capabilities_command_test.go
+++ b/internal/cli/cmdtest/capabilities_command_test.go
@@ -48,17 +48,17 @@ func TestRun_CapabilitiesJSONReportsKnownGaps(t *testing.T) {
 	if resp.Summary.SchemaEndpointCount == 0 {
 		t.Fatalf("expected embedded schema endpoint count to be populated")
 	}
-	for _, status := range []string{"cli-supported", "experimental-web", "not-public-api"} {
+	for _, status := range []string{"cli-supported", "web-session", "not-public-api"} {
 		if resp.Summary.Statuses[status] == 0 {
 			t.Fatalf("expected status %q to be represented in summary: %+v", status, resp.Summary.Statuses)
 		}
 	}
 
 	assertCapability(t, resp, "App Store release submission", "cli-supported", "asc publish appstore --submit")
-	assertCapability(t, resp, "App creation", "experimental-web", "asc web apps create")
+	assertCapability(t, resp, "App creation", "web-session", "asc web apps create")
 	assertCapability(t, resp, "Metadata and localization sync", "cli-supported", "asc metadata init")
 	assertCapability(t, resp, "Metadata and localization sync", "cli-supported", "asc metadata validate")
-	assertCapability(t, resp, "App privacy data-use declarations", "experimental-web", "asc web privacy")
+	assertCapability(t, resp, "App privacy data-use declarations", "web-session", "asc web privacy")
 	assertCapability(t, resp, "Transaction tax reports", "not-public-api", "")
 }
 

--- a/internal/cli/cmdtest/pricing_availability_set_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_set_create_test.go
@@ -27,7 +27,7 @@ func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T)
 				"--output", "json",
 			},
 			wantPrefix: `pricing availability edit: app availability not found for app "app-1"; this command only updates existing app availability`,
-			wantHint:   `use the experimental "asc web apps availability create" flow`,
+			wantHint:   `use the "asc web apps availability create" flow`,
 		},
 		{
 			name: "app-setup availability edit",
@@ -40,7 +40,7 @@ func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T)
 				"--output", "json",
 			},
 			wantPrefix: `app-setup availability edit: app availability not found for app "app-1"; this command only updates existing app availability`,
-			wantHint:   `use the experimental "asc web apps availability create" flow`,
+			wantHint:   `use the "asc web apps availability create" flow`,
 		},
 	}
 

--- a/internal/cli/cmdtest/stability_tiers_test.go
+++ b/internal/cli/cmdtest/stability_tiers_test.go
@@ -14,12 +14,6 @@ import (
 func TestExperimentalCommandsHaveStabilityLabel(t *testing.T) {
 	root := RootCommand("1.2.3")
 
-	webCmd := findSubcommand(root, "web")
-	if webCmd == nil {
-		t.Fatal("command [web] not found")
-	}
-	assertExperimentalCommandTree(t, webCmd, []string{"web"})
-
 	cases := []struct {
 		path []string // subcommand path from root
 	}{
@@ -40,13 +34,33 @@ func TestExperimentalCommandsHaveStabilityLabel(t *testing.T) {
 	}
 }
 
-func assertExperimentalCommandTree(t *testing.T, cmd *ffcli.Command, path []string) {
+func TestWebCommandsDoNotHaveExperimentalStabilityLabel(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	webCmd := findSubcommand(root, "web")
+	if webCmd == nil {
+		t.Fatal("command [web] not found")
+	}
+	assertCommandTreeDoesNotMentionExperimental(t, webCmd, []string{"web"})
+}
+
+func TestWebCommandsDoNotHaveEndpointWarningLabels(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	webCmd := findSubcommand(root, "web")
+	if webCmd == nil {
+		t.Fatal("command [web] not found")
+	}
+	assertCommandTreeDoesNotMentionEndpointWarnings(t, webCmd, []string{"web"})
+}
+
+func assertCommandTreeDoesNotMentionExperimental(t *testing.T, cmd *ffcli.Command, path []string) {
 	t.Helper()
 
-	assertExperimentalCommand(t, cmd, path)
+	assertCommandDoesNotMentionExperimental(t, cmd, path)
 
 	for _, sub := range cmd.Subcommands {
-		assertExperimentalCommandTree(t, sub, append(path, sub.Name))
+		assertCommandTreeDoesNotMentionExperimental(t, sub, append(path, sub.Name))
 	}
 }
 
@@ -59,5 +73,55 @@ func assertExperimentalCommand(t *testing.T, cmd *ffcli.Command, path []string) 
 	}
 	if !strings.HasPrefix(cmd.ShortHelp, "[experimental]") {
 		t.Errorf("command %v: expected ShortHelp to start with [experimental], got %q", path, cmd.ShortHelp)
+	}
+}
+
+func assertCommandDoesNotMentionExperimental(t *testing.T, cmd *ffcli.Command, path []string) {
+	t.Helper()
+
+	if cmd == nil {
+		t.Errorf("command %v not found", path)
+		return
+	}
+	if strings.Contains(strings.ToLower(cmd.ShortHelp), "experimental") {
+		t.Errorf("command %v: expected ShortHelp not to mention experimental, got %q", path, cmd.ShortHelp)
+	}
+	if strings.Contains(strings.ToLower(cmd.LongHelp), "experimental") {
+		t.Errorf("command %v: expected LongHelp not to mention experimental, got %q", path, cmd.LongHelp)
+	}
+}
+
+func assertCommandTreeDoesNotMentionEndpointWarnings(t *testing.T, cmd *ffcli.Command, path []string) {
+	t.Helper()
+
+	assertCommandDoesNotMentionEndpointWarnings(t, cmd, path)
+
+	for _, sub := range cmd.Subcommands {
+		assertCommandTreeDoesNotMentionEndpointWarnings(t, sub, append(path, sub.Name))
+	}
+}
+
+func assertCommandDoesNotMentionEndpointWarnings(t *testing.T, cmd *ffcli.Command, path []string) {
+	t.Helper()
+
+	if cmd == nil {
+		t.Errorf("command %v not found", path)
+		return
+	}
+	help := strings.ToLower(cmd.ShortHelp + "\n" + cmd.LongHelp)
+	for _, token := range []string{
+		"unofficial",
+		"discouraged",
+		"private endpoint",
+		"private web",
+		"not sanctioned",
+		"at your own risk",
+		"account restrictions",
+		"production-critical",
+		"break without notice",
+	} {
+		if strings.Contains(help, token) {
+			t.Errorf("command %v: expected help not to mention %q, got %q", path, token, cmd.LongHelp)
+		}
 	}
 }

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -9,19 +9,19 @@ import (
 	"testing"
 )
 
-func TestRootUsageIncludesExperimentalWebGroup(t *testing.T) {
+func TestRootUsageIncludesWebSessionGroup(t *testing.T) {
 	root := RootCommand("1.2.3")
 	usage := root.UsageFunc(root)
 
-	if !strings.Contains(usage, "EXPERIMENTAL COMMANDS") {
-		t.Fatalf("expected experimental group in root usage, got %q", usage)
+	if !strings.Contains(usage, "WEB SESSION COMMANDS") {
+		t.Fatalf("expected web session group in root usage, got %q", usage)
 	}
 	if !strings.Contains(usage, "  web:") {
 		t.Fatalf("expected web command in root usage, got %q", usage)
 	}
 }
 
-func TestWebCommandIncludesWarningContract(t *testing.T) {
+func TestWebCommandUsesProductionHelpContract(t *testing.T) {
 	root := RootCommand("1.2.3")
 	webCmd := findSubcommand(root, "web")
 	if webCmd == nil {
@@ -30,10 +30,15 @@ func TestWebCommandIncludesWarningContract(t *testing.T) {
 	}
 
 	usage := webCmd.UsageFunc(webCmd)
-	for _, token := range []string{"EXPERIMENTAL", "UNOFFICIAL", "DISCOURAGED"} {
-		if !strings.Contains(usage, token) {
-			t.Fatalf("expected %q token in web usage, got %q", token, usage)
+	if !strings.Contains(usage, "WEB SESSION WORKFLOWS") {
+		t.Fatalf("expected web-session help heading, got %q", usage)
+	}
+	lowerUsage := strings.ToLower(usage)
+	for _, token := range []string{"experimental", "unofficial", "discouraged", "private", "risk"} {
+		if !strings.Contains(lowerUsage, token) {
+			continue
 		}
+		t.Fatalf("expected %q not to appear in web usage, got %q", token, usage)
 	}
 }
 

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -41,7 +41,7 @@ Do not memorize flags. Always use `--help` for the current interface.
 | Run auth doctor | `asc doctor --output json` |
 | Check account health | `asc account status` |
 | Generate ASC.md | `asc init` |
-| Create an app (unofficial web flow) | `asc web apps create --name "My App" --bundle-id "com.example.app" --sku "SKU123"` |
+| Create an app (web flow) | `asc web apps create --name "My App" --bundle-id "com.example.app" --sku "SKU123"` |
 | List apps | `asc apps` |
 | List builds | `asc builds list --app "APP_ID"` |
 | List TestFlight groups | `asc testflight groups list --app "APP_ID"` |
@@ -124,7 +124,7 @@ Use `asc <command> --help` for subcommands and flags.
 
 - `auth` - Manage authentication for the App Store Connect API.
 - `doctor` - Diagnose authentication configuration issues.
-- `web` - `[experimental]` Unofficial Apple web-session `/iris` workflows (discouraged; not part of the official API). Uses low-rate calls, user-owned Apple ID sessions, and signed-URL redaction by default. Use `asc web apps create` as the canonical app-creation path in this family.
+- `web` - Apple web-session `/iris` workflows. Use `asc web apps create` as the canonical app-creation path in this family.
 - `account` - Inspect account-level health and access signals.
 - `install-skills` - Install the asc skill pack globally for App Store Connect workflows.
 - `init` - Initialize asc helper docs in the current repo.
@@ -141,7 +141,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `ads` - Manage Apple Ads Campaign Management API resources.
 - `performance` - Access performance metrics and diagnostic logs.
 - `finance` - Download payments and financial reports.
-- `apps` - List and manage apps in App Store Connect. App creation moved out of `asc apps`; use `asc web apps create` for the unofficial web-session path.
+- `apps` - List and manage apps in App Store Connect. App creation moved out of `asc apps`; use `asc web apps create` for the web-session path.
 - `app-clips` - Manage App Clip experiences and invocations.
 - `android-ios-mapping` - Manage Android-to-iOS app mapping details.
 - `app-setup` - Post-create app setup automation.
@@ -224,7 +224,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `ASC_STOREKIT_BUNDLE_ID`, `ASC_STOREKIT_ENVIRONMENT`, `ASC_STOREKIT_PROFILE`, `ASC_STOREKIT_STRICT_AUTH` - StoreKit app, environment, profile, and mixed-source auth behavior
 - `ASC_STOREKIT_BYPASS_KEYCHAIN` - Disable StoreKit keychain usage and use config-backed storage
 - Web password environment variable (`ASC_WEB` + `_PASSWORD`) - Password source for `asc web auth login` and `asc web apps create`
-- `ASC_WEB_SESSION_CACHE`, `ASC_WEB_SESSION_CACHE_DIR`, `ASC_WEB_SESSION_CACHE_BACKEND` - Web-session cache controls for unofficial web flows
+- `ASC_WEB_SESSION_CACHE`, `ASC_WEB_SESSION_CACHE_DIR`, `ASC_WEB_SESSION_CACHE_BACKEND` - Web-session cache controls for web flows
 - `ASC_IRIS_SESSION_CACHE`, `ASC_IRIS_SESSION_CACHE_DIR` - Deprecated legacy app-create cache settings; imported into the web session cache during the transition window
 - `ASC_SPINNER_DISABLED` - Disable interactive stderr spinner
 - `ASC_SKILLS_AUTO_CHECK` - Automatic skills update checks (`true`/`1`/`yes`/`y`/`on` enables, `false`/`0`/`no`/`n`/`off` disables; default enabled)

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -602,7 +602,7 @@ Examples:
 
 Note:
   Pricing availability commands operate on existing availability records.
-  For initial bootstrap, use App Store Connect or the experimental
+  For initial bootstrap, use App Store Connect or the
   "asc web apps availability create" flow.`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -743,7 +743,7 @@ Examples:
 Note:
   This command only updates an existing app availability. If the app has no
   availability record yet, initialize availability in App Store Connect first,
-  or use the experimental "asc web apps availability create" flow.`,
+  or use the "asc web apps availability create" flow.`,
 		ErrorPrefix:                      "pricing availability set",
 		IncludeAvailableInNewTerritories: true,
 	})

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -96,7 +96,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 			if err != nil {
 				if isAppAvailabilityMissing(err) {
 					return fmt.Errorf(
-						"%s: app availability not found for app %q; this command only updates existing app availability, so initialize availability in App Store Connect first or use the experimental \"asc web apps availability create\" flow",
+						"%s: app availability not found for app %q; this command only updates existing app availability, so initialize availability in App Store Connect first or use the \"asc web apps availability create\" flow",
 						config.ErrorPrefix,
 						resolvedAppID,
 					)

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -12,23 +12,18 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-const webWarningText = "EXPERIMENTAL / UNOFFICIAL / DISCOURAGED: This command family uses private, undocumented Apple web-session endpoints (not the public App Store Connect API). These endpoints are not sanctioned by Apple for third-party use. Using them may violate Apple's Developer Program License Agreement and may result in account restrictions, lockouts, or termination. You use these commands entirely at your own risk. The authors of this tool accept no responsibility for any action Apple takes against your account. As a precaution, these commands enforce an intentionally low request rate (default 1 request/second) to avoid appearing as bot traffic, require user-owned Apple Account sessions, and redact signed URLs/tokens by default. They may break without notice and should not be used for production-critical automation."
-
-// WebCommand returns the detached experimental web command group.
+// WebCommand returns the web command group.
 func WebCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web", flag.ExitOnError)
 
 	return &ffcli.Command{
 		Name:       "web",
 		ShortUsage: "asc web <subcommand> [flags]",
-		ShortHelp:  "[experimental] Unofficial web-session workflows (discouraged).",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Apple web-session workflows.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Use Apple web-session /iris flows that are not part of the official App Store Connect API.
-These commands can break without notice and are intentionally detached from official asc workflows.
-Use ` + "`asc web apps create`" + ` as the canonical app-creation command when you need this unofficial path.
-
-` + webWarningText + `
+Use Apple web-session /iris flows for App Store Connect workflows.
+Use ` + "`asc web apps create`" + ` as the canonical app-creation command in this family.
 
 Examples:
   asc web auth status

--- a/internal/cli/web/web_analytics.go
+++ b/internal/cli/web/web_analytics.go
@@ -69,13 +69,13 @@ func WebAnalyticsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "analytics",
 		ShortUsage: "asc web analytics <subcommand> [flags]",
-		ShortHelp:  "[experimental] Recreate App Store Connect analytics web dashboards.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate App Store Connect analytics web dashboards.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-	Query Apple's private analytics web endpoints using a user-owned App Store Connect
+	Query Apple's analytics web endpoints using a user-owned App Store Connect
 	web session. These commands are separate from the official Analytics Reports API.
 
-` + webWarningText + `
+
 
 Examples:
   asc web analytics overview --app "123456789" --start 2025-12-24 --end 2026-03-23 --apple-id "user@example.com"
@@ -121,13 +121,13 @@ func WebAnalyticsOverviewCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "overview",
 		ShortUsage: "asc web analytics overview [flags]",
-		ShortHelp:  "[experimental] Recreate the Analytics overview dashboard.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the Analytics overview dashboard.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 	Recreate the App Store Connect Analytics overview dashboard: acquisition, sales,
 	subscription summary cards, top breakdowns, and retention/cohort payloads.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -174,14 +174,14 @@ func WebAnalyticsSubscriptionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "subscriptions",
 		ShortUsage: "asc web analytics subscriptions [flags]",
-		ShortHelp:  "[experimental] Recreate the subscriptions summary dashboard.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the subscriptions summary dashboard.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 	Recreate the App Store Connect subscriptions summary view: active/paid plan cards,
 	monthly recurring revenue, net plan timeline, active plans by subscription, and
 	subscription retention cohorts.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -230,12 +230,12 @@ func WebAnalyticsMetricsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "metrics",
 		ShortUsage: "asc web analytics metrics [flags]",
-		ShortHelp:  "[experimental] Query private analytics measures.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Query analytics measures.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-	Query private App Store Connect analytics measures over a custom date range.
+	Query App Store Connect analytics measures over a custom date range.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -291,7 +291,7 @@ func WebAnalyticsMetricsCommand() *ffcli.Command {
 	}
 }
 
-// WebAnalyticsRetentionCommand queries private analytics retention data.
+// WebAnalyticsRetentionCommand queries analytics retention data.
 func WebAnalyticsRetentionCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web analytics retention", flag.ExitOnError)
 	sessionFlags := bindWebSessionFlags(fs)
@@ -304,12 +304,12 @@ func WebAnalyticsRetentionCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "retention",
 		ShortUsage: "asc web analytics retention [flags]",
-		ShortHelp:  "[experimental] Query private analytics retention data.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Query analytics retention data.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-	Query private App Store Connect app retention data over a custom date range.
+	Query App Store Connect app retention data over a custom date range.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -360,7 +360,7 @@ func WebAnalyticsRetentionCommand() *ffcli.Command {
 	}
 }
 
-// WebAnalyticsCohortsCommand queries private analytics cohorts directly.
+// WebAnalyticsCohortsCommand queries analytics cohorts directly.
 func WebAnalyticsCohortsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web analytics cohorts", flag.ExitOnError)
 	sessionFlags := bindWebSessionFlags(fs)
@@ -375,13 +375,13 @@ func WebAnalyticsCohortsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "cohorts",
 		ShortUsage: "asc web analytics cohorts [flags]",
-		ShortHelp:  "[experimental] Query private analytics cohort data.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Query analytics cohort data.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-	Query private App Store Connect cohort data such as download-to-paid or
+	Query App Store Connect cohort data such as download-to-paid or
 	subscription retention cohorts.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_analytics_pages.go
+++ b/internal/cli/web/web_analytics_pages.go
@@ -62,13 +62,13 @@ func WebAnalyticsSourcesCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "sources",
 		ShortUsage: "asc web analytics sources [flags]",
-		ShortHelp:  "[experimental] Recreate the Acquisition > Sources page.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the Acquisition > Sources page.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 	Show the default Acquisition > Sources view: Product Page Views (Unique Devices)
 	grouped by source over the selected date range.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -106,7 +106,7 @@ func WebAnalyticsSourcesCommand() *ffcli.Command {
 func WebAnalyticsProductPagesCommand() *ffcli.Command {
 	return newAnalyticsCapabilityCommand(
 		"product-pages",
-		"[experimental] Inspect Product Pages tab availability.",
+		"Inspect Product Pages tab availability.",
 		"Product Pages tab availability",
 		func(appInfo *webcore.AnalyticsAppInfoResult) analyticsPageCapabilityOutput {
 			count := analyticsAppFeatureCount(appInfo, "customProductPage")
@@ -144,14 +144,14 @@ func WebAnalyticsInAppEventsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "in-app-events",
 		ShortUsage: "asc web analytics in-app-events [flags]",
-		ShortHelp:  "[experimental] Recreate the Acquisition > In-App Events page.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the Acquisition > In-App Events page.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 	Show the In-App Events tab using the app's event list and the default selected
 	event metrics. App Store Connect currently uses the event's lifetime range for
 	the selected event metrics.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -189,7 +189,7 @@ func WebAnalyticsInAppEventsCommand() *ffcli.Command {
 func WebAnalyticsAppClipsCommand() *ffcli.Command {
 	return newAnalyticsCapabilityCommand(
 		"app-clips",
-		"[experimental] Inspect App Clip tab availability.",
+		"Inspect App Clip tab availability.",
 		"App Clip tab availability",
 		func(appInfo *webcore.AnalyticsAppInfoResult) analyticsPageCapabilityOutput {
 			status := "unavailable"
@@ -225,12 +225,12 @@ func WebAnalyticsCampaignsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "campaigns",
 		ShortUsage: "asc web analytics campaigns [flags]",
-		ShortHelp:  "[experimental] Recreate the Acquisition > Campaigns page.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the Acquisition > Campaigns page.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-	Show the Campaigns tab using Apple's private sources/list endpoint.
+	Show the Campaigns tab using Apple's sources/list endpoint.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -276,12 +276,12 @@ func WebAnalyticsSalesCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "sales",
 		ShortUsage: "asc web analytics sales [flags]",
-		ShortHelp:  "[experimental] Recreate the Monetization > Sales page.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the Monetization > Sales page.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 	Show the Sales summary cards, revenue cohort cards, and top revenue breakdowns.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -319,7 +319,7 @@ func WebAnalyticsSalesCommand() *ffcli.Command {
 func WebAnalyticsOffersCommand() *ffcli.Command {
 	return newAnalyticsCapabilityCommand(
 		"offers",
-		"[experimental] Inspect Offers tab capability.",
+		"Inspect Offers tab capability.",
 		"Offers tab capability",
 		func(appInfo *webcore.AnalyticsAppInfoResult) analyticsPageCapabilityOutput {
 			status := "unknown"
@@ -353,12 +353,12 @@ func WebAnalyticsBenchmarksCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "benchmarks",
 		ShortUsage: "asc web analytics benchmarks [flags]",
-		ShortHelp:  "[experimental] Recreate the Benchmarks summary page.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Recreate the Benchmarks summary page.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 	Show the latest available benchmark week using Apple's analytics v2 endpoints.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -407,12 +407,12 @@ func newAnalyticsCapabilityCommand(
 		Name:       name,
 		ShortUsage: "asc web analytics " + name + " [flags]",
 		ShortHelp:  shortHelp,
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Inspect whether this analytics tab is available for the current app and show the
 relevant analytics features or dimensions we observed while mapping the sidebar.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_app_availability.go
+++ b/internal/cli/web/web_app_availability.go
@@ -36,13 +36,13 @@ func WebAppsAvailabilityCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "availability",
 		ShortUsage: "asc web apps availability <subcommand> [flags]",
-		ShortHelp:  "[experimental] Bootstrap app availability via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Bootstrap app availability via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Create the initial app availability record through Apple's internal web API.
 This path is intended only for apps that do not yet have an availability record.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -68,8 +68,8 @@ func WebAppsAvailabilityCreateCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "create",
 		ShortUsage: "asc web apps availability create --app APP_ID --territory \"US,France\" [flags]",
-		ShortHelp:  "[experimental] Create initial app availability via web API.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Create initial app availability via web API.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Create the initial app availability record for an app that does not yet have one.
 The territories passed with --territory become initially available.
@@ -78,7 +78,7 @@ Examples:
   asc web apps availability create --app "123456789" --territory "United States" --available-in-new-territories false
   asc web apps availability create --app "123456789" --territory "US,France" --available-in-new-territories true
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -21,14 +21,13 @@ func WebAppsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "apps",
 		ShortUsage: "asc web apps <subcommand> [flags]",
-		ShortHelp:  "[experimental] Unofficial app management via web sessions; canonical path for app creation.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "App management via web sessions; canonical path for app creation.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage app operations using Apple web sessions and internal APIs.
-This command group is detached from official App Store Connect API flows.
 Use ` + "`asc web apps create`" + ` as the canonical app-creation command.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -232,13 +231,12 @@ func WebAppsCreateCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "create",
 		ShortUsage: "asc web apps create [flags]",
-		ShortHelp:  "[experimental] Create app via unofficial Apple web API.",
+		ShortHelp:  "Create app via Apple web API.",
 		LongHelp: fmt.Sprintf(
-			`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+			`WEB SESSION WORKFLOWS
 
-Create an app through Apple's internal web API using a web-session login.
-This is the canonical app-creation path for web-session based flows and is
-detached from official API-key workflows.
+Create an app through Apple's web API using a web-session login.
+This is the canonical app-creation path for web-session based flows.
 
 If required fields are omitted in an interactive terminal, the CLI will prompt
 for the missing app-creation inputs.
@@ -257,7 +255,7 @@ Bundle ID preflight:
   If official ASC API authentication is available, the CLI will check or create
   the Bundle ID before app creation. Otherwise it assumes the Bundle ID already exists.
 
-`+webWarningText+`
+
 
 Examples:
   asc web apps create

--- a/internal/cli/web/web_apps_compatibility.go
+++ b/internal/cli/web/web_apps_compatibility.go
@@ -30,13 +30,13 @@ func WebAppsCompatibilityCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "compatibility",
 		ShortUsage: "asc web apps compatibility <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage App Store Mac and Vision Pro opt-in settings.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage App Store Mac and Vision Pro opt-in settings.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage App Store compatibility opt-in settings for iPhone and iPad apps on
 Apple silicon Mac and Apple Vision Pro using Apple's internal web API.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -60,7 +60,7 @@ func WebAppsCompatibilityViewCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "view",
 		ShortUsage: "asc web apps compatibility view --app APP_ID [flags]",
-		ShortHelp:  "[experimental] View App Store Mac and Vision Pro opt-in settings.",
+		ShortHelp:  "View App Store Mac and Vision Pro opt-in settings.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -112,7 +112,7 @@ func WebAppsCompatibilityEditCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "edit",
 		ShortUsage: "asc web apps compatibility edit --app APP_ID [--ios-app-on-mac true|false] [--ios-app-on-vision-pro true|false] [flags]",
-		ShortHelp:  "[experimental] Edit App Store Mac and Vision Pro opt-in settings.",
+		ShortHelp:  "Edit App Store Mac and Vision Pro opt-in settings.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_apps_create_shared.go
+++ b/internal/cli/web/web_apps_create_shared.go
@@ -103,7 +103,7 @@ func promptAppsCreateFields(opts *AppsCreateRunOptions) error {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Create a new app in App Store Connect")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, "Note: App creation uses Apple's unofficial web-session create flow.")
+	fmt.Fprintln(os.Stderr, "Note: App creation uses Apple's web-session create flow.")
 	fmt.Fprintln(os.Stderr)
 
 	nameValue := strings.TrimSpace(opts.Name)

--- a/internal/cli/web/web_apps_medical_device.go
+++ b/internal/cli/web/web_apps_medical_device.go
@@ -24,8 +24,8 @@ func WebAppsMedicalDeviceCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "medical-device",
 		ShortUsage: "asc web apps medical-device <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage the regulated medical device declaration via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage the regulated medical device declaration via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage the regulated medical device declaration exposed in App Store Connect
 under App Information -> App Store Regulations & Permits.
@@ -34,7 +34,7 @@ This command currently automates only the common "No" path. If your app is
 actually a regulated medical device, continue using the App Store Connect web UI
 until the full undocumented "Yes" write contract is captured safely.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -59,11 +59,10 @@ func WebAppsMedicalDeviceSetCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "set",
 		ShortUsage: "asc web apps medical-device set --app APP_ID --declared false [flags]",
-		ShortHelp:  "[experimental] Set regulated medical device declaration via web API.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Set regulated medical device declaration via web API.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Set the regulated medical device declaration through Apple's private
-compliance-form web endpoint used by App Store Connect.
+Set the regulated medical device declaration through Apple web-session compliance-form web endpoint used by App Store Connect.
 
 Only the "No" path is currently supported, which covers the common case for
 apps that are not regulated medical devices.
@@ -71,7 +70,7 @@ apps that are not regulated medical devices.
 Examples:
   asc web apps medical-device set --app "6748252780" --declared false
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -691,13 +691,12 @@ func WebAuthCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "auth",
 		ShortUsage: "asc web auth <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage unofficial Apple web sessions (discouraged).",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage Apple web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage Apple web-session authentication used by "asc web" commands.
-This is not the official App Store Connect API-key auth flow.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -726,11 +725,11 @@ func WebAuthLoginCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "login",
 		ShortUsage: "asc web auth login --apple-id EMAIL [--public-provider-id TEAM_ID]",
-		ShortHelp:  "[experimental] Authenticate unofficial Apple web session.",
+		ShortHelp:  "Authenticate Apple web session.",
 		LongHelp: fmt.Sprintf(
-			`EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+			`WEB SESSION WORKFLOWS
 
-Authenticate using Apple web-session behavior for detached "asc web" workflows.
+Authenticate using Apple web-session behavior for "asc web" workflows.
 
 Password input options:
   - secure interactive prompt (default and recommended for local use)
@@ -746,7 +745,7 @@ Provider selection:
   - --public-provider-id selects the public App Store Connect provider/team ID
   - --provider-id selects Apple's numeric App Store Connect provider ID
 
-`+webWarningText+`
+
 
 Examples:
   asc web auth login --apple-id "user@example.com"
@@ -800,13 +799,13 @@ func WebAuthStatusCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "status",
 		ShortUsage: "asc web auth status [--apple-id EMAIL]",
-		ShortHelp:  "[experimental] Show unofficial web-session status.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show web-session status.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Check whether an existing cached web session can be resumed.
 If --apple-id is not provided, this checks the last cached session.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -856,12 +855,12 @@ func WebAuthLogoutCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "logout",
 		ShortUsage: "asc web auth logout [--apple-id EMAIL | --all]",
-		ShortHelp:  "[experimental] Clear unofficial web-session cache.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Clear web-session cache.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Remove cached web-session credentials for detached "asc web" commands.
+Remove cached web-session credentials for "asc web" commands.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_auth_capabilities.go
+++ b/internal/cli/web/web_auth_capabilities.go
@@ -114,8 +114,8 @@ func WebAuthCapabilitiesCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "capabilities",
 		ShortUsage: "asc web auth capabilities [--key-id ID] [flags]",
-		ShortHelp:  "[experimental] Show exact web-visible API key roles and full documented capability metadata.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show exact web-visible API key roles and full documented capability metadata.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Return exact role metadata for an App Store Connect API key using Apple web-session endpoints, then map those roles to the bundled Apple capability reference.
 Unlike "asc auth capabilities", which probes effective public-API access, this command reads the web-visible key role assignment directly and expands it with documented role capabilities.
@@ -132,7 +132,7 @@ If --key-id is omitted, the command resolves the current API key ID from the sel
 That metadata-only resolution avoids loading private key material just to pick the key ID.
 For deterministic cache selection, prefer passing --apple-id like other "asc web" commands.
 
-` + webWarningText + `
+
 
 Examples:
   asc web auth capabilities --apple-id "user@example.com"

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -19,20 +19,19 @@ var syncAppClipBundleIDCapabilityFn = func(ctx context.Context, client *webcore.
 	return client.SyncAppClipBundleIDCapability(ctx, req)
 }
 
-// WebBundleIDsCommand returns the private Bundle ID command group.
+// WebBundleIDsCommand returns the Bundle ID command group.
 func WebBundleIDsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web bundle-ids", flag.ExitOnError)
 
 	return &ffcli.Command{
 		Name:       "bundle-ids",
 		ShortUsage: "asc web bundle-ids <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage Bundle IDs via private web-session endpoints.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage Bundle IDs via web-session endpoints.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Manage Bundle ID operations that are only available through Apple's private
-web-session endpoints.
+Manage Bundle ID operations that are only available through Apple web-session web-session endpoints.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -44,19 +43,19 @@ web-session endpoints.
 	}
 }
 
-// WebBundleIDCapabilitiesCommand returns the private Bundle ID capabilities group.
+// WebBundleIDCapabilitiesCommand returns the Bundle ID capabilities group.
 func WebBundleIDCapabilitiesCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web bundle-ids capabilities", flag.ExitOnError)
 
 	return &ffcli.Command{
 		Name:       "capabilities",
 		ShortUsage: "asc web bundle-ids capabilities <subcommand> [flags]",
-		ShortHelp:  "[experimental] Sync Bundle ID capabilities via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Sync Bundle ID capabilities via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Sync Bundle ID capabilities through Apple's private Bundle ID patch endpoint.
+Sync Bundle ID capabilities through Apple's Bundle ID patch endpoint.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -82,10 +81,10 @@ func WebBundleIDCapabilitiesSyncAppClipCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "sync-app-clip",
 		ShortUsage: "asc web bundle-ids capabilities sync-app-clip --bundle-id BUNDLE_ID --parent-bundle-id PARENT_BUNDLE_ID --capability CAPABILITY [flags]",
-		ShortHelp:  "[experimental] Sync an App Clip capability with parentBundleId.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Sync an App Clip capability with parentBundleId.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Patch an App Clip Bundle ID capability through Apple's private Bundle ID update
+Patch an App Clip Bundle ID capability through Apple's Bundle ID update
 payload and include the parentBundleId relationship required for App Clip
 targets. This mirrors the App Store Connect web-session shape used for App Clip
 Bundle IDs, not the public API-key capability endpoint.
@@ -94,7 +93,7 @@ Examples:
   asc web bundle-ids capabilities sync-app-clip --bundle-id "CLIP_BUNDLE_ID" --parent-bundle-id "PARENT_BUNDLE_ID" --capability "PUSH_NOTIFICATIONS"
   asc web bundle-ids capabilities sync-app-clip --bundle-id "CLIP_BUNDLE_ID" --parent-bundle-id "PARENT_BUNDLE_ID" --capability "PUSH_NOTIFICATIONS" --settings-json '[{"key":"PUSH_NOTIFICATION_FEATURES","options":[{"key":"PUSH_NOTIFICATION_FEATURE_BROADCAST","enabled":true}]}]'
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -1116,8 +1116,8 @@ func WebPrivacyCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "privacy",
 		ShortUsage: "asc web privacy <subcommand> [flags]",
-		ShortHelp:  "[experimental] App privacy declaration workflows.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "App privacy declaration workflows.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Agent-friendly app privacy declaration workflows over Apple web-session /iris endpoints.
 Use pull/plan/apply/publish with explicit mutation controls.
@@ -1129,7 +1129,7 @@ Subcommands:
   apply    Apply planned changes (never publishes automatically)
   publish  Explicitly publish app data usage declarations
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -1155,8 +1155,8 @@ func WebPrivacyCatalogCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "catalog",
 		ShortUsage: "asc web privacy catalog [flags]",
-		ShortHelp:  "[experimental] List app privacy catalog values.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "List app privacy catalog values.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Fetch category, purpose, and data-protection tokens that can be used in
 privacy declaration files.
@@ -1231,8 +1231,8 @@ func WebPrivacyPullCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "pull",
 		ShortUsage: "asc web privacy pull --app APP_ID [--out FILE] [flags]",
-		ShortHelp:  "[experimental] Pull app privacy declaration state.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Pull app privacy declaration state.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Fetch current app data usage declarations from web-session endpoints and emit
 canonical JSON that can be used with plan/apply.
@@ -1317,8 +1317,8 @@ func WebPrivacyPlanCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "plan",
 		ShortUsage: "asc web privacy plan --app APP_ID --file FILE [flags]",
-		ShortHelp:  "[experimental] Plan app privacy declaration changes.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Plan app privacy declaration changes.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Compute a deterministic diff between local declaration JSON and remote
 app data usage tuples.
@@ -1396,8 +1396,8 @@ func WebPrivacyApplyCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "apply",
 		ShortUsage: "asc web privacy apply --app APP_ID --file FILE [--allow-deletes --confirm] [flags]",
-		ShortHelp:  "[experimental] Apply app privacy declaration changes.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Apply app privacy declaration changes.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Apply local declaration tuples to remote app data usages.
 This command never publishes automatically.
@@ -1502,8 +1502,8 @@ func WebPrivacyPublishCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "publish",
 		ShortUsage: "asc web privacy publish --app APP_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Publish app privacy declarations.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Publish app privacy declarations.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Explicitly publish app data usage declarations after apply.
 

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -688,8 +688,8 @@ func WebReviewCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "review",
 		ShortUsage: "asc web review <subcommand> [flags]",
-		ShortHelp:  "[experimental] App-centric review and rejection inspection.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "App-centric review and rejection inspection.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 App-centric review workflows over Apple web-session /iris endpoints.
 Use --app to scope all operations to one app.
@@ -700,7 +700,7 @@ Subcommands:
   subscriptions  Inspect and mutate next-version subscription review selection
   iaps  Attach non-renewing IAPs to the next app version review
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -727,7 +727,7 @@ func WebReviewListCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc web review list --app APP_ID [--state CSV] [flags]",
-		ShortHelp:  "[experimental] List app review submissions.",
+		ShortHelp:  "List app review submissions.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -786,8 +786,8 @@ func WebReviewShowCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "show",
 		ShortUsage: "asc web review show --app APP_ID [--submission ID] [--out DIR] [--pattern GLOB] [--overwrite] [flags]",
-		ShortHelp:  "[experimental] Show review details and auto-download screenshots.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show review details and auto-download screenshots.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show one submission's review context (threads, messages, rejections) and
 auto-download available screenshots/attachments in the same command.
@@ -796,7 +796,7 @@ Selection:
   - --submission ID          Use an explicit submission
   - without --submission     Pick latest UNRESOLVED_ISSUES submission, otherwise latest submission
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_review_iaps.go
+++ b/internal/cli/web/web_review_iaps.go
@@ -121,11 +121,10 @@ func WebReviewIAPsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "iaps",
 		ShortUsage: "asc web review iaps <subcommand> [flags]",
-		ShortHelp:  "[experimental] Attach non-renewing IAPs to the next app version review.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Attach non-renewing IAPs to the next app version review.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Attach a non-renewing in-app purchase to the next app version review. This
-uses private Apple web-session /iris endpoints and may break without notice.
+Attach a non-renewing in-app purchase to the next app version review.
 
 Subcommands:
   attach  Attach one non-renewing IAP to the next app version review
@@ -137,7 +136,7 @@ FIRST_IAP_MUST_BE_SUBMITTED_ON_VERSION. The web UI's "Add App In-App Purchase
 or Subscription" dialog posts to /iris/v1/inAppPurchaseSubmissions with
 submitWithNextAppStoreVersion=true; this command exposes that same call.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -150,7 +149,7 @@ submitWithNextAppStoreVersion=true; this command exposes that same call.
 }
 
 // WebReviewIAPsAttachCommand attaches a non-renewing IAP to the next app
-// version review via the private iris endpoint.
+// version review via the iris endpoint.
 func WebReviewIAPsAttachCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web review iaps attach", flag.ExitOnError)
 
@@ -163,16 +162,16 @@ func WebReviewIAPsAttachCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "attach",
 		ShortUsage: "asc web review iaps attach --app APP_ID --iap-id IAP_ID_OR_PRODUCT_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Attach a non-renewing IAP to the next app version review.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Attach a non-renewing IAP to the next app version review.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Attach a non-renewing in-app purchase to the next app version review.
 
-The --iap-id selector accepts the private Iris resource id or the bundle-style
+The --iap-id selector accepts the Iris resource id or the bundle-style
 productId from ` + "`asc iap list`" + `. Apple's Iris listing does not expose the
 public numeric ASC IAP id, so that numeric id is not resolved by this command.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_review_subscriptions.go
+++ b/internal/cli/web/web_review_subscriptions.go
@@ -418,11 +418,10 @@ func WebReviewSubscriptionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "subscriptions",
 		ShortUsage: "asc web review subscriptions <subcommand> [flags]",
-		ShortHelp:  "[experimental] Inspect and mutate review-attached subscriptions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Inspect and mutate review-attached subscriptions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Inspect and mutate subscription selection for the next app version review.
-This uses private Apple web-session /iris endpoints and may break without notice.
 
 Subcommands:
   list    List subscriptions and their next-version attach state
@@ -431,7 +430,7 @@ Subcommands:
   remove  Remove one subscription from the next app version review
   remove-group  Remove all attached subscriptions in one group
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -458,7 +457,7 @@ func WebReviewSubscriptionsListCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc web review subscriptions list --app APP_ID [flags]",
-		ShortHelp:  "[experimental] List subscriptions and next-version attach state.",
+		ShortHelp:  "List subscriptions and next-version attach state.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -510,7 +509,7 @@ func WebReviewSubscriptionsAttachCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "attach",
 		ShortUsage: "asc web review subscriptions attach --app APP_ID --subscription-id SUB_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Attach a subscription to the next app version review.",
+		ShortHelp:  "Attach a subscription to the next app version review.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -599,7 +598,7 @@ func WebReviewSubscriptionsAttachGroupCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "attach-group",
 		ShortUsage: "asc web review subscriptions attach-group --app APP_ID --group-id GROUP_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Attach all READY_TO_SUBMIT subscriptions in one group.",
+		ShortHelp:  "Attach all READY_TO_SUBMIT subscriptions in one group.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -711,7 +710,7 @@ func WebReviewSubscriptionsRemoveCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "remove",
 		ShortUsage: "asc web review subscriptions remove --app APP_ID --subscription-id SUB_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Remove a subscription from the next app version review.",
+		ShortHelp:  "Remove a subscription from the next app version review.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -795,7 +794,7 @@ func WebReviewSubscriptionsRemoveGroupCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "remove-group",
 		ShortUsage: "asc web review subscriptions remove-group --app APP_ID --group-id GROUP_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Remove all attached subscriptions in one group.",
+		ShortHelp:  "Remove all attached subscriptions in one group.",
 		FlagSet:    fs,
 		UsageFunc:  shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_sandbox.go
+++ b/internal/cli/web/web_sandbox.go
@@ -35,14 +35,13 @@ func WebSandboxCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "sandbox",
 		ShortUsage: "asc web sandbox <subcommand> [flags]",
-		ShortHelp:  "[experimental] Create sandbox testers via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Create sandbox testers via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Create sandbox testers using App Store Connect's private web session endpoints.
-This command is intentionally detached from the official App Store Connect API
-because Apple does not expose sandbox tester creation there.
+Create sandbox testers using App Store Connect's web session endpoints.
+Use this command to create sandbox testers through App Store Connect web sessions.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -55,7 +54,7 @@ because Apple does not expose sandbox tester creation there.
 }
 
 // WebSandboxCreateCommand creates a sandbox tester via App Store Connect's
-// private web session endpoints.
+// web session endpoints.
 func WebSandboxCreateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web sandbox create", flag.ExitOnError)
 
@@ -70,10 +69,10 @@ func WebSandboxCreateCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "create",
 		ShortUsage: "asc web sandbox create --first-name NAME --last-name NAME --email EMAIL --password PASS --territory USA [flags]",
-		ShortHelp:  "[experimental] Create a sandbox tester via web API.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Create a sandbox tester via web API.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Create a sandbox tester through App Store Connect's private web API.
+Create a sandbox tester through App Store Connect's web API.
 The current web flow validates the name/email first, validates the password,
 then submits the create request with a 3-letter storefront code such as USA.
 Apple may still require email verification before the tester is usable.
@@ -85,7 +84,7 @@ Examples:
   asc web sandbox create --first-name "Jane" --last-name "Tester" --email "jane+sandbox@example.com" --password "Passwordtest1" --territory "USA"
   asc web sandbox create --first-name "Monthly" --last-name "Probe" --email "billing+monthly@example.com" --password "Passwordtest1" --territory "USA" --apple-id "user@example.com"
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_subscriptions.go
+++ b/internal/cli/web/web_subscriptions.go
@@ -41,12 +41,12 @@ func WebSubscriptionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "subscriptions",
 		ShortUsage: "asc web subscriptions <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage subscriptions via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage subscriptions via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage subscription workflows that App Store Connect exposes only through web-session endpoints.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -66,12 +66,12 @@ func WebSubscriptionsAvailabilityCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "availability",
 		ShortUsage: "asc web subscriptions availability <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage subscription sale availability via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage subscription sale availability via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage subscription sale availability through Apple's internal web API.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -97,8 +97,8 @@ func WebSubscriptionsAvailabilityRemoveFromSaleCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "remove-from-sale",
 		ShortUsage: "asc web subscriptions availability remove-from-sale --subscription-id SUB_ID --confirm [flags]",
-		ShortHelp:  "[experimental] Remove an auto-renewable subscription from sale.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Remove an auto-renewable subscription from sale.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Remove an approved auto-renewable subscription from sale using the same internal web API flow
 as App Store Connect. Apple allows this action only for Account Holder users.
@@ -108,7 +108,7 @@ Examples:
   asc web subscriptions availability remove-from-sale --app "APP_ID" --subscription-id "com.example.monthly" --confirm
   asc web subscriptions availability remove-from-sale --subscription-id "SUB_ID" --plan-availability-id "PLAN_AVAILABILITY_ID" --confirm
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_subscriptions_pricing.go
+++ b/internal/cli/web/web_subscriptions_pricing.go
@@ -53,12 +53,12 @@ func WebSubscriptionsPricingCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "pricing",
 		ShortUsage: "asc web subscriptions pricing <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage subscription pricing via web sessions.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage subscription pricing via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage subscription pricing through Apple's internal web API.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -78,12 +78,12 @@ func WebSubscriptionsPricingMonthlyCommitmentCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "monthly-commitment",
 		ShortUsage: "asc web subscriptions pricing monthly-commitment <subcommand> [flags]",
-		ShortHelp:  "[experimental] Bootstrap monthly-with-commitment pricing.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Bootstrap monthly-with-commitment pricing.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Bootstrap monthly-with-12-month-commitment pricing through Apple's internal web API.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -115,14 +115,14 @@ func WebSubscriptionsPricingMonthlyCommitmentBootstrapCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "bootstrap",
 		ShortUsage: "asc web subscriptions pricing monthly-commitment bootstrap --subscription-id SUB_ID --territory NOR (--upfront-price PRICE | --upfront-price-point-id ID) (--monthly-price PRICE | --monthly-price-point-id ID) [--dry-run | --confirm] [flags]",
-		ShortHelp:  "[experimental] Create monthly plan availability and paired prices.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Create monthly plan availability and paired prices.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Create MONTHLY plan availability, then attach paired UPFRONT and MONTHLY prices
-using the same private inline subscription PATCH as App Store Connect.
+using the same inline subscription PATCH as App Store Connect.
 
 Prefer asc subscriptions pricing monthly-commitment enable for normal setup.
-Use this private command only when you specifically need App Store Connect's
+Use this command when you specifically need App Store Connect's
 paired web pricing workflow or a paired scheduled price change.
 
 Prices may be supplied as exact customer prices or price point IDs. Use
@@ -130,7 +130,7 @@ Prices may be supplied as exact customer prices or price point IDs. Use
 applies only to scheduled changes. --dry-run performs all reads and price
 resolution but does not mutate App Store Connect.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -255,7 +255,7 @@ func WebSubscriptionsPricingAdjustedEqualizationsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web subscriptions pricing adjusted-equalizations", flag.ExitOnError)
 	return &ffcli.Command{
 		Name: "adjusted-equalizations", ShortUsage: "asc web subscriptions pricing adjusted-equalizations view [flags]",
-		ShortHelp: "[experimental] Inspect Apple's adjusted subscription price matrix.",
+		ShortHelp: "Inspect Apple's adjusted subscription price matrix.",
 		FlagSet:   fs, UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{WebSubscriptionsPricingAdjustedEqualizationsViewCommand()},
 		Exec:        func(ctx context.Context, args []string) error { return flag.ErrHelp },
@@ -272,7 +272,7 @@ func WebSubscriptionsPricingAdjustedEqualizationsViewCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "view",
 		ShortUsage: "asc web subscriptions pricing adjusted-equalizations view --price-point-id PRICE_POINT_ID [--plan-type MONTHLY] [flags]",
-		ShortHelp:  "[experimental] View a generated MONTHLY subscription price matrix.",
+		ShortHelp:  "View a generated MONTHLY subscription price matrix.",
 		FlagSet:    fs, UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
@@ -284,7 +284,7 @@ func WebSubscriptionsPricingAdjustedEqualizationsViewCommand() *ffcli.Command {
 				return shared.UsageError("--price-point-id is required")
 			}
 			if normalizedPlanType != "MONTHLY" {
-				return shared.UsageError(`--plan-type only supports "MONTHLY"; Apple's private endpoint rejects UPFRONT`)
+				return shared.UsageError(`--plan-type only supports "MONTHLY"; Apple's endpoint rejects UPFRONT`)
 			}
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()

--- a/internal/cli/web/web_xcode_cloud.go
+++ b/internal/cli/web/web_xcode_cloud.go
@@ -27,13 +27,13 @@ func WebXcodeCloudCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "xcode-cloud",
 		ShortUsage: "asc web xcode-cloud <subcommand> [flags]",
-		ShortHelp:  "[experimental] Xcode Cloud usage and workflow management.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Xcode Cloud usage and workflow management.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Query Xcode Cloud compute usage (plan quota, monthly/daily breakdowns, products)
-using Apple's private CI API. Requires a web session.
+using Apple's CI API. Requires a web session.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud usage summary --apple-id "user@example.com"
@@ -69,12 +69,12 @@ func webXcodeCloudUsageCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "usage",
 		ShortUsage: "asc web xcode-cloud usage <subcommand> [flags]",
-		ShortHelp:  "[experimental] Xcode Cloud usage queries.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Xcode Cloud usage queries.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Query Xcode Cloud compute usage: plan summary, monthly history, daily breakdown, per-workflow usage.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -98,12 +98,12 @@ func webXcodeCloudUsageSummaryCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "summary",
 		ShortUsage: "asc web xcode-cloud usage summary [flags]",
-		ShortHelp:  "[experimental] Show Xcode Cloud plan quota.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show Xcode Cloud plan quota.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show current Xcode Cloud plan usage: used/available/total compute minutes and reset date.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud usage summary --apple-id "user@example.com"
@@ -162,13 +162,13 @@ func webXcodeCloudUsageMonthsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "months",
 		ShortUsage: "asc web xcode-cloud usage months [flags]",
-		ShortHelp:  "[experimental] Show monthly Xcode Cloud usage.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show monthly Xcode Cloud usage.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show monthly Xcode Cloud compute usage with per-product breakdown.
 Defaults to the last 12 months. Use --product-ids to filter the product breakdown.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud usage months --apple-id "user@example.com"
@@ -254,14 +254,14 @@ func webXcodeCloudUsageDaysCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "days",
 		ShortUsage: "asc web xcode-cloud usage days --product-ids IDS [flags]",
-		ShortHelp:  "[experimental] Show daily Xcode Cloud usage for products.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show daily Xcode Cloud usage for products.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show daily Xcode Cloud compute usage for one or more products with per-workflow breakdown.
 The first product ID drives the daily/workflow tables; all product IDs are shown in the scope comparison table.
 Defaults to the last 30 days.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud usage days --product-ids "UUID" --apple-id "user@example.com"
@@ -382,15 +382,15 @@ func webXcodeCloudUsageWorkflowsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "workflows",
 		ShortUsage: "asc web xcode-cloud usage workflows --product-id ID [flags]",
-		ShortHelp:  "[experimental] Show per-workflow Xcode Cloud usage.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show per-workflow Xcode Cloud usage.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show Xcode Cloud compute usage broken down by workflow for a product.
 Without --workflow-id, lists all workflows and their usage.
 With --workflow-id, shows daily breakdown for that specific workflow.
 Defaults to the last 30 days.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud usage workflows --product-id "UUID" --apple-id "user@example.com" --output table
@@ -627,13 +627,13 @@ func webXcodeCloudProductsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "products",
 		ShortUsage: "asc web xcode-cloud products [flags]",
-		ShortHelp:  "[experimental] List Xcode Cloud products.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "List Xcode Cloud products.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 List Xcode Cloud products (apps) for the authenticated team.
 Use the product IDs with 'usage days' for per-product daily breakdowns.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud products --apple-id "user@example.com"

--- a/internal/cli/web/web_xcode_cloud_alert.go
+++ b/internal/cli/web/web_xcode_cloud_alert.go
@@ -151,8 +151,8 @@ func webXcodeCloudUsageAlertCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "alert",
 		ShortUsage: "asc web xcode-cloud usage alert [flags]",
-		ShortHelp:  "[experimental] Evaluate usage thresholds and send alerts.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Evaluate usage thresholds and send alerts.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Evaluate Xcode Cloud usage thresholds from plan quota, optionally include monthly trend context,
 and optionally notify Slack/webhook endpoints.
@@ -162,7 +162,7 @@ Exit behavior:
   - Exit 1 when severity meets --fail-on level (warning/critical)
   - Exit 2 for invalid flag usage
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud usage alert --apple-id "user@example.com"

--- a/internal/cli/web/web_xcode_cloud_envvars.go
+++ b/internal/cli/web/web_xcode_cloud_envvars.go
@@ -22,16 +22,16 @@ func webXcodeCloudEnvVarsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "env-vars",
 		ShortUsage: "asc web xcode-cloud env-vars <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage Xcode Cloud environment variables.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage Xcode Cloud environment variables.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Manage environment variables on Xcode Cloud workflows and products
-using Apple's private CI API. Requires a web session.
+using Apple's CI API. Requires a web session.
 
 Use list/set/delete for workflow-scoped variables.
 Use "shared" subcommand for product-level shared variables.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars list --product-id "UUID" --workflow-id "WF-UUID" --apple-id "user@example.com"
@@ -87,13 +87,13 @@ func webXcodeCloudEnvVarsListCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc web xcode-cloud env-vars list --product-id ID --workflow-id ID [flags]",
-		ShortHelp:  "[experimental] List workflow environment variables.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "List workflow environment variables.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 List environment variables for an Xcode Cloud workflow.
 Plaintext variables show their values; secret variables show "(redacted)".
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars list --product-id "UUID" --workflow-id "WF-UUID" --apple-id "user@example.com"
@@ -170,14 +170,14 @@ func webXcodeCloudEnvVarsSetCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "set",
 		ShortUsage: "asc web xcode-cloud env-vars set --product-id ID --workflow-id ID --name NAME --value VALUE [--secret] [flags]",
-		ShortHelp:  "[experimental] Set a workflow environment variable.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Set a workflow environment variable.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Set (create or update) an environment variable on an Xcode Cloud workflow.
 Use --secret to encrypt the value using ECIES (the same scheme as the ASC web UI).
 If a variable with the same name already exists, it will be updated.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars set --product-id "UUID" --workflow-id "WF-UUID" --name MY_VAR --value hello --apple-id "user@example.com"
@@ -314,12 +314,12 @@ func webXcodeCloudEnvVarsDeleteCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "delete",
 		ShortUsage: "asc web xcode-cloud env-vars delete --product-id ID --workflow-id ID --name NAME --confirm [flags]",
-		ShortHelp:  "[experimental] Delete a workflow environment variable.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Delete a workflow environment variable.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Delete an environment variable from an Xcode Cloud workflow by name.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars delete --product-id "UUID" --workflow-id "WF-UUID" --name MY_VAR --confirm --apple-id "user@example.com"`,

--- a/internal/cli/web/web_xcode_cloud_shared_envvars.go
+++ b/internal/cli/web/web_xcode_cloud_shared_envvars.go
@@ -20,15 +20,15 @@ func webXcodeCloudEnvVarsSharedCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "shared",
 		ShortUsage: "asc web xcode-cloud env-vars shared <subcommand> [flags]",
-		ShortHelp:  "[experimental] Manage shared (product-level) environment variables.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Manage shared (product-level) environment variables.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 List, set, and delete shared (product-level) environment variables for
-Xcode Cloud products using Apple's private CI API. Requires a web session.
+Xcode Cloud products using Apple's CI API. Requires a web session.
 
 Shared env vars are scoped to a product and can be linked to specific workflows.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars shared list --product-id "UUID" --apple-id "user@example.com"
@@ -79,13 +79,13 @@ func webXcodeCloudEnvVarsSharedListCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc web xcode-cloud env-vars shared list --product-id ID [flags]",
-		ShortHelp:  "[experimental] List shared (product-level) environment variables.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "List shared (product-level) environment variables.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 List shared environment variables for an Xcode Cloud product.
 Plaintext variables show their values; secret variables show "(redacted)".
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars shared list --product-id "UUID" --apple-id "user@example.com"
@@ -154,8 +154,8 @@ func webXcodeCloudEnvVarsSharedSetCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "set",
 		ShortUsage: "asc web xcode-cloud env-vars shared set --product-id ID --name NAME --value VALUE [--secret] [--locked] [--workflow-ids IDS] [flags]",
-		ShortHelp:  "[experimental] Set a shared (product-level) environment variable.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Set a shared (product-level) environment variable.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Set (create or update) a shared environment variable on an Xcode Cloud product.
 Use --secret to encrypt the value (the same scheme as the ASC web UI).
@@ -163,7 +163,7 @@ Use --locked to restrict editing of this variable.
 Use --workflow-ids to link the variable to specific workflows.
 If a variable with the same name already exists, it will be updated.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars shared set --product-id "UUID" --name MY_VAR --value hello --apple-id "user@example.com"
@@ -295,12 +295,12 @@ func webXcodeCloudEnvVarsSharedDeleteCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "delete",
 		ShortUsage: "asc web xcode-cloud env-vars shared delete --product-id ID --name NAME --confirm [flags]",
-		ShortHelp:  "[experimental] Delete a shared (product-level) environment variable.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Delete a shared (product-level) environment variable.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Delete a shared environment variable from an Xcode Cloud product by name.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud env-vars shared delete --product-id "UUID" --name MY_VAR --confirm --apple-id "user@example.com"`,

--- a/internal/cli/web/web_xcode_cloud_workflow_options.go
+++ b/internal/cli/web/web_xcode_cloud_workflow_options.go
@@ -38,15 +38,15 @@ func webXcodeCloudWorkflowOptionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "options",
 		ShortUsage: "asc web xcode-cloud workflows options <subcommand> [flags]",
-		ShortHelp:  "[experimental] Inspect private workflow editor option endpoints.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Inspect workflow editor option endpoints.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Inspect Xcode Cloud workflow editor option endpoints from Apple's private CI API.
+Inspect Xcode Cloud workflow editor option endpoints from Apple's CI API.
 These endpoints surface UI-driven data such as team workflow defaults, product
 configuration recommendations, schemes, test destinations, and Slack notification
 targets. JSON output only.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows options team-config --apple-id "user@example.com"
@@ -79,13 +79,13 @@ func webXcodeCloudWorkflowOptionsTeamConfigCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "team-config",
 		ShortUsage: "asc web xcode-cloud workflows options team-config [flags]",
-		ShortHelp:  "[experimental] Show team workflow editor configuration.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show team workflow editor configuration.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show team-level workflow editor configuration, including available platforms
 and default timezone settings. JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -111,13 +111,13 @@ func webXcodeCloudWorkflowOptionsBuildVersionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "build-versions",
 		ShortUsage: "asc web xcode-cloud workflows options build-versions [flags]",
-		ShortHelp:  "[experimental] Show workflow build version defaults.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show workflow build version defaults.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
-Show workflow build version defaults/options exposed by the private CI API.
+Show workflow build version defaults/options exposed by the CI API.
 JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -144,13 +144,13 @@ func webXcodeCloudWorkflowOptionsProductConfigCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "product-config",
 		ShortUsage: "asc web xcode-cloud workflows options product-config --product-id ID [flags]",
-		ShortHelp:  "[experimental] Show product workflow configuration options.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show product workflow configuration options.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show product-level workflow configuration options, such as repository defaults
 and container file path recommendations. JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -186,13 +186,13 @@ func webXcodeCloudWorkflowOptionsSchemesCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "schemes",
 		ShortUsage: "asc web xcode-cloud workflows options schemes --product-id ID [flags]",
-		ShortHelp:  "[experimental] Show available workflow schemes.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show available workflow schemes.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show available schemes and test plans for a product's container file paths.
 JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -229,12 +229,12 @@ func webXcodeCloudWorkflowOptionsTestDestinationsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "test-destinations",
 		ShortUsage: "asc web xcode-cloud workflows options test-destinations --xcode-version VALUE [flags]",
-		ShortHelp:  "[experimental] Show workflow test destination options.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show workflow test destination options.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show workflow test destination options for a given Xcode version. JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -266,13 +266,13 @@ func webXcodeCloudWorkflowOptionsSlackProviderCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "slack-provider",
 		ShortUsage: "asc web xcode-cloud workflows options slack-provider [flags]",
-		ShortHelp:  "[experimental] Show Slack workflow notification integration state.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show Slack workflow notification integration state.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show Slack integration state used by workflow notification post-actions.
 JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -298,13 +298,13 @@ func webXcodeCloudWorkflowOptionsSlackChannelsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "slack-channels",
 		ShortUsage: "asc web xcode-cloud workflows options slack-channels [flags]",
-		ShortHelp:  "[experimental] Show Slack channels available to workflow notifications.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show Slack channels available to workflow notifications.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show Slack channels available for workflow notification post-actions.
 JSON output only.
 
-` + webWarningText,
+`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/web_xcode_cloud_workflows.go
+++ b/internal/cli/web/web_xcode_cloud_workflows.go
@@ -23,19 +23,19 @@ func webXcodeCloudWorkflowsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "workflows",
 		ShortUsage: "asc web xcode-cloud workflows <subcommand> [flags]",
-		ShortHelp:  "[experimental] Describe, create, and edit Xcode Cloud workflows.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Describe, create, and edit Xcode Cloud workflows.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Describe and manage workflow state for Xcode Cloud workflows
-using Apple's private CI API. Requires a web session.
+using Apple's CI API. Requires a web session.
 
 Use describe to inspect workflow configuration.
-Use create to create a workflow from a full private workflow payload.
-Use options to inspect the private editor option payloads.
-Use edit to apply a JSON merge patch to the private workflow payload.
+Use create to create a workflow from a full workflow payload.
+Use options to inspect the editor option payloads.
+Use edit to apply a JSON merge patch to the workflow payload.
 Use enable/disable to toggle workflow state.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows describe --product-id "UUID" --workflow-id "WF-UUID" --apple-id "user@example.com"
@@ -113,13 +113,13 @@ func webXcodeCloudWorkflowDescribeCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "describe",
 		ShortUsage: "asc web xcode-cloud workflows describe --product-id ID --workflow-id ID [flags]",
-		ShortHelp:  "[experimental] Show workflow configuration.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Show workflow configuration.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Show workflow configuration for a specific Xcode Cloud workflow.
 Includes state, toolchain versions, triggers, actions, and linked shared env vars.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows describe --product-id "UUID" --workflow-id "WF-UUID" --apple-id "user@example.com"
@@ -193,15 +193,15 @@ func webXcodeCloudWorkflowCreateCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "create",
 		ShortUsage: "asc web xcode-cloud workflows create --product-id ID --file ./workflow.json [--workflow-id ID] [flags]",
-		ShortHelp:  "[experimental] Create a workflow from a full private payload.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Create a workflow from a full payload.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Create an Xcode Cloud workflow by sending a full workflow payload to the
-private workflow save endpoint used by the ASC web UI.
+workflow save endpoint used by the ASC web UI.
 
 If --workflow-id is omitted, a UUID is generated automatically.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows create --product-id "UUID" --file ./workflow.json --apple-id "user@example.com"
@@ -298,16 +298,16 @@ func webXcodeCloudWorkflowEditCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "edit",
 		ShortUsage: "asc web xcode-cloud workflows edit --product-id ID --workflow-id ID --patch-file ./workflow.patch.json [flags]",
-		ShortHelp:  "[experimental] Edit a workflow with a JSON merge patch.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Edit a workflow with a JSON merge patch.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Edit an Xcode Cloud workflow by applying a JSON merge patch to the
-private workflow content returned by the ASC web UI.
+workflow content returned by the ASC web UI.
 Unspecified fields are preserved. For string fields such as description,
-prefer explicit empty values when clearing content because Apple's private
-workflow API does not consistently accept null removals.
+prefer explicit empty values when clearing content because Apple's workflow
+API does not consistently accept null removals.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows edit --product-id "UUID" --workflow-id "WF-UUID" --patch-file ./workflow.patch.json --apple-id "user@example.com"`,
@@ -407,13 +407,13 @@ func webXcodeCloudWorkflowEnableCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "enable",
 		ShortUsage: "asc web xcode-cloud workflows enable --product-id ID --workflow-id ID [flags]",
-		ShortHelp:  "[experimental] Enable a workflow.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Enable a workflow.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Enable an Xcode Cloud workflow by setting disabled=false.
 If already enabled, this command reports no change and exits successfully.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows enable --product-id "UUID" --workflow-id "WF-UUID" --apple-id "user@example.com"`,
@@ -459,14 +459,14 @@ func webXcodeCloudWorkflowDisableCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "disable",
 		ShortUsage: "asc web xcode-cloud workflows disable --product-id ID --workflow-id ID --confirm [flags]",
-		ShortHelp:  "[experimental] Disable a workflow.",
-		LongHelp: `EXPERIMENTAL / UNOFFICIAL / DISCOURAGED
+		ShortHelp:  "Disable a workflow.",
+		LongHelp: `WEB SESSION WORKFLOWS
 
 Disable an Xcode Cloud workflow by setting disabled=true.
 Requires --confirm.
 If already disabled, this command reports no change and exits successfully.
 
-` + webWarningText + `
+
 
 Examples:
   asc web xcode-cloud workflows disable --product-id "UUID" --workflow-id "WF-UUID" --confirm --apple-id "user@example.com"`,


### PR DESCRIPTION
## Summary
- Promote the `asc web` command family out of the experimental tier into `WEB SESSION COMMANDS`.
- Remove experimental/unofficial/discouraged/private-endpoint warning copy from web command help and docs.
- Rename capability status output from `experimental-web` to `web-session` and update tests/docs accordingly.

## Validation
- `make format`
- `make check-docs`
- `make lint` (0 issues; emitted a stale-path warning for an old sibling worktree)
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/web`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'Test(Web|RootUsage|Experimental|Run_Capabilities|AvailabilitySet)'`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Smoke checked `./asc web --help` and `./asc capabilities --output json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated CLI help and command grouping so `web` is now presented as “Web Session Commands” with clearer, more consistent descriptions.
* **Bug Fixes**
  * Removed outdated experimental/unofficial/discouraged wording from `web`-related help, usage, and reference output.
  * Improved guidance for session handling, pricing, availability, auth, and workflow commands.
* **Documentation**
  * Aligned command docs, guides, and release notes with the new web-session terminology and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->