### PR TITLE
ci: select checks by change scope

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -29,9 +29,9 @@ jobs:
           before="${{ github.event.before }}"
           after="${{ github.sha }}"
           if [ -n "$before" ] && [ "$before" != "0000000000000000000000000000000000000000" ]; then
-            files="$(git diff --name-only "$before" "$after")"
+            files="$(git diff --name-only --no-renames "$before" "$after")"
           else
-            files="$(git diff-tree --no-commit-id --name-only -r "$after")"
+            files="$(git diff-tree --no-commit-id --name-only --no-renames -r "$after")"
           fi
 
           selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
@@ -121,7 +121,7 @@ jobs:
             run: make check-docs
 
           - name: Run lint
-            if: needs.changes.outputs.scope == 'full'
+            if: contains(fromJSON('["telemetry", "full"]'), needs.changes.outputs.scope)
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -112,6 +112,10 @@ jobs:
             if: needs.changes.outputs.scope == 'full'
             run: python3 scripts/test_ci_workflows.py
 
+          - name: Test CI change selection
+            if: needs.changes.outputs.scope == 'full'
+            run: python3 scripts/test_ci_change_scope.py
+
           - name: Check documentation
             if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: make check-docs

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -34,7 +34,20 @@ jobs:
             files="$(git diff-tree --no-commit-id --name-only --no-renames -r "$after")"
           fi
 
