### PR TITLE
[codex] Add web app delete command

### DIFF
--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -49,6 +49,13 @@ func TestWebAppsCreateSubcommandIsRegistered(t *testing.T) {
 	}
 }
 
+func TestWebAppsDeleteSubcommandIsRegistered(t *testing.T) {
+	root := RootCommand("1.2.3")
+	if sub := findSubcommand(root, "web", "apps", "delete"); sub == nil {
+		t.Fatalf("expected web apps delete to be registered")
+	}
+}
+
 func TestWebAppsMedicalDeviceSetSubcommandIsRegistered(t *testing.T) {
 	root := RootCommand("1.2.3")
 	if sub := findSubcommand(root, "web", "apps", "medical-device", "set"); sub == nil {

--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -32,6 +32,7 @@ Use ` + "`asc web apps create`" + ` as the canonical app-creation command.
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			WebAppsCreateCommand(),
+			WebAppsDeleteCommand(),
 			WebAppsAvailabilityCommand(),
 			WebAppsCompatibilityCommand(),
 			WebAppsMedicalDeviceCommand(),
@@ -50,6 +51,15 @@ var (
 	deleteBundleIDFn = deleteBundleIDByIdentifier
 	createWebAppFn   = func(ctx context.Context, client *webcore.Client, attrs webcore.AppCreateAttributes) (*webcore.AppResponse, error) {
 		return client.CreateApp(ctx, attrs)
+	}
+	findWebAppFn = func(ctx context.Context, client *webcore.Client, bundleID string) (*webcore.AppResponse, error) {
+		return client.FindApp(ctx, bundleID)
+	}
+	getWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		return client.GetApp(ctx, appID)
+	}
+	deleteWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		return client.DeleteApp(ctx, appID)
 	}
 )
 

--- a/internal/cli/web/web_apps_delete.go
+++ b/internal/cli/web/web_apps_delete.go
@@ -177,9 +177,9 @@ func webAppDeleteResultFromResponse(appID string, deleted, fallback *webcore.App
 	if source != nil {
 		result.Name = webAppAttrString(source, "name")
 		result.BundleID = webAppAttrString(source, "bundleId")
-		if removed, ok := webAppAttrBool(source, "removed"); ok {
-			result.Removed = removed
-		}
+	}
+	if removed, ok := webAppAttrBool(deleted, "removed"); ok {
+		result.Removed = removed
 	}
 	return result
 }

