### PR TITLE
fix(telemetry): allow production collector latency

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -17,7 +17,7 @@ import (
 const (
 	DefaultEndpoint = "https://rork.com/cf-api/asc/v1/events"
 	endpointEnvVar  = "ASC_TELEMETRY_ENDPOINT"
-	maxSendDuration = 250 * time.Millisecond
+	maxSendDuration = 3 * time.Second
 )
 
 func Emit(commandName, version string, duration time.Duration, exitCode int) {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -206,7 +206,7 @@ func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
 	}
 }
 
-func TestSendHTTPEventCapsTelemetryTimeout(t *testing.T) {
+func TestSendHTTPEventHonorsConfiguredTimeoutBelowCap(t *testing.T) {
 	originalClient := http.DefaultClient
 	http.DefaultClient = &http.Client{
 		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -231,8 +231,28 @@ func TestSendHTTPEventCapsTelemetryTimeout(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("sendHTTPEvent() error = %v, want context deadline exceeded", err)
 	}
-	if elapsed >= 750*time.Millisecond {
-		t.Fatalf("sendHTTPEvent() elapsed = %s, want telemetry timeout cap before 750ms", elapsed)
+	if elapsed < 750*time.Millisecond || elapsed >= 1500*time.Millisecond {
+		t.Fatalf("sendHTTPEvent() elapsed = %s, want configured timeout near 1s", elapsed)
+	}
+}
+
+func TestSendHTTPEventAllowsSlowCollectorResponse(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(350 * time.Millisecond)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	originalClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	t.Setenv("ASC_TIMEOUT", "")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	setTelemetryTestHome(t)
+
+	if err := sendHTTPEventToEndpoint(Event{}, server.URL); err != nil {
+		t.Fatalf("sendHTTPEvent() error = %v, want slow collector response accepted", err)
 	}
 }
 


### PR DESCRIPTION
## What broke

The production collector returns `202` in roughly 0.97–1.15 seconds, but the detached telemetry worker capped each request at 250 ms. Valid schema-v4 events stayed in the local spool and never reached storage.

## Fix

Raise the detached worker request cap to 3 seconds. Foreground CLI latency is unchanged, and a shorter user-configured `ASC_TIMEOUT` still takes precedence.

## Verification

- Added a regression that fails at the old 250 ms cap and passes with a 350 ms collector response.
- `make format`, `make check-docs`, `make check-wall-of-apps`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`, and `make build` pass.
- A release-shaped 2.7.0 RC drained its spool and stored production event `fb71c1fd-680d-4dc1-95a8-0fbc8a936f67` with the expected schema-v4 fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry delivery reliability by allowing slower collector responses to complete successfully.
  * Configured telemetry timeouts below the maximum limit are now honored accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->