### PR TITLE
apps wall: add Envelope Budget - Kualia

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -394,6 +394,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5c/b3/ab/5cb3ab34-60e5-81f8-c555-518185d61f87/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Envelope Budget - Kualia",
+    "link": "https://apps.apple.com/us/app/envelope-budget-kualia/id6466455367?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c9/42/c0/c942c0f5-bb5c-faf0-0306-0eaa72a08112/AppIcon-Kualia-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Expense Tracker: ExpenseKit",
     "link": "https://apps.apple.com/us/app/expense-tracker-expensekit/id6756433597?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a5/14/d8/a514d826-9475-8c8e-b4f5-6fe7b4fa660c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Envelope Budget - Kualia` to the Wall of Apps

## Entry

- App ID: 6466455367
- App: Envelope Budget - Kualia
- Link: https://apps.apple.com/us/app/envelope-budget-kualia/id6466455367?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Envelope Budget - Kualia” to the app directory, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->