--- a/internal/cli/web/web_apps_delete.go
+++ b/internal/cli/web/web_apps_delete.go
@@ -1,0 +1,234 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+type webAppDeleteResult struct {
+	AppID    string `json:"appId"`
+	Name     string `json:"name,omitempty"`
+	BundleID string `json:"bundleId,omitempty"`
+	Removed  bool   `json:"removed"`
+}
+
+// WebAppsDeleteCommand removes apps using the internal web API.
+func WebAppsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web apps delete", flag.ExitOnError)
+
+	app := fs.String("app", "", "App Store Connect app ID or exact bundle ID")
+	expectedBundleID := fs.String("expected-bundle-id", "", "Require the app bundle ID to match before deleting")
+	expectedName := fs.String("expected-name", "", "Require the app name to match before deleting")
+	confirm := fs.Bool("confirm", false, "Confirm deleting this app")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "asc web apps delete --app APP_ID_OR_BUNDLE_ID --confirm [flags]",
+		ShortHelp:  "Delete an app via Apple web API.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+Delete an app through Apple's web API using a web-session login.
+
+The public App Store Connect API does not expose app deletion. This command uses
+the same web-session PATCH observed from App Store Connect: it marks the app
+resource as removed. Pass an explicit App Store Connect app ID, or an exact
+bundle ID for a web API lookup before deletion. Exact identity guard flags can
+be used to stop before mutation if the resolved app is not the one expected.
+
+Examples:
+  asc web apps delete --app "1234567890" --confirm
+  asc web apps delete --app "com.example.throwaway" --confirm
+  asc web apps delete --app "1234567890" --expected-bundle-id "com.example.throwaway" --confirm
+  asc web apps delete --app "1234567890" --expected-name "Throwaway" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web apps delete does not accept positional arguments")
+			}
+
+			selector := strings.TrimSpace(*app)
+			wantBundleID := strings.TrimSpace(*expectedBundleID)
+			wantName := strings.TrimSpace(*expectedName)
+			switch {
+			case selector == "":
+				return shared.UsageError("--app is required")
+			case !*confirm:
+				return shared.UsageError("--confirm is required")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			appID, loaded, err := resolveWebAppDeleteTarget(requestCtx, client, selector)
+			if err != nil {
+				return err
+			}
+
+			if wantBundleID != "" || wantName != "" {
+				if loaded == nil || loaded.Data.Attributes == nil {
+					loaded, err = getWebAppFn(requestCtx, client, appID)
+					if err != nil {
+						return withWebAuthHint(err, "web apps delete")
+					}
+				}
+				if err := validateWebAppDeleteGuards(loaded, wantBundleID, wantName); err != nil {
+					return err
+				}
+			}
+
+			deleted, err := deleteWebAppFn(requestCtx, client, appID)
+			if err != nil {
+				return withWebAuthHint(err, "web apps delete")
+			}
+
+			result := webAppDeleteResultFromResponse(appID, deleted, loaded)
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderWebAppDeleteTable(result) },
+				func() error { return renderWebAppDeleteMarkdown(result) },
+			)
+		},
+	}
+}
+
+func resolveWebAppDeleteTarget(ctx context.Context, client *webcore.Client, selector string) (string, *webcore.AppResponse, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return "", nil, fmt.Errorf("app selector is required")
+	}
+	if shared.IsNumericAppID(selector) {
+		return selector, nil, nil
+	}
+
+	app, err := findWebAppFn(ctx, client, selector)
+	if err != nil {
+		return "", nil, withWebAuthHint(err, "web apps delete")
+	}
+	if app == nil || strings.TrimSpace(app.Data.ID) == "" {
+		return "", nil, fmt.Errorf("web apps delete failed: app %q not found by exact bundle ID; pass the App Store Connect app ID", selector)
+	}
+	actualBundleID := webAppAttrString(app, "bundleId")
+	if actualBundleID == "" {
+		return "", nil, fmt.Errorf("web apps delete failed: Apple did not return a bundle ID for app %q; pass the App Store Connect app ID", selector)
+	}
+	if actualBundleID != selector {
+		return "", nil, fmt.Errorf("web apps delete failed: exact bundle ID lookup for %q returned %q; pass the App Store Connect app ID", selector, actualBundleID)
+	}
+	return strings.TrimSpace(app.Data.ID), app, nil
+}
+
+func validateWebAppDeleteGuards(app *webcore.AppResponse, expectedBundleID, expectedName string) error {
+	if app == nil {
+		return fmt.Errorf("web apps delete failed: app identity could not be loaded")
+	}
+	if expectedBundleID != "" {
+		actual := webAppAttrString(app, "bundleId")
+		if actual == "" {
+			return fmt.Errorf("web apps delete failed: expected bundle ID %q, but Apple did not return a bundle ID for app %q", expectedBundleID, strings.TrimSpace(app.Data.ID))
+		}
+		if actual != expectedBundleID {
+			return fmt.Errorf("web apps delete failed: expected bundle ID %q, got %q for app %q", expectedBundleID, actual, strings.TrimSpace(app.Data.ID))
+		}
+	}
+	if expectedName != "" {
+		actual := webAppAttrString(app, "name")
+		if actual == "" {
+			return fmt.Errorf("web apps delete failed: expected name %q, but Apple did not return a name for app %q", expectedName, strings.TrimSpace(app.Data.ID))
+		}
+		if actual != expectedName {
+			return fmt.Errorf("web apps delete failed: expected name %q, got %q for app %q", expectedName, actual, strings.TrimSpace(app.Data.ID))
+		}
+	}
+	return nil
+}
+
+func webAppDeleteResultFromResponse(appID string, deleted, fallback *webcore.AppResponse) webAppDeleteResult {
+	source := deleted
+	if source == nil || source.Data.Attributes == nil {
+		source = fallback
+	}
+
+	result := webAppDeleteResult{
+		AppID:   strings.TrimSpace(appID),
+		Removed: true,
+	}
+	if deleted != nil && strings.TrimSpace(deleted.Data.ID) != "" {
+		result.AppID = strings.TrimSpace(deleted.Data.ID)
+	}
+	if source != nil {
+		result.Name = webAppAttrString(source, "name")
+		result.BundleID = webAppAttrString(source, "bundleId")
+		if removed, ok := webAppAttrBool(source, "removed"); ok {
+			result.Removed = removed
+		}
+	}
+	return result
+}
+
+func webAppAttrString(app *webcore.AppResponse, key string) string {
+	if app == nil || app.Data.Attributes == nil {
+		return ""
+	}
+	value, ok := app.Data.Attributes[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func webAppAttrBool(app *webcore.AppResponse, key string) (bool, bool) {
+	if app == nil || app.Data.Attributes == nil {
+		return false, false
+	}
+	switch value := app.Data.Attributes[key].(type) {
+	case bool:
+		return value, true
+	case string:
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "true" {
+			return true, true
+		}
+		if normalized == "false" {
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func webAppDeleteRows(result webAppDeleteResult) [][]string {
+	return [][]string{{
+		result.AppID,
+		result.Name,
+		result.BundleID,
+		fmt.Sprintf("%t", result.Removed),
+	}}
+}
+
+func renderWebAppDeleteTable(result webAppDeleteResult) error {
+	asc.RenderTable([]string{"App ID", "Name", "Bundle ID", "Removed"}, webAppDeleteRows(result))
+	return nil
+}
+
+func renderWebAppDeleteMarkdown(result webAppDeleteResult) error {
+	asc.RenderMarkdown([]string{"App ID", "Name", "Bundle ID", "Removed"}, webAppDeleteRows(result))
+	return nil
+}

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -1258,6 +1258,35 @@ func TestWebAppsDeleteByBundleID(t *testing.T) {
 	}
 }
 
+func TestWebAppsDeleteResultKeepsRemovedTrueWhenDeleteResponseOmitsAttributes(t *testing.T) {
+	deleted := &webcore.AppResponse{}
+	deleted.Data.ID = "1234567890"
+	deleted.Data.Type = "apps"
+
+	fallback := &webcore.AppResponse{}
+	fallback.Data.ID = "1234567890"
+	fallback.Data.Type = "apps"
+	fallback.Data.Attributes = map[string]any{
+		"name":     "Throwaway",
+		"bundleId": "com.example.throwaway",
+		"removed":  false,
+	}
+
+	result := webAppDeleteResultFromResponse("1234567890", deleted, fallback)
+	if result.AppID != "1234567890" {
+		t.Fatalf("expected app ID from delete response, got %q", result.AppID)
+	}
+	if result.Name != "Throwaway" {
+		t.Fatalf("expected fallback name, got %q", result.Name)
+	}
+	if result.BundleID != "com.example.throwaway" {
+		t.Fatalf("expected fallback bundle ID, got %q", result.BundleID)
+	}
+	if !result.Removed {
+		t.Fatal("expected removed to stay true when delete response omits attributes")
+	}
+}
+
 func TestWebAppsDeleteBundleIDLookupMismatchStopsBeforeDelete(t *testing.T) {
 	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
 		return &webcore.AuthSession{}, "cache", nil

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -1298,7 +1298,16 @@ func TestWebAppsDeleteBundleIDLookupMismatchStopsBeforeDelete(t *testing.T) {
 		t.Fatalf("parse error: %v", err)
 	}
 
-	err := cmd.Exec(context.Background(), nil)
+	var err error
+	stdout, stderr := captureOutput(t, func() {
+		err = cmd.Exec(context.Background(), nil)
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
 	if err == nil {
 		t.Fatal("expected bundle lookup mismatch error")
 	}
@@ -1348,7 +1357,16 @@ func TestWebAppsDeleteExpectedBundleIDMismatchStopsBeforeDelete(t *testing.T) {
 		t.Fatalf("parse error: %v", err)
 	}
 
-	err := cmd.Exec(context.Background(), nil)
+	var err error
+	stdout, stderr := captureOutput(t, func() {
+		err = cmd.Exec(context.Background(), nil)
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
 	if err == nil {
 		t.Fatal("expected guard mismatch error")
 	}
@@ -1370,7 +1388,16 @@ func TestWebAppsDeleteRequiresConfirmBeforeResolvingSession(t *testing.T) {
 		t.Fatalf("parse error: %v", err)
 	}
 
-	err := cmd.Exec(context.Background(), nil)
+	var err error
+	stdout, stderr := captureOutput(t, func() {
+		err = cmd.Exec(context.Background(), nil)
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("expected confirm stderr, got %q", stderr)
+	}
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected usage error, got %v", err)
 	}

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -1179,3 +1179,205 @@ func TestBundleIDPlatformForWebApp(t *testing.T) {
 		}
 	})
 }
+
+func TestWebAppsDeleteByBundleID(t *testing.T) {
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	origNewWebClient := newWebClientFn
+	origFindWebApp := findWebAppFn
+	origGetWebApp := getWebAppFn
+	origDeleteWebApp := deleteWebAppFn
+	t.Cleanup(func() {
+		restoreSession()
+		newWebClientFn = origNewWebClient
+		findWebAppFn = origFindWebApp
+		getWebAppFn = origGetWebApp
+		deleteWebAppFn = origDeleteWebApp
+	})
+
+	var deletedID string
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	findWebAppFn = func(ctx context.Context, client *webcore.Client, bundleID string) (*webcore.AppResponse, error) {
+		if bundleID != "com.example.throwaway" {
+			t.Fatalf("expected bundle ID lookup, got %q", bundleID)
+		}
+		resp := &webcore.AppResponse{}
+		resp.Data.ID = "1234567890"
+		resp.Data.Type = "apps"
+		resp.Data.Attributes = map[string]any{
+			"name":     "Throwaway",
+			"bundleId": "com.example.throwaway",
+		}
+		return resp, nil
+	}
+	getWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		t.Fatal("did not expect app get when bundle lookup already loaded attributes")
+		return nil, nil
+	}
+	deleteWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		deletedID = appID
+		resp := &webcore.AppResponse{}
+		resp.Data.ID = appID
+		resp.Data.Type = "apps"
+		resp.Data.Attributes = map[string]any{
+			"name":     "Throwaway",
+			"bundleId": "com.example.throwaway",
+			"removed":  true,
+		}
+		return resp, nil
+	}
+
+	cmd := WebAppsDeleteCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "com.example.throwaway",
+		"--expected-bundle-id", "com.example.throwaway",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if deletedID != "1234567890" {
+		t.Fatalf("expected deleted app ID, got %q", deletedID)
+	}
+	for _, want := range []string{`"appId":"1234567890"`, `"bundleId":"com.example.throwaway"`, `"removed":true`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected stdout to contain %s, got %q", want, stdout)
+		}
+	}
+}
+
+func TestWebAppsDeleteBundleIDLookupMismatchStopsBeforeDelete(t *testing.T) {
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	origNewWebClient := newWebClientFn
+	origFindWebApp := findWebAppFn
+	origDeleteWebApp := deleteWebAppFn
+	t.Cleanup(func() {
+		restoreSession()
+		newWebClientFn = origNewWebClient
+		findWebAppFn = origFindWebApp
+		deleteWebAppFn = origDeleteWebApp
+	})
+
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	findWebAppFn = func(ctx context.Context, client *webcore.Client, bundleID string) (*webcore.AppResponse, error) {
+		resp := &webcore.AppResponse{}
+		resp.Data.ID = "1234567890"
+		resp.Data.Type = "apps"
+		resp.Data.Attributes = map[string]any{
+			"name":     "Wrong App",
+			"bundleId": "com.example.actual",
+		}
+		return resp, nil
+	}
+	deleteWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		t.Fatal("did not expect delete after bundle lookup mismatch")
+		return nil, nil
+	}
+
+	cmd := WebAppsDeleteCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "com.example.expected",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected bundle lookup mismatch error")
+	}
+	if !strings.Contains(err.Error(), `exact bundle ID lookup for "com.example.expected" returned "com.example.actual"`) {
+		t.Fatalf("expected lookup mismatch error, got %v", err)
+	}
+}
+
+func TestWebAppsDeleteExpectedBundleIDMismatchStopsBeforeDelete(t *testing.T) {
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	origNewWebClient := newWebClientFn
+	origGetWebApp := getWebAppFn
+	origDeleteWebApp := deleteWebAppFn
+	t.Cleanup(func() {
+		restoreSession()
+		newWebClientFn = origNewWebClient
+		getWebAppFn = origGetWebApp
+		deleteWebAppFn = origDeleteWebApp
+	})
+
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	getWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		resp := &webcore.AppResponse{}
+		resp.Data.ID = appID
+		resp.Data.Type = "apps"
+		resp.Data.Attributes = map[string]any{
+			"name":     "Throwaway",
+			"bundleId": "com.example.actual",
+		}
+		return resp, nil
+	}
+	deleteWebAppFn = func(ctx context.Context, client *webcore.Client, appID string) (*webcore.AppResponse, error) {
+		t.Fatal("did not expect delete after identity guard mismatch")
+		return nil, nil
+	}
+
+	cmd := WebAppsDeleteCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "1234567890",
+		"--expected-bundle-id", "com.example.expected",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected guard mismatch error")
+	}
+	if !strings.Contains(err.Error(), `expected bundle ID "com.example.expected"`) {
+		t.Fatalf("expected bundle mismatch error, got %v", err)
+	}
+}
+
+func TestWebAppsDeleteRequiresConfirmBeforeResolvingSession(t *testing.T) {
+	resolveCalled := false
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		resolveCalled = true
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	cmd := WebAppsDeleteCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", "1234567890"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "--confirm is required") {
+		t.Fatalf("expected confirm error, got %v", err)
+	}
+	if resolveCalled {
+		t.Fatal("did not expect session resolution before confirm validation")
+	}
+}

