### PR TITLE
ci: run checks on native runners

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -170,8 +170,8 @@ jobs:
             runner: macos-latest
             command: |
               ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/screenshots
-              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
-              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
+              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macos_amd64 .
+              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macos_arm64 .
           - name: Linux
             runner: ubuntu-latest
             command: |

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -169,6 +169,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             command: |
+              ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/screenshots
               GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
               GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
           - name: Linux

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -51,7 +51,7 @@ jobs:
   wall-only-check:
     needs: changes
     if: needs.changes.outputs.wall_only == 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -68,7 +68,7 @@ jobs:
   format-and-lint:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -102,6 +102,9 @@ jobs:
           - name: Self-test docs validators
             run: python3 scripts/test_check_docs.py
 
+          - name: Check CI workflow contracts
+            run: python3 scripts/test_ci_workflows.py
+
           - name: Check documentation
             run: make check-docs
 
@@ -114,7 +117,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
     name: test shard (${{ matrix.name }})
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -154,13 +157,28 @@ jobs:
             exit 1
           fi
 
-  build:
+  build-platforms:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
-    runs-on: macos-latest
-    permissions:
-      contents: read
-      actions: write
+    name: build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS
+            runner: macos-latest
+            command: |
+              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
+              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
+          - name: Linux
+            runner: ubuntu-latest
+            command: |
+              GOOS=linux GOARCH=amd64 go build -o build/asc_dev_linux_amd64 .
+              GOOS=linux GOARCH=arm64 go build -o build/asc_dev_linux_arm64 .
+          - name: Windows
+            runner: windows-latest
+            command: GOOS=windows GOARCH=amd64 go build -o build/asc_dev_windows_amd64.exe .
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -173,30 +191,20 @@ jobs:
 
       - name: Create build directory
         run: mkdir -p build
+        shell: bash
 
-      - parallel:
-          - name: Build for macOS
-            run: |
-              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
-              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
+      - name: Build for ${{ matrix.name }}
+        run: ${{ matrix.command }}
+        shell: bash
 
-          - name: Build for Linux
-            run: |
-              GOOS=linux GOARCH=amd64 go build -o build/asc_dev_linux_amd64 .
-              GOOS=linux GOARCH=arm64 go build -o build/asc_dev_linux_arm64 .
-
-          - name: Build for Windows
-            run: |
-              GOOS=windows GOARCH=amd64 go build -o build/asc_dev_windows_amd64.exe .
-
-      - name: Create checksums
+  build:
+    needs: [changes, build-platforms]
+    if: always() && needs.changes.outputs.wall_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify platform builds
         run: |
-          cd build
-          shasum -a 256 * > asc_dev_checksums.txt
-          cat asc_dev_checksums.txt
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: main-builds
-          path: build/
+          if [ "${{ needs.build-platforms.result }}" != "success" ]; then
+            echo "build-platforms result: ${{ needs.build-platforms.result }}"
+            exit 1
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,7 +54,7 @@ jobs:
   wall-only-check:
     needs: changes
     if: needs.changes.outputs.wall_only == 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -71,7 +71,7 @@ jobs:
   format-and-lint:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -105,6 +105,9 @@ jobs:
           - name: Self-test docs validators
             run: python3 scripts/test_check_docs.py
 
+          - name: Check CI workflow contracts
+            run: python3 scripts/test_ci_workflows.py
+
           - name: Check documentation
             run: make check-docs
 
@@ -117,7 +120,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
     name: unit-test shard (${{ matrix.name }})
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -174,13 +177,28 @@ jobs:
       - name: Run telemetry tests
         run: go test -short ./internal/telemetry
 
-  build:
+  build-platforms:
     needs: changes
     if: needs.changes.outputs.wall_only != 'true'
-    runs-on: macos-latest
-    permissions:
-      contents: read
-      actions: write
+    name: build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS
+            runner: macos-latest
+            command: |
+              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
+              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
+          - name: Linux
+            runner: ubuntu-latest
+            command: |
+              GOOS=linux GOARCH=amd64 go build -o build/asc_dev_linux_amd64 .
+              GOOS=linux GOARCH=arm64 go build -o build/asc_dev_linux_arm64 .
+          - name: Windows
+            runner: windows-latest
+            command: GOOS=windows GOARCH=amd64 go build -o build/asc_dev_windows_amd64.exe .
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -193,24 +211,20 @@ jobs:
 
       - name: Create build directory
         run: mkdir -p build
