### PR TITLE
Speed up repeated local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 BINARY_NAME := asc
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Keep local build metadata stable so unchanged builds can reuse Go's link cache.
+# Release builds set their actual build timestamp in the release workflow.
+DATE := $(shell git show -s --format=%cI HEAD 2>/dev/null || echo "unknown")
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
 # Go variables


### PR DESCRIPTION
## What changed

Local `make build` now uses the commit timestamp for embedded version metadata. The value stays fixed until `HEAD` changes, so Go can reuse its link cache.

Release builds are unchanged; `.github/workflows/release.yml` still records the actual release build time. `DATE=... make build` also continues to override the default.

## Benchmark

Go 1.26.5 on darwin/arm64, warm `GOCACHE`, five unchanged `make build` runs after one warm-up:

| | Before | After |
|---|---:|---:|
| Mean | 2.516 s | 0.200 s |
| Range | 2.49-2.54 s | 0.20-0.20 s |

Repeated builds are 12.6x faster, a 92.1% reduction in wall time.

## Checks

- `make format`
- `make check-docs` (validators run individually; all passed)
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test -v ./...`
- manual `DATE` override check
- clean-tree five-run benchmark after commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Local builds now use a stable timestamp based on the latest committed change.
  * Release builds continue to receive their actual release timestamp automatically.
  * Builds use a fallback value when commit timestamp information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->