### PR TITLE
fix: send X-Csrf-Itc header on compliance form requests

### DIFF
--- a/internal/web/medical_device.go
+++ b/internal/web/medical_device.go
@@ -93,6 +93,10 @@ func (c *Client) doAppComplianceRequest(ctx context.Context, appID, method, path
 	headers.Set("Content-Type", "application/json")
 	headers.Set("Accept", "application/json")
 	headers.Set("X-Requested-With", "XMLHttpRequest")
+	// The ppm/complianceform service rejects mutating requests with an empty
+	// 403 unless this App Store Connect UI CSRF header is present; GETs work
+	// without it, so send it unconditionally to match the web client.
+	headers.Set("X-Csrf-Itc", "itc")
 	headers.Set("Origin", baseURL)
 	headers.Set("Referer", strings.TrimRight(baseURL, "/")+"/apps/"+url.PathEscape(strings.TrimSpace(appID))+"/distribution/info")
 	return c.doRequestBase(ctx, baseURL, method, path, body, headers)

--- a/internal/web/medical_device_test.go
+++ b/internal/web/medical_device_test.go
@@ -87,6 +87,9 @@ func TestSetMedicalDeviceDeclarationPostsExpectedRequest(t *testing.T) {
 				}
 			}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/ppm/complianceform/v1/accounts/account-123/contents/app-123/requirements/req-123/forms":
+			if got := r.Header.Get("X-Csrf-Itc"); got != "itc" {
+				t.Fatalf("expected X-Csrf-Itc itc, got %q", got)
+			}
 			var body struct {
 				AccountID          string   `json:"accountId"`
 				ContentID          string   `json:"contentId"`


### PR DESCRIPTION
## Problem

`asc web apps medical-device set --app <APP_ID> --declared false` fails with:

```
Error: web apps medical-device set failed: web session is unauthorized or expired (run 'asc web auth login'): web api error (status 403)
```

even immediately after a fresh `asc web auth login` (reproduced on 2.6.0 and 2.8.0). With `--debug` the two GETs to `ppm/complianceform/v1` succeed (200), but the form `POST .../contents/{appId}/requirements/{reqId}/forms` returns an empty-body 403 from the daiquiri gateway, so the CLI misreports it as an expired session.

## Cause

The `ppm/complianceform` service requires the App Store Connect UI CSRF header `X-Csrf-Itc: itc` on mutating requests. GETs work without it, which is why only the final POST fails.

## Fix

Send `X-Csrf-Itc: itc` unconditionally from `doAppComplianceRequest`, matching what the ASC web client sends. Extended the existing `TestSetMedicalDeviceDeclarationPostsExpectedRequest` to pin the header.

## Verification

- Replayed the exact CLI payload against the live endpoint with the same session cookies: without the header → empty 403; with it → 200, requirement status `COLLECTED`, and the app (blocked on "You must declare whether your app is a regulated medical device") submitted for review successfully.
- With the patched binary, a repeat `set --declared false` on the already-collected app returns 400 (duplicate-state validation) instead of 403 — i.e. the request now passes the security gate and reaches business logic.
- `go build ./...`, `go vet ./internal/web/`, `go test ./internal/web/ -count=1` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of medical device declaration submissions by including the required security header on outbound requests.
  * Added validation to ensure submissions contain the expected security information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->