### PR TITLE
fix(validate): inspect subscription plan availability

### DIFF
--- a/internal/asc/subscription_plan_availability.go
+++ b/internal/asc/subscription_plan_availability.go
@@ -70,7 +70,26 @@ type SubscriptionPlanAvailabilitiesResponse = Response[SubscriptionPlanAvailabil
 type SubscriptionPlanAvailabilitiesOption func(*subscriptionPlanAvailabilitiesQuery)
 
 type subscriptionPlanAvailabilitiesQuery struct {
+	listQuery
 	planTypes []SubscriptionPlanType
+}
+
+// WithSubscriptionPlanAvailabilitiesLimit sets the maximum number of plan availabilities to return.
+func WithSubscriptionPlanAvailabilitiesLimit(limit int) SubscriptionPlanAvailabilitiesOption {
+	return func(q *subscriptionPlanAvailabilitiesQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithSubscriptionPlanAvailabilitiesNextURL uses a next page URL directly.
+func WithSubscriptionPlanAvailabilitiesNextURL(next string) SubscriptionPlanAvailabilitiesOption {
+	return func(q *subscriptionPlanAvailabilitiesQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
+	}
 }
 
 // WithSubscriptionPlanAvailabilitiesPlanTypes filters returned plan availabilities by plan type.
@@ -192,6 +211,14 @@ func (c *Client) GetSubscriptionPlanAvailabilitiesForSubscription(ctx context.Co
 	}
 
 	path := fmt.Sprintf("/v1/subscriptions/%s/planAvailabilities", subID)
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("subscriptionPlanAvailabilities: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildListQuery(&query.listQuery); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/subscription_plan_availability_test.go
+++ b/internal/asc/subscription_plan_availability_test.go
@@ -170,6 +170,41 @@ func TestGetSubscriptionPlanAvailabilitiesForSubscriptionFiltersPlanType(t *test
 	}
 }
 
+func TestGetSubscriptionPlanAvailabilitiesForSubscriptionSupportsPaginationOptions(t *testing.T) {
+	t.Run("limit", func(t *testing.T) {
+		client := newTestClient(t, func(req *http.Request) {
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected limit 200, got %q", got)
+			}
+		}, jsonResponse(http.StatusOK, `{"data":[]}`))
+
+		if _, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(
+			context.Background(),
+			"sub-1",
+			WithSubscriptionPlanAvailabilitiesLimit(200),
+		); err != nil {
+			t.Fatalf("GetSubscriptionPlanAvailabilitiesForSubscription() error: %v", err)
+		}
+	})
+
+	t.Run("next URL", func(t *testing.T) {
+		next := "https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/planAvailabilities?cursor=next"
+		client := newTestClient(t, func(req *http.Request) {
+			if req.URL.String() != next {
+				t.Fatalf("expected next URL %q, got %q", next, req.URL.String())
+			}
+		}, jsonResponse(http.StatusOK, `{"data":[]}`))
+
+		if _, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(
+			context.Background(),
+			"sub-1",
+			WithSubscriptionPlanAvailabilitiesNextURL(next),
+		); err != nil {
+			t.Fatalf("GetSubscriptionPlanAvailabilitiesForSubscription() error: %v", err)
+		}
+	})
+}
+
 func TestGetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"territories","id":"NOR"},{"type":"territories","id":"DEU"}],"links":{"next":""}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/cli/cmdtest/validate_subscriptions_test.go
