### PR TITLE
Preserve Xcode Cloud workflow response fields

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -5399,7 +5399,37 @@ func TestDeleteCiProduct(t *testing.T) {
 }
 
 func TestGetCiWorkflow(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciWorkflows","id":"wf-1"}}`)
+	response := jsonResponse(http.StatusOK, `{
+		"data": {
+			"type": "ciWorkflows",
+			"id": "wf-1",
+			"attributes": {
+				"actions": [{
+					"name": "Archive - iOS",
+					"actionType": "ARCHIVE",
+					"destination": "ANY_IOS_DEVICE",
+					"buildDistributionAudience": "APP_STORE_ELIGIBLE",
+					"scheme": "Example",
+					"platform": "IOS",
+					"isRequiredToPass": true
+				}]
+			},
+			"relationships": {
+				"repository": {
+					"links": {
+						"self": "https://api.appstoreconnect.apple.com/v1/ciWorkflows/wf-1/relationships/repository",
+						"related": "https://api.appstoreconnect.apple.com/v1/ciWorkflows/wf-1/repository"
+					}
+				},
+				"buildRuns": {
+					"links": {
+						"self": "https://api.appstoreconnect.apple.com/v1/ciWorkflows/wf-1/relationships/buildRuns",
+						"related": "https://api.appstoreconnect.apple.com/v1/ciWorkflows/wf-1/buildRuns"
+					}
+				}
+			}
+		}
+	}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -5410,8 +5440,29 @@ func TestGetCiWorkflow(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetCiWorkflow(context.Background(), "wf-1"); err != nil {
+	got, err := client.GetCiWorkflow(context.Background(), "wf-1")
+	if err != nil {
 		t.Fatalf("GetCiWorkflow() error: %v", err)
+	}
+	if len(got.Data.Attributes.Actions) != 1 || got.Data.Attributes.Actions[0].Scheme != "Example" {
+		t.Fatalf("unexpected actions: %#v", got.Data.Attributes.Actions)
+	}
+	if got.Data.Relationships == nil || got.Data.Relationships.Repository == nil {
+		t.Fatal("expected repository relationship")
+	}
+	if got.Data.Relationships.Repository.Links.Related != "https://api.appstoreconnect.apple.com/v1/ciWorkflows/wf-1/repository" {
+		t.Fatalf("unexpected repository links: %#v", got.Data.Relationships.Repository.Links)
+	}
+	if got.Data.Relationships.BuildRuns == nil || got.Data.Relationships.BuildRuns.Links.Related == "" {
+		t.Fatalf("unexpected build runs relationship: %#v", got.Data.Relationships.BuildRuns)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if strings.Contains(string(encoded), `"data":{"type":"","id":""}`) {
+		t.Fatalf("workflow response invented empty relationship data: %s", encoded)
 	}
 }
 

--- a/internal/asc/xcode_cloud.go
+++ b/internal/asc/xcode_cloud.go
@@ -101,11 +101,24 @@ type CiWorkflowAttributes struct {
 	ManualBranchStartCondition      *CiManualStartCondition      `json:"manualBranchStartCondition,omitempty"`
 	ManualTagStartCondition         *CiManualStartCondition      `json:"manualTagStartCondition,omitempty"`
 	ManualPullRequestStartCondition *CiManualStartCondition      `json:"manualPullRequestStartCondition,omitempty"`
+	Actions                         []CiAction                   `json:"actions,omitempty"`
 	IsEnabled                       bool                         `json:"isEnabled,omitempty"`
 	IsLockedForEditing              bool                         `json:"isLockedForEditing,omitempty"`
 	Clean                           bool                         `json:"clean,omitempty"`
 	ContainerFilePath               string                       `json:"containerFilePath,omitempty"`
 	LastModifiedDate                string                       `json:"lastModifiedDate,omitempty"`
+}
+
+// CiAction describes a build, analyze, test, or archive action in a CI workflow.
+type CiAction struct {
+	Name                      string          `json:"name,omitempty"`
+	ActionType                string          `json:"actionType,omitempty"`
+	Destination               string          `json:"destination,omitempty"`
+	BuildDistributionAudience string          `json:"buildDistributionAudience,omitempty"`
+	TestConfiguration         json.RawMessage `json:"testConfiguration,omitempty"`
+	Scheme                    string          `json:"scheme,omitempty"`
+	Platform                  string          `json:"platform,omitempty"`
+	IsRequiredToPass          bool            `json:"isRequiredToPass"`
 }
 
 // CiBranchStartCondition describes branch start conditions.
@@ -176,10 +189,29 @@ type CiSchedule struct {
 
 // CiWorkflowRelationships describes relationships for a CI workflow.
 type CiWorkflowRelationships struct {
-	Product      *Relationship `json:"product,omitempty"`
-	Repository   *Relationship `json:"repository,omitempty"`
-	XcodeVersion *Relationship `json:"xcodeVersion,omitempty"`
-	MacOsVersion *Relationship `json:"macOsVersion,omitempty"`
+	Product      *Relationship                     `json:"product,omitempty"`
+	Repository   *CiWorkflowRepositoryRelationship `json:"repository,omitempty"`
+	XcodeVersion *Relationship                     `json:"xcodeVersion,omitempty"`
+	MacOsVersion *Relationship                     `json:"macOsVersion,omitempty"`
+	BuildRuns    *CiWorkflowBuildRunsRelationship  `json:"buildRuns,omitempty"`
+}
+
+// CiRelationshipLinks contains JSON:API links for an Xcode Cloud relationship.
+type CiRelationshipLinks struct {
+	Self    string `json:"self,omitempty"`
+	Related string `json:"related,omitempty"`
+}
+
+// CiWorkflowRepositoryRelationship describes a workflow's repository relationship.
+// Apple may return only links when the repository isn't included in the response.
+type CiWorkflowRepositoryRelationship struct {
+	Links CiRelationshipLinks `json:"links"`
+	Data  *ResourceData       `json:"data,omitempty"`
+}
+
+// CiWorkflowBuildRunsRelationship describes a workflow's build-runs relationship.
+type CiWorkflowBuildRunsRelationship struct {
+	Links CiRelationshipLinks `json:"links"`
 }
 
 // CiWorkflowResource represents a CI workflow resource.


### PR DESCRIPTION
## What changed

- Decode Xcode Cloud workflow actions instead of dropping them during JSON unmarshalling.
- Preserve the link-only `repository` and `buildRuns` relationships returned by App Store Connect.
- Add a regression test that rejects the fabricated `data: {type: "", id: ""}` linkage produced by the old model.

## Root cause

A live `GET /v1/ciWorkflows/{id}` returned repository and build-run relationships with `links` but no inline `data`. `CiWorkflowRelationships.Repository` used the generic data-only `Relationship` type, so the CLI discarded those links and then serialized a zero-value resource identifier. `CiWorkflowAttributes` also had no `actions` field, which removed the archive configuration from `view`, `create`, and `update` output.

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run '^TestGetCiWorkflow$'`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built the branch and ran a read-only live workflow view; output now includes the `ARCHIVE` action plus both relationship link sets, with no empty linkage data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI workflow details now include workflow actions and richer relationship information, making workflow data more complete and accurate.
  * Repository and build run links are now surfaced when viewing workflow information.

* **Bug Fixes**
  * Fixed workflow output so empty placeholder relationship data is no longer shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->