### PR TITLE
feat(telemetry): emit bounded v4 outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,13 @@ one installation be grouped over time; it is not derived from an Apple account
 or machine identifier.
 
 Telemetry includes the CLI version, operating system and architecture,
-registered command path, duration and exit outcome, runtime context, invocation
-source, low-cardinality invocation shape and failure classifications, the public
-flag name involved in a failed usage parse when it can be safely identified, and
-random event and session IDs. It does **not** include raw arguments, stderr,
-error messages, or flag values, credentials, private keys, Apple account, team,
-or issuer IDs, app or bundle IDs, API responses, usernames, hostnames,
-repository names, or file paths.
+registered command path, duration, runtime context, invocation source, help or
+execution intent, a bounded outcome class, and the HTTP status when an API
+request fails. It may include a sanitized public flag name and a
+launcher-supplied random task UUID. It does **not** include raw arguments,
+stderr, error messages, flag values, response bodies, credentials, private
+keys, Apple account, team, or issuer IDs, app or bundle IDs, usernames,
+hostnames, repository names, or file paths.
 
 Review or change telemetry at any time:
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,9 @@ one installation be grouped over time; it is not derived from an Apple account
 or machine identifier.
 
 Telemetry includes the CLI version, operating system and architecture,
-registered command path, duration, runtime context, invocation source, help or
-execution intent, a bounded outcome class, and the HTTP status when an API
-request fails. It may include a sanitized public flag name and a
-launcher-supplied random task UUID. It does **not** include raw arguments,
+registered command path, duration, runtime context, invocation source, a
+bounded outcome class, and the HTTP status when an API request fails. It may
+include a sanitized public flag name. It does **not** include raw arguments,
 stderr, error messages, flag values, response bodies, credentials, private
 keys, Apple account, team, or issuer IDs, app or bundle IDs, usernames,
 hostnames, repository names, or file paths.

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -127,7 +127,6 @@ func parseFailureContext(analysis invocationAnalysis) telemetry.EventContext {
 		ErrorKind:        kind,
 		FailureStage:     telemetry.FailureStageParse,
 		FailureParameter: parameter,
-		EventKind:        telemetry.EventKindExecution,
 		OutcomeKind:      telemetry.OutcomeUsageError,
 	}
 }
@@ -148,7 +147,6 @@ func validationFailureContext(analysis invocationAnalysis, err error) telemetry.
 		ErrorKind:        kind,
 		FailureStage:     telemetry.FailureStageValidation,
 		FailureParameter: failureParameterFromError(err),
-		EventKind:        telemetry.EventKindExecution,
 		OutcomeKind:      telemetry.OutcomeUsageError,
 	}
 }
@@ -162,7 +160,6 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 		InvocationShape: analysis.shape,
 		ErrorKind:       telemetry.ErrorKindOther,
 		FailureStage:    telemetry.FailureStageExecution,
-		EventKind:       telemetry.EventKindExecution,
 		HTTPStatus:      httpStatusFromError(err),
 	}
 	switch {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared/suggest"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
 type invocationAnalysis struct {
@@ -194,7 +195,7 @@ func runtimeOutcomeKind(err error, exitCode int, eventContext telemetry.EventCon
 	switch {
 	case errors.Is(err, context.Canceled):
 		return telemetry.OutcomeCancelled
-	case errors.Is(err, shared.ErrMissingAuth), exitCode == ExitAuth:
+	case errors.Is(err, shared.ErrMissingAuth), errors.Is(err, webcore.ErrInvalidAppleAccountCredentials), exitCode == ExitAuth:
 		return telemetry.OutcomeAuthError
 	case shared.IsValidationError(err):
 		return telemetry.OutcomeExpectedNegative

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -127,6 +127,8 @@ func parseFailureContext(analysis invocationAnalysis) telemetry.EventContext {
 		ErrorKind:        kind,
 		FailureStage:     telemetry.FailureStageParse,
 		FailureParameter: parameter,
+		EventKind:        telemetry.EventKindExecution,
+		OutcomeKind:      telemetry.OutcomeUsageError,
 	}
 }
 
@@ -142,9 +144,12 @@ func validationFailureContext(analysis invocationAnalysis, err error) telemetry.
 		kind = telemetry.ErrorKindOther
 	}
 	return telemetry.EventContext{
-		InvocationShape: analysis.shape,
-		ErrorKind:       kind,
-		FailureStage:    telemetry.FailureStageValidation,
+		InvocationShape:  analysis.shape,
+		ErrorKind:        kind,
+		FailureStage:     telemetry.FailureStageValidation,
+		FailureParameter: failureParameterFromError(err),
+		EventKind:        telemetry.EventKindExecution,
+		OutcomeKind:      telemetry.OutcomeUsageError,
 	}
 }
 
@@ -157,6 +162,8 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 		InvocationShape: analysis.shape,
 		ErrorKind:       telemetry.ErrorKindOther,
 		FailureStage:    telemetry.FailureStageExecution,
+		EventKind:       telemetry.EventKindExecution,
+		HTTPStatus:      httpStatusFromError(err),
 	}
 	switch {
 	case errors.Is(err, shared.ErrMissingAuth):
@@ -164,6 +171,14 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 	case shared.IsValidationError(err):
 		eventContext.FailureStage = telemetry.FailureStageValidation
 	case errors.Is(err, context.DeadlineExceeded):
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	case eventContext.HTTPStatus == 409:
+		eventContext.ErrorKind = telemetry.ErrorKindAPIConflict
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	case eventContext.HTTPStatus >= 500:
+		eventContext.ErrorKind = telemetry.ErrorKindAPI5xx
+		eventContext.FailureStage = telemetry.FailureStageRequest
+	case eventContext.HTTPStatus >= 400:
 		eventContext.FailureStage = telemetry.FailureStageRequest
 	case exitCode == ExitConflict:
 		eventContext.ErrorKind = telemetry.ErrorKindAPIConflict
@@ -174,7 +189,62 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 	case exitCode == ExitAuth || exitCode == ExitNotFound || (exitCode >= 10 && exitCode <= 59):
 		eventContext.FailureStage = telemetry.FailureStageRequest
 	}
+	eventContext.OutcomeKind = runtimeOutcomeKind(err, exitCode, eventContext)
 	return eventContext