+++ b/internal/cli/cmdtest/validate_subscriptions_test.go
@@ -42,6 +42,10 @@ type validateSubscriptionsFixture struct {
 	subscriptionAvailabilityStatusBySub       map[string]int
 	availabilityTerritoriesByAvailability     map[string]string
 	availabilityTerritoryStatusByAvailability map[string]int
+	planAvailabilitiesBySubscription          map[string]string
+	planAvailabilityStatusBySubscription      map[string]int
+	planTerritoriesByAvailability             map[string]string
+	planTerritoryStatusByAvailability         map[string]int
 	pricesBySubscription                      map[string]string
 	expectedPriceInclude                      string
 	pricesStatusBySubscription                map[string]int
@@ -142,6 +146,24 @@ func newValidateSubscriptionsClient(t *testing.T, fixture validateSubscriptionsF
 				return jsonResponse(status, apiErrorJSONForStatus(status))
 			}
 			if body, ok := fixture.availabilityTerritoriesByAvailability[availabilityID]; ok {
+				return jsonResponse(http.StatusOK, body)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case strings.HasPrefix(path, "/v1/subscriptions/") && strings.HasSuffix(path, "/planAvailabilities"):
+			subscriptionID := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/subscriptions/"), "/planAvailabilities")
+			if status, ok := fixture.planAvailabilityStatusBySubscription[subscriptionID]; ok {
+				return jsonResponse(status, apiErrorJSONForStatus(status))
+			}
+			if body, ok := fixture.planAvailabilitiesBySubscription[subscriptionID]; ok {
+				return jsonResponse(http.StatusOK, body)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case strings.HasPrefix(path, "/v1/subscriptionPlanAvailabilities/") && strings.HasSuffix(path, "/relationships/availableTerritories"):
+			planID := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/subscriptionPlanAvailabilities/"), "/relationships/availableTerritories")
+			if status, ok := fixture.planTerritoryStatusByAvailability[planID]; ok {
+				return jsonResponse(status, apiErrorJSONForStatus(status))
+			}
+			if body, ok := fixture.planTerritoriesByAvailability[planID]; ok {
 				return jsonResponse(http.StatusOK, body)
 			}
 			return jsonResponse(http.StatusOK, `{"data":[]}`)
@@ -1052,6 +1074,12 @@ func TestValidateSubscriptionsIncludesDiagnosticsMatrixForOpaqueMissingMetadata(
 	fixture.availabilityTerritoriesByAvailability = map[string]string{
 		"sub-avail-1": `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}]}`,
 	}
+	fixture.planAvailabilitiesBySubscription = map[string]string{
+		"sub-1": `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":true}}]}`,
+	}
+	fixture.planTerritoriesByAvailability = map[string]string{
+		"plan-upfront": `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}]}`,
+	}
 	fixture.reviewScreenshotBySub = map[string]string{
 		"sub-1": `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}}}`,
 	}
@@ -1096,6 +1124,8 @@ func TestValidateSubscriptionsIncludesDiagnosticsMatrixForOpaqueMissingMetadata(
 		"subscription_localizations",
 		"review_screenshot",
 		"subscription_availability",
+		"upfront_plan_availability",
+		"availability_surface_consistency",
 		"price_records",
 		"price_coverage_subscription_availability",
 		"price_coverage_app_availability",
@@ -1160,6 +1190,12 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 	}
 	fixture.availabilityTerritoriesByAvailability = map[string]string{
 		"sub-avail-1": `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}]}`,
+	}
+	fixture.planAvailabilitiesBySubscription = map[string]string{
+		"sub-1": `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":true}}]}`,
+	}
+	fixture.planTerritoriesByAvailability = map[string]string{
+		"plan-upfront": `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}]}`,
 	}
 	fixture.reviewScreenshotBySub = map[string]string{
 		"sub-1": `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}}}`,

--- a/internal/cli/validate/subscription_fetch.go
+++ b/internal/cli/validate/subscription_fetch.go
@@ -164,13 +164,23 @@ func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) (
 				return nil
 			},
 			func(taskCtx context.Context) error {
-				id, territories, status, fetchErr := fetchSubscriptionAvailabilityTerritories(taskCtx, client, subscriptionID)
+				id, territories, availableInNew, status, fetchErr := fetchSubscriptionAvailabilityTerritories(taskCtx, client, subscriptionID)
 				if fetchErr != nil {
 					return fmt.Errorf("fetch subscription availability for %s: %w", subscriptionID, fetchErr)
 				}
 				enrichments[index].availabilityID = id
 				enrichments[index].availabilityTerritories = territories
+				enrichments[index].availabilityInNewTerritories = availableInNew
 				enrichments[index].availabilityStatus = status
+				return nil
+			},
+			func(taskCtx context.Context) error {
+				plans, status, fetchErr := fetchSubscriptionPlanAvailabilities(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription plan availabilities for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].planAvailabilities = plans
+				enrichments[index].planAvailabilityStatus = status
 				return nil
 			},
 			func(taskCtx context.Context) error {
@@ -220,6 +230,7 @@ func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) (
 			HasImage:             enrichment.image.HasImage,
 			ImageCheckSkipped:    !enrichment.image.Verified,
 			ImageCheckSkipReason: enrichment.image.SkipReason,
+			SubscriptionPeriod:   attrs.SubscriptionPeriod,
 		}
 
 		state := strings.ToUpper(strings.TrimSpace(attrs.State))
@@ -242,8 +253,12 @@ func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) (
 				valSub.ReviewScreenshotCheckReason = enrichment.reviewScreenshotStatus.SkipReason
 				valSub.AvailabilityID = enrichment.availabilityID
 				valSub.AvailabilityTerritories = enrichment.availabilityTerritories
+				valSub.AvailabilityInNewTerritories = enrichment.availabilityInNewTerritories
 				valSub.AvailabilityCheckSkipped = !enrichment.availabilityStatus.Verified
 				valSub.AvailabilityCheckSkipReason = enrichment.availabilityStatus.SkipReason
+				valSub.PlanAvailabilities = enrichment.planAvailabilities
+				valSub.PlanAvailabilityCheckSkipped = !enrichment.planAvailabilityStatus.Verified
+				valSub.PlanAvailabilityCheckReason = enrichment.planAvailabilityStatus.SkipReason
 				valSub.IntroductoryOfferCount = enrichment.introductoryOfferCount
 				valSub.IntroductoryOfferCheckSkipped = !enrichment.introductoryOfferStatus.Verified
 				valSub.IntroductoryOfferCheckReason = enrichment.introductoryOfferStatus.SkipReason
@@ -276,22 +291,25 @@ type subscriptionGroupMetadata struct {
 }
 
 type subscriptionEnrichment struct {
-	image                   subscriptionImageStatus
-	priceTerritories        []string
-	priceStatus             metadataCheckStatus
-	localizations           []validation.SubscriptionLocalizationInfo
-	localizationStatus      metadataCheckStatus
-	reviewScreenshotID      string
-	reviewScreenshotStatus  metadataCheckStatus
-	availabilityID          string
-	availabilityTerritories []string
-	availabilityStatus      metadataCheckStatus
-	introductoryOfferCount  int
-	introductoryOfferStatus metadataCheckStatus
-	promotionalOfferCount   int
-	promotionalOfferStatus  metadataCheckStatus
-	winBackOfferCount       int
-	winBackOfferStatus      metadataCheckStatus
+	image                        subscriptionImageStatus
+	priceTerritories             []string
+	priceStatus                  metadataCheckStatus
+	localizations                []validation.SubscriptionLocalizationInfo
+	localizationStatus           metadataCheckStatus
+	reviewScreenshotID           string
+	reviewScreenshotStatus       metadataCheckStatus
+	availabilityID               string
+	availabilityTerritories      []string
+	availabilityInNewTerritories *bool
+	availabilityStatus           metadataCheckStatus
+	planAvailabilities           []validation.SubscriptionPlanAvailabilityInfo
+	planAvailabilityStatus       metadataCheckStatus
+	introductoryOfferCount       int
+	introductoryOfferStatus      metadataCheckStatus
+	promotionalOfferCount        int
+	promotionalOfferStatus       metadataCheckStatus
+	winBackOfferCount            int
+	winBackOfferStatus           metadataCheckStatus
 }
 
 func fetchSubscriptionsForGroup(ctx context.Context, client *asc.Client, groupID string) ([]asc.Resource[asc.SubscriptionAttributes], error) {
@@ -523,27 +541,28 @@ func fetchSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, 
 	return strings.TrimSpace(resp.Data.ID), metadataCheckStatus{Verified: true}, nil
 }
 
-func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (string, []string, metadataCheckStatus, error) {
+func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (string, []string, *bool, metadataCheckStatus, error) {
 	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionAvailabilityResponse, error) {
 		return client.GetSubscriptionAvailabilityForSubscription(requestCtx, strings.TrimSpace(subscriptionID))
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return "", nil, metadataCheckStatus{}, err
+			return "", nil, nil, metadataCheckStatus{}, err
 		}
 		if asc.IsNotFound(err) {
-			return "", nil, metadataCheckStatus{Verified: true}, nil
+			return "", nil, nil, metadataCheckStatus{Verified: true}, nil
 		}
 		if reason, ok := metadataCheckSkipReason(err, "subscription availability"); ok {
-			return "", nil, metadataCheckStatus{SkipReason: reason}, nil
+			return "", nil, nil, metadataCheckStatus{SkipReason: reason}, nil
 		}
-		return "", nil, metadataCheckStatus{}, err
+		return "", nil, nil, metadataCheckStatus{}, err
 	}
 
 	availabilityID := strings.TrimSpace(resp.Data.ID)
 	if availabilityID == "" {
-		return "", nil, metadataCheckStatus{Verified: true}, nil
+		return "", nil, nil, metadataCheckStatus{Verified: true}, nil
 	}
+	availableInNew := resp.Data.Attributes.AvailableInNewTerritories
 
 	allTerritories := make([]string, 0)
 	nextURL := ""
@@ -557,12 +576,12 @@ func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.C
 		err = requestErr
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				return "", nil, metadataCheckStatus{}, err
+				return "", nil, nil, metadataCheckStatus{}, err
 			}
 			if reason, ok := metadataCheckSkipReason(err, "subscription availability territories"); ok {
-				return "", nil, metadataCheckStatus{SkipReason: reason}, nil
+				return "", nil, nil, metadataCheckStatus{SkipReason: reason}, nil
 			}
-			return "", nil, metadataCheckStatus{}, err
+			return "", nil, nil, metadataCheckStatus{}, err
 		}
 
 		for _, territory := range territoryResp.Data {
@@ -575,7 +594,87 @@ func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.C
 		}
 	}
 
-	return availabilityID, validation.SortedUniqueNonEmptyStrings(allTerritories), metadataCheckStatus{Verified: true}, nil
+	return availabilityID, validation.SortedUniqueNonEmptyStrings(allTerritories), &availableInNew, metadataCheckStatus{Verified: true}, nil
+}
+
+func fetchSubscriptionPlanAvailabilities(ctx context.Context, client *asc.Client, subscriptionID string) ([]validation.SubscriptionPlanAvailabilityInfo, metadataCheckStatus, error) {
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionPlanAvailabilitiesResponse, error) {
+		return client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionPlanAvailabilitiesLimit(200))
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, metadataCheckStatus{}, err
+		}
+		if reason, ok := metadataCheckSkipReason(err, "subscription plan availabilities"); ok {
+			return nil, metadataCheckStatus{SkipReason: reason}, nil
+		}
+		return nil, metadataCheckStatus{}, err
+	}
+	paginated, err := asc.PaginateAll(ctx, resp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionPlanAvailabilitiesForSubscription(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionPlanAvailabilitiesNextURL(nextURL))
+		})
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, metadataCheckStatus{}, err
+		}
+		if reason, ok := metadataCheckSkipReason(err, "subscription plan availabilities"); ok {
+			return nil, metadataCheckStatus{SkipReason: reason}, nil
+		}
+		return nil, metadataCheckStatus{}, err
+	}
+	typed, ok := paginated.(*asc.SubscriptionPlanAvailabilitiesResponse)
+	if !ok {
+		return nil, metadataCheckStatus{}, fmt.Errorf("unexpected subscription plan availabilities response type %T", paginated)
+	}
+
+	plans := make([]validation.SubscriptionPlanAvailabilityInfo, 0, len(typed.Data))
+	for _, plan := range typed.Data {
+		planID := strings.TrimSpace(plan.ID)
+		territoryResp, fetchErr := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.LinkagesResponse, error) {
+			return client.GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(requestCtx, planID, asc.WithLinkagesLimit(200))
+		})
+		if fetchErr != nil {
+			if errors.Is(fetchErr, context.Canceled) {
+				return nil, metadataCheckStatus{}, fetchErr
+			}
+			if reason, ok := metadataCheckSkipReason(fetchErr, "subscription plan availability territories"); ok {
+				return nil, metadataCheckStatus{SkipReason: reason}, nil
+			}
+			return nil, metadataCheckStatus{}, fetchErr
+		}
+		all, fetchErr := asc.PaginateAll(ctx, territoryResp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+				return client.GetSubscriptionPlanAvailabilityAvailableTerritoriesRelationships(requestCtx, planID, asc.WithLinkagesNextURL(nextURL))
+			})
+		})
+		if fetchErr != nil {
+			if errors.Is(fetchErr, context.Canceled) {
+				return nil, metadataCheckStatus{}, fetchErr
+			}
+			if reason, ok := metadataCheckSkipReason(fetchErr, "subscription plan availability territories"); ok {
+				return nil, metadataCheckStatus{SkipReason: reason}, nil
+			}
+			return nil, metadataCheckStatus{}, fetchErr
+		}
+		links, ok := all.(*asc.LinkagesResponse)
+		if !ok {
+			return nil, metadataCheckStatus{}, fmt.Errorf("unexpected subscription plan territory response type %T", all)
+		}
+		territories := make([]string, 0, len(links.Data))
+		for _, territory := range links.Data {
+			territories = append(territories, strings.ToUpper(strings.TrimSpace(territory.ID)))
+		}
+		plans = append(plans, validation.SubscriptionPlanAvailabilityInfo{ID: planID, PlanType: string(plan.Attributes.PlanType), AvailableInNewTerritories: plan.Attributes.AvailableInNewTerritories, Territories: validation.SortedUniqueNonEmptyStrings(territories)})
+	}
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].PlanType != plans[j].PlanType {
+			return plans[i].PlanType < plans[j].PlanType
+		}
+		return plans[i].ID < plans[j].ID
+	})
+	return plans, metadataCheckStatus{Verified: true}, nil
 }
 
 func fetchSubscriptionIntroductoryOfferCount(ctx context.Context, client *asc.Client, subscriptionID string) (int, metadataCheckStatus, error) {

--- a/internal/cli/validate/subscription_fetch.go
+++ b/internal/cli/validate/subscription_fetch.go
@@ -585,7 +585,7 @@ func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.C
 		}
 
 		for _, territory := range territoryResp.Data {
-			allTerritories = append(allTerritories, strings.TrimSpace(territory.ID))
+			allTerritories = append(allTerritories, strings.ToUpper(strings.TrimSpace(territory.ID)))
 		}
 
 		nextURL = strings.TrimSpace(territoryResp.Links.Next)