--- a/internal/web/apps.go
+++ b/internal/web/apps.go
@@ -60,6 +60,16 @@ type appCreateRequest struct {
 	Included []any `json:"included"`
 }
 
+type appDeleteRequest struct {
+	Data struct {
+		Type       string `json:"type"`
+		ID         string `json:"id"`
+		Attributes struct {
+			Removed bool `json:"removed"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
 func normalizeCreateAttrs(attrs AppCreateAttributes) (AppCreateAttributes, error) {
 	attrs.Name = strings.TrimSpace(attrs.Name)
 	attrs.SKU = strings.TrimSpace(attrs.SKU)
@@ -203,6 +213,53 @@ func (c *Client) CreateApp(ctx context.Context, attrs AppCreateAttributes) (*App
 	var result AppResponse
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse app response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetApp retrieves an app by ID using the internal web API.
+func (c *Client) GetApp(ctx context.Context, appID string) (*AppResponse, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, fmt.Errorf("app id is required")
+	}
+
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/apps/%s", url.PathEscape(appID)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result AppResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse app response: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteApp marks an app as removed with the internal App Store Connect web API.
+func (c *Client) DeleteApp(ctx context.Context, appID string) (*AppResponse, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, fmt.Errorf("app id is required")
+	}
+
+	req := &appDeleteRequest{}
+	req.Data.Type = "apps"
+	req.Data.ID = appID
+	req.Data.Attributes.Removed = true
+
+	respBody, err := c.doRequest(ctx, "PATCH", fmt.Sprintf("/apps/%s", url.PathEscape(appID)), req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result AppResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse app response: %w", err)
+	}
+	if strings.TrimSpace(result.Data.ID) == "" {
+		result.Data.ID = appID
+		result.Data.Type = "apps"
 	}
 	return &result, nil
 }

--- a/internal/web/apps_test.go
+++ b/internal/web/apps_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -90,5 +91,52 @@ func TestFindAppEscapesBundleIDQuery(t *testing.T) {
 	}
 	if !strings.Contains(gotRawQuery, "filter%5BbundleId%5D=") && !strings.Contains(gotRawQuery, "filter[bundleId]=") {
 		t.Fatalf("expected bundleId filter query, got %q", gotRawQuery)
+	}
+}
+
+func TestDeleteAppSendsRemovedPatch(t *testing.T) {
+	var gotMethod, gotPath, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":{"type":"apps","id":"1234567890","attributes":{"name":"Throwaway","bundleId":"com.example.throwaway","removed":true}}}`))
+	}))
+	defer server.Close()
+
+	client := &Client{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+	}
+	app, err := client.DeleteApp(context.Background(), "1234567890")
+	if err != nil {
+		t.Fatalf("DeleteApp error: %v", err)
+	}
+	if gotMethod != http.MethodPatch {
+		t.Fatalf("expected PATCH, got %s", gotMethod)
+	}
+	if gotPath != "/apps/1234567890" {
+		t.Fatalf("expected /apps/1234567890, got %s", gotPath)
+	}
+	for _, want := range []string{
+		`"type":"apps"`,
+		`"id":"1234567890"`,
+		`"removed":true`,
+	} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("expected request body to contain %s, got %s", want, gotBody)
+		}
+	}
+	if app == nil || app.Data.ID != "1234567890" {
+		t.Fatalf("expected app response id, got %+v", app)
+	}
+}
+
+func TestDeleteAppRequiresID(t *testing.T) {
+	client := &Client{}
+	if _, err := client.DeleteApp(context.Background(), "  "); err == nil {
+		t.Fatal("expected missing app id error")
 	}
 }