+}
+
+func runtimeOutcomeKind(err error, exitCode int, eventContext telemetry.EventContext) telemetry.OutcomeKind {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return telemetry.OutcomeCancelled
+	case errors.Is(err, shared.ErrMissingAuth), exitCode == ExitAuth:
+		return telemetry.OutcomeAuthError
+	case shared.IsValidationError(err):
+		return telemetry.OutcomeExpectedNegative
+	case eventContext.HTTPStatus == 401 || eventContext.HTTPStatus == 403:
+		return telemetry.OutcomeAuthError
+	case eventContext.HTTPStatus == 404:
+		return telemetry.OutcomeNotFound
+	case eventContext.HTTPStatus == 409:
+		return telemetry.OutcomeConflict
+	case eventContext.HTTPStatus >= 400 && eventContext.HTTPStatus < 500:
+		return telemetry.OutcomeAPIClientError
+	case eventContext.HTTPStatus >= 500:
+		return telemetry.OutcomeAPIServerError
+	case exitCode == ExitNotFound:
+		return telemetry.OutcomeNotFound
+	case exitCode == ExitConflict:
+		return telemetry.OutcomeConflict
+	case errors.Is(err, context.DeadlineExceeded), eventContext.FailureStage == telemetry.FailureStageRequest:
+		return telemetry.OutcomeTransportError
+	default:
+		return telemetry.OutcomeInternalError
+	}
+}
+
+func httpStatusFromError(err error) int {
+	var statusError interface{ HTTPStatusCode() int }
+	if !errors.As(err, &statusError) {
+		return 0
+	}
+	status := statusError.HTTPStatusCode()
+	if status < 400 || status > 599 {
+		return 0
+	}
+	return status
+}
+
+func failureParameterFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	for _, field := range strings.Fields(err.Error()) {
+		candidate := strings.Trim(field, "`'\"(),:;.")
+		if strings.HasPrefix(candidate, "--") {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func shouldRenderGroupHelp(analysis invocationAnalysis, err error) bool {

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
@@ -11,54 +13,95 @@ import (
 func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 	analysis := invocationAnalysis{shape: telemetry.InvocationShapeLeaf}
 	tests := []struct {
-		name      string
-		err       error
-		exitCode  int
-		wantKind  telemetry.ErrorKind
-		wantStage telemetry.FailureStage
+		name        string
+		err         error
+		exitCode    int
+		wantKind    telemetry.ErrorKind
+		wantStage   telemetry.FailureStage
+		wantOutcome telemetry.OutcomeKind
+		wantStatus  int
 	}{
 		{
-			name:      "missing auth is local validation",
-			err:       shared.ErrMissingAuth,
-			exitCode:  ExitAuth,
-			wantKind:  telemetry.ErrorKindOther,
-			wantStage: telemetry.FailureStageValidation,
+			name:        "missing auth is local validation",
+			err:         shared.ErrMissingAuth,
+			exitCode:    ExitAuth,
+			wantKind:    telemetry.ErrorKindOther,
+			wantStage:   telemetry.FailureStageValidation,
+			wantOutcome: telemetry.OutcomeAuthError,
 		},
 		{
-			name:      "reported validation failure",
-			err:       shared.NewValidationReportedError(errors.New("found blocking issues")),
-			exitCode:  ExitError,
-			wantKind:  telemetry.ErrorKindOther,
-			wantStage: telemetry.FailureStageValidation,
+			name:        "reported validation failure",
+			err:         shared.NewValidationReportedError(errors.New("found blocking issues")),
+			exitCode:    ExitError,
+			wantKind:    telemetry.ErrorKindOther,
+			wantStage:   telemetry.FailureStageValidation,
+			wantOutcome: telemetry.OutcomeExpectedNegative,
 		},
 		{
-			name:      "API conflict",
-			err:       errors.New("conflict"),
-			exitCode:  ExitConflict,
-			wantKind:  telemetry.ErrorKindAPIConflict,
-			wantStage: telemetry.FailureStageRequest,
+			name:        "API conflict",
+			err:         errors.New("conflict"),
+			exitCode:    ExitConflict,
+			wantKind:    telemetry.ErrorKindAPIConflict,
+			wantStage:   telemetry.FailureStageRequest,
+			wantOutcome: telemetry.OutcomeConflict,
 		},
 		{
-			name:      "API server failure",
-			err:       errors.New("server failure"),
-			exitCode:  ExitHTTPInternalServer,
-			wantKind:  telemetry.ErrorKindAPI5xx,
-			wantStage: telemetry.FailureStageRequest,
+			name:        "API server failure",
+			err:         errors.New("server failure"),
+			exitCode:    ExitHTTPInternalServer,
+			wantKind:    telemetry.ErrorKindAPI5xx,
+			wantStage:   telemetry.FailureStageRequest,
+			wantOutcome: telemetry.OutcomeTransportError,
 		},
 		{
-			name:      "API server failure at upper exit code boundary",
-			err:       errors.New("server failure"),
-			exitCode:  HTTPStatusToExitCode(599),
-			wantKind:  telemetry.ErrorKindAPI5xx,
-			wantStage: telemetry.FailureStageRequest,
+			name:        "API server failure at upper exit code boundary",
+			err:         errors.New("server failure"),
+			exitCode:    HTTPStatusToExitCode(599),
+			wantKind:    telemetry.ErrorKindAPI5xx,
+			wantStage:   telemetry.FailureStageRequest,
+			wantOutcome: telemetry.OutcomeTransportError,
+		},
+		{
+			name:        "exact API permission failure",
+			err:         &asc.APIError{StatusCode: 403},
+			exitCode:    ExitHTTPForbidden,
+			wantKind:    telemetry.ErrorKindOther,
+			wantStage:   telemetry.FailureStageRequest,
+			wantOutcome: telemetry.OutcomeAuthError,
+			wantStatus:  403,
+		},
+		{
+			name:        "exact API server failure",
+			err:         &asc.APIError{StatusCode: 503},
+			exitCode:    ExitHTTPServiceUnavailable,
+			wantKind:    telemetry.ErrorKindAPI5xx,
+			wantStage:   telemetry.FailureStageRequest,
+			wantOutcome: telemetry.OutcomeAPIServerError,
+			wantStatus:  503,
+		},
+		{
+			name:        "cancelled command",
+			err:         context.Canceled,
+			exitCode:    ExitError,
+			wantKind:    telemetry.ErrorKindOther,
+			wantStage:   telemetry.FailureStageExecution,
+			wantOutcome: telemetry.OutcomeCancelled,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := runtimeFailureContext(analysis, test.err, test.exitCode)
-			if got.ErrorKind != test.wantKind || got.FailureStage != test.wantStage {
-				t.Fatalf("runtimeFailureContext() = %+v, want kind=%q stage=%q", got, test.wantKind, test.wantStage)
+			if got.ErrorKind != test.wantKind || got.FailureStage != test.wantStage ||
+				got.OutcomeKind != test.wantOutcome || got.HTTPStatus != test.wantStatus {
+				t.Fatalf(
+					"runtimeFailureContext() = %+v, want kind=%q stage=%q outcome=%q status=%d",
+					got,
+					test.wantKind,
+					test.wantStage,
+					test.wantOutcome,
+					test.wantStatus,
+				)
 			}
 		})
 	}

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
 func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
@@ -27,6 +29,14 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 			exitCode:    ExitAuth,
 			wantKind:    telemetry.ErrorKindOther,
 			wantStage:   telemetry.FailureStageValidation,
+			wantOutcome: telemetry.OutcomeAuthError,
+		},
+		{
+			name:        "invalid Apple Account credentials",
+			err:         fmt.Errorf("SRP login failed: %w", webcore.ErrInvalidAppleAccountCredentials),
+			exitCode:    ExitError,
+			wantKind:    telemetry.ErrorKindOther,
+			wantStage:   telemetry.FailureStageExecution,
 			wantOutcome: telemetry.OutcomeAuthError,
 		},
 		{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,10 +54,6 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 		}
 		if errors.Is(parseErr, flag.ErrHelp) {
-			commandName := getCommandName(root, args)
-			if commandName != "asc" {
-				emitTelemetry(commandName, versionInfo, 0, ExitSuccess, helpEventContext(analysis))
-			}
 			return ExitSuccess
 		}
 		if parseOutput.Len() == 0 {
@@ -148,7 +144,6 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	if renderGroupHelp {
-		emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, helpEventContext(analysis))
 		return ExitSuccess
 	}
 
@@ -174,14 +169,6 @@ func Run(args []string, versionInfo string) int {
 		InvocationShape: analysis.shape,
 	})
 	return ExitSuccess
-}
-
-func helpEventContext(analysis invocationAnalysis) telemetry.EventContext {
-	return telemetry.EventContext{
-		InvocationShape: analysis.shape,
-		EventKind:       telemetry.EventKindHelp,
-		OutcomeKind:     telemetry.OutcomeSuccess,
-	}
 }
 
 func redirectCommandFlagOutput(command *ffcli.Command, output io.Writer) func() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,6 +54,10 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 		}
 		if errors.Is(parseErr, flag.ErrHelp) {
+			commandName := getCommandName(root, args)
+			if commandName != "asc" {
+				emitTelemetry(commandName, versionInfo, 0, ExitSuccess, helpEventContext(analysis))
+			}
 			return ExitSuccess
 		}
 		if parseOutput.Len() == 0 {
@@ -145,6 +149,7 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	if renderGroupHelp {
+		emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, helpEventContext(analysis))
 		return ExitSuccess
 	}
 
@@ -170,6 +175,14 @@ func Run(args []string, versionInfo string) int {
 		InvocationShape: analysis.shape,
 	})
 	return ExitSuccess