--- a/internal/cli/validate/subscription_fetch_test.go
+++ b/internal/cli/validate/subscription_fetch_test.go
@@ -124,6 +124,31 @@ func TestFetchSubscriptionPlanAvailabilitiesPreservesUnverifiedFallback(t *testi
 	}
 }
 
+func TestFetchSubscriptionAvailabilityTerritoriesNormalizesTerritoryIDs(t *testing.T) {
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/subscriptions/sub-1/subscriptionAvailability":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`)
+		case "/v1/subscriptionAvailabilities/availability-1/availableTerritories":
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"territories","id":" can "},{"type":"territories","id":"fra"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	id, territories, availableInNew, status, err := fetchSubscriptionAvailabilityTerritories(context.Background(), client, "sub-1")
+	if err != nil {
+		t.Fatalf("fetchSubscriptionAvailabilityTerritories() error = %v", err)
+	}
+	if id != "availability-1" || strings.Join(territories, ",") != "CAN,FRA" {
+		t.Fatalf("unexpected normalized availability: id=%q territories=%v", id, territories)
+	}
+	if availableInNew == nil || !*availableInNew || !status.Verified {
+		t.Fatalf("unexpected availability metadata: availableInNew=%v status=%+v", availableInNew, status)
+	}
+}
+
 func TestFetchSubscriptionPriceTerritories_DeduplicatesAndSortsTerritories(t *testing.T) {
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {

--- a/internal/cli/validate/subscription_fetch_test.go
+++ b/internal/cli/validate/subscription_fetch_test.go
@@ -33,6 +33,7 @@ func TestFetchSubscriptions_BoundsGroupAndMetadataFanOutAndSortsDeterministicall
 			return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
 		case strings.HasSuffix(req.URL.Path, "/images"),
 			strings.HasSuffix(req.URL.Path, "/prices"),
+			strings.HasSuffix(req.URL.Path, "/planAvailabilities"),
 			strings.HasSuffix(req.URL.Path, "/subscriptionLocalizations"),
 			strings.HasSuffix(req.URL.Path, "/introductoryOffers"),
 			strings.HasSuffix(req.URL.Path, "/promotionalOffers"),
@@ -63,6 +64,63 @@ func TestFetchSubscriptions_BoundsGroupAndMetadataFanOutAndSortsDeterministicall
 	}
 	if subscriptions[1].ID != "sub-z" || subscriptions[1].GroupID != "group-z" {
 		t.Fatalf("second subscription is not stably sorted: %+v", subscriptions[1])
+	}
+}
+
+func TestFetchSubscriptionPlanAvailabilitiesPaginatesPlansAndTerritories(t *testing.T) {
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/subscriptions/sub-1/planAvailabilities" && req.URL.Query().Get("cursor") == "next":
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}]}`)
+		case req.URL.Path == "/v1/subscriptions/sub-1/planAvailabilities":
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected plan limit=200, got %q", got)
+			}
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":true}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/planAvailabilities?cursor=next"}}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-upfront/relationships/availableTerritories" && req.URL.Query().Get("cursor") == "next":
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"territories","id":"CAN"}]}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-upfront/relationships/availableTerritories":
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected territory limit=200, got %q", got)
+			}
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptionPlanAvailabilities/plan-upfront/relationships/availableTerritories?cursor=next"}}`)
+		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-monthly/relationships/availableTerritories":
+			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	plans, status, err := fetchSubscriptionPlanAvailabilities(context.Background(), client, "sub-1")
+	if err != nil {
+		t.Fatalf("fetchSubscriptionPlanAvailabilities() error = %v", err)
+	}
+	if !status.Verified || status.SkipReason != "" {
+		t.Fatalf("expected verified status, got %+v", status)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("expected two plans, got %+v", plans)
+	}
+	if plans[0].PlanType != "MONTHLY" || len(plans[0].Territories) != 0 {
+		t.Fatalf("unexpected monthly plan: %+v", plans[0])
+	}
+	if plans[1].PlanType != "UPFRONT" || strings.Join(plans[1].Territories, ",") != "CAN,USA" {
+		t.Fatalf("unexpected upfront plan: %+v", plans[1])
+	}
+}
+
+func TestFetchSubscriptionPlanAvailabilitiesPreservesUnverifiedFallback(t *testing.T) {
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return buildsJSONResponse(http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden","detail":"not allowed"}]}`)
+	}))
+
+	plans, status, err := fetchSubscriptionPlanAvailabilities(context.Background(), client, "sub-1")
+	if err != nil {
+		t.Fatalf("fetchSubscriptionPlanAvailabilities() error = %v", err)
+	}
+	if plans != nil || status.Verified || !strings.Contains(status.SkipReason, "subscription plan availabilities") {
+		t.Fatalf("expected unverified fallback with endpoint context, got plans=%+v status=%+v", plans, status)
 	}
 }
 

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -145,7 +145,7 @@ func analyzeSubscriptionPlanAvailability(sub Subscription) subscriptionPlanAvail
 	}
 	analysis.duplicateTypes = counts["UPFRONT"] > 1 || counts["MONTHLY"] > 1
 
