### PR TITLE
Add metadata approval workflow

### DIFF
--- a/docs/design/metadata-approval-workflow.md
+++ b/docs/design/metadata-approval-workflow.md
@@ -1,0 +1,19 @@
+# Metadata approval workflow design
+
+Issue #1717 asks for agent-friendly metadata changes with a durable plan, explicit approval, and a guarded apply. Current `metadata apply --dry-run` computes a useful plan but does not persist a review artifact or bind approval to the exact plan that was reviewed.
+
+## Chosen approach
+
+Add `metadata plan`, `metadata approve`, and `metadata status` as thin artifact workflow commands around the existing metadata push/apply planner. `metadata plan` runs the same dry-run planner as `metadata apply --dry-run`, writes `.asc/metadata/review/plan.json`, and records a SHA-256 hash over a stable payload containing the normalized command options plus the planned changes. `metadata approve` reads that plan and writes `.asc/metadata/review/approved.json` with the reviewed plan hash and approved change keys. `metadata apply --review-dir ... --confirm` recomputes the plan, compares hashes, verifies all current change keys are approved, then delegates to the existing executor.
+
+## Compatibility
+
+Direct `metadata apply` and `metadata push` stay compatible. Approval is enforced only when `--review-dir` is supplied to `metadata apply`. Existing `--dry-run` behavior remains available for quick previews.
+
+## Trade-offs
+
+This first slice requires all currently planned changes to be approved before guarded apply. It supports selective approval artifacts for review/status, but partial application is not enabled yet because the current executor applies a whole computed plan. That keeps the first implementation deterministic and avoids introducing a second mutation engine.
+
+## Verification
+
+Tests should cover artifact writes, approval selection, status output, drift rejection before mutation, and successful guarded apply. Live verification should run the artifact workflow against one real app only after inspecting the generated plan.

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -77,6 +77,8 @@ func TestMetadataPlanApproveStatusAndApplyReviewDir(t *testing.T) {
 
 	reviewDir := filepath.Join(t.TempDir(), "review")
 	patches := 0
+	appInfoLocalizationReads := 0
+	versionLocalizationReads := 0
 	withMetadataReviewHTTP(t, func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
 		case "/v1/apps/app-1/appInfos":
@@ -84,8 +86,10 @@ func TestMetadataPlanApproveStatusAndApplyReviewDir(t *testing.T) {
 		case "/v1/apps/app-1/appStoreVersions":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
 		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			appInfoLocalizationReads++
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Outslept","subtitle":"Sleep tracker"}}],"links":{"next":""}}`), nil
 		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			versionLocalizationReads++
 			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
 		case "/v1/appInfoLocalizations/loc-en":
 			if req.Method != http.MethodPatch {
@@ -178,6 +182,36 @@ func TestMetadataPlanApproveStatusAndApplyReviewDir(t *testing.T) {
 		t.Fatalf("unexpected status output: %+v", statusOut)
 	}
 
+	appInfoLocalizationReads = 0
+	versionLocalizationReads = 0
+	dryRunStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "apply",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--platform", "IOS",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--dry-run",
+		"--confirm",
+		"--output", "json",
+	})
+	var dryRunOut struct {
+		DryRun  bool          `json:"dryRun"`
+		Updates []interface{} `json:"updates"`
+		Actions []interface{} `json:"actions"`
+	}
+	if err := json.Unmarshal([]byte(dryRunStdout), &dryRunOut); err != nil {
+		t.Fatalf("parse dry-run output: %v\n%s", err, dryRunStdout)
+	}
+	if !dryRunOut.DryRun || len(dryRunOut.Updates) != 1 || len(dryRunOut.Actions) != 0 || patches != 0 {
+		t.Fatalf("review-dir dry-run mutated or returned unexpected output: dryRun=%+v patches=%d", dryRunOut, patches)
+	}
+	if appInfoLocalizationReads != 1 || versionLocalizationReads != 1 {
+		t.Fatalf("expected one verification read per localization endpoint on dry-run, got app-info=%d version=%d", appInfoLocalizationReads, versionLocalizationReads)
+	}
+
+	appInfoLocalizationReads = 0
+	versionLocalizationReads = 0
 	applyStdout := runMetadataReviewCommand(t, []string{
 		"metadata", "apply",
 		"--app", "app-1",
@@ -199,6 +233,9 @@ func TestMetadataPlanApproveStatusAndApplyReviewDir(t *testing.T) {
 	}
 	if !applyOut.Applied || applyOut.Total != 1 || applyOut.Succeeded != 1 || applyOut.Failed != 0 || patches != 1 {
 		t.Fatalf("unexpected apply output=%+v patches=%d", applyOut, patches)
+	}
+	if appInfoLocalizationReads != 1 || versionLocalizationReads != 1 {
+		t.Fatalf("expected guarded apply to verify and apply from one plan pass, got app-info=%d version=%d", appInfoLocalizationReads, versionLocalizationReads)
 	}
 }
 

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -62,6 +62,32 @@ func TestMetadataApplyValidationErrors(t *testing.T) {
 	}
 }
 
+func TestMetadataApplyReviewDirRequiresConfirmBeforeSideEffects(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	reviewDir := filepath.Join(t.TempDir(), "review")
+	stdout, stderr, runErr := runMetadataReviewCommandRaw(t, []string{
+		"metadata", "apply",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--output", "json",
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %T: %v", runErr, runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm is required when applying an approved metadata plan") {
+		t.Fatalf("expected confirm error, got %q", stderr)
+	}
+}
+
 func TestMetadataPlanApproveStatusAndApplyReviewDir(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -292,22 +292,14 @@ func TestMetadataApplyReviewDirRejectsDriftBeforeMutation(t *testing.T) {
 		t.Fatalf("write drifted app-info metadata: %v", err)
 	}
 
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{
-			"metadata", "apply",
-			"--app", "app-1",
-			"--version", "1.2.3",
-			"--dir", dir,
-			"--review-dir", reviewDir,
-			"--confirm",
-			"--output", "json",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = root.Run(context.Background())
+	stdout, stderr, runErr := runMetadataReviewCommandRaw(t, []string{
+		"metadata", "apply",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--confirm",
+		"--output", "json",
 	})
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected usage error, got %T: %v", runErr, runErr)
@@ -323,6 +315,87 @@ func TestMetadataApplyReviewDirRejectsDriftBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestMetadataApplyReviewDirAllowsEmptyPlanWithoutApproval(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"Outslept","subtitle":"Sleep tracker"}`), 0o644); err != nil {
+		t.Fatalf("write app-info metadata: %v", err)
+	}
+
+	reviewDir := filepath.Join(t.TempDir(), "review")
+	mutations := 0
+	withMetadataReviewHTTP(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			mutations++
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Outslept","subtitle":"Sleep tracker"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_ = runMetadataReviewCommand(t, []string{
+		"metadata", "plan",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--platform", "IOS",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--output", "json",
+	})
+	statusStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "status",
+		"--review-dir", reviewDir,
+		"--output", "json",
+	})
+	var statusOut struct {
+		Ready      bool `json:"ready"`
+		TotalCount int  `json:"totalCount"`
+	}
+	if err := json.Unmarshal([]byte(statusStdout), &statusOut); err != nil {
+		t.Fatalf("parse status output: %v\n%s", err, statusStdout)
+	}
+	if !statusOut.Ready || statusOut.TotalCount != 0 {
+		t.Fatalf("expected empty plan to be ready, got %+v", statusOut)
+	}
+
+	applyStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "apply",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--platform", "IOS",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--confirm",
+		"--output", "json",
+	})
+	var applyOut struct {
+		Applied bool `json:"applied"`
+		Total   int  `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(applyStdout), &applyOut); err != nil {
+		t.Fatalf("parse apply output: %v\n%s", err, applyStdout)
+	}
+	if !applyOut.Applied || applyOut.Total != 0 || mutations != 0 {
+		t.Fatalf("expected no-op apply without mutations, output=%+v mutations=%d", applyOut, mutations)
+	}
+}
+
 func withMetadataReviewHTTP(t *testing.T, fn roundTripFunc) {
 	t.Helper()
 	originalTransport := http.DefaultTransport
@@ -330,17 +403,22 @@ func withMetadataReviewHTTP(t *testing.T, fn roundTripFunc) {
 	http.DefaultTransport = fn
 }
 
-func runMetadataReviewCommand(t *testing.T, args []string) string {
+func runMetadataReviewCommandRaw(t *testing.T, args []string) (stdout, stderr string, runErr error) {
 	t.Helper()
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
+	stdout, stderr = captureOutput(t, func() {
 		if err := root.Parse(args); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = root.Run(context.Background())
 	})
+	return stdout, stderr, runErr
+}
+
+func runMetadataReviewCommand(t *testing.T, args []string) string {
+	t.Helper()
+	stdout, stderr, runErr := runMetadataReviewCommandRaw(t, args)
 	if runErr != nil {
 		t.Fatalf("run %v: %T %v\nstdout=%s\nstderr=%s", args, runErr, runErr, stdout, stderr)
 	}

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -62,6 +62,257 @@ func TestMetadataApplyValidationErrors(t *testing.T) {
 	}
 }
 
+func TestMetadataPlanApproveStatusAndApplyReviewDir(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app-info", "en-US.json"), []byte(`{"name":"Outslept","subtitle":"Sleep debt recovery"}`), 0o644); err != nil {
+		t.Fatalf("write app-info metadata: %v", err)
+	}
+
+	reviewDir := filepath.Join(t.TempDir(), "review")
+	patches := 0
+	withMetadataReviewHTTP(t, func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Outslept","subtitle":"Sleep tracker"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case "/v1/appInfoLocalizations/loc-en":
+			if req.Method != http.MethodPatch {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+			patches++
+			assertMetadataPatchPayload(t, req, "appInfoLocalizations", "loc-en", map[string]string{
+				"name":     "Outslept",
+				"subtitle": "Sleep debt recovery",
+			})
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Outslept","subtitle":"Sleep debt recovery"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	planStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "plan",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--platform", "IOS",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--output", "json",
+		"--pretty",
+	})
+	var planOut struct {
+		PlanHash string `json:"planHash"`
+		PlanPath string `json:"planPath"`
+		Plan     struct {
+			Updates []struct {
+				Key string `json:"key"`
+			} `json:"updates"`
+		} `json:"plan"`
+	}
+	if err := json.Unmarshal([]byte(planStdout), &planOut); err != nil {
+		t.Fatalf("parse plan output: %v\n%s", err, planStdout)
+	}
+	if planOut.PlanHash == "" || planOut.PlanPath != filepath.Join(reviewDir, "plan.json") {
+		t.Fatalf("unexpected plan artifact identity: %+v", planOut)
+	}
+	if len(planOut.Plan.Updates) != 1 || planOut.Plan.Updates[0].Key != "app-info:en-US:subtitle" {
+		t.Fatalf("unexpected planned updates: %+v", planOut.Plan.Updates)
+	}
+	if _, err := os.Stat(filepath.Join(reviewDir, "plan.json")); err != nil {
+		t.Fatalf("expected plan artifact: %v", err)
+	}
+	if patches != 0 {
+		t.Fatalf("plan must not mutate, patches=%d", patches)
+	}
+
+	approveStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "approve",
+		"--review-dir", reviewDir,
+		"--all",
+		"--note", "reviewed by test",
+		"--output", "json",
+		"--pretty",
+	})
+	var approvalOut struct {
+		PlanHash     string   `json:"planHash"`
+		ApprovedKeys []string `json:"approvedKeys"`
+	}
+	if err := json.Unmarshal([]byte(approveStdout), &approvalOut); err != nil {
+		t.Fatalf("parse approval output: %v\n%s", err, approveStdout)
+	}
+	if approvalOut.PlanHash != planOut.PlanHash || len(approvalOut.ApprovedKeys) != 1 || approvalOut.ApprovedKeys[0] != "app-info:en-US:subtitle" {
+		t.Fatalf("unexpected approval output: %+v", approvalOut)
+	}
+	if _, err := os.Stat(filepath.Join(reviewDir, "approved.json")); err != nil {
+		t.Fatalf("expected approval artifact: %v", err)
+	}
+
+	statusStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "status",
+		"--review-dir", reviewDir,
+		"--output", "json",
+		"--pretty",
+	})
+	var statusOut struct {
+		Ready         bool `json:"ready"`
+		ApprovedCount int  `json:"approvedCount"`
+		PendingCount  int  `json:"pendingCount"`
+	}
+	if err := json.Unmarshal([]byte(statusStdout), &statusOut); err != nil {
+		t.Fatalf("parse status output: %v\n%s", err, statusStdout)
+	}
+	if !statusOut.Ready || statusOut.ApprovedCount != 1 || statusOut.PendingCount != 0 {
+		t.Fatalf("unexpected status output: %+v", statusOut)
+	}
+
+	applyStdout := runMetadataReviewCommand(t, []string{
+		"metadata", "apply",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--platform", "IOS",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--confirm",
+		"--output", "json",
+	})
+	var applyOut struct {
+		Applied   bool `json:"applied"`
+		Total     int  `json:"total"`
+		Succeeded int  `json:"succeeded"`
+		Failed    int  `json:"failed"`
+	}
+	if err := json.Unmarshal([]byte(applyStdout), &applyOut); err != nil {
+		t.Fatalf("parse apply output: %v\n%s", err, applyStdout)
+	}
+	if !applyOut.Applied || applyOut.Total != 1 || applyOut.Succeeded != 1 || applyOut.Failed != 0 || patches != 1 {
+		t.Fatalf("unexpected apply output=%+v patches=%d", applyOut, patches)
+	}
+}
+
+func TestMetadataApplyReviewDirRejectsDriftBeforeMutation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app-info"), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	metadataPath := filepath.Join(dir, "app-info", "en-US.json")
+	if err := os.WriteFile(metadataPath, []byte(`{"name":"Outslept","subtitle":"Sleep debt recovery"}`), 0o644); err != nil {
+		t.Fatalf("write app-info metadata: %v", err)
+	}
+
+	reviewDir := filepath.Join(t.TempDir(), "review")
+	mutations := 0
+	withMetadataReviewHTTP(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			mutations++
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`), nil
+		case "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"loc-en","attributes":{"locale":"en-US","name":"Outslept","subtitle":"Sleep tracker"}}],"links":{"next":""}}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	_ = runMetadataReviewCommand(t, []string{
+		"metadata", "plan",
+		"--app", "app-1",
+		"--version", "1.2.3",
+		"--dir", dir,
+		"--review-dir", reviewDir,
+		"--output", "json",
+	})
+	_ = runMetadataReviewCommand(t, []string{
+		"metadata", "approve",
+		"--review-dir", reviewDir,
+		"--all",
+		"--output", "json",
+	})
+	if err := os.WriteFile(metadataPath, []byte(`{"name":"Outslept","subtitle":"Sleep debt and bedtime"}`), 0o644); err != nil {
+		t.Fatalf("write drifted app-info metadata: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"metadata", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", dir,
+			"--review-dir", reviewDir,
+			"--confirm",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %T: %v", runErr, runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "approved metadata plan drifted") {
+		t.Fatalf("expected drift error, got %q", stderr)
+	}
+	if mutations != 0 {
+		t.Fatalf("expected no mutation before drift rejection, got %d", mutations)
+	}
+}
+
+func withMetadataReviewHTTP(t *testing.T, fn roundTripFunc) {
+	t.Helper()
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = fn
+}
+
+func runMetadataReviewCommand(t *testing.T, args []string) string {
+	t.Helper()
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run %v: %T %v\nstdout=%s\nstderr=%s", args, runErr, runErr, stdout, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr for %v: %q", args, stderr)
+	}
+	return stdout
+}
+
 func TestMetadataApplyDryRunSuggestsApplyCommandForAmbiguousAppInfos(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/metadata/command.go
+++ b/internal/cli/metadata/command.go
@@ -37,13 +37,19 @@ Examples:
   asc metadata init --dir "./metadata" --version "1.2.3" --locale "en-US"
   asc metadata pull --app "APP_ID" --version "1.2.3" --dir "./metadata"
   asc metadata pull --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+  asc metadata plan --app "APP_ID" --version "1.2.3" --dir "./metadata"
+  asc metadata approve --review-dir ".asc/metadata/review" --all
+  asc metadata apply --app "APP_ID" --version "1.2.3" --dir "./metadata" --review-dir ".asc/metadata/review" --confirm
   asc metadata keywords import --dir "./metadata" --version "1.2.3" --locale "en-US" --input "./keywords.csv"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			MetadataInitCommand(),
 			MetadataPullCommand(),
+			MetadataPlanCommand(),
+			MetadataApproveCommand(),
 			MetadataApplyCommand(),
+			MetadataStatusCommand(),
 			MetadataKeywordsCommand(),
 			MetadataPushCommand(),
 			MetadataValidateCommand(),

--- a/internal/cli/metadata/execute_push.go
+++ b/internal/cli/metadata/execute_push.go
@@ -22,6 +22,7 @@ type PushExecutionOptions struct {
 	DryRun       bool
 	AllowDeletes bool
 	Confirm      bool
+	ReviewDir    string
 }
 
 // ExecutePush computes and optionally applies a metadata push plan.
@@ -195,6 +196,15 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 		Updates:   updates,
 		Deletes:   deletes,
 		APICalls:  apiCalls,
+	}
+
+	if strings.TrimSpace(opts.ReviewDir) != "" {
+		if err := VerifyApprovedMetadataPlan(opts, result, opts.ReviewDir); err != nil {
+			return PushPlanResult{}, warnings, err
+		}
+		if !opts.DryRun && !opts.Confirm {
+			return PushPlanResult{}, nil, shared.UsageError("--confirm is required when applying an approved metadata plan")
+		}
 	}
 
 	if opts.DryRun {

--- a/internal/cli/metadata/execute_push.go
+++ b/internal/cli/metadata/execute_push.go
@@ -52,6 +52,9 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 	if dirValue == "" {
 		return PushPlanResult{}, nil, shared.UsageError("--dir is required")
 	}
+	if strings.TrimSpace(opts.ReviewDir) != "" && !opts.DryRun && !opts.Confirm {
+		return PushPlanResult{}, nil, shared.UsageError("--confirm is required when applying an approved metadata plan")
+	}
 
 	platformValue := strings.TrimSpace(opts.Platform)
 	if platformValue != "" {
@@ -201,9 +204,6 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 	if strings.TrimSpace(opts.ReviewDir) != "" {
 		if err := VerifyApprovedMetadataPlan(opts, result, opts.ReviewDir); err != nil {
 			return PushPlanResult{}, warnings, err
-		}
-		if !opts.DryRun && !opts.Confirm {
-			return PushPlanResult{}, nil, shared.UsageError("--confirm is required when applying an approved metadata plan")
 		}
 	}
 

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -201,14 +201,10 @@ Notes:
 				AllowDeletes: *allowDeletes,
 				Confirm:      *confirm,
 			}
-			var result PushPlanResult
-			var warnings []shared.SubmitReadinessCreateWarning
-			var err error
 			if cfg.name == "apply" && reviewDir != nil && strings.TrimSpace(*reviewDir) != "" {
-				result, warnings, err = ExecuteApprovedMetadataApplyWithWarnings(ctx, opts, *reviewDir)
-			} else {
-				result, warnings, err = ExecutePushWithWarnings(ctx, opts)
+				opts.ReviewDir = *reviewDir
 			}
+			result, warnings, err := ExecutePushWithWarnings(ctx, opts)
 			if err != nil && len(result.Actions) == 0 {
 				return err
 			}

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -145,7 +145,7 @@ func newMetadataMutationCommand(cfg metadataMutationCommandConfig) *ffcli.Comman
 	include := fs.String("include", includeLocalizations, "Included metadata scopes (comma-separated)")
 	dryRun := fs.Bool("dry-run", false, "Preview changes without mutating App Store Connect")
 	allowDeletes := fs.Bool("allow-deletes", false, "Allow destructive delete operations when applying changes (disables default locale fallback for missing locales)")
-	confirm := fs.Bool("confirm", false, "Confirm destructive operations (required with --allow-deletes)")
+	confirm := fs.Bool("confirm", false, "Confirm destructive operations (required with --allow-deletes or --review-dir)")
 	var reviewDir *string
 	if cfg.name == "apply" {
 		reviewDir = fs.String("review-dir", "", "Apply only after verifying metadata review artifacts in this directory")

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -146,7 +146,16 @@ func newMetadataMutationCommand(cfg metadataMutationCommandConfig) *ffcli.Comman
 	dryRun := fs.Bool("dry-run", false, "Preview changes without mutating App Store Connect")
 	allowDeletes := fs.Bool("allow-deletes", false, "Allow destructive delete operations when applying changes (disables default locale fallback for missing locales)")
 	confirm := fs.Bool("confirm", false, "Confirm destructive operations (required with --allow-deletes)")
+	var reviewDir *string
+	if cfg.name == "apply" {
+		reviewDir = fs.String("review-dir", "", "Apply only after verifying metadata review artifacts in this directory")
+	}
 	output := shared.BindOutputFlags(fs)
+	reviewExample := ""
+	if cfg.name == "apply" {
+		reviewExample = fmt.Sprintf(`
+  asc metadata %s --app "APP_ID" --version "1.2.3" --dir "./metadata" --review-dir ".asc/metadata/review" --confirm`, cfg.name)
+	}
 
 	return &ffcli.Command{
 		Name:       cfg.name,
@@ -160,7 +169,7 @@ Examples:
   asc metadata %s --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run
   asc metadata %s --app "APP_ID" --app-info "APP_INFO_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run
   asc metadata %s --app "APP_ID" --version "1.2.3" --dir "./metadata"
-  asc metadata %s --app "APP_ID" --version "1.2.3" --dir "./metadata" --allow-deletes --confirm
+  asc metadata %s --app "APP_ID" --version "1.2.3" --dir "./metadata" --allow-deletes --confirm%s
 
 Notes:
   - default.json fallback is applied only when --allow-deletes is not set.
@@ -172,6 +181,7 @@ Notes:
 			cfg.name,
 			cfg.name,
 			cfg.name,
+			reviewExample,
 		),
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -179,7 +189,7 @@ Notes:
 			if len(args) > 0 {
 				return shared.UsageError(fmt.Sprintf("metadata %s does not accept positional arguments", cfg.name))
 			}
-			result, warnings, err := ExecutePushWithWarnings(ctx, PushExecutionOptions{
+			opts := PushExecutionOptions{
 				CommandName:  cfg.name,
 				AppID:        *appID,
 				AppInfoID:    *appInfoID,
@@ -190,7 +200,15 @@ Notes:
 				DryRun:       *dryRun,
 				AllowDeletes: *allowDeletes,
 				Confirm:      *confirm,
-			})
+			}
+			var result PushPlanResult
+			var warnings []shared.SubmitReadinessCreateWarning
+			var err error
+			if cfg.name == "apply" && reviewDir != nil && strings.TrimSpace(*reviewDir) != "" {
+				result, warnings, err = ExecuteApprovedMetadataApplyWithWarnings(ctx, opts, *reviewDir)
+			} else {
+				result, warnings, err = ExecutePushWithWarnings(ctx, opts)
+			}
 			if err != nil && len(result.Actions) == 0 {
 				return err
 			}

--- a/internal/cli/metadata/review.go
+++ b/internal/cli/metadata/review.go
@@ -298,20 +298,22 @@ func ExecuteMetadataApprove(opts MetadataApproveOptions) (MetadataApprovalArtifa
 		return MetadataApprovalArtifact{}, err
 	}
 	pendingKeys := diffMetadataKeys(allKeys, approvedKeys)
+	planPath := filepath.Join(reviewDir, metadataPlanFileName)
+	approvalPath := filepath.Join(reviewDir, metadataApprovalFileName)
 	approval := MetadataApprovalArtifact{
 		SchemaVersion: metadataReviewSchemaV1,
 		ApprovedAt:    time.Now().UTC().Format(time.RFC3339),
 		PlanHash:      plan.PlanHash,
 		ReviewDir:     reviewDir,
-		PlanPath:      plan.PlanPath,
-		ApprovalPath:  plan.ApprovalPath,
+		PlanPath:      planPath,
+		ApprovalPath:  approvalPath,
 		Mode:          mode,
 		Note:          strings.TrimSpace(opts.Note),
 		ApprovedKeys:  approvedKeys,
 		PendingKeys:   pendingKeys,
 	}
-	if err := writeMetadataReviewJSON(plan.ApprovalPath, approval); err != nil {
-		return MetadataApprovalArtifact{}, fmt.Errorf("metadata approve: write %s: %w", plan.ApprovalPath, err)
+	if err := writeMetadataReviewJSON(approvalPath, approval); err != nil {
+		return MetadataApprovalArtifact{}, fmt.Errorf("metadata approve: write %s: %w", approvalPath, err)
 	}
 	return approval, nil
 }
@@ -474,6 +476,13 @@ func readMetadataPlanArtifact(path string) (MetadataPlanArtifact, error) {
 	}
 	if strings.TrimSpace(artifact.PlanHash) == "" {
 		return MetadataPlanArtifact{}, shared.UsageError("metadata plan artifact is missing planHash")
+	}
+	actualHash, err := hashMetadataPlan(artifact.Options, artifact.Plan)
+	if err != nil {
+		return MetadataPlanArtifact{}, fmt.Errorf("metadata plan: hash %s: %w", path, err)
+	}
+	if actualHash != artifact.PlanHash {
+		return MetadataPlanArtifact{}, shared.UsageError("metadata plan artifact planHash does not match its contents; rerun asc metadata plan")
 	}
 	return artifact, nil
 }

--- a/internal/cli/metadata/review.go
+++ b/internal/cli/metadata/review.go
@@ -370,9 +370,21 @@ func VerifyApprovedMetadataPlan(opts PushExecutionOptions, currentPlan PushPlanR
 	if err != nil {
 		return err
 	}
+	hashPlan := currentPlan
+	hashPlan.DryRun = true
+	currentOptions := metadataPlanOptionsFromPush(opts, hashPlan)
+	currentHash, err := hashMetadataPlan(currentOptions, hashPlan)
+	if err != nil {
+		return fmt.Errorf("metadata apply: hash current plan: %w", err)
+	}
+	currentKeys := metadataPlanKeys(metadataPlanItems(currentPlan))
 	approval, err := readMetadataApprovalArtifact(filepath.Join(resolvedReviewDir, metadataApprovalFileName))
 	if err != nil {
 		if os.IsNotExist(err) {
+			planKeys := metadataPlanKeys(metadataPlanItems(plan.Plan))
+			if len(planKeys) == 0 && len(currentKeys) == 0 && currentHash == plan.PlanHash {
+				return nil
+			}
 			return shared.UsageError("approved metadata plan is missing; run asc metadata approve first")
 		}
 		return err
@@ -381,17 +393,9 @@ func VerifyApprovedMetadataPlan(opts PushExecutionOptions, currentPlan PushPlanR
 		return shared.UsageError("approved metadata plan hash does not match plan.json; rerun asc metadata approve")
 	}
 
-	hashPlan := currentPlan
-	hashPlan.DryRun = true
-	currentOptions := metadataPlanOptionsFromPush(opts, hashPlan)
-	currentHash, err := hashMetadataPlan(currentOptions, hashPlan)
-	if err != nil {
-		return fmt.Errorf("metadata apply: hash current plan: %w", err)
-	}
 	if currentHash != plan.PlanHash {
 		return shared.UsageError("approved metadata plan drifted; rerun asc metadata plan and asc metadata approve")
 	}
-	currentKeys := metadataPlanKeys(metadataPlanItems(currentPlan))
 	pendingKeys := diffMetadataKeys(currentKeys, approval.ApprovedKeys)
 	if len(pendingKeys) > 0 {
 		return shared.UsageErrorf("approved metadata plan is incomplete; pending key(s): %s", strings.Join(pendingKeys, ", "))

--- a/internal/cli/metadata/review.go
+++ b/internal/cli/metadata/review.go
@@ -297,9 +297,16 @@ func ExecuteMetadataApprove(opts MetadataApproveOptions) (MetadataApprovalArtifa
 	if err != nil {
 		return MetadataApprovalArtifact{}, err
 	}
-	pendingKeys := diffMetadataKeys(allKeys, approvedKeys)
 	planPath := filepath.Join(reviewDir, metadataPlanFileName)
 	approvalPath := filepath.Join(reviewDir, metadataApprovalFileName)
+	existingApproval, err := readMetadataApprovalArtifact(approvalPath)
+	if err != nil && !os.IsNotExist(err) {
+		return MetadataApprovalArtifact{}, err
+	}
+	if err == nil && existingApproval.PlanHash == plan.PlanHash {
+		approvedKeys = mergeMetadataApprovalKeys(allKeys, existingApproval.ApprovedKeys, approvedKeys)
+	}
+	pendingKeys := diffMetadataKeys(allKeys, approvedKeys)
 	approval := MetadataApprovalArtifact{
 		SchemaVersion: metadataReviewSchemaV1,
 		ApprovedAt:    time.Now().UTC().Format(time.RFC3339),
@@ -379,14 +386,17 @@ func VerifyApprovedMetadataPlan(opts PushExecutionOptions, currentPlan PushPlanR
 	if err != nil {
 		return fmt.Errorf("metadata apply: hash current plan: %w", err)
 	}
+	planKeys := metadataPlanKeys(metadataPlanItems(plan.Plan))
 	currentKeys := metadataPlanKeys(metadataPlanItems(currentPlan))
+	if currentHash != plan.PlanHash {
+		return shared.UsageError("approved metadata plan drifted; rerun asc metadata plan and asc metadata approve")
+	}
+	if len(planKeys) == 0 && len(currentKeys) == 0 {
+		return nil
+	}
 	approval, err := readMetadataApprovalArtifact(filepath.Join(resolvedReviewDir, metadataApprovalFileName))
 	if err != nil {
 		if os.IsNotExist(err) {
-			planKeys := metadataPlanKeys(metadataPlanItems(plan.Plan))
-			if len(planKeys) == 0 && len(currentKeys) == 0 && currentHash == plan.PlanHash {
-				return nil
-			}
 			return shared.UsageError("approved metadata plan is missing; run asc metadata approve first")
 		}
 		return err
@@ -395,9 +405,6 @@ func VerifyApprovedMetadataPlan(opts PushExecutionOptions, currentPlan PushPlanR
 		return shared.UsageError("approved metadata plan hash does not match plan.json; rerun asc metadata approve")
 	}
 
-	if currentHash != plan.PlanHash {
-		return shared.UsageError("approved metadata plan drifted; rerun asc metadata plan and asc metadata approve")
-	}
 	pendingKeys := diffMetadataKeys(currentKeys, approval.ApprovedKeys)
 	if len(pendingKeys) > 0 {
 		return shared.UsageErrorf("approved metadata plan is incomplete; pending key(s): %s", strings.Join(pendingKeys, ", "))
@@ -624,6 +631,30 @@ func intersectMetadataKeys(all []string, approved []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func mergeMetadataApprovalKeys(all []string, existing []string, selected []string) []string {
+	allSet := make(map[string]struct{}, len(all))
+	for _, key := range all {
+		allSet[key] = struct{}{}
+	}
+	mergedSet := make(map[string]struct{}, len(existing)+len(selected))
+	for _, key := range existing {
+		if _, ok := allSet[key]; ok {
+			mergedSet[key] = struct{}{}
+		}
+	}
+	for _, key := range selected {
+		if _, ok := allSet[key]; ok {
+			mergedSet[key] = struct{}{}
+		}
+	}
+	merged := make([]string, 0, len(mergedSet))
+	for key := range mergedSet {
+		merged = append(merged, key)
+	}
+	sort.Strings(merged)
+	return merged
 }
 
 func printMetadataPlanArtifactTable(artifact MetadataPlanArtifact, markdown bool) error {

--- a/internal/cli/metadata/review.go
+++ b/internal/cli/metadata/review.go
@@ -364,7 +364,7 @@ func ExecuteMetadataReviewStatus(reviewDir string) (MetadataReviewStatus, error)
 		PlanHash:            plan.PlanHash,
 		ApprovalPlanHash:    approval.PlanHash,
 		ApprovalMatchesPlan: matches,
-		Ready:               matches && len(pendingKeys) == 0,
+		Ready:               len(allKeys) == 0 || (matches && len(pendingKeys) == 0),
 		TotalCount:          len(allKeys),
 		ApprovedCount:       len(approvedKeys),
 		PendingCount:        len(pendingKeys),

--- a/internal/cli/metadata/review.go
+++ b/internal/cli/metadata/review.go
@@ -364,49 +364,44 @@ func ExecuteMetadataReviewStatus(reviewDir string) (MetadataReviewStatus, error)
 	}, nil
 }
 
-func ExecuteApprovedMetadataApplyWithWarnings(ctx context.Context, opts PushExecutionOptions, reviewDir string) (PushPlanResult, []shared.SubmitReadinessCreateWarning, error) {
-	if !opts.Confirm {
-		return PushPlanResult{}, nil, shared.UsageError("--confirm is required when applying an approved metadata plan")
-	}
+func VerifyApprovedMetadataPlan(opts PushExecutionOptions, currentPlan PushPlanResult, reviewDir string) error {
 	resolvedReviewDir := metadataReviewDir(reviewDir)
 	plan, err := readMetadataPlanArtifact(filepath.Join(resolvedReviewDir, metadataPlanFileName))
 	if err != nil {
-		return PushPlanResult{}, nil, err
+		return err
 	}
 	approval, err := readMetadataApprovalArtifact(filepath.Join(resolvedReviewDir, metadataApprovalFileName))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return PushPlanResult{}, nil, shared.UsageError("approved metadata plan is missing; run asc metadata approve first")
+			return shared.UsageError("approved metadata plan is missing; run asc metadata approve first")
 		}
-		return PushPlanResult{}, nil, err
+		return err
 	}
 	if approval.PlanHash != plan.PlanHash {
-		return PushPlanResult{}, nil, shared.UsageError("approved metadata plan hash does not match plan.json; rerun asc metadata approve")
+		return shared.UsageError("approved metadata plan hash does not match plan.json; rerun asc metadata approve")
 	}
 
-	currentOpts := opts
-	currentOpts.DryRun = true
-	currentPlan, warnings, err := ExecutePushWithWarnings(ctx, currentOpts)
+	hashPlan := currentPlan
+	hashPlan.DryRun = true
+	currentOptions := metadataPlanOptionsFromPush(opts, hashPlan)
+	currentHash, err := hashMetadataPlan(currentOptions, hashPlan)
 	if err != nil {
-		return PushPlanResult{}, warnings, err
-	}
-	currentOptions := metadataPlanOptionsFromPush(currentOpts, currentPlan)
-	currentHash, err := hashMetadataPlan(currentOptions, currentPlan)
-	if err != nil {
-		return PushPlanResult{}, warnings, fmt.Errorf("metadata apply: hash current plan: %w", err)
+		return fmt.Errorf("metadata apply: hash current plan: %w", err)
 	}
 	if currentHash != plan.PlanHash {
-		return PushPlanResult{}, warnings, shared.UsageError("approved metadata plan drifted; rerun asc metadata plan and asc metadata approve")
+		return shared.UsageError("approved metadata plan drifted; rerun asc metadata plan and asc metadata approve")
 	}
 	currentKeys := metadataPlanKeys(metadataPlanItems(currentPlan))
 	pendingKeys := diffMetadataKeys(currentKeys, approval.ApprovedKeys)
 	if len(pendingKeys) > 0 {
-		return PushPlanResult{}, warnings, shared.UsageErrorf("approved metadata plan is incomplete; pending key(s): %s", strings.Join(pendingKeys, ", "))
+		return shared.UsageErrorf("approved metadata plan is incomplete; pending key(s): %s", strings.Join(pendingKeys, ", "))
 	}
+	return nil
+}
 
-	applyOpts := opts
-	applyOpts.DryRun = false
-	return ExecutePushWithWarnings(ctx, applyOpts)
+func ExecuteApprovedMetadataApplyWithWarnings(ctx context.Context, opts PushExecutionOptions, reviewDir string) (PushPlanResult, []shared.SubmitReadinessCreateWarning, error) {
+	opts.ReviewDir = reviewDir
+	return ExecutePushWithWarnings(ctx, opts)
 }
 
 func metadataReviewDir(reviewDir string) string {

--- a/internal/cli/metadata/review.go
+++ b/internal/cli/metadata/review.go
@@ -1,0 +1,665 @@
+package metadata
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const (
+	defaultMetadataReviewDir  = ".asc/metadata/review"
+	metadataPlanFileName      = "plan.json"
+	metadataApprovalFileName  = "approved.json"
+	metadataReviewSchemaV1    = 1
+	metadataApprovalAllOption = "all"
+)
+
+type MetadataPlanArtifact struct {
+	SchemaVersion int                 `json:"schemaVersion"`
+	GeneratedAt   string              `json:"generatedAt"`
+	Command       string              `json:"command"`
+	ReviewDir     string              `json:"reviewDir"`
+	PlanPath      string              `json:"planPath"`
+	ApprovalPath  string              `json:"approvalPath"`
+	PlanHash      string              `json:"planHash"`
+	Options       metadataPlanOptions `json:"options"`
+	Plan          PushPlanResult      `json:"plan"`
+}
+
+type MetadataApprovalArtifact struct {
+	SchemaVersion int      `json:"schemaVersion"`
+	ApprovedAt    string   `json:"approvedAt"`
+	PlanHash      string   `json:"planHash"`
+	ReviewDir     string   `json:"reviewDir"`
+	PlanPath      string   `json:"planPath"`
+	ApprovalPath  string   `json:"approvalPath"`
+	Mode          string   `json:"mode"`
+	Note          string   `json:"note,omitempty"`
+	ApprovedKeys  []string `json:"approvedKeys"`
+	PendingKeys   []string `json:"pendingKeys,omitempty"`
+}
+
+type MetadataReviewStatus struct {
+	ReviewDir           string   `json:"reviewDir"`
+	PlanPath            string   `json:"planPath"`
+	ApprovalPath        string   `json:"approvalPath"`
+	PlanHash            string   `json:"planHash"`
+	ApprovalPlanHash    string   `json:"approvalPlanHash,omitempty"`
+	ApprovalMatchesPlan bool     `json:"approvalMatchesPlan"`
+	Ready               bool     `json:"ready"`
+	TotalCount          int      `json:"totalCount"`
+	ApprovedCount       int      `json:"approvedCount"`
+	PendingCount        int      `json:"pendingCount"`
+	ApprovedKeys        []string `json:"approvedKeys,omitempty"`
+	PendingKeys         []string `json:"pendingKeys,omitempty"`
+}
+
+type metadataPlanOptions struct {
+	AppID        string   `json:"appId"`
+	AppInfoID    string   `json:"appInfoId,omitempty"`
+	Version      string   `json:"version"`
+	Platform     string   `json:"platform,omitempty"`
+	Dir          string   `json:"dir"`
+	Includes     []string `json:"includes"`
+	AllowDeletes bool     `json:"allowDeletes"`
+}
+
+type metadataPlanHashPayload struct {
+	SchemaVersion int                 `json:"schemaVersion"`
+	Options       metadataPlanOptions `json:"options"`
+	Plan          PushPlanResult      `json:"plan"`
+}
+
+// MetadataPlanCommand returns the metadata plan subcommand.
+func MetadataPlanCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metadata plan", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	appInfoID := fs.String("app-info", "", "App Info ID (optional override)")
+	version := fs.String("version", "", "App version string (for example 1.2.3)")
+	platform := fs.String("platform", "", "Optional platform: IOS, MAC_OS, TV_OS, or VISION_OS")
+	dir := fs.String("dir", "", "Metadata root directory (required)")
+	include := fs.String("include", includeLocalizations, "Included metadata scopes (comma-separated)")
+	allowDeletes := fs.Bool("allow-deletes", false, "Plan destructive delete operations (disables default locale fallback for missing locales)")
+	reviewDir := fs.String("review-dir", defaultMetadataReviewDir, "Directory for metadata review artifacts")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "plan",
+		ShortUsage: `asc metadata plan --app "APP_ID" --version "1.2.3" --dir "./metadata" [--review-dir ".asc/metadata/review"]`,
+		ShortHelp:  "Plan metadata changes and write a review artifact.",
+		LongHelp: `Plan metadata changes from canonical files and write a review artifact.
+
+Examples:
+  asc metadata plan --app "APP_ID" --version "1.2.3" --dir "./metadata"
+  asc metadata plan --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --review-dir ".asc/metadata/review"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("metadata plan does not accept positional arguments")
+			}
+			artifact, warnings, err := ExecuteMetadataPlanWithWarnings(ctx, PushExecutionOptions{
+				CommandName:  "plan",
+				AppID:        *appID,
+				AppInfoID:    *appInfoID,
+				Version:      *version,
+				Platform:     *platform,
+				Dir:          *dir,
+				Include:      *include,
+				DryRun:       true,
+				AllowDeletes: *allowDeletes,
+			}, *reviewDir)
+			if err != nil {
+				return err
+			}
+			if err := shared.PrintOutputWithRenderers(
+				artifact,
+				*output.Output,
+				*output.Pretty,
+				func() error { return printMetadataPlanArtifactTable(artifact, false) },
+				func() error { return printMetadataPlanArtifactTable(artifact, true) },
+			); err != nil {
+				return err
+			}
+			return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings)
+		},
+	}
+}
+
+// MetadataApproveCommand returns the metadata approve subcommand.
+func MetadataApproveCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metadata approve", flag.ExitOnError)
+
+	reviewDir := fs.String("review-dir", defaultMetadataReviewDir, "Directory containing metadata review artifacts")
+	all := fs.Bool("all", false, "Approve every planned metadata change")
+	key := fs.String("key", "", "Approve specific plan key(s), comma-separated")
+	scope := fs.String("scope", "", "Approve all changes in scope(s): app-info, version")
+	note := fs.String("note", "", "Optional reviewer note written to approved.json")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "approve",
+		ShortUsage: `asc metadata approve [--review-dir ".asc/metadata/review"] (--all | --key "KEY" | --scope app-info,version)`,
+		ShortHelp:  "Approve a metadata review plan.",
+		LongHelp: `Approve a metadata review plan by writing approved.json.
+
+Examples:
+  asc metadata approve --all
+  asc metadata approve --review-dir ".asc/metadata/review" --scope app-info
+  asc metadata approve --review-dir ".asc/metadata/review" --key "app-info:en-US:subtitle"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			_ = ctx
+			if len(args) > 0 {
+				return shared.UsageError("metadata approve does not accept positional arguments")
+			}
+			approval, err := ExecuteMetadataApprove(MetadataApproveOptions{
+				ReviewDir: *reviewDir,
+				All:       *all,
+				Key:       *key,
+				Scope:     *scope,
+				Note:      *note,
+			})
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutputWithRenderers(
+				approval,
+				*output.Output,
+				*output.Pretty,
+				func() error { return printMetadataApprovalTable(approval, false) },
+				func() error { return printMetadataApprovalTable(approval, true) },
+			)
+		},
+	}
+}
+
+// MetadataStatusCommand returns the metadata status subcommand.
+func MetadataStatusCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("metadata status", flag.ExitOnError)
+
+	reviewDir := fs.String("review-dir", defaultMetadataReviewDir, "Directory containing metadata review artifacts")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "status",
+		ShortUsage: `asc metadata status [--review-dir ".asc/metadata/review"]`,
+		ShortHelp:  "Show local metadata review approval status.",
+		LongHelp: `Show local metadata review approval status.
+
+Examples:
+  asc metadata status
+  asc metadata status --review-dir ".asc/metadata/review" --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			_ = ctx
+			if len(args) > 0 {
+				return shared.UsageError("metadata status does not accept positional arguments")
+			}
+			status, err := ExecuteMetadataReviewStatus(*reviewDir)
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutputWithRenderers(
+				status,
+				*output.Output,
+				*output.Pretty,
+				func() error { return printMetadataReviewStatusTable(status, false) },
+				func() error { return printMetadataReviewStatusTable(status, true) },
+			)
+		},
+	}
+}
+
+type MetadataApproveOptions struct {
+	ReviewDir string
+	All       bool
+	Key       string
+	Scope     string
+	Note      string
+}
+
+func ExecuteMetadataPlanWithWarnings(ctx context.Context, opts PushExecutionOptions, reviewDir string) (MetadataPlanArtifact, []shared.SubmitReadinessCreateWarning, error) {
+	opts.DryRun = true
+	result, warnings, err := ExecutePushWithWarnings(ctx, opts)
+	if err != nil {
+		return MetadataPlanArtifact{}, warnings, err
+	}
+
+	resolvedReviewDir := metadataReviewDir(reviewDir)
+	planPath := filepath.Join(resolvedReviewDir, metadataPlanFileName)
+	approvalPath := filepath.Join(resolvedReviewDir, metadataApprovalFileName)
+	options := metadataPlanOptionsFromPush(opts, result)
+	planHash, err := hashMetadataPlan(options, result)
+	if err != nil {
+		return MetadataPlanArtifact{}, warnings, fmt.Errorf("metadata plan: hash plan: %w", err)
+	}
+
+	artifact := MetadataPlanArtifact{
+		SchemaVersion: metadataReviewSchemaV1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Command:       "metadata plan",
+		ReviewDir:     resolvedReviewDir,
+		PlanPath:      planPath,
+		ApprovalPath:  approvalPath,
+		PlanHash:      planHash,
+		Options:       options,
+		Plan:          result,
+	}
+	if err := writeMetadataReviewJSON(planPath, artifact); err != nil {
+		return MetadataPlanArtifact{}, warnings, fmt.Errorf("metadata plan: write %s: %w", planPath, err)
+	}
+	return artifact, warnings, nil
+}
+
+func ExecuteMetadataApprove(opts MetadataApproveOptions) (MetadataApprovalArtifact, error) {
+	selectedModes := 0
+	if opts.All {
+		selectedModes++
+	}
+	if strings.TrimSpace(opts.Key) != "" {
+		selectedModes++
+	}
+	if strings.TrimSpace(opts.Scope) != "" {
+		selectedModes++
+	}
+	if selectedModes == 0 {
+		return MetadataApprovalArtifact{}, shared.UsageError("--all, --key, or --scope is required")
+	}
+	if selectedModes > 1 {
+		return MetadataApprovalArtifact{}, shared.UsageError("--all, --key, and --scope cannot be combined")
+	}
+
+	reviewDir := metadataReviewDir(opts.ReviewDir)
+	plan, err := readMetadataPlanArtifact(filepath.Join(reviewDir, metadataPlanFileName))
+	if err != nil {
+		return MetadataApprovalArtifact{}, err
+	}
+	allItems := metadataPlanItems(plan.Plan)
+	allKeys := metadataPlanKeys(allItems)
+	approvedKeys, mode, err := selectApprovedMetadataKeys(allItems, opts)
+	if err != nil {
+		return MetadataApprovalArtifact{}, err
+	}
+	pendingKeys := diffMetadataKeys(allKeys, approvedKeys)
+	approval := MetadataApprovalArtifact{
+		SchemaVersion: metadataReviewSchemaV1,
+		ApprovedAt:    time.Now().UTC().Format(time.RFC3339),
+		PlanHash:      plan.PlanHash,
+		ReviewDir:     reviewDir,
+		PlanPath:      plan.PlanPath,
+		ApprovalPath:  plan.ApprovalPath,
+		Mode:          mode,
+		Note:          strings.TrimSpace(opts.Note),
+		ApprovedKeys:  approvedKeys,
+		PendingKeys:   pendingKeys,
+	}
+	if err := writeMetadataReviewJSON(plan.ApprovalPath, approval); err != nil {
+		return MetadataApprovalArtifact{}, fmt.Errorf("metadata approve: write %s: %w", plan.ApprovalPath, err)
+	}
+	return approval, nil
+}
+
+func ExecuteMetadataReviewStatus(reviewDir string) (MetadataReviewStatus, error) {
+	resolvedReviewDir := metadataReviewDir(reviewDir)
+	planPath := filepath.Join(resolvedReviewDir, metadataPlanFileName)
+	approvalPath := filepath.Join(resolvedReviewDir, metadataApprovalFileName)
+	plan, err := readMetadataPlanArtifact(planPath)
+	if err != nil {
+		return MetadataReviewStatus{}, err
+	}
+	allKeys := metadataPlanKeys(metadataPlanItems(plan.Plan))
+
+	approval, err := readMetadataApprovalArtifact(approvalPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MetadataReviewStatus{
+				ReviewDir:           resolvedReviewDir,
+				PlanPath:            planPath,
+				ApprovalPath:        approvalPath,
+				PlanHash:            plan.PlanHash,
+				ApprovalMatchesPlan: false,
+				Ready:               len(allKeys) == 0,
+				TotalCount:          len(allKeys),
+				ApprovedCount:       0,
+				PendingCount:        len(allKeys),
+				PendingKeys:         allKeys,
+			}, nil
+		}
+		return MetadataReviewStatus{}, err
+	}
+
+	approvedKeys := intersectMetadataKeys(allKeys, approval.ApprovedKeys)
+	pendingKeys := diffMetadataKeys(allKeys, approvedKeys)
+	matches := approval.PlanHash == plan.PlanHash
+	return MetadataReviewStatus{
+		ReviewDir:           resolvedReviewDir,
+		PlanPath:            planPath,
+		ApprovalPath:        approvalPath,
+		PlanHash:            plan.PlanHash,
+		ApprovalPlanHash:    approval.PlanHash,
+		ApprovalMatchesPlan: matches,
+		Ready:               matches && len(pendingKeys) == 0,
+		TotalCount:          len(allKeys),
+		ApprovedCount:       len(approvedKeys),
+		PendingCount:        len(pendingKeys),
+		ApprovedKeys:        approvedKeys,
+		PendingKeys:         pendingKeys,
+	}, nil
+}
+
+func ExecuteApprovedMetadataApplyWithWarnings(ctx context.Context, opts PushExecutionOptions, reviewDir string) (PushPlanResult, []shared.SubmitReadinessCreateWarning, error) {
+	if !opts.Confirm {
+		return PushPlanResult{}, nil, shared.UsageError("--confirm is required when applying an approved metadata plan")
+	}
+	resolvedReviewDir := metadataReviewDir(reviewDir)
+	plan, err := readMetadataPlanArtifact(filepath.Join(resolvedReviewDir, metadataPlanFileName))
+	if err != nil {
+		return PushPlanResult{}, nil, err
+	}
+	approval, err := readMetadataApprovalArtifact(filepath.Join(resolvedReviewDir, metadataApprovalFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PushPlanResult{}, nil, shared.UsageError("approved metadata plan is missing; run asc metadata approve first")
+		}
+		return PushPlanResult{}, nil, err
+	}
+	if approval.PlanHash != plan.PlanHash {
+		return PushPlanResult{}, nil, shared.UsageError("approved metadata plan hash does not match plan.json; rerun asc metadata approve")
+	}
+
+	currentOpts := opts
+	currentOpts.DryRun = true
+	currentPlan, warnings, err := ExecutePushWithWarnings(ctx, currentOpts)
+	if err != nil {
+		return PushPlanResult{}, warnings, err
+	}
+	currentOptions := metadataPlanOptionsFromPush(currentOpts, currentPlan)
+	currentHash, err := hashMetadataPlan(currentOptions, currentPlan)
+	if err != nil {
+		return PushPlanResult{}, warnings, fmt.Errorf("metadata apply: hash current plan: %w", err)
+	}
+	if currentHash != plan.PlanHash {
+		return PushPlanResult{}, warnings, shared.UsageError("approved metadata plan drifted; rerun asc metadata plan and asc metadata approve")
+	}
+	currentKeys := metadataPlanKeys(metadataPlanItems(currentPlan))
+	pendingKeys := diffMetadataKeys(currentKeys, approval.ApprovedKeys)
+	if len(pendingKeys) > 0 {
+		return PushPlanResult{}, warnings, shared.UsageErrorf("approved metadata plan is incomplete; pending key(s): %s", strings.Join(pendingKeys, ", "))
+	}
+
+	applyOpts := opts
+	applyOpts.DryRun = false
+	return ExecutePushWithWarnings(ctx, applyOpts)
+}
+
+func metadataReviewDir(reviewDir string) string {
+	trimmed := strings.TrimSpace(reviewDir)
+	if trimmed == "" {
+		return defaultMetadataReviewDir
+	}
+	return trimmed
+}
+
+func metadataPlanOptionsFromPush(opts PushExecutionOptions, result PushPlanResult) metadataPlanOptions {
+	platform := strings.TrimSpace(opts.Platform)
+	if platform != "" {
+		if normalized, err := shared.NormalizeAppStoreVersionPlatform(platform); err == nil {
+			platform = normalized
+		}
+	}
+	return metadataPlanOptions{
+		AppID:        result.AppID,
+		AppInfoID:    result.AppInfoID,
+		Version:      result.Version,
+		Platform:     platform,
+		Dir:          result.Dir,
+		Includes:     append([]string(nil), result.Includes...),
+		AllowDeletes: opts.AllowDeletes,
+	}
+}
+
+func hashMetadataPlan(options metadataPlanOptions, plan PushPlanResult) (string, error) {
+	payload := metadataPlanHashPayload{
+		SchemaVersion: metadataReviewSchemaV1,
+		Options:       options,
+		Plan:          plan,
+	}
+	data, err := encodeCanonicalJSON(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func writeMetadataReviewJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFileNoFollow(path, data)
+}
+
+func readMetadataPlanArtifact(path string) (MetadataPlanArtifact, error) {
+	data, err := readFileNoFollow(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MetadataPlanArtifact{}, shared.UsageErrorf("metadata plan artifact not found at %s; run asc metadata plan first", path)
+		}
+		return MetadataPlanArtifact{}, fmt.Errorf("metadata plan: read %s: %w", path, err)
+	}
+	var artifact MetadataPlanArtifact
+	if err := decodeStrictJSON(data, &artifact); err != nil {
+		return MetadataPlanArtifact{}, fmt.Errorf("metadata plan: parse %s: %w", path, err)
+	}
+	if artifact.SchemaVersion != metadataReviewSchemaV1 {
+		return MetadataPlanArtifact{}, shared.UsageErrorf("unsupported metadata plan schema version %d", artifact.SchemaVersion)
+	}
+	if strings.TrimSpace(artifact.PlanHash) == "" {
+		return MetadataPlanArtifact{}, shared.UsageError("metadata plan artifact is missing planHash")
+	}
+	return artifact, nil
+}
+
+func readMetadataApprovalArtifact(path string) (MetadataApprovalArtifact, error) {
+	data, err := readFileNoFollow(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MetadataApprovalArtifact{}, err
+		}
+		return MetadataApprovalArtifact{}, fmt.Errorf("metadata approve: read %s: %w", path, err)
+	}
+	var artifact MetadataApprovalArtifact
+	if err := decodeStrictJSON(data, &artifact); err != nil {
+		return MetadataApprovalArtifact{}, fmt.Errorf("metadata approve: parse %s: %w", path, err)
+	}
+	if artifact.SchemaVersion != metadataReviewSchemaV1 {
+		return MetadataApprovalArtifact{}, shared.UsageErrorf("unsupported metadata approval schema version %d", artifact.SchemaVersion)
+	}
+	return artifact, nil
+}
+
+func metadataPlanItems(plan PushPlanResult) []PlanItem {
+	items := make([]PlanItem, 0, len(plan.Adds)+len(plan.Updates)+len(plan.Deletes))
+	items = append(items, plan.Adds...)
+	items = append(items, plan.Updates...)
+	items = append(items, plan.Deletes...)
+	sortPlanItems(items)
+	return items
+}
+
+func metadataPlanKeys(items []PlanItem) []string {
+	keys := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		key := strings.TrimSpace(item.Key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func selectApprovedMetadataKeys(items []PlanItem, opts MetadataApproveOptions) ([]string, string, error) {
+	allKeys := metadataPlanKeys(items)
+	if opts.All {
+		return allKeys, metadataApprovalAllOption, nil
+	}
+
+	itemByKey := make(map[string]PlanItem, len(items))
+	for _, item := range items {
+		itemByKey[item.Key] = item
+	}
+	if strings.TrimSpace(opts.Key) != "" {
+		requested := splitReviewCSV(opts.Key)
+		for _, key := range requested {
+			if _, ok := itemByKey[key]; !ok {
+				return nil, "", shared.UsageErrorf("metadata approve key %q was not found in plan", key)
+			}
+		}
+		sort.Strings(requested)
+		return requested, "key", nil
+	}
+
+	scopes := splitReviewCSV(opts.Scope)
+	if len(scopes) == 0 {
+		return nil, "", shared.UsageError("--scope must include at least one scope")
+	}
+	allowedScopes := map[string]struct{}{
+		appInfoDirName: {},
+		versionDirName: {},
+	}
+	scopeSet := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		if _, ok := allowedScopes[scope]; !ok {
+			return nil, "", shared.UsageErrorf("--scope must be one of %s, %s", appInfoDirName, versionDirName)
+		}
+		scopeSet[scope] = struct{}{}
+	}
+	approved := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, ok := scopeSet[item.Scope]; ok {
+			approved = append(approved, item.Key)
+		}
+	}
+	sort.Strings(approved)
+	return approved, "scope", nil
+}
+
+func splitReviewCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func diffMetadataKeys(all []string, approved []string) []string {
+	approvedSet := make(map[string]struct{}, len(approved))
+	for _, key := range approved {
+		approvedSet[key] = struct{}{}
+	}
+	pending := make([]string, 0)
+	for _, key := range all {
+		if _, ok := approvedSet[key]; !ok {
+			pending = append(pending, key)
+		}
+	}
+	sort.Strings(pending)
+	return pending
+}
+
+func intersectMetadataKeys(all []string, approved []string) []string {
+	allSet := make(map[string]struct{}, len(all))
+	for _, key := range all {
+		allSet[key] = struct{}{}
+	}
+	out := make([]string, 0)
+	for _, key := range approved {
+		if _, ok := allSet[key]; ok {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func printMetadataPlanArtifactTable(artifact MetadataPlanArtifact, markdown bool) error {
+	fmt.Printf("Review Dir: %s\n", artifact.ReviewDir)
+	fmt.Printf("Plan Path: %s\n", artifact.PlanPath)
+	fmt.Printf("Approval Path: %s\n", artifact.ApprovalPath)
+	fmt.Printf("Plan Hash: %s\n\n", artifact.PlanHash)
+	if markdown {
+		return printPushPlanMarkdown(artifact.Plan)
+	}
+	return printPushPlanTable(artifact.Plan)
+}
+
+func printMetadataApprovalTable(approval MetadataApprovalArtifact, markdown bool) error {
+	headers := []string{"planHash", "mode", "approved", "pending", "approvalPath"}
+	rows := [][]string{{
+		approval.PlanHash,
+		approval.Mode,
+		fmt.Sprintf("%d", len(approval.ApprovedKeys)),
+		fmt.Sprintf("%d", len(approval.PendingKeys)),
+		approval.ApprovalPath,
+	}}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return nil
+	}
+	asc.RenderTable(headers, rows)
+	return nil
+}
+
+func printMetadataReviewStatusTable(status MetadataReviewStatus, markdown bool) error {
+	headers := []string{"ready", "planHash", "approvalMatchesPlan", "total", "approved", "pending"}
+	rows := [][]string{{
+		fmt.Sprintf("%t", status.Ready),
+		status.PlanHash,
+		fmt.Sprintf("%t", status.ApprovalMatchesPlan),
+		fmt.Sprintf("%d", status.TotalCount),
+		fmt.Sprintf("%d", status.ApprovedCount),
+		fmt.Sprintf("%d", status.PendingCount),
+	}}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return nil
+	}
+	asc.RenderTable(headers, rows)
+	return nil
+}

--- a/internal/cli/metadata/review_test.go
+++ b/internal/cli/metadata/review_test.go
@@ -1,0 +1,108 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMetadataApproveWritesToRequestedReviewDir(t *testing.T) {
+	reviewDir := filepath.Join(t.TempDir(), "relative-review")
+	if err := os.MkdirAll(reviewDir, 0o755); err != nil {
+		t.Fatalf("mkdir review dir: %v", err)
+	}
+	plan := metadataReviewTestPlan(t, reviewDir)
+	plan.PlanPath = filepath.Join("relative-review", metadataPlanFileName)
+	plan.ApprovalPath = filepath.Join("relative-review", metadataApprovalFileName)
+	if err := writeMetadataReviewJSON(filepath.Join(reviewDir, metadataPlanFileName), plan); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	otherCWD := t.TempDir()
+	if err := os.Mkdir(filepath.Join(otherCWD, "relative-review"), 0o755); err != nil {
+		t.Fatalf("mkdir stale relative review dir: %v", err)
+	}
+	t.Chdir(otherCWD)
+
+	approval, err := ExecuteMetadataApprove(MetadataApproveOptions{
+		ReviewDir: reviewDir,
+		All:       true,
+	})
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if approval.ApprovalPath != filepath.Join(reviewDir, metadataApprovalFileName) {
+		t.Fatalf("expected approval path under requested review dir, got %q", approval.ApprovalPath)
+	}
+	if _, err := os.Stat(filepath.Join(reviewDir, metadataApprovalFileName)); err != nil {
+		t.Fatalf("expected approval in requested review dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(otherCWD, "relative-review", metadataApprovalFileName)); !os.IsNotExist(err) {
+		t.Fatalf("expected no approval in stale cwd-relative dir, err=%v", err)
+	}
+}
+
+func TestReadMetadataPlanArtifactRejectsMismatchedHash(t *testing.T) {
+	reviewDir := t.TempDir()
+	plan := metadataReviewTestPlan(t, reviewDir)
+	plan.Plan.Updates[0].To = "Edited after review"
+	planPath := filepath.Join(reviewDir, metadataPlanFileName)
+	if err := writeMetadataReviewJSON(planPath, plan); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	_, err := readMetadataPlanArtifact(planPath)
+	if err == nil {
+		t.Fatal("expected mismatched hash error")
+	}
+	if !strings.Contains(err.Error(), "planHash does not match") {
+		t.Fatalf("expected planHash mismatch error, got %v", err)
+	}
+}
+
+func metadataReviewTestPlan(t *testing.T, reviewDir string) MetadataPlanArtifact {
+	t.Helper()
+	result := PushPlanResult{
+		AppID:     "app-1",
+		AppInfoID: "appinfo-1",
+		Version:   "1.2.3",
+		VersionID: "version-1",
+		Dir:       "./metadata",
+		DryRun:    true,
+		Includes:  []string{includeLocalizations},
+		Updates: []PlanItem{{
+			Key:    "app-info:en-US:subtitle",
+			Scope:  appInfoDirName,
+			Locale: "en-US",
+			Field:  "subtitle",
+			Reason: "field differs",
+			From:   "Sleep tracker",
+			To:     "Sleep scores",
+		}},
+	}
+	options := metadataPlanOptionsFromPush(PushExecutionOptions{
+		AppID:        result.AppID,
+		Version:      result.Version,
+		Dir:          result.Dir,
+		Include:      includeLocalizations,
+		DryRun:       true,
+		AllowDeletes: false,
+	}, result)
+	planHash, err := hashMetadataPlan(options, result)
+	if err != nil {
+		t.Fatalf("hash plan: %v", err)
+	}
+	return MetadataPlanArtifact{
+		SchemaVersion: metadataReviewSchemaV1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Command:       "metadata plan",
+		ReviewDir:     reviewDir,
+		PlanPath:      filepath.Join(reviewDir, metadataPlanFileName),
+		ApprovalPath:  filepath.Join(reviewDir, metadataApprovalFileName),
+		PlanHash:      planHash,
+		Options:       options,
+		Plan:          result,
+	}
+}

--- a/internal/cli/metadata/review_test.go
+++ b/internal/cli/metadata/review_test.go
@@ -152,6 +152,13 @@ func TestVerifyApprovedMetadataPlanAllowsEmptyPlanWithStaleApproval(t *testing.T
 	if err := VerifyApprovedMetadataPlan(metadataReviewTestPushOptions(plan.Plan), plan.Plan, reviewDir); err != nil {
 		t.Fatalf("expected empty plan with stale approval to be ready: %v", err)
 	}
+	status, err := ExecuteMetadataReviewStatus(reviewDir)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !status.Ready || status.TotalCount != 0 || status.PendingCount != 0 {
+		t.Fatalf("expected empty plan status to be ready despite stale approval, got %+v", status)
+	}
 }
 
 func metadataReviewTestPlan(t *testing.T, reviewDir string) MetadataPlanArtifact {

--- a/internal/cli/metadata/review_test.go
+++ b/internal/cli/metadata/review_test.go
@@ -62,6 +62,98 @@ func TestReadMetadataPlanArtifactRejectsMismatchedHash(t *testing.T) {
 	}
 }
 
+func TestMetadataApproveMergesExistingApprovalForSamePlan(t *testing.T) {
+	reviewDir := t.TempDir()
+	plan := metadataReviewTestPlan(t, reviewDir)
+	plan.Plan.Updates = append(plan.Plan.Updates, PlanItem{
+		Key:    "app-info:en-US:name",
+		Scope:  appInfoDirName,
+		Locale: "en-US",
+		Field:  "name",
+		Reason: "field differs",
+		From:   "Outslept",
+		To:     "Outslept: Sleep Scores",
+	})
+	updateMetadataReviewTestPlanHash(t, &plan)
+	if err := writeMetadataReviewJSON(filepath.Join(reviewDir, metadataPlanFileName), plan); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	first, err := ExecuteMetadataApprove(MetadataApproveOptions{
+		ReviewDir: reviewDir,
+		Key:       "app-info:en-US:subtitle",
+	})
+	if err != nil {
+		t.Fatalf("approve first key: %v", err)
+	}
+	if len(first.ApprovedKeys) != 1 || first.ApprovedKeys[0] != "app-info:en-US:subtitle" {
+		t.Fatalf("unexpected first approval: %+v", first.ApprovedKeys)
+	}
+
+	second, err := ExecuteMetadataApprove(MetadataApproveOptions{
+		ReviewDir: reviewDir,
+		Key:       "app-info:en-US:name",
+	})
+	if err != nil {
+		t.Fatalf("approve second key: %v", err)
+	}
+	want := []string{"app-info:en-US:name", "app-info:en-US:subtitle"}
+	if strings.Join(second.ApprovedKeys, ",") != strings.Join(want, ",") {
+		t.Fatalf("expected merged approvals %v, got %v", want, second.ApprovedKeys)
+	}
+	status, err := ExecuteMetadataReviewStatus(reviewDir)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !status.Ready || status.PendingCount != 0 || status.ApprovedCount != 2 {
+		t.Fatalf("expected merged approvals to be ready, got %+v", status)
+	}
+}
+
+func TestVerifyApprovedMetadataPlanReportsDriftBeforeMissingApproval(t *testing.T) {
+	reviewDir := t.TempDir()
+	plan := metadataReviewTestPlan(t, reviewDir)
+	if err := writeMetadataReviewJSON(filepath.Join(reviewDir, metadataPlanFileName), plan); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	currentPlan := plan.Plan
+	currentPlan.Updates[0].To = "Drifted after planning"
+	err := VerifyApprovedMetadataPlan(metadataReviewTestPushOptions(plan.Plan), currentPlan, reviewDir)
+	if err == nil {
+		t.Fatal("expected drift error")
+	}
+	if !strings.Contains(err.Error(), "approved metadata plan drifted") {
+		t.Fatalf("expected drift error, got %v", err)
+	}
+}
+
+func TestVerifyApprovedMetadataPlanAllowsEmptyPlanWithStaleApproval(t *testing.T) {
+	reviewDir := t.TempDir()
+	plan := metadataReviewTestPlan(t, reviewDir)
+	plan.Plan.Updates = nil
+	updateMetadataReviewTestPlanHash(t, &plan)
+	if err := writeMetadataReviewJSON(filepath.Join(reviewDir, metadataPlanFileName), plan); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	staleApproval := MetadataApprovalArtifact{
+		SchemaVersion: metadataReviewSchemaV1,
+		ApprovedAt:    time.Now().UTC().Format(time.RFC3339),
+		PlanHash:      "stale-plan-hash",
+		ReviewDir:     reviewDir,
+		PlanPath:      filepath.Join(reviewDir, metadataPlanFileName),
+		ApprovalPath:  filepath.Join(reviewDir, metadataApprovalFileName),
+		Mode:          metadataApprovalAllOption,
+	}
+	if err := writeMetadataReviewJSON(filepath.Join(reviewDir, metadataApprovalFileName), staleApproval); err != nil {
+		t.Fatalf("write stale approval: %v", err)
+	}
+
+	if err := VerifyApprovedMetadataPlan(metadataReviewTestPushOptions(plan.Plan), plan.Plan, reviewDir); err != nil {
+		t.Fatalf("expected empty plan with stale approval to be ready: %v", err)
+	}
+}
+
 func metadataReviewTestPlan(t *testing.T, reviewDir string) MetadataPlanArtifact {
 	t.Helper()
 	result := PushPlanResult{
@@ -104,5 +196,28 @@ func metadataReviewTestPlan(t *testing.T, reviewDir string) MetadataPlanArtifact
 		PlanHash:      planHash,
 		Options:       options,
 		Plan:          result,
+	}
+}
+
+func updateMetadataReviewTestPlanHash(t *testing.T, plan *MetadataPlanArtifact) {
+	t.Helper()
+	options := metadataPlanOptionsFromPush(metadataReviewTestPushOptions(plan.Plan), plan.Plan)
+	planHash, err := hashMetadataPlan(options, plan.Plan)
+	if err != nil {
+		t.Fatalf("hash plan: %v", err)
+	}
+	plan.Options = options
+	plan.PlanHash = planHash
+}
+
+func metadataReviewTestPushOptions(plan PushPlanResult) PushExecutionOptions {
+	return PushExecutionOptions{
+		AppID:        plan.AppID,
+		AppInfoID:    plan.AppInfoID,
+		Version:      plan.Version,
+		Dir:          plan.Dir,
+		Include:      strings.Join(plan.Includes, ","),
+		DryRun:       true,
+		AllowDeletes: false,
 	}
 }


### PR DESCRIPTION
## Summary

Implements the metadata plan / approve / apply workflow requested in #1717.

- Adds `asc metadata plan` to persist a reviewable `plan.json` with a stable `planHash`.
- Adds `asc metadata approve` and `asc metadata status` for explicit approval artifacts.
- Adds guarded `asc metadata apply --review-dir ... --confirm`, which recomputes the current plan, compares hashes, verifies approval coverage, and only then delegates to the existing metadata executor.
- Keeps direct `metadata apply` / `metadata push` compatibility intact.
- Adds a short design note covering the chosen approach and trade-offs.

## Validation

- RED first: focused CLI tests failed before implementation because `metadata plan` did not exist.
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/metadata ./internal/cli/cmdtest -run 'TestMetadata' -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- Commit hook reran docs checks, format, lint, and the short test suite successfully.

## Live dogfood

Built the branch binary to `/tmp/asc` and used it against Outslept (`6787681131`, bundle `com.rudrankriyam.outslept`, version `1.0.0`, `PREPARE_FOR_SUBMISSION`).

- Pulled current metadata.
- Made a small ASO pass: title punctuation, subtitle, description opener/body, keywords, and promotional text.
- Ran `metadata validate` with zero issues.
- Ran `metadata plan` and approved plan hash `7868c0d6147abc8025571af79ec4054e4fa46ad49cf7c632ddddf6598b6d2bbf`.
- Ran guarded `metadata apply --review-dir ... --confirm`; both app-info and version localization updates succeeded.
- Re-ran `metadata plan`; it returned zero adds, updates, and deletes.
- Pulled fresh metadata and confirmed the live values.

Closes #1717.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metadata review workflow with `metadata plan`, `metadata approve`, and `metadata status`, using persisted plan/approval artifacts in a review directory.
  * Enabled applying only approved changes via `metadata apply --review-dir`, with `--dry-run` previews.
* **Bug Fixes**
  * Guarded apply now validates approved-plan consistency and rejects drift before any mutations.
  * Applying with `--review-dir` now requires `--confirm` for destructive execution (not for dry runs).
* **Documentation**
  * Updated metadata help and workflow docs to cover `plan/approve/status`, `--review-dir`, and required `--confirm`.
* **Tests**
  * Added CLI and end-to-end coverage for confirm gating, plan/approve/status/apply, drift rejection, and empty-plan behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->