+        shell: bash
 
-      - parallel:
-          - name: Build for macOS
-            run: |
-              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
-              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
+      - name: Build for ${{ matrix.name }}
+        run: ${{ matrix.command }}
+        shell: bash
 
-          - name: Build for Linux
-            run: |
-              GOOS=linux GOARCH=amd64 go build -o build/asc_dev_linux_amd64 .
-              GOOS=linux GOARCH=arm64 go build -o build/asc_dev_linux_arm64 .
-
-          - name: Build for Windows
-            run: |
-              GOOS=windows GOARCH=amd64 go build -o build/asc_dev_windows_amd64.exe .
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: builds
-          path: build/
+  build:
+    needs: [changes, build-platforms]
+    if: always() && needs.changes.outputs.wall_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify platform builds
+        run: |
+          if [ "${{ needs.build-platforms.result }}" != "success" ]; then
+            echo "build-platforms result: ${{ needs.build-platforms.result }}"
+            exit 1
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -190,8 +190,8 @@ jobs:
             runner: macos-latest
             command: |
               ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/screenshots
-              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
-              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
+              GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macos_amd64 .
+              GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macos_arm64 .
           - name: Linux
             runner: ubuntu-latest
             command: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -189,6 +189,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             command: |
+              ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/screenshots
               GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
               GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
           - name: Linux

--- a/docs/design/ci-runner-and-artifact-optimization.md
+++ b/docs/design/ci-runner-and-artifact-optimization.md
@@ -1,0 +1,36 @@
+# CI Runner and Artifact Optimization
+
+## Current behavior
+
+Every non-Wall pull request runs platform-independent formatting, documentation,
+lint, and unit-test work on macOS. One macOS build job then cross-compiles five
+binaries concurrently and uploads roughly 105 MB of development artifacts.
+The main-branch workflow repeats the build and upload. No workflow downloads
+either artifact; release binaries are built independently by `release.yml`.
+
+## Proposed behavior
+
+- Run platform-independent formatting, documentation, lint, Wall validation,
+  and unit-test shards on Ubuntu.
+- Build macOS, Linux, and Windows binaries on their native hosted runners.
+- Preserve a stable aggregate `build` job for required-check compatibility.
+- Keep cross-platform compilation on pull requests and `main`.
+- Remove pull-request and main-branch artifact uploads and development
+  checksums. Official artifact publication remains owned by `release.yml`.
+
+This changes CI execution only. CLI commands, flags, output, exit codes,
+authentication, and API behavior remain unchanged.
+
+## Alternatives
+
+- A larger runner would require paid compute even for this public repository.
+- Parallel build steps on one macOS runner retain CPU and memory contention.
+- Removing cross-platform compilation would be faster but would weaken the PR
+  compatibility gate.
+
+## Verification
+
+- Run the workflow contract test before and after the change.
+- Run formatting, documentation, lint, and the full Go test suite locally.
+- Let the pull request exercise the native Linux, macOS, and Windows runners.
+- Compare total and per-job duration with recent successful PR runs.

--- a/docs/design/ci-runner-and-artifact-optimization.md
+++ b/docs/design/ci-runner-and-artifact-optimization.md
@@ -13,6 +13,7 @@ either artifact; release binaries are built independently by `release.yml`.
 - Run platform-independent formatting, documentation, lint, Wall validation,
   and unit-test shards on Ubuntu.
 - Build macOS, Linux, and Windows binaries on their native hosted runners.
+- Run the Darwin-only screenshot tests on the macOS build runner.
 - Preserve a stable aggregate `build` job for required-check compatibility.
 - Keep cross-platform compilation on pull requests and `main`.
 - Remove pull-request and main-branch artifact uploads and development

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -41,6 +41,7 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     build_platforms = job_block(workflow, "build-platforms")
     for runner in ("macos-latest", "ubuntu-latest", "windows-latest"):
         assert f"runner: {runner}" in build_platforms, f"{path}: missing native build runner {runner}"
+    assert "go test -short ./internal/screenshots" in build_platforms, f"{path}: missing Darwin-only tests"
 
     build = job_block(workflow, "build")
     assert "needs: [changes, build-platforms]" in build

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -17,16 +17,13 @@ def job_block(workflow: str, job: str) -> str:
         raise AssertionError(f"missing job {job!r}")
 
     end = len(workflow)