-	if !sub.AvailabilityCheckSkipped && strings.TrimSpace(sub.AvailabilityID) != "" && analysis.upfront != nil {
+	if !analysis.duplicateTypes && !sub.AvailabilityCheckSkipped && strings.TrimSpace(sub.AvailabilityID) != "" && analysis.upfront != nil {
 		legacy := sortedUniqueNonEmpty(sub.AvailabilityTerritories)
 		analysis.legacyOnly = missingValues(legacy, analysis.upfrontTerritories)
 		analysis.planOnly = missingValues(analysis.upfrontTerritories, legacy)
@@ -154,7 +154,7 @@ func analyzeSubscriptionPlanAvailability(sub Subscription) subscriptionPlanAvail
 		analysis.surfaceMismatch = len(analysis.legacyOnly) > 0 || len(analysis.planOnly) > 0 || analysis.newTerritoriesMismatch
 	}
 
-	if analysis.monthly != nil && len(analysis.monthlyTerritories) > 0 {
+	if !analysis.duplicateTypes && analysis.monthly != nil && len(analysis.monthlyTerritories) > 0 {
 		if strings.ToUpper(strings.TrimSpace(sub.SubscriptionPeriod)) != "ONE_YEAR" {
 			analysis.monthlyIssues = append(analysis.monthlyIssues, "subscription period is not ONE_YEAR")
 		}
@@ -213,6 +213,12 @@ func buildAvailabilitySurfaceConsistencyDiagnosticRow(sub Subscription) Subscrip
 		row.Remediation = firstNonEmpty(sub.PlanAvailabilityCheckReason, sub.AvailabilityCheckSkipReason, "Validation could not compare availability surfaces")
 		return row
 	}
+	if analysis.duplicateTypes {
+		row.Status = DiagnosticStatusNo
+		row.Evidence = "duplicate UPFRONT or MONTHLY records prevent a reliable comparison"
+		row.Remediation = "Review and repair duplicate plan availability records in App Store Connect."
+		return row
+	}
 	if strings.TrimSpace(sub.AvailabilityID) == "" || analysis.upfront == nil {
 		row.Status = DiagnosticStatusUnknown
 		row.Blocking = false
@@ -239,6 +245,13 @@ func buildMonthlyPlanAvailabilityDiagnosticRow(sub Subscription) SubscriptionDia
 	if analysis.unverified {
 		row.Status = DiagnosticStatusUnverified
 		row.Remediation = fallbackString(sub.PlanAvailabilityCheckReason, "Validation could not verify MONTHLY plan availability")
+		return row
+	}
+	if analysis.duplicateTypes {
+		row.Status = DiagnosticStatusNo
+		row.Blocking = true
+		row.Evidence = "duplicate UPFRONT or MONTHLY records prevent reliable MONTHLY validation"
+		row.Remediation = "Review and repair duplicate plan availability records in App Store Connect."
 		return row
 	}
 	if analysis.monthly == nil || len(analysis.monthlyTerritories) == 0 {

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -60,6 +60,9 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 			buildSubscriptionLocalizationsDiagnosticRow(sub),
 			buildReviewScreenshotDiagnosticRow(sub),
 			buildSubscriptionAvailabilityDiagnosticRow(sub),
+			buildUpfrontPlanAvailabilityDiagnosticRow(sub),
+			buildAvailabilitySurfaceConsistencyDiagnosticRow(sub),
+			buildMonthlyPlanAvailabilityDiagnosticRow(sub),
 			buildPriceRecordsDiagnosticRow(sub),
 			buildSubscriptionAvailabilityCoverageDiagnosticRow(sub),
 			buildAppAvailabilityCoverageDiagnosticRow(sub, appTerritories, appTerritoryCount, input.PricingCoverageSkipReason),
@@ -104,6 +107,155 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 	}
 
 	return diagnostics
+}
+
+type subscriptionPlanAvailabilityAnalysis struct {
+	unverified             bool
+	duplicateTypes         bool
+	upfront                *SubscriptionPlanAvailabilityInfo
+	monthly                *SubscriptionPlanAvailabilityInfo
+	upfrontTerritories     []string
+	monthlyTerritories     []string
+	surfaceMismatch        bool
+	legacyOnly             []string
+	planOnly               []string
+	newTerritoriesMismatch bool
+	monthlyIssues          []string
+}
+
+func analyzeSubscriptionPlanAvailability(sub Subscription) subscriptionPlanAvailabilityAnalysis {
+	analysis := subscriptionPlanAvailabilityAnalysis{unverified: sub.PlanAvailabilityCheckSkipped}
+	counts := map[string]int{}
+	for i := range sub.PlanAvailabilities {
+		plan := sub.PlanAvailabilities[i]
+		plan.PlanType = strings.ToUpper(strings.TrimSpace(plan.PlanType))
+		counts[plan.PlanType]++
+		switch plan.PlanType {
+		case "UPFRONT":
+			if analysis.upfront == nil {
+				analysis.upfront = &plan
+				analysis.upfrontTerritories = sortedUniqueNonEmpty(plan.Territories)
+			}
+		case "MONTHLY":
+			if analysis.monthly == nil {
+				analysis.monthly = &plan
+				analysis.monthlyTerritories = sortedUniqueNonEmpty(plan.Territories)
+			}
+		}
+	}
+	analysis.duplicateTypes = counts["UPFRONT"] > 1 || counts["MONTHLY"] > 1
+
+	if !sub.AvailabilityCheckSkipped && strings.TrimSpace(sub.AvailabilityID) != "" && analysis.upfront != nil {
+		legacy := sortedUniqueNonEmpty(sub.AvailabilityTerritories)
+		analysis.legacyOnly = missingValues(legacy, analysis.upfrontTerritories)
+		analysis.planOnly = missingValues(analysis.upfrontTerritories, legacy)
+		legacyNew, planNew := sub.AvailabilityInNewTerritories, analysis.upfront.AvailableInNewTerritories
+		analysis.newTerritoriesMismatch = legacyNew != nil && planNew != nil && *legacyNew != *planNew
+		analysis.surfaceMismatch = len(analysis.legacyOnly) > 0 || len(analysis.planOnly) > 0 || analysis.newTerritoriesMismatch
+	}
+
+	if analysis.monthly != nil && len(analysis.monthlyTerritories) > 0 {
+		if strings.ToUpper(strings.TrimSpace(sub.SubscriptionPeriod)) != "ONE_YEAR" {
+			analysis.monthlyIssues = append(analysis.monthlyIssues, "subscription period is not ONE_YEAR")
+		}
+		if outside := missingValues(analysis.monthlyTerritories, analysis.upfrontTerritories); len(outside) > 0 {
+			analysis.monthlyIssues = append(analysis.monthlyIssues, "not in UPFRONT: "+formatList(outside))
+		}
+		forbidden := make([]string, 0, 2)
+		for _, territory := range analysis.monthlyTerritories {
+			if territory == "USA" || territory == "SGP" {
+				forbidden = append(forbidden, territory)
+			}
+		}
+		if len(forbidden) > 0 {
+			analysis.monthlyIssues = append(analysis.monthlyIssues, "unsupported: "+formatList(forbidden))
+		}
+	}
+	return analysis
+}
+
+func buildUpfrontPlanAvailabilityDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {
+	row := SubscriptionDiagnosticRow{Key: "upfront_plan_availability", Label: "UPFRONT plan availability", Source: "public-api", Blocking: true}
+	analysis := analyzeSubscriptionPlanAvailability(sub)
+	if analysis.unverified {
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = fallbackString(sub.PlanAvailabilityCheckReason, "Validation could not verify billing-plan availability")
+		return row
+	}
+	if analysis.duplicateTypes {
+		row.Status = DiagnosticStatusNo
+		row.Evidence = "duplicate UPFRONT or MONTHLY records"
+		row.Remediation = "Review and repair duplicate plan availability records in App Store Connect."
+		return row
+	}
+	if analysis.upfront == nil {
+		row.Status = DiagnosticStatusNo
+		row.Evidence = "none"
+		row.Remediation = "Configure UPFRONT plan availability for at least one territory."
+		return row
+	}
+	if len(analysis.upfrontTerritories) == 0 {
+		row.Status = DiagnosticStatusNo
+		row.Evidence = fmt.Sprintf("id=%s territories=none", strings.TrimSpace(analysis.upfront.ID))
+		row.Remediation = "Enable at least one territory for the UPFRONT plan."
+		return row
+	}
+	row.Status = DiagnosticStatusYes
+	row.Evidence = fmt.Sprintf("id=%s territories=%s", strings.TrimSpace(analysis.upfront.ID), formatList(analysis.upfrontTerritories))
+	return row
+}
+
+func buildAvailabilitySurfaceConsistencyDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {
+	row := SubscriptionDiagnosticRow{Key: "availability_surface_consistency", Label: "Legacy and UPFRONT availability agree", Source: "derived", Blocking: true}
+	analysis := analyzeSubscriptionPlanAvailability(sub)
+	if analysis.unverified || sub.AvailabilityCheckSkipped {
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = firstNonEmpty(sub.PlanAvailabilityCheckReason, sub.AvailabilityCheckSkipReason, "Validation could not compare availability surfaces")
+		return row
+	}
+	if strings.TrimSpace(sub.AvailabilityID) == "" || analysis.upfront == nil {
+		row.Status = DiagnosticStatusUnknown
+		row.Blocking = false
+		row.Evidence = "one or both availability surfaces are missing"
+		return row
+	}
+	if analysis.surfaceMismatch {
+		row.Status = DiagnosticStatusNo
+		row.Evidence = fmt.Sprintf("legacy_only=%s plan_only=%s", formatList(analysis.legacyOnly), formatList(analysis.planOnly))
+		if analysis.newTerritoriesMismatch {
+			row.Evidence += fmt.Sprintf(" available_in_new_territories legacy=%t plan=%t", *sub.AvailabilityInNewTerritories, *analysis.upfront.AvailableInNewTerritories)
+		}
+		row.Remediation = "Make legacy subscription availability and UPFRONT plan availability agree, then re-validate."
+		return row
+	}
+	row.Status = DiagnosticStatusYes
+	row.Evidence = fmt.Sprintf("territories=%s", formatList(analysis.upfrontTerritories))
+	return row
+}
+
+func buildMonthlyPlanAvailabilityDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {
+	row := SubscriptionDiagnosticRow{Key: "monthly_plan_availability", Label: "MONTHLY commitment availability", Source: "public-api", Blocking: false}
+	analysis := analyzeSubscriptionPlanAvailability(sub)
+	if analysis.unverified {
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = fallbackString(sub.PlanAvailabilityCheckReason, "Validation could not verify MONTHLY plan availability")
+		return row
+	}
+	if analysis.monthly == nil || len(analysis.monthlyTerritories) == 0 {
+		row.Status = DiagnosticStatusOptional
+		row.Evidence = "not configured"
+		return row
+	}
+	row.Blocking = true
+	if len(analysis.monthlyIssues) > 0 {
+		row.Status = DiagnosticStatusNo
+		row.Evidence = strings.Join(analysis.monthlyIssues, "; ")
+		row.Remediation = "Use MONTHLY only for ONE_YEAR subscriptions, only in UPFRONT territories, and exclude USA and SGP."
+		return row
+	}
+	row.Status = DiagnosticStatusYes
+	row.Evidence = fmt.Sprintf("id=%s territories=%s", strings.TrimSpace(analysis.monthly.ID), formatList(analysis.monthlyTerritories))
+	return row
 }
 
 func buildGroupLocalizationsDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {

--- a/internal/validation/subscriptions_validate.go
+++ b/internal/validation/subscriptions_validate.go
@@ -23,6 +23,11 @@ type Subscription struct {
 	AvailabilityTerritories      []string
 	AvailabilityCheckSkipped     bool
 	AvailabilityCheckSkipReason  string
+	AvailabilityInNewTerritories *bool
+	SubscriptionPeriod           string
+	PlanAvailabilities           []SubscriptionPlanAvailabilityInfo
+	PlanAvailabilityCheckSkipped bool
+	PlanAvailabilityCheckReason  string
 
 	// Deep diagnostics (populated when State is MISSING_METADATA).
 	Localizations                 []SubscriptionLocalizationInfo
@@ -44,6 +49,14 @@ type Subscription struct {
 	WinBackOfferCount             int
 	WinBackOfferCheckSkipped      bool
 	WinBackOfferCheckReason       string
+}
+
+// SubscriptionPlanAvailabilityInfo holds one billing plan's territory availability.
+type SubscriptionPlanAvailabilityInfo struct {
+	ID                        string
+	PlanType                  string
+	AvailableInNewTerritories *bool
+	Territories               []string
 }
 
 // SubscriptionLocalizationInfo holds per-locale metadata for a subscription.
@@ -563,6 +576,54 @@ func subscriptionMetadataDiagnostics(subs []Subscription) []CheckResult {
 				ResourceID:   strings.TrimSpace(sub.ID),
 				Message:      fmt.Sprintf("%s has subscription availability configured but no available territories", label),
 				Remediation:  "Enable at least one subscription availability territory via `asc subscriptions availability edit`",
+			})
+		}
+
+		planAnalysis := analyzeSubscriptionPlanAvailability(sub)
+		switch {
+		case planAnalysis.unverified:
+			checks = append(checks, CheckResult{
+				ID: "subscriptions.diagnostics.plan_availability_unverified", Severity: SeverityInfo,
+				Field: "planAvailabilities", ResourceType: "subscription", ResourceID: strings.TrimSpace(sub.ID),
+				Message:     fmt.Sprintf("Could not verify %s billing-plan availability", label),
+				Remediation: fallbackString(sub.PlanAvailabilityCheckReason, "Review billing-plan availability in App Store Connect"),
+			})
+		case planAnalysis.duplicateTypes:
+			checks = append(checks, CheckResult{
+				ID: "subscriptions.diagnostics.plan_availability_duplicate", Severity: SeverityWarning,
+				Field: "planAvailabilities", ResourceType: "subscription", ResourceID: strings.TrimSpace(sub.ID),
+				Message:     fmt.Sprintf("%s has duplicate billing-plan availability records", label),
+				Remediation: "Review and repair duplicate plan availability records in App Store Connect",
+			})
+		case planAnalysis.upfront == nil:
+			checks = append(checks, CheckResult{
+				ID: "subscriptions.diagnostics.upfront_plan_availability_missing", Severity: SeverityWarning,
+				Field: "planAvailabilities", ResourceType: "subscription", ResourceID: strings.TrimSpace(sub.ID),
+				Message:     fmt.Sprintf("%s has no UPFRONT billing-plan availability", label),
+				Remediation: "Configure UPFRONT plan availability for at least one territory",
+			})
+		case len(planAnalysis.upfrontTerritories) == 0:
+			checks = append(checks, CheckResult{
+				ID: "subscriptions.diagnostics.upfront_plan_availability_empty", Severity: SeverityWarning,
+				Field: "planAvailabilities", ResourceType: "subscription", ResourceID: strings.TrimSpace(sub.ID),
+				Message:     fmt.Sprintf("%s has UPFRONT billing-plan availability with no territories", label),
+				Remediation: "Enable at least one territory for the UPFRONT plan",
+			})
+		}
+		if !planAnalysis.unverified && planAnalysis.surfaceMismatch {
+			checks = append(checks, CheckResult{
+				ID: "subscriptions.diagnostics.availability_surfaces_mismatch", Severity: SeverityWarning,
+				Field: "planAvailabilities", ResourceType: "subscription", ResourceID: strings.TrimSpace(sub.ID),
+				Message:     fmt.Sprintf("%s has different territories on legacy and UPFRONT availability surfaces", label),
+				Remediation: "Make legacy subscription availability and UPFRONT plan availability agree, then re-validate",
+			})
+		}
+		if !planAnalysis.unverified && len(planAnalysis.monthlyIssues) > 0 {
+			checks = append(checks, CheckResult{
+				ID: "subscriptions.diagnostics.monthly_plan_invalid", Severity: SeverityWarning,
+				Field: "planAvailabilities", ResourceType: "subscription", ResourceID: strings.TrimSpace(sub.ID),
+				Message:     fmt.Sprintf("%s has invalid MONTHLY commitment availability: %s", label, strings.Join(planAnalysis.monthlyIssues, "; ")),
+				Remediation: "Use MONTHLY only for ONE_YEAR subscriptions, only in UPFRONT territories, and exclude USA and SGP",
 			})
 		}
 

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -388,9 +388,13 @@ func TestValidateSubscriptionsIncludesDetailedDiagnosticsForOpaqueMissingMetadat
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA", "CAN"},
-				HasImage:                true,
-				PriceCount:              2,
-				PriceTerritories:        []string{"USA", "CAN"},
+				SubscriptionPeriod:      "ONE_MONTH",
+				PlanAvailabilities: []SubscriptionPlanAvailabilityInfo{{
+					ID: "plan-upfront", PlanType: "UPFRONT", Territories: []string{"USA", "CAN"},
+				}},
+				HasImage:         true,
+				PriceCount:       2,
+				PriceTerritories: []string{"USA", "CAN"},
 			},
 		},
 	}, false)
