### PR TITLE
chore(wall): remove MewMax AI entry

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -818,11 +818,6 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/50/8e/ed/508eedf3-5d31-7f42-c7dc-4c5551ce5d4a/AppIcon-0-0-1x_U007epad-0-0-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
-    "app": "MewMax AI: Looksmax Face Scan",
-    "link": "https://apps.apple.com/us/app/mewmax-ai-looksmax-face-scan/id6770394192?uo=4",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b8/9f/25/b89f25d8-3da6-ea04-889b-b4b47ac758e9/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
-  },
-  {
     "app": "Midnight: Couples App & Games",
     "link": "https://apps.apple.com/us/app/midnight-couples-app-games/id6758623374?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/e5/81/e1/e581e1f6-fed0-f6b0-0e70-cb2ad5a0c764/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- Remove `MewMax AI: Looksmax Face Scan` (App ID 6770394192) from the Wall of Apps.

## Notes

- The entry was added unintentionally via `asc apps wall submit` (#1721) — the developer did not intend to list the app. Sorry for the noise, and thanks for the great CLI!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed “MewMax AI: Looksmax Face Scan” from the Wall of Apps listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->