-          selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
+          force_full=false
+          while IFS= read -r path; do
+            case "$path" in
+              .github/workflows/*|scripts/ci_change_scope.py|scripts/test_ci_change_scope.py|scripts/test_ci_workflows.py)
+                force_full=true
+                ;;
+            esac
+          done <<< "$files"
+
+          if [ "$force_full" = true ]; then
+            selection="$(printf '%s\n' 'scope=full' 'website_affected=true' 'studio_affected=true')"
+          else
+            selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
+          fi
           scope="$(printf '%s\n' "$selection" | sed -n 's/^scope=//p')"
           case "$scope" in
             wall|docs|website|studio|telemetry|full) ;;

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -306,8 +306,8 @@ jobs:
           go-version: '1.26.5'
           cache: true
 
-      - name: Compile all packages
-        run: go build ./...
+      - name: Compile CLI
+        run: go build .
 
   build:
     needs: [changes, build-platforms, ordinary-build]

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -11,7 +11,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      wall_only: ${{ steps.scope.outputs.wall_only }}
+      scope: ${{ steps.scope.outputs.scope }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -32,25 +32,16 @@ jobs:
             files="$(git diff-tree --no-commit-id --name-only -r "$after")"
           fi
 
-          wall_only=true
-          has_files=false
-          while IFS= read -r path; do
-            [ -z "$path" ] && continue
-            has_files=true
-            if [ "$path" != "docs/wall-of-apps.json" ]; then
-              wall_only=false
-            fi
-          done <<< "$files"
-
-          if [ "$has_files" = false ]; then
-            wall_only=false
-          fi
-
-          echo "wall_only=$wall_only" >> "$GITHUB_OUTPUT"
+          scope="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py)"
+          case "$scope" in
+            wall|docs|website|studio|telemetry|full) ;;
+            *) echo "invalid CI scope: $scope" >&2; exit 1 ;;
+          esac
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
 
   wall-only-check:
     needs: changes
-    if: needs.changes.outputs.wall_only == 'true'
+    if: needs.changes.outputs.scope == 'wall'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -67,19 +58,30 @@ jobs:
 
   format-and-lint:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Verify change detection
+        if: needs.changes.result != 'success'
+        run: exit 1
+
+      - name: Report delegated checks
+        if: contains(fromJSON('["wall", "website", "studio"]'), needs.changes.outputs.scope)
+        run: echo "${{ needs.changes.outputs.scope }} changes use their dedicated workflow"
+
       - name: Checkout code
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/checkout@v6
 
       - name: Set up Go
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.5'
           cache: true
 
       - name: Cache Go tools
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         id: go-tools-cache
         uses: actions/cache@v5
         with:
@@ -87,35 +89,41 @@ jobs:
           key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
 
       - name: Install tooling
-        if: steps.go-tools-cache.outputs.cache-hit != 'true'
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope) && steps.go-tools-cache.outputs.cache-hit != 'true'
         run: make tools
 
       - parallel:
           - name: Check formatting
+            if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make format-check
 
           - name: Check Wall of Apps source
+            if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: make check-wall-of-apps
 
           - name: Self-test docs validators
+            if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: python3 scripts/test_check_docs.py
 
           - name: Check CI workflow contracts
+            if: needs.changes.outputs.scope == 'full'
             run: python3 scripts/test_ci_workflows.py
 
           - name: Check documentation
+            if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: make check-docs
 
           - name: Run lint
+            if: needs.changes.outputs.scope == 'full'
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint
 
   test-shards:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: needs.changes.outputs.scope == 'full'
     name: test shard (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
@@ -145,21 +153,71 @@ jobs:
       - name: Run Go test shard
         run: ASC_BYPASS_KEYCHAIN=1 ${{ matrix.command }}
 
-  test:
-    needs: [changes, test-shards]
-    if: always() && needs.changes.outputs.wall_only != 'true'
+  telemetry-linux-tests:
+    needs: changes
+    if: needs.changes.outputs.scope == 'telemetry'
     runs-on: ubuntu-latest
     steps:
-      - name: Verify test shards
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Run telemetry tests
+        run: ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/telemetry ./internal/cli/telemetry ./cmd
+
+  telemetry-windows-tests:
+    needs: changes
+    if: needs.changes.outputs.scope == 'telemetry'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Run telemetry tests
+        run: go test -short ./internal/telemetry
+
+  test:
+    needs: [changes, test-shards, telemetry-linux-tests, telemetry-windows-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify selected tests
         run: |
-          if [ "${{ needs.test-shards.result }}" != "success" ]; then
-            echo "test-shards result: ${{ needs.test-shards.result }}"
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "change detection result: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          case "${{ needs.changes.outputs.scope }}" in
+            full) results="${{ needs.test-shards.result }}" ;;
+            telemetry)
+              results="${{ needs.telemetry-linux-tests.result }} ${{ needs.telemetry-windows-tests.result }}"
+              ;;
+            *)
+              echo "No general Go tests required for ${{ needs.changes.outputs.scope }} changes"
+              exit 0
+              ;;
+          esac
+
+          if [ "$results" != "success" ] && [ "$results" != "success success" ]; then
+            echo "selected test results: $results"
             exit 1
           fi
 
   build-platforms:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: needs.changes.outputs.scope == 'full'
     name: build (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -197,14 +255,45 @@ jobs:
         run: ${{ matrix.command }}
         shell: bash
 
-  build:
-    needs: [changes, build-platforms]
-    if: always() && needs.changes.outputs.wall_only != 'true'
+  ordinary-build:
+    needs: changes
+    if: needs.changes.outputs.scope == 'telemetry'
     runs-on: ubuntu-latest
     steps:
-      - name: Verify platform builds
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Compile all packages
+        run: go build ./...
+
+  build:
+    needs: [changes, build-platforms, ordinary-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify selected builds
         run: |
-          if [ "${{ needs.build-platforms.result }}" != "success" ]; then
-            echo "build-platforms result: ${{ needs.build-platforms.result }}"
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "change detection result: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          case "${{ needs.changes.outputs.scope }}" in
+            full) result="${{ needs.build-platforms.result }}" ;;
+            telemetry) result="${{ needs.ordinary-build.result }}" ;;
+            *)
+              echo "No CLI build required for ${{ needs.changes.outputs.scope }} changes"
+              exit 0
+              ;;
+          esac
+
+          if [ "$result" != "success" ]; then
+            echo "selected build result: $result"
             exit 1
           fi

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       scope: ${{ steps.scope.outputs.scope }}
+      website_affected: ${{ steps.scope.outputs.website_affected }}
+      studio_affected: ${{ steps.scope.outputs.studio_affected }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -32,12 +34,13 @@ jobs:
             files="$(git diff-tree --no-commit-id --name-only -r "$after")"
           fi
 
-          scope="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py)"
+          selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
+          scope="$(printf '%s\n' "$selection" | sed -n 's/^scope=//p')"
           case "$scope" in
             wall|docs|website|studio|telemetry|full) ;;
             *) echo "invalid CI scope: $scope" >&2; exit 1 ;;
           esac
-          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$selection" >> "$GITHUB_OUTPUT"
 
   wall-only-check:
     needs: changes
@@ -56,32 +59,31 @@ jobs:
       - name: Check Wall of Apps source
         run: make check-wall-of-apps
 
-  format-and-lint:
+  website-checks:
     needs: changes
-    if: always()
+    if: needs.changes.outputs.website_affected == 'true'
+    uses: ./.github/workflows/website-checks.yml
+
+  studio-checks:
+    needs: changes
+    if: needs.changes.outputs.studio_affected == 'true'
+    uses: ./.github/workflows/studio-checks.yml
+
+  quality-checks:
+    needs: changes
+    if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
     runs-on: ubuntu-latest
     steps:
-      - name: Verify change detection
-        if: needs.changes.result != 'success'
-        run: exit 1
-
-      - name: Report delegated checks
-        if: contains(fromJSON('["wall", "website", "studio"]'), needs.changes.outputs.scope)
-        run: echo "${{ needs.changes.outputs.scope }} changes use their dedicated workflow"
-
       - name: Checkout code
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/checkout@v6
 
       - name: Set up Go
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.5'
           cache: true
 
       - name: Cache Go tools
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         id: go-tools-cache
         uses: actions/cache@v5
         with:
@@ -89,12 +91,11 @@ jobs:
           key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
 
       - name: Install tooling
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope) && steps.go-tools-cache.outputs.cache-hit != 'true'
+        if: steps.go-tools-cache.outputs.cache-hit != 'true'
         run: make tools
 
       - parallel:
           - name: Check formatting
-            if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make format-check
@@ -120,6 +121,39 @@ jobs:
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint
+
+  format-and-lint:
+    needs: [changes, wall-only-check, quality-checks, website-checks, studio-checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify selected quality checks
+        run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "change detection result: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          case "${{ needs.changes.outputs.scope }}" in
+            wall) required="${{ needs.wall-only-check.result }}" ;;
+            docs|telemetry|full) required="${{ needs.quality-checks.result }}" ;;
+            website) required="${{ needs.website-checks.result }}" ;;
+            studio) required="${{ needs.studio-checks.result }}" ;;
+            *) echo "unknown CI scope"; exit 1 ;;
+          esac
+
+          if [ "$required" != "success" ]; then
+            echo "required quality result: $required"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.website_affected }}" = "true" ] && [ "${{ needs.website-checks.result }}" != "success" ]; then
+            echo "website checks result: ${{ needs.website-checks.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.studio_affected }}" = "true" ] && [ "${{ needs.studio-checks.result }}" != "success" ]; then
+            echo "studio checks result: ${{ needs.studio-checks.result }}"
+            exit 1
+          fi
 
   test-shards:
     needs: changes
@@ -172,7 +206,7 @@ jobs:
 
   telemetry-windows-tests:
     needs: changes
-    if: needs.changes.outputs.scope == 'telemetry'
+    if: contains(fromJSON('["telemetry", "full"]'), needs.changes.outputs.scope)
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -200,7 +234,9 @@ jobs:
           fi
 
           case "${{ needs.changes.outputs.scope }}" in
-            full) results="${{ needs.test-shards.result }}" ;;
+            full)
+              results="${{ needs.test-shards.result }} ${{ needs.telemetry-windows-tests.result }}"
+              ;;
             telemetry)
               results="${{ needs.telemetry-linux-tests.result }} ${{ needs.telemetry-windows-tests.result }}"
               ;;
@@ -210,7 +246,7 @@ jobs:
               ;;
           esac
 
-          if [ "$results" != "success" ] && [ "$results" != "success success" ]; then
+          if [ "$results" != "success success" ]; then
             echo "selected test results: $results"
             exit 1
           fi
@@ -227,6 +263,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             command: |
+              ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/screenshots
               GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
               GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
           - name: Linux

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -299,7 +299,16 @@ jobs:
   ordinary-build:
     needs: changes
     if: needs.changes.outputs.scope == 'telemetry'
-    runs-on: ubuntu-latest
+    name: ordinary build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: ubuntu-latest
+          - name: macOS
+            runner: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,7 +32,7 @@ jobs:
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+            files="$(git diff --name-only --no-renames "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
           else
             files=""
           fi
@@ -124,7 +124,7 @@ jobs:
             run: make check-docs
 
           - name: Run lint
-            if: needs.changes.outputs.scope == 'full'
+            if: contains(fromJSON('["telemetry", "full"]'), needs.changes.outputs.scope)
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -309,8 +309,8 @@ jobs:
           go-version: '1.26.5'
           cache: true
 
-      - name: Compile all packages
-        run: go build ./...
+      - name: Compile CLI
+        run: go build .
 
   build:
     needs: [changes, build-platforms, ordinary-build]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       scope: ${{ steps.scope.outputs.scope }}
+      website_affected: ${{ steps.scope.outputs.website_affected }}
+      studio_affected: ${{ steps.scope.outputs.studio_affected }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -35,12 +37,13 @@ jobs:
             files=""
           fi
 
-          scope="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py)"
+          selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
+          scope="$(printf '%s\n' "$selection" | sed -n 's/^scope=//p')"
           case "$scope" in
             wall|docs|website|studio|telemetry|full) ;;
             *) echo "invalid CI scope: $scope" >&2; exit 1 ;;
           esac
-          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$selection" >> "$GITHUB_OUTPUT"
 
   wall-only-check:
     needs: changes
@@ -59,32 +62,31 @@ jobs:
       - name: Check Wall of Apps source
         run: make check-wall-of-apps
 
-  format-and-lint:
+  website-checks:
     needs: changes
-    if: always()
+    if: needs.changes.outputs.website_affected == 'true'
+    uses: ./.github/workflows/website-checks.yml
+
+  studio-checks:
+    needs: changes
+    if: needs.changes.outputs.studio_affected == 'true'
+    uses: ./.github/workflows/studio-checks.yml
+
+  quality-checks:
+    needs: changes
+    if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
     runs-on: ubuntu-latest
     steps:
-      - name: Verify change detection
-        if: needs.changes.result != 'success'
-        run: exit 1
-
-      - name: Report delegated checks
-        if: contains(fromJSON('["wall", "website", "studio"]'), needs.changes.outputs.scope)
-        run: echo "${{ needs.changes.outputs.scope }} changes use their dedicated workflow"
-
       - name: Checkout code
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/checkout@v6
 
       - name: Set up Go
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.5'
           cache: true
 
       - name: Cache Go tools
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         id: go-tools-cache
         uses: actions/cache@v5
         with:
@@ -92,12 +94,11 @@ jobs:
           key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
 
       - name: Install tooling
-        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope) && steps.go-tools-cache.outputs.cache-hit != 'true'
+        if: steps.go-tools-cache.outputs.cache-hit != 'true'
         run: make tools
 
       - parallel:
           - name: Check formatting
-            if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make format-check
@@ -123,6 +124,39 @@ jobs:
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint
+
+  format-and-lint:
+    needs: [changes, wall-only-check, quality-checks, website-checks, studio-checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify selected quality checks
+        run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "change detection result: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          case "${{ needs.changes.outputs.scope }}" in
+            wall) required="${{ needs.wall-only-check.result }}" ;;
+            docs|telemetry|full) required="${{ needs.quality-checks.result }}" ;;
+            website) required="${{ needs.website-checks.result }}" ;;
+            studio) required="${{ needs.studio-checks.result }}" ;;
+            *) echo "unknown CI scope"; exit 1 ;;
+          esac
+
+          if [ "$required" != "success" ]; then
+            echo "required quality result: $required"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.website_affected }}" = "true" ] && [ "${{ needs.website-checks.result }}" != "success" ]; then
+            echo "website checks result: ${{ needs.website-checks.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.studio_affected }}" = "true" ] && [ "${{ needs.studio-checks.result }}" != "success" ]; then
+            echo "studio checks result: ${{ needs.studio-checks.result }}"
+            exit 1
+          fi
 
   unit-test-shards:
     needs: changes
@@ -232,6 +266,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             command: |
+              ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/screenshots
               GOOS=darwin GOARCH=amd64 go build -o build/asc_dev_macOS_amd64 .
               GOOS=darwin GOARCH=arm64 go build -o build/asc_dev_macOS_arm64 .
           - name: Linux

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,7 +37,20 @@ jobs:
             files=""
           fi
 
-          selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
+          force_full=false
+          while IFS= read -r path; do
+            case "$path" in
+              .github/workflows/*|scripts/ci_change_scope.py|scripts/test_ci_change_scope.py|scripts/test_ci_workflows.py)
+                force_full=true
+                ;;
+            esac
+          done <<< "$files"
+
+          if [ "$force_full" = true ]; then
+            selection="$(printf '%s\n' 'scope=full' 'website_affected=true' 'studio_affected=true')"
+          else
+            selection="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py --github-output)"
+          fi
           scope="$(printf '%s\n' "$selection" | sed -n 's/^scope=//p')"
           case "$scope" in
             wall|docs|website|studio|telemetry|full) ;;

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -115,6 +115,10 @@ jobs:
             if: needs.changes.outputs.scope == 'full'
             run: python3 scripts/test_ci_workflows.py
 
+          - name: Test CI change selection
+            if: needs.changes.outputs.scope == 'full'
+            run: python3 scripts/test_ci_change_scope.py
+
           - name: Check documentation
             if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: make check-docs

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -302,7 +302,16 @@ jobs:
   ordinary-build:
     needs: changes
     if: needs.changes.outputs.scope == 'telemetry'
-    runs-on: ubuntu-latest
+    name: ordinary build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: ubuntu-latest
+          - name: macOS
+            runner: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      wall_only: ${{ steps.scope.outputs.wall_only }}
+      scope: ${{ steps.scope.outputs.scope }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -35,25 +35,16 @@ jobs:
             files=""
           fi
 
-          wall_only=true
-          has_files=false
-          while IFS= read -r path; do
-            [ -z "$path" ] && continue
-            has_files=true
-            if [ "$path" != "docs/wall-of-apps.json" ]; then
-              wall_only=false
-            fi
-          done <<< "$files"
-
-          if [ "$has_files" = false ]; then
-            wall_only=false
-          fi
-
-          echo "wall_only=$wall_only" >> "$GITHUB_OUTPUT"
+          scope="$(printf '%s\n' "$files" | python3 scripts/ci_change_scope.py)"
+          case "$scope" in
+            wall|docs|website|studio|telemetry|full) ;;
+            *) echo "invalid CI scope: $scope" >&2; exit 1 ;;
+          esac
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
 
   wall-only-check:
     needs: changes
-    if: needs.changes.outputs.wall_only == 'true'
+    if: needs.changes.outputs.scope == 'wall'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -70,19 +61,30 @@ jobs:
 
   format-and-lint:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Verify change detection
+        if: needs.changes.result != 'success'
+        run: exit 1
+
+      - name: Report delegated checks
+        if: contains(fromJSON('["wall", "website", "studio"]'), needs.changes.outputs.scope)
+        run: echo "${{ needs.changes.outputs.scope }} changes use their dedicated workflow"
+
       - name: Checkout code
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/checkout@v6
 
       - name: Set up Go
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.5'
           cache: true
 
       - name: Cache Go tools
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
         id: go-tools-cache
         uses: actions/cache@v5
         with:
@@ -90,35 +92,41 @@ jobs:
           key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}
 
       - name: Install tooling
-        if: steps.go-tools-cache.outputs.cache-hit != 'true'
+        if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope) && steps.go-tools-cache.outputs.cache-hit != 'true'
         run: make tools
 
       - parallel:
           - name: Check formatting
+            if: contains(fromJSON('["docs", "telemetry", "full"]'), needs.changes.outputs.scope)
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make format-check
 
           - name: Check Wall of Apps source
+            if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: make check-wall-of-apps
 
           - name: Self-test docs validators
+            if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: python3 scripts/test_check_docs.py
 
           - name: Check CI workflow contracts
+            if: needs.changes.outputs.scope == 'full'
             run: python3 scripts/test_ci_workflows.py
 
           - name: Check documentation
+            if: contains(fromJSON('["docs", "full"]'), needs.changes.outputs.scope)
             run: make check-docs
 
           - name: Run lint
+            if: needs.changes.outputs.scope == 'full'
             run: |
               export PATH="$(go env GOPATH)/bin:$PATH"
               make lint
 
   unit-test-shards:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: needs.changes.outputs.scope == 'full'
     name: unit-test shard (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
@@ -148,21 +156,26 @@ jobs:
       - name: Run Go test shard
         run: ASC_BYPASS_KEYCHAIN=1 ${{ matrix.command }}
 
-  unit-tests:
-    needs: [changes, unit-test-shards]
-    if: always() && needs.changes.outputs.wall_only != 'true'
+  telemetry-linux-tests:
+    needs: changes
+    if: needs.changes.outputs.scope == 'telemetry'
     runs-on: ubuntu-latest
     steps:
-      - name: Verify unit test shards
-        run: |
-          if [ "${{ needs.unit-test-shards.result }}" != "success" ]; then
-            echo "unit-test-shards result: ${{ needs.unit-test-shards.result }}"
-            exit 1
-          fi
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Run telemetry tests
+        run: ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/telemetry ./internal/cli/telemetry ./cmd
 
   telemetry-windows-tests:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: contains(fromJSON('["telemetry", "full"]'), needs.changes.outputs.scope)
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -177,9 +190,39 @@ jobs:
       - name: Run telemetry tests
         run: go test -short ./internal/telemetry
 
+  unit-tests:
+    needs: [changes, unit-test-shards, telemetry-linux-tests, telemetry-windows-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify selected tests
+        run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "change detection result: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          case "${{ needs.changes.outputs.scope }}" in
+            full)
+              results="${{ needs.unit-test-shards.result }} ${{ needs.telemetry-windows-tests.result }}"
+              ;;
+            telemetry)
+              results="${{ needs.telemetry-linux-tests.result }} ${{ needs.telemetry-windows-tests.result }}"
+              ;;
+            *)
+              echo "No general Go tests required for ${{ needs.changes.outputs.scope }} changes"
+              exit 0
+              ;;
+          esac
+
+          if [ "$results" != "success success" ]; then
+            echo "selected test results: $results"
+            exit 1
+          fi
+
   build-platforms:
     needs: changes
-    if: needs.changes.outputs.wall_only != 'true'
+    if: needs.changes.outputs.scope == 'full'
     name: build (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -217,14 +260,45 @@ jobs:
         run: ${{ matrix.command }}
         shell: bash
 
-  build:
-    needs: [changes, build-platforms]
-    if: always() && needs.changes.outputs.wall_only != 'true'
+  ordinary-build:
+    needs: changes
+    if: needs.changes.outputs.scope == 'telemetry'
     runs-on: ubuntu-latest
     steps:
-      - name: Verify platform builds
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Compile all packages
+        run: go build ./...
+
+  build:
+    needs: [changes, build-platforms, ordinary-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify selected builds
         run: |
-          if [ "${{ needs.build-platforms.result }}" != "success" ]; then
-            echo "build-platforms result: ${{ needs.build-platforms.result }}"
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "change detection result: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          case "${{ needs.changes.outputs.scope }}" in
+            full) result="${{ needs.build-platforms.result }}" ;;
+            telemetry) result="${{ needs.ordinary-build.result }}" ;;
+            *)
+              echo "No CLI build required for ${{ needs.changes.outputs.scope }} changes"
+              exit 0
+              ;;
+          esac
+
+          if [ "$result" != "success" ]; then
+            echo "selected build result: $result"
             exit 1
           fi

--- a/.github/workflows/studio-checks.yml
+++ b/.github/workflows/studio-checks.yml
@@ -4,36 +4,11 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    paths:
-      - 'apps/studio/**'
-      - 'internal/asc/**'
-      - 'internal/auth/**'
-      - 'internal/config/**'
-      - 'internal/screenshots/**'
-      - 'internal/validation/**'
-      - 'internal/workflow/**'
-      - 'internal/xcode/**'
-      - 'go.mod'
-      - 'go.sum'
-  push:
-    branches:
-      - main
-    paths:
-      - 'apps/studio/**'
-      - 'internal/asc/**'
-      - 'internal/auth/**'
-      - 'internal/config/**'
-      - 'internal/screenshots/**'
-      - 'internal/validation/**'
-      - 'internal/workflow/**'
-      - 'internal/xcode/**'
-      - 'go.mod'
-      - 'go.sum'
+  workflow_call:
 
 jobs:
   studio:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/studio-checks.yml
+++ b/.github/workflows/studio-checks.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   studio:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/website-checks.yml
+++ b/.github/workflows/website-checks.yml
@@ -4,29 +4,7 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    paths:
-      - '.mintignore'
-      - '.mintlify/**'
-      - '*.mdx'
-      - 'commands/**'
-      - 'concepts/**'
-      - 'configuration/**'
-      - 'docs.json'
-      - 'guides/**'
-      - 'resources/**'
-  push:
-    branches: [main]
-    paths:
-      - '.mintignore'
-      - '.mintlify/**'
-      - '*.mdx'
-      - 'commands/**'
-      - 'concepts/**'
-      - 'configuration/**'
-      - 'docs.json'
-      - 'guides/**'
-      - 'resources/**'
+  workflow_call:
 
 jobs:
   website:

--- a/.github/workflows/website-checks.yml
+++ b/.github/workflows/website-checks.yml
@@ -1,0 +1,48 @@
+name: Website Checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - '.mintignore'
+      - '.mintlify/**'
+      - '*.mdx'
+      - 'commands/**'
+      - 'concepts/**'
+      - 'configuration/**'
+      - 'docs.json'
+      - 'guides/**'
+      - 'resources/**'
+  push:
+    branches: [main]
+    paths:
+      - '.mintignore'
+      - '.mintlify/**'
+      - '*.mdx'
+      - 'commands/**'
+      - 'concepts/**'
+      - 'configuration/**'
+      - 'docs.json'
+      - 'guides/**'
+      - 'resources/**'
+
+jobs:
+  website:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Self-test documentation validators
+        run: python3 scripts/test_check_docs.py
+
+      - name: Check website documentation
+        run: make check-website-docs

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -47,6 +47,8 @@ optimization change, with Darwin-only screenshot tests on the macOS leg.
   always receive the full suite.
 - Go source is always treated as code, even when it lives under a documentation
   directory.
+- The OpenAPI snapshot receives the full suite because Go tests consume it as
+  schema-drift input.
 - A manual PR workflow dispatch has no changed-file list and therefore receives
   the full suite.
 

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -25,14 +25,17 @@ scope:
 | Telemetry packages only | Formatting, targeted Linux and Windows tests, and `go build ./...` |
 | Any general, mixed, or unknown change | Full required suite and native platform builds |
 
-The three required PR jobs always resolve. For delegated scopes their aggregate
-jobs report that no general test or CLI build is required. A failure in the
-change detector fails all required aggregates instead of silently selecting a
-smaller suite.
+The three required PR jobs always resolve. The required `format-and-lint`
+aggregate waits for and verifies every affected Wall, website, Studio, or
+general quality job. The test and build aggregates report when no general Go
+work is required. A failure in the change detector fails all required
+aggregates instead of silently selecting a smaller suite.
 
-Website and Studio workflows run on Ubuntu. General cross-platform compilation
-continues to use Linux, macOS, and Windows runners through the runner split from
-the preceding CI optimization change.
+Website validation is an Ubuntu reusable workflow. Studio remains a macOS
+reusable workflow because its Wails build requires native GUI development
+libraries on Linux. General cross-platform compilation continues to use Linux,
+macOS, and Windows runners through the runner split from the preceding CI
+optimization change, with Darwin-only screenshot tests on the macOS leg.
 
 ## Safety boundaries
 

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -22,7 +22,7 @@ scope:
 | Repository documentation only | Formatting and documentation validation |
 | Mintlify website content only | Dedicated website validator workflow |
 | `apps/studio` only | Dedicated Studio frontend, Go test, and build workflow |
-| Telemetry packages only | Formatting, targeted Linux and Windows tests, and Linux/macOS `go build .` |
+| Telemetry runtime package only | Formatting, targeted Linux and Windows tests, and Linux/macOS `go build .` |
 | Any general, mixed, or unknown change | Full required suite and native platform builds |
 
 The three required PR jobs always resolve. The required `format-and-lint`
@@ -49,6 +49,11 @@ optimization change, with Darwin-only screenshot tests on the macOS leg.
   directory.
 - The OpenAPI snapshot receives the full suite because Go tests consume it as
   schema-drift input.
+- The API notes and workflow guides receive the full suite because they are
+  compiled into the `asc docs show` runtime surface.
+- Telemetry CLI command changes receive the full suite so command behavior and
+  generated documentation remain covered; only `internal/telemetry` uses the
+  targeted telemetry lane.
 - A manual PR workflow dispatch has no changed-file list and therefore receives
   the full suite.
 

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -21,7 +21,7 @@ scope:
 | Wall source only | Wall source validation |
 | Repository documentation only | Formatting and documentation validation |
 | Mintlify website content only | Dedicated website validator workflow |
-| `apps/studio` only | Dedicated Studio frontend, Go test, and build workflow |
+| Non-Go `apps/studio` files only | Dedicated Studio frontend, Go test, and build workflow |
 | Telemetry runtime package only | Formatting, targeted Linux and Windows tests, and Linux/macOS `go build .` |
 | Any general, mixed, or unknown change | Full required suite and native platform builds |
 
@@ -40,6 +40,8 @@ optimization change, with Darwin-only screenshot tests on the macOS leg.
 ## Safety boundaries
 
 - Only exact, allowlisted paths receive a reduced scope.
+- Rename detection is disabled while collecting paths so both the removed and
+  added sides of a rename participate in classification.
 - Mixed specialized areas fall back to the full suite.
 - Specialized code plus documentation falls back to the full suite so the
   documentation is not skipped.
@@ -47,13 +49,15 @@ optimization change, with Darwin-only screenshot tests on the macOS leg.
   always receive the full suite.
 - Go source is always treated as code, even when it lives under a documentation
   directory.
+- Studio Go source receives the full formatting, lint, test, and native-build
+  suite in addition to the dedicated Studio workflow.
 - The OpenAPI snapshot receives the full suite because Go tests consume it as
   schema-drift input.
 - The API notes and workflow guides receive the full suite because they are
   compiled into the `asc docs show` runtime surface.
 - Telemetry CLI command changes receive the full suite so command behavior and
-  generated documentation remain covered; only `internal/telemetry` uses the
-  targeted telemetry lane.
+  generated documentation remain covered. Only `internal/telemetry` uses the
+  targeted telemetry lane, which still runs repository formatting and lint.
 - A manual PR workflow dispatch has no changed-file list and therefore receives
   the full suite.
 

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -22,7 +22,7 @@ scope:
 | Repository documentation only | Formatting and documentation validation |
 | Mintlify website content only | Dedicated website validator workflow |
 | `apps/studio` only | Dedicated Studio frontend, Go test, and build workflow |
-| Telemetry packages only | Formatting, targeted Linux and Windows tests, and `go build ./...` |
+| Telemetry packages only | Formatting, targeted Linux and Windows tests, and `go build .` |
 | Any general, mixed, or unknown change | Full required suite and native platform builds |
 
 The three required PR jobs always resolve. The required `format-and-lint`
@@ -45,6 +45,8 @@ optimization change, with Darwin-only screenshot tests on the macOS leg.
   documentation is not skipped.
 - Workflow, build-system, dependency, shared package, and classifier changes
   always receive the full suite.
+- Go source is always treated as code, even when it lives under a documentation
+  directory.
 - A manual PR workflow dispatch has no changed-file list and therefore receives
   the full suite.
 

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -1,0 +1,55 @@
+# Scope-Aware CI Selection
+
+## Current behavior
+
+Except for Wall-only changes, every pull request runs the complete formatting,
+documentation, lint, test-shard, Windows telemetry, and five-binary build suite.
+Website content and Studio changes also pay for those general CLI checks despite
+having narrower validation needs.
+
+The protected branch requires three PR check names: `format-and-lint`,
+`unit-tests`, and `build`. Any selection scheme must keep those checks present
+and must fail closed when change detection is unavailable or ambiguous.
+
+## Proposed behavior
+
+Classify the complete base-to-head changed-file list into one conservative
+scope:
+
+| Scope | Selected validation |
+| --- | --- |
+| Wall source only | Wall source validation |
+| Repository documentation only | Formatting and documentation validation |
+| Mintlify website content only | Dedicated website validator workflow |
+| `apps/studio` only | Dedicated Studio frontend, Go test, and build workflow |
+| Telemetry packages only | Formatting, targeted Linux and Windows tests, and `go build ./...` |
+| Any general, mixed, or unknown change | Full required suite and native platform builds |
+
+The three required PR jobs always resolve. For delegated scopes their aggregate
+jobs report that no general test or CLI build is required. A failure in the
+change detector fails all required aggregates instead of silently selecting a
+smaller suite.
+
+Website and Studio workflows run on Ubuntu. General cross-platform compilation
+continues to use Linux, macOS, and Windows runners through the runner split from
+the preceding CI optimization change.
+
+## Safety boundaries
+
+- Only exact, allowlisted paths receive a reduced scope.
+- Mixed specialized areas fall back to the full suite.
+- Specialized code plus documentation falls back to the full suite so the
+  documentation is not skipped.
+- Workflow, build-system, dependency, shared package, and classifier changes
+  always receive the full suite.
+- A manual PR workflow dispatch has no changed-file list and therefore receives
+  the full suite.
+
+## Verification
+
+- Unit-test path classification, including empty, mixed, and unknown changes.
+- Assert workflow ownership, required aggregate jobs, native build runners, and
+  release-only artifact publication.
+- Parse every workflow as YAML and run the repository documentation, lint, and
+  Go test gates.
+- Exercise the full suite on this pull request because it changes CI files.

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -22,7 +22,7 @@ scope:
 | Repository documentation only | Formatting and documentation validation |
 | Mintlify website content only | Dedicated website validator workflow |
 | `apps/studio` only | Dedicated Studio frontend, Go test, and build workflow |
-| Telemetry packages only | Formatting, targeted Linux and Windows tests, and `go build .` |
+| Telemetry packages only | Formatting, targeted Linux and Windows tests, and Linux/macOS `go build .` |
 | Any general, mixed, or unknown change | Full required suite and native platform builds |
 
 The three required PR jobs always resolve. The required `format-and-lint`

--- a/docs/design/ci-scope-aware-selection.md
+++ b/docs/design/ci-scope-aware-selection.md
@@ -42,6 +42,10 @@ optimization change, with Darwin-only screenshot tests on the macOS leg.
 - Only exact, allowlisted paths receive a reduced scope.
 - Rename detection is disabled while collecting paths so both the removed and
   added sides of a rename participate in classification.
+- Workflow and classifier-contract paths are matched in shell before executing
+  the checked-out classifier. Those changes force the full suite plus both
+  dedicated validators, so a broken classifier cannot select a reduced lane
+  for its own validation.
 - Mixed specialized areas fall back to the full suite.
 - Specialized code plus documentation falls back to the full suite so the
   documentation is not skipped.

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Classify changed paths for conservative CI test selection."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+
+
+WALL_SOURCE = "docs/wall-of-apps.json"
+WEBSITE_FILES = {".mintignore", "docs.json"}
+WEBSITE_PREFIXES = (
+    ".mintlify/",
+    "commands/",
+    "concepts/",
+    "configuration/",
+    "guides/",
+    "resources/",
+)
+TELEMETRY_PREFIXES = ("internal/telemetry/", "internal/cli/telemetry/")
+STUDIO_PREFIX = "apps/studio/"
+
+
+def path_kind(path: str) -> str:
+    if path == WALL_SOURCE:
+        return "wall"
+    if path in WEBSITE_FILES or path.startswith(WEBSITE_PREFIXES):
+        return "website"
+    if "/" not in path and path.endswith(".mdx"):
+        return "website"
+    if path.startswith(TELEMETRY_PREFIXES):
+        return "telemetry"
+    if path.startswith(STUDIO_PREFIX):
+        return "studio"
+    if path.startswith("docs/"):
+        return "docs"
+    if "/" not in path and path.endswith(".md"):
+        return "docs"
+    return "full"
+
+
+def classify(paths: Iterable[str]) -> str:
+    normalized = [path.strip() for path in paths if path.strip()]
+    if not normalized:
+        return "full"
+    if normalized == [WALL_SOURCE]:
+        return "wall"
+
+    kinds = {path_kind(path) for path in normalized}
+    if "wall" in kinds or "full" in kinds:
+        return "full"
+
+    if kinds == {"telemetry"}:
+        return "telemetry"
+    if kinds == {"studio"}:
+        return "studio"
+    if kinds == {"website"}:
+        return "website"
+    if kinds <= {"docs", "website"}:
+        return "docs"
+    return "full"
+
+
+def main() -> None:
+    print(classify(sys.stdin))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 from collections.abc import Iterable
 
@@ -18,7 +19,17 @@ WEBSITE_PREFIXES = (
     "resources/",
 )
 TELEMETRY_PREFIXES = ("internal/telemetry/", "internal/cli/telemetry/")
-STUDIO_PREFIX = "apps/studio/"
+STUDIO_PREFIXES = (
+    "apps/studio/",
+    "internal/asc/",
+    "internal/auth/",
+    "internal/config/",
+    "internal/screenshots/",
+    "internal/validation/",
+    "internal/workflow/",
+    "internal/xcode/",
+)
+STUDIO_FILES = {"go.mod", "go.sum"}
 
 
 def path_kind(path: str) -> str:
@@ -30,7 +41,7 @@ def path_kind(path: str) -> str:
         return "website"
     if path.startswith(TELEMETRY_PREFIXES):
         return "telemetry"
-    if path.startswith(STUDIO_PREFIX):
+    if path.startswith("apps/studio/"):
         return "studio"
     if path.startswith("docs/"):
         return "docs"
@@ -61,8 +72,30 @@ def classify(paths: Iterable[str]) -> str:
     return "full"
 
 
+def affects_website(paths: Iterable[str]) -> bool:
+    return any(path_kind(path.strip()) == "website" for path in paths if path.strip())
+
+
+def affects_studio(paths: Iterable[str]) -> bool:
+    return any(
+        path.strip() in STUDIO_FILES or path.strip().startswith(STUDIO_PREFIXES)
+        for path in paths
+        if path.strip()
+    )
+
+
 def main() -> None:
-    print(classify(sys.stdin))
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--github-output", action="store_true")
+    args = parser.parse_args()
+    paths = list(sys.stdin)
+
+    if args.github_output:
+        print(f"scope={classify(paths)}")
+        print(f"website_affected={str(affects_website(paths)).lower()}")
+        print(f"studio_affected={str(affects_studio(paths)).lower()}")
+        return
+    print(classify(paths))
 
 
 if __name__ == "__main__":

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -35,14 +35,16 @@ STUDIO_FILES = {"go.mod", "go.sum"}
 def path_kind(path: str) -> str:
     if path == WALL_SOURCE:
         return "wall"
-    if path in WEBSITE_FILES or path.startswith(WEBSITE_PREFIXES):
-        return "website"
-    if "/" not in path and path.endswith(".mdx"):
-        return "website"
     if path.startswith(TELEMETRY_PREFIXES):
         return "telemetry"
     if path.startswith("apps/studio/"):
         return "studio"
+    if path.endswith(".go"):
+        return "full"
+    if path in WEBSITE_FILES or path.startswith(WEBSITE_PREFIXES):
+        return "website"
+    if "/" not in path and path.endswith(".mdx"):
+        return "website"
     if path.startswith("docs/"):
         return "docs"
     if "/" not in path and path.endswith(".md"):

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 
 WALL_SOURCE = "docs/wall-of-apps.json"
 OPENAPI_SNAPSHOT = "docs/openapi/latest.json"
+EMBEDDED_GUIDES = {"docs/API_NOTES.md", "docs/WORKFLOWS.md"}
 WEBSITE_FILES = {".mintignore", "docs.json"}
 WEBSITE_PREFIXES = (
     ".mintlify/",
@@ -19,7 +20,8 @@ WEBSITE_PREFIXES = (
     "guides/",
     "resources/",
 )
-TELEMETRY_PREFIXES = ("internal/telemetry/", "internal/cli/telemetry/")
+TELEMETRY_PREFIX = "internal/telemetry/"
+TELEMETRY_CLI_PREFIX = "internal/cli/telemetry/"
 STUDIO_PREFIXES = (
     "apps/studio/",
     "internal/asc/",
@@ -36,9 +38,11 @@ STUDIO_FILES = {"go.mod", "go.sum"}
 def path_kind(path: str) -> str:
     if path == WALL_SOURCE:
         return "wall"
-    if path == OPENAPI_SNAPSHOT:
+    if path == OPENAPI_SNAPSHOT or path in EMBEDDED_GUIDES:
         return "full"
-    if path.startswith(TELEMETRY_PREFIXES):
+    if path.startswith(TELEMETRY_CLI_PREFIX):
+        return "full"
+    if path.startswith(TELEMETRY_PREFIX):
         return "telemetry"
     if path.startswith("apps/studio/"):
         return "studio"

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -44,10 +44,10 @@ def path_kind(path: str) -> str:
         return "full"
     if path.startswith(TELEMETRY_PREFIX):
         return "telemetry"
-    if path.startswith("apps/studio/"):
-        return "studio"
     if path.endswith(".go"):
         return "full"
+    if path.startswith("apps/studio/"):
+        return "studio"
     if path in WEBSITE_FILES or path.startswith(WEBSITE_PREFIXES):
         return "website"
     if "/" not in path and path.endswith(".mdx"):

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -9,6 +9,7 @@ from collections.abc import Iterable
 
 
 WALL_SOURCE = "docs/wall-of-apps.json"
+OPENAPI_SNAPSHOT = "docs/openapi/latest.json"
 WEBSITE_FILES = {".mintignore", "docs.json"}
 WEBSITE_PREFIXES = (
     ".mintlify/",
@@ -35,6 +36,8 @@ STUDIO_FILES = {"go.mod", "go.sum"}
 def path_kind(path: str) -> str:
     if path == WALL_SOURCE:
         return "wall"
+    if path == OPENAPI_SNAPSHOT:
+        return "full"
     if path.startswith(TELEMETRY_PREFIXES):
         return "telemetry"
     if path.startswith("apps/studio/"):

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Tests for conservative CI change-scope classification."""
+
+import unittest
+
+import ci_change_scope
+
+
+class ChangeScopeTest(unittest.TestCase):
+    def test_empty_change_list_requires_full_suite(self) -> None:
+        self.assertEqual(ci_change_scope.classify([]), "full")
+
+    def test_wall_source_is_the_only_wall_only_change(self) -> None:
+        self.assertEqual(ci_change_scope.classify(["docs/wall-of-apps.json"]), "wall")
+        self.assertEqual(
+            ci_change_scope.classify(["docs/wall-of-apps.json", "README.md"]),
+            "full",
+        )
+
+    def test_repository_documentation_uses_docs_scope(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(["README.md", "docs/TESTING.md"]),
+            "docs",
+        )
+
+    def test_mintlify_content_uses_website_scope(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(["docs.json", "guides/getting-started.mdx"]),
+            "website",
+        )
+
+    def test_telemetry_scope_requires_only_telemetry_files(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(["internal/telemetry/client.go"]),
+            "telemetry",
+        )
+        self.assertEqual(
+            ci_change_scope.classify(
+                ["internal/telemetry/client.go", "commands/telemetry.mdx"]
+            ),
+            "full",
+        )
+
+    def test_studio_scope_requires_only_studio_files(self) -> None:
+        self.assertEqual(ci_change_scope.classify(["apps/studio/main.go"]), "studio")
+        self.assertEqual(
+            ci_change_scope.classify(
+                ["apps/studio/main.go", "guides/studio.mdx"]
+            ),
+            "full",
+        )
+
+    def test_mixed_specialized_changes_require_full_suite(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(
+                ["apps/studio/main.go", "internal/telemetry/client.go"]
+            ),
+            "full",
+        )
+
+    def test_general_go_and_ci_changes_require_full_suite(self) -> None:
+        for path in ("main.go", "internal/asc/client.go", ".github/workflows/pr-checks.yml"):
+            with self.subTest(path=path):
+                self.assertEqual(ci_change_scope.classify([path]), "full")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -99,6 +99,16 @@ class ChangeScopeTest(unittest.TestCase):
             "full",
         )
 
+    def test_ci_bootstrap_files_require_full_scope(self) -> None:
+        for path in (
+            ".github/workflows/pr-checks.yml",
+            "scripts/ci_change_scope.py",
+            "scripts/test_ci_change_scope.py",
+            "scripts/test_ci_workflows.py",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(ci_change_scope.classify([path]), "full")
+
     def test_dedicated_workflow_impact_matches_owned_paths(self) -> None:
         self.assertTrue(ci_change_scope.affects_website(["guides/testflight.mdx"]))
         self.assertFalse(ci_change_scope.affects_website(["docs/TESTING.md"]))

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -34,6 +34,11 @@ class ChangeScopeTest(unittest.TestCase):
             "full",
         )
 
+    def test_embedded_guides_require_runtime_docs_tests(self) -> None:
+        for path in ("docs/API_NOTES.md", "docs/WORKFLOWS.md"):
+            with self.subTest(path=path):
+                self.assertEqual(ci_change_scope.classify([path]), "full")
+
     def test_mintlify_content_uses_website_scope(self) -> None:
         self.assertEqual(
             ci_change_scope.classify(["docs.json", "guides/getting-started.mdx"]),
@@ -49,6 +54,12 @@ class ChangeScopeTest(unittest.TestCase):
             ci_change_scope.classify(
                 ["internal/telemetry/client.go", "commands/telemetry.mdx"]
             ),
+            "full",
+        )
+
+    def test_telemetry_cli_changes_require_command_coverage(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(["internal/cli/telemetry/telemetry.go"]),
             "full",
         )
 

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -23,6 +23,11 @@ class ChangeScopeTest(unittest.TestCase):
             "docs",
         )
 
+    def test_go_source_under_documentation_requires_full_suite(self) -> None:
+        for path in ("docs/embed.go", "guides/example.go"):
+            with self.subTest(path=path):
+                self.assertEqual(ci_change_scope.classify([path]), "full")
+
     def test_mintlify_content_uses_website_scope(self) -> None:
         self.assertEqual(
             ci_change_scope.classify(["docs.json", "guides/getting-started.mdx"]),

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -28,6 +28,12 @@ class ChangeScopeTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(ci_change_scope.classify([path]), "full")
 
+    def test_openapi_snapshot_requires_schema_drift_tests(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(["docs/openapi/latest.json"]),
+            "full",
+        )
+
     def test_mintlify_content_uses_website_scope(self) -> None:
         self.assertEqual(
             ci_change_scope.classify(["docs.json", "guides/getting-started.mdx"]),

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -63,11 +63,17 @@ class ChangeScopeTest(unittest.TestCase):
             "full",
         )
 
-    def test_studio_scope_requires_only_studio_files(self) -> None:
-        self.assertEqual(ci_change_scope.classify(["apps/studio/main.go"]), "studio")
+    def test_studio_go_source_requires_full_quality_checks(self) -> None:
+        self.assertEqual(ci_change_scope.classify(["apps/studio/main.go"]), "full")
+
+    def test_studio_scope_requires_only_non_go_studio_files(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(["apps/studio/frontend/src/App.tsx"]),
+            "studio",
+        )
         self.assertEqual(
             ci_change_scope.classify(
-                ["apps/studio/main.go", "guides/studio.mdx"]
+                ["apps/studio/frontend/src/App.tsx", "guides/studio.mdx"]
             ),
             "full",
         )
@@ -84,6 +90,14 @@ class ChangeScopeTest(unittest.TestCase):
         for path in ("main.go", "internal/asc/client.go", ".github/workflows/pr-checks.yml"):
             with self.subTest(path=path):
                 self.assertEqual(ci_change_scope.classify([path]), "full")
+
+    def test_renamed_code_keeps_source_and_destination_in_full_scope(self) -> None:
+        self.assertEqual(
+            ci_change_scope.classify(
+                ["internal/asc/removed.go", "docs/removed.md"]
+            ),
+            "full",
+        )
 
     def test_dedicated_workflow_impact_matches_owned_paths(self) -> None:
         self.assertTrue(ci_change_scope.affects_website(["guides/testflight.mdx"]))

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -63,6 +63,14 @@ class ChangeScopeTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(ci_change_scope.classify([path]), "full")
 
+    def test_dedicated_workflow_impact_matches_owned_paths(self) -> None:
+        self.assertTrue(ci_change_scope.affects_website(["guides/testflight.mdx"]))
+        self.assertFalse(ci_change_scope.affects_website(["docs/TESTING.md"]))
+        self.assertTrue(ci_change_scope.affects_studio(["apps/studio/main.go"]))
+        self.assertTrue(ci_change_scope.affects_studio(["internal/asc/client.go"]))
+        self.assertTrue(ci_change_scope.affects_studio(["go.mod"]))
+        self.assertFalse(ci_change_scope.affects_studio(["internal/telemetry/client.go"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -38,6 +38,7 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     assert "website_affected: ${{ steps.scope.outputs.website_affected }}" in changes
     assert "studio_affected: ${{ steps.scope.outputs.studio_affected }}" in changes
     assert "python3 scripts/ci_change_scope.py --github-output" in changes
+    assert "git diff --name-only --no-renames" in changes
     assert "wall|docs|website|studio|telemetry|full" in changes
     assert "invalid CI scope" in changes
 
@@ -46,6 +47,7 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     quality = job_block(workflow, "quality-checks")
     assert "runs-on: ubuntu-latest" in quality
     assert "python3 scripts/test_ci_change_scope.py" in quality
+    assert "contains(fromJSON('[\"telemetry\", \"full\"]'), needs.changes.outputs.scope)" in quality
     for called_job, called_workflow in (
         ("website-checks", "website-checks.yml"),
         ("studio-checks", "studio-checks.yml"),
@@ -101,6 +103,7 @@ def main() -> None:
     assert "runs-on: macos-latest" in job_block(studio, "studio")
 
     main = MAIN_WORKFLOW.read_text()
+    assert "git diff-tree --no-commit-id --name-only --no-renames -r" in main
     main_windows = job_block(main, "telemetry-windows-tests")
     assert "[\"telemetry\", \"full\"]" in main_windows
     assert "needs.telemetry-windows-tests.result" in job_block(main, "test")

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -66,7 +66,8 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
 
     ordinary_build = job_block(workflow, "ordinary-build")
     assert "needs.changes.outputs.scope == 'telemetry'" in ordinary_build
-    assert "go build ./..." in ordinary_build
+    assert "run: go build ." in ordinary_build
+    assert "go build ./..." not in ordinary_build
 
     build = job_block(workflow, "build")
     assert "needs: [changes, build-platforms, ordinary-build]" in build

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -39,6 +39,19 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     assert "studio_affected: ${{ steps.scope.outputs.studio_affected }}" in changes
     assert "python3 scripts/ci_change_scope.py --github-output" in changes
     assert "git diff --name-only --no-renames" in changes
+    for guarded_path in (
+        ".github/workflows/*",
+        "scripts/ci_change_scope.py",
+        "scripts/test_ci_change_scope.py",
+        "scripts/test_ci_workflows.py",
+    ):
+        assert guarded_path in changes
+    assert changes.index("force_full=false") < changes.index(
+        "python3 scripts/ci_change_scope.py --github-output"
+    )
+    assert 'if [ "$force_full" = true ]; then' in changes
+    assert "website_affected=true" in changes
+    assert "studio_affected=true" in changes
     assert "wall|docs|website|studio|telemetry|full" in changes
     assert "invalid CI scope" in changes
 

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -46,7 +46,9 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
 
     assert "runs-on: ubuntu-latest" in job_block(workflow, "wall-only-check")
     assert "runs-on: ubuntu-latest" in job_block(workflow, "format-and-lint")
-    assert "runs-on: ubuntu-latest" in job_block(workflow, "quality-checks")
+    quality = job_block(workflow, "quality-checks")
+    assert "runs-on: ubuntu-latest" in quality
+    assert "python3 scripts/test_ci_change_scope.py" in quality
     for called_job, called_workflow in (
         ("website-checks", "website-checks.yml"),
         ("studio-checks", "studio-checks.yml"),

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -68,6 +68,8 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
 
     ordinary_build = job_block(workflow, "ordinary-build")
     assert "needs.changes.outputs.scope == 'telemetry'" in ordinary_build
+    assert "runner: ubuntu-latest" in ordinary_build
+    assert "runner: macos-latest" in ordinary_build
     assert "run: go build ." in ordinary_build
     assert "go build ./..." not in ordinary_build
 

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -3,8 +3,6 @@
 
 from pathlib import Path
 
-import ci_change_scope
-
 
 ROOT = Path(__file__).resolve().parent.parent
 PR_WORKFLOW = ROOT / ".github/workflows/pr-checks.yml"
@@ -40,12 +38,22 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     assert "actions/upload-artifact" not in workflow, f"{path}: development artifacts must not be uploaded"
     changes = job_block(workflow, "changes")
     assert "scope: ${{ steps.scope.outputs.scope }}" in changes
-    assert "python3 scripts/ci_change_scope.py" in changes
+    assert "website_affected: ${{ steps.scope.outputs.website_affected }}" in changes
+    assert "studio_affected: ${{ steps.scope.outputs.studio_affected }}" in changes
+    assert "python3 scripts/ci_change_scope.py --github-output" in changes
     assert "wall|docs|website|studio|telemetry|full" in changes
     assert "invalid CI scope" in changes
 
     assert "runs-on: ubuntu-latest" in job_block(workflow, "wall-only-check")
     assert "runs-on: ubuntu-latest" in job_block(workflow, "format-and-lint")
+    assert "runs-on: ubuntu-latest" in job_block(workflow, "quality-checks")
+    for called_job, called_workflow in (
+        ("website-checks", "website-checks.yml"),
+        ("studio-checks", "studio-checks.yml"),
+    ):
+        called = job_block(workflow, called_job)
+        assert f"uses: ./.github/workflows/{called_workflow}" in called
+        assert f"needs.changes.outputs.{called_job.removesuffix('-checks')}_affected == 'true'" in called
     tests = job_block(workflow, test_job)
     assert "runs-on: ubuntu-latest" in tests
     assert "needs.changes.outputs.scope == 'full'" in tests
@@ -54,6 +62,7 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     assert "needs.changes.outputs.scope == 'full'" in build_platforms
     for runner in ("macos-latest", "ubuntu-latest", "windows-latest"):
         assert f"runner: {runner}" in build_platforms, f"{path}: missing native build runner {runner}"
+    assert "go test -short ./internal/screenshots" in build_platforms
 
     ordinary_build = job_block(workflow, "ordinary-build")
     assert "needs.changes.outputs.scope == 'telemetry'" in ordinary_build
@@ -73,19 +82,24 @@ def main() -> None:
     pr = PR_WORKFLOW.read_text()
     for required_job in ("format-and-lint", "unit-tests", "build"):
         assert "if: always()" in job_block(pr, required_job), f"required job {required_job} must always resolve"
+    quality_gate = job_block(pr, "format-and-lint")
+    assert "needs: [changes, wall-only-check, quality-checks, website-checks, studio-checks]" in quality_gate
+    assert "needs.website-checks.result" in quality_gate
+    assert "needs.studio-checks.result" in quality_gate
 
     website = WEBSITE_WORKFLOW.read_text()
+    assert "workflow_call:" in website
     assert "runs-on: ubuntu-latest" in job_block(website, "website")
     assert "make check-website-docs" in website
-    for path in ci_change_scope.WEBSITE_FILES:
-        assert f"'{path}'" in website, f"website workflow does not own {path}"
-    for prefix in ci_change_scope.WEBSITE_PREFIXES:
-        assert f"'{prefix}**'" in website, f"website workflow does not own {prefix}"
-    assert "'*.mdx'" in website
 
     studio = STUDIO_WORKFLOW.read_text()
-    assert "runs-on: ubuntu-latest" in job_block(studio, "studio")
-    assert f"'{ci_change_scope.STUDIO_PREFIX}**'" in studio
+    assert "workflow_call:" in studio
+    assert "runs-on: macos-latest" in job_block(studio, "studio")
+
+    main = MAIN_WORKFLOW.read_text()
+    main_windows = job_block(main, "telemetry-windows-tests")
+    assert "[\"telemetry\", \"full\"]" in main_windows
+    assert "needs.telemetry-windows-tests.result" in job_block(main, "test")
 
     release = RELEASE_WORKFLOW.read_text()
     assert "actions/upload-artifact" in release, "release workflow must retain official artifact publication"

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -3,11 +3,15 @@
 
 from pathlib import Path
 
+import ci_change_scope
+
 
 ROOT = Path(__file__).resolve().parent.parent
 PR_WORKFLOW = ROOT / ".github/workflows/pr-checks.yml"
 MAIN_WORKFLOW = ROOT / ".github/workflows/main-branch.yml"
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+STUDIO_WORKFLOW = ROOT / ".github/workflows/studio-checks.yml"
+WEBSITE_WORKFLOW = ROOT / ".github/workflows/website-checks.yml"
 
 
 def job_block(workflow: str, job: str) -> str:
@@ -34,22 +38,54 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     workflow = path.read_text()
 
     assert "actions/upload-artifact" not in workflow, f"{path}: development artifacts must not be uploaded"
+    changes = job_block(workflow, "changes")
+    assert "scope: ${{ steps.scope.outputs.scope }}" in changes
+    assert "python3 scripts/ci_change_scope.py" in changes
+    assert "wall|docs|website|studio|telemetry|full" in changes
+    assert "invalid CI scope" in changes
+
     assert "runs-on: ubuntu-latest" in job_block(workflow, "wall-only-check")
     assert "runs-on: ubuntu-latest" in job_block(workflow, "format-and-lint")
-    assert "runs-on: ubuntu-latest" in job_block(workflow, test_job)
+    tests = job_block(workflow, test_job)
+    assert "runs-on: ubuntu-latest" in tests
+    assert "needs.changes.outputs.scope == 'full'" in tests
 
     build_platforms = job_block(workflow, "build-platforms")
+    assert "needs.changes.outputs.scope == 'full'" in build_platforms
     for runner in ("macos-latest", "ubuntu-latest", "windows-latest"):
         assert f"runner: {runner}" in build_platforms, f"{path}: missing native build runner {runner}"
 
+    ordinary_build = job_block(workflow, "ordinary-build")
+    assert "needs.changes.outputs.scope == 'telemetry'" in ordinary_build
+    assert "go build ./..." in ordinary_build
+
     build = job_block(workflow, "build")
-    assert "needs: [changes, build-platforms]" in build
+    assert "needs: [changes, build-platforms, ordinary-build]" in build
+    assert "if: always()" in build
     assert "needs.build-platforms.result" in build
+    assert "needs.ordinary-build.result" in build
 
 
 def main() -> None:
     assert_optimized_workflow(PR_WORKFLOW, "unit-test-shards")
     assert_optimized_workflow(MAIN_WORKFLOW, "test-shards")
+
+    pr = PR_WORKFLOW.read_text()
+    for required_job in ("format-and-lint", "unit-tests", "build"):
+        assert "if: always()" in job_block(pr, required_job), f"required job {required_job} must always resolve"
+
+    website = WEBSITE_WORKFLOW.read_text()
+    assert "runs-on: ubuntu-latest" in job_block(website, "website")
+    assert "make check-website-docs" in website
+    for path in ci_change_scope.WEBSITE_FILES:
+        assert f"'{path}'" in website, f"website workflow does not own {path}"
+    for prefix in ci_change_scope.WEBSITE_PREFIXES:
+        assert f"'{prefix}**'" in website, f"website workflow does not own {prefix}"
+    assert "'*.mdx'" in website
+
+    studio = STUDIO_WORKFLOW.read_text()
+    assert "runs-on: ubuntu-latest" in job_block(studio, "studio")
+    assert f"'{ci_change_scope.STUDIO_PREFIX}**'" in studio
 
     release = RELEASE_WORKFLOW.read_text()
     assert "actions/upload-artifact" in release, "release workflow must retain official artifact publication"


### PR DESCRIPTION
## Summary
- classify complete changed-file sets conservatively as wall, docs, website, Studio, telemetry, or full
- run docs-only changes through formatting and documentation checks without native CLI builds
- run telemetry-runtime-only changes through formatting, lint, targeted Linux and Windows tests, and Linux/macOS CLI compilation
- run website content validation in its own Ubuntu workflow and keep Studio checks on macOS
- keep required `format-and-lint`, `unit-tests`, and `build` check names present for every PR
- fail closed to the full suite for mixed, unknown, dependency, build-system, workflow, Studio Go, or rename-sensitive changes
- bootstrap workflow/classifier contract paths in shell before trusting the checked-out classifier

## Stack
Depends on #1736. This PR is intentionally based on `codex/ci-runner-artifacts` and should be retargeted to `main` after #1736 merges.

## Verification
- `python3 scripts/test_ci_change_scope.py`
- `python3 scripts/test_ci_workflows.py`
- manual scope probes for Studio Go, Studio frontend, and telemetry runtime paths
- historical-rename probe confirming `--no-renames` exposes both source and destination paths
- RED/GREEN workflow-contract coverage for the pre-classifier bootstrap guard
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- targeted website validation
- targeted telemetry tests and native CLI builds
- Studio Go tests/build and frontend tests/build
- commit hooks: command docs, formatting, lint, and short tests