@@ -412,6 +416,8 @@ func TestValidateSubscriptionsIncludesDetailedDiagnosticsForOpaqueMissingMetadat
 		"subscription_localizations",
 		"review_screenshot",
 		"subscription_availability",
+		"upfront_plan_availability",
+		"availability_surface_consistency",
 		"price_records",
 		"price_coverage_subscription_availability",
 		"price_coverage_app_availability",
@@ -426,6 +432,10 @@ func TestValidateSubscriptionsIncludesDetailedDiagnosticsForOpaqueMissingMetadat
 			t.Fatalf("expected %s row to be yes, got %+v", key, row)
 		}
 	}
+	monthlyRow, ok := findSubscriptionDiagnosticRow(diag.Rows, "monthly_plan_availability")
+	if !ok || monthlyRow.Status != DiagnosticStatusOptional || monthlyRow.Blocking {
+		t.Fatalf("expected absent MONTHLY plan to be optional, got %+v", monthlyRow)
+	}
 
 	buildRow, ok := findSubscriptionDiagnosticRow(diag.Rows, "app_has_build")
 	if !ok {
@@ -433,6 +443,72 @@ func TestValidateSubscriptionsIncludesDetailedDiagnosticsForOpaqueMissingMetadat
 	}
 	if buildRow.Status != DiagnosticStatusYes {
 		t.Fatalf("expected app_has_build=yes when app build count is non-zero, got %+v", buildRow)
+	}
+}
+
+func TestSubscriptionPlanAvailabilityDiagnosticsTruthTable(t *testing.T) {
+	base := Subscription{
+		ID: "sub-1", Name: "Annual", ProductID: "com.example.annual", State: "MISSING_METADATA",
+		SubscriptionPeriod: "ONE_YEAR", AvailabilityID: "legacy", AvailabilityTerritories: []string{"CAN", "FRA"},
+	}
+
+	tests := []struct {
+		name       string
+		mutate     func(*Subscription)
+		rowKey     string
+		wantStatus DiagnosticStatus
+		wantBlock  bool
+		wantCheck  string
+	}{
+		{name: "missing upfront", rowKey: "upfront_plan_availability", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.upfront_plan_availability_missing"},
+		{name: "unverified fetch", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilityCheckSkipped = true
+			sub.PlanAvailabilityCheckReason = "forbidden"
+		}, rowKey: "upfront_plan_availability", wantStatus: DiagnosticStatusUnverified, wantBlock: true, wantCheck: "subscriptions.diagnostics.plan_availability_unverified"},
+		{name: "matching surfaces", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"FRA", "CAN"}}}
+		}, rowKey: "availability_surface_consistency", wantStatus: DiagnosticStatusYes, wantBlock: true},
+		{name: "mismatched surfaces", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN", "GBR"}}}
+		}, rowKey: "availability_surface_consistency", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.availability_surfaces_mismatch"},
+		{name: "mismatched new territory policy", mutate: func(sub *Subscription) {
+			legacy, plan := true, false
+			sub.AvailabilityInNewTerritories = &legacy
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", AvailableInNewTerritories: &plan, Territories: []string{"CAN", "FRA"}}}
+		}, rowKey: "availability_surface_consistency", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.availability_surfaces_mismatch"},
+		{name: "monthly absent is optional", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN", "FRA"}}}
+		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusOptional, wantBlock: false},
+		{name: "monthly valid", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN", "FRA"}}, {ID: "monthly", PlanType: "MONTHLY", Territories: []string{"CAN"}}}
+		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusYes, wantBlock: true},
+		{name: "monthly outside upfront", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN", "FRA"}}, {ID: "monthly", PlanType: "MONTHLY", Territories: []string{"GBR"}}}
+		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.monthly_plan_invalid"},
+		{name: "monthly forbidden territory", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN", "USA"}}, {ID: "monthly", PlanType: "MONTHLY", Territories: []string{"USA"}}}
+		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.monthly_plan_invalid"},
+		{name: "monthly wrong period", mutate: func(sub *Subscription) {
+			sub.SubscriptionPeriod = "ONE_MONTH"
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN"}}, {ID: "monthly", PlanType: "MONTHLY", Territories: []string{"CAN"}}}
+		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.monthly_plan_invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := base
+			if tt.mutate != nil {
+				tt.mutate(&sub)
+			}
+			report := ValidateSubscriptions(SubscriptionsInput{Subscriptions: []Subscription{sub}}, false)
+			row, ok := findSubscriptionDiagnosticRow(report.Diagnostics[0].Rows, tt.rowKey)
+			if !ok || row.Status != tt.wantStatus || row.Blocking != tt.wantBlock {
+				t.Fatalf("row %q = %+v, want status=%s blocking=%v", tt.rowKey, row, tt.wantStatus, tt.wantBlock)
+			}
+			if tt.wantCheck != "" && !hasCheckID(report.Checks, tt.wantCheck) {
+				t.Fatalf("missing check %q in %+v", tt.wantCheck, report.Checks)
+			}
+		})
 	}
 }
 
@@ -454,6 +530,7 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA", "CAN"},
+				PlanAvailabilities:      upfrontPlan("USA", "CAN"),
 				PriceCount:              2,
 				PriceTerritories:        []string{"USA", "CAN"},
 			},
