### PR TITLE
apps wall: add Velko: IPTV Player & TV Guide

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1562,6 +1562,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3f/90/6f/3f906ff7-be78-e596-b72c-c5dee3bb0b7c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Velko: IPTV Player & TV Guide",
+    "link": "https://apps.apple.com/us/app/velko-iptv-player-tv-guide/id6775969853?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/53/c3/b7/53c3b765-6630-5db0-a5f8-abf88f38d181/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Video Annotation",
     "link": "https://apps.apple.com/us/app/video-annotation/id6758316355",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/c3/a9/43c3a9e9-e32b-081c-8a8b-a4f401846771/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Velko: IPTV Player & TV Guide` to the Wall of Apps

## Entry

- App ID: 6775969853
- App: Velko: IPTV Player & TV Guide
- Link: https://apps.apple.com/us/app/velko-iptv-player-tv-guide/id6775969853?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new app listing to the app showcase, including its store link and icon.
  * The new entry appears in the app gallery alongside existing featured apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->