+}
+
+func helpEventContext(analysis invocationAnalysis) telemetry.EventContext {
+	return telemetry.EventContext{
+		InvocationShape: analysis.shape,
+		EventKind:       telemetry.EventKindHelp,
+		OutcomeKind:     telemetry.OutcomeSuccess,
+	}
 }
 
 func redirectCommandFlagOutput(command *ffcli.Command, output io.Writer) func() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,10 +63,9 @@ func Run(args []string, versionInfo string) int {
 		if parseOutput.Len() == 0 {
 			fmt.Fprint(os.Stderr, errfmt.FormatStderr(parseErr))
 		}
-		exitCode := ExitCodeFromError(parseErr)
-		if parseOutput.Len() > 0 {
-			exitCode = ExitUsage
-		}
+		// Every non-help error returned by command-tree parsing is invalid usage,
+		// including NoExecError cases that do not write flag output.
+		exitCode := ExitUsage
 		printUnknownFlagSuggestion(analysis)
 		emitImmediateTelemetry(args, root, versionInfo, exitCode, parseFailureContext(analysis))
 		return exitCode

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -206,10 +206,8 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
 	var telemetryCalls int
-	var gotContext telemetry.EventContext
-	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
 		telemetryCalls++
-		gotContext = eventContext
 	}
 
 	stdout, stderr := captureCommandOutput(t, func() {
@@ -224,11 +222,8 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if telemetryCalls != 1 {
-		t.Fatalf("telemetry calls = %d, want 1 for group help", telemetryCalls)
-	}
-	if gotContext.EventKind != telemetry.EventKindHelp || gotContext.OutcomeKind != telemetry.OutcomeSuccess {
-		t.Fatalf("unexpected help telemetry context: %+v", gotContext)
+	if telemetryCalls != 0 {
+		t.Fatalf("telemetry calls = %d, want 0 for group help", telemetryCalls)
 	}
 }
 
@@ -820,18 +815,14 @@ func TestRun_HelpSkipsAuthResolution(t *testing.T) {
 	}
 }
 
-func TestRun_HelpEmitsHelpTelemetry(t *testing.T) {
+func TestRun_HelpSkipsTelemetry(t *testing.T) {
 	resetReportFlags(t)
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
 	var telemetryCalls int
-	var commandName string
-	var gotContext telemetry.EventContext
-	emitTelemetry = func(command string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
 		telemetryCalls++
-		commandName = command
-		gotContext = eventContext
 	}
 
 	captureCommandOutput(t, func() {
@@ -839,14 +830,8 @@ func TestRun_HelpEmitsHelpTelemetry(t *testing.T) {
 			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
 		}
 	})
-	if telemetryCalls != 1 {
-		t.Fatalf("telemetry calls = %d, want 1 for help", telemetryCalls)
-	}
-	if commandName != "asc builds" {
-		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")
-	}
-	if gotContext.EventKind != telemetry.EventKindHelp || gotContext.OutcomeKind != telemetry.OutcomeSuccess {
-		t.Fatalf("unexpected help telemetry context: %+v", gotContext)
+	if telemetryCalls != 0 {
+		t.Fatalf("telemetry calls = %d, want 0 for help", telemetryCalls)
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -176,8 +176,10 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
 	var telemetryCalls int
-	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
 		telemetryCalls++
+		gotContext = eventContext
 	}
 
 	stdout, stderr := captureCommandOutput(t, func() {
@@ -192,8 +194,11 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if telemetryCalls != 0 {
-		t.Fatalf("telemetry calls = %d, want 0 for group help", telemetryCalls)
+	if telemetryCalls != 1 {
+		t.Fatalf("telemetry calls = %d, want 1 for group help", telemetryCalls)
+	}
+	if gotContext.EventKind != telemetry.EventKindHelp || gotContext.OutcomeKind != telemetry.OutcomeSuccess {
+		t.Fatalf("unexpected help telemetry context: %+v", gotContext)
 	}
 }
 
@@ -259,6 +264,9 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	if gotContext.ErrorKind != telemetry.ErrorKindMissingRequired || gotContext.FailureStage != telemetry.FailureStageValidation {
 		t.Fatalf("unexpected telemetry context: %+v", gotContext)
 	}
+	if gotContext.FailureParameter != "--version" || gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+		t.Fatalf("unexpected missing-parameter telemetry context: %+v", gotContext)
+	}
 }
 
 func TestRun_MissingRequiredFlagsEmitContext(t *testing.T) {
@@ -296,6 +304,9 @@ func TestRun_MissingRequiredFlagsEmitContext(t *testing.T) {
 			}
 			if gotContext.ErrorKind != telemetry.ErrorKindMissingRequired || gotContext.FailureStage != telemetry.FailureStageValidation {
 				t.Fatalf("unexpected telemetry context: %+v", gotContext)
+			}
+			if gotContext.FailureParameter != "--app" || gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+				t.Fatalf("unexpected missing-parameter telemetry context: %+v", gotContext)
 			}
 		})
 	}
@@ -433,7 +444,8 @@ func TestRun_UnknownFlagSuggestsRealFlagAndEmitsContext(t *testing.T) {
 	}
 	if gotContext.InvocationShape != telemetry.InvocationShapeLeaf ||
 		gotContext.ErrorKind != telemetry.ErrorKindUnknownFlag ||
-		gotContext.FailureStage != telemetry.FailureStageParse {
+		gotContext.FailureStage != telemetry.FailureStageParse ||
+		gotContext.OutcomeKind != telemetry.OutcomeUsageError {
 		t.Fatalf("unexpected telemetry context: %+v", gotContext)
 	}
 	if gotContext.FailureParameter != "--build-id" {
@@ -778,14 +790,18 @@ func TestRun_HelpSkipsAuthResolution(t *testing.T) {
 	}
 }
 
-func TestRun_HelpSkipsTelemetry(t *testing.T) {
+func TestRun_HelpEmitsHelpTelemetry(t *testing.T) {
 	resetReportFlags(t)
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
 	var telemetryCalls int
-	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
+	var commandName string
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(command string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
 		telemetryCalls++
+		commandName = command
+		gotContext = eventContext
 	}
 
 	captureCommandOutput(t, func() {
@@ -793,8 +809,14 @@ func TestRun_HelpSkipsTelemetry(t *testing.T) {
 			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
 		}
 	})
-	if telemetryCalls != 0 {
-		t.Fatalf("telemetry calls = %d, want 0 for help", telemetryCalls)
+	if telemetryCalls != 1 {
+		t.Fatalf("telemetry calls = %d, want 1 for help", telemetryCalls)
+	}
+	if commandName != "asc builds" {
+		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")
+	}
+	if gotContext.EventKind != telemetry.EventKindHelp || gotContext.OutcomeKind != telemetry.OutcomeSuccess {
+		t.Fatalf("unexpected help telemetry context: %+v", gotContext)
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -137,6 +137,36 @@ func TestRun_ParseErrorEmitsTelemetry(t *testing.T) {
 	}
 }
 
+func TestRun_ParseErrorWithoutFlagOutputReturnsUsage(t *testing.T) {
+	resetReportFlags(t)
+
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var gotExitCode int
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+		gotExitCode = exitCode
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"ads", "geo"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "doesn't define an Exec function") {
+		t.Fatalf("expected parse failure, got %q", stderr)
+	}
+	if gotExitCode != ExitUsage || gotContext.FailureStage != telemetry.FailureStageParse ||
+		gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+		t.Fatalf("unexpected telemetry: exit=%d context=%+v", gotExitCode, gotContext)
+	}
+}
+
 func TestRun_ReportWriteFailureReturnsExitError(t *testing.T) {
 	resetReportFlags(t)
 

--- a/cmd/run_telemetry_blackbox_test.go
+++ b/cmd/run_telemetry_blackbox_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"net"
 	"os"
@@ -8,7 +9,60 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
+
+func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
+	binaryPath := buildASCBlackboxBinary(t)
+	home := t.TempDir()
+	command := exec.Command(
+		binaryPath,
+		"versions",
+		"attach-build",
+		"--version-id",
+		"VERSION_ID",
+		"--build-id",
+		"BUILD_ID",
+	)
+	command.Env = telemetryBlackboxEnv(home, false, "https://127.0.0.1:1/events")
+	output, err := command.CombinedOutput()
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) || exitError.ExitCode() != ExitUsage {
+		t.Fatalf("built command error = %v, want exit %d; output=%s", err, ExitUsage, output)
+	}
+
+	spoolData, err := os.ReadFile(filepath.Join(home, ".asc", "telemetry-spool.jsonl"))
+	if err != nil {
+		t.Fatalf("read built CLI telemetry spool: %v", err)
+	}
+	var record struct {
+		Event json.RawMessage `json:"event"`
+	}
+	if err := json.Unmarshal(spoolData, &record); err != nil {
+		t.Fatalf("decode built CLI telemetry spool: %v", err)
+	}
+	var event telemetry.Event
+	if err := json.Unmarshal(record.Event, &event); err != nil {
+		t.Fatalf("decode built CLI telemetry event: %v", err)
+	}
+	if event.SchemaVersion != 4 || event.EventKind != telemetry.EventKindExecution ||
+		event.OutcomeKind != telemetry.OutcomeUsageError {
+		t.Fatalf("unexpected schema-v4 payload: %+v", event)
+	}
+	if event.FailureParameter == nil || *event.FailureParameter != "--build-id" {
+		t.Fatalf("FailureParameter = %v, want --build-id", event.FailureParameter)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(record.Event, &payload); err != nil {
+		t.Fatalf("decode built CLI telemetry JSON: %v", err)
+	}
+	for _, field := range []string{"http_status", "task_id"} {
+		if value, exists := payload[field]; !exists || value != nil {
+			t.Fatalf("%s = %v (exists=%t), want explicit null", field, value, exists)
+		}
+	}
+}
 
 func TestRun_BuiltBinaryDoesNotWaitForBlockedTelemetryEndpoint(t *testing.T) {
 	binaryPath := buildASCBlackboxBinary(t)
@@ -68,10 +122,12 @@ func telemetryBlackboxEnv(home string, disabled bool, endpoint string) []string 
 		"ASC_TELEMETRY_DISABLED",
 		"ASC_TELEMETRY_ENDPOINT",
 		"ASC_TELEMETRY_EPHEMERAL",
+		"ASC_TELEMETRY_TASK_ID",
 		"ASC_TIMEOUT",
 		"ASC_TIMEOUT_SECONDS",
 		"DO_NOT_TRACK",
 		"HOME",
+		"SSL_CERT_FILE",
 	)
 	disabledValue := ""
 	if disabled {
@@ -85,6 +141,7 @@ func telemetryBlackboxEnv(home string, disabled bool, endpoint string) []string 
 		"ASC_TELEMETRY_DISABLED="+disabledValue,
 		"ASC_TELEMETRY_ENDPOINT="+endpoint,
 		"ASC_TELEMETRY_EPHEMERAL=",
+		"ASC_TELEMETRY_TASK_ID=",
 		"ASC_TIMEOUT=1s",
 		"ASC_TIMEOUT_SECONDS=",
 		"DO_NOT_TRACK=",

--- a/cmd/run_telemetry_blackbox_test.go
+++ b/cmd/run_telemetry_blackbox_test.go
@@ -46,8 +46,7 @@ func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
 	if err := json.Unmarshal(record.Event, &event); err != nil {
 		t.Fatalf("decode built CLI telemetry event: %v", err)
 	}
-	if event.SchemaVersion != 4 || event.EventKind != telemetry.EventKindExecution ||
-		event.OutcomeKind != telemetry.OutcomeUsageError {
+	if event.SchemaVersion != 4 || event.OutcomeKind != telemetry.OutcomeUsageError {
 		t.Fatalf("unexpected schema-v4 payload: %+v", event)
 	}
 	if event.FailureParameter == nil || *event.FailureParameter != "--build-id" {
@@ -57,10 +56,8 @@ func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
 	if err := json.Unmarshal(record.Event, &payload); err != nil {
 		t.Fatalf("decode built CLI telemetry JSON: %v", err)
 	}
-	for _, field := range []string{"http_status", "task_id"} {
-		if value, exists := payload[field]; !exists || value != nil {
-			t.Fatalf("%s = %v (exists=%t), want explicit null", field, value, exists)
-		}
+	if value, exists := payload["http_status"]; !exists || value != nil {
+		t.Fatalf("http_status = %v (exists=%t), want explicit null", value, exists)
 	}
 }
 
@@ -122,7 +119,6 @@ func telemetryBlackboxEnv(home string, disabled bool, endpoint string) []string 
 		"ASC_TELEMETRY_DISABLED",
 		"ASC_TELEMETRY_ENDPOINT",
 		"ASC_TELEMETRY_EPHEMERAL",
-		"ASC_TELEMETRY_TASK_ID",
 		"ASC_TIMEOUT",
 		"ASC_TIMEOUT_SECONDS",
 		"DO_NOT_TRACK",
@@ -141,7 +137,6 @@ func telemetryBlackboxEnv(home string, disabled bool, endpoint string) []string 
 		"ASC_TELEMETRY_DISABLED="+disabledValue,
 		"ASC_TELEMETRY_ENDPOINT="+endpoint,
 		"ASC_TELEMETRY_EPHEMERAL=",
-		"ASC_TELEMETRY_TASK_ID=",
 		"ASC_TIMEOUT=1s",
 		"ASC_TIMEOUT_SECONDS=",
 		"DO_NOT_TRACK=",

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -84,13 +84,6 @@ asc telemetry reset-id
   or `on`. Events are still sent, but the local install ID is omitted.
 </ParamField>
 
-<ParamField path="ASC_TELEMETRY_TASK_ID" type="uuid">
-  Attach a random UUID supplied by the launcher to events from one high-level
-  task. The CLI accepts only UUID syntax and never derives this value from a
-  thread, project, account, path, or machine. Leave it unset unless the launcher
-  can generate a fresh UUID for the task.
-</ParamField>
-
 ## Event Payload
 
 The CLI sends a single best-effort JSON event after command completion:
@@ -116,10 +109,8 @@ The CLI sends a single best-effort JSON event after command completion:
   "error_kind": null,
   "failure_stage": null,
   "failure_parameter": null,
-  "event_kind": "execution",
   "outcome_kind": "success",
-  "http_status": null,
-  "task_id": null
+  "http_status": null
 }
 ```
 
@@ -136,16 +127,10 @@ never contain stderr, error text, flag values, or positional values.
 `failure_parameter` is limited to a sanitized public long flag name such as
 `--app`.
 
-`event_kind` separates command execution from help output. `outcome_kind`
-separates success, expected negative validation results, usage errors,
+`outcome_kind` separates success, expected negative validation results, usage errors,
 authentication and API failures, transport failures, cancellations, and
 internal errors. `http_status` contains a number from 400 through 599 only when
 an API client exposes the exact response status.
-
-`task_id` is nullable. Agent launchers can set `ASC_TELEMETRY_TASK_ID` to a fresh
-UUID for one user task, which lets aggregate analytics measure help-before-use
-and recovery after a failed command. The CLI rejects non-UUID values, and raw
-task IDs aren't shown in the admin analytics.
 
 `runtime_context` describes where the command runs, independently from
 `invocation_source`, which describes what launched it. A command launched by
@@ -208,10 +193,8 @@ CREATE TABLE asc_cli_events
   error_kind Nullable(LowCardinality(String)),
   failure_stage Nullable(LowCardinality(String)),
   failure_parameter Nullable(LowCardinality(String)),
-  event_kind Nullable(LowCardinality(String)),
   outcome_kind Nullable(LowCardinality(String)),
   http_status Nullable(Int16),
-  task_id Nullable(UUID),
   source LowCardinality(String),
   collector_version LowCardinality(String)
 )

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -22,7 +22,8 @@ values, Apple account identifiers, team IDs, issuer IDs, key IDs, app IDs,
 bundle IDs, usernames, hostnames, repository names, IP addresses, user-agent
 strings, or file paths. Failed usage events may include the public flag name
 that caused the failure, such as `--app`, but never the value passed to that
-flag. As with any HTTPS service, the collector's edge provider sees the
+flag. Failed API requests may include the numeric HTTP status, but never the
+response body. As with any HTTPS service, the collector's edge provider sees the
 connection address; the Rork collector may use it transiently for abuse
 throttling but does not persist it in telemetry events or analytics storage.
 
@@ -83,6 +84,13 @@ asc telemetry reset-id
   or `on`. Events are still sent, but the local install ID is omitted.
 </ParamField>
 
+<ParamField path="ASC_TELEMETRY_TASK_ID" type="uuid">
+  Attach a random UUID supplied by the launcher to events from one high-level
+  task. The CLI accepts only UUID syntax and never derives this value from a
+  thread, project, account, path, or machine. Leave it unset unless the launcher
+  can generate a fresh UUID for the task.
+</ParamField>
+
 ## Event Payload
 
 The CLI sends a single best-effort JSON event after command completion:
@@ -90,7 +98,7 @@ The CLI sends a single best-effort JSON event after command completion:
 ```json
 {
   "event_id": "2d2f86dd-6d75-4a6f-b97f-a6ce15d4bc79",
-  "schema_version": 3,
+  "schema_version": 4,
   "asc_version": "1.13.0",
   "os": "darwin",
   "arch": "arm64",
@@ -107,7 +115,11 @@ The CLI sends a single best-effort JSON event after command completion:
   "invocation_shape": "leaf",
   "error_kind": null,
   "failure_stage": null,
-  "failure_parameter": null
+  "failure_parameter": null,
+  "event_kind": "execution",
+  "outcome_kind": "success",
+  "http_status": null,
+  "task_id": null
 }
 ```
 
@@ -117,12 +129,23 @@ cannot become telemetry dimensions. `session_id` is reused only within one CLI
 process and changes the next time `asc` starts.
 
 `invocation_shape` is one of `leaf`, `bare_group`, `group_with_flags`, or
-`unknown_child`. Failed schema-v3 events also include an allowlisted
+`unknown_child`. Failed schema-v4 events also include an allowlisted
 `error_kind`, `failure_stage`, and nullable `failure_parameter`; successful
 events set these fields to `null`. These fields are derived inside the CLI and
 never contain stderr, error text, flag values, or positional values.
 `failure_parameter` is limited to a sanitized public long flag name such as
 `--app`.
+
+`event_kind` separates command execution from help output. `outcome_kind`
+separates success, expected negative validation results, usage errors,
+authentication and API failures, transport failures, cancellations, and
+internal errors. `http_status` contains a number from 400 through 599 only when
+an API client exposes the exact response status.
+
+`task_id` is nullable. Agent launchers can set `ASC_TELEMETRY_TASK_ID` to a fresh
+UUID for one user task, which lets aggregate analytics measure help-before-use
+and recovery after a failed command. The CLI rejects non-UUID values, and raw
+task IDs aren't shown in the admin analytics.
 
 `runtime_context` describes where the command runs, independently from
 `invocation_source`, which describes what launched it. A command launched by
@@ -154,7 +177,10 @@ telemetry hostname.
 
 Collectors should accept `POST /asc/v1/events`, validate the event schema, add
 server-side receive metadata, and insert accepted events into analytics storage.
-Collector credentials must never be shipped in the CLI.
+They should return a 2xx response only after that insert commits; temporary
+storage failures should return a retryable non-2xx response so the CLI keeps the
+event in its bounded local spool. Collector credentials must never be shipped
+in the CLI.
 
 Recommended ClickHouse table:
 
@@ -182,6 +208,10 @@ CREATE TABLE asc_cli_events
   error_kind Nullable(LowCardinality(String)),
   failure_stage Nullable(LowCardinality(String)),
   failure_parameter Nullable(LowCardinality(String)),
+  event_kind Nullable(LowCardinality(String)),
+  outcome_kind Nullable(LowCardinality(String)),
+  http_status Nullable(Int16),
+  task_id Nullable(UUID),
   source LowCardinality(String),
   collector_version LowCardinality(String)
 )

--- a/internal/appleads/errors.go
+++ b/internal/appleads/errors.go
@@ -46,6 +46,13 @@ func (e *APIError) Error() string {
 	return strings.Join(parts, ": ")
 }
 
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}
+
 func parseError(body []byte, statusCode int) error {
 	var errResp struct {
 		Error struct {

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -57,6 +57,13 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s\n\n%s", baseMessage, associated)
 }
 
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}
+
 func formatAssociatedErrors(values map[string][]APIAssociatedError) string {
 	if len(values) == 0 {
 		return ""

--- a/internal/cli/assets/assets_download_helpers.go
+++ b/internal/cli/assets/assets_download_helpers.go
@@ -33,6 +33,13 @@ func (e *downloadHTTPStatusError) Error() string {
 	return fmt.Sprintf("unexpected status %d (%s)", e.StatusCode, e.Message)
 }
 
+func (e *downloadHTTPStatusError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}
+
 func sanitizeBaseFileName(value string) string {
 	base := strings.TrimSpace(value)
 	if base == "" {

--- a/internal/cli/assets/assets_download_helpers_test.go
+++ b/internal/cli/assets/assets_download_helpers_test.go
@@ -15,6 +15,14 @@ type readerThatFailsAfterFirstRead struct {
 	readOnce bool
 }
 
+func TestDownloadHTTPStatusErrorExposesHTTPStatus(t *testing.T) {
+	err := &downloadHTTPStatusError{StatusCode: 503}
+
+	if got := err.HTTPStatusCode(); got != 503 {
+		t.Fatalf("HTTPStatusCode() = %d, want 503", got)
+	}
+}
+
 func (r *readerThatFailsAfterFirstRead) Read(p []byte) (int, error) {
 	if !r.readOnce {
 		r.readOnce = true

--- a/internal/cli/assets/assets_screenshots_review_plan.go
+++ b/internal/cli/assets/assets_screenshots_review_plan.go
@@ -216,7 +216,7 @@ func executeScreenshotReviewPlan(ctx context.Context, opts screenshotReviewPlanO
 	resolvedAppID := shared.ResolveAppID(opts.AppID)
 	if strings.TrimSpace(resolvedAppID) == "" {
 		fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-		return nil, shared.MissingRequiredUsageError()
+		return nil, shared.MissingRequiredUsageError("--app")
 	}
 
 	versionValue := strings.TrimSpace(opts.Version)

--- a/internal/cli/reviews/reviews.go
+++ b/internal/cli/reviews/reviews.go
@@ -122,7 +122,7 @@ Examples:
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintf(os.Stderr, "Error: --app is required (or set ASC_APP_ID)\n\n")
-				return shared.MissingRequiredUsageError()
+				return shared.MissingRequiredUsageError("--app")
 			}
 
 			return executeReviewsList(ctx, resolvedAppID, *output.Output, *output.Pretty, *stars, *territory, *sort, *limit, *next, *paginate, *responseState, *onlyUnresponded, *includeResponse, *responseFields)

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -122,8 +122,12 @@ func UsageErrorf(format string, args ...any) error {
 
 // MissingRequiredUsageError classifies a required-input failure after the
 // command has already written its diagnostic to stderr.
-func MissingRequiredUsageError() error {
-	return classifiedUsageError{kind: UsageErrorMissingRequired}
+func MissingRequiredUsageError(parameters ...string) error {
+	parameter := ""
+	if len(parameters) > 0 {
+		parameter = strings.TrimSpace(parameters[0])
+	}
+	return classifiedUsageError{kind: UsageErrorMissingRequired, message: parameter}
 }
 
 func ClassifyUsageError(err error) UsageErrorKind {

--- a/internal/iris/auth.go
+++ b/internal/iris/auth.go
@@ -758,6 +758,13 @@ func (e *twoFAVerificationFailedError) Error() string {
 	return fmt.Sprintf("%s 2FA failed (status %d)", e.Kind, e.Status)
 }
 
+func (e *twoFAVerificationFailedError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Status
+}
+
 func appleSessionHeaders(session *AuthSession) http.Header {
 	header := make(http.Header)
 	header.Set("X-Apple-ID-Session-Id", session.AppleIDSessionID)

--- a/internal/iris/auth.go
+++ b/internal/iris/auth.go
@@ -160,6 +160,13 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("API error (status %d): %s", e.Status, string(e.Body))
 }
 
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Status
+}
+
 // NewClient creates a new IRIS client with an authenticated session
 func NewClient(session *AuthSession) *Client {
 	return &Client{

--- a/internal/iris/auth_test.go
+++ b/internal/iris/auth_test.go
@@ -26,6 +26,14 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 type sessionInfoContextKey struct{}
 
+func TestTwoFactorVerificationErrorExposesHTTPStatus(t *testing.T) {
+	err := &twoFAVerificationFailedError{Status: http.StatusForbidden}
+
+	if got := err.HTTPStatusCode(); got != http.StatusForbidden {
+		t.Fatalf("HTTPStatusCode() = %d, want %d", got, http.StatusForbidden)
+	}
+}
+
 func TestEnsureTwoFactorCodeRequestedRequestsPhoneCodeWhenNoTrustedDevicesHasMultipleNumbers(t *testing.T) {
 	session := &AuthSession{
 		Client: &http.Client{

--- a/internal/storekit/errors.go
+++ b/internal/storekit/errors.go
@@ -40,6 +40,13 @@ func (e *APIError) Error() string {
 	return strings.Join(parts, ": ")
 }
 
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}
+
 func parseAPIError(body []byte, statusCode int, retryAfter string) error {
 	var response struct {
 		Code    json.RawMessage `json:"errorCode"`

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -167,7 +167,6 @@ func clearContextEnv(t *testing.T) {
 		"JENKINS_URL",
 		"TRAVIS",
 		"APPVEYOR",
-		"ASC_TELEMETRY_TASK_ID",
 	} {
 		t.Setenv(key, "")
 	}

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -167,6 +167,7 @@ func clearContextEnv(t *testing.T) {
 		"JENKINS_URL",
 		"TRAVIS",
 		"APPVEYOR",
+		"ASC_TELEMETRY_TASK_ID",
 	} {
 		t.Setenv(key, "")
 	}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"encoding/json"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -31,18 +30,9 @@ type Event struct {
 	ErrorKind        *ErrorKind       `json:"error_kind"`
 	FailureStage     *FailureStage    `json:"failure_stage"`
 	FailureParameter *string          `json:"failure_parameter"`
-	EventKind        EventKind        `json:"event_kind,omitempty"`
 	OutcomeKind      OutcomeKind      `json:"outcome_kind,omitempty"`
 	HTTPStatus       *int             `json:"http_status,omitempty"`
-	TaskID           *string          `json:"task_id,omitempty"`
 }
-
-type EventKind string
-
-const (
-	EventKindExecution EventKind = "execution"
-	EventKindHelp      EventKind = "help"
-)
 
 type OutcomeKind string
 
@@ -95,7 +85,6 @@ type EventContext struct {
 	ErrorKind        ErrorKind
 	FailureStage     FailureStage
 	FailureParameter string
-	EventKind        EventKind
 	OutcomeKind      OutcomeKind
 	HTTPStatus       int
 }
@@ -107,7 +96,6 @@ var processSessionID = uuid.NewString()
 func BuildEvent(commandName, version string, duration time.Duration, exitCode int) (Event, bool) {
 	return BuildEventWithContext(commandName, version, duration, exitCode, EventContext{
 		InvocationShape: InvocationShapeLeaf,
-		EventKind:       EventKindExecution,
 	})
 }
 
@@ -157,10 +145,8 @@ func BuildEventWithContext(
 		ErrorKind:        optionalErrorKind(eventContext.ErrorKind),
 		FailureStage:     optionalFailureStage(eventContext.FailureStage),
 		FailureParameter: optionalFailureParameter(eventContext.FailureParameter, exitCode),
-		EventKind:        eventContext.EventKind,
 		OutcomeKind:      eventContext.OutcomeKind,
 		HTTPStatus:       optionalHTTPStatus(eventContext.HTTPStatus),
-		TaskID:           telemetryTaskID(),
 	}, true
 }
 
@@ -171,9 +157,6 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 		eventContext.InvocationShape = InvocationShapeLeaf
 	}
 
-	if eventContext.EventKind != EventKindHelp {
-		eventContext.EventKind = EventKindExecution
-	}
 	eventContext.HTTPStatus = sanitizeHTTPStatus(eventContext.HTTPStatus)
 
 	if exitCode == 0 {
@@ -184,7 +167,6 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 		eventContext.HTTPStatus = 0
 		return eventContext
 	}
-	eventContext.EventKind = EventKindExecution
 	if eventContext.ErrorKind == "" {
 		eventContext.ErrorKind = ErrorKindOther
 	}
@@ -290,16 +272,6 @@ func sanitizeHTTPStatus(status int) int {
 	return status
 }
 
-func telemetryTaskID() *string {
-	raw := strings.TrimSpace(os.Getenv("ASC_TELEMETRY_TASK_ID"))
-	parsed, err := uuid.Parse(raw)
-	if err != nil {
-		return nil
-	}
-	value := parsed.String()
-	return &value
-}
-
 // MarshalJSON keeps queued schema-v3 records wire-compatible while ensuring
 // nullable schema-v4 fields are present even when their value is null.
 func (event Event) MarshalJSON() ([]byte, error) {
@@ -309,12 +281,10 @@ func (event Event) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(struct {
 		eventAlias
-		HTTPStatus *int    `json:"http_status"`
-		TaskID     *string `json:"task_id"`
+		HTTPStatus *int `json:"http_status"`
 	}{
 		eventAlias: eventAlias(event),
 		HTTPStatus: event.HTTPStatus,
-		TaskID:     event.TaskID,
 	})
 }
 

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -205,6 +205,12 @@ func normalizeOutcomeKind(eventContext EventContext, exitCode int) OutcomeKind {
 	case status >= 500:
 		return OutcomeAPIServerError
 	}
+	switch eventContext.ErrorKind {
+	case ErrorKindAPIConflict:
+		return OutcomeConflict
+	case ErrorKindAPI5xx:
+		return OutcomeAPIServerError
+	}
 
 	switch eventContext.OutcomeKind {
 	case OutcomeExpectedNegative:
@@ -215,7 +221,7 @@ func normalizeOutcomeKind(eventContext EventContext, exitCode int) OutcomeKind {
 		if exitCode == 2 && (eventContext.FailureStage == FailureStageParse || eventContext.FailureStage == FailureStageValidation) {
 			return OutcomeUsageError
 		}
-	case OutcomeAuthError, OutcomeNotFound, OutcomeConflict, OutcomeCancelled, OutcomeInternalError:
+	case OutcomeAuthError, OutcomeNotFound, OutcomeConflict, OutcomeAPIClientError, OutcomeAPIServerError, OutcomeCancelled, OutcomeInternalError:
 		return eventContext.OutcomeKind
 	case OutcomeTransportError:
 		if eventContext.FailureStage == FailureStageRequest {

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"encoding/json"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -29,7 +31,34 @@ type Event struct {
 	ErrorKind        *ErrorKind       `json:"error_kind"`
 	FailureStage     *FailureStage    `json:"failure_stage"`
 	FailureParameter *string          `json:"failure_parameter"`
+	EventKind        EventKind        `json:"event_kind,omitempty"`
+	OutcomeKind      OutcomeKind      `json:"outcome_kind,omitempty"`
+	HTTPStatus       *int             `json:"http_status,omitempty"`
+	TaskID           *string          `json:"task_id,omitempty"`
 }
+
+type EventKind string
+
+const (
+	EventKindExecution EventKind = "execution"
+	EventKindHelp      EventKind = "help"
+)
+
+type OutcomeKind string
+
+const (
+	OutcomeSuccess          OutcomeKind = "success"
+	OutcomeExpectedNegative OutcomeKind = "expected_negative"
+	OutcomeUsageError       OutcomeKind = "usage_error"
+	OutcomeAuthError        OutcomeKind = "auth_error"
+	OutcomeNotFound         OutcomeKind = "not_found"
+	OutcomeConflict         OutcomeKind = "conflict"
+	OutcomeAPIClientError   OutcomeKind = "api_client_error"
+	OutcomeAPIServerError   OutcomeKind = "api_server_error"
+	OutcomeTransportError   OutcomeKind = "transport_error"
+	OutcomeCancelled        OutcomeKind = "cancelled"
+	OutcomeInternalError    OutcomeKind = "internal_error"
+)
 
 type InvocationShape string
 
@@ -66,6 +95,9 @@ type EventContext struct {
 	ErrorKind        ErrorKind
 	FailureStage     FailureStage
 	FailureParameter string
+	EventKind        EventKind
+	OutcomeKind      OutcomeKind
+	HTTPStatus       int
 }
 
 // processSessionID groups events from one CLI process without linking separate
@@ -75,6 +107,7 @@ var processSessionID = uuid.NewString()
 func BuildEvent(commandName, version string, duration time.Duration, exitCode int) (Event, bool) {
 	return BuildEventWithContext(commandName, version, duration, exitCode, EventContext{
 		InvocationShape: InvocationShapeLeaf,
+		EventKind:       EventKindExecution,
 	})
 }
 
@@ -106,7 +139,7 @@ func BuildEventWithContext(
 
 	return Event{
 		EventID:          uuid.NewString(),
-		SchemaVersion:    3,
+		SchemaVersion:    4,
 		ASCVersion:       strings.TrimSpace(version),
 		OS:               runtime.GOOS,
 		Arch:             runtime.GOARCH,
@@ -124,6 +157,10 @@ func BuildEventWithContext(
 		ErrorKind:        optionalErrorKind(eventContext.ErrorKind),
 		FailureStage:     optionalFailureStage(eventContext.FailureStage),
 		FailureParameter: optionalFailureParameter(eventContext.FailureParameter, exitCode),
+		EventKind:        eventContext.EventKind,
+		OutcomeKind:      eventContext.OutcomeKind,
+		HTTPStatus:       optionalHTTPStatus(eventContext.HTTPStatus),
+		TaskID:           telemetryTaskID(),
 	}, true
 }
 
@@ -134,12 +171,20 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 		eventContext.InvocationShape = InvocationShapeLeaf
 	}
 
+	if eventContext.EventKind != EventKindHelp {
+		eventContext.EventKind = EventKindExecution
+	}
+	eventContext.HTTPStatus = sanitizeHTTPStatus(eventContext.HTTPStatus)
+
 	if exitCode == 0 {
 		eventContext.ErrorKind = ""
 		eventContext.FailureStage = ""
 		eventContext.FailureParameter = ""
+		eventContext.OutcomeKind = OutcomeSuccess
+		eventContext.HTTPStatus = 0
 		return eventContext
 	}
+	eventContext.EventKind = EventKindExecution
 	if eventContext.ErrorKind == "" {
 		eventContext.ErrorKind = ErrorKindOther
 	}
@@ -160,7 +205,49 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 		eventContext.ErrorKind = ErrorKindOther
 		eventContext.FailureStage = FailureStageExecution
 	}
+	eventContext.OutcomeKind = normalizeOutcomeKind(eventContext, exitCode)
 	return eventContext
+}
+
+func normalizeOutcomeKind(eventContext EventContext, exitCode int) OutcomeKind {
+	status := eventContext.HTTPStatus
+	switch {
+	case status == 401 || status == 403:
+		return OutcomeAuthError
+	case status == 404:
+		return OutcomeNotFound
+	case status == 409:
+		return OutcomeConflict
+	case status >= 400 && status < 500:
+		return OutcomeAPIClientError
+	case status >= 500:
+		return OutcomeAPIServerError
+	}
+
+	switch eventContext.OutcomeKind {
+	case OutcomeExpectedNegative:
+		if eventContext.FailureStage == FailureStageValidation {
+			return OutcomeExpectedNegative
+		}
+	case OutcomeUsageError:
+		if exitCode == 2 && (eventContext.FailureStage == FailureStageParse || eventContext.FailureStage == FailureStageValidation) {
+			return OutcomeUsageError
+		}
+	case OutcomeAuthError, OutcomeNotFound, OutcomeConflict, OutcomeCancelled, OutcomeInternalError:
+		return eventContext.OutcomeKind
+	case OutcomeTransportError:
+		if eventContext.FailureStage == FailureStageRequest {
+			return OutcomeTransportError
+		}
+	}
+
+	if exitCode == 2 && (eventContext.FailureStage == FailureStageParse || eventContext.FailureStage == FailureStageValidation) {
+		return OutcomeUsageError
+	}
+	if eventContext.FailureStage == FailureStageRequest {
+		return OutcomeTransportError
+	}
+	return OutcomeInternalError
 }
 
 func optionalErrorKind(kind ErrorKind) *ErrorKind {
@@ -186,6 +273,49 @@ func optionalFailureParameter(parameter string, exitCode int) *string {
 		return nil
 	}
 	return &parameter
+}
+
+func optionalHTTPStatus(status int) *int {
+	status = sanitizeHTTPStatus(status)
+	if status == 0 {
+		return nil
+	}
+	return &status
+}
+
+func sanitizeHTTPStatus(status int) int {
+	if status < 400 || status > 599 {
+		return 0
+	}
+	return status
+}
+
+func telemetryTaskID() *string {
+	raw := strings.TrimSpace(os.Getenv("ASC_TELEMETRY_TASK_ID"))
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	value := parsed.String()
+	return &value
+}
+
+// MarshalJSON keeps queued schema-v3 records wire-compatible while ensuring
+// nullable schema-v4 fields are present even when their value is null.
+func (event Event) MarshalJSON() ([]byte, error) {
+	type eventAlias Event
+	if event.SchemaVersion != 4 {
+		return json.Marshal(eventAlias(event))
+	}
+	return json.Marshal(struct {
+		eventAlias
+		HTTPStatus *int    `json:"http_status"`
+		TaskID     *string `json:"task_id"`
+	}{
+		eventAlias: eventAlias(event),
+		HTTPStatus: event.HTTPStatus,
+		TaskID:     event.TaskID,
+	})
 }
 
 func sanitizeFailureParameter(parameter string) string {

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -133,6 +133,65 @@ func TestBuildEventWithContextCapturesBoundedHTTPContext(t *testing.T) {
 	}
 }
 
+func TestBuildEventWithContextPreservesAPIOutcomesWithoutHTTPStatus(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	tests := []struct {
+		name    string
+		context EventContext
+		want    OutcomeKind
+	}{
+		{
+			name: "explicit client error",
+			context: EventContext{
+				ErrorKind:    ErrorKindOther,
+				FailureStage: FailureStageRequest,
+				OutcomeKind:  OutcomeAPIClientError,
+			},
+			want: OutcomeAPIClientError,
+		},
+		{
+			name: "explicit server error",
+			context: EventContext{
+				ErrorKind:    ErrorKindOther,
+				FailureStage: FailureStageRequest,
+				OutcomeKind:  OutcomeAPIServerError,
+			},
+			want: OutcomeAPIServerError,
+		},
+		{
+			name: "conflict error kind",
+			context: EventContext{
+				ErrorKind: ErrorKindAPIConflict,
+			},
+			want: OutcomeConflict,
+		},
+		{
+			name: "server error kind",
+			context: EventContext{
+				ErrorKind: ErrorKindAPI5xx,
+			},
+			want: OutcomeAPIServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev, ok := BuildEventWithContext("asc builds list", "2.7.0", time.Second, 1, tt.context)
+			if !ok {
+				t.Fatal("expected event")
+			}
+			if ev.OutcomeKind != tt.want {
+				t.Fatalf("OutcomeKind = %q, want %q", ev.OutcomeKind, tt.want)
+			}
+			if ev.HTTPStatus != nil {
+				t.Fatalf("HTTPStatus = %v, want nil", ev.HTTPStatus)
+			}
+		})
+	}
+}
+
 func TestSchemaV3SpoolRecordOmitsSchemaV4Fields(t *testing.T) {
 	data, err := json.Marshal(Event{
 		SchemaVersion:   3,

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -45,6 +45,15 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 	if payload["invocation_source"] != string(SourceTerminal) {
 		t.Fatalf("invocation_source = %v, want %q", payload["invocation_source"], SourceTerminal)
 	}
+	if payload["event_kind"] != string(EventKindExecution) || payload["outcome_kind"] != string(OutcomeSuccess) {
+		t.Fatalf("unexpected v4 event context: %v", payload)
+	}
+	if value, exists := payload["http_status"]; !exists || value != nil {
+		t.Fatalf("http_status = %v (exists=%t), want explicit null", value, exists)
+	}
+	if value, exists := payload["task_id"]; !exists || value != nil {
+		t.Fatalf("task_id = %v (exists=%t), want explicit null", value, exists)
+	}
 	if _, exists := payload["execution_context"]; exists {
 		t.Fatal("legacy execution_context field should not be emitted")
 	}
@@ -74,8 +83,8 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 	if !ok {
 		t.Fatal("expected event")
 	}
-	if ev.SchemaVersion != 3 {
-		t.Fatalf("SchemaVersion = %d, want 3", ev.SchemaVersion)
+	if ev.SchemaVersion != 4 {
+		t.Fatalf("SchemaVersion = %d, want 4", ev.SchemaVersion)
 	}
 	if ev.InvocationShape != InvocationShapeLeaf || ev.ErrorKind == nil || *ev.ErrorKind != ErrorKindUnknownFlag ||
 		ev.FailureStage == nil || *ev.FailureStage != FailureStageParse {
@@ -83,6 +92,9 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 	}
 	if ev.FailureParameter == nil || *ev.FailureParameter != "--build-id" {
 		t.Fatalf("FailureParameter = %v, want --build-id", ev.FailureParameter)
+	}
+	if ev.EventKind != EventKindExecution || ev.OutcomeKind != OutcomeUsageError || ev.HTTPStatus != nil {
+		t.Fatalf("unexpected v4 outcome context: %+v", ev)
 	}
 
 	data, err := json.Marshal(ev)
@@ -92,6 +104,76 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 	for _, forbidden := range []string{"stderr", "error_message", "args", "argv"} {
 		if strings.Contains(string(data), forbidden) {
 			t.Fatalf("payload contains forbidden field %q: %s", forbidden, data)
+		}
+	}
+}
+
+func TestBuildEventWithContextCapturesBoundedHTTPAndTaskContext(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	const taskID = "9df30b58-934d-48c8-82f4-105bdb5c3295"
+	t.Setenv("ASC_TELEMETRY_TASK_ID", taskID)
+
+	ev, ok := BuildEventWithContext(
+		"asc analytics sales",
+		"2.7.0",
+		time.Second,
+		12,
+		EventContext{
+			InvocationShape: InvocationShapeLeaf,
+			ErrorKind:       ErrorKindOther,
+			FailureStage:    FailureStageRequest,
+			EventKind:       EventKindExecution,
+			OutcomeKind:     OutcomeAuthError,
+			HTTPStatus:      403,
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.HTTPStatus == nil || *ev.HTTPStatus != 403 {
+		t.Fatalf("HTTPStatus = %v, want 403", ev.HTTPStatus)
+	}
+	if ev.TaskID == nil || *ev.TaskID != taskID {
+		t.Fatalf("TaskID = %v, want %q", ev.TaskID, taskID)
+	}
+	if ev.OutcomeKind != OutcomeAuthError {
+		t.Fatalf("OutcomeKind = %q, want %q", ev.OutcomeKind, OutcomeAuthError)
+	}
+}
+
+func TestBuildEventOmitsInvalidTelemetryTaskID(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_TASK_ID", "private-project-name")
+
+	ev, ok := BuildEvent("asc builds list", "2.7.0", 0, 0)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.TaskID != nil {
+		t.Fatalf("TaskID = %q, want nil", *ev.TaskID)
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	if strings.Contains(string(data), "private-project-name") {
+		t.Fatalf("payload leaked invalid task ID: %s", data)
+	}
+}
+
+func TestSchemaV3SpoolRecordOmitsSchemaV4Fields(t *testing.T) {
+	data, err := json.Marshal(Event{
+		SchemaVersion:   3,
+		InvocationShape: InvocationShapeLeaf,
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	for _, field := range []string{"event_kind", "outcome_kind", "http_status", "task_id"} {
+		if strings.Contains(string(data), `"`+field+`"`) {
+			t.Fatalf("schema-v3 payload contains schema-v4 field %q: %s", field, data)
 		}
 	}
 }

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -45,14 +45,11 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 	if payload["invocation_source"] != string(SourceTerminal) {
 		t.Fatalf("invocation_source = %v, want %q", payload["invocation_source"], SourceTerminal)
 	}
-	if payload["event_kind"] != string(EventKindExecution) || payload["outcome_kind"] != string(OutcomeSuccess) {
+	if payload["outcome_kind"] != string(OutcomeSuccess) {
 		t.Fatalf("unexpected v4 event context: %v", payload)
 	}
 	if value, exists := payload["http_status"]; !exists || value != nil {
 		t.Fatalf("http_status = %v (exists=%t), want explicit null", value, exists)
-	}
-	if value, exists := payload["task_id"]; !exists || value != nil {
-		t.Fatalf("task_id = %v (exists=%t), want explicit null", value, exists)
 	}
 	if _, exists := payload["execution_context"]; exists {
 		t.Fatal("legacy execution_context field should not be emitted")
@@ -93,7 +90,7 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 	if ev.FailureParameter == nil || *ev.FailureParameter != "--build-id" {
 		t.Fatalf("FailureParameter = %v, want --build-id", ev.FailureParameter)
 	}
-	if ev.EventKind != EventKindExecution || ev.OutcomeKind != OutcomeUsageError || ev.HTTPStatus != nil {
+	if ev.OutcomeKind != OutcomeUsageError || ev.HTTPStatus != nil {
 		t.Fatalf("unexpected v4 outcome context: %+v", ev)
 	}
 
@@ -108,11 +105,9 @@ func TestBuildEventWithContextEmitsOnlyLowCardinalityClassifications(t *testing.
 	}
 }
 
-func TestBuildEventWithContextCapturesBoundedHTTPAndTaskContext(t *testing.T) {
+func TestBuildEventWithContextCapturesBoundedHTTPContext(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
-	const taskID = "9df30b58-934d-48c8-82f4-105bdb5c3295"
-	t.Setenv("ASC_TELEMETRY_TASK_ID", taskID)
 
 	ev, ok := BuildEventWithContext(
 		"asc analytics sales",
@@ -123,7 +118,6 @@ func TestBuildEventWithContextCapturesBoundedHTTPAndTaskContext(t *testing.T) {
 			InvocationShape: InvocationShapeLeaf,
 			ErrorKind:       ErrorKindOther,
 			FailureStage:    FailureStageRequest,
-			EventKind:       EventKindExecution,
 			OutcomeKind:     OutcomeAuthError,
 			HTTPStatus:      403,
 		},
@@ -134,32 +128,8 @@ func TestBuildEventWithContextCapturesBoundedHTTPAndTaskContext(t *testing.T) {
 	if ev.HTTPStatus == nil || *ev.HTTPStatus != 403 {
 		t.Fatalf("HTTPStatus = %v, want 403", ev.HTTPStatus)
 	}
-	if ev.TaskID == nil || *ev.TaskID != taskID {
-		t.Fatalf("TaskID = %v, want %q", ev.TaskID, taskID)
-	}
 	if ev.OutcomeKind != OutcomeAuthError {
 		t.Fatalf("OutcomeKind = %q, want %q", ev.OutcomeKind, OutcomeAuthError)
-	}
-}
-
-func TestBuildEventOmitsInvalidTelemetryTaskID(t *testing.T) {
-	clearContextEnv(t)
-	setTelemetryTestHome(t)
-	t.Setenv("ASC_TELEMETRY_TASK_ID", "private-project-name")
-
-	ev, ok := BuildEvent("asc builds list", "2.7.0", 0, 0)
-	if !ok {
-		t.Fatal("expected event")
-	}
-	if ev.TaskID != nil {
-		t.Fatalf("TaskID = %q, want nil", *ev.TaskID)
-	}
-	data, err := json.Marshal(ev)
-	if err != nil {
-		t.Fatalf("marshal event: %v", err)
-	}
-	if strings.Contains(string(data), "private-project-name") {
-		t.Fatalf("payload leaked invalid task ID: %s", data)
 	}
 }
 
@@ -171,7 +141,7 @@ func TestSchemaV3SpoolRecordOmitsSchemaV4Fields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal event: %v", err)
 	}
-	for _, field := range []string{"event_kind", "outcome_kind", "http_status", "task_id"} {
+	for _, field := range []string{"outcome_kind", "http_status"} {
 		if strings.Contains(string(data), `"`+field+`"`) {
 			t.Fatalf("schema-v3 payload contains schema-v4 field %q: %s", field, data)
 		}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -180,6 +180,13 @@ func (e *sessionInfoStatusError) Error() string {
 	return fmt.Sprintf("failed to get session info with status %d", e.Status)
 }
 
+func (e *sessionInfoStatusError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Status
+}
+
 func (e *APIError) Error() string {
 	parts := []string{fmt.Sprintf("web api error (status %d)", e.Status)}
 	if e.AppleRequestID != "" {
@@ -290,6 +297,13 @@ func (e *twoFAVerificationFailedError) Error() string {
 		return fmt.Sprintf("%s 2fa failed (status %d, codes=%v)", e.Kind, e.Status, codes)
 	}
 	return fmt.Sprintf("%s 2fa failed (status %d)", e.Kind, e.Status)
+}
+
+func (e *twoFAVerificationFailedError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Status
 }
 
 func newWebHTTPClient(jar http.CookieJar) *http.Client {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -194,6 +194,13 @@ func (e *APIError) Error() string {
 	return strings.Join(parts, ", ")
 }
 
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Status
+}
+
 // rawResponseBody exposes the body to package-internal helpers only.
 func (e *APIError) rawResponseBody() []byte {
 	return e.rawBody

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -30,6 +30,24 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func TestAuthStatusErrorsExposeHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  interface{ HTTPStatusCode() int }
+	}{
+		{name: "session info", err: &sessionInfoStatusError{Status: http.StatusUnauthorized}},
+		{name: "two-factor verification", err: &twoFAVerificationFailedError{Status: http.StatusForbidden}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.HTTPStatusCode(); got < 400 || got > 599 {
+				t.Fatalf("HTTPStatusCode() = %d, want an HTTP error status", got)
+			}
+		})
+	}
+}
+
 func TestLogWebAuthHTTPRedactsSensitiveQueryValues(t *testing.T) {
 	origLogger := webDebugLogger
 	origDebugEnabled := webDebugEnabledFn


### PR DESCRIPTION
## Scope

Emit schema-v4 telemetry with two new bounded diagnostics:

- `outcome_kind` distinguishes success, expected negatives, usage/auth/API/transport/internal failures
- `http_status` carries only a known HTTP error status (400-599)

This intentionally excludes help-event tracking, task IDs/correlation, raw errors, URLs, arguments, file paths, Apple IDs, and credentials.

## Server dependency

Do not release this emitter until rorkai #3962 and #3954 are migrated, deployed, and verified with v1-v4 ingestion.

## Why the CLI diff spans clients

The telemetry layer cannot safely infer an HTTP status from rendered error text. Existing typed client errors therefore expose status through a small private interface across ASC, StoreKit, Iris, Apple Ads, asset downloads, and web auth.

## Verification

- `make format`: passed
- docs checks: passed
- lint: passed, 0 issues
- repository test suite with `ASC_BYPASS_KEYCHAIN=1`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry schema v4 now reports a more specific outcome category and includes an explicitly nullable HTTP status for applicable API failures.
* **Bug Fixes**
  * Command parsing/usage failures now consistently return the usage exit code.
  * Runtime failure telemetry is more accurate, including cancellation and API/auth error status mapping.
  * Missing required-flag messaging now names the specific flag (e.g., `--app`/`--version`).
* **Documentation**
  * Updated privacy/telemetry docs and refreshed schema v4 payload/collector contract details and example/table fields.
* **Tests**
  * Expanded coverage for schema v4 telemetry payloads and usage/runtime telemetry context assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->