@@ -498,6 +575,7 @@ func TestValidateSubscriptionsDiagnosticsShowExactMissingTerritories(t *testing.
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA", "CAN"},
+				PlanAvailabilities:      upfrontPlan("USA", "CAN"),
 				PriceCount:              1,
 				PriceTerritories:        []string{"USA"},
 			},
@@ -549,6 +627,7 @@ func TestValidateSubscriptionsMarksSkippedBuildDiagnosticAsUnverified(t *testing
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA", "CAN"},
+				PlanAvailabilities:      upfrontPlan("USA", "CAN"),
 				PriceCount:              2,
 				PriceTerritories:        []string{"USA", "CAN"},
 			},
@@ -588,6 +667,7 @@ func TestValidateSubscriptionsFallsBackToAppTerritoryCountInDiagnostics(t *testi
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA", "CAN"},
+				PlanAvailabilities:      upfrontPlan("USA", "CAN"),
 				PriceCount:              2,
 				PriceTerritories:        []string{"USA", "CAN"},
 			},
@@ -628,6 +708,7 @@ func TestValidateSubscriptionsTreatsAppOnlyTerritoriesAsAdvisoryInDiagnostics(t 
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA"},
+				PlanAvailabilities:      upfrontPlan("USA"),
 				HasImage:                true,
 				PriceCount:              1,
 				PriceTerritories:        []string{"USA"},
@@ -673,6 +754,7 @@ func TestValidateSubscriptionsDoesNotBlockDiagnosticsWhenAppAvailabilityIsMissin
 				ReviewScreenshotID:      "shot-1",
 				AvailabilityID:          "avail-1",
 				AvailabilityTerritories: []string{"USA"},
+				PlanAvailabilities:      upfrontPlan("USA"),
 				HasImage:                true,
 				PriceCount:              1,
 				PriceTerritories:        []string{"USA"},
@@ -752,4 +834,8 @@ func findSubscriptionDiagnosticRow(rows []SubscriptionDiagnosticRow, key string)
 		}
 	}
 	return SubscriptionDiagnosticRow{}, false
