### PR TITLE
fix(release): harden 2.8.0 readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,10 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
 
       - name: Validate release tag
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
         run: |
-          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}"
+          TAG="${RELEASE_TAG}"
 
           if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Release tags must match x.y.z. Got: ${TAG}"

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -74,3 +74,23 @@ func TestReleaseWorkflowKeepsDocsGuardrails(t *testing.T) {
 		}
 	}
 }
+
+func TestReleaseWorkflowDoesNotInterpolateDispatchInputIntoShell(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	if strings.Contains(workflow, `TAG="${{ github.event_name == 'workflow_dispatch'`) {
+		t.Fatal("release workflow interpolates dispatch input directly into shell")
+	}
+	for _, want := range []string{
+		`RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}`,
+		`TAG="${RELEASE_TAG}"`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("release workflow missing safe dispatch handling %q", want)
+		}
+	}
+}

--- a/scripts/test_ci_change_scope.py
+++ b/scripts/test_ci_change_scope.py
@@ -66,7 +66,7 @@ class ChangeScopeTest(unittest.TestCase):
     def test_mixed_specialized_changes_require_full_suite(self) -> None:
         self.assertEqual(
             ci_change_scope.classify(
-                ["main.go", "internal/telemetry/client.go"]
+                ["docs/wall-of-apps.json", "internal/telemetry/client.go"]
             ),
             "full",
         )


### PR DESCRIPTION
## What changed

- pass the manual release version through an environment variable before shell validation
- make the mixed-scope CI test combine Wall and telemetry paths, so it tests the intended classifier rule

## Why

PR #1731 placed the manual release input directly inside a shell script. Shell expansion happens before the numeric tag check, so a crafted dispatch value could execute syntax in a job with release permissions and secrets.

The post-merge review on #1741 also found that `main.go` made the mixed specialized-scope test pass by itself. Using Wall plus telemetry paths now proves that mixed narrow scopes fall back to the full suite.

## Verification

- `make format`
- `make check-docs`
- `make check-wall-of-apps`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `python3 scripts/test_ci_change_scope.py`
- `python3 scripts/test_ci_workflows.py`
- `go test . -run 'TestReleaseWorkflow' -count=1`
- `go mod verify`
- `govulncheck ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow handling for manually selected release tags, preventing unsafe shell interpolation.
  * Preserved existing tag validation and export behavior.

* **Tests**
  * Added coverage to verify safe handling of manually provided release tags.
  * Updated CI scope testing for specialized documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->