-    for line_start in range(start + len(marker), len(workflow)):
-        if line_start > 0 and workflow[line_start - 1] != "\n":
-            continue
-        line_end = workflow.find("\n", line_start)
-        if line_end < 0:
-            line_end = len(workflow)
-        line = workflow[line_start:line_end]
-        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
-            end = line_start
+    offset = start + len(marker)
+    for line in workflow[offset:].splitlines(keepends=True):
+        content = line.rstrip("\r\n")
+        if content.startswith("  ") and not content.startswith("    ") and content.endswith(":"):
+            end = offset
             break
+        offset += len(line)
     return workflow[start:end]
 
 
@@ -42,6 +39,8 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     for runner in ("macos-latest", "ubuntu-latest", "windows-latest"):
         assert f"runner: {runner}" in build_platforms, f"{path}: missing native build runner {runner}"
     assert "go test -short ./internal/screenshots" in build_platforms, f"{path}: missing Darwin-only tests"
+    assert "asc_dev_macos_amd64" in build_platforms
+    assert "asc_dev_macos_arm64" in build_platforms
 
     build = job_block(workflow, "build")
     assert "needs: [changes, build-platforms]" in build

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Protect CI runner, build, and artifact ownership contracts."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PR_WORKFLOW = ROOT / ".github/workflows/pr-checks.yml"
+MAIN_WORKFLOW = ROOT / ".github/workflows/main-branch.yml"
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+
+
+def job_block(workflow: str, job: str) -> str:
+    marker = f"  {job}:\n"
+    start = workflow.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing job {job!r}")
+
+    end = len(workflow)
+    for line_start in range(start + len(marker), len(workflow)):
+        if line_start > 0 and workflow[line_start - 1] != "\n":
+            continue
+        line_end = workflow.find("\n", line_start)
+        if line_end < 0:
+            line_end = len(workflow)
+        line = workflow[line_start:line_end]
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            end = line_start
+            break
+    return workflow[start:end]
+
+
+def assert_optimized_workflow(path: Path, test_job: str) -> None:
+    workflow = path.read_text()
+
+    assert "actions/upload-artifact" not in workflow, f"{path}: development artifacts must not be uploaded"
+    assert "runs-on: ubuntu-latest" in job_block(workflow, "wall-only-check")
+    assert "runs-on: ubuntu-latest" in job_block(workflow, "format-and-lint")
+    assert "runs-on: ubuntu-latest" in job_block(workflow, test_job)
+
+    build_platforms = job_block(workflow, "build-platforms")
+    for runner in ("macos-latest", "ubuntu-latest", "windows-latest"):
+        assert f"runner: {runner}" in build_platforms, f"{path}: missing native build runner {runner}"
+
+    build = job_block(workflow, "build")
+    assert "needs: [changes, build-platforms]" in build
+    assert "needs.build-platforms.result" in build
+
+
+def main() -> None:
+    assert_optimized_workflow(PR_WORKFLOW, "unit-test-shards")
+    assert_optimized_workflow(MAIN_WORKFLOW, "test-shards")
+
+    release = RELEASE_WORKFLOW.read_text()
+    assert "actions/upload-artifact" in release, "release workflow must retain official artifact publication"
+
+    print("CI workflow contracts passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- run platform-independent checks and test shards on Ubuntu
- build macOS, Linux, and Windows binaries on native runners
- stop uploading development binaries on pull requests and main while preserving release artifacts
- preserve stable aggregate build and test checks

## Verification
- python3 scripts/test_ci_workflows.py
- GOCACHE=/tmp/asc-ci-go-cache ASC_BYPASS_KEYCHAIN=1 make check-docs
- GOCACHE=/tmp/asc-ci-go-cache make lint
- GOCACHE=/tmp/asc-ci-go-cache ASC_BYPASS_KEYCHAIN=1 go test ./...
- local cross-compilation for Darwin amd64/arm64, Linux amd64/arm64, and Windows amd64
- commit hooks: docs, formatting, lint, and short tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * CI validation and lint/test jobs now run on Ubuntu for more consistent results.
  * Added an automated CI “workflow contract” check to ensure expected job structure and runner usage.
  * Binary builds now run on native macOS, Linux, and Windows runners via a platforms matrix, with a separate gate that stops the workflow if platform builds fail.
* **Documentation**
  * Added documentation describing the CI runner and artifact optimization approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->