+}
+
+func upfrontPlan(territories ...string) []SubscriptionPlanAvailabilityInfo {
+	return []SubscriptionPlanAvailabilityInfo{{ID: "plan-upfront", PlanType: "UPFRONT", Territories: territories}}
 }

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -492,6 +492,19 @@ func TestSubscriptionPlanAvailabilityDiagnosticsTruthTable(t *testing.T) {
 			sub.SubscriptionPeriod = "ONE_MONTH"
 			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN"}}, {ID: "monthly", PlanType: "MONTHLY", Territories: []string{"CAN"}}}
 		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.monthly_plan_invalid"},
+		{name: "duplicate upfront does not report surface consistency", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{
+				{ID: "upfront-1", PlanType: "UPFRONT", Territories: []string{"CAN", "FRA"}},
+				{ID: "upfront-2", PlanType: "UPFRONT", Territories: []string{"GBR"}},
+			}
+		}, rowKey: "availability_surface_consistency", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.plan_availability_duplicate"},
+		{name: "duplicate monthly does not report monthly validity", mutate: func(sub *Subscription) {
+			sub.PlanAvailabilities = []SubscriptionPlanAvailabilityInfo{
+				{ID: "upfront", PlanType: "UPFRONT", Territories: []string{"CAN", "FRA"}},
+				{ID: "monthly-1", PlanType: "MONTHLY", Territories: []string{"CAN"}},
+				{ID: "monthly-2", PlanType: "MONTHLY", Territories: []string{"USA"}},
+			}
+		}, rowKey: "monthly_plan_availability", wantStatus: DiagnosticStatusNo, wantBlock: true, wantCheck: "subscriptions.diagnostics.plan_availability_duplicate"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- inspect and paginate `subscriptionPlanAvailabilities` in deep subscription validation
- compare UPFRONT plan availability with legacy sale availability
- validate MONTHLY commitment-plan constraints and surface endpoint failures as unverified

## Verification
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Scope
This is intentionally separate from the full subscription price-matrix repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription validation now enriches subscriptions with billing-plan (UPFRONT/MONTHLY) availability, territory linkages, and “available in new territories” signals.
  * Added new plan-availability diagnostics, including UPFRONT availability, legacy-vs-UPFRONT surface consistency, and MONTHLY commitment availability checks.
  * Plan availability retrieval supports configurable pagination (limit and next-page navigation).

* **Bug Fixes**
  * Improved behavior when plan availability data is missing or access-restricted, including clearer optional/non-blocking outcomes.
  * Normalizes territory identifiers to ensure consistent validation comparisons.

* **Tests**
  * Expanded test coverage for pagination, fallback handling, territory normalization, and the new diagnostic truth table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->