### PR DESCRIPTION
## Summary

Adds a guarded `asc web apps delete` command for removing throwaway App Store Connect apps through the web-session API.

## What changed

- Added web client support for `GET /apps/{id}` and the observed web-session delete shape: `PATCH /apps/{id}` with `attributes.removed = true`.
- Added `asc web apps delete --app APP_ID_OR_BUNDLE_ID --confirm` under the existing web apps command group.
- Added exact identity guard flags, `--expected-bundle-id` and `--expected-name`, so destructive calls can stop before mutation when the resolved app is not the intended target.
- Added CLI and HTTP coverage for confirm gating, exact bundle-ID lookup, identity mismatch behavior, command registration, and the outgoing PATCH payload.

## Behavior

Examples:

```bash
asc web apps delete --app "1234567890" --confirm
asc web apps delete --app "com.example.throwaway" --confirm
asc web apps delete --app "1234567890" --expected-bundle-id "com.example.throwaway" --confirm
```

The command does not use ambient `ASC_APP_ID` fallback. Numeric `--app` values are treated as explicit App Store Connect app IDs; non-numeric values resolve via exact bundle ID lookup.

## Validation

- `git diff --check`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/web ./internal/cli/web ./internal/cli/cmdtest`
- `make check-docs`
- pre-commit hook on each commit: command docs, formatting, lint, and short test suite
- Live web-session smoke: command returned `removed: true` for disposable throwaway apps and follow-up `asc apps list --paginate` no longer returned those app IDs

Note: lint passed with `0 issues`; golangci-lint printed a stale cache warning referencing an unrelated deleted local worktree path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `web apps delete` to the CLI for removing apps.
  * Supports lookup by app ID or bundle ID, includes guardrails (`--expected-bundle-id`, `--expected-name`) and requires `--confirm`.
  * Outputs structured results (including `removed:true`) and renders in table/markdown formats.

* **Bug Fixes**
  * Deletion now halts before making API calls when lookups/guards don’t match or when `--confirm` is missing.

* **Tests**
  * Added unit tests for command registration, deletion behavior, guard/confirmation enforcement, and correct handling when delete responses omit attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->