### PR TITLE
apps wall: add Capture GO - AI & Online

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -180,6 +180,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d3/da/14/d3da14c9-99e0-1a7c-21b7-7f380b078084/AppIcon-0-1x_U007ephone-0-1-P3-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Capture GO - AI & Online",
+    "link": "https://apps.apple.com/us/app/capture-go-ai-online/id6751532288?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/b3/d6/f9/b3d6f97c-0a17-9972-860c-03e401426033/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Cat on Chair",
     "link": "https://apps.apple.com/ca/app/cat-on-chair-focus-timer/id6746562271",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/02/3d/6e/023d6ea0-1a98-d132-613c-d01b115d2e0d/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- recreate closed contributor PR #1712 for Capture GO - AI & Online
- add the same Wall of Apps entry from the unavailable fork head

## Entry

- App ID: 6751532288
- App: Capture GO - AI & Online
- Link: https://apps.apple.com/us/app/capture-go-ai-online/id6751532288?uo=4

## Notes

- Original contributor PR: #1712
- Commit includes `Co-authored-by: engin y <engin@yazilan.org>` for attribution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new app listing to the wall-of-apps content, including its link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->