### PR TITLE
[codex] Add web removed apps list command

### DIFF
--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -49,6 +49,13 @@ func TestWebAppsCreateSubcommandIsRegistered(t *testing.T) {
 	}
 }
 
+func TestWebRemovedAppsListSubcommandIsRegistered(t *testing.T) {
+	root := RootCommand("1.2.3")
+	if sub := findSubcommand(root, "web", "removed-apps", "list"); sub == nil {
+		t.Fatalf("expected web removed-apps list to be registered")
+	}
+}
+
 func TestWebAppsMedicalDeviceSetSubcommandIsRegistered(t *testing.T) {
 	root := RootCommand("1.2.3")
 	if sub := findSubcommand(root, "web", "apps", "medical-device", "set"); sub == nil {

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -30,6 +30,7 @@ Examples:
   asc web sandbox create --first-name "Jane" --last-name "Tester" --email "jane+sandbox@example.com" --password "Passwordtest1" --territory "USA"
   asc web auth login --apple-id "user@example.com"
   asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP123"
+  asc web removed-apps list --paginate
   asc web privacy plan --app "123456789" --file "./privacy.json"
   asc web review list --app "123456789" --apple-id "user@example.com"
   asc web review show --app "123456789" --apple-id "user@example.com"
@@ -42,6 +43,7 @@ Examples:
 			WebAuthCommand(),
 			WebSandboxCommand(),
 			WebAppsCommand(),
+			WebRemovedAppsCommand(),
 			WebBundleIDsCommand(),
 			WebPrivacyCommand(),
 			WebReviewCommand(),

--- a/internal/cli/web/web_removed_apps.go
+++ b/internal/cli/web/web_removed_apps.go
@@ -124,6 +124,9 @@ func validateRemovedAppsNextURL(next string) error {
 	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "appstoreconnect.apple.com") || parsed.EscapedPath() != "/iris/v1/apps" {
 		return fmt.Errorf("--next must be an App Store Connect web URL")
 	}
+	if parsed.Query().Get("filter[removed]") != "true" {
+		return fmt.Errorf("--next must include filter[removed]=true")
+	}
 	return nil
 }
 

--- a/internal/cli/web/web_removed_apps.go
+++ b/internal/cli/web/web_removed_apps.go
@@ -50,7 +50,7 @@ func WebRemovedAppsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web removed-apps list", flag.ExitOnError)
 
 	authFlags := bindWebSessionFlags(fs)
-	limit := fs.Int("limit", 48, "Maximum results per page (1-200)")
+	limit := fs.Int("limit", webcore.DefaultRemovedAppsLimit, fmt.Sprintf("Maximum results per page (1-%d)", webcore.MaxRemovedAppsLimit))
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
@@ -73,8 +73,8 @@ Examples:
 			if len(args) > 0 {
 				return shared.UsageError("web removed-apps list does not accept positional arguments")
 			}
-			if *limit < 1 || *limit > 200 {
-				return shared.UsageError("web removed-apps list: --limit must be between 1 and 200")
+			if *limit < 1 || *limit > webcore.MaxRemovedAppsLimit {
+				return shared.UsageError(fmt.Sprintf("web removed-apps list: --limit must be between 1 and %d", webcore.MaxRemovedAppsLimit))
 			}
 			nextValue := strings.TrimSpace(*next)
 			if nextValue != "" && *paginate {

--- a/internal/cli/web/web_removed_apps.go
+++ b/internal/cli/web/web_removed_apps.go
@@ -1,0 +1,160 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+var listRemovedWebAppsFn = func(ctx context.Context, client *webcore.Client, opts webcore.RemovedAppsListOptions) (*webcore.RemovedAppsListResponse, error) {
+	return client.ListRemovedApps(ctx, opts)
+}
+
+// WebRemovedAppsCommand returns the removed apps command group.
+func WebRemovedAppsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web removed-apps", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "removed-apps",
+		ShortUsage: "asc web removed-apps <subcommand> [flags]",
+		ShortHelp:  "Inspect removed apps via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+Inspect apps shown in App Store Connect's Removed Apps status view.
+
+Examples:
+  asc web removed-apps list
+  asc web removed-apps list --paginate --output table
+  asc web removed-apps list --apple-id "user@example.com" --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebRemovedAppsListCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebRemovedAppsListCommand lists removed apps using the internal web API.
+func WebRemovedAppsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web removed-apps list", flag.ExitOnError)
+
+	authFlags := bindWebSessionFlags(fs)
+	limit := fs.Int("limit", 48, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc web removed-apps list [flags]",
+		ShortHelp:  "List removed apps via Apple web sessions.",
+		LongHelp: `List apps from App Store Connect's Removed Apps status view using the
+Apple web-session API.
+
+Examples:
+  asc web removed-apps list
+  asc web removed-apps list --limit 25 --output table
+  asc web removed-apps list --paginate --output json
+  asc web removed-apps list --next "<links.next>"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web removed-apps list does not accept positional arguments")
+			}
+			if *limit < 1 || *limit > 200 {
+				return shared.UsageError("web removed-apps list: --limit must be between 1 and 200")
+			}
+			nextValue := strings.TrimSpace(*next)
+			if nextValue != "" && *paginate {
+				return shared.UsageError("web removed-apps list: --next cannot be combined with --paginate")
+			}
+			if err := validateRemovedAppsNextURL(nextValue); err != nil {
+				return shared.UsageError("web removed-apps list: " + err.Error())
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return withWebAuthHint(err, "web removed-apps list")
+			}
+
+			result, err := listRemovedWebAppsFn(requestCtx, newWebClientFn(session), webcore.RemovedAppsListOptions{
+				Limit:    *limit,
+				Next:     nextValue,
+				Paginate: *paginate,
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web removed-apps list")
+			}
+
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderRemovedAppsTable(result) },
+				func() error { return renderRemovedAppsMarkdown(result) },
+			)
+		},
+	}
+}
+
+func validateRemovedAppsNextURL(next string) error {
+	next = strings.TrimSpace(next)
+	if next == "" {
+		return nil
+	}
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return fmt.Errorf("--next must be a valid URL: %w", err)
+	}
+	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "appstoreconnect.apple.com") || parsed.EscapedPath() != "/iris/v1/apps" {
+		return fmt.Errorf("--next must be an App Store Connect web URL")
+	}
+	return nil
+}
+
+func removedAppsHeaders() []string {
+	return []string{"ID", "Name", "Bundle ID", "Version", "Status", "SKU"}
+}
+
+func removedAppsRows(result *webcore.RemovedAppsListResponse) [][]string {
+	if result == nil {
+		return nil
+	}
+	rows := make([][]string, 0, len(result.Data))
+	for _, app := range result.Data {
+		rows = append(rows, []string{
+			shared.OrNA(app.ID),
+			shared.OrNA(app.Name),
+			shared.OrNA(app.BundleID),
+			shared.OrNA(app.VersionSummary),
+			shared.OrNA(app.Status),
+			shared.OrNA(app.SKU),
+		})
+	}
+	return rows
+}
+
+func renderRemovedAppsTable(result *webcore.RemovedAppsListResponse) error {
+	asc.RenderTable(removedAppsHeaders(), removedAppsRows(result))
+	return nil
+}
+
+func renderRemovedAppsMarkdown(result *webcore.RemovedAppsListResponse) error {
+	asc.RenderMarkdown(removedAppsHeaders(), removedAppsRows(result))
+	return nil
+}

--- a/internal/cli/web/web_removed_apps.go
+++ b/internal/cli/web/web_removed_apps.go
@@ -121,7 +121,14 @@ func validateRemovedAppsNextURL(next string) error {
 	if err != nil {
 		return fmt.Errorf("--next must be a valid URL: %w", err)
 	}
-	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "appstoreconnect.apple.com") || parsed.EscapedPath() != "/iris/v1/apps" {
+	if parsed.IsAbs() {
+		if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "appstoreconnect.apple.com") {
+			return fmt.Errorf("--next must be an App Store Connect web URL")
+		}
+	} else if parsed.Host != "" {
+		return fmt.Errorf("--next must be an App Store Connect web URL")
+	}
+	if path := parsed.EscapedPath(); path != "/iris/v1/apps" && path != "/apps" {
 		return fmt.Errorf("--next must be an App Store Connect web URL")
 	}
 	if parsed.Query().Get("filter[removed]") != "true" {

--- a/internal/cli/web/web_removed_apps_test.go
+++ b/internal/cli/web/web_removed_apps_test.go
@@ -140,6 +140,7 @@ func TestWebRemovedAppsListValidationErrors(t *testing.T) {
 		{name: "limit low", args: []string{"--limit", "0"}, wantErr: "--limit must be between 1 and 200"},
 		{name: "next with paginate", args: []string{"--next", "https://appstoreconnect.apple.com/iris/v1/apps?page=2", "--paginate"}, wantErr: "--next cannot be combined with --paginate"},
 		{name: "bad next host", args: []string{"--next", "https://example.com/iris/v1/apps?page=2"}, wantErr: "--next must be an App Store Connect web URL"},
+		{name: "protocol relative next host", args: []string{"--next", "//example.com/iris/v1/apps?filter[removed]=true"}, wantErr: "--next must be an App Store Connect web URL"},
 		{name: "next missing removed filter", args: []string{"--next", "https://appstoreconnect.apple.com/iris/v1/apps?limit=48"}, wantErr: "--next must include filter[removed]=true"},
 	}
 	for _, tc := range tests {
@@ -156,6 +157,20 @@ func TestWebRemovedAppsListValidationErrors(t *testing.T) {
 			})
 			if !strings.Contains(stderr, tc.wantErr) {
 				t.Fatalf("expected stderr to contain %q, got %q", tc.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestValidateRemovedAppsNextURLAcceptsSafeRelativeLinks(t *testing.T) {
+	for _, next := range []string{
+		"/iris/v1/apps?filter[removed]=true&cursor=abc",
+		"/apps?filter[removed]=true&cursor=abc",
+		"https://appstoreconnect.apple.com/iris/v1/apps?filter[removed]=true&cursor=abc",
+	} {
+		t.Run(next, func(t *testing.T) {
+			if err := validateRemovedAppsNextURL(next); err != nil {
+				t.Fatalf("expected %q to validate, got %v", next, err)
 			}
 		})
 	}

--- a/internal/cli/web/web_removed_apps_test.go
+++ b/internal/cli/web/web_removed_apps_test.go
@@ -1,0 +1,161 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebRemovedAppsCommandHierarchy(t *testing.T) {
+	cmd := WebRemovedAppsCommand()
+	if cmd.Name != "removed-apps" {
+		t.Fatalf("expected command name %q, got %q", "removed-apps", cmd.Name)
+	}
+	if cmd.UsageFunc == nil {
+		t.Fatal("expected command usage func")
+	}
+	if len(cmd.Subcommands) != 1 || cmd.Subcommands[0].Name != "list" {
+		t.Fatalf("expected list subcommand, got %+v", cmd.Subcommands)
+	}
+}
+
+func TestWebRemovedAppsListOutputsJSON(t *testing.T) {
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode, twoFactorCodeCommand string) (*webcore.AuthSession, string, error) {
+		if appleID != "user@example.com" {
+			t.Fatalf("expected apple id %q, got %q", "user@example.com", appleID)
+		}
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	origNewWebClient := newWebClientFn
+	origListRemoved := listRemovedWebAppsFn
+	t.Cleanup(func() {
+		restoreSession()
+		newWebClientFn = origNewWebClient
+		listRemovedWebAppsFn = origListRemoved
+	})
+
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	listRemovedWebAppsFn = func(ctx context.Context, client *webcore.Client, opts webcore.RemovedAppsListOptions) (*webcore.RemovedAppsListResponse, error) {
+		if opts.Limit != 10 {
+			t.Fatalf("expected limit 10, got %d", opts.Limit)
+		}
+		return &webcore.RemovedAppsListResponse{
+			Data: []webcore.RemovedApp{{
+				ID:                   "1234567890",
+				Name:                 "Throwaway",
+				BundleID:             "com.example.throwaway",
+				SKU:                  "THROWAWAY",
+				PrimaryLocale:        "en-US",
+				Removed:              true,
+				AppStoreLegacyStatus: "PREPARE_FOR_SUBMISSION",
+				DisplayableVersions: []webcore.RemovedAppVersion{{
+					ID:            "version-1",
+					Platform:      "IOS",
+					VersionString: "1.0",
+				}},
+			}},
+		}, nil
+	}
+
+	cmd := WebRemovedAppsListCommand()
+	if err := cmd.FlagSet.Parse([]string{"--apple-id", "user@example.com", "--limit", "10", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload webcore.RemovedAppsListResponse
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("expected JSON output, got error %v and output %q", err, stdout)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].Name != "Throwaway" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestWebRemovedAppsListTableIncludesCoreColumns(t *testing.T) {
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode, twoFactorCodeCommand string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	origNewWebClient := newWebClientFn
+	origListRemoved := listRemovedWebAppsFn
+	t.Cleanup(func() {
+		restoreSession()
+		newWebClientFn = origNewWebClient
+		listRemovedWebAppsFn = origListRemoved
+	})
+
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	listRemovedWebAppsFn = func(ctx context.Context, client *webcore.Client, opts webcore.RemovedAppsListOptions) (*webcore.RemovedAppsListResponse, error) {
+		return &webcore.RemovedAppsListResponse{
+			Data: []webcore.RemovedApp{{
+				ID:             "1234567890",
+				Name:           "Throwaway",
+				BundleID:       "com.example.throwaway",
+				VersionSummary: "iOS 1.0",
+				Status:         "PREPARE_FOR_SUBMISSION",
+				Removed:        true,
+			}},
+		}, nil
+	}
+
+	cmd := WebRemovedAppsListCommand()
+	if err := cmd.FlagSet.Parse([]string{"--output", "table"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, _ := captureWebCommandOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+	for _, want := range []string{"ID", "Name", "Bundle ID", "Version", "Status", "Throwaway", "com.example.throwaway", "iOS 1.0", "PREPARE_FOR_SUBMISSION"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected table output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestWebRemovedAppsListValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "positional", args: []string{"extra"}, wantErr: "web removed-apps list does not accept positional arguments"},
+		{name: "limit low", args: []string{"--limit", "0"}, wantErr: "--limit must be between 1 and 200"},
+		{name: "next with paginate", args: []string{"--next", "https://appstoreconnect.apple.com/iris/v1/apps?page=2", "--paginate"}, wantErr: "--next cannot be combined with --paginate"},
+		{name: "bad next host", args: []string{"--next", "https://example.com/iris/v1/apps?page=2"}, wantErr: "--next must be an App Store Connect web URL"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := WebRemovedAppsListCommand()
+			if err := cmd.FlagSet.Parse(tc.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			_, stderr := captureWebCommandOutput(t, func() {
+				err := cmd.Exec(context.Background(), cmd.FlagSet.Args())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected flag.ErrHelp, got %v", err)
+				}
+			})
+			if !strings.Contains(stderr, tc.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", tc.wantErr, stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/web/web_removed_apps_test.go
+++ b/internal/cli/web/web_removed_apps_test.go
@@ -140,6 +140,7 @@ func TestWebRemovedAppsListValidationErrors(t *testing.T) {
 		{name: "limit low", args: []string{"--limit", "0"}, wantErr: "--limit must be between 1 and 200"},
 		{name: "next with paginate", args: []string{"--next", "https://appstoreconnect.apple.com/iris/v1/apps?page=2", "--paginate"}, wantErr: "--next cannot be combined with --paginate"},
 		{name: "bad next host", args: []string{"--next", "https://example.com/iris/v1/apps?page=2"}, wantErr: "--next must be an App Store Connect web URL"},
+		{name: "next missing removed filter", args: []string{"--next", "https://appstoreconnect.apple.com/iris/v1/apps?limit=48"}, wantErr: "--next must include filter[removed]=true"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/apps_test.go
+++ b/internal/web/apps_test.go
@@ -202,10 +202,10 @@ func TestListRemovedAppsPaginatesNextLinks(t *testing.T) {
 					"id": "app-1",
 					"attributes": {"name": "First", "removed": true}
 				}],
-				"links": {"next": "` + serverURL + `/iris/v1/apps?page=2"}
+				"links": {"next": "` + serverURL + `/iris/v1/apps?filter[removed]=true&page=2"}
 			}`))
 		case 2:
-			if r.URL.Path != "/iris/v1/apps" || r.URL.Query().Get("page") != "2" {
+			if r.URL.Path != "/iris/v1/apps" || r.URL.Query().Get("filter[removed]") != "true" || r.URL.Query().Get("page") != "2" {
 				t.Fatalf("expected second request to follow next link, got %s?%s", r.URL.Path, r.URL.RawQuery)
 			}
 			_, _ = w.Write([]byte(`{
@@ -239,5 +239,21 @@ func TestListRemovedAppsPaginatesNextLinks(t *testing.T) {
 	}
 	if requests != 2 {
 		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+}
+
+func TestListRemovedAppsRejectsNextWithoutRemovedFilter(t *testing.T) {
+	client := &Client{
+		httpClient: http.DefaultClient,
+		baseURL:    "https://appstoreconnect.apple.com/iris/v1",
+	}
+	_, err := client.ListRemovedApps(context.Background(), RemovedAppsListOptions{
+		Next: "https://appstoreconnect.apple.com/iris/v1/apps?limit=48",
+	})
+	if err == nil {
+		t.Fatal("expected missing removed filter error")
+	}
+	if !strings.Contains(err.Error(), "filter[removed]=true") {
+		t.Fatalf("expected removed filter error, got %v", err)
 	}
 }

--- a/internal/web/apps_test.go
+++ b/internal/web/apps_test.go
@@ -92,3 +92,152 @@ func TestFindAppEscapesBundleIDQuery(t *testing.T) {
 		t.Fatalf("expected bundleId filter query, got %q", gotRawQuery)
 	}
 }
+
+func TestListRemovedAppsUsesRemovedFilterAndDecodesVersions(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/iris/v1/apps" {
+			t.Fatalf("expected /iris/v1/apps, got %s", r.URL.Path)
+		}
+		gotQuery = r.URL.RawQuery
+		query := r.URL.Query()
+		if query.Get("filter[removed]") != "true" {
+			t.Fatalf("expected removed filter, got query %q", r.URL.RawQuery)
+		}
+		if query.Get("limit") != "48" {
+			t.Fatalf("expected limit=48, got query %q", r.URL.RawQuery)
+		}
+		if query.Get("include") != "appStoreIcon,displayableVersions" {
+			t.Fatalf("expected displayable versions include, got query %q", r.URL.RawQuery)
+		}
+		if !strings.Contains(query.Get("fields[apps]"), "removed") {
+			t.Fatalf("expected removed app fields, got query %q", r.URL.RawQuery)
+		}
+		if query.Get("limit[displayableVersions]") != "20" {
+			t.Fatalf("expected displayable version limit, got query %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{
+			"data": [{
+				"type": "apps",
+				"id": "1234567890",
+				"attributes": {
+					"name": "Throwaway",
+					"bundleId": "com.example.throwaway",
+					"primaryLocale": "en-US",
+					"sku": "THROWAWAY",
+					"removed": true,
+					"appStoreLegacyStatus": "PREPARE_FOR_SUBMISSION",
+					"marketplace": "APP_STORE"
+				},
+				"relationships": {
+					"displayableVersions": {
+						"data": [{"type": "appStoreVersions", "id": "version-1"}]
+					}
+				}
+			}],
+			"included": [{
+				"type": "appStoreVersions",
+				"id": "version-1",
+				"attributes": {
+					"platform": "IOS",
+					"versionString": "1.0",
+					"appStoreState": "PREPARE_FOR_SUBMISSION",
+					"createdDate": "2026-07-06T10:00:00Z",
+					"isWatchOnly": false
+				}
+			}],
+			"links": {"self": "https://appstoreconnect.apple.com/iris/v1/apps?filter[removed]=true"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := &Client{
+		httpClient: server.Client(),
+		baseURL:    server.URL + "/iris/v1",
+	}
+	result, err := client.ListRemovedApps(context.Background(), RemovedAppsListOptions{Limit: 48})
+	if err != nil {
+		t.Fatalf("ListRemovedApps error: %v", err)
+	}
+	if !strings.Contains(gotQuery, "filter%5Bremoved%5D=true") && !strings.Contains(gotQuery, "filter[removed]=true") {
+		t.Fatalf("expected removed filter in raw query, got %q", gotQuery)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(result.Data))
+	}
+	app := result.Data[0]
+	if app.ID != "1234567890" || app.Name != "Throwaway" || app.BundleID != "com.example.throwaway" || !app.Removed {
+		t.Fatalf("unexpected app result: %+v", app)
+	}
+	if app.Status != "PREPARE_FOR_SUBMISSION" {
+		t.Fatalf("expected displayable version status, got %q", app.Status)
+	}
+	if len(app.DisplayableVersions) != 1 {
+		t.Fatalf("expected 1 displayable version, got %d", len(app.DisplayableVersions))
+	}
+	version := app.DisplayableVersions[0]
+	if version.ID != "version-1" || version.Platform != "IOS" || version.VersionString != "1.0" {
+		t.Fatalf("unexpected version result: %+v", version)
+	}
+}
+
+func TestListRemovedAppsPaginatesNextLinks(t *testing.T) {
+	requests := 0
+	serverURL := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch requests {
+		case 1:
+			if r.URL.Query().Get("filter[removed]") != "true" {
+				t.Fatalf("expected first page to use removed filter, got query %q", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{
+				"data": [{
+					"type": "apps",
+					"id": "app-1",
+					"attributes": {"name": "First", "removed": true}
+				}],
+				"links": {"next": "` + serverURL + `/iris/v1/apps?page=2"}
+			}`))
+		case 2:
+			if r.URL.Path != "/iris/v1/apps" || r.URL.Query().Get("page") != "2" {
+				t.Fatalf("expected second request to follow next link, got %s?%s", r.URL.Path, r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{
+				"data": [{
+					"type": "apps",
+					"id": "app-2",
+					"attributes": {"name": "Second", "removed": true}
+				}],
+				"links": {}
+			}`))
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	client := &Client{
+		httpClient: server.Client(),
+		baseURL:    server.URL + "/iris/v1",
+	}
+	result, err := client.ListRemovedApps(context.Background(), RemovedAppsListOptions{Limit: 48, Paginate: true})
+	if err != nil {
+		t.Fatalf("ListRemovedApps error: %v", err)
+	}
+	if len(result.Data) != 2 {
+		t.Fatalf("expected 2 apps, got %d", len(result.Data))
+	}
+	if result.Data[0].ID != "app-1" || result.Data[1].ID != "app-2" {
+		t.Fatalf("unexpected app ids: %+v", result.Data)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+}

--- a/internal/web/removed_apps.go
+++ b/internal/web/removed_apps.go
@@ -1,0 +1,275 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultRemovedAppsLimit          = 48
+	maxRemovedAppsLimit              = 200
+	removedAppsDisplayableVersionMax = 20
+)
+
+// RemovedAppsListOptions controls the removed-apps IRIS listing.
+type RemovedAppsListOptions struct {
+	Limit    int
+	Next     string
+	Paginate bool
+}
+
+// RemovedAppsListResponse is the normalized output for removed apps.
+type RemovedAppsListResponse struct {
+	Data  []RemovedApp      `json:"data"`
+	Links *RemovedAppsLinks `json:"links,omitempty"`
+}
+
+// RemovedAppsLinks contains pagination links returned by IRIS.
+type RemovedAppsLinks struct {
+	Self string `json:"self,omitempty"`
+	Next string `json:"next,omitempty"`
+}
+
+// RemovedApp summarizes one app from App Store Connect's Removed Apps view.
+type RemovedApp struct {
+	ID                   string              `json:"id"`
+	Type                 string              `json:"type,omitempty"`
+	Name                 string              `json:"name,omitempty"`
+	BundleID             string              `json:"bundleId,omitempty"`
+	SKU                  string              `json:"sku,omitempty"`
+	PrimaryLocale        string              `json:"primaryLocale,omitempty"`
+	Removed              bool                `json:"removed"`
+	Status               string              `json:"status,omitempty"`
+	AppStoreLegacyStatus string              `json:"appStoreLegacyStatus,omitempty"`
+	Marketplace          string              `json:"marketplace,omitempty"`
+	VersionSummary       string              `json:"versionSummary,omitempty"`
+	DisplayableVersions  []RemovedAppVersion `json:"displayableVersions,omitempty"`
+}
+
+// RemovedAppVersion summarizes one displayable version attached to a removed app.
+type RemovedAppVersion struct {
+	ID              string `json:"id"`
+	Type            string `json:"type,omitempty"`
+	Platform        string `json:"platform,omitempty"`
+	VersionString   string `json:"versionString,omitempty"`
+	AppStoreState   string `json:"appStoreState,omitempty"`
+	AppVersionState string `json:"appVersionState,omitempty"`
+	CreatedDate     string `json:"createdDate,omitempty"`
+	IsWatchOnly     bool   `json:"isWatchOnly,omitempty"`
+}
+
+// ListRemovedApps lists apps from App Store Connect's Removed Apps web view.
+func (c *Client) ListRemovedApps(ctx context.Context, opts RemovedAppsListOptions) (*RemovedAppsListResponse, error) {
+	path, err := c.removedAppsListPath(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RemovedAppsListResponse{Data: []RemovedApp{}}
+	visited := map[string]struct{}{}
+	for strings.TrimSpace(path) != "" {
+		if _, seen := visited[path]; seen {
+			return nil, fmt.Errorf("removed apps pagination loop detected")
+		}
+		visited[path] = struct{}{}
+
+		page, err := c.fetchRemovedAppsPage(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		result.Data = append(result.Data, page.Data...)
+		result.Links = page.Links
+		if !opts.Paginate {
+			break
+		}
+
+		nextPath, err := nextLookupPagePath(page.rawLinks, c.baseURL, "removed apps")
+		if err != nil {
+			return nil, err
+		}
+		path = nextPath
+	}
+
+	return result, nil
+}
+
+func (c *Client) removedAppsListPath(opts RemovedAppsListOptions) (string, error) {
+	next := strings.TrimSpace(opts.Next)
+	if next != "" {
+		return normalizeNextPath(next, c.baseURL)
+	}
+
+	limit := opts.Limit
+	if limit == 0 {
+		limit = defaultRemovedAppsLimit
+	}
+	if limit < 1 || limit > maxRemovedAppsLimit {
+		return "", fmt.Errorf("limit must be between 1 and 200")
+	}
+
+	values := url.Values{}
+	values.Set("include", "appStoreIcon,displayableVersions")
+	values.Set("limit", strconv.Itoa(limit))
+	values.Set("filter[removed]", "true")
+	values.Set("fields[apps]", "name,bundleId,primaryLocale,sku,removed,appStoreLegacyStatus,marketplace,appStoreIcon,displayableVersions")
+	values.Set("fields[appStoreVersions]", "platform,versionString,appStoreState,storeIcon,watchStoreIcon,isWatchOnly,createdDate,appVersionState")
+	values.Set("limit[displayableVersions]", strconv.Itoa(removedAppsDisplayableVersionMax))
+	return "/apps?" + values.Encode(), nil
+}
+
+type removedAppsPage struct {
+	Data     []RemovedApp
+	Links    *RemovedAppsLinks
+	rawLinks map[string]any
+}
+
+func (c *Client) fetchRemovedAppsPage(ctx context.Context, path string) (removedAppsPage, error) {
+	respBody, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return removedAppsPage{}, err
+	}
+
+	var payload jsonAPIListPayload
+	if err := json.Unmarshal(respBody, &payload); err != nil {
+		return removedAppsPage{}, fmt.Errorf("failed to parse removed apps response: %w", err)
+	}
+
+	included := make(map[string]jsonAPIResource, len(payload.Included))
+	for _, resource := range payload.Included {
+		included[jsonAPIResourceKey(resource.Type, resource.ID)] = resource
+	}
+
+	apps := make([]RemovedApp, 0, len(payload.Data))
+	for _, resource := range payload.Data {
+		apps = append(apps, decodeRemovedAppResource(resource, included))
+	}
+
+	return removedAppsPage{
+		Data:     apps,
+		Links:    decodeRemovedAppsLinks(payload.Links),
+		rawLinks: payload.Links,
+	}, nil
+}
+
+func decodeRemovedAppResource(resource jsonAPIResource, included map[string]jsonAPIResource) RemovedApp {
+	app := RemovedApp{
+		ID:                   strings.TrimSpace(resource.ID),
+		Type:                 strings.TrimSpace(resource.Type),
+		Name:                 stringAttr(resource.Attributes, "name"),
+		BundleID:             stringAttr(resource.Attributes, "bundleId"),
+		SKU:                  stringAttr(resource.Attributes, "sku"),
+		PrimaryLocale:        stringAttr(resource.Attributes, "primaryLocale"),
+		Removed:              boolAttr(resource.Attributes, "removed"),
+		AppStoreLegacyStatus: stringAttr(resource.Attributes, "appStoreLegacyStatus"),
+		Marketplace:          stringAttr(resource.Attributes, "marketplace"),
+	}
+
+	for _, ref := range relationshipRefs(resource, "displayableVersions") {
+		versionResource, ok := included[jsonAPIResourceKey(ref.Type, ref.ID)]
+		if !ok {
+			continue
+		}
+		app.DisplayableVersions = append(app.DisplayableVersions, decodeRemovedAppVersionResource(versionResource))
+	}
+	app.VersionSummary = removedAppVersionSummary(app.DisplayableVersions)
+	app.Status = removedAppStatus(app)
+	return app
+}
+
+func decodeRemovedAppVersionResource(resource jsonAPIResource) RemovedAppVersion {
+	return RemovedAppVersion{
+		ID:              strings.TrimSpace(resource.ID),
+		Type:            strings.TrimSpace(resource.Type),
+		Platform:        stringAttr(resource.Attributes, "platform"),
+		VersionString:   stringAttr(resource.Attributes, "versionString"),
+		AppStoreState:   stringAttr(resource.Attributes, "appStoreState"),
+		AppVersionState: stringAttr(resource.Attributes, "appVersionState"),
+		CreatedDate:     stringAttr(resource.Attributes, "createdDate"),
+		IsWatchOnly:     boolAttr(resource.Attributes, "isWatchOnly"),
+	}
+}
+
+func decodeRemovedAppsLinks(raw map[string]any) *RemovedAppsLinks {
+	self := extractLinkValue(raw, "self")
+	next, _ := extractNextLink(raw)
+	if self == "" && next == "" {
+		return nil
+	}
+	return &RemovedAppsLinks{Self: self, Next: next}
+}
+
+func extractLinkValue(links map[string]any, key string) string {
+	if len(links) == 0 {
+		return ""
+	}
+	raw, ok := links[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case map[string]any:
+		if href, ok := value["href"].(string); ok {
+			return strings.TrimSpace(href)
+		}
+		if urlValue, ok := value["url"].(string); ok {
+			return strings.TrimSpace(urlValue)
+		}
+	}
+	return ""
+}
+
+func removedAppVersionSummary(versions []RemovedAppVersion) string {
+	if len(versions) == 0 {
+		return ""
+	}
+	first := versions[0]
+	parts := []string{}
+	if platform := displayPlatform(first.Platform); platform != "" {
+		parts = append(parts, platform)
+	}
+	if version := strings.TrimSpace(first.VersionString); version != "" {
+		parts = append(parts, version)
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, " ")
+	}
+	if state := strings.TrimSpace(first.AppStoreState); state != "" {
+		return state
+	}
+	return strings.TrimSpace(first.AppVersionState)
+}
+
+func removedAppStatus(app RemovedApp) string {
+	if len(app.DisplayableVersions) > 0 {
+		first := app.DisplayableVersions[0]
+		if state := strings.TrimSpace(first.AppStoreState); state != "" {
+			return state
+		}
+		if state := strings.TrimSpace(first.AppVersionState); state != "" {
+			return state
+		}
+	}
+	return strings.TrimSpace(app.AppStoreLegacyStatus)
+}
+
+func displayPlatform(platform string) string {
+	switch strings.ToUpper(strings.TrimSpace(platform)) {
+	case "IOS":
+		return "iOS"
+	case "MAC_OS":
+		return "macOS"
+	case "TV_OS":
+		return "tvOS"
+	case "VISION_OS":
+		return "visionOS"
+	default:
+		return strings.TrimSpace(platform)
+	}
+}

--- a/internal/web/removed_apps.go
+++ b/internal/web/removed_apps.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	defaultRemovedAppsLimit          = 48
-	maxRemovedAppsLimit              = 200
+	// DefaultRemovedAppsLimit is the default page size for removed-apps listing.
+	DefaultRemovedAppsLimit = 48
+	// MaxRemovedAppsLimit is the largest accepted page size for removed-apps listing.
+	MaxRemovedAppsLimit              = 200
 	removedAppsDisplayableVersionMax = 20
 )
 
@@ -109,10 +111,10 @@ func (c *Client) removedAppsListPath(opts RemovedAppsListOptions) (string, error
 
 	limit := opts.Limit
 	if limit == 0 {
-		limit = defaultRemovedAppsLimit
+		limit = DefaultRemovedAppsLimit
 	}
-	if limit < 1 || limit > maxRemovedAppsLimit {
-		return "", fmt.Errorf("limit must be between 1 and 200")
+	if limit < 1 || limit > MaxRemovedAppsLimit {
+		return "", fmt.Errorf("limit must be between 1 and %d", MaxRemovedAppsLimit)
 	}
 
 	values := url.Values{}

--- a/internal/web/removed_apps.go
+++ b/internal/web/removed_apps.go
@@ -92,6 +92,9 @@ func (c *Client) ListRemovedApps(ctx context.Context, opts RemovedAppsListOption
 		if err != nil {
 			return nil, err
 		}
+		if err := validateRemovedAppsNextPath(nextPath); err != nil {
+			return nil, err
+		}
 		path = nextPath
 	}
 
@@ -101,7 +104,7 @@ func (c *Client) ListRemovedApps(ctx context.Context, opts RemovedAppsListOption
 func (c *Client) removedAppsListPath(opts RemovedAppsListOptions) (string, error) {
 	next := strings.TrimSpace(opts.Next)
 	if next != "" {
-		return normalizeNextPath(next, c.baseURL)
+		return removedAppsNextPath(next, c.baseURL)
 	}
 
 	limit := opts.Limit
@@ -120,6 +123,35 @@ func (c *Client) removedAppsListPath(opts RemovedAppsListOptions) (string, error
 	values.Set("fields[appStoreVersions]", "platform,versionString,appStoreState,storeIcon,watchStoreIcon,isWatchOnly,createdDate,appVersionState")
 	values.Set("limit[displayableVersions]", strconv.Itoa(removedAppsDisplayableVersionMax))
 	return "/apps?" + values.Encode(), nil
+}
+
+func removedAppsNextPath(next, baseURL string) (string, error) {
+	path, err := normalizeNextPath(next, baseURL)
+	if err != nil {
+		return "", err
+	}
+	if err := validateRemovedAppsNextPath(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func validateRemovedAppsNextPath(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return fmt.Errorf("invalid removed apps next link: %w", err)
+	}
+	if parsed.EscapedPath() != "/apps" {
+		return fmt.Errorf("removed apps next link must point to /apps")
+	}
+	if parsed.Query().Get("filter[removed]") != "true" {
+		return fmt.Errorf("removed apps next link must include filter[removed]=true")
+	}
+	return nil
 }
 
 type removedAppsPage struct {


### PR DESCRIPTION
## Summary

- add a web-session client for App Store Connect's Removed Apps IRIS view using `filter[removed]=true`
- add `asc web removed-apps list` with `--limit`, `--next`, `--paginate`, and standard output renderers
- register the command under `asc web` and cover query shape, pagination, output, validation, and command registration

## Verification

- `go test ./internal/web ./internal/cli/web ./internal/cli/cmdtest -run 'TestListRemovedApps|TestFindAppEscapesBundleIDQuery|TestWebRemovedApps|TestWebCommandUsesProductionHelpContract'`
- `make format`
- `make check-docs`
- `make lint`
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 make test` passed on retry; the first run hit the existing `TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError` interrupt flake, and the isolated rerun passed 3x
- `./asc web removed-apps list --limit 5 --output json`
- `./asc web removed-apps list --limit 3 --output table`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `web removed-apps list` under the `web` command to show Removed Apps from App Store Connect.
  * Supports `--paginate` (with `--limit`/`--next`) and renders results in table, markdown, and JSON; help text now includes a `--paginate` example.
* **Bug Fixes**
  * Improved `list` input validation: stricter `--limit`, rejects positional arguments, enforces `--next` vs `--paginate` exclusivity, and validates `--next` URLs for the removed-apps endpoint.
  * Pagination now safely follows `next` links while preventing loops and aggregating results across pages.
* **Tests**
  * Added coverage for command registration, `--next` URL validation, and Removed Apps client pagination and filter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->