### PR TITLE
feat(telemetry): emit sanitized failure parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,12 @@ or machine identifier.
 
 Telemetry includes the CLI version, operating system and architecture,
 registered command path, duration and exit outcome, runtime context, invocation
-source, low-cardinality invocation shape and failure classifications, and random
-event and session IDs. It does **not** include raw arguments, stderr, error messages,
-or flag values, credentials, private keys, Apple account, team, or issuer IDs,
-app or bundle IDs, API responses, usernames, hostnames, repository names, or
-file paths.
+source, low-cardinality invocation shape and failure classifications, the public
+flag name involved in a failed usage parse when it can be safely identified, and
+random event and session IDs. It does **not** include raw arguments, stderr,
+error messages, or flag values, credentials, private keys, Apple account, team,
+or issuer IDs, app or bundle IDs, API responses, usernames, hostnames,
+repository names, or file paths.
 
 Review or change telemetry at any time:
 

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -115,15 +115,18 @@ func isHelpToken(token string) bool {
 
 func parseFailureContext(analysis invocationAnalysis) telemetry.EventContext {
 	kind := telemetry.ErrorKindInvalidValue
+	parameter := ""
 	if analysis.unknownFlag {
 		kind = telemetry.ErrorKindUnknownFlag
+		parameter = analysis.unknownToken
 	} else if analysis.shape == telemetry.InvocationShapeUnknownChild {
 		kind = telemetry.ErrorKindOther
 	}
 	return telemetry.EventContext{
-		InvocationShape: analysis.shape,
-		ErrorKind:       kind,
-		FailureStage:    telemetry.FailureStageParse,
+		InvocationShape:  analysis.shape,
+		ErrorKind:        kind,
+		FailureStage:     telemetry.FailureStageParse,
+		FailureParameter: parameter,
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -429,6 +429,9 @@ func TestRun_UnknownFlagSuggestsRealFlagAndEmitsContext(t *testing.T) {
 		gotContext.FailureStage != telemetry.FailureStageParse {
 		t.Fatalf("unexpected telemetry context: %+v", gotContext)
 	}
+	if gotContext.FailureParameter != "--build-id" {
+		t.Fatalf("FailureParameter = %q, want --build-id", gotContext.FailureParameter)
+	}
 }
 
 func TestRun_UnknownGroupFlagIsNotClassifiedAsBareGroup(t *testing.T) {

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -17,12 +17,14 @@ Rork sandboxes, Rork GitHub workflows, and explicitly ephemeral environments;
 events from those disposable runtimes omit the durable local install ID. Use
 `asc telemetry disable`, `ASC_TELEMETRY_DISABLED`, or `DO_NOT_TRACK` to opt out.
 
-The CLI payload does **not** include raw arguments, stderr, error messages, Apple account identifiers,
-team IDs, issuer IDs, key IDs, app IDs, bundle IDs, usernames, hostnames,
-repository names, IP addresses, user-agent strings, or file paths. As with any
-HTTPS service, the collector's edge provider sees the connection address; the
-Rork collector may use it transiently for abuse throttling but does not persist
-it in telemetry events or analytics storage.
+The CLI payload does **not** include raw arguments, stderr, error messages, flag
+values, Apple account identifiers, team IDs, issuer IDs, key IDs, app IDs,
+bundle IDs, usernames, hostnames, repository names, IP addresses, user-agent
+strings, or file paths. Failed usage events may include the public flag name
+that caused the failure, such as `--app`, but never the value passed to that
+flag. As with any HTTPS service, the collector's edge provider sees the
+connection address; the Rork collector may use it transiently for abuse
+throttling but does not persist it in telemetry events or analytics storage.
 
 ## Usage
 
@@ -88,7 +90,7 @@ The CLI sends a single best-effort JSON event after command completion:
 ```json
 {
   "event_id": "2d2f86dd-6d75-4a6f-b97f-a6ce15d4bc79",
-  "schema_version": 2,
+  "schema_version": 3,
   "asc_version": "1.13.0",
   "os": "darwin",
   "arch": "arm64",
@@ -104,7 +106,8 @@ The CLI sends a single best-effort JSON event after command completion:
   "session_id": "ac8062e3-e6d2-4301-8d08-bb444cd55004",
   "invocation_shape": "leaf",
   "error_kind": null,
-  "failure_stage": null
+  "failure_stage": null,
+  "failure_parameter": null
 }
 ```
 
@@ -114,10 +117,12 @@ cannot become telemetry dimensions. `session_id` is reused only within one CLI
 process and changes the next time `asc` starts.
 
 `invocation_shape` is one of `leaf`, `bare_group`, `group_with_flags`, or
-`unknown_child`. Failed schema-v2 events also include an allowlisted
-`error_kind` and `failure_stage`; successful events set both fields to `null`.
-These fields are derived inside the CLI and never contain stderr, error text,
-flag values, or positional values.
+`unknown_child`. Failed schema-v3 events also include an allowlisted
+`error_kind`, `failure_stage`, and nullable `failure_parameter`; successful
+events set these fields to `null`. These fields are derived inside the CLI and
+never contain stderr, error text, flag values, or positional values.
+`failure_parameter` is limited to a sanitized public long flag name such as
+`--app`.
 
 `runtime_context` describes where the command runs, independently from
 `invocation_source`, which describes what launched it. A command launched by
@@ -176,6 +181,7 @@ CREATE TABLE asc_cli_events
   invocation_shape Nullable(LowCardinality(String)),
   error_kind Nullable(LowCardinality(String)),
   failure_stage Nullable(LowCardinality(String)),
+  failure_parameter Nullable(LowCardinality(String)),
   source LowCardinality(String),
   collector_version LowCardinality(String)
 )

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -28,6 +28,7 @@ type Event struct {
 	InvocationShape  InvocationShape  `json:"invocation_shape"`
 	ErrorKind        *ErrorKind       `json:"error_kind"`
 	FailureStage     *FailureStage    `json:"failure_stage"`
+	FailureParameter *string          `json:"failure_parameter"`
 }
 
 type InvocationShape string
@@ -61,9 +62,10 @@ const (
 )
 
 type EventContext struct {
-	InvocationShape InvocationShape
-	ErrorKind       ErrorKind
-	FailureStage    FailureStage
+	InvocationShape  InvocationShape
+	ErrorKind        ErrorKind
+	FailureStage     FailureStage
+	FailureParameter string
 }
 
 // processSessionID groups events from one CLI process without linking separate
@@ -104,7 +106,7 @@ func BuildEventWithContext(
 
 	return Event{
 		EventID:          uuid.NewString(),
-		SchemaVersion:    2,
+		SchemaVersion:    3,
 		ASCVersion:       strings.TrimSpace(version),
 		OS:               runtime.GOOS,
 		Arch:             runtime.GOARCH,
@@ -121,6 +123,7 @@ func BuildEventWithContext(
 		InvocationShape:  eventContext.InvocationShape,
 		ErrorKind:        optionalErrorKind(eventContext.ErrorKind),
 		FailureStage:     optionalFailureStage(eventContext.FailureStage),
+		FailureParameter: optionalFailureParameter(eventContext.FailureParameter, exitCode),
 	}, true
 }
 
@@ -134,6 +137,7 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 	if exitCode == 0 {
 		eventContext.ErrorKind = ""
 		eventContext.FailureStage = ""
+		eventContext.FailureParameter = ""
 		return eventContext
 	}
 	if eventContext.ErrorKind == "" {
@@ -171,6 +175,39 @@ func optionalFailureStage(stage FailureStage) *FailureStage {
 		return nil
 	}
 	return &stage
+}
+
+func optionalFailureParameter(parameter string, exitCode int) *string {
+	if exitCode == 0 {
+		return nil
+	}
+	parameter = sanitizeFailureParameter(parameter)
+	if parameter == "" {
+		return nil
+	}
+	return &parameter
+}
+
+func sanitizeFailureParameter(parameter string) string {
+	parameter = strings.TrimSpace(parameter)
+	if parameter == "" {
+		return ""
+	}
+	name := strings.SplitN(parameter, "=", 2)[0]
+	name = strings.TrimLeft(name, "-")
+	if name == "" || len(name) > 64 {
+		return ""
+	}
+	for i, r := range name {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '-' && i > 0 {
+			continue
+		}
+		return ""
+	}
+	return "--" + name
 }
 
 func sanitizeCommandName(commandName string) string {

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -201,6 +201,9 @@ func sanitizeFailureParameter(parameter string) string {
 	if name[0] < 'a' || name[0] > 'z' || isUUIDLike(name) {
 		return ""
 	}
+	if !isKnownFailureParameter(name) {
+		return ""
+	}
 	for i, r := range name {
 		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
 			continue
@@ -211,6 +214,51 @@ func sanitizeFailureParameter(parameter string) string {
 		return ""
 	}
 	return "--" + name
+}
+
+func isKnownFailureParameter(name string) bool {
+	_, ok := knownFailureParameters[name]
+	return ok
+}
+
+// Keep this list deliberately small: failure_parameter is a telemetry
+// dimension, so only public flags and compatibility aliases that help diagnose
+// common agent failures belong here.
+var knownFailureParameters = map[string]struct{}{
+	"all":             {},
+	"app":             {},
+	"app-id":          {},
+	"build":           {},
+	"build-id":        {},
+	"bundle-id":       {},
+	"confirm":         {},
+	"cursor":          {},
+	"dry-run":         {},
+	"email":           {},
+	"file":            {},
+	"group-id":        {},
+	"id":              {},
+	"ipa":             {},
+	"issuer-id":       {},
+	"key-id":          {},
+	"limit":           {},
+	"locale":          {},
+	"localization-id": {},
+	"next":            {},
+	"org":             {},
+	"output":          {},
+	"output-dir":      {},
+	"paginate":        {},
+	"platform":        {},
+	"profile":         {},
+	"review-id":       {},
+	"subscription-id": {},
+	"team-id":         {},
+	"tester-id":       {},
+	"version":         {},
+	"version-id":      {},
+	"workflow-id":     {},
+	"xcodebuild-flag": {},
 }
 
 func isUUIDLike(name string) bool {

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -198,6 +198,9 @@ func sanitizeFailureParameter(parameter string) string {
 	if name == "" || len(name) > 64 {
 		return ""
 	}
+	if name[0] < 'a' || name[0] > 'z' || isUUIDLike(name) {
+		return ""
+	}
 	for i, r := range name {
 		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
 			continue
@@ -208,6 +211,25 @@ func sanitizeFailureParameter(parameter string) string {
 		return ""
 	}
 	return "--" + name
+}
+
+func isUUIDLike(name string) bool {
+	if len(name) != 36 {
+		return false
+	}
+	for i, r := range name {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if r != '-' {
+				return false
+			}
+			continue
+		}
+		if r >= '0' && r <= '9' || r >= 'a' && r <= 'f' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func sanitizeCommandName(commandName string) string {

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -154,6 +154,43 @@ func TestBuildEventWithContextRejectsUnboundedContextValues(t *testing.T) {
 	}
 }
 
+func TestBuildEventWithContextRejectsIdentifierShapedFailureParameters(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	for _, parameter := range []string{
+		"--6759231657",
+		"--123e4567-e89b-12d3-a456-426614174000",
+	} {
+		ev, ok := BuildEventWithContext(
+			"asc builds",
+			"1.2.3",
+			0,
+			2,
+			EventContext{
+				InvocationShape:  InvocationShapeLeaf,
+				ErrorKind:        ErrorKindUnknownFlag,
+				FailureStage:     FailureStageParse,
+				FailureParameter: parameter,
+			},
+		)
+		if !ok {
+			t.Fatal("expected event")
+		}
+		if ev.FailureParameter != nil {
+			t.Fatalf("FailureParameter for %q = %q, want nil", parameter, *ev.FailureParameter)
+		}
+
+		data, err := json.Marshal(ev)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		if strings.Contains(string(data), strings.TrimPrefix(parameter, "--")) {
+			t.Fatalf("payload leaked identifier-shaped parameter %q: %s", parameter, data)
+		}
+	}
+}
+
 func TestBuildEventReusesProcessSessionID(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -96,6 +96,34 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 	}
 }
 
+func TestBuildEventWithContextAllowsKnownFailureParameters(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	for _, parameter := range []string{"--id", "--app", "--app-id"} {
+		t.Run(parameter, func(t *testing.T) {
+			ev, ok := BuildEventWithContext(
+				"asc apps view",
+				"1.2.3",
+				0,
+				2,
+				EventContext{
+					InvocationShape:  InvocationShapeLeaf,
+					ErrorKind:        ErrorKindUnknownFlag,
+					FailureStage:     FailureStageParse,
+					FailureParameter: parameter,
+				},
+			)
+			if !ok {
+				t.Fatal("expected event")
+			}
+			if ev.FailureParameter == nil || *ev.FailureParameter != parameter {
+				t.Fatalf("FailureParameter = %v, want %q", ev.FailureParameter, parameter)
+			}
+		})
+	}
+}
+
 func TestBuildEventWithContextCanonicalizesFailureStage(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
@@ -191,6 +219,30 @@ func TestBuildEventWithContextRejectsIdentifierShapedFailureParameters(t *testin
 				t.Fatalf("payload leaked identifier-shaped parameter %q: %s", parameter, data)
 			}
 		})
+	}
+}
+
+func TestBuildEventWithContextRejectsUnknownFailureParameterNames(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc builds",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			InvocationShape:  InvocationShapeLeaf,
+			ErrorKind:        ErrorKindUnknownFlag,
+			FailureStage:     FailureStageParse,
+			FailureParameter: "--my-secret-project",
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.FailureParameter != nil {
+		t.Fatalf("FailureParameter = %q, want nil", *ev.FailureParameter)
 	}
 }
 

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -65,20 +65,24 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 		0,
 		2,
 		EventContext{
-			InvocationShape: InvocationShapeLeaf,
-			ErrorKind:       ErrorKindUnknownFlag,
-			FailureStage:    FailureStageParse,
+			InvocationShape:  InvocationShapeLeaf,
+			ErrorKind:        ErrorKindUnknownFlag,
+			FailureStage:     FailureStageParse,
+			FailureParameter: "--build-id=BUILD_ID",
 		},
 	)
 	if !ok {
 		t.Fatal("expected event")
 	}
-	if ev.SchemaVersion != 2 {
-		t.Fatalf("SchemaVersion = %d, want 2", ev.SchemaVersion)
+	if ev.SchemaVersion != 3 {
+		t.Fatalf("SchemaVersion = %d, want 3", ev.SchemaVersion)
 	}
 	if ev.InvocationShape != InvocationShapeLeaf || ev.ErrorKind == nil || *ev.ErrorKind != ErrorKindUnknownFlag ||
 		ev.FailureStage == nil || *ev.FailureStage != FailureStageParse {
 		t.Fatalf("unexpected classifications: %+v", ev)
+	}
+	if ev.FailureParameter == nil || *ev.FailureParameter != "--build-id" {
+		t.Fatalf("FailureParameter = %v, want --build-id", ev.FailureParameter)
 	}
 
 	data, err := json.Marshal(ev)
@@ -125,15 +129,17 @@ func TestBuildEventWithContextRejectsUnboundedContextValues(t *testing.T) {
 		0,
 		2,
 		EventContext{
-			InvocationShape: InvocationShape("unknown_child:private-app-name"),
-			ErrorKind:       ErrorKind("unknown_flag:--private-value"),
-			FailureStage:    FailureStage("stderr:private-error"),
+			InvocationShape:  InvocationShape("unknown_child:private-app-name"),
+			ErrorKind:        ErrorKind("unknown_flag:--private-value"),
+			FailureStage:     FailureStage("stderr:private-error"),
+			FailureParameter: "--private_value=SECRET",
 		},
 	)
 	if !ok || ev.ErrorKind == nil || ev.FailureStage == nil {
 		t.Fatal("expected canonicalized event")
 	}
-	if ev.InvocationShape != InvocationShapeLeaf || *ev.ErrorKind != ErrorKindOther || *ev.FailureStage != FailureStageExecution {
+	if ev.InvocationShape != InvocationShapeLeaf || *ev.ErrorKind != ErrorKindOther || *ev.FailureStage != FailureStageExecution ||
+		ev.FailureParameter != nil {
 		t.Fatalf("unexpected canonicalized context: %+v", ev)
 	}
 
@@ -141,7 +147,7 @@ func TestBuildEventWithContextRejectsUnboundedContextValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal event: %v", err)
 	}
-	for _, privateValue := range []string{"private-app-name", "private-value", "private-error"} {
+	for _, privateValue := range []string{"private-app-name", "private-value", "private-error", "SECRET"} {
 		if strings.Contains(string(data), privateValue) {
 			t.Fatalf("payload leaked unbounded context %q: %s", privateValue, data)
 		}

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -161,33 +161,36 @@ func TestBuildEventWithContextRejectsIdentifierShapedFailureParameters(t *testin
 	for _, parameter := range []string{
 		"--6759231657",
 		"--123e4567-e89b-12d3-a456-426614174000",
+		"--a1b2c3d4-e5f6-47a8-9012-3456789abcde",
 	} {
-		ev, ok := BuildEventWithContext(
-			"asc builds",
-			"1.2.3",
-			0,
-			2,
-			EventContext{
-				InvocationShape:  InvocationShapeLeaf,
-				ErrorKind:        ErrorKindUnknownFlag,
-				FailureStage:     FailureStageParse,
-				FailureParameter: parameter,
-			},
-		)
-		if !ok {
-			t.Fatal("expected event")
-		}
-		if ev.FailureParameter != nil {
-			t.Fatalf("FailureParameter for %q = %q, want nil", parameter, *ev.FailureParameter)
-		}
+		t.Run(parameter, func(t *testing.T) {
+			ev, ok := BuildEventWithContext(
+				"asc builds",
+				"1.2.3",
+				0,
+				2,
+				EventContext{
+					InvocationShape:  InvocationShapeLeaf,
+					ErrorKind:        ErrorKindUnknownFlag,
+					FailureStage:     FailureStageParse,
+					FailureParameter: parameter,
+				},
+			)
+			if !ok {
+				t.Fatal("expected event")
+			}
+			if ev.FailureParameter != nil {
+				t.Fatalf("FailureParameter for %q = %q, want nil", parameter, *ev.FailureParameter)
+			}
 
-		data, err := json.Marshal(ev)
-		if err != nil {
-			t.Fatalf("marshal event: %v", err)
-		}
-		if strings.Contains(string(data), strings.TrimPrefix(parameter, "--")) {
-			t.Fatalf("payload leaked identifier-shaped parameter %q: %s", parameter, data)
-		}
+			data, err := json.Marshal(ev)
+			if err != nil {
+				t.Fatalf("marshal event: %v", err)
+			}
+			if strings.Contains(string(data), strings.TrimPrefix(parameter, "--")) {
+				t.Fatalf("payload leaked identifier-shaped parameter %q: %s", parameter, data)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- bump ASC CLI telemetry events to schema v3
- include a nullable `failure_parameter` for failed usage parses when the public flag name can be safely identified
- sanitize to flag names only, e.g. `--app`, and never emit raw args or flag values
- update telemetry docs/privacy text for the schema-v3 field

## Verification
- `go test ./internal/telemetry ./cmd`
- `make check-docs`
- `make lint`
- pre-commit hook: docs checks, format, lint, short test suite

## Rollout note
Merge and deploy the rorkai collector/storage PR before releasing this CLI change so schema-v3 events are accepted before clients emit them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry events now include an optional nullable `failure_parameter` for relevant failures, using schema v3 and a sanitized public long flag name.
* **Bug Fixes**
  * Unknown-flag telemetry context now records the associated public flag when safely identifiable.
  * Privacy protections tightened: secret-like and identifier-shaped values are rejected/omitted.
* **Documentation**
  * Updated the README and telemetry docs (including payload examples and ClickHouse schema) to reflect `failure_parameter` and schema v3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->