### PR TITLE
fix(subscriptions): materialize complete price matrix

### DIFF
--- a/internal/asc/client_subscription_price_matrix_test.go
+++ b/internal/asc/client_subscription_price_matrix_test.go
@@ -1,0 +1,120 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSetSubscriptionPriceMatrix_MultiRowOrderingAndDedupe(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1"}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptions/sub-1" {
+			t.Fatalf("expected path /v1/subscriptions/sub-1, got %s", req.URL.Path)
+		}
+
+		var payload SubscriptionUpdateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.Prices == nil {
+			t.Fatal("expected prices relationship")
+		}
+		if got := len(payload.Data.Relationships.Prices.Data); got != 2 {
+			t.Fatalf("expected 2 relationship rows after dedupe, got %d", got)
+		}
+		if got := len(payload.Included); got != 2 {
+			t.Fatalf("expected 2 included rows after dedupe, got %d", got)
+		}
+
+		for i, wantID := range []string{"${price-1}", "${price-2}"} {
+			linkage := payload.Data.Relationships.Prices.Data[i]
+			if linkage.Type != ResourceTypeSubscriptionPrices || linkage.ID != wantID {
+				t.Fatalf("relationship row %d = %+v, want subscriptionPrices %s", i, linkage, wantID)
+			}
+			if payload.Included[i].ID != wantID {
+				t.Fatalf("included row %d ID = %q, want %q", i, payload.Included[i].ID, wantID)
+			}
+		}
+
+		canada := payload.Included[0]
+		if got := canada.Relationships.Territory.Data.ID; got != "CAN" {
+			t.Fatalf("first territory = %q, want CAN", got)
+		}
+		if got := canada.Relationships.SubscriptionPricePoint.Data.ID; got != "point-can" {
+			t.Fatalf("CAN price point = %q, want point-can", got)
+		}
+		if canada.Attributes == nil || canada.Attributes.StartDate != "2026-08-01" {
+			t.Fatalf("CAN attributes = %+v", canada.Attributes)
+		}
+
+		usa := payload.Included[1]
+		if got := usa.Relationships.Territory.Data.ID; got != "USA" {
+			t.Fatalf("second territory = %q, want USA", got)
+		}
+		if got := usa.Relationships.SubscriptionPricePoint.Data.ID; got != "point-usa" {
+			t.Fatalf("USA price point = %q, want point-usa", got)
+		}
+		if usa.Attributes != nil {
+			t.Fatalf("expected empty USA attributes to be omitted, got %+v", usa.Attributes)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	rows := []SubscriptionInlinePrice{
+		{PricePointID: " point-usa ", TerritoryID: " usa "},
+		{PricePointID: "point-can", TerritoryID: "CAN", Attributes: SubscriptionPriceCreateAttributes{StartDate: "2026-08-01"}},
+		{PricePointID: " point-can ", TerritoryID: " can ", Attributes: SubscriptionPriceCreateAttributes{StartDate: "2026-08-01"}},
+	}
+	if _, err := client.SetSubscriptionPriceMatrix(context.Background(), " sub-1 ", rows); err != nil {
+		t.Fatalf("SetSubscriptionPriceMatrix() error: %v", err)
+	}
+}
+
+func TestSetSubscriptionPriceMatrix_RejectsConflictingDuplicateTerritory(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+	}, jsonResponse(http.StatusOK, `{}`))
+
+	_, err := client.SetSubscriptionPriceMatrix(context.Background(), "sub-1", []SubscriptionInlinePrice{
+		{PricePointID: "point-1", TerritoryID: "USA"},
+		{PricePointID: "point-2", TerritoryID: " usa "},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate territory error")
+	}
+	if !strings.Contains(err.Error(), `duplicate territory "USA"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetSubscriptionPriceMatrix_ValidatesRequiredInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		subID string
+		rows  []SubscriptionInlinePrice
+		want  string
+	}{
+		{name: "subscription", rows: []SubscriptionInlinePrice{{PricePointID: "point-1", TerritoryID: "USA"}}, want: "subscription ID is required"},
+		{name: "rows", subID: "sub-1", want: "at least one subscription price is required"},
+		{name: "price point", subID: "sub-1", rows: []SubscriptionInlinePrice{{TerritoryID: "USA"}}, want: "price point ID is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.Path)
+			}, jsonResponse(http.StatusOK, `{}`))
+
+			_, err := client.SetSubscriptionPriceMatrix(context.Background(), tt.subID, tt.rows)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -235,58 +236,85 @@ func (c *Client) UpdateSubscription(ctx context.Context, subID string, attrs Sub
 	return &response, nil
 }
 
-// SetSubscriptionInitialPrice sets the initial base price on a subscription that
-// has no existing prices. This uses PATCH /v1/subscriptions/{id} with inline
-// SubscriptionPriceInlineCreate resources, which is the only supported method
-// for setting the first price on a new subscription. POST /v1/subscriptionPrices
-// only works for price *changes* on subscriptions that already have a price.
-func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePointID, territoryID string, attrs SubscriptionPriceCreateAttributes) (*SubscriptionResponse, error) {
+// SetSubscriptionPriceMatrix atomically sets an initial subscription price
+// matrix using inline SubscriptionPriceInlineCreate resources.
+func (c *Client) SetSubscriptionPriceMatrix(ctx context.Context, subID string, entries []SubscriptionInlinePrice) (*SubscriptionResponse, error) {
 	subID = strings.TrimSpace(subID)
-	pricePointID = strings.TrimSpace(pricePointID)
-	territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
-	if subID == "" || pricePointID == "" {
-		return nil, fmt.Errorf("subscription ID and price point ID are required")
+	if subID == "" {
+		return nil, fmt.Errorf("subscription ID is required")
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("at least one subscription price is required")
 	}
 
-	var attributes *SubscriptionPriceCreateAttributes
-	if attrs.StartDate != "" || attrs.Preserved != nil || attrs.PlanType != "" {
-		attributes = &attrs
-	}
-
-	relationships := SubscriptionPriceInlineRelationships{
-		Subscription:           Relationship{Data: ResourceData{Type: ResourceTypeSubscriptions, ID: subID}},
-		SubscriptionPricePoint: Relationship{Data: ResourceData{Type: ResourceTypeSubscriptionPricePoints, ID: pricePointID}},
-	}
-	if territoryID != "" {
-		relationships.Territory = &Relationship{
-			Data: ResourceData{
-				Type: ResourceTypeTerritories,
-				ID:   territoryID,
-			},
+	normalized := make([]SubscriptionInlinePrice, 0, len(entries))
+	byTerritory := make(map[string]SubscriptionInlinePrice, len(entries))
+	for i, entry := range entries {
+		entry.PricePointID = strings.TrimSpace(entry.PricePointID)
+		entry.TerritoryID = strings.ToUpper(strings.TrimSpace(entry.TerritoryID))
+		entry.Attributes.StartDate = strings.TrimSpace(entry.Attributes.StartDate)
+		entry.Attributes.PlanType = SubscriptionPlanType(strings.TrimSpace(string(entry.Attributes.PlanType)))
+		if entry.PricePointID == "" {
+			return nil, fmt.Errorf("subscription price row %d: price point ID is required", i+1)
 		}
+		if previous, ok := byTerritory[entry.TerritoryID]; ok {
+			if subscriptionPriceMatrixEntriesEqual(previous, entry) {
+				continue
+			}
+			return nil, fmt.Errorf("subscription price matrix has duplicate territory %q with conflicting values", entry.TerritoryID)
+		}
+		byTerritory[entry.TerritoryID] = entry
+		normalized = append(normalized, entry)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i].TerritoryID < normalized[j].TerritoryID
+	})
+
+	relationshipData := make([]ResourceData, 0, len(normalized))
+	included := make([]SubscriptionPriceInlineCreate, 0, len(normalized))
+	for i, entry := range normalized {
+		inlinePriceID := fmt.Sprintf("${price-%d}", i+1)
+		relationshipData = append(relationshipData, ResourceData{
+			Type: ResourceTypeSubscriptionPrices,
+			ID:   inlinePriceID,
+		})
+
+		var attributes *SubscriptionPriceCreateAttributes
+		if entry.Attributes.StartDate != "" || entry.Attributes.Preserved != nil || entry.Attributes.PlanType != "" {
+			attrs := entry.Attributes
+			attributes = &attrs
+		}
+		relationships := SubscriptionPriceInlineRelationships{
+			Subscription:           Relationship{Data: ResourceData{Type: ResourceTypeSubscriptions, ID: subID}},
+			SubscriptionPricePoint: Relationship{Data: ResourceData{Type: ResourceTypeSubscriptionPricePoints, ID: entry.PricePointID}},
+		}
+		if entry.TerritoryID != "" {
+			relationships.Territory = &Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeTerritories,
+					ID:   entry.TerritoryID,
+				},
+			}
+		}
+		included = append(included, SubscriptionPriceInlineCreate{
+			Type:          ResourceTypeSubscriptionPrices,
+			ID:            inlinePriceID,
+			Attributes:    attributes,
+			Relationships: relationships,
+		})
 	}
 
-	inlinePriceID := "${price-1}"
 	payload := SubscriptionUpdateRequest{
 		Data: SubscriptionUpdateData{
 			Type: ResourceTypeSubscriptions,
 			ID:   subID,
 			Relationships: &SubscriptionUpdateRelationships{
 				Prices: &RelationshipList{
-					Data: []ResourceData{
-						{Type: ResourceTypeSubscriptionPrices, ID: inlinePriceID},
-					},
+					Data: relationshipData,
 				},
 			},
 		},
-		Included: []SubscriptionPriceInlineCreate{
-			{
-				Type:          ResourceTypeSubscriptionPrices,
-				ID:            inlinePriceID,
-				Attributes:    attributes,
-				Relationships: relationships,
-			},
-		},
+		Included: included,
 	}
 
 	path := fmt.Sprintf("/v1/subscriptions/%s", subID)
@@ -305,6 +333,29 @@ func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePo
 	}
 
 	return &response, nil
+}
+
+func subscriptionPriceMatrixEntriesEqual(a, b SubscriptionInlinePrice) bool {
+	if a.PricePointID != b.PricePointID || a.TerritoryID != b.TerritoryID || a.Attributes.StartDate != b.Attributes.StartDate || a.Attributes.PlanType != b.Attributes.PlanType {
+		return false
+	}
+	if a.Attributes.Preserved == nil || b.Attributes.Preserved == nil {
+		return a.Attributes.Preserved == nil && b.Attributes.Preserved == nil
+	}
+	return *a.Attributes.Preserved == *b.Attributes.Preserved
+}
+
+// SetSubscriptionInitialPrice sets the initial base price on a subscription that
+// has no existing prices. This uses PATCH /v1/subscriptions/{id} with inline
+// SubscriptionPriceInlineCreate resources, which is the only supported method
+// for setting the first price on a new subscription. POST /v1/subscriptionPrices
+// only works for price *changes* on subscriptions that already have a price.
+func (c *Client) SetSubscriptionInitialPrice(ctx context.Context, subID, pricePointID, territoryID string, attrs SubscriptionPriceCreateAttributes) (*SubscriptionResponse, error) {
+	return c.SetSubscriptionPriceMatrix(ctx, subID, []SubscriptionInlinePrice{{
+		PricePointID: pricePointID,
+		TerritoryID:  territoryID,
+		Attributes:   attrs,
+	}})
 }
 
 // DeleteSubscription deletes a subscription.

--- a/internal/asc/subscriptions.go
+++ b/internal/asc/subscriptions.go
@@ -149,6 +149,14 @@ type SubscriptionPriceCreateAttributes struct {
 	PlanType  SubscriptionPlanType `json:"planType,omitempty"`
 }
 
+// SubscriptionInlinePrice describes one price in an atomic subscription price
+// matrix update.
+type SubscriptionInlinePrice struct {
+	PricePointID string
+	TerritoryID  string
+	Attributes   SubscriptionPriceCreateAttributes
+}
+
 // SubscriptionPriceRelationships describes relationships for prices.
 type SubscriptionPriceRelationships struct {
 	Subscription           *Relationship `json:"subscription"`

--- a/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
@@ -559,6 +559,81 @@ func TestSubscriptionsPricesAdd_ExistingMatchingPriceSkipsCreate(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsPricesAdd_ForceRepostsExistingMatchingPrice(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var posted bool
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/relationships/prices"):
+			body := `{"data":[{"type":"subscriptionPrices","id":"existing-price-1"}],"links":{}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/prices"):
+			body := subscriptionPriceListFixture("PP_ID", "USA", `{"planType":"UPFRONT"}`)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
+			posted = true
+			body := `{"data":{"type":"subscriptionPrices","id":"forced-price-1","attributes":{"planType":"UPFRONT"}}}`
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "prices", "set",
+			"--subscription-id", "8000000003",
+			"--price-point", "PP_ID",
+			"--territory", "USA",
+			"--force",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !posted {
+		t.Fatal("expected forced create request")
+	}
+	if !strings.Contains(stdout, `"id":"forced-price-1"`) {
+		t.Fatalf("expected forced subscription price response in stdout, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsPricesAdd_ForceRejectsInvalidBoolean(t *testing.T) {
+	assertUsageExit(t, []string{
+		"subscriptions", "pricing", "prices", "set",
+		"--subscription-id", "8000000003",
+		"--price-point", "PP_ID",
+		"--force=maybe",
+	}, `invalid boolean value "maybe" for -force`)
+}
+
 func TestSubscriptionsPricesAdd_TierRequiresTerritory(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
+++ b/internal/cli/cmdtest/subscriptions_prices_add_tier_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func subscriptionPriceListFixture(pricePointID, territoryID, attrs string) string {
@@ -559,12 +561,12 @@ func TestSubscriptionsPricesAdd_ExistingMatchingPriceSkipsCreate(t *testing.T) {
 	}
 }
 
-func TestSubscriptionsPricesAdd_ForceRepostsExistingMatchingPrice(t *testing.T) {
+func TestSubscriptionsPricesAdd_ForceResavesCompletePriceMatrix(t *testing.T) {
 	setupAuth(t)
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
-	var posted bool
+	var patched bool
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/relationships/prices"):
@@ -581,11 +583,25 @@ func TestSubscriptionsPricesAdd_ForceRepostsExistingMatchingPrice(t *testing.T) 
 				Body:       io.NopCloser(strings.NewReader(body)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
-		case req.Method == http.MethodPost && req.URL.Path == "/v1/subscriptionPrices":
-			posted = true
-			body := `{"data":{"type":"subscriptionPrices","id":"forced-price-1","attributes":{"planType":"UPFRONT"}}}`
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/PP_ID/equalizations":
+			body := `{"data":[{"type":"subscriptionPricePoints","id":"PP_CAN","attributes":{"customerPrice":"1.49"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{}}`
 			return &http.Response{
-				StatusCode: http.StatusCreated,
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/8000000003":
+			patched = true
+			var payload asc.SubscriptionUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode price matrix payload: %v", err)
+			}
+			if len(payload.Included) != 2 {
+				t.Fatalf("expected complete two-territory matrix, got %+v", payload.Included)
+			}
+			body := `{"data":{"type":"subscriptions","id":"8000000003","attributes":{"state":"READY_TO_SUBMIT"}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
@@ -617,11 +633,11 @@ func TestSubscriptionsPricesAdd_ForceRepostsExistingMatchingPrice(t *testing.T) 
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !posted {
-		t.Fatal("expected forced create request")
+	if !patched {
+		t.Fatal("expected forced atomic price matrix PATCH")
 	}
-	if !strings.Contains(stdout, `"id":"forced-price-1"`) {
-		t.Fatalf("expected forced subscription price response in stdout, got %q", stdout)
+	if !strings.Contains(stdout, `"id":"8000000003"`) {
+		t.Fatalf("expected updated subscription response in stdout, got %q", stdout)
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -17,21 +17,27 @@ import (
 type subscriptionsSetupOutput struct {
 	Status               string `json:"status"`
 	GroupID              string `json:"groupId,omitempty"`
+	GroupLocalizationID  string `json:"groupLocalizationId,omitempty"`
 	SubscriptionID       string `json:"subscriptionId,omitempty"`
 	LocalizationID       string `json:"localizationId,omitempty"`
+	ReviewScreenshotID   string `json:"reviewScreenshotId,omitempty"`
 	AvailabilityID       string `json:"availabilityId,omitempty"`
 	ResolvedPricePointID string `json:"resolvedPricePointId,omitempty"`
 	Error                string `json:"error,omitempty"`
 	FailedStep           string `json:"failedStep,omitempty"`
 	Verification         struct {
-		Status               string `json:"status"`
-		GroupExists          *bool  `json:"groupExists,omitempty"`
-		SubscriptionExists   bool   `json:"subscriptionExists,omitempty"`
-		LocalizationExists   *bool  `json:"localizationExists,omitempty"`
-		PriceVerified        *bool  `json:"priceVerified,omitempty"`
-		AvailabilityVerified *bool  `json:"availabilityVerified,omitempty"`
-		PriceTerritory       string `json:"priceTerritory,omitempty"`
-		CurrentPrice         *struct {
+		Status                  string   `json:"status"`
+		SubscriptionState       string   `json:"subscriptionState,omitempty"`
+		GroupExists             *bool    `json:"groupExists,omitempty"`
+		SubscriptionExists      bool     `json:"subscriptionExists,omitempty"`
+		LocalizationExists      *bool    `json:"localizationExists,omitempty"`
+		PriceVerified           *bool    `json:"priceVerified,omitempty"`
+		AvailabilityVerified    *bool    `json:"availabilityVerified,omitempty"`
+		PriceCoverageVerified   *bool    `json:"priceCoverageVerified,omitempty"`
+		PricedTerritories       []string `json:"pricedTerritories,omitempty"`
+		MissingPriceTerritories []string `json:"missingPriceTerritories,omitempty"`
+		PriceTerritory          string   `json:"priceTerritory,omitempty"`
+		CurrentPrice            *struct {
 			Amount   string `json:"amount"`
 			Currency string `json:"currency"`
 		} `json:"currentPrice,omitempty"`
@@ -76,6 +82,17 @@ func TestSubscriptionsHelpShowsSetupCommand(t *testing.T) {
 	}
 	if !strings.Contains(setupUsage, "--enable-monthly-commitment") {
 		t.Fatalf("expected subscriptions setup help to show --enable-monthly-commitment, got %q", setupUsage)
+	}
+	for _, flagName := range []string{
+		"--group-locale",
+		"--group-display-name",
+		"--group-custom-app-name",
+		"--review-screenshot",
+		"--repair",
+	} {
+		if !strings.Contains(setupUsage, flagName) {
+			t.Fatalf("expected subscriptions setup help to show %s, got %q", flagName, setupUsage)
+		}
 	}
 }
 
@@ -161,6 +178,28 @@ func TestSubscriptionsSetupValidationErrors(t *testing.T) {
 				"--price-territory", "USA",
 			},
 			wantErr: "one of --price-point-id, --tier, or --price is required when pricing flags are provided",
+		},
+		{
+			name: "missing group display name when group localization requested",
+			args: []string{
+				"subscriptions", "setup",
+				"--group-id", "GROUP_ID",
+				"--reference-name", "Pro Monthly",
+				"--product-id", "com.example.pro.monthly",
+				"--group-locale", "en-US",
+			},
+			wantErr: "--group-display-name is required when group localization flags are provided",
+		},
+		{
+			name: "repair requires pricing",
+			args: []string{
+				"subscriptions", "setup",
+				"--group-id", "GROUP_ID",
+				"--reference-name", "Pro Monthly",
+				"--product-id", "com.example.pro.monthly",
+				"--repair",
+			},
+			wantErr: "--repair requires pricing flags",
 		},
 		{
 			name: "pricing selectors are mutually exclusive",
@@ -269,7 +308,7 @@ func TestSubscriptionsSetupCreateOnlySuccess(t *testing.T) {
 			if payload.Data.Attributes.Name != "Pro Monthly" || payload.Data.Attributes.ProductID != "com.example.pro.monthly" {
 				t.Fatalf("unexpected subscription attrs: %+v", payload.Data.Attributes)
 			}
-			body := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA","familySharable":false}}}`
+			body := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT","familySharable":false}}}`
 			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body)), Header: http.Header{"Content-Type": []string{"application/json"}}}, nil
 		case 4:
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionGroups/group-1" {
@@ -281,7 +320,7 @@ func TestSubscriptionsSetupCreateOnlySuccess(t *testing.T) {
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1" {
 				t.Fatalf("unexpected verify subscription request: %s %s", req.Method, req.URL.Path)
 			}
-			body := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA","familySharable":false}}}`
+			body := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT","familySharable":false}}}`
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: http.Header{"Content-Type": []string{"application/json"}}}, nil
 		default:
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.Path)
@@ -324,6 +363,129 @@ func TestSubscriptionsSetupCreateOnlySuccess(t *testing.T) {
 	}
 	if result.Verification.Status != "verified" || result.Verification.GroupExists == nil || !*result.Verification.GroupExists || !result.Verification.SubscriptionExists {
 		t.Fatalf("expected verified group/subscription create-only result, got %+v", result.Verification)
+	}
+}
+
+func TestSubscriptionsSetupRejectsAppleMissingMetadataState(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case 2:
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA"}}}`), nil
+		case 3:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Pro"}}}`), nil
+		case 4:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var result subscriptionsSetupOutput
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "setup",
+			"--group-id", "group-1",
+			"--reference-name", "Pro Monthly",
+			"--product-id", "com.example.pro.monthly",
+			"--subscription-period", "ONE_MONTH",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "MISSING_METADATA") {
+			t.Fatalf("expected MISSING_METADATA failure, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected structured error without stderr duplication, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse setup result: %v\nstdout=%q", err, stdout)
+	}
+	if result.Status != "error" || result.FailedStep != "verify_state" || result.Verification.Status != "failed" || result.Verification.SubscriptionState != "MISSING_METADATA" {
+		t.Fatalf("expected truthful Apple state failure, got %+v", result)
+	}
+}
+
+func TestSubscriptionsSetupVerifiesAllExistingAvailabilityPriceCoverage(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT"}}],"links":{"next":""}}`), nil
+		case 2:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Pro"}}}`), nil
+		case 3:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT"}}}`), nil
+		case 4:
+			if req.URL.Path != "/v1/subscriptions/sub-1/subscriptionAvailability" {
+				t.Fatalf("unexpected availability request: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case 5:
+			if req.URL.Path != "/v1/subscriptionAvailabilities/availability-1/availableTerritories" {
+				t.Fatalf("unexpected availability territories request: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{"next":""}}`), nil
+		case 6:
+			if req.URL.Path != "/v1/subscriptions/sub-1/prices" || req.URL.Query().Get("filter[planType]") != "UPFRONT" {
+				t.Fatalf("unexpected price coverage request: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-usa","attributes":{"planType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}}}}],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var result subscriptionsSetupOutput
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "setup",
+			"--group-id", "group-1",
+			"--reference-name", "Pro Monthly",
+			"--product-id", "com.example.pro.monthly",
+			"--subscription-period", "ONE_MONTH",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "CAN") {
+			t.Fatalf("expected missing CAN price coverage failure, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected structured error without stderr duplication, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse setup result: %v\nstdout=%q", err, stdout)
+	}
+	if result.Verification.PriceCoverageVerified == nil || *result.Verification.PriceCoverageVerified || len(result.Verification.MissingPriceTerritories) != 1 || result.Verification.MissingPriceTerritories[0] != "CAN" {
+		t.Fatalf("expected missing CAN coverage in verification, got %+v", result.Verification)
 	}
 }
 
@@ -930,6 +1092,79 @@ func TestSubscriptionsSetupReusesExistingPriceAndAvailability(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsSetupRepairResavesMatchingPrice(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH"}}],"links":{"next":""}}`), nil
+		case 2:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-point-1"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
+		case 3:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case 4:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`), nil
+		case 5:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionPrices" {
+				t.Fatalf("expected repair price POST, got %s %s", req.Method, req.URL.String())
+			}
+			var payload asc.SubscriptionPriceCreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode repair price payload: %v", err)
+			}
+			if payload.Data.Attributes != nil && payload.Data.Attributes.PlanType != "" {
+				t.Fatalf("expected repair price POST to omit planType, got %+v", payload.Data.Attributes)
+			}
+			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-repair","attributes":{"planType":"UPFRONT"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var result subscriptionsSetupOutput
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "setup",
+			"--group-id", "group-1",
+			"--reference-name", "Pro Monthly",
+			"--product-id", "com.example.pro.monthly",
+			"--subscription-period", "ONE_MONTH",
+			"--price-point-id", "price-point-1",
+			"--price-territory", "USA",
+			"--repair",
+			"--no-verify",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse setup result: %v", err)
+	}
+	foundRepair := false
+	for _, step := range result.Steps {
+		if step.Name == "set_price" && step.Message == "re-saved existing price for repair" {
+			foundRepair = true
+		}
+	}
+	if !foundRepair {
+		t.Fatalf("expected repair step, got %+v", result.Steps)
+	}
+}
+
 func TestSubscriptionsSetupRejectsInitialPricePatchWhenExistingPricesMismatch(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -1194,7 +1429,33 @@ func TestSubscriptionsSetupCreateLocalizationPricingAndAvailabilitySuccess(t *te
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
 	requestCount := 0
+	coveragePriceReads := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/pp-399/equalizations" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-can-399","attributes":{"customerPrice":"5.49"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{"next":""}}`), nil
+		}
+		if req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/sub-1" && coveragePriceReads > 0 {
+			var payload asc.SubscriptionUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode CAN starting price payload: %v", err)
+			}
+			if len(payload.Included) != 1 || payload.Included[0].Relationships.Territory == nil || payload.Included[0].Relationships.Territory.Data.ID != "CAN" || payload.Included[0].Relationships.SubscriptionPricePoint.Data.ID != "pp-can-399" {
+				t.Fatalf("unexpected CAN starting price payload: %+v", payload.Included)
+			}
+			if payload.Included[0].Attributes == nil || payload.Included[0].Attributes.PlanType != asc.SubscriptionPlanTypeUpfront {
+				t.Fatalf("expected CAN inline starting price to include UPFRONT planType, got %+v", payload.Included[0].Attributes)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"state":"MISSING_METADATA"}}}`), nil
+		}
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" && req.URL.Query().Get("filter[planType]") == "UPFRONT" && req.URL.Query().Get("filter[territory]") == "" {
+			coveragePriceReads++
+			canada := ""
+			if coveragePriceReads > 1 {
+				canada = `,{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2026-03-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-can-399"}},"territory":{"data":{"type":"territories","id":"CAN"}}}}`
+			}
+			body := `{"data":[{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2026-03-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-399"}},"territory":{"data":{"type":"territories","id":"USA"}}}}` + canada + `],"links":{"next":""}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		}
 		requestCount++
 		switch requestCount {
 		case 1:
@@ -1303,7 +1564,7 @@ func TestSubscriptionsSetupCreateLocalizationPricingAndAvailabilitySuccess(t *te
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1" {
 				t.Fatalf("unexpected verify subscription request: %s %s", req.Method, req.URL.Path)
 			}
-			body := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA","familySharable":true}}}`
+			body := `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT","familySharable":true}}}`
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: http.Header{"Content-Type": []string{"application/json"}}}, nil
 		case 10:
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/subscriptionLocalizations" {
@@ -1397,6 +1658,12 @@ func TestSubscriptionsSetupCreateLocalizationPricingAndAvailabilitySuccess(t *te
 	if result.Verification.AvailabilityVerified == nil || !*result.Verification.AvailabilityVerified {
 		t.Fatalf("expected availability verification, got %+v", result.Verification)
 	}
+	if result.Verification.SubscriptionState != "READY_TO_SUBMIT" {
+		t.Fatalf("expected Apple state READY_TO_SUBMIT, got %+v", result.Verification)
+	}
+	if result.Verification.PriceCoverageVerified == nil || !*result.Verification.PriceCoverageVerified || len(result.Verification.MissingPriceTerritories) != 0 {
+		t.Fatalf("expected complete price coverage, got %+v", result.Verification)
+	}
 	if result.Verification.CurrentPrice == nil || result.Verification.CurrentPrice.Amount != "3.99" || result.Verification.CurrentPrice.Currency != "USD" {
 		t.Fatalf("expected verified current price 3.99 USD, got %+v", result.Verification.CurrentPrice)
 	}
@@ -1443,6 +1710,28 @@ func TestSubscriptionsSetupNormalizesTerritories(t *testing.T) {
 			}
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA"}}}`), nil
 		case 6:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionPricePoints/pp-399/equalizations" {
+				t.Fatalf("unexpected equalizations request: %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-fra-399","attributes":{"customerPrice":"3.99"},"relationships":{"territory":{"data":{"type":"territories","id":"FRA"}}}}],"links":{"next":""}}`), nil
+		case 7:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/prices" {
+				t.Fatalf("unexpected price coverage request: %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-usa","attributes":{"planType":"UPFRONT"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-399"}}}}],"links":{"next":""}}`), nil
+		case 8:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptions/sub-1" {
+				t.Fatalf("unexpected FRA starting price request: %s %s", req.Method, req.URL.String())
+			}
+			var payload asc.SubscriptionUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode FRA starting price payload: %v", err)
+			}
+			if len(payload.Included) != 1 || payload.Included[0].Relationships.Territory == nil || payload.Included[0].Relationships.Territory.Data.ID != "FRA" || payload.Included[0].Relationships.SubscriptionPricePoint.Data.ID != "pp-fra-399" {
+				t.Fatalf("unexpected FRA starting price payload: %+v", payload.Included)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"state":"MISSING_METADATA"}}}`), nil
+		case 9:
 			if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionAvailabilities" {
 				t.Fatalf("unexpected availability request: %s %s", req.Method, req.URL.Path)
 			}
@@ -1487,7 +1776,7 @@ func TestSubscriptionsSetupNormalizesTerritories(t *testing.T) {
 	if err := root.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
-	if requestCount != 6 {
-		t.Fatalf("expected 5 setup requests, got %d", requestCount)
+	if requestCount != 9 {
+		t.Fatalf("expected 9 setup requests, got %d", requestCount)
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -1102,7 +1102,7 @@ func TestSubscriptionsSetupReusesExistingPriceAndAvailability(t *testing.T) {
 	}
 }
 
-func TestSubscriptionsSetupRepairResavesMatchingPrice(t *testing.T) {
+func TestSubscriptionsSetupRepairReplacesMismatchedPrice(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -1116,7 +1116,7 @@ func TestSubscriptionsSetupRepairResavesMatchingPrice(t *testing.T) {
 		case 1:
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH"}}],"links":{"next":""}}`), nil
 		case 2:
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-point-1"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"old-price-point"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
 		case 3:
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case 4:
@@ -1130,7 +1130,7 @@ func TestSubscriptionsSetupRepairResavesMatchingPrice(t *testing.T) {
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/prices" {
 				t.Fatalf("expected repair state GET, got %s %s", req.Method, req.URL.String())
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-point-1"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"old-price-point"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
 		case 7:
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptions/sub-1" {
 				t.Fatalf("expected repair matrix PATCH, got %s %s", req.Method, req.URL.String())

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -7,11 +7,15 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	subscriptionscli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/subscriptions"
 )
 
 type subscriptionsSetupOutput struct {
@@ -1106,31 +1110,33 @@ func TestSubscriptionsSetupRepairReplacesMismatchedPrice(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
+		respond := func(status int, body string) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+		}
 		switch requestCount {
 		case 1:
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH"}}],"links":{"next":""}}`), nil
+			respond(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH"}}],"links":{"next":""}}`)
 		case 2:
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"old-price-point"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
+			respond(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"old-price-point"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`)
 		case 3:
-			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+			respond(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`)
 		case 4:
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`), nil
+			respond(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`)
 		case 5:
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionPricePoints/price-point-1/equalizations" {
 				t.Fatalf("expected repair equalizations GET, got %s %s", req.Method, req.URL.String())
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+			respond(http.StatusOK, `{"data":[],"links":{}}`)
 		case 6:
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/prices" {
 				t.Fatalf("expected repair state GET, got %s %s", req.Method, req.URL.String())
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"old-price-point"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
+			respond(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"old-price-point"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`)
 		case 7:
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptions/sub-1" {
 				t.Fatalf("expected repair matrix PATCH, got %s %s", req.Method, req.URL.String())
@@ -1142,12 +1148,42 @@ func TestSubscriptionsSetupRepairReplacesMismatchedPrice(t *testing.T) {
 			if len(payload.Included) != 1 || payload.Included[0].Attributes == nil || payload.Included[0].Attributes.PlanType != asc.SubscriptionPlanTypeUpfront {
 				t.Fatalf("expected one UPFRONT repair matrix row, got %+v", payload.Included)
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1"}}`), nil
+			if payload.Included[0].Relationships.SubscriptionPricePoint.Data.ID != "price-point-1" {
+				t.Fatalf("expected repair price point price-point-1, got %+v", payload.Included[0].Relationships.SubscriptionPricePoint.Data)
+			}
+			if payload.Included[0].Relationships.Territory == nil || payload.Included[0].Relationships.Territory.Data.ID != "USA" {
+				t.Fatalf("expected repair territory USA, got %+v", payload.Included[0].Relationships.Territory)
+			}
+			respond(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1"}}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
 		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
 	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create setup test client: %v", err)
+	}
+	restoreClient := subscriptionscli.SetSetupClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restoreClient)
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -1030,6 +1030,16 @@ func TestSubscriptionsSetupReusesExistingPriceAndAvailability(t *testing.T) {
 				t.Fatalf("expected second availability territories page, got cursor %q", got)
 			}
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`), nil
+		case 6:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionPricePoints/price-point-1/equalizations" {
+				t.Fatalf("unexpected equalizations request: %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case 7:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/prices" {
+				t.Fatalf("unexpected price matrix read: %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-point-1"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
 		default:
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -1070,7 +1080,7 @@ func TestSubscriptionsSetupReusesExistingPriceAndAvailability(t *testing.T) {
 		t.Fatalf("unexpected setup result: %+v", result)
 	}
 	wantMessages := map[string]string{
-		"set_price":        "used existing price",
+		"set_price":        "verified complete price matrix across 1 territories",
 		"set_availability": "used existing availability",
 	}
 	for name, want := range wantMessages {
@@ -1087,7 +1097,7 @@ func TestSubscriptionsSetupReusesExistingPriceAndAvailability(t *testing.T) {
 			t.Fatalf("expected step %q in %+v", name, result.Steps)
 		}
 	}
-	if requestCount != 5 {
+	if requestCount != 7 {
 		t.Fatalf("expected lookup requests only, got %d", requestCount)
 	}
 }
@@ -1112,17 +1122,27 @@ func TestSubscriptionsSetupRepairResavesMatchingPrice(t *testing.T) {
 		case 4:
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`), nil
 		case 5:
-			if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionPrices" {
-				t.Fatalf("expected repair price POST, got %s %s", req.Method, req.URL.String())
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionPricePoints/price-point-1/equalizations" {
+				t.Fatalf("expected repair equalizations GET, got %s %s", req.Method, req.URL.String())
 			}
-			var payload asc.SubscriptionPriceCreateRequest
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		case 6:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/sub-1/prices" {
+				t.Fatalf("expected repair state GET, got %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-point-1"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`), nil
+		case 7:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptions/sub-1" {
+				t.Fatalf("expected repair matrix PATCH, got %s %s", req.Method, req.URL.String())
+			}
+			var payload asc.SubscriptionUpdateRequest
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode repair price payload: %v", err)
+				t.Fatalf("decode repair matrix payload: %v", err)
 			}
-			if payload.Data.Attributes != nil && payload.Data.Attributes.PlanType != "" {
-				t.Fatalf("expected repair price POST to omit planType, got %+v", payload.Data.Attributes)
+			if len(payload.Included) != 1 || payload.Included[0].Attributes == nil || payload.Included[0].Attributes.PlanType != asc.SubscriptionPlanTypeUpfront {
+				t.Fatalf("expected one UPFRONT repair matrix row, got %+v", payload.Included)
 			}
-			return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionPrices","id":"price-repair","attributes":{"planType":"UPFRONT"}}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1"}}`), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -1156,7 +1176,7 @@ func TestSubscriptionsSetupRepairResavesMatchingPrice(t *testing.T) {
 	}
 	foundRepair := false
 	for _, step := range result.Steps {
-		if step.Name == "set_price" && step.Message == "re-saved existing price for repair" {
+		if step.Name == "set_price" && step.Message == "materialized complete price matrix across 1 territories" {
 			foundRepair = true
 		}
 	}
@@ -1295,6 +1315,12 @@ func TestSubscriptionsSetupPricingAutoEnablesPriceTerritoryAvailability(t *testi
 
 	requestCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/pp-nok-19/equalizations" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		requestCount++
 		switch requestCount {
 		case 1:
@@ -1439,12 +1465,15 @@ func TestSubscriptionsSetupCreateLocalizationPricingAndAvailabilitySuccess(t *te
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode CAN starting price payload: %v", err)
 			}
-			if len(payload.Included) != 1 || payload.Included[0].Relationships.Territory == nil || payload.Included[0].Relationships.Territory.Data.ID != "CAN" || payload.Included[0].Relationships.SubscriptionPricePoint.Data.ID != "pp-can-399" {
-				t.Fatalf("unexpected CAN starting price payload: %+v", payload.Included)
+			if len(payload.Included) != 2 {
+				t.Fatalf("expected complete USA/CAN matrix, got %+v", payload.Included)
 			}
-			if payload.Included[0].Attributes == nil || payload.Included[0].Attributes.PlanType != asc.SubscriptionPlanTypeUpfront {
-				t.Fatalf("expected CAN inline starting price to include UPFRONT planType, got %+v", payload.Included[0].Attributes)
+			for _, included := range payload.Included {
+				if included.Attributes == nil || included.Attributes.PlanType != asc.SubscriptionPlanTypeUpfront {
+					t.Fatalf("expected each matrix row to include UPFRONT planType, got %+v", included.Attributes)
+				}
 			}
+			requestCount++ // replace the historical single-price PATCH slot
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"state":"MISSING_METADATA"}}}`), nil
 		}
 		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" && req.URL.Query().Get("filter[planType]") == "UPFRONT" && req.URL.Query().Get("filter[territory]") == "" {
@@ -1679,6 +1708,12 @@ func TestSubscriptionsSetupNormalizesTerritories(t *testing.T) {
 
 	requestCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/pp-399/equalizations" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-fra-399","attributes":{"customerPrice":"3.99"},"relationships":{"territory":{"data":{"type":"territories","id":"FRA"}}}}],"links":{}}`), nil
+		}
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{}}`), nil
+		}
 		requestCount++
 		switch requestCount {
 		case 1:
@@ -1708,6 +1743,14 @@ func TestSubscriptionsSetupNormalizesTerritories(t *testing.T) {
 			if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptions/sub-1" {
 				t.Fatalf("unexpected initial price request: %s %s", req.Method, req.URL.Path)
 			}
+			var payload asc.SubscriptionUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode full price matrix: %v", err)
+			}
+			if len(payload.Included) != 2 {
+				t.Fatalf("expected USA/FRA price matrix, got %+v", payload.Included)
+			}
+			requestCount = 8
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"MISSING_METADATA"}}}`), nil
 		case 6:
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptionPricePoints/pp-399/equalizations" {

--- a/internal/cli/cmdtest/validate_subscriptions_test.go
+++ b/internal/cli/cmdtest/validate_subscriptions_test.go
@@ -24,6 +24,7 @@ type validateSubscriptionsFixture struct {
 	availabilityV2                            string
 	availabilityV2Status                      int
 	territories                               string
+	pricingTerritories                        string
 	territoriesByQuery                        map[string]string
 	territoryStatusByQuery                    map[string]int
 	builds                                    string
@@ -84,6 +85,11 @@ func newValidateSubscriptionsClient(t *testing.T, fixture validateSubscriptionsF
 				return jsonResponse(http.StatusOK, fixture.availabilityV2)
 			}
 			return jsonResponse(http.StatusNotFound, notFound)
+		case path == "/v1/territories":
+			if fixture.pricingTerritories != "" {
+				return jsonResponse(http.StatusOK, fixture.pricingTerritories)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{}}`)
 		case path == "/v1/apps/app-1/builds":
 			if fixture.buildsStatus != 0 {
 				return jsonResponse(fixture.buildsStatus, apiErrorJSONForStatus(fixture.buildsStatus))
@@ -304,6 +310,7 @@ func TestValidateSubscriptionsOutputsJSONAndTable(t *testing.T) {
 
 func TestValidateSubscriptionsWarnsPartialSubscriptionPricingCoverage(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
 	fixture.availabilityV2 = `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`
 	fixture.territories = `{"data":[` +
 		`{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}},` +
@@ -347,6 +354,7 @@ func TestValidateSubscriptionsWarnsPartialSubscriptionPricingCoverage(t *testing
 
 func TestValidateSubscriptionsCountsAvailableTerritoriesAcrossPages(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
 	fixture.availabilityV2 = `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`
 	fixture.territories = `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}}],"links":{"next":"https://api.appstoreconnect.apple.com/v2/appAvailabilities/avail-1/territoryAvailabilities?cursor=page-2"}}`
 	fixture.territoriesByQuery = map[string]string{
@@ -387,6 +395,7 @@ func TestValidateSubscriptionsCountsAvailableTerritoriesAcrossPages(t *testing.T
 
 func TestValidateSubscriptionsFallsBackToCountWhenAppTerritoryIDsAreIncomplete(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
 	fixture.availabilityV2 = `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`
 	fixture.territories = `{"data":[
 		{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}},
@@ -432,18 +441,20 @@ func TestValidateSubscriptionsFallsBackToCountWhenAppTerritoryIDsAreIncomplete(t
 		t.Fatalf("expected pricing coverage warning when app territory IDs are incomplete, got %+v", report.Checks)
 		return
 	}
-	if !strings.Contains(coverageCheck.Message, "1 of 2 available territories") {
-		t.Fatalf("expected count-based fallback coverage warning, got %+v", *coverageCheck)
-	}
-	if strings.Contains(coverageCheck.Message, "missing:") {
-		t.Fatalf("did not expect exact territory diff when app territory IDs are incomplete, got %+v", *coverageCheck)
+	if !strings.Contains(coverageCheck.Message, "1 of 2 App Store pricing territories") || !strings.Contains(coverageCheck.Message, "missing: CAN") {
+		t.Fatalf("expected canonical pricing-territory coverage warning, got %+v", *coverageCheck)
 	}
 }
 
-func TestValidateSubscriptionsSkipsPricingCoverageWhenAvailabilityForbidden(t *testing.T) {
+func TestValidateSubscriptionsChecksPricingMatrixWhenAvailabilityForbidden(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
 	fixture.availabilityV2Status = http.StatusForbidden
 	fixture.availabilityV2 = apiErrorJSONForStatus(http.StatusForbidden)
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
+	fixture.expectedPriceInclude = "territory"
+	fixture.pricesBySubscription = map[string]string{
+		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
+	}
 
 	client := newValidateSubscriptionsClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {
@@ -468,18 +479,23 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenAvailabilityForbidden(t *t
 	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
-	if !hasCheckWithID(report.Checks, "subscriptions.pricing_coverage.unverified") {
-		t.Fatalf("expected pricing coverage skip info check, got %+v", report.Checks)
+	if hasCheckWithID(report.Checks, "subscriptions.pricing_coverage.unverified") {
+		t.Fatalf("did not expect app availability failure to suppress pricing-matrix validation, got %+v", report.Checks)
 	}
-	if hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
-		t.Fatalf("did not expect pricing coverage warning when availability could not be read, got %+v", report.Checks)
+	if !hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected missing canonical pricing territory to be reported, got %+v", report.Checks)
 	}
 }
 
-func TestValidateSubscriptionsSkipsPricingCoverageWhenAvailabilityRateLimited(t *testing.T) {
+func TestValidateSubscriptionsChecksPricingMatrixWhenAvailabilityRateLimited(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
 	fixture.availabilityV2Status = http.StatusTooManyRequests
 	fixture.availabilityV2 = apiErrorJSONForStatus(http.StatusTooManyRequests)
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
+	fixture.expectedPriceInclude = "territory"
+	fixture.pricesBySubscription = map[string]string{
+		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
+	}
 
 	client := newValidateSubscriptionsClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {
@@ -505,26 +521,15 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenAvailabilityRateLimited(t 
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
 
-	var skipCheck *validation.CheckResult
-	for i := range report.Checks {
-		if report.Checks[i].ID == "subscriptions.pricing_coverage.unverified" {
-			skipCheck = &report.Checks[i]
-			break
-		}
+	if hasCheckWithID(report.Checks, "subscriptions.pricing_coverage.unverified") {
+		t.Fatalf("did not expect app availability rate limit to suppress pricing-matrix validation, got %+v", report.Checks)
 	}
-	if skipCheck == nil {
-		t.Fatalf("expected pricing coverage skip info check, got %+v", report.Checks)
-		return
-	}
-	if !strings.Contains(skipCheck.Remediation, "temporarily unavailable or rate limited") {
-		t.Fatalf("expected retryable remediation, got %+v", *skipCheck)
-	}
-	if hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
-		t.Fatalf("did not expect pricing coverage warning when availability is retryable, got %+v", report.Checks)
+	if !hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected missing canonical pricing territory to be reported, got %+v", report.Checks)
 	}
 }
 
-func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityRateLimited(t *testing.T) {
+func TestValidateSubscriptionsChecksPricingMatrixWhenPaginatedAvailabilityRateLimited(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
 	fixture.availabilityV2 = `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`
 	fixture.territories = `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}}],"links":{"next":"https://api.appstoreconnect.apple.com/v2/appAvailabilities/avail-1/territoryAvailabilities?cursor=page-2"}}`
@@ -535,6 +540,7 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityRateL
 	fixture.pricesBySubscription = map[string]string{
 		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
 	}
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
 
 	client := newValidateSubscriptionsClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {
@@ -560,26 +566,15 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityRateL
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
 
-	var skipCheck *validation.CheckResult
-	for i := range report.Checks {
-		if report.Checks[i].ID == "subscriptions.pricing_coverage.unverified" {
-			skipCheck = &report.Checks[i]
-			break
-		}
+	if hasCheckWithID(report.Checks, "subscriptions.pricing_coverage.unverified") {
+		t.Fatalf("did not expect paginated app availability failure to suppress pricing-matrix validation, got %+v", report.Checks)
 	}
-	if skipCheck == nil {
-		t.Fatalf("expected pricing coverage skip info check, got %+v", report.Checks)
-		return
-	}
-	if !strings.Contains(skipCheck.Remediation, "temporarily unavailable or rate limited") {
-		t.Fatalf("expected retryable remediation, got %+v", *skipCheck)
-	}
-	if hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
-		t.Fatalf("did not expect pricing coverage warning when paginated availability is retryable, got %+v", report.Checks)
+	if !hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected missing canonical pricing territory to be reported, got %+v", report.Checks)
 	}
 }
 
-func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityTimeoutHasPartialCount(t *testing.T) {
+func TestValidateSubscriptionsChecksPricingMatrixWhenPaginatedAvailabilityHasPartialCount(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
 	fixture.availabilityV2 = `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`
 	fixture.territories = `{"data":[
@@ -593,6 +588,7 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityTimeo
 	fixture.pricesBySubscription = map[string]string{
 		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
 	}
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}],"links":{}}`
 
 	client := newValidateSubscriptionsClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {
@@ -617,11 +613,11 @@ func TestValidateSubscriptionsSkipsPricingCoverageWhenPaginatedAvailabilityTimeo
 	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
-	if !hasCheckWithID(report.Checks, "subscriptions.pricing_coverage.unverified") {
-		t.Fatalf("expected pricing coverage skip info check, got %+v", report.Checks)
+	if hasCheckWithID(report.Checks, "subscriptions.pricing_coverage.unverified") {
+		t.Fatalf("did not expect partial app availability to suppress pricing-matrix validation, got %+v", report.Checks)
 	}
-	if hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
-		t.Fatalf("did not expect pricing coverage warning when only a partial availability count was fetched, got %+v", report.Checks)
+	if !hasCheckWithID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected missing canonical pricing territory to be reported, got %+v", report.Checks)
 	}
 }
 

--- a/internal/cli/cmdtest/validate_subscriptions_test.go
+++ b/internal/cli/cmdtest/validate_subscriptions_test.go
@@ -1053,7 +1053,7 @@ func TestValidateSubscriptionsIncludesDiagnosticsMatrixForOpaqueMissingMetadata(
 		"sub-avail-1": `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}]}`,
 	}
 	fixture.reviewScreenshotBySub = map[string]string{
-		"sub-1": `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}}}`,
+		"sub-1": `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","assetDeliveryState":{"state":"COMPLETE"}}}}`,
 	}
 
 	client := newValidateSubscriptionsClient(t, fixture)
@@ -1133,7 +1133,7 @@ func TestValidateSubscriptionsIncludesDiagnosticsMatrixForOpaqueMissingMetadata(
 	}
 }
 
-func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *testing.T) {
+func TestValidateSubscriptionsReportsOpaqueAppleStateWhenOnlyAdvisoriesRemain(t *testing.T) {
 	fixture := validValidateSubscriptionsFixture()
 	fixture.availabilityV2 = `{"data":{"type":"appAvailabilities","id":"app-avail-1","attributes":{"availableInNewTerritories":true}}}`
 	fixture.territories = `{"data":[
@@ -1162,7 +1162,7 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 		"sub-avail-1": `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"CAN"}]}`,
 	}
 	fixture.reviewScreenshotBySub = map[string]string{
-		"sub-1": `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png"}}}`,
+		"sub-1": `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":{"fileName":"review.png","assetDeliveryState":{"state":"COMPLETE"}}}}`,
 	}
 	fixture.imagesBySubscription["sub-1"] = `{"data":[]}`
 
@@ -1194,11 +1194,11 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 	}
 
 	diag := report.Diagnostics[0]
-	if diag.Conclusion != "advisory_only" {
-		t.Fatalf("expected advisory_only conclusion when only advisory findings remain, got %+v", diag)
+	if diag.Conclusion != "opaque_apple_state" {
+		t.Fatalf("expected opaque_apple_state when blocking public checks pass but Apple still reports missing metadata, got %+v", diag)
 	}
-	if !strings.Contains(diag.Summary, "only advisory subscription findings remain") {
-		t.Fatalf("expected advisory-only summary, got %+v", diag)
+	if !strings.Contains(diag.Summary, "do not explain why Apple still reports MISSING_METADATA") {
+		t.Fatalf("expected opaque Apple state summary, got %+v", diag)
 	}
 
 	imageRow, ok := findSubscriptionDiagnosticRow(t, diag.Rows, "promotional_image")

--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -35,6 +35,8 @@ type validateFixture struct {
 	availabilityV2Status       int
 	territories                string
 	territoriesByQuery         map[string]string
+	pricingTerritories         string
+	pricingTerritoriesByQuery  map[string]string
 	screenshotSets             map[string]string
 	screenshotsBySet           map[string]string
 	subscriptionGroups         string
@@ -118,6 +120,14 @@ func newValidateTestClient(t *testing.T, fixture validateFixture) *asc.Client {
 				return jsonResponse(http.StatusOK, fixture.availabilityV2)
 			}
 			return jsonResponse(http.StatusNotFound, `{"errors":[{"code":"NOT_FOUND","title":"Not Found","detail":"resource not found"}]}`)
+		case path == "/v1/territories":
+			if body, ok := fixture.pricingTerritoriesByQuery[req.URL.RawQuery]; ok {
+				return jsonResponse(http.StatusOK, body)
+			}
+			if fixture.pricingTerritories != "" {
+				return jsonResponse(http.StatusOK, fixture.pricingTerritories)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`)
 		case strings.HasPrefix(path, "/v2/appAvailabilities/") && strings.HasSuffix(path, "/territoryAvailabilities"):
 			if body, ok := fixture.territoriesByQuery[req.URL.RawQuery]; ok {
 				return jsonResponse(http.StatusOK, body)
@@ -251,18 +261,19 @@ func hasCheckWithID(checks []validation.CheckResult, id string) bool {
 
 func validValidateFixture() validateFixture {
 	return validateFixture{
-		app:             `{"data":{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US","contentRightsDeclaration":"DOES_NOT_USE_THIRD_PARTY_CONTENT"}}}`,
-		versions:        `{"data":[{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0","copyright":"2026 Test Company"}}]}`,
-		version:         `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0","appVersionState":"PREPARE_FOR_SUBMISSION","copyright":"2026 Test Company"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`,
-		appInfos:        `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`,
-		appInfoLocs:     `{"data":[{"type":"appInfoLocalizations","id":"info-loc-1","attributes":{"locale":"en-US","name":"My App","subtitle":"Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}]}`,
-		versionLocs:     fmt.Sprintf(`{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US","description":"Description. Terms of Use: %s","keywords":"keyword","whatsNew":"Notes","promotionalText":"Promo","supportUrl":"https://support.example.com","marketingUrl":"https://marketing.example.com"}}]}`, validation.AppleStandardEULAURL),
-		reviewDetails:   `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"123","demoAccountName":"","demoAccountPassword":"","demoAccountRequired":false,"notes":"Review notes"}}}`,
-		primaryCategory: `{"data":{"type":"appCategories","id":"cat-1"}}`,
-		build:           `{"data":{"type":"builds","id":"build-1","attributes":{"version":"1.0","processingState":"VALID","expired":false,"usesNonExemptEncryption":false}}}`,
-		priceSchedule:   `{"data":{"type":"appPriceSchedules","id":"sched-1","attributes":{}}}`,
-		availabilityV2:  `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`,
-		territories:     `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}}]}`,
+		app:                `{"data":{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US","contentRightsDeclaration":"DOES_NOT_USE_THIRD_PARTY_CONTENT"}}}`,
+		versions:           `{"data":[{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0","copyright":"2026 Test Company"}}]}`,
+		version:            `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0","appVersionState":"PREPARE_FOR_SUBMISSION","copyright":"2026 Test Company"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`,
+		appInfos:           `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`,
+		appInfoLocs:        `{"data":[{"type":"appInfoLocalizations","id":"info-loc-1","attributes":{"locale":"en-US","name":"My App","subtitle":"Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}]}`,
+		versionLocs:        fmt.Sprintf(`{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US","description":"Description. Terms of Use: %s","keywords":"keyword","whatsNew":"Notes","promotionalText":"Promo","supportUrl":"https://support.example.com","marketingUrl":"https://marketing.example.com"}}]}`, validation.AppleStandardEULAURL),
+		reviewDetails:      `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"123","demoAccountName":"","demoAccountPassword":"","demoAccountRequired":false,"notes":"Review notes"}}}`,
+		primaryCategory:    `{"data":{"type":"appCategories","id":"cat-1"}}`,
+		build:              `{"data":{"type":"builds","id":"build-1","attributes":{"version":"1.0","processingState":"VALID","expired":false,"usesNonExemptEncryption":false}}}`,
+		priceSchedule:      `{"data":{"type":"appPriceSchedules","id":"sched-1","attributes":{}}}`,
+		availabilityV2:     `{"data":{"type":"appAvailabilities","id":"avail-1","attributes":{"availableInNewTerritories":true}}}`,
+		territories:        `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}}]}`,
+		pricingTerritories: `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`,
 		ageRating: `{"data":{"type":"ageRatingDeclarations","id":"age-1","attributes":{
 			"advertising":false,
 			"gambling":false,
@@ -1961,20 +1972,19 @@ func TestValidateFailsWhenNoTerritoriesAvailable(t *testing.T) {
 
 func TestValidateWarnsPartialSubscriptionPricingCoverage(t *testing.T) {
 	fixture := validValidateFixture()
-	// Subscription with pricing for 1 territory but app available in many.
+	// Subscription with pricing for 1 territory but a larger App Store pricing universe.
 	fixture.subscriptionsByGroup["group-1"] = `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly","state":"APPROVED"}}]}`
 	fixture.expectedPriceInclude = "territory"
 	fixture.pricesBySubscription = map[string]string{
 		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
 	}
-	// Make the app available in 5 territories so the coverage gap is clear.
-	fixture.territories = `{"data":[` +
-		`{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}},` +
-		`{"type":"territoryAvailabilities","id":"ta-2","attributes":{"available":true}},` +
-		`{"type":"territoryAvailabilities","id":"ta-3","attributes":{"available":true}},` +
-		`{"type":"territoryAvailabilities","id":"ta-4","attributes":{"available":true}},` +
-		`{"type":"territoryAvailabilities","id":"ta-5","attributes":{"available":true}}` +
-		`]}`
+	fixture.pricingTerritories = `{"data":[` +
+		`{"type":"territories","id":"USA"},` +
+		`{"type":"territories","id":"CAN"},` +
+		`{"type":"territories","id":"GBR"},` +
+		`{"type":"territories","id":"FRA"},` +
+		`{"type":"territories","id":"DEU"}` +
+		`],"links":{"next":""}}`
 
 	client := newValidateTestClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {
@@ -2011,13 +2021,13 @@ func TestValidateWarnsPartialSubscriptionPricingCoverageAcrossTerritoryPages(t *
 	fixture.pricesBySubscription = map[string]string{
 		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
 	}
-	fixture.territories = `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true}}],"links":{"next":"https://api.appstoreconnect.apple.com/v2/appAvailabilities/avail-1/territoryAvailabilities?cursor=page-2"}}`
-	fixture.territoriesByQuery = map[string]string{
+	fixture.pricingTerritories = `{"data":[{"type":"territories","id":"USA"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/territories?cursor=page-2"}}`
+	fixture.pricingTerritoriesByQuery = map[string]string{
 		"cursor=page-2": `{"data":[
-			{"type":"territoryAvailabilities","id":"ta-2","attributes":{"available":true}},
-			{"type":"territoryAvailabilities","id":"ta-3","attributes":{"available":true}},
-			{"type":"territoryAvailabilities","id":"ta-4","attributes":{"available":true}},
-			{"type":"territoryAvailabilities","id":"ta-5","attributes":{"available":true}}
+			{"type":"territories","id":"CAN"},
+			{"type":"territories","id":"GBR"},
+			{"type":"territories","id":"FRA"},
+			{"type":"territories","id":"DEU"}
 		],"links":{"next":""}}`,
 	}
 
@@ -2049,17 +2059,17 @@ func TestValidateWarnsPartialSubscriptionPricingCoverageAcrossTerritoryPages(t *
 	}
 }
 
-func TestValidateNamesMissingSubscriptionPricingTerritoriesWhenAppTerritoryIDsAreAvailable(t *testing.T) {
+func TestValidateNamesMissingSubscriptionPricingTerritoriesWhenPricingTerritoryIDsAreAvailable(t *testing.T) {
 	fixture := validValidateFixture()
 	fixture.subscriptionsByGroup["group-1"] = `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly","state":"APPROVED"}}]}`
 	fixture.expectedPriceInclude = "territory"
 	fixture.pricesBySubscription = map[string]string{
 		"sub-1": `{"data":[{"type":"subscriptionPrices","id":"price-1","attributes":{"startDate":"2026-01-01"},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}]}`,
 	}
-	fixture.territories = `{"data":[
-		{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}},
-		{"type":"territoryAvailabilities","id":"ta-2","attributes":{"available":true},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}
-	]}`
+	fixture.pricingTerritories = `{"data":[
+		{"type":"territories","id":"USA"},
+		{"type":"territories","id":"CAN"}
+	],"links":{"next":""}}`
 
 	client := newValidateTestClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -1194,7 +1194,7 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		covered := len(verification.MissingPriceTerritories) == 0
 		if covered {
 			for _, target := range expectedMatrix {
-				if !priceState.matches(subscriptionPriceImportResolvedRow{
+				if !subscriptionSetupPriceStateMatches(priceState, subscriptionPriceImportResolvedRow{
 					territoryID:  target.TerritoryID,
 					pricePointID: target.PricePointID,
 					startDate:    strings.TrimSpace(target.Attributes.StartDate),
@@ -1377,7 +1377,7 @@ func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client
 			startDate:    strings.TrimSpace(attrs.StartDate),
 			planType:     attrs.PlanType,
 		}
-		if !state.matches(resolved) {
+		if !subscriptionSetupPriceStateMatches(state, resolved) {
 			complete = false
 			break
 		}
@@ -1392,6 +1392,33 @@ func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client
 		return nil, false, err
 	}
 	return territories, true, nil
+}
+
+// subscriptionSetupPriceStateMatches accepts an omitted start date only when
+// Apple otherwise echoes the exact setup matrix row. App Store Connect can omit
+// startDate on equalized UPFRONT rows even when the compound PATCH included it;
+// a different explicit date remains a mismatch.
+func subscriptionSetupPriceStateMatches(index *subscriptionPriceImportStateIndex, target subscriptionPriceImportResolvedRow) bool {
+	if index == nil {
+		return false
+	}
+	if index.matches(target) {
+		return true
+	}
+	if strings.TrimSpace(target.startDate) == "" {
+		return false
+	}
+	targetTerritory := strings.ToUpper(strings.TrimSpace(target.territoryID))
+	targetPricePoint := strings.TrimSpace(target.pricePointID)
+	for _, state := range index.states {
+		if state.territoryID == targetTerritory &&
+			state.planType == target.planType &&
+			state.pricePointID == targetPricePoint &&
+			strings.TrimSpace(state.startDate) == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func buildSubscriptionSetupPriceMatrix(basePricePointID, baseTerritory string, attrs asc.SubscriptionPriceCreateAttributes, equalizations []equalization) ([]asc.SubscriptionInlinePrice, error) {

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -615,7 +615,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 			return result, fmt.Errorf("subscriptions setup: failed to find existing price: %w", err)
 		}
 		pricePreflightDone = true
-		if preflightHasExistingPrices && !preflightFoundPrice {
+		if preflightHasExistingPrices && !preflightFoundPrice && !opts.Repair {
 			err := mismatchedExistingSubscriptionSetupPriceError(result.SubscriptionID)
 			result.Status = "error"
 			result.Error = err.Error()
@@ -1164,7 +1164,9 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 	}
 
 	if opts.hasPricing(opts.StartDate) {
-		equalizations, err := fetchEqualizations(ctx, client, result.ResolvedPricePointID, opts.PriceTerritory)
+		equalizationsCtx, equalizationsCancel := shared.ContextWithTimeout(ctx)
+		equalizations, err := fetchEqualizations(equalizationsCtx, client, result.ResolvedPricePointID, opts.PriceTerritory)
+		equalizationsCancel()
 		if err != nil {
 			verification.Status = "failed"
 			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch expected price matrix: %w", err)
@@ -1344,7 +1346,9 @@ func validateExistingSubscriptionSetupGroupLocalization(localization asc.Resourc
 
 func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client, subscriptionID, basePricePointID, baseTerritory string, attrs asc.SubscriptionPriceCreateAttributes, repair bool) ([]string, bool, error) {
 	baseTerritory = strings.ToUpper(strings.TrimSpace(baseTerritory))
-	equalizations, err := fetchEqualizations(ctx, client, basePricePointID, baseTerritory)
+	equalizationsCtx, equalizationsCancel := shared.ContextWithTimeout(ctx)
+	equalizations, err := fetchEqualizations(equalizationsCtx, client, basePricePointID, baseTerritory)
+	equalizationsCancel()
 	if err != nil {
 		return nil, false, err
 	}
@@ -1357,7 +1361,9 @@ func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client
 		territories = append(territories, target.TerritoryID)
 	}
 
-	state, err := fetchSubscriptionPriceImportState(ctx, client, subscriptionID)
+	stateCtx, stateCancel := shared.ContextWithTimeout(ctx)
+	state, err := fetchSubscriptionPriceImportState(stateCtx, client, subscriptionID)
+	stateCancel()
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -167,7 +167,7 @@ func SubscriptionsSetupCommand() *ffcli.Command {
 	availableInNewTerritories := fs.Bool("available-in-new-territories", false, "Include new territories automatically when creating availability")
 	enableMonthlyCommitment := fs.Bool("enable-monthly-commitment", false, "Also configure Monthly with 12-Month Commitment availability for ONE_YEAR subscriptions")
 	noVerify := fs.Bool("no-verify", false, "Skip post-create readback verification for faster execution")
-	repair := fs.Bool("repair", false, "Re-send matching price writes to trigger App Store Connect metadata recalculation")
+	repair := fs.Bool("repair", false, "Atomically rebuild and re-save the complete equalized price matrix")
 	output := shared.BindOutputFlags(fs)
 
 	shared.HideFlagFromHelp(fs.Lookup("group-ref-name"))
@@ -186,15 +186,15 @@ The setup command is create-oriented: use it when you want a one-shot happy
 path for a new subscription. Existing low-level commands remain available
 for partial updates, repair flows, and advanced cases.
 
-When pricing and availability cover multiple territories, setup uses Apple's
-price-point equalizations to create a price in every enabled territory.
+Setup uses Apple's price-point equalizations to materialize the complete App
+Store price matrix. Sale availability remains the independently selected subset.
 
 By default, setup reads Apple's final subscription state back and verifies the
 resulting metadata, screenshot delivery, pricing, and availability. A final
 MISSING_METADATA state fails the command and includes deep diagnostics when
---app is available. Use --repair to replay same-value price writes when Apple
-needs a metadata recalculation. Use --no-verify only when intentionally
-skipping these postcondition checks.
+--app is available. Use --repair to atomically rebuild and re-save that complete
+matrix even when the selected base price is unchanged. Use --no-verify only
+when intentionally skipping these postcondition checks.
 
 Examples:
   asc subscriptions setup --app "APP_ID" --group-reference-name "Pro" --reference-name "Pro Monthly" --product-id "com.example.pro.monthly" --subscription-period ONE_MONTH
@@ -577,7 +577,6 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 	}
 
 	var preflightPricePointID string
-	var preflightExistingPrice asc.Resource[asc.SubscriptionPriceAttributes]
 	var preflightFoundPrice bool
 	var preflightHasExistingPrices bool
 	pricePreflightDone := false
@@ -602,7 +601,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 			PlanType:  asc.SubscriptionPlanTypeUpfront,
 		}
 		priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-		preflightExistingPrice, preflightFoundPrice, preflightHasExistingPrices, err = findExistingSubscriptionSetupPrice(priceCtx, client, result.SubscriptionID, resolvedPricePointID, opts.PriceTerritory, priceAttrs)
+		preflightFoundPrice, preflightHasExistingPrices, err = findExistingSubscriptionSetupPrice(priceCtx, client, result.SubscriptionID, resolvedPricePointID, opts.PriceTerritory, priceAttrs)
 		priceCancel()
 		if err != nil {
 			result.Status = "error"
@@ -812,17 +811,15 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 			StartDate: opts.StartDate,
 			PlanType:  asc.SubscriptionPlanTypeUpfront,
 		}
-		var existingPrice asc.Resource[asc.SubscriptionPriceAttributes]
 		found := false
 		hasExistingPrices := false
 		if reusedSubscription {
 			if pricePreflightDone {
-				existingPrice = preflightExistingPrice
 				found = preflightFoundPrice
 				hasExistingPrices = preflightHasExistingPrices
 			} else {
 				priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-				existingPrice, found, hasExistingPrices, err = findExistingSubscriptionSetupPrice(priceCtx, client, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, priceAttrs)
+				found, hasExistingPrices, err = findExistingSubscriptionSetupPrice(priceCtx, client, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, priceAttrs)
 				priceCancel()
 				if err != nil {
 					result.Status = "error"
@@ -837,29 +834,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 				}
 			}
 		}
-		if found && opts.Repair {
-			repairAttrs := priceAttrs
-			repairAttrs.PlanType = ""
-			priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-			priceResp, writeErr := client.CreateSubscriptionPrice(priceCtx, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, repairAttrs)
-			priceCancel()
-			if writeErr != nil {
-				return failSubscriptionsSetupStep(result, subscriptionsSetupStepSetPrice, writeErr, "failed to re-save existing price for repair")
-			}
-			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
-				Name:    subscriptionsSetupStepSetPrice,
-				Status:  "completed",
-				ID:      strings.TrimSpace(priceResp.Data.ID),
-				Message: "re-saved existing price for repair",
-			})
-		} else if found {
-			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
-				Name:    subscriptionsSetupStepSetPrice,
-				Status:  "completed",
-				ID:      strings.TrimSpace(existingPrice.ID),
-				Message: "used existing price",
-			})
-		} else if hasExistingPrices {
+		if hasExistingPrices && !found && !opts.Repair {
 			err := mismatchedExistingSubscriptionSetupPriceError(result.SubscriptionID)
 			result.Status = "error"
 			result.Error = err.Error()
@@ -870,31 +845,21 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 				Message: err.Error(),
 			})
 			return result, err
-		} else {
-			priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-			_, err = client.SetSubscriptionInitialPrice(priceCtx, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, priceAttrs)
-			priceCancel()
-			if err != nil {
-				result.Status = "error"
-				result.Error = err.Error()
-				result.FailedStep = subscriptionsSetupStepSetPrice
-				result.Steps = append(result.Steps, subscriptionsSetupStepResult{
-					Name:    subscriptionsSetupStepSetPrice,
-					Status:  "failed",
-					Message: err.Error(),
-				})
-				return result, fmt.Errorf("subscriptions setup: failed to set initial price: %w", err)
-			}
-			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
-				Name:   subscriptionsSetupStepSetPrice,
-				Status: "completed",
-				ID:     result.SubscriptionID,
-			})
 		}
-
-		if err := ensureSubscriptionsSetupPriceCoverage(ctx, client, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, availabilityTerritories, priceAttrs, opts.Repair); err != nil {
-			return failSubscriptionsSetupStep(result, subscriptionsSetupStepSetPrice, err, "failed to set price coverage")
+		matrixTerritories, mutated, err := ensureSubscriptionsSetupPriceMatrix(ctx, client, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, priceAttrs, opts.Repair)
+		if err != nil {
+			return failSubscriptionsSetupStep(result, subscriptionsSetupStepSetPrice, err, "failed to materialize complete price matrix")
 		}
+		message := fmt.Sprintf("verified complete price matrix across %d territories", len(matrixTerritories))
+		if mutated {
+			message = fmt.Sprintf("materialized complete price matrix across %d territories", len(matrixTerritories))
+		}
+		result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+			Name:    subscriptionsSetupStepSetPrice,
+			Status:  "completed",
+			ID:      result.SubscriptionID,
+			Message: message,
+		})
 	}
 
 	if len(availabilityTerritories) == 0 {
@@ -1198,7 +1163,52 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		}
 	}
 
-	if len(verification.Territories) > 0 {
+	if opts.hasPricing(opts.StartDate) {
+		equalizations, err := fetchEqualizations(ctx, client, result.ResolvedPricePointID, opts.PriceTerritory)
+		if err != nil {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch expected price matrix: %w", err)
+		}
+		priceAttrs := asc.SubscriptionPriceCreateAttributes{StartDate: opts.StartDate, PlanType: asc.SubscriptionPlanTypeUpfront}
+		expectedMatrix, err := buildSubscriptionSetupPriceMatrix(result.ResolvedPricePointID, opts.PriceTerritory, priceAttrs, equalizations)
+		if err != nil {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, err
+		}
+		expectedTerritories := make([]string, 0, len(expectedMatrix))
+		for _, target := range expectedMatrix {
+			expectedTerritories = append(expectedTerritories, target.TerritoryID)
+		}
+		priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
+		priceState, err := fetchSubscriptionPriceImportState(priceCtx, client, result.SubscriptionID)
+		priceCancel()
+		if err != nil {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch subscription price coverage: %w", err)
+		}
+		verification.PricedTerritories, verification.MissingPriceTerritories = subscriptionSetupPriceCoverage(priceState.states, expectedTerritories)
+		covered := len(verification.MissingPriceTerritories) == 0
+		if covered {
+			for _, target := range expectedMatrix {
+				if !priceState.matches(subscriptionPriceImportResolvedRow{
+					territoryID:  target.TerritoryID,
+					pricePointID: target.PricePointID,
+					startDate:    strings.TrimSpace(target.Attributes.StartDate),
+					planType:     target.Attributes.PlanType,
+				}) {
+					covered = false
+					verification.MissingPriceTerritories = append(verification.MissingPriceTerritories, target.TerritoryID)
+				}
+			}
+		}
+		verification.PriceCoverageVerified = &covered
+		if !covered {
+			verification.Status = "failed"
+			sort.Strings(verification.MissingPriceTerritories)
+			message := fmt.Sprintf("incomplete or mismatched App Store price matrix for territories: %s", strings.Join(verification.MissingPriceTerritories, ","))
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: message}, fmt.Errorf("%s", message)
+		}
+	} else if len(verification.Territories) > 0 {
 		priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
 		priceState, err := fetchSubscriptionPriceImportState(priceCtx, client, result.SubscriptionID)
 		priceCancel()
@@ -1211,7 +1221,7 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		verification.PriceCoverageVerified = &covered
 		if !covered {
 			verification.Status = "failed"
-			message := fmt.Sprintf("missing price coverage for availability territories: %s", strings.Join(verification.MissingPriceTerritories, ","))
+			message := fmt.Sprintf("missing price coverage for enabled availability territories: %s", strings.Join(verification.MissingPriceTerritories, ","))
 			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: message}, fmt.Errorf("%s", message)
 		}
 	}
@@ -1332,83 +1342,82 @@ func validateExistingSubscriptionSetupGroupLocalization(localization asc.Resourc
 	return nil
 }
 
-func ensureSubscriptionsSetupPriceCoverage(ctx context.Context, client *asc.Client, subscriptionID, basePricePointID, baseTerritory string, territories []string, attrs asc.SubscriptionPriceCreateAttributes, repair bool) error {
-	if len(territories) == 0 {
-		return nil
-	}
+func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client, subscriptionID, basePricePointID, baseTerritory string, attrs asc.SubscriptionPriceCreateAttributes, repair bool) ([]string, bool, error) {
 	baseTerritory = strings.ToUpper(strings.TrimSpace(baseTerritory))
-	needsEqualization := false
-	for _, territory := range territories {
-		if strings.ToUpper(strings.TrimSpace(territory)) != baseTerritory {
-			needsEqualization = true
-			break
-		}
-	}
-	if !needsEqualization {
-		return nil
-	}
 	equalizations, err := fetchEqualizations(ctx, client, basePricePointID, baseTerritory)
 	if err != nil {
-		return err
+		return nil, false, err
 	}
-	targetsByTerritory := map[string]equalization{
-		baseTerritory: {
-			Territory:    baseTerritory,
-			PricePointID: strings.TrimSpace(basePricePointID),
-		},
+	matrix, err := buildSubscriptionSetupPriceMatrix(basePricePointID, baseTerritory, attrs, equalizations)
+	if err != nil {
+		return nil, false, err
 	}
-	for _, target := range equalizations {
-		targetsByTerritory[strings.ToUpper(strings.TrimSpace(target.Territory))] = target
+	territories := make([]string, 0, len(matrix))
+	for _, target := range matrix {
+		territories = append(territories, target.TerritoryID)
 	}
 
 	state, err := fetchSubscriptionPriceImportState(ctx, client, subscriptionID)
 	if err != nil {
-		return err
+		return nil, false, err
 	}
-	for _, rawTerritory := range territories {
-		territory := strings.ToUpper(strings.TrimSpace(rawTerritory))
-		if territory == baseTerritory {
-			continue
-		}
-		target, ok := targetsByTerritory[territory]
-		if !ok || strings.TrimSpace(target.PricePointID) == "" {
-			return fmt.Errorf("no equalized price point found for availability territory %s", territory)
-		}
+	complete := true
+	for _, target := range matrix {
 		resolved := subscriptionPriceImportResolvedRow{
-			territoryID:  territory,
-			pricePointID: strings.TrimSpace(target.PricePointID),
+			territoryID:  target.TerritoryID,
+			pricePointID: target.PricePointID,
 			startDate:    strings.TrimSpace(attrs.StartDate),
 			planType:     attrs.PlanType,
 		}
-		matches := state.matches(resolved)
-		if matches && !repair {
-			continue
+		if !state.matches(resolved) {
+			complete = false
+			break
 		}
-		if !subscriptionSetupHasPricedTerritory(state.states, territory) {
-			priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-			_, err := client.SetSubscriptionInitialPrice(priceCtx, subscriptionID, resolved.pricePointID, territory, attrs)
-			priceCancel()
-			if err != nil {
-				return fmt.Errorf("set starting %s price: %w", territory, err)
-			}
-			state.add(resolved)
-			continue
-		}
-		// planType is required on the inline initial-price resource, but sending
-		// UPFRONT on ordinary territory price POSTs causes Apple to reject the
-		// request as invalid pricing information. Apple assigns the plan type to
-		// the created record from the subscription context.
-		createAttrs := attrs
-		createAttrs.PlanType = ""
-		priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-		_, err := client.CreateSubscriptionPrice(priceCtx, subscriptionID, resolved.pricePointID, territory, createAttrs)
-		priceCancel()
-		if err != nil {
-			return fmt.Errorf("set %s price: %w", territory, err)
-		}
-		state.add(resolved)
 	}
-	return nil
+	if complete && !repair {
+		return territories, false, nil
+	}
+	priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
+	_, err = client.SetSubscriptionPriceMatrix(priceCtx, subscriptionID, matrix)
+	priceCancel()
+	if err != nil {
+		return nil, false, err
+	}
+	return territories, true, nil
+}
+
+func buildSubscriptionSetupPriceMatrix(basePricePointID, baseTerritory string, attrs asc.SubscriptionPriceCreateAttributes, equalizations []equalization) ([]asc.SubscriptionInlinePrice, error) {
+	basePricePointID = strings.TrimSpace(basePricePointID)
+	baseTerritory = strings.ToUpper(strings.TrimSpace(baseTerritory))
+	if basePricePointID == "" || baseTerritory == "" {
+		return nil, fmt.Errorf("base price point and territory are required")
+	}
+	byTerritory := map[string]string{baseTerritory: basePricePointID}
+	for _, target := range equalizations {
+		territory := strings.ToUpper(strings.TrimSpace(target.Territory))
+		pricePointID := strings.TrimSpace(target.PricePointID)
+		if territory == "" || pricePointID == "" {
+			return nil, fmt.Errorf("equalized territory and price point are required")
+		}
+		if existing, ok := byTerritory[territory]; ok && existing != pricePointID {
+			return nil, fmt.Errorf("conflicting equalized price points for territory %s", territory)
+		}
+		byTerritory[territory] = pricePointID
+	}
+	territories := make([]string, 0, len(byTerritory))
+	for territory := range byTerritory {
+		territories = append(territories, territory)
+	}
+	sort.Strings(territories)
+	matrix := make([]asc.SubscriptionInlinePrice, 0, len(territories))
+	for _, territory := range territories {
+		matrix = append(matrix, asc.SubscriptionInlinePrice{
+			TerritoryID:  territory,
+			PricePointID: byTerritory[territory],
+			Attributes:   attrs,
+		})
+	}
+	return matrix, nil
 }
 
 func subscriptionSetupHasPricedTerritory(states []subscriptionPriceImportState, territory string) bool {
@@ -1550,11 +1559,11 @@ func findExistingSubscriptionSetupLocalization(ctx context.Context, client *asc.
 	return foundLocalization, strings.TrimSpace(foundLocalization.ID) != "", nil
 }
 
-func findExistingSubscriptionSetupPrice(ctx context.Context, client *asc.Client, subID, pricePointID, territoryID string, attrs asc.SubscriptionPriceCreateAttributes) (asc.Resource[asc.SubscriptionPriceAttributes], bool, bool, error) {
+func findExistingSubscriptionSetupPrice(ctx context.Context, client *asc.Client, subID, pricePointID, territoryID string, attrs asc.SubscriptionPriceCreateAttributes) (bool, bool, error) {
 	pricePointID = strings.TrimSpace(pricePointID)
 	territoryID = strings.ToUpper(strings.TrimSpace(territoryID))
 	if pricePointID == "" {
-		return asc.Resource[asc.SubscriptionPriceAttributes]{}, false, false, nil
+		return false, false, nil
 	}
 
 	opts := []asc.SubscriptionPricesOption{
@@ -1563,10 +1572,10 @@ func findExistingSubscriptionSetupPrice(ctx context.Context, client *asc.Client,
 	}
 	firstPage, err := client.GetSubscriptionPrices(ctx, subID, opts...)
 	if err != nil {
-		return asc.Resource[asc.SubscriptionPriceAttributes]{}, false, false, err
+		return false, false, err
 	}
 	if firstPage == nil {
-		return asc.Resource[asc.SubscriptionPriceAttributes]{}, false, false, nil
+		return false, false, nil
 	}
 
 	var foundPrice asc.Resource[asc.SubscriptionPriceAttributes]
@@ -1592,9 +1601,9 @@ func findExistingSubscriptionSetupPrice(ctx context.Context, client *asc.Client,
 			return nil
 		},
 	); err != nil && !errors.Is(err, errSubscriptionsSetupExistingResourceFound) {
-		return asc.Resource[asc.SubscriptionPriceAttributes]{}, false, false, err
+		return false, false, err
 	}
-	return foundPrice, strings.TrimSpace(foundPrice.ID) != "", hasExistingPrices, nil
+	return strings.TrimSpace(foundPrice.ID) != "", hasExistingPrices, nil
 }
 
 func mismatchedExistingSubscriptionSetupPriceError(subscriptionID string) error {

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -18,6 +18,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
+var subscriptionsSetupClientFactory = shared.GetASCClient
+
 var errSubscriptionsSetupExistingResourceFound = errors.New("existing subscription setup resource found")
 
 const (
@@ -384,7 +386,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		Steps:              make([]subscriptionsSetupStepResult, 0, 7),
 	}
 
-	client, err := shared.GetASCClient()
+	client, err := subscriptionsSetupClientFactory()
 	if err != nil {
 		result.Status = "error"
 		result.Error = err.Error()

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -13,24 +14,31 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/ascterritory"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	validatecmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/validate"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 var errSubscriptionsSetupExistingResourceFound = errors.New("existing subscription setup resource found")
 
 const (
-	subscriptionsSetupStepEnsureGroup        = "ensure_group"
-	subscriptionsSetupStepCreateSubscription = "create_subscription"
-	subscriptionsSetupStepCreateLocalization = "create_localization"
-	subscriptionsSetupStepResolvePricePoint  = "resolve_price_point"
-	subscriptionsSetupStepSetPrice           = "set_price"
-	subscriptionsSetupStepSetAvailability    = "set_availability"
-	subscriptionsSetupStepVerifyState        = "verify_state"
+	subscriptionsSetupStepEnsureGroup             = "ensure_group"
+	subscriptionsSetupStepCreateGroupLocalization = "create_group_localization"
+	subscriptionsSetupStepCreateSubscription      = "create_subscription"
+	subscriptionsSetupStepCreateLocalization      = "create_localization"
+	subscriptionsSetupStepUploadReviewScreenshot  = "upload_review_screenshot"
+	subscriptionsSetupStepResolvePricePoint       = "resolve_price_point"
+	subscriptionsSetupStepSetPrice                = "set_price"
+	subscriptionsSetupStepSetAvailability         = "set_availability"
+	subscriptionsSetupStepVerifyState             = "verify_state"
 )
 
 type subscriptionsSetupOptions struct {
 	AppID                     string
 	GroupID                   string
 	GroupReferenceName        string
+	GroupLocale               string
+	GroupDisplayName          string
+	GroupCustomAppName        string
 	ReferenceName             string
 	ProductID                 string
 	SubscriptionPeriod        asc.SubscriptionPeriod
@@ -38,6 +46,7 @@ type subscriptionsSetupOptions struct {
 	Locale                    string
 	DisplayName               string
 	Description               string
+	ReviewScreenshot          string
 	PriceTerritory            string
 	PricePointID              string
 	Tier                      int
@@ -48,6 +57,7 @@ type subscriptionsSetupOptions struct {
 	AvailableInNewTerritories bool
 	EnableMonthlyCommitment   bool
 	NoVerify                  bool
+	Repair                    bool
 }
 
 func (o subscriptionsSetupOptions) hasPricing(startDateInput string) bool {
@@ -63,6 +73,10 @@ func (o subscriptionsSetupOptions) hasLocalization() bool {
 	return o.Locale != "" || o.DisplayName != "" || o.Description != ""
 }
 
+func (o subscriptionsSetupOptions) hasGroupLocalization() bool {
+	return o.GroupLocale != "" || o.GroupDisplayName != "" || o.GroupCustomAppName != ""
+}
+
 func (o subscriptionsSetupOptions) hasAvailability() bool {
 	return len(o.Territories) > 0 || o.AvailableInNewTerritories
 }
@@ -75,37 +89,47 @@ type subscriptionsSetupStepResult struct {
 }
 
 type subscriptionsSetupResult struct {
-	Status               string                          `json:"status"`
-	Error                string                          `json:"error,omitempty"`
-	AppID                string                          `json:"appId,omitempty"`
-	GroupID              string                          `json:"groupId,omitempty"`
-	GroupReferenceName   string                          `json:"groupReferenceName,omitempty"`
-	SubscriptionID       string                          `json:"subscriptionId,omitempty"`
-	ReferenceName        string                          `json:"referenceName,omitempty"`
-	ProductID            string                          `json:"productId,omitempty"`
-	SubscriptionPeriod   string                          `json:"subscriptionPeriod,omitempty"`
-	Locale               string                          `json:"locale,omitempty"`
-	PriceTerritory       string                          `json:"priceTerritory,omitempty"`
-	LocalizationID       string                          `json:"localizationId,omitempty"`
-	AvailabilityID       string                          `json:"availabilityId,omitempty"`
-	ResolvedPricePointID string                          `json:"resolvedPricePointId,omitempty"`
-	Verification         *subscriptionsSetupVerification `json:"verification,omitempty"`
-	FailedStep           string                          `json:"failedStep,omitempty"`
-	Steps                []subscriptionsSetupStepResult  `json:"steps"`
+	Status               string                               `json:"status"`
+	Error                string                               `json:"error,omitempty"`
+	AppID                string                               `json:"appId,omitempty"`
+	GroupID              string                               `json:"groupId,omitempty"`
+	GroupReferenceName   string                               `json:"groupReferenceName,omitempty"`
+	GroupLocalizationID  string                               `json:"groupLocalizationId,omitempty"`
+	SubscriptionID       string                               `json:"subscriptionId,omitempty"`
+	ReferenceName        string                               `json:"referenceName,omitempty"`
+	ProductID            string                               `json:"productId,omitempty"`
+	SubscriptionPeriod   string                               `json:"subscriptionPeriod,omitempty"`
+	Locale               string                               `json:"locale,omitempty"`
+	PriceTerritory       string                               `json:"priceTerritory,omitempty"`
+	LocalizationID       string                               `json:"localizationId,omitempty"`
+	ReviewScreenshotID   string                               `json:"reviewScreenshotId,omitempty"`
+	AvailabilityID       string                               `json:"availabilityId,omitempty"`
+	ResolvedPricePointID string                               `json:"resolvedPricePointId,omitempty"`
+	Verification         *subscriptionsSetupVerification      `json:"verification,omitempty"`
+	Diagnostics          []validation.SubscriptionDiagnostics `json:"diagnostics,omitempty"`
+	FailedStep           string                               `json:"failedStep,omitempty"`
+	Steps                []subscriptionsSetupStepResult       `json:"steps"`
 }
 
 type subscriptionsSetupVerification struct {
-	Status               string    `json:"status"`
-	GroupExists          *bool     `json:"groupExists,omitempty"`
-	SubscriptionExists   bool      `json:"subscriptionExists,omitempty"`
-	LocalizationExists   *bool     `json:"localizationExists,omitempty"`
-	PriceVerified        *bool     `json:"priceVerified,omitempty"`
-	AvailabilityVerified *bool     `json:"availabilityVerified,omitempty"`
-	PriceTerritory       string    `json:"priceTerritory,omitempty"`
-	CurrentPrice         *subMoney `json:"currentPrice,omitempty"`
-	ScheduledPrice       *subMoney `json:"scheduledPrice,omitempty"`
-	ScheduledStartDate   string    `json:"scheduledStartDate,omitempty"`
-	Territories          []string  `json:"territories,omitempty"`
+	Status                   string    `json:"status"`
+	SubscriptionState        string    `json:"subscriptionState,omitempty"`
+	GroupExists              *bool     `json:"groupExists,omitempty"`
+	SubscriptionExists       bool      `json:"subscriptionExists,omitempty"`
+	LocalizationExists       *bool     `json:"localizationExists,omitempty"`
+	GroupLocalizationExists  *bool     `json:"groupLocalizationExists,omitempty"`
+	ReviewScreenshotVerified *bool     `json:"reviewScreenshotVerified,omitempty"`
+	ReviewScreenshotState    string    `json:"reviewScreenshotState,omitempty"`
+	PriceVerified            *bool     `json:"priceVerified,omitempty"`
+	AvailabilityVerified     *bool     `json:"availabilityVerified,omitempty"`
+	PriceTerritory           string    `json:"priceTerritory,omitempty"`
+	CurrentPrice             *subMoney `json:"currentPrice,omitempty"`
+	ScheduledPrice           *subMoney `json:"scheduledPrice,omitempty"`
+	ScheduledStartDate       string    `json:"scheduledStartDate,omitempty"`
+	Territories              []string  `json:"territories,omitempty"`
+	PriceCoverageVerified    *bool     `json:"priceCoverageVerified,omitempty"`
+	PricedTerritories        []string  `json:"pricedTerritories,omitempty"`
+	MissingPriceTerritories  []string  `json:"missingPriceTerritories,omitempty"`
 }
 
 // SubscriptionsSetupCommand returns the high-level subscriptions bootstrap workflow command.
@@ -116,6 +140,9 @@ func SubscriptionsSetupCommand() *ffcli.Command {
 	groupID := fs.String("group-id", "", "Existing subscription group ID")
 	groupReferenceName := fs.String("group-reference-name", "", "Reference name for a new subscription group")
 	groupRefNameAlias := fs.String("group-ref-name", "", "Reference name alias for a new subscription group")
+	groupLocale := fs.String("group-locale", "", "Locale for the subscription group localization (e.g., en-US)")
+	groupDisplayName := fs.String("group-display-name", "", "Localized display name for the subscription group")
+	groupCustomAppName := fs.String("group-custom-app-name", "", "Optional custom app name for the subscription group localization")
 
 	referenceName := fs.String("reference-name", "", "Subscription reference name")
 	refNameAlias := fs.String("ref-name", "", "Subscription reference name alias")
@@ -127,6 +154,7 @@ func SubscriptionsSetupCommand() *ffcli.Command {
 	displayName := fs.String("display-name", "", "Display name for the first subscription localization")
 	nameAlias := fs.String("name", "", "Display name alias")
 	description := fs.String("description", "", "Description for the first subscription localization")
+	reviewScreenshot := fs.String("review-screenshot", "", "Path to the App Review screenshot for the subscription")
 
 	priceTerritory := fs.String("price-territory", "", "Territory used to resolve and verify the initial subscription price (accepts alpha-2, alpha-3, or exact English country name)")
 	pricePointID := fs.String("price-point-id", "", "Explicit price point ID for the initial subscription price")
@@ -139,6 +167,7 @@ func SubscriptionsSetupCommand() *ffcli.Command {
 	availableInNewTerritories := fs.Bool("available-in-new-territories", false, "Include new territories automatically when creating availability")
 	enableMonthlyCommitment := fs.Bool("enable-monthly-commitment", false, "Also configure Monthly with 12-Month Commitment availability for ONE_YEAR subscriptions")
 	noVerify := fs.Bool("no-verify", false, "Skip post-create readback verification for faster execution")
+	repair := fs.Bool("repair", false, "Re-send matching price writes to trigger App Store Connect metadata recalculation")
 	output := shared.BindOutputFlags(fs)
 
 	shared.HideFlagFromHelp(fs.Lookup("group-ref-name"))
@@ -148,22 +177,28 @@ func SubscriptionsSetupCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "setup",
 		ShortUsage: "asc subscriptions setup [flags]",
-		ShortHelp:  "Create a subscription with optional group, localization, pricing, and availability.",
-		LongHelp: `Create a new subscription and optionally bootstrap its group,
-first localization, initial pricing, and availability in one workflow.
+		ShortHelp:  "Create or reconcile a subscription with complete App Store metadata.",
+		LongHelp: `Create or reconcile a subscription and its required App Store metadata,
+including group localization, subscription localization, review screenshot,
+pricing, and availability.
 
 The setup command is create-oriented: use it when you want a one-shot happy
 path for a new subscription. Existing low-level commands remain available
 for partial updates, repair flows, and advanced cases.
 
-By default, setup reads the created state back from App Store Connect and
-verifies the resulting group, subscription, localization, pricing, and
-availability. Use --no-verify to skip that postcondition check when speed
-matters more than confirmed final state.
+When pricing and availability cover multiple territories, setup uses Apple's
+price-point equalizations to create a price in every enabled territory.
+
+By default, setup reads Apple's final subscription state back and verifies the
+resulting metadata, screenshot delivery, pricing, and availability. A final
+MISSING_METADATA state fails the command and includes deep diagnostics when
+--app is available. Use --repair to replay same-value price writes when Apple
+needs a metadata recalculation. Use --no-verify only when intentionally
+skipping these postcondition checks.
 
 Examples:
   asc subscriptions setup --app "APP_ID" --group-reference-name "Pro" --reference-name "Pro Monthly" --product-id "com.example.pro.monthly" --subscription-period ONE_MONTH
-  asc subscriptions setup --app "APP_ID" --group-reference-name "Pro" --reference-name "Pro Monthly" --product-id "com.example.pro.monthly" --subscription-period ONE_MONTH --locale "en-US" --display-name "Pro Monthly" --description "Unlock everything"
+  asc subscriptions setup --app "APP_ID" --group-reference-name "Pro" --group-locale "en-US" --group-display-name "Premium" --reference-name "Pro Monthly" --product-id "com.example.pro.monthly" --subscription-period ONE_MONTH --locale "en-US" --display-name "Pro Monthly" --description "Unlock everything" --review-screenshot "./review.png"
   asc subscriptions setup --app "APP_ID" --group-reference-name "Pro" --reference-name "Pro Monthly" --product-id "com.example.pro.monthly" --price "3.99" --price-territory "United States" --territories "US,Canada"
   asc subscriptions setup --app "APP_ID" --group-reference-name "Pro" --reference-name "Pro Yearly" --product-id "com.example.pro.yearly" --subscription-period ONE_YEAR --enable-monthly-commitment
   asc subscriptions setup --group-id "GROUP_ID" --reference-name "Pro Monthly" --product-id "com.example.pro.monthly" --subscription-period ONE_MONTH --no-verify`,
@@ -203,12 +238,16 @@ Examples:
 				AppID:                     shared.ResolveAppID(*appID),
 				GroupID:                   strings.TrimSpace(*groupID),
 				GroupReferenceName:        groupReferenceNameValue,
+				GroupLocale:               strings.TrimSpace(*groupLocale),
+				GroupDisplayName:          strings.TrimSpace(*groupDisplayName),
+				GroupCustomAppName:        strings.TrimSpace(*groupCustomAppName),
 				ReferenceName:             referenceNameValue,
 				ProductID:                 strings.TrimSpace(*productID),
 				FamilySharable:            *familySharable,
 				Locale:                    strings.TrimSpace(*locale),
 				DisplayName:               displayNameValue,
 				Description:               strings.TrimSpace(*description),
+				ReviewScreenshot:          strings.TrimSpace(*reviewScreenshot),
 				PriceTerritory:            priceTerritoryValue,
 				PricePointID:              strings.TrimSpace(*pricePointID),
 				Tier:                      *tier,
@@ -218,6 +257,7 @@ Examples:
 				EnableMonthlyCommitment:   *enableMonthlyCommitment,
 				RefreshTierCache:          *refresh,
 				NoVerify:                  *noVerify,
+				Repair:                    *repair,
 			}
 
 			if opts.GroupID == "" && opts.GroupReferenceName == "" {
@@ -255,6 +295,24 @@ Examples:
 				if opts.DisplayName == "" {
 					return shared.UsageError("--display-name is required when localization flags are provided")
 				}
+			}
+			if opts.hasGroupLocalization() {
+				if opts.GroupLocale == "" {
+					return shared.UsageError("--group-locale is required when group localization flags are provided")
+				}
+				if opts.GroupDisplayName == "" {
+					return shared.UsageError("--group-display-name is required when group localization flags are provided")
+				}
+			}
+			if opts.Repair && !opts.hasPricing(*startDate) {
+				return shared.UsageError("--repair requires pricing flags")
+			}
+			if opts.ReviewScreenshot != "" {
+				file, _, err := openSubscriptionImageFile(opts.ReviewScreenshot)
+				if err != nil {
+					return shared.UsageError(fmt.Sprintf("invalid --review-screenshot: %v", err))
+				}
+				_ = file.Close()
 			}
 
 			if err := shared.ValidateFinitePriceFlag("--price", opts.Price); err != nil {
@@ -395,6 +453,53 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 			ID:      result.GroupID,
 			Message: "used existing group",
 		})
+	}
+
+	if !opts.hasGroupLocalization() {
+		result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+			Name:    subscriptionsSetupStepCreateGroupLocalization,
+			Status:  "skipped",
+			Message: "no group localization flags provided",
+		})
+	} else {
+		groupLocCtx, groupLocCancel := shared.ContextWithTimeout(ctx)
+		groupLocalization, found, err := findExistingSubscriptionSetupGroupLocalization(groupLocCtx, client, result.GroupID, opts.GroupLocale)
+		groupLocCancel()
+		if err != nil {
+			return failSubscriptionsSetupStep(result, subscriptionsSetupStepCreateGroupLocalization, err, "failed to inspect group localization")
+		}
+		if found {
+			if err := validateExistingSubscriptionSetupGroupLocalization(groupLocalization, opts); err != nil {
+				return failSubscriptionsSetupStep(result, subscriptionsSetupStepCreateGroupLocalization, err, "group localization does not match")
+			}
+			result.GroupLocalizationID = strings.TrimSpace(groupLocalization.ID)
+			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+				Name:    subscriptionsSetupStepCreateGroupLocalization,
+				Status:  "completed",
+				ID:      result.GroupLocalizationID,
+				Message: "used existing group localization",
+			})
+		} else {
+			attrs := asc.SubscriptionGroupLocalizationCreateAttributes{
+				Locale: opts.GroupLocale,
+				Name:   opts.GroupDisplayName,
+			}
+			if opts.GroupCustomAppName != "" {
+				attrs.CustomAppName = opts.GroupCustomAppName
+			}
+			groupLocCtx, groupLocCancel := shared.ContextWithTimeout(ctx)
+			groupLocalizationResp, err := client.CreateSubscriptionGroupLocalization(groupLocCtx, result.GroupID, attrs)
+			groupLocCancel()
+			if err != nil {
+				return failSubscriptionsSetupStep(result, subscriptionsSetupStepCreateGroupLocalization, err, "failed to create group localization")
+			}
+			result.GroupLocalizationID = strings.TrimSpace(groupLocalizationResp.Data.ID)
+			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+				Name:   subscriptionsSetupStepCreateGroupLocalization,
+				Status: "completed",
+				ID:     result.GroupLocalizationID,
+			})
+		}
 	}
 
 	subAttrs := asc.SubscriptionCreateAttributes{
@@ -635,6 +740,34 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		}
 	}
 
+	if opts.ReviewScreenshot == "" {
+		result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+			Name:    subscriptionsSetupStepUploadReviewScreenshot,
+			Status:  "skipped",
+			Message: "no review screenshot provided",
+		})
+	} else {
+		file, info, err := openSubscriptionImageFile(opts.ReviewScreenshot)
+		if err != nil {
+			return failSubscriptionsSetupStep(result, subscriptionsSetupStepUploadReviewScreenshot, err, "invalid review screenshot")
+		}
+		_ = file.Close()
+		checksum, err := asc.ComputeFileChecksum(opts.ReviewScreenshot, asc.ChecksumAlgorithmMD5)
+		if err != nil {
+			return failSubscriptionsSetupStep(result, subscriptionsSetupStepUploadReviewScreenshot, err, "review screenshot checksum failed")
+		}
+		screenshotResp, err := createOrResumeSubscriptionReviewScreenshot(ctx, client, result.SubscriptionID, opts.ReviewScreenshot, info, checksum.Hash)
+		if err != nil {
+			return failSubscriptionsSetupStep(result, subscriptionsSetupStepUploadReviewScreenshot, err, "failed to upload review screenshot")
+		}
+		result.ReviewScreenshotID = strings.TrimSpace(screenshotResp.Data.ID)
+		result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+			Name:   subscriptionsSetupStepUploadReviewScreenshot,
+			Status: "completed",
+			ID:     result.ReviewScreenshotID,
+		})
+	}
+
 	if !opts.hasPricing(opts.StartDate) {
 		result.Steps = append(
 			result.Steps,
@@ -704,7 +837,22 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 				}
 			}
 		}
-		if found {
+		if found && opts.Repair {
+			repairAttrs := priceAttrs
+			repairAttrs.PlanType = ""
+			priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
+			priceResp, writeErr := client.CreateSubscriptionPrice(priceCtx, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, repairAttrs)
+			priceCancel()
+			if writeErr != nil {
+				return failSubscriptionsSetupStep(result, subscriptionsSetupStepSetPrice, writeErr, "failed to re-save existing price for repair")
+			}
+			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+				Name:    subscriptionsSetupStepSetPrice,
+				Status:  "completed",
+				ID:      strings.TrimSpace(priceResp.Data.ID),
+				Message: "re-saved existing price for repair",
+			})
+		} else if found {
 			result.Steps = append(result.Steps, subscriptionsSetupStepResult{
 				Name:    subscriptionsSetupStepSetPrice,
 				Status:  "completed",
@@ -742,6 +890,10 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 				Status: "completed",
 				ID:     result.SubscriptionID,
 			})
+		}
+
+		if err := ensureSubscriptionsSetupPriceCoverage(ctx, client, result.SubscriptionID, result.ResolvedPricePointID, opts.PriceTerritory, availabilityTerritories, priceAttrs, opts.Repair); err != nil {
+			return failSubscriptionsSetupStep(result, subscriptionsSetupStepSetPrice, err, "failed to set price coverage")
 		}
 	}
 
@@ -834,12 +986,20 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 		return result, nil
 	}
 
-	verification, verifyStep, err := verifySubscriptionsSetupState(ctx, client, result, opts, availabilityTerritories)
+	verification, verifyStep, err := verifySubscriptionsSetupState(ctx, client, result, opts, availabilityTerritories, reusedSubscription)
 	if err != nil {
 		result.Status = "error"
 		result.Error = err.Error()
 		result.FailedStep = subscriptionsSetupStepVerifyState
 		result.Verification = verification
+		if verification != nil && strings.EqualFold(strings.TrimSpace(verification.SubscriptionState), "MISSING_METADATA") && opts.AppID != "" {
+			diagnostics, diagnosticsErr := subscriptionsSetupDiagnostics(ctx, opts.AppID, result.SubscriptionID)
+			if diagnosticsErr != nil {
+				verifyStep.Message = fmt.Sprintf("%s; deep diagnostics unavailable: %v", verifyStep.Message, diagnosticsErr)
+			} else {
+				result.Diagnostics = diagnostics
+			}
+		}
 		result.Steps = append(result.Steps, verifyStep)
 		return result, fmt.Errorf("subscriptions setup: verify state: %w", err)
 	}
@@ -849,7 +1009,7 @@ func executeSubscriptionsSetup(ctx context.Context, opts subscriptionsSetupOptio
 	return result, nil
 }
 
-func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, result subscriptionsSetupResult, opts subscriptionsSetupOptions, availabilityTerritories []string) (*subscriptionsSetupVerification, subscriptionsSetupStepResult, error) {
+func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, result subscriptionsSetupResult, opts subscriptionsSetupOptions, availabilityTerritories []string, reusedSubscription bool) (*subscriptionsSetupVerification, subscriptionsSetupStepResult, error) {
 	verification := &subscriptionsSetupVerification{Status: "verified"}
 
 	groupCtx, groupCancel := shared.ContextWithTimeout(ctx)
@@ -865,6 +1025,21 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		verification.Status = "failed"
 		return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: fmt.Sprintf("group reference mismatch: got %q", groupResp.Data.Attributes.ReferenceName)}, fmt.Errorf("group reference mismatch: got %q want %q", groupResp.Data.Attributes.ReferenceName, opts.GroupReferenceName)
 	}
+	if opts.hasGroupLocalization() {
+		groupLocCtx, groupLocCancel := shared.ContextWithTimeout(ctx)
+		groupLocalization, found, err := findExistingSubscriptionSetupGroupLocalization(groupLocCtx, client, result.GroupID, opts.GroupLocale)
+		groupLocCancel()
+		if err != nil {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch created group localization: %w", err)
+		}
+		if !found || strings.TrimSpace(groupLocalization.ID) != result.GroupLocalizationID {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "created group localization was not found"}, fmt.Errorf("created group localization was not found")
+		}
+		value := true
+		verification.GroupLocalizationExists = &value
+	}
 
 	subCtx, subCancel := shared.ContextWithTimeout(ctx)
 	subResp, err := client.GetSubscription(subCtx, result.SubscriptionID)
@@ -877,6 +1052,7 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		verification.Status = "failed"
 		return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "created subscription readback returned empty id"}, fmt.Errorf("created subscription readback returned empty id")
 	}
+	verification.SubscriptionState = strings.TrimSpace(subResp.Data.Attributes.State)
 	if subResp.Data.Attributes.Name != opts.ReferenceName {
 		verification.Status = "failed"
 		return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: fmt.Sprintf("reference name mismatch: got %q", subResp.Data.Attributes.Name)}, fmt.Errorf("reference name mismatch: got %q want %q", subResp.Data.Attributes.Name, opts.ReferenceName)
@@ -921,6 +1097,35 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		verification.LocalizationExists = &value
 	}
 
+	if opts.ReviewScreenshot != "" {
+		screenshotCtx, screenshotCancel := shared.ContextWithTimeout(ctx)
+		screenshotResp, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(
+			screenshotCtx,
+			result.SubscriptionID,
+			asc.WithSubscriptionAppStoreReviewScreenshotFields(subscriptionReviewScreenshotFields),
+		)
+		screenshotCancel()
+		if err != nil {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch review screenshot: %w", err)
+		}
+		if strings.TrimSpace(screenshotResp.Data.ID) == "" || strings.TrimSpace(screenshotResp.Data.ID) != result.ReviewScreenshotID {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "review screenshot readback did not match uploaded screenshot"}, fmt.Errorf("review screenshot readback did not match uploaded screenshot")
+		}
+		verification.ReviewScreenshotState = subscriptionReviewScreenshotDeliveryState(screenshotResp)
+		if verification.ReviewScreenshotState != "COMPLETE" {
+			verification.Status = "failed"
+			message := fmt.Sprintf("review screenshot delivery is %q, expected COMPLETE", verification.ReviewScreenshotState)
+			if verification.ReviewScreenshotState == "FAILED" {
+				message = subscriptionReviewScreenshotDeliveryError(screenshotResp).Error()
+			}
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: message}, fmt.Errorf("%s", message)
+		}
+		value := true
+		verification.ReviewScreenshotVerified = &value
+	}
+
 	if opts.hasPricing(opts.StartDate) {
 		pricePointCtx, pricePointCancel := shared.ContextWithTimeout(ctx)
 		expectedPrice, err := resolveExpectedSubscriptionSetupVerificationPrice(pricePointCtx, client, result.SubscriptionID, opts)
@@ -951,42 +1156,269 @@ func verifySubscriptionsSetupState(ctx context.Context, client *asc.Client, resu
 		verification.PriceVerified = &value
 	}
 
-	if len(availabilityTerritories) > 0 {
+	if len(availabilityTerritories) > 0 || reusedSubscription {
 		availabilityCtx, availabilityCancel := shared.ContextWithTimeout(ctx)
 		availabilityResp, err := client.GetSubscriptionAvailabilityForSubscription(availabilityCtx, result.SubscriptionID)
 		availabilityCancel()
 		if err != nil {
-			verification.Status = "failed"
-			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch created availability: %w", err)
-		}
-		resultID := strings.TrimSpace(availabilityResp.Data.ID)
-		if resultID == "" {
-			verification.Status = "failed"
-			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "created availability readback returned empty id"}, fmt.Errorf("created availability readback returned empty id")
-		}
-		if availabilityResp.Data.Attributes.AvailableInNewTerritories != opts.AvailableInNewTerritories {
-			verification.Status = "failed"
-			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "available-in-new-territories mismatch"}, fmt.Errorf("available-in-new-territories mismatch")
-		}
-		territoriesCtx, territoriesCancel := shared.ContextWithTimeout(ctx)
-		actualSet, actualTerritories, err := fetchSubscriptionSetupAvailabilityTerritories(territoriesCtx, client, resultID)
-		territoriesCancel()
-		if err != nil {
-			verification.Status = "failed"
-			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch availability territories: %w", err)
-		}
-		for _, expected := range availabilityTerritories {
-			if _, ok := actualSet[expected]; !ok {
+			if asc.IsNotFound(err) && len(availabilityTerritories) == 0 {
+				availabilityResp = nil
+			} else {
 				verification.Status = "failed"
-				return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: fmt.Sprintf("missing availability territory %q", expected)}, fmt.Errorf("missing availability territory %q", expected)
+				return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch created availability: %w", err)
 			}
 		}
-		value := true
-		verification.AvailabilityVerified = &value
-		verification.Territories = actualTerritories
+		if availabilityResp != nil {
+			resultID := strings.TrimSpace(availabilityResp.Data.ID)
+			if resultID == "" {
+				verification.Status = "failed"
+				return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "created availability readback returned empty id"}, fmt.Errorf("created availability readback returned empty id")
+			}
+			if len(availabilityTerritories) > 0 && availabilityResp.Data.Attributes.AvailableInNewTerritories != opts.AvailableInNewTerritories {
+				verification.Status = "failed"
+				return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: "available-in-new-territories mismatch"}, fmt.Errorf("available-in-new-territories mismatch")
+			}
+			territoriesCtx, territoriesCancel := shared.ContextWithTimeout(ctx)
+			actualSet, actualTerritories, err := fetchSubscriptionSetupAvailabilityTerritories(territoriesCtx, client, resultID)
+			territoriesCancel()
+			if err != nil {
+				verification.Status = "failed"
+				return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch availability territories: %w", err)
+			}
+			for _, expected := range availabilityTerritories {
+				if _, ok := actualSet[expected]; !ok {
+					verification.Status = "failed"
+					return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: fmt.Sprintf("missing availability territory %q", expected)}, fmt.Errorf("missing availability territory %q", expected)
+				}
+			}
+			value := true
+			verification.AvailabilityVerified = &value
+			sort.Strings(actualTerritories)
+			verification.Territories = actualTerritories
+		}
+	}
+
+	if len(verification.Territories) > 0 {
+		priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
+		priceState, err := fetchSubscriptionPriceImportState(priceCtx, client, result.SubscriptionID)
+		priceCancel()
+		if err != nil {
+			verification.Status = "failed"
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: err.Error()}, fmt.Errorf("fetch subscription price coverage: %w", err)
+		}
+		verification.PricedTerritories, verification.MissingPriceTerritories = subscriptionSetupPriceCoverage(priceState.states, verification.Territories)
+		covered := len(verification.MissingPriceTerritories) == 0
+		verification.PriceCoverageVerified = &covered
+		if !covered {
+			verification.Status = "failed"
+			message := fmt.Sprintf("missing price coverage for availability territories: %s", strings.Join(verification.MissingPriceTerritories, ","))
+			return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: message}, fmt.Errorf("%s", message)
+		}
+	}
+
+	if !subscriptionSetupStateIsComplete(verification.SubscriptionState) {
+		verification.Status = "failed"
+		state := strings.ToUpper(strings.TrimSpace(verification.SubscriptionState))
+		if state == "" {
+			state = "UNKNOWN"
+		}
+		message := fmt.Sprintf("Apple reports subscription state %s after setup", state)
+		return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "failed", Message: message}, fmt.Errorf("apple reports subscription state %s after setup", state)
 	}
 
 	return verification, subscriptionsSetupStepResult{Name: subscriptionsSetupStepVerifyState, Status: "completed"}, nil
+}
+
+func subscriptionSetupStateIsComplete(state string) bool {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "APPROVED":
+		return true
+	default:
+		return false
+	}
+}
+
+func subscriptionSetupPriceCoverage(states []subscriptionPriceImportState, availabilityTerritories []string) ([]string, []string) {
+	pricedSet := make(map[string]struct{})
+	for _, state := range states {
+		territory := strings.ToUpper(strings.TrimSpace(state.territoryID))
+		if territory != "" {
+			pricedSet[territory] = struct{}{}
+		}
+	}
+	priced := make([]string, 0, len(pricedSet))
+	for territory := range pricedSet {
+		priced = append(priced, territory)
+	}
+	sort.Strings(priced)
+	missing := make([]string, 0)
+	for _, rawTerritory := range availabilityTerritories {
+		territory := strings.ToUpper(strings.TrimSpace(rawTerritory))
+		if _, ok := pricedSet[territory]; !ok {
+			missing = append(missing, territory)
+		}
+	}
+	sort.Strings(missing)
+	return priced, missing
+}
+
+func subscriptionsSetupDiagnostics(ctx context.Context, appID, subscriptionID string) ([]validation.SubscriptionDiagnostics, error) {
+	report, err := validatecmd.BuildSubscriptionsReport(ctx, validatecmd.SubscriptionsOptions{AppID: appID})
+	if err != nil {
+		return nil, err
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if strings.TrimSpace(diagnostic.SubscriptionID) == strings.TrimSpace(subscriptionID) {
+			return []validation.SubscriptionDiagnostics{diagnostic}, nil
+		}
+	}
+	return nil, fmt.Errorf("deep diagnostics did not include subscription %q; App Store Connect may still be propagating the new resource", subscriptionID)
+}
+
+func failSubscriptionsSetupStep(result subscriptionsSetupResult, step string, err error, message string) (subscriptionsSetupResult, error) {
+	result.Status = "error"
+	result.Error = err.Error()
+	result.FailedStep = step
+	result.Steps = append(result.Steps, subscriptionsSetupStepResult{
+		Name:    step,
+		Status:  "failed",
+		Message: err.Error(),
+	})
+	return result, fmt.Errorf("subscriptions setup: %s: %w", message, err)
+}
+
+func findExistingSubscriptionSetupGroupLocalization(ctx context.Context, client *asc.Client, groupID, locale string) (asc.Resource[asc.SubscriptionGroupLocalizationAttributes], bool, error) {
+	locale = strings.TrimSpace(locale)
+	if locale == "" {
+		return asc.Resource[asc.SubscriptionGroupLocalizationAttributes]{}, false, nil
+	}
+	firstPage, err := client.GetSubscriptionGroupLocalizations(ctx, groupID, asc.WithSubscriptionGroupLocalizationsLimit(200))
+	if err != nil {
+		return asc.Resource[asc.SubscriptionGroupLocalizationAttributes]{}, false, err
+	}
+	var found asc.Resource[asc.SubscriptionGroupLocalizationAttributes]
+	if err := asc.PaginateEach(
+		ctx,
+		firstPage,
+		func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionGroupLocalizations(ctx, groupID, asc.WithSubscriptionGroupLocalizationsNextURL(nextURL))
+		},
+		func(page asc.PaginatedResponse) error {
+			resp, ok := page.(*asc.SubscriptionGroupLocalizationsResponse)
+			if !ok {
+				return fmt.Errorf("unexpected subscription group localizations pagination type %T", page)
+			}
+			for _, localization := range resp.Data {
+				if strings.TrimSpace(localization.Attributes.Locale) == locale {
+					found = localization
+					return errSubscriptionsSetupExistingResourceFound
+				}
+			}
+			return nil
+		},
+	); err != nil && !errors.Is(err, errSubscriptionsSetupExistingResourceFound) {
+		return asc.Resource[asc.SubscriptionGroupLocalizationAttributes]{}, false, err
+	}
+	return found, strings.TrimSpace(found.ID) != "", nil
+}
+
+func validateExistingSubscriptionSetupGroupLocalization(localization asc.Resource[asc.SubscriptionGroupLocalizationAttributes], opts subscriptionsSetupOptions) error {
+	if strings.TrimSpace(localization.Attributes.Name) != opts.GroupDisplayName {
+		return fmt.Errorf("existing group localization %q has a different name", localization.ID)
+	}
+	if opts.GroupCustomAppName != "" && strings.TrimSpace(localization.Attributes.CustomAppName) != opts.GroupCustomAppName {
+		return fmt.Errorf("existing group localization %q has a different custom app name", localization.ID)
+	}
+	return nil
+}
+
+func ensureSubscriptionsSetupPriceCoverage(ctx context.Context, client *asc.Client, subscriptionID, basePricePointID, baseTerritory string, territories []string, attrs asc.SubscriptionPriceCreateAttributes, repair bool) error {
+	if len(territories) == 0 {
+		return nil
+	}
+	baseTerritory = strings.ToUpper(strings.TrimSpace(baseTerritory))
+	needsEqualization := false
+	for _, territory := range territories {
+		if strings.ToUpper(strings.TrimSpace(territory)) != baseTerritory {
+			needsEqualization = true
+			break
+		}
+	}
+	if !needsEqualization {
+		return nil
+	}
+	equalizations, err := fetchEqualizations(ctx, client, basePricePointID, baseTerritory)
+	if err != nil {
+		return err
+	}
+	targetsByTerritory := map[string]equalization{
+		baseTerritory: {
+			Territory:    baseTerritory,
+			PricePointID: strings.TrimSpace(basePricePointID),
+		},
+	}
+	for _, target := range equalizations {
+		targetsByTerritory[strings.ToUpper(strings.TrimSpace(target.Territory))] = target
+	}
+
+	state, err := fetchSubscriptionPriceImportState(ctx, client, subscriptionID)
+	if err != nil {
+		return err
+	}
+	for _, rawTerritory := range territories {
+		territory := strings.ToUpper(strings.TrimSpace(rawTerritory))
+		if territory == baseTerritory {
+			continue
+		}
+		target, ok := targetsByTerritory[territory]
+		if !ok || strings.TrimSpace(target.PricePointID) == "" {
+			return fmt.Errorf("no equalized price point found for availability territory %s", territory)
+		}
+		resolved := subscriptionPriceImportResolvedRow{
+			territoryID:  territory,
+			pricePointID: strings.TrimSpace(target.PricePointID),
+			startDate:    strings.TrimSpace(attrs.StartDate),
+			planType:     attrs.PlanType,
+		}
+		matches := state.matches(resolved)
+		if matches && !repair {
+			continue
+		}
+		if !subscriptionSetupHasPricedTerritory(state.states, territory) {
+			priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
+			_, err := client.SetSubscriptionInitialPrice(priceCtx, subscriptionID, resolved.pricePointID, territory, attrs)
+			priceCancel()
+			if err != nil {
+				return fmt.Errorf("set starting %s price: %w", territory, err)
+			}
+			state.add(resolved)
+			continue
+		}
+		// planType is required on the inline initial-price resource, but sending
+		// UPFRONT on ordinary territory price POSTs causes Apple to reject the
+		// request as invalid pricing information. Apple assigns the plan type to
+		// the created record from the subscription context.
+		createAttrs := attrs
+		createAttrs.PlanType = ""
+		priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
+		_, err := client.CreateSubscriptionPrice(priceCtx, subscriptionID, resolved.pricePointID, territory, createAttrs)
+		priceCancel()
+		if err != nil {
+			return fmt.Errorf("set %s price: %w", territory, err)
+		}
+		state.add(resolved)
+	}
+	return nil
+}
+
+func subscriptionSetupHasPricedTerritory(states []subscriptionPriceImportState, territory string) bool {
+	territory = strings.ToUpper(strings.TrimSpace(territory))
+	for _, state := range states {
+		if strings.ToUpper(strings.TrimSpace(state.territoryID)) == territory {
+			return true
+		}
+	}
+	return false
 }
 
 func findExistingSubscriptionSetupGroup(ctx context.Context, client *asc.Client, appID, referenceName string) (string, bool, error) {
@@ -1372,36 +1804,83 @@ func resolveExpectedSubscriptionSetupVerificationPrice(ctx context.Context, clie
 
 func printSubscriptionsSetupResult(result *subscriptionsSetupResult, format string, pretty bool) error {
 	headers, rows := subscriptionsSetupResultRows(result)
+	diagnosticHeaders, diagnosticRows := subscriptionsSetupDiagnosticRows(result.Diagnostics)
 	return shared.PrintOutputWithRenderers(
 		result,
 		format,
 		pretty,
 		func() error {
 			asc.RenderTable(headers, rows)
+			if len(diagnosticRows) > 0 {
+				asc.RenderTable(diagnosticHeaders, diagnosticRows)
+			}
 			return nil
 		},
 		func() error {
 			asc.RenderMarkdown(headers, rows)
+			if len(diagnosticRows) > 0 {
+				asc.RenderMarkdown(diagnosticHeaders, diagnosticRows)
+			}
 			return nil
 		},
 	)
 }
 
+func subscriptionsSetupDiagnosticRows(diagnostics []validation.SubscriptionDiagnostics) ([]string, [][]string) {
+	headers := []string{"Subscription ID", "Conclusion", "Diagnostic", "Status", "Blocking", "Evidence", "Remediation"}
+	rows := make([][]string, 0)
+	for _, diagnostic := range diagnostics {
+		for _, row := range diagnostic.Rows {
+			rows = append(rows, []string{
+				diagnostic.SubscriptionID,
+				diagnostic.Conclusion,
+				row.Label,
+				string(row.Status),
+				fmt.Sprintf("%t", row.Blocking),
+				row.Evidence,
+				row.Remediation,
+			})
+		}
+	}
+	return headers, rows
+}
+
 func subscriptionsSetupResultRows(result *subscriptionsSetupResult) ([]string, [][]string) {
-	headers := []string{"Status", "Verification", "Group ID", "Subscription ID", "Localization ID", "Availability ID", "Price Point ID", "Current Price", "Failed Step", "Error"}
+	headers := []string{"Status", "Verification", "Apple State", "Group ID", "Group Localization ID", "Subscription ID", "Localization ID", "Review Screenshot ID", "Availability ID", "Price Point ID", "Price Coverage", "Current Price", "Failed Step", "Error"}
 	rows := [][]string{{
 		result.Status,
 		subscriptionsSetupVerificationStatus(result.Verification),
+		subscriptionsSetupVerificationState(result.Verification),
 		result.GroupID,
+		result.GroupLocalizationID,
 		result.SubscriptionID,
 		result.LocalizationID,
+		result.ReviewScreenshotID,
 		result.AvailabilityID,
 		result.ResolvedPricePointID,
+		subscriptionsSetupVerificationPriceCoverage(result.Verification),
 		subscriptionsSetupVerificationCurrentPrice(result.Verification),
 		result.FailedStep,
 		result.Error,
 	}}
 	return headers, rows
+}
+
+func subscriptionsSetupVerificationState(verification *subscriptionsSetupVerification) string {
+	if verification == nil {
+		return ""
+	}
+	return verification.SubscriptionState
+}
+
+func subscriptionsSetupVerificationPriceCoverage(verification *subscriptionsSetupVerification) string {
+	if verification == nil || verification.PriceCoverageVerified == nil {
+		return ""
+	}
+	if *verification.PriceCoverageVerified {
+		return "verified"
+	}
+	return "missing: " + strings.Join(verification.MissingPriceTerritories, ",")
 }
 
 func resolveSubscriptionsSetupAlias(primary, alias, primaryName, aliasName string) (string, error) {

--- a/internal/cli/subscriptions/setup_test.go
+++ b/internal/cli/subscriptions/setup_test.go
@@ -62,6 +62,42 @@ func TestSubscriptionSetupHasPricedTerritory(t *testing.T) {
 	}
 }
 
+func TestBuildSubscriptionSetupPriceMatrixIncludesAllEqualizations(t *testing.T) {
+	attrs := asc.SubscriptionPriceCreateAttributes{PlanType: asc.SubscriptionPlanTypeUpfront}
+	matrix, err := buildSubscriptionSetupPriceMatrix("pp-usa", "USA", attrs, []equalization{
+		{Territory: "FRA", PricePointID: "pp-fra"},
+		{Territory: "CAN", PricePointID: "pp-can"},
+	})
+	if err != nil {
+		t.Fatalf("build matrix: %v", err)
+	}
+	want := []asc.SubscriptionInlinePrice{
+		{TerritoryID: "CAN", PricePointID: "pp-can", Attributes: attrs},
+		{TerritoryID: "FRA", PricePointID: "pp-fra", Attributes: attrs},
+		{TerritoryID: "USA", PricePointID: "pp-usa", Attributes: attrs},
+	}
+	if !reflect.DeepEqual(matrix, want) {
+		t.Fatalf("unexpected matrix:\n got: %#v\nwant: %#v", matrix, want)
+	}
+}
+
+func TestBuildSubscriptionSetupPriceMatrixRejectsMissingOrConflictingEqualization(t *testing.T) {
+	attrs := asc.SubscriptionPriceCreateAttributes{PlanType: asc.SubscriptionPlanTypeUpfront}
+	for name, equalizations := range map[string][]equalization{
+		"missing point": {{Territory: "CAN"}},
+		"conflicting duplicate": {
+			{Territory: "CAN", PricePointID: "pp-can-1"},
+			{Territory: "CAN", PricePointID: "pp-can-2"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := buildSubscriptionSetupPriceMatrix("pp-usa", "USA", attrs, equalizations); err == nil {
+				t.Fatal("expected matrix validation error")
+			}
+		})
+	}
+}
+
 func TestSubscriptionSetupStateIsComplete(t *testing.T) {
 	for _, state := range []string{"READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "APPROVED"} {
 		if !subscriptionSetupStateIsComplete(state) {

--- a/internal/cli/subscriptions/setup_test.go
+++ b/internal/cli/subscriptions/setup_test.go
@@ -2,10 +2,12 @@ package subscriptions
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 func TestSubscriptionSetupPriceMatchesTargetRequiresPlanType(t *testing.T) {
@@ -35,6 +37,66 @@ func TestSubscriptionSetupPriceMatchesTargetRequiresPlanType(t *testing.T) {
 	}
 }
 
+func TestSubscriptionSetupPriceCoverageFindsEveryMissingAvailabilityTerritory(t *testing.T) {
+	priced, missing := subscriptionSetupPriceCoverage([]subscriptionPriceImportState{
+		{territoryID: "USA"},
+		{territoryID: "JPN"},
+		{territoryID: "USA"},
+	}, []string{"CAN", "USA", "FRA"})
+
+	if !reflect.DeepEqual(priced, []string{"JPN", "USA"}) {
+		t.Fatalf("unexpected priced territories: %v", priced)
+	}
+	if !reflect.DeepEqual(missing, []string{"CAN", "FRA"}) {
+		t.Fatalf("unexpected missing territories: %v", missing)
+	}
+}
+
+func TestSubscriptionSetupHasPricedTerritory(t *testing.T) {
+	states := []subscriptionPriceImportState{{territoryID: "USA"}, {territoryID: "can"}}
+	if !subscriptionSetupHasPricedTerritory(states, "CAN") {
+		t.Fatal("expected territory lookup to be case-insensitive")
+	}
+	if subscriptionSetupHasPricedTerritory(states, "FRA") {
+		t.Fatal("did not expect an absent territory to be reported as priced")
+	}
+}
+
+func TestSubscriptionSetupStateIsComplete(t *testing.T) {
+	for _, state := range []string{"READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "APPROVED"} {
+		if !subscriptionSetupStateIsComplete(state) {
+			t.Fatalf("expected %s to be complete", state)
+		}
+	}
+	for _, state := range []string{"", "MISSING_METADATA", "DEVELOPER_ACTION_NEEDED", "REJECTED", "REMOVED_FROM_SALE", "UNEXPECTED"} {
+		if subscriptionSetupStateIsComplete(state) {
+			t.Fatalf("did not expect %s to be complete", state)
+		}
+	}
+}
+
+func TestSubscriptionsSetupDiagnosticRowsExposeDeepDiagnostics(t *testing.T) {
+	diagnostics := []validation.SubscriptionDiagnostics{{
+		SubscriptionID: "sub-1",
+		Conclusion:     "known_blocker",
+		Rows: []validation.SubscriptionDiagnosticRow{{
+			Label:       "Review screenshot delivery",
+			Status:      validation.DiagnosticStatusNo,
+			Blocking:    true,
+			Evidence:    "asset_delivery_state=FAILED errors=IMAGE_INCORRECT_DIMENSIONS",
+			Remediation: "Delete and re-upload the screenshot.",
+		}},
+	}}
+
+	headers, rows := subscriptionsSetupDiagnosticRows(diagnostics)
+	if len(headers) != 7 || len(rows) != 1 {
+		t.Fatalf("unexpected diagnostics table: headers=%v rows=%v", headers, rows)
+	}
+	if !strings.Contains(strings.Join(rows[0], " "), "IMAGE_INCORRECT_DIMENSIONS") {
+		t.Fatalf("expected diagnostics evidence in table row, got %v", rows[0])
+	}
+}
+
 func TestValidateExistingSubscriptionSetupLocalizationComparesEmptyDescription(t *testing.T) {
 	localization := asc.Resource[asc.SubscriptionLocalizationAttributes]{
 		ID: "loc-1",
@@ -52,5 +114,45 @@ func TestValidateExistingSubscriptionSetupLocalizationComparesEmptyDescription(t
 	err := validateExistingSubscriptionSetupLocalization(localization, opts)
 	if err == nil || !strings.Contains(err.Error(), "different description") {
 		t.Fatalf("expected different description error, got %v", err)
+	}
+}
+
+func TestValidateExistingSubscriptionSetupGroupLocalizationIgnoresUnspecifiedCustomAppName(t *testing.T) {
+	localization := asc.Resource[asc.SubscriptionGroupLocalizationAttributes]{
+		ID: "group-loc-1",
+		Attributes: asc.SubscriptionGroupLocalizationAttributes{
+			Locale:        "en-US",
+			Name:          "Premium",
+			CustomAppName: "Existing App Name",
+		},
+	}
+	opts := subscriptionsSetupOptions{
+		GroupLocale:      "en-US",
+		GroupDisplayName: "Premium",
+	}
+
+	if err := validateExistingSubscriptionSetupGroupLocalization(localization, opts); err != nil {
+		t.Fatalf("unspecified custom app name should not reject an existing value: %v", err)
+	}
+}
+
+func TestValidateExistingSubscriptionSetupGroupLocalizationComparesSpecifiedCustomAppName(t *testing.T) {
+	localization := asc.Resource[asc.SubscriptionGroupLocalizationAttributes]{
+		ID: "group-loc-1",
+		Attributes: asc.SubscriptionGroupLocalizationAttributes{
+			Locale:        "en-US",
+			Name:          "Premium",
+			CustomAppName: "Existing App Name",
+		},
+	}
+	opts := subscriptionsSetupOptions{
+		GroupLocale:        "en-US",
+		GroupDisplayName:   "Premium",
+		GroupCustomAppName: "Requested App Name",
+	}
+
+	err := validateExistingSubscriptionSetupGroupLocalization(localization, opts)
+	if err == nil || !strings.Contains(err.Error(), "different custom app name") {
+		t.Fatalf("expected different custom app name error, got %v", err)
 	}
 }

--- a/internal/cli/subscriptions/setup_test.go
+++ b/internal/cli/subscriptions/setup_test.go
@@ -98,6 +98,29 @@ func TestBuildSubscriptionSetupPriceMatrixRejectsMissingOrConflictingEqualizatio
 	}
 }
 
+func TestSubscriptionSetupPriceStateMatchesAllowsOmittedStartDate(t *testing.T) {
+	state := &subscriptionPriceImportStateIndex{states: []subscriptionPriceImportState{{
+		territoryID:  "CAN",
+		pricePointID: "pp-can",
+		planType:     asc.SubscriptionPlanTypeUpfront,
+	}}}
+	target := subscriptionPriceImportResolvedRow{
+		territoryID:  "CAN",
+		pricePointID: "pp-can",
+		startDate:    "2026-08-01",
+		planType:     asc.SubscriptionPlanTypeUpfront,
+	}
+
+	if !subscriptionSetupPriceStateMatches(state, target) {
+		t.Fatal("expected setup verification to accept Apple's omitted equalized start date")
+	}
+
+	state.states[0].startDate = "2026-09-01"
+	if subscriptionSetupPriceStateMatches(state, target) {
+		t.Fatal("expected setup verification to reject a different explicit start date")
+	}
+}
+
 func TestSubscriptionSetupStateIsComplete(t *testing.T) {
 	for _, state := range []string{"READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "APPROVED"} {
 		if !subscriptionSetupStateIsComplete(state) {

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1150,7 +1150,7 @@ func SubscriptionsPricesAddCommand() *ffcli.Command {
 	territory := fs.String("territory", "", "Territory input (accepts alpha-2, alpha-3, or exact English country name; e.g., US, USA, United States)")
 	startDate := fs.String("start-date", "", "Start date (YYYY-MM-DD)")
 	preserved := fs.Bool("preserved", false, "Preserve existing prices")
-	force := fs.Bool("force", false, "Send the price write even when an identical price exists")
+	force := fs.Bool("force", false, "Re-save the complete equalized price matrix even when the selected price is unchanged")
 	refresh := fs.Bool("refresh", false, "Force refresh of tier cache")
 	output := shared.BindOutputFlags(fs)
 
@@ -1168,8 +1168,8 @@ Examples:
   asc subscriptions prices add --subscription-id "SUB_ID" --price "4.99" --territory "France" --force
 
 By default, an identical existing price is returned without sending another
-write. Use --force when you intentionally need App Store Connect to process
-the same price assignment again.`,
+write. Use --force with --territory to rebuild and atomically re-save the full
+equalized price matrix when repairing Apple's MISSING_METADATA state.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -1205,6 +1205,10 @@ the same price assignment again.`,
 					fmt.Fprintln(os.Stderr, "Error: --territory is required when using --tier or --price")
 					return shared.MissingRequiredUsageError()
 				}
+			}
+			if *force && territoryID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --territory is required with --force")
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -1270,6 +1274,26 @@ the same price assignment again.`,
 			}
 			if matchingPrice != nil && !*force {
 				return shared.PrintOutput(matchingPrice, *output.Output, *output.Pretty)
+			}
+			if matchingPrice != nil && *force {
+				equalizations, equalizationsErr := fetchEqualizations(requestCtx, client, pricePoint, territoryID)
+				if equalizationsErr != nil {
+					return fmt.Errorf("subscriptions prices add: build repair matrix: %w", equalizationsErr)
+				}
+				matrixAttrs := attrs
+				matrixAttrs.PlanType = matchingPrice.Data.Attributes.PlanType
+				if matrixAttrs.PlanType == "" {
+					matrixAttrs.PlanType = asc.SubscriptionPlanTypeUpfront
+				}
+				matrix, matrixErr := buildSubscriptionSetupPriceMatrix(pricePoint, territoryID, matrixAttrs, equalizations)
+				if matrixErr != nil {
+					return fmt.Errorf("subscriptions prices add: build repair matrix: %w", matrixErr)
+				}
+				resp, matrixErr := client.SetSubscriptionPriceMatrix(requestCtx, id, matrix)
+				if matrixErr != nil {
+					return fmt.Errorf("subscriptions prices add: failed to re-save price matrix: %w", matrixErr)
+				}
+				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 			}
 
 			// Existing prices: use POST /v1/subscriptionPrices for a price change

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1150,6 +1150,7 @@ func SubscriptionsPricesAddCommand() *ffcli.Command {
 	territory := fs.String("territory", "", "Territory input (accepts alpha-2, alpha-3, or exact English country name; e.g., US, USA, United States)")
 	startDate := fs.String("start-date", "", "Start date (YYYY-MM-DD)")
 	preserved := fs.Bool("preserved", false, "Preserve existing prices")
+	force := fs.Bool("force", false, "Send the price write even when an identical price exists")
 	refresh := fs.Bool("refresh", false, "Force refresh of tier cache")
 	output := shared.BindOutputFlags(fs)
 
@@ -1163,7 +1164,12 @@ Examples:
   asc subscriptions prices add --subscription-id "SUB_ID" --price-point "PRICE_POINT_ID"
   asc subscriptions prices add --subscription-id "SUB_ID" --price-point "PRICE_POINT_ID" --territory "United States"
   asc subscriptions prices add --subscription-id "SUB_ID" --tier 5 --territory "US"
-  asc subscriptions prices add --subscription-id "SUB_ID" --price "4.99" --territory "France"`,
+  asc subscriptions prices add --subscription-id "SUB_ID" --price "4.99" --territory "France"
+  asc subscriptions prices add --subscription-id "SUB_ID" --price "4.99" --territory "France" --force
+
+By default, an identical existing price is returned without sending another
+write. Use --force when you intentionally need App Store Connect to process
+the same price assignment again.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -1262,7 +1268,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("subscriptions prices add: failed to check matching price: %w", err)
 			}
-			if matchingPrice != nil {
+			if matchingPrice != nil && !*force {
 				return shared.PrintOutput(matchingPrice, *output.Output, *output.Pretty)
 			}
 

--- a/internal/cli/subscriptions/test_hooks.go
+++ b/internal/cli/subscriptions/test_hooks.go
@@ -1,0 +1,20 @@
+package subscriptions
+
+import (
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// SetSetupClientFactory replaces the setup ASC client factory for tests.
+// It returns a restore function to reset the previous factory.
+func SetSetupClientFactory(fn func() (*asc.Client, error)) func() {
+	previous := subscriptionsSetupClientFactory
+	if fn == nil {
+		subscriptionsSetupClientFactory = shared.GetASCClient
+	} else {
+		subscriptionsSetupClientFactory = fn
+	}
+	return func() {
+		subscriptionsSetupClientFactory = previous
+	}
+}

--- a/internal/cli/validate/availability.go
+++ b/internal/cli/validate/availability.go
@@ -109,3 +109,19 @@ func availabilityCheckSkipReason(err error) (string, bool) {
 
 	return "", false
 }
+
+func pricingTerritoryCheckSkipReason(err error) (string, bool) {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "Subscription pricing matrix verification was skipped because the App Store pricing territories endpoint timed out", true
+	case errors.Is(err, asc.ErrForbidden) || asc.IsUnauthorized(err):
+		return "Subscription pricing matrix verification was skipped because this App Store Connect account cannot read pricing territories", true
+	case asc.IsRetryable(err):
+		return "Subscription pricing matrix verification was skipped because the App Store pricing territories endpoint was temporarily unavailable or rate limited", true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return "Subscription pricing matrix verification was skipped because the App Store pricing territories endpoint could not be reached", true
+	}
+	return "", false
+}

--- a/internal/cli/validate/availability.go
+++ b/internal/cli/validate/availability.go
@@ -95,16 +95,16 @@ func territoryAvailabilityTerritoryID(raw json.RawMessage) (string, error) {
 func availabilityCheckSkipReason(err error) (string, bool) {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
-		return "Subscription pricing coverage verification was skipped because the App Store Connect availability endpoints timed out", true
+		return "Subscription availability coverage verification was skipped because the App Store Connect availability endpoints timed out", true
 	case errors.Is(err, asc.ErrForbidden) || asc.IsUnauthorized(err):
-		return "Subscription pricing coverage verification was skipped because this App Store Connect account cannot read app availability territories", true
+		return "Subscription availability coverage verification was skipped because this App Store Connect account cannot read app availability territories", true
 	case asc.IsRetryable(err):
-		return "Subscription pricing coverage verification was skipped because the App Store Connect availability endpoints were temporarily unavailable or rate limited", true
+		return "Subscription availability coverage verification was skipped because the App Store Connect availability endpoints were temporarily unavailable or rate limited", true
 	}
 
 	var netErr net.Error
 	if errors.As(err, &netErr) {
-		return "Subscription pricing coverage verification was skipped because the App Store Connect availability endpoints could not be reached", true
+		return "Subscription availability coverage verification was skipped because the App Store Connect availability endpoints could not be reached", true
 	}
 
 	return "", false

--- a/internal/cli/validate/concurrency_test.go
+++ b/internal/cli/validate/concurrency_test.go
@@ -103,7 +103,7 @@ func TestFetchScreenshotSets_OverlapsRequestsWithinCapAndSortsDeterministically(
 	}
 }
 
-func TestBuildReadinessReport_OverlapsFiveIndependentReadGroups(t *testing.T) {
+func TestBuildReadinessReport_OverlapsSixIndependentReadGroups(t *testing.T) {
 	const (
 		slowDelay  = 300 * time.Millisecond
 		shortDelay = 100 * time.Millisecond
@@ -111,11 +111,12 @@ func TestBuildReadinessReport_OverlapsFiveIndependentReadGroups(t *testing.T) {
 	delays := map[string]time.Duration{
 		"/v1/apps/app-1/appPriceSchedule":                              slowDelay,
 		"/v1/apps/app-1/appAvailabilityV2":                             shortDelay,
+		"/v1/territories":                                              shortDelay,
 		"/v1/appStoreVersionLocalizations/ver-loc-1/appScreenshotSets": shortDelay,
 		"/v1/apps/app-1/subscriptionGroups":                            shortDelay,
 		"/v1/apps/app-1/inAppPurchasesV2":                              shortDelay,
 	}
-	serialDelay := slowDelay + 4*shortDelay
+	serialDelay := slowDelay + 5*shortDelay
 
 	tracker := &requestConcurrencyTracker{}
 	var mu sync.Mutex
@@ -156,6 +157,8 @@ func TestBuildReadinessReport_OverlapsFiveIndependentReadGroups(t *testing.T) {
 		case "/v1/apps/app-1/appAvailabilityV2":
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(w, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case "/v1/territories":
+			fmt.Fprint(w, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`)
 		case "/v1/appStoreVersionLocalizations/ver-loc-1/appScreenshotSets",
 			"/v1/apps/app-1/subscriptionGroups",
 			"/v1/apps/app-1/inAppPurchasesV2":
@@ -199,9 +202,9 @@ func TestBuildReadinessReport_OverlapsFiveIndependentReadGroups(t *testing.T) {
 		t.Fatalf("maximum in-flight top-level reads = %d, want %d", got, readinessConcurrencyLimit)
 	}
 	if elapsed >= 550*time.Millisecond {
-		t.Fatalf("five independent read groups took %s; slowest group is %s and serial fixture time is %s", elapsed, slowDelay, serialDelay)
+		t.Fatalf("six independent read groups took %s; slowest group is %s and serial fixture time is %s", elapsed, slowDelay, serialDelay)
 	}
-	t.Logf("five independent read groups completed in %s (slowest=%s, serial=%s, max-in-flight=%d)", elapsed, slowDelay, serialDelay, tracker.max.Load())
+	t.Logf("six independent read groups completed in %s (slowest=%s, serial=%s, max-in-flight=%d)", elapsed, slowDelay, serialDelay, tracker.max.Load())
 }
 
 func TestBuildReadinessReport_CancelsSiblingCompoundReadOnHardError(t *testing.T) {

--- a/internal/cli/validate/readiness.go
+++ b/internal/cli/validate/readiness.go
@@ -73,6 +73,7 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 	appAvailableTerritories := []string(nil)
 	availableTerritories := 0
 	availabilityFetchSkipReason := ""
+	pricingTerritories := []string(nil)
 	pricingCoverageSkipReason := ""
 	var screenshotSets []validation.ScreenshotSet
 	var subscriptions []validation.Subscription
@@ -122,12 +123,21 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 				availabilityID = ""
 				appAvailableTerritories = nil
 				availableTerritories = 0
-				if coverageReason, coverageOK := availabilityCheckSkipReason(fetchErr); coverageOK {
-					pricingCoverageSkipReason = coverageReason
-				}
 				return nil
 			}
 			return fetchErr
+		},
+		func(taskCtx context.Context) error {
+			territories, fetchErr := fetchPricingTerritoriesFn(taskCtx, client)
+			if fetchErr != nil {
+				if reason, ok := pricingTerritoryCheckSkipReason(fetchErr); ok {
+					pricingCoverageSkipReason = reason
+					return nil
+				}
+				return fetchErr
+			}
+			pricingTerritories = territories
+			return nil
 		},
 		func(taskCtx context.Context) error {
 			var fetchErr error
@@ -234,6 +244,8 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 		AvailabilityID:              availabilityID,
 		AvailableTerritories:        availableTerritories,
 		AppAvailableTerritories:     appAvailableTerritories,
+		PricingTerritories:          pricingTerritories,
+		PricingTerritoryCount:       len(pricingTerritories),
 		AvailabilityFetchSkipReason: availabilityFetchSkipReason,
 		PricingCoverageSkipReason:   pricingCoverageSkipReason,
 		ScreenshotSets:              screenshotSets,

--- a/internal/cli/validate/readiness_compound_test.go
+++ b/internal/cli/validate/readiness_compound_test.go
@@ -89,6 +89,12 @@ func TestBuildReadinessReport_UsesCompoundReadsWithoutFallbacks(t *testing.T) {
 		return "availability-1", 1, nil
 	})
 	t.Cleanup(restoreAvailability)
+	pricingTerritoryFetches := 0
+	restorePricingTerritories := SetFetchPricingTerritoriesFunc(func(context.Context, *asc.Client) ([]string, error) {
+		pricingTerritoryFetches++
+		return []string{"USA", "CAN"}, nil
+	})
+	t.Cleanup(restorePricingTerritories)
 	restoreScreenshots := SetFetchScreenshotSetsFunc(func(context.Context, *asc.Client, []asc.Resource[asc.AppStoreVersionLocalizationAttributes]) ([]validation.ScreenshotSet, error) {
 		return nil, nil
 	})
@@ -118,6 +124,9 @@ func TestBuildReadinessReport_UsesCompoundReadsWithoutFallbacks(t *testing.T) {
 	}
 	if totalRequests != 3 {
 		t.Fatalf("compound readiness request count = %d, want 3 (version, app infos, price schedule)", totalRequests)
+	}
+	if pricingTerritoryFetches != 1 {
+		t.Fatalf("pricing territory fetches = %d, want 1", pricingTerritoryFetches)
 	}
 
 	for _, path := range []string{

--- a/internal/cli/validate/subscription_fetch.go
+++ b/internal/cli/validate/subscription_fetch.go
@@ -155,11 +155,13 @@ func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) (
 				return nil
 			},
 			func(taskCtx context.Context) error {
-				id, status, fetchErr := fetchSubscriptionReviewScreenshot(taskCtx, client, subscriptionID)
+				id, assetDeliveryState, assetDeliveryErrors, status, fetchErr := fetchSubscriptionReviewScreenshot(taskCtx, client, subscriptionID)
 				if fetchErr != nil {
 					return fmt.Errorf("fetch subscription review screenshot for %s: %w", subscriptionID, fetchErr)
 				}
 				enrichments[index].reviewScreenshotID = id
+				enrichments[index].reviewScreenshotAssetDeliveryState = assetDeliveryState
+				enrichments[index].reviewScreenshotAssetDeliveryErrors = assetDeliveryErrors
 				enrichments[index].reviewScreenshotStatus = status
 				return nil
 			},
@@ -238,6 +240,8 @@ func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) (
 				valSub.LocalizationCheckSkipped = !enrichment.localizationStatus.Verified
 				valSub.LocalizationCheckSkipReason = enrichment.localizationStatus.SkipReason
 				valSub.ReviewScreenshotID = enrichment.reviewScreenshotID
+				valSub.ReviewScreenshotAssetDeliveryState = enrichment.reviewScreenshotAssetDeliveryState
+				valSub.ReviewScreenshotAssetDeliveryErrors = enrichment.reviewScreenshotAssetDeliveryErrors
 				valSub.ReviewScreenshotCheckSkipped = !enrichment.reviewScreenshotStatus.Verified
 				valSub.ReviewScreenshotCheckReason = enrichment.reviewScreenshotStatus.SkipReason
 				valSub.AvailabilityID = enrichment.availabilityID
@@ -276,22 +280,24 @@ type subscriptionGroupMetadata struct {
 }
 
 type subscriptionEnrichment struct {
-	image                   subscriptionImageStatus
-	priceTerritories        []string
-	priceStatus             metadataCheckStatus
-	localizations           []validation.SubscriptionLocalizationInfo
-	localizationStatus      metadataCheckStatus
-	reviewScreenshotID      string
-	reviewScreenshotStatus  metadataCheckStatus
-	availabilityID          string
-	availabilityTerritories []string
-	availabilityStatus      metadataCheckStatus
-	introductoryOfferCount  int
-	introductoryOfferStatus metadataCheckStatus
-	promotionalOfferCount   int
-	promotionalOfferStatus  metadataCheckStatus
-	winBackOfferCount       int
-	winBackOfferStatus      metadataCheckStatus
+	image                               subscriptionImageStatus
+	priceTerritories                    []string
+	priceStatus                         metadataCheckStatus
+	localizations                       []validation.SubscriptionLocalizationInfo
+	localizationStatus                  metadataCheckStatus
+	reviewScreenshotID                  string
+	reviewScreenshotAssetDeliveryState  string
+	reviewScreenshotAssetDeliveryErrors []string
+	reviewScreenshotStatus              metadataCheckStatus
+	availabilityID                      string
+	availabilityTerritories             []string
+	availabilityStatus                  metadataCheckStatus
+	introductoryOfferCount              int
+	introductoryOfferStatus             metadataCheckStatus
+	promotionalOfferCount               int
+	promotionalOfferStatus              metadataCheckStatus
+	winBackOfferCount                   int
+	winBackOfferStatus                  metadataCheckStatus
 }
 
 func fetchSubscriptionsForGroup(ctx context.Context, client *asc.Client, groupID string) ([]asc.Resource[asc.SubscriptionAttributes], error) {
@@ -501,26 +507,56 @@ func subscriptionPriceTerritoryID(raw json.RawMessage) (string, error) {
 	return strings.TrimSpace(relationships.Territory.Data.ID), nil
 }
 
-func fetchSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, subscriptionID string) (string, metadataCheckStatus, error) {
+func fetchSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, subscriptionID string) (string, string, []string, metadataCheckStatus, error) {
 	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
-		return client.GetSubscriptionAppStoreReviewScreenshotForSubscription(requestCtx, strings.TrimSpace(subscriptionID))
+		return client.GetSubscriptionAppStoreReviewScreenshotForSubscription(
+			requestCtx,
+			strings.TrimSpace(subscriptionID),
+			asc.WithSubscriptionAppStoreReviewScreenshotFields([]string{"assetDeliveryState"}),
+		)
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return "", metadataCheckStatus{}, err
+			return "", "", nil, metadataCheckStatus{}, err
 		}
 		if asc.IsNotFound(err) {
-			return "", metadataCheckStatus{Verified: true}, nil
+			return "", "", nil, metadataCheckStatus{Verified: true}, nil
 		}
 		if reason, ok := metadataCheckSkipReason(err, "subscription App Review screenshot"); ok {
-			return "", metadataCheckStatus{SkipReason: reason}, nil
+			return "", "", nil, metadataCheckStatus{SkipReason: reason}, nil
 		}
-		return "", metadataCheckStatus{}, err
+		return "", "", nil, metadataCheckStatus{}, err
 	}
 	if resp == nil {
-		return "", metadataCheckStatus{Verified: true}, nil
+		return "", "", nil, metadataCheckStatus{Verified: true}, nil
 	}
-	return strings.TrimSpace(resp.Data.ID), metadataCheckStatus{Verified: true}, nil
+
+	id := strings.TrimSpace(resp.Data.ID)
+	state := ""
+	details := make([]string, 0)
+	if resp.Data.Attributes.AssetDeliveryState != nil && resp.Data.Attributes.AssetDeliveryState.State != nil {
+		state = strings.ToUpper(strings.TrimSpace(*resp.Data.Attributes.AssetDeliveryState.State))
+		for _, detail := range resp.Data.Attributes.AssetDeliveryState.Errors {
+			code := strings.TrimSpace(detail.Code)
+			message := strings.TrimSpace(detail.Message)
+			switch {
+			case code != "" && message != "":
+				details = append(details, code+": "+message)
+			case code != "":
+				details = append(details, code)
+			case message != "":
+				details = append(details, message)
+			}
+		}
+	}
+	switch state {
+	case "COMPLETE", "FAILED":
+		return id, state, details, metadataCheckStatus{Verified: true}, nil
+	case "":
+		return id, state, details, metadataCheckStatus{SkipReason: "Validation could not verify the subscription App Review screenshot because Apple did not return its asset delivery state"}, nil
+	default:
+		return id, state, details, metadataCheckStatus{SkipReason: fmt.Sprintf("Validation could not verify the subscription App Review screenshot because its asset delivery state is %s, not COMPLETE", state)}, nil
+	}
 }
 
 func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (string, []string, metadataCheckStatus, error) {

--- a/internal/cli/validate/subscription_fetch.go
+++ b/internal/cli/validate/subscription_fetch.go
@@ -437,6 +437,7 @@ func fetchSubscriptionPriceTerritories(ctx context.Context, client *asc.Client, 
 			requestCtx,
 			strings.TrimSpace(subscriptionID),
 			asc.WithSubscriptionPricesInclude([]string{"territory"}),
+			asc.WithSubscriptionPricesPlanType(asc.SubscriptionPlanTypeUpfront),
 			asc.WithSubscriptionPricesLimit(200),
 		)
 	})

--- a/internal/cli/validate/subscription_fetch_test.go
+++ b/internal/cli/validate/subscription_fetch_test.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -181,5 +182,54 @@ func TestFetchSubscriptionPriceTerritories_SkipsWhenTerritoryRelationshipMissing
 	}
 	if !strings.Contains(status.SkipReason, "omitted territory relationships") {
 		t.Fatalf("expected missing-territory skip reason, got %q", status.SkipReason)
+	}
+}
+
+func TestFetchSubscriptionReviewScreenshot_ReportsAssetDeliveryState(t *testing.T) {
+	tests := []struct {
+		name         string
+		state        string
+		errors       string
+		wantDetails  []string
+		wantVerified bool
+		wantReason   string
+	}{
+		{name: "complete", state: "COMPLETE", wantVerified: true},
+		{name: "failed", state: "FAILED", errors: `,"errors":[{"code":"IMAGE_INCORRECT_DIMENSIONS","message":"The image dimensions are invalid."}]`, wantDetails: []string{"IMAGE_INCORRECT_DIMENSIONS: The image dimensions are invalid."}, wantVerified: true},
+		{name: "processing", state: "PROCESSING", wantReason: "PROCESSING"},
+		{name: "upload complete", state: "UPLOAD_COMPLETE", wantReason: "UPLOAD_COMPLETE"},
+		{name: "unknown", state: "", wantReason: "did not return"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if got := req.URL.Query().Get("fields[subscriptionAppStoreReviewScreenshots]"); got != "assetDeliveryState" {
+					t.Fatalf("expected assetDeliveryState field request, got %q", got)
+				}
+				attributes := `{}`
+				if test.state != "" {
+					attributes = `{"assetDeliveryState":{"state":"` + test.state + `"` + test.errors + `}}`
+				}
+				return buildsJSONResponse(http.StatusOK, `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1","attributes":`+attributes+`}}`)
+			}))
+
+			id, state, details, status, err := fetchSubscriptionReviewScreenshot(context.Background(), client, "sub-1")
+			if err != nil {
+				t.Fatalf("fetchSubscriptionReviewScreenshot() error = %v", err)
+			}
+			if id != "shot-1" || state != test.state {
+				t.Fatalf("got id=%q state=%q, want id=shot-1 state=%q", id, state, test.state)
+			}
+			if !slices.Equal(details, test.wantDetails) {
+				t.Fatalf("details=%v, want %v", details, test.wantDetails)
+			}
+			if status.Verified != test.wantVerified {
+				t.Fatalf("verified=%t, want %t; status=%+v", status.Verified, test.wantVerified, status)
+			}
+			if test.wantReason != "" && !strings.Contains(status.SkipReason, test.wantReason) {
+				t.Fatalf("skip reason %q does not contain %q", status.SkipReason, test.wantReason)
+			}
+		})
 	}
 }

--- a/internal/cli/validate/subscription_fetch_test.go
+++ b/internal/cli/validate/subscription_fetch_test.go
@@ -81,6 +81,9 @@ func TestFetchSubscriptionPriceTerritories_DeduplicatesAndSortsTerritories(t *te
 		if got := req.URL.Query().Get("limit"); got != "200" {
 			t.Fatalf("expected limit=200 query, got %q", got)
 		}
+		if got := req.URL.Query().Get("filter[planType]"); got != "UPFRONT" {
+			t.Fatalf("expected filter[planType]=UPFRONT query, got %q", got)
+		}
 		return buildsJSONResponse(http.StatusOK, `{
 			"data": [
 				{

--- a/internal/cli/validate/subscriptions.go
+++ b/internal/cli/validate/subscriptions.go
@@ -111,6 +111,7 @@ func BuildSubscriptionsReport(ctx context.Context, opts SubscriptionsOptions) (v
 func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts SubscriptionsOptions) (validation.SubscriptionsReport, error) {
 	ctx = withReadinessRequestGate(ctx)
 	pricingCoverageSkipReason := ""
+	appAvailabilityCoverageSkipReason := ""
 	var appAvailableTerritories []string
 	availableTerritories := 0
 	var pricingTerritories []string
@@ -120,7 +121,8 @@ func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts Subs
 		func(taskCtx context.Context) error {
 			_, territories, count, fetchErr := fetchAvailableTerritoryDetailsFn(taskCtx, client, opts.AppID)
 			if fetchErr != nil {
-				if _, ok := availabilityCheckSkipReason(fetchErr); ok {
+				if reason, ok := availabilityCheckSkipReason(fetchErr); ok {
+					appAvailabilityCoverageSkipReason = reason
 					return nil
 				}
 				return fmt.Errorf("validate subscriptions: %w", fetchErr)
@@ -171,16 +173,17 @@ func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts Subs
 	}
 
 	report := validation.ValidateSubscriptions(validation.SubscriptionsInput{
-		AppID:                     opts.AppID,
-		Subscriptions:             subs,
-		AvailableTerritories:      availableTerritories,
-		AppAvailableTerritories:   appAvailableTerritories,
-		PricingTerritories:        pricingTerritories,
-		PricingTerritoryCount:     len(pricingTerritories),
-		PricingCoverageSkipReason: pricingCoverageSkipReason,
-		AppBuildCount:             buildCount,
-		BuildCheckSkipped:         buildCheckSkipped,
-		BuildCheckSkipReason:      buildCheckSkipReason,
+		AppID:                             opts.AppID,
+		Subscriptions:                     subs,
+		AvailableTerritories:              availableTerritories,
+		AppAvailableTerritories:           appAvailableTerritories,
+		AppAvailabilityCoverageSkipReason: appAvailabilityCoverageSkipReason,
+		PricingTerritories:                pricingTerritories,
+		PricingTerritoryCount:             len(pricingTerritories),
+		PricingCoverageSkipReason:         pricingCoverageSkipReason,
+		AppBuildCount:                     buildCount,
+		BuildCheckSkipped:                 buildCheckSkipped,
+		BuildCheckSkipReason:              buildCheckSkipReason,
 	}, opts.Strict)
 
 	return report, nil

--- a/internal/cli/validate/subscriptions.go
+++ b/internal/cli/validate/subscriptions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
@@ -18,6 +19,12 @@ type validateSubscriptionsOptions struct {
 	Strict bool
 	Output string
 	Pretty bool
+}
+
+// SubscriptionsOptions configures a non-printing subscription readiness report.
+type SubscriptionsOptions struct {
+	AppID  string
+	Strict bool
 }
 
 // ValidateSubscriptionsCommand returns the asc validate subscriptions subcommand.
@@ -31,13 +38,14 @@ func ValidateSubscriptionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "subscriptions",
 		ShortUsage: "asc validate subscriptions --app \"APP_ID\" [flags]",
-		ShortHelp:  "Validate subscription review readiness and promotional image guidance.",
+		ShortHelp:  "Validate subscription metadata, screenshot delivery, pricing, and availability.",
 		LongHelp: `Validate review readiness for auto-renewable subscriptions.
 
-This command is conservative: it emits warnings for subscriptions that need
-review attention or are missing promotional images Apple uses for App Store
-promotion, offer-code redemption pages, and win-back offers. Use --strict to
-gate on warnings in CI.
+For subscriptions in MISSING_METADATA, this command inspects group and
+subscription localizations, App Review screenshot delivery, availability, and
+price coverage. It also emits advisory guidance for promotional images Apple
+uses for App Store promotion, offer-code redemption pages, and win-back offers.
+Use --strict to gate on warnings in CI.
 
 Examples:
   asc validate subscriptions --app "APP_ID"
@@ -68,6 +76,36 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 		return fmt.Errorf("validate subscriptions: %w", err)
 	}
 
+	report, err := buildSubscriptionsReport(ctx, client, SubscriptionsOptions{
+		AppID:  opts.AppID,
+		Strict: opts.Strict,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := shared.PrintOutput(&report, opts.Output, opts.Pretty); err != nil {
+		return err
+	}
+
+	if report.Summary.Blocking > 0 {
+		return shared.NewValidationReportedError(fmt.Errorf("validate subscriptions: found %d blocking issue(s)", report.Summary.Blocking))
+	}
+
+	return nil
+}
+
+// BuildSubscriptionsReport fetches live subscription state and returns the same
+// structured report emitted by `asc validate subscriptions` without printing it.
+func BuildSubscriptionsReport(ctx context.Context, opts SubscriptionsOptions) (validation.SubscriptionsReport, error) {
+	client, err := clientFactory()
+	if err != nil {
+		return validation.SubscriptionsReport{}, fmt.Errorf("validate subscriptions: %w", err)
+	}
+	return buildSubscriptionsReport(ctx, client, opts)
+}
+
+func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts SubscriptionsOptions) (validation.SubscriptionsReport, error) {
 	ctx = withReadinessRequestGate(ctx)
 	pricingCoverageSkipReason := ""
 	var appAvailableTerritories []string
@@ -97,7 +135,7 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 			return nil
 		},
 	); err != nil {
-		return err
+		return validation.SubscriptionsReport{}, err
 	}
 
 	buildCount := 0
@@ -106,9 +144,10 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 	var buildStatus metadataCheckStatus
 	for _, sub := range subs {
 		if strings.EqualFold(strings.TrimSpace(sub.State), "MISSING_METADATA") {
+			var err error
 			buildCount, buildStatus, err = fetchAppBuildCountFn(ctx, client, opts.AppID)
 			if err != nil {
-				return fmt.Errorf("validate subscriptions: %w", err)
+				return validation.SubscriptionsReport{}, fmt.Errorf("validate subscriptions: %w", err)
 			}
 			buildCheckSkipped = !buildStatus.Verified
 			buildCheckSkipReason = buildStatus.SkipReason
@@ -127,13 +166,5 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 		BuildCheckSkipReason:      buildCheckSkipReason,
 	}, opts.Strict)
 
-	if err := shared.PrintOutput(&report, opts.Output, opts.Pretty); err != nil {
-		return err
-	}
-
-	if report.Summary.Blocking > 0 {
-		return shared.NewValidationReportedError(fmt.Errorf("validate subscriptions: found %d blocking issue(s)", report.Summary.Blocking))
-	}
-
-	return nil
+	return report, nil
 }

--- a/internal/cli/validate/subscriptions.go
+++ b/internal/cli/validate/subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -13,6 +14,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
+
+var fetchPricingTerritoriesFn = fetchPricingTerritories
 
 type validateSubscriptionsOptions struct {
 	AppID  string
@@ -43,7 +46,7 @@ func ValidateSubscriptionsCommand() *ffcli.Command {
 
 For subscriptions in MISSING_METADATA, this command inspects group and
 subscription localizations, App Review screenshot delivery, availability, and
-price coverage. It also emits advisory guidance for promotional images Apple
+the complete App Store pricing matrix. It also emits advisory guidance for promotional images Apple
 uses for App Store promotion, offer-code redemption pages, and win-back offers.
 Use --strict to gate on warnings in CI.
 
@@ -110,20 +113,32 @@ func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts Subs
 	pricingCoverageSkipReason := ""
 	var appAvailableTerritories []string
 	availableTerritories := 0
+	var pricingTerritories []string
 	var subs []validation.Subscription
 	if err := runReadinessTasks(
 		ctx,
 		func(taskCtx context.Context) error {
 			_, territories, count, fetchErr := fetchAvailableTerritoryDetailsFn(taskCtx, client, opts.AppID)
 			if fetchErr != nil {
-				if reason, ok := availabilityCheckSkipReason(fetchErr); ok {
-					pricingCoverageSkipReason = reason
+				if _, ok := availabilityCheckSkipReason(fetchErr); ok {
 					return nil
 				}
 				return fmt.Errorf("validate subscriptions: %w", fetchErr)
 			}
 			appAvailableTerritories = territories
 			availableTerritories = count
+			return nil
+		},
+		func(taskCtx context.Context) error {
+			territories, fetchErr := fetchPricingTerritoriesFn(taskCtx, client)
+			if fetchErr != nil {
+				if reason, ok := pricingTerritoryCheckSkipReason(fetchErr); ok {
+					pricingCoverageSkipReason = reason
+					return nil
+				}
+				return fmt.Errorf("validate subscriptions: %w", fetchErr)
+			}
+			pricingTerritories = territories
 			return nil
 		},
 		func(taskCtx context.Context) error {
@@ -160,6 +175,8 @@ func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts Subs
 		Subscriptions:             subs,
 		AvailableTerritories:      availableTerritories,
 		AppAvailableTerritories:   appAvailableTerritories,
+		PricingTerritories:        pricingTerritories,
+		PricingTerritoryCount:     len(pricingTerritories),
 		PricingCoverageSkipReason: pricingCoverageSkipReason,
 		AppBuildCount:             buildCount,
 		BuildCheckSkipped:         buildCheckSkipped,
@@ -167,4 +184,40 @@ func buildSubscriptionsReport(ctx context.Context, client *asc.Client, opts Subs
 	}, opts.Strict)
 
 	return report, nil
+}
+
+func fetchPricingTerritories(ctx context.Context, client *asc.Client) ([]string, error) {
+	firstPage, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.TerritoriesResponse, error) {
+		return client.GetTerritories(requestCtx, asc.WithTerritoriesLimit(200))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch App Store pricing territories: %w", err)
+	}
+	allPages, err := asc.PaginateAll(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetTerritories(requestCtx, asc.WithTerritoriesNextURL(nextURL))
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate App Store pricing territories: %w", err)
+	}
+	typed, ok := allPages.(*asc.TerritoriesResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected pricing territories response type %T", allPages)
+	}
+	seen := make(map[string]struct{}, len(typed.Data))
+	territories := make([]string, 0, len(typed.Data))
+	for _, territory := range typed.Data {
+		id := strings.ToUpper(strings.TrimSpace(territory.ID))
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		territories = append(territories, id)
+	}
+	sort.Strings(territories)
+	return territories, nil
 }

--- a/internal/cli/validate/test_hooks.go
+++ b/internal/cli/validate/test_hooks.go
@@ -75,6 +75,20 @@ func SetFetchAvailableTerritoriesFunc(fn func(context.Context, *asc.Client, stri
 	}
 }
 
+// SetFetchPricingTerritoriesFunc replaces the pricing-territory fetcher for tests.
+// It returns a restore function to reset the previous handler.
+func SetFetchPricingTerritoriesFunc(fn func(context.Context, *asc.Client) ([]string, error)) func() {
+	previous := fetchPricingTerritoriesFn
+	if fn == nil {
+		fetchPricingTerritoriesFn = fetchPricingTerritories
+	} else {
+		fetchPricingTerritoriesFn = fn
+	}
+	return func() {
+		fetchPricingTerritoriesFn = previous
+	}
+}
+
 // SetFetchAppBuildCountFunc replaces the app build-count fetcher for tests.
 // The hook models one outbound probe and receives a fresh request context.
 // It returns a restore function to reset the previous handler.

--- a/internal/validation/pricing_availability_test.go
+++ b/internal/validation/pricing_availability_test.go
@@ -103,3 +103,26 @@ func TestValidateAvailabilitySkipSuppressesPartialCoverageAndAddsCoverageSkipChe
 		t.Fatalf("expected pricing coverage skip check in unified validate, got %+v", report.Checks)
 	}
 }
+
+func TestValidateUsesPricingUniverseInsteadOfAppSaleAvailabilityForSubscriptionMatrix(t *testing.T) {
+	report := Validate(Input{
+		AppID:                   "app-1",
+		VersionID:               "ver-1",
+		AvailableTerritories:    1,
+		AppAvailableTerritories: []string{"USA"},
+		PricingTerritories:      []string{"USA", "CAN"},
+		PricingTerritoryCount:   2,
+		Subscriptions: []Subscription{
+			{
+				ID:               "sub-1",
+				State:            "APPROVED",
+				PriceCount:       1,
+				PriceTerritories: []string{"USA"},
+			},
+		},
+	}, false)
+
+	if !hasCheckID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected unified validate to require the full pricing universe, got %+v", report.Checks)
+	}
+}

--- a/internal/validation/report.go
+++ b/internal/validation/report.go
@@ -6,9 +6,15 @@ func Validate(input Input, strict bool) Report {
 	reviewRelevantSubscriptions := hasReviewRelevantSubscriptions(input.Subscriptions)
 	availableTerritories := input.AvailableTerritories
 	appAvailableTerritories := input.AppAvailableTerritories
+	pricingTerritoryCount := input.PricingTerritoryCount
+	pricingTerritories := input.PricingTerritories
+	if pricingTerritoryCount == 0 && len(pricingTerritories) == 0 {
+		pricingTerritoryCount = availableTerritories
+		pricingTerritories = appAvailableTerritories
+	}
 	if input.PricingCoverageSkipReason != "" {
-		availableTerritories = 0
-		appAvailableTerritories = nil
+		pricingTerritoryCount = 0
+		pricingTerritories = nil
 	}
 
 	checks := make([]CheckResult, 0)
@@ -29,7 +35,7 @@ func Validate(input Input, strict bool) Report {
 	checks = append(checks, subscriptionPricingVerificationChecks(input.Subscriptions)...)
 	checks = append(checks, subscriptionMetadataDiagnostics(input.Subscriptions)...)
 	checks = append(checks, subscriptionPricingCoverageSkipChecks(input.AppID, input.PricingCoverageSkipReason)...)
-	checks = append(checks, subscriptionPricingCoverageChecks(input.Subscriptions, availableTerritories, appAvailableTerritories)...)
+	checks = append(checks, subscriptionPricingCoverageChecks(input.Subscriptions, pricingTerritoryCount, pricingTerritories)...)
 	checks = append(checks, iapFetchChecks(input.IAPFetchSkipReason)...)
 	checks = append(checks, iapReviewReadinessChecks(input.IAPs)...)
 	checks = append(checks, ageRatingChecks(input.AgeRatingDeclaration)...)

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -144,7 +144,7 @@ func buildPricingMatrixDiagnosticRow(sub Subscription, pricingTerritories []stri
 		}
 		row.Status = DiagnosticStatusNo
 		row.Evidence = fmt.Sprintf("priced=%d required=%d missing=%s", len(sortedUniqueNonEmpty(sub.PriceTerritories)), len(pricingTerritories), formatList(missing))
-		row.Remediation = fmt.Sprintf("Materialize the full price matrix with `asc subscriptions setup --subscription-id %q --repair ...`; sale availability does not narrow Apple's pricing requirement.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+		row.Remediation = "Re-run `asc subscriptions setup` with the original group, subscription, and pricing flags plus `--repair`; sale availability does not narrow Apple's pricing requirement."
 		return row
 	}
 	if pricingTerritoryCount <= 0 {
@@ -157,7 +157,7 @@ func buildPricingMatrixDiagnosticRow(sub Subscription, pricingTerritories []stri
 		row.Status = DiagnosticStatusYes
 	} else {
 		row.Status = DiagnosticStatusNo
-		row.Remediation = fmt.Sprintf("Materialize the full price matrix with `asc subscriptions setup --subscription-id %q --repair ...`.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+		row.Remediation = "Re-run `asc subscriptions setup` with the original group, subscription, and pricing flags plus `--repair`."
 	}
 	row.Evidence = fmt.Sprintf("priced=%d required=%d", pricedCount, pricingTerritoryCount)
 	return row

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -46,13 +46,13 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 	if len(appTerritories) > 0 {
 		appTerritoryCount = len(appTerritories)
 	}
-	pricingMatrixContextAvailable := len(input.PricingTerritories) > 0 || input.PricingTerritoryCount > 0 || strings.TrimSpace(input.PricingCoverageSkipReason) != ""
 	pricingTerritories := sortedUniqueNonEmpty(input.PricingTerritories)
 	pricingTerritoryCount := input.PricingTerritoryCount
 	if len(pricingTerritories) == 0 && pricingTerritoryCount == 0 {
 		pricingTerritories = appTerritories
 		pricingTerritoryCount = appTerritoryCount
 	}
+	pricingMatrixContextAvailable := len(pricingTerritories) > 0 || pricingTerritoryCount > 0 || strings.TrimSpace(input.PricingCoverageSkipReason) != ""
 
 	for _, sub := range input.Subscriptions {
 		if isRemovedMonetizationState(sub.State) {

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -206,7 +206,7 @@ func buildSubscriptionLocalizationsDiagnosticRow(sub Subscription) SubscriptionD
 func buildReviewScreenshotDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {
 	row := SubscriptionDiagnosticRow{
 		Key:      "review_screenshot",
-		Label:    "Review screenshot attached",
+		Label:    "Review screenshot delivery",
 		Status:   DiagnosticStatusUnknown,
 		Source:   "public-api",
 		Blocking: true,
@@ -214,6 +214,10 @@ func buildReviewScreenshotDiagnosticRow(sub Subscription) SubscriptionDiagnostic
 
 	if sub.ReviewScreenshotCheckSkipped {
 		row.Status = DiagnosticStatusUnverified
+		if screenshotID := strings.TrimSpace(sub.ReviewScreenshotID); screenshotID != "" {
+			state := fallbackString(strings.ToUpper(strings.TrimSpace(sub.ReviewScreenshotAssetDeliveryState)), "unknown")
+			row.Evidence = fmt.Sprintf("id=%s asset_delivery_state=%s", screenshotID, state)
+		}
 		row.Remediation = fallbackString(sub.ReviewScreenshotCheckReason, "Validation could not verify the subscription App Review screenshot automatically")
 		return row
 	}
@@ -225,9 +229,36 @@ func buildReviewScreenshotDiagnosticRow(sub Subscription) SubscriptionDiagnostic
 		return row
 	}
 
-	row.Status = DiagnosticStatusYes
-	row.Evidence = fmt.Sprintf("id=%s", strings.TrimSpace(sub.ReviewScreenshotID))
+	state := strings.ToUpper(strings.TrimSpace(sub.ReviewScreenshotAssetDeliveryState))
+	row.Evidence = fmt.Sprintf("id=%s asset_delivery_state=%s", strings.TrimSpace(sub.ReviewScreenshotID), fallbackString(state, "unknown"))
+	if len(sub.ReviewScreenshotAssetDeliveryErrors) > 0 {
+		row.Evidence += " errors=" + strings.Join(sub.ReviewScreenshotAssetDeliveryErrors, "; ")
+	}
+	switch state {
+	case "COMPLETE":
+		row.Status = DiagnosticStatusYes
+	case "FAILED":
+		row.Status = DiagnosticStatusNo
+		row.Remediation = reviewScreenshotFailedRemediation(sub)
+	default:
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = reviewScreenshotDeliveryRemediation(state)
+	}
 	return row
+}
+
+func reviewScreenshotFailedRemediation(sub Subscription) string {
+	screenshotID := fallbackString(strings.TrimSpace(sub.ReviewScreenshotID), "SHOT_ID")
+	subscriptionID := fallbackString(strings.TrimSpace(sub.ID), "SUB_ID")
+	return fmt.Sprintf("Delete the failed screenshot with `asc subscriptions review screenshots delete --screenshot-id %q --confirm`, then re-upload it with `asc subscriptions review screenshots create --subscription-id %q --file \"./review.png\"`.", screenshotID, subscriptionID)
+}
+
+func reviewScreenshotDeliveryRemediation(state string) string {
+	state = strings.ToUpper(strings.TrimSpace(state))
+	if state == "" {
+		return "Apple did not return the screenshot asset delivery state; retry validation and confirm it reaches COMPLETE before submission."
+	}
+	return fmt.Sprintf("The screenshot asset delivery state is %s; wait for it to reach COMPLETE, then re-run validation.", state)
 }
 
 func buildPromotionalImageDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {
@@ -248,7 +279,7 @@ func buildPromotionalImageDiagnosticRow(sub Subscription) SubscriptionDiagnostic
 	if !sub.HasImage {
 		row.Status = DiagnosticStatusNo
 		row.Evidence = "missing"
-		row.Remediation = fmt.Sprintf("Upload a promotional image with `asc subscriptions images create --subscription-id %q --file \"./image.png\"` if you plan to use offer codes, win-back offers, or App Store promotion.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+		row.Remediation = fmt.Sprintf("Apple documents this image as optional unless you use offers or App Store promotion. For an otherwise-complete subscription stuck in MISSING_METADATA, uploading a 1024x1024 image with `asc subscriptions images create --subscription-id %q --file \"./image.png\"` can also serve as an undocumented recalculation attempt; re-run validation afterward.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
 		return row
 	}
 
@@ -537,6 +568,8 @@ func summarizeSubscriptionDiagnostics(sub Subscription, rows []SubscriptionDiagn
 		return "known_blocker", fmt.Sprintf("%d known blocking subscription issue(s) found", blockingFailures)
 	case blockingUnknown > 0:
 		return "unknown", fmt.Sprintf("%d blocking subscription check(s) could not be verified automatically", blockingUnknown)
+	case state == "MISSING_METADATA" && advisoryFailures > 0:
+		return "opaque_apple_state", fmt.Sprintf("All blocking public checks passed; %d advisory finding(s) remain, but they do not explain why Apple still reports MISSING_METADATA.", advisoryFailures)
 	case advisoryFailures > 0:
 		return "advisory_only", "No blocking issues found; only advisory subscription findings remain."
 	case state == "MISSING_METADATA":

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -69,7 +69,7 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 			buildSubscriptionAvailabilityDiagnosticRow(sub),
 			buildPriceRecordsDiagnosticRow(sub),
 			buildSubscriptionAvailabilityCoverageDiagnosticRow(sub),
-			buildAppAvailabilityCoverageDiagnosticRow(sub, appTerritories, appTerritoryCount, input.PricingCoverageSkipReason),
+			buildAppAvailabilityCoverageDiagnosticRow(sub, appTerritories, appTerritoryCount, input.AppAvailabilityCoverageSkipReason),
 			buildPromotionalImageDiagnosticRow(sub),
 			buildAppBuildDiagnosticRow(input.AppBuildCount, input.BuildCheckSkipped, input.BuildCheckSkipReason),
 			buildOptionalOfferDiagnosticRow(

--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -46,6 +46,13 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 	if len(appTerritories) > 0 {
 		appTerritoryCount = len(appTerritories)
 	}
+	pricingMatrixContextAvailable := len(input.PricingTerritories) > 0 || input.PricingTerritoryCount > 0 || strings.TrimSpace(input.PricingCoverageSkipReason) != ""
+	pricingTerritories := sortedUniqueNonEmpty(input.PricingTerritories)
+	pricingTerritoryCount := input.PricingTerritoryCount
+	if len(pricingTerritories) == 0 && pricingTerritoryCount == 0 {
+		pricingTerritories = appTerritories
+		pricingTerritoryCount = appTerritoryCount
+	}
 
 	for _, sub := range input.Subscriptions {
 		if isRemovedMonetizationState(sub.State) {
@@ -90,6 +97,9 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 				"Optional: configure win-back offers with `asc subscriptions offers win-back create` if you plan to use them.",
 			),
 		}
+		if pricingMatrixContextAvailable {
+			rows = append(rows, buildPricingMatrixDiagnosticRow(sub, pricingTerritories, pricingTerritoryCount, input.PricingCoverageSkipReason))
+		}
 
 		conclusion, summary := summarizeSubscriptionDiagnostics(sub, rows)
 		diagnostics = append(diagnostics, SubscriptionDiagnostics{
@@ -104,6 +114,53 @@ func buildSubscriptionDiagnostics(input SubscriptionsInput) []SubscriptionDiagno
 	}
 
 	return diagnostics
+}
+
+func buildPricingMatrixDiagnosticRow(sub Subscription, pricingTerritories []string, pricingTerritoryCount int, skipReason string) SubscriptionDiagnosticRow {
+	row := SubscriptionDiagnosticRow{
+		Key:      "complete_pricing_matrix",
+		Label:    "Complete App Store pricing matrix",
+		Status:   DiagnosticStatusUnknown,
+		Source:   "derived",
+		Blocking: true,
+	}
+	if strings.TrimSpace(skipReason) != "" {
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = strings.TrimSpace(skipReason)
+		return row
+	}
+	if sub.PriceCheckSkipped {
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = fallbackString(sub.PriceCheckSkipReason, "Validation could not verify subscription pricing automatically")
+		return row
+	}
+	pricingTerritories = sortedUniqueNonEmpty(pricingTerritories)
+	if len(pricingTerritories) > 0 {
+		missing := missingValues(pricingTerritories, sortedUniqueNonEmpty(sub.PriceTerritories))
+		if len(missing) == 0 {
+			row.Status = DiagnosticStatusYes
+			row.Evidence = fmt.Sprintf("priced=%d required=%d", len(pricingTerritories), len(pricingTerritories))
+			return row
+		}
+		row.Status = DiagnosticStatusNo
+		row.Evidence = fmt.Sprintf("priced=%d required=%d missing=%s", len(sortedUniqueNonEmpty(sub.PriceTerritories)), len(pricingTerritories), formatList(missing))
+		row.Remediation = fmt.Sprintf("Materialize the full price matrix with `asc subscriptions setup --subscription-id %q --repair ...`; sale availability does not narrow Apple's pricing requirement.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+		return row
+	}
+	if pricingTerritoryCount <= 0 {
+		row.Status = DiagnosticStatusUnverified
+		row.Remediation = "App Store pricing territories were unavailable."
+		return row
+	}
+	pricedCount := max(sub.PriceCount, len(sortedUniqueNonEmpty(sub.PriceTerritories)))
+	if pricedCount >= pricingTerritoryCount {
+		row.Status = DiagnosticStatusYes
+	} else {
+		row.Status = DiagnosticStatusNo
+		row.Remediation = fmt.Sprintf("Materialize the full price matrix with `asc subscriptions setup --subscription-id %q --repair ...`.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+	}
+	row.Evidence = fmt.Sprintf("priced=%d required=%d", pricedCount, pricingTerritoryCount)
+	return row
 }
 
 func buildGroupLocalizationsDiagnosticRow(sub Subscription) SubscriptionDiagnosticRow {

--- a/internal/validation/subscriptions_validate.go
+++ b/internal/validation/subscriptions_validate.go
@@ -67,6 +67,8 @@ type SubscriptionsInput struct {
 	Subscriptions             []Subscription
 	AvailableTerritories      int
 	AppAvailableTerritories   []string
+	PricingTerritories        []string
+	PricingTerritoryCount     int
 	PricingCoverageSkipReason string
 	AppBuildCount             int
 	BuildCheckSkipped         bool
@@ -85,11 +87,17 @@ type SubscriptionsReport struct {
 
 // ValidateSubscriptions validates subscription review readiness and returns a report.
 func ValidateSubscriptions(input SubscriptionsInput, strict bool) SubscriptionsReport {
-	availableTerritories := input.AvailableTerritories
-	appAvailableTerritories := input.AppAvailableTerritories
+	pricingTerritoryCount := input.PricingTerritoryCount
+	pricingTerritories := input.PricingTerritories
+	// Preserve programmatic callers compiled before pricing-territory discovery
+	// was added; the CLI always supplies the canonical pricing universe.
+	if pricingTerritoryCount == 0 && len(pricingTerritories) == 0 {
+		pricingTerritoryCount = input.AvailableTerritories
+		pricingTerritories = input.AppAvailableTerritories
+	}
 	if input.PricingCoverageSkipReason != "" {
-		availableTerritories = 0
-		appAvailableTerritories = nil
+		pricingTerritoryCount = 0
+		pricingTerritories = nil
 	}
 
 	checks := make([]CheckResult, 0)
@@ -98,7 +106,7 @@ func ValidateSubscriptions(input SubscriptionsInput, strict bool) SubscriptionsR
 	checks = append(checks, subscriptionPricingVerificationChecks(input.Subscriptions)...)
 	checks = append(checks, subscriptionPricingCoverageSkipChecks(input.AppID, input.PricingCoverageSkipReason)...)
 	checks = append(checks, subscriptionMetadataDiagnostics(input.Subscriptions)...)
-	checks = append(checks, subscriptionPricingCoverageChecks(input.Subscriptions, availableTerritories, appAvailableTerritories)...)
+	checks = append(checks, subscriptionPricingCoverageChecks(input.Subscriptions, pricingTerritoryCount, pricingTerritories)...)
 	diagnostics := buildSubscriptionDiagnostics(input)
 	summary := summarize(checks, strict)
 
@@ -286,16 +294,16 @@ func subscriptionPricingCoverageSkipChecks(appID, reason string) []CheckResult {
 	}}
 }
 
-// subscriptionPricingCoverageChecks warns when a subscription has prices configured
-// but doesn't cover all territories the app is available in. This catches the common
-// submission failure where only a single territory (e.g., US) has pricing set.
-func subscriptionPricingCoverageChecks(subs []Subscription, availableTerritories int, appAvailableTerritories []string) []CheckResult {
-	appAvailableTerritories = sortedUniqueNonEmpty(appAvailableTerritories)
-	if len(appAvailableTerritories) == 0 && availableTerritories <= 0 {
+// subscriptionPricingCoverageChecks warns when a subscription does not have the
+// complete pricing matrix returned by App Store Connect. Sale availability is an
+// independent subset and must not narrow this check.
+func subscriptionPricingCoverageChecks(subs []Subscription, availableTerritories int, pricingTerritories []string) []CheckResult {
+	pricingTerritories = sortedUniqueNonEmpty(pricingTerritories)
+	if len(pricingTerritories) == 0 && availableTerritories <= 0 {
 		return nil
 	}
-	if len(appAvailableTerritories) > 0 {
-		availableTerritories = len(appAvailableTerritories)
+	if len(pricingTerritories) > 0 {
+		availableTerritories = len(pricingTerritories)
 	}
 
 	var checks []CheckResult
@@ -310,47 +318,8 @@ func subscriptionPricingCoverageChecks(subs []Subscription, availableTerritories
 
 		label := formatSubscriptionLabel(sub)
 		priceTerritories := sortedUniqueNonEmpty(sub.PriceTerritories)
-		subscriptionAvailabilityTerritories := sortedUniqueNonEmpty(sub.AvailabilityTerritories)
-		if state == "MISSING_METADATA" {
-			availabilityUnknown := sub.AvailabilityCheckSkipped || strings.TrimSpace(sub.AvailabilityID) == ""
-			availabilityEmpty := strings.TrimSpace(sub.AvailabilityID) != "" && len(subscriptionAvailabilityTerritories) == 0
-			if availabilityUnknown || availabilityEmpty {
-				continue
-			}
-		}
-		if len(subscriptionAvailabilityTerritories) > 0 {
-			if len(priceTerritories) > 0 {
-				missing := missingValues(subscriptionAvailabilityTerritories, priceTerritories)
-				if len(missing) == 0 {
-					continue
-				}
-				checks = append(checks, CheckResult{
-					ID:           "subscriptions.pricing.partial_territory_coverage",
-					Severity:     SeverityWarning,
-					Field:        "pricing",
-					ResourceType: "subscription",
-					ResourceID:   strings.TrimSpace(sub.ID),
-					Message:      fmt.Sprintf("%s has pricing for %d of %d subscription availability territories; missing: %s", label, len(priceTerritories), len(subscriptionAvailabilityTerritories), strings.Join(missing, ",")),
-					Remediation:  "Set prices for all subscription availability territories using `asc subscriptions pricing equalize` or `asc subscriptions pricing prices set`; missing territory pricing blocks App Store submission",
-				})
-				continue
-			}
-			if sub.PriceCount >= len(subscriptionAvailabilityTerritories) {
-				continue
-			}
-			checks = append(checks, CheckResult{
-				ID:           "subscriptions.pricing.partial_territory_coverage",
-				Severity:     SeverityWarning,
-				Field:        "pricing",
-				ResourceType: "subscription",
-				ResourceID:   strings.TrimSpace(sub.ID),
-				Message:      fmt.Sprintf("%s has pricing for %d of %d subscription availability territories", label, sub.PriceCount, len(subscriptionAvailabilityTerritories)),
-				Remediation:  "Set prices for all subscription availability territories using `asc subscriptions pricing equalize` or `asc subscriptions pricing prices set`; missing territory pricing blocks App Store submission",
-			})
-			continue
-		}
-		if len(appAvailableTerritories) > 0 && len(priceTerritories) > 0 {
-			missing := missingValues(appAvailableTerritories, priceTerritories)
+		if len(pricingTerritories) > 0 && len(priceTerritories) > 0 {
+			missing := missingValues(pricingTerritories, priceTerritories)
 			if len(missing) == 0 {
 				continue
 			}
@@ -360,8 +329,8 @@ func subscriptionPricingCoverageChecks(subs []Subscription, availableTerritories
 				Field:        "pricing",
 				ResourceType: "subscription",
 				ResourceID:   strings.TrimSpace(sub.ID),
-				Message:      fmt.Sprintf("%s has pricing for %d of %d app availability territories; missing: %s", label, len(priceTerritories), len(appAvailableTerritories), strings.Join(missing, ",")),
-				Remediation:  "Set prices for all app availability territories using `asc subscriptions pricing equalize` or `asc subscriptions pricing prices set`; missing territory pricing blocks App Store submission",
+				Message:      fmt.Sprintf("%s has pricing for %d of %d App Store pricing territories; missing: %s", label, len(priceTerritories), len(pricingTerritories), strings.Join(missing, ",")),
+				Remediation:  "Materialize the complete App Store pricing matrix using `asc subscriptions setup --repair` or `asc subscriptions pricing equalize`; missing pricing territories can leave Apple reporting MISSING_METADATA",
 			})
 			continue
 		}
@@ -374,8 +343,8 @@ func subscriptionPricingCoverageChecks(subs []Subscription, availableTerritories
 			Field:        "pricing",
 			ResourceType: "subscription",
 			ResourceID:   strings.TrimSpace(sub.ID),
-			Message:      fmt.Sprintf("%s has pricing for %d of %d available territories", label, sub.PriceCount, availableTerritories),
-			Remediation:  "Set prices for all available territories using `asc subscriptions pricing equalize` or `asc subscriptions pricing prices set`; missing territory pricing blocks App Store submission",
+			Message:      fmt.Sprintf("%s has pricing for %d of %d App Store pricing territories", label, sub.PriceCount, availableTerritories),
+			Remediation:  "Materialize the complete App Store pricing matrix using `asc subscriptions setup --repair` or `asc subscriptions pricing equalize`; missing pricing territories can leave Apple reporting MISSING_METADATA",
 		})
 	}
 

--- a/internal/validation/subscriptions_validate.go
+++ b/internal/validation/subscriptions_validate.go
@@ -63,16 +63,17 @@ type SubscriptionGroupLocalizationInfo struct {
 
 // SubscriptionsInput collects subscription validation inputs.
 type SubscriptionsInput struct {
-	AppID                     string
-	Subscriptions             []Subscription
-	AvailableTerritories      int
-	AppAvailableTerritories   []string
-	PricingTerritories        []string
-	PricingTerritoryCount     int
-	PricingCoverageSkipReason string
-	AppBuildCount             int
-	BuildCheckSkipped         bool
-	BuildCheckSkipReason      string
+	AppID                             string
+	Subscriptions                     []Subscription
+	AvailableTerritories              int
+	AppAvailableTerritories           []string
+	AppAvailabilityCoverageSkipReason string
+	PricingTerritories                []string
+	PricingTerritoryCount             int
+	PricingCoverageSkipReason         string
+	AppBuildCount                     int
+	BuildCheckSkipped                 bool
+	BuildCheckSkipReason              string
 }
 
 // SubscriptionsReport is the top-level validate subscriptions output.
@@ -289,7 +290,7 @@ func subscriptionPricingCoverageSkipChecks(appID, reason string) []CheckResult {
 		Field:        "pricing",
 		ResourceType: "app",
 		ResourceID:   strings.TrimSpace(appID),
-		Message:      "Could not verify subscription pricing coverage against app availability territories",
+		Message:      "Could not verify the complete subscription price matrix against App Store pricing territories",
 		Remediation:  reason,
 	}}
 }

--- a/internal/validation/subscriptions_validate.go
+++ b/internal/validation/subscriptions_validate.go
@@ -7,22 +7,24 @@ import (
 
 // Subscription represents an auto-renewable subscription for review-readiness validation.
 type Subscription struct {
-	ID                           string
-	Name                         string
-	ProductID                    string
-	State                        string
-	GroupID                      string
-	GroupName                    string
-	HasImage                     bool
-	ImageCheckSkipped            bool
-	ImageCheckSkipReason         string
-	ReviewScreenshotID           string
-	ReviewScreenshotCheckSkipped bool
-	ReviewScreenshotCheckReason  string
-	AvailabilityID               string
-	AvailabilityTerritories      []string
-	AvailabilityCheckSkipped     bool
-	AvailabilityCheckSkipReason  string
+	ID                                  string
+	Name                                string
+	ProductID                           string
+	State                               string
+	GroupID                             string
+	GroupName                           string
+	HasImage                            bool
+	ImageCheckSkipped                   bool
+	ImageCheckSkipReason                string
+	ReviewScreenshotID                  string
+	ReviewScreenshotAssetDeliveryState  string
+	ReviewScreenshotAssetDeliveryErrors []string
+	ReviewScreenshotCheckSkipped        bool
+	ReviewScreenshotCheckReason         string
+	AvailabilityID                      string
+	AvailabilityTerritories             []string
+	AvailabilityCheckSkipped            bool
+	AvailabilityCheckSkipReason         string
 
 	// Deep diagnostics (populated when State is MISSING_METADATA).
 	Localizations                 []SubscriptionLocalizationInfo
@@ -503,7 +505,8 @@ func subscriptionMetadataDiagnostics(subs []Subscription) []CheckResult {
 			}
 		}
 
-		// Check pricing.
+		// Check the App Review screenshot and its asset delivery state.
+		reviewScreenshotState := strings.ToUpper(strings.TrimSpace(sub.ReviewScreenshotAssetDeliveryState))
 		if sub.ReviewScreenshotCheckSkipped {
 			remediation := strings.TrimSpace(sub.ReviewScreenshotCheckReason)
 			if remediation == "" {
@@ -527,6 +530,26 @@ func subscriptionMetadataDiagnostics(subs []Subscription) []CheckResult {
 				ResourceID:   strings.TrimSpace(sub.ID),
 				Message:      fmt.Sprintf("%s has no App Review screenshot", label),
 				Remediation:  "Upload a subscription App Review screenshot via `asc subscriptions review screenshots create`",
+			})
+		} else if reviewScreenshotState == "FAILED" {
+			checks = append(checks, CheckResult{
+				ID:           "subscriptions.diagnostics.review_screenshot_failed",
+				Severity:     SeverityWarning,
+				Field:        "reviewScreenshot",
+				ResourceType: "subscription",
+				ResourceID:   strings.TrimSpace(sub.ID),
+				Message:      fmt.Sprintf("%s App Review screenshot failed asset delivery", label),
+				Remediation:  reviewScreenshotFailedRemediation(sub),
+			})
+		} else if reviewScreenshotState != "COMPLETE" {
+			checks = append(checks, CheckResult{
+				ID:           "subscriptions.diagnostics.review_screenshot_unverified",
+				Severity:     SeverityInfo,
+				Field:        "reviewScreenshot",
+				ResourceType: "subscription",
+				ResourceID:   strings.TrimSpace(sub.ID),
+				Message:      fmt.Sprintf("Could not verify whether %s has a completed App Review screenshot", label),
+				Remediation:  reviewScreenshotDeliveryRemediation(reviewScreenshotState),
 			})
 		}
 

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -717,6 +717,62 @@ func TestValidateSubscriptionsDoesNotBlockDiagnosticsWhenAppAvailabilityIsMissin
 	}
 }
 
+func TestValidateSubscriptionsKeepsAppAvailabilityDiagnosticVerifiedWhenPricingTerritoriesAreUnavailable(t *testing.T) {
+	report := ValidateSubscriptions(SubscriptionsInput{
+		AppID:                     "app-1",
+		AppBuildCount:             1,
+		AppAvailableTerritories:   []string{"USA"},
+		PricingCoverageSkipReason: "App Store pricing territories could not be fetched",
+		Subscriptions: []Subscription{
+			{
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA"},
+				HasImage:                           true,
+				PriceCount:                         1,
+				PriceTerritories:                   []string{"USA"},
+			},
+		},
+	}, false)
+
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("expected one subscription diagnostics entry, got %+v", report.Diagnostics)
+	}
+	appCoverageRow, ok := findSubscriptionDiagnosticRow(report.Diagnostics[0].Rows, "price_coverage_app_availability")
+	if !ok {
+		t.Fatalf("expected app coverage diagnostic row, got %+v", report.Diagnostics[0].Rows)
+	}
+	if appCoverageRow.Status != DiagnosticStatusYes {
+		t.Fatalf("expected fetched app availability to remain verified, got %+v", appCoverageRow)
+	}
+	matrixRow, ok := findSubscriptionDiagnosticRow(report.Diagnostics[0].Rows, "complete_pricing_matrix")
+	if !ok || matrixRow.Status != DiagnosticStatusUnverified {
+		t.Fatalf("expected only the pricing matrix to be unverified, got %+v", matrixRow)
+	}
+}
+
+func TestSubscriptionPricingCoverageSkipCheckNamesPricingTerritories(t *testing.T) {
+	checks := subscriptionPricingCoverageSkipChecks("app-1", "pricing endpoint unavailable")
+	if len(checks) != 1 {
+		t.Fatalf("expected one pricing coverage skip check, got %+v", checks)
+	}
+	if strings.Contains(strings.ToLower(checks[0].Message), "app availability") {
+		t.Fatalf("expected pricing-territory-specific message, got %+v", checks[0])
+	}
+	if !strings.Contains(strings.ToLower(checks[0].Message), "app store pricing territories") {
+		t.Fatalf("expected pricing-territory-specific message, got %+v", checks[0])
+	}
+}
+
 func TestValidateSubscriptionsSkipsAppCoverageUntilSubscriptionAvailabilityExists(t *testing.T) {
 	report := ValidateSubscriptions(SubscriptionsInput{
 		AppID:                   "app-1",

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -661,6 +661,12 @@ func TestValidateSubscriptionsTreatsIncompletePricingMatrixAsBlocker(t *testing.
 	if !ok || matrixRow.Status != DiagnosticStatusNo || !matrixRow.Blocking {
 		t.Fatalf("expected blocking full pricing matrix diagnostic, got %+v", matrixRow)
 	}
+	if strings.Contains(matrixRow.Remediation, "--subscription-id") {
+		t.Fatalf("expected remediation to avoid unsupported setup flag, got %+v", matrixRow)
+	}
+	if !strings.Contains(matrixRow.Remediation, "Re-run `asc subscriptions setup`") || !strings.Contains(matrixRow.Remediation, "--repair") {
+		t.Fatalf("expected valid setup repair guidance, got %+v", matrixRow)
+	}
 
 	appCoverageRow, ok := findSubscriptionDiagnosticRow(diag.Rows, "price_coverage_app_availability")
 	if !ok {

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -419,6 +419,7 @@ func TestValidateSubscriptionsIncludesDetailedDiagnosticsForOpaqueMissingMetadat
 		"price_records",
 		"price_coverage_subscription_availability",
 		"price_coverage_app_availability",
+		"complete_pricing_matrix",
 		"promotional_image",
 		"app_has_build",
 	} {

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -168,7 +168,7 @@ func TestSubscriptionPricingCoverage_SkipsWhenPriceCheckSkipped(t *testing.T) {
 	}
 }
 
-func TestSubscriptionPricingCoverage_PrefersSubscriptionAvailabilityTerritories(t *testing.T) {
+func TestSubscriptionPricingCoverage_RequiresFullPricingMatrixWhenAvailabilityIsNarrower(t *testing.T) {
 	checks := subscriptionPricingCoverageChecks([]Subscription{
 		{
 			ID:                      "sub-1",
@@ -180,8 +180,11 @@ func TestSubscriptionPricingCoverage_PrefersSubscriptionAvailabilityTerritories(
 			PriceTerritories:        []string{"USA"},
 		},
 	}, 2, []string{"USA", "CAN"})
-	if len(checks) != 0 {
-		t.Fatalf("expected no app-territory warning when subscription availability is narrower, got %v", checks)
+	if !hasCheckID(checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected full pricing matrix warning even when sale availability is narrower, got %v", checks)
+	}
+	if !strings.Contains(checks[0].Message, "CAN") {
+		t.Fatalf("expected missing pricing territory in warning, got %q", checks[0].Message)
 	}
 }
 
@@ -618,11 +621,13 @@ func TestValidateSubscriptionsFallsBackToAppTerritoryCountInDiagnostics(t *testi
 	}
 }
 
-func TestValidateSubscriptionsTreatsAppOnlyTerritoriesAsAdvisoryInDiagnostics(t *testing.T) {
+func TestValidateSubscriptionsTreatsIncompletePricingMatrixAsBlocker(t *testing.T) {
 	report := ValidateSubscriptions(SubscriptionsInput{
 		AppID:                   "app-1",
 		AppBuildCount:           1,
 		AppAvailableTerritories: []string{"USA", "CAN"},
+		PricingTerritories:      []string{"USA", "CAN"},
+		PricingTerritoryCount:   2,
 		Subscriptions: []Subscription{
 			{
 				ID:                                 "sub-1",
@@ -649,8 +654,12 @@ func TestValidateSubscriptionsTreatsAppOnlyTerritoriesAsAdvisoryInDiagnostics(t 
 	}
 
 	diag := report.Diagnostics[0]
-	if diag.Conclusion != "opaque_apple_state" {
-		t.Fatalf("expected opaque_apple_state when only app-only territories remain, got %+v", diag)
+	if diag.Conclusion != "known_blocker" {
+		t.Fatalf("expected incomplete full pricing matrix to be a known blocker, got %+v", diag)
+	}
+	matrixRow, ok := findSubscriptionDiagnosticRow(diag.Rows, "complete_pricing_matrix")
+	if !ok || matrixRow.Status != DiagnosticStatusNo || !matrixRow.Blocking {
+		t.Fatalf("expected blocking full pricing matrix diagnostic, got %+v", matrixRow)
 	}
 
 	appCoverageRow, ok := findSubscriptionDiagnosticRow(diag.Rows, "price_coverage_app_availability")
@@ -732,8 +741,8 @@ func TestValidateSubscriptionsSkipsAppCoverageUntilSubscriptionAvailabilityExist
 		},
 	}, false)
 
-	if hasCheckID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
-		t.Fatalf("did not expect app-territory pricing warning before subscription availability exists, got %+v", report.Checks)
+	if !hasCheckID(report.Checks, "subscriptions.pricing.partial_territory_coverage") {
+		t.Fatalf("expected pricing matrix warning independent of subscription availability, got %+v", report.Checks)
 	}
 	if len(report.Diagnostics) != 1 {
 		t.Fatalf("expected one subscription diagnostics entry, got %+v", report.Diagnostics)

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -377,20 +377,21 @@ func TestValidateSubscriptionsIncludesDetailedDiagnosticsForOpaqueMissingMetadat
 		AppAvailableTerritories: []string{"USA", "CAN"},
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA", "CAN"},
-				HasImage:                true,
-				PriceCount:              2,
-				PriceTerritories:        []string{"USA", "CAN"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA", "CAN"},
+				HasImage:                           true,
+				PriceCount:                         2,
+				PriceTerritories:                   []string{"USA", "CAN"},
 			},
 		},
 	}, false)
@@ -443,19 +444,20 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 		AppAvailableTerritories: []string{"USA", "CAN"},
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA", "CAN"},
-				PriceCount:              2,
-				PriceTerritories:        []string{"USA", "CAN"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA", "CAN"},
+				PriceCount:                         2,
+				PriceTerritories:                   []string{"USA", "CAN"},
 			},
 		},
 	}, false)
@@ -465,11 +467,11 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 	}
 
 	diag := report.Diagnostics[0]
-	if diag.Conclusion != "advisory_only" {
-		t.Fatalf("expected advisory_only conclusion when only advisory rows fail, got %+v", diag)
+	if diag.Conclusion != "opaque_apple_state" {
+		t.Fatalf("expected opaque_apple_state conclusion when only advisory rows fail but Apple remains stuck, got %+v", diag)
 	}
-	if !strings.Contains(diag.Summary, "only advisory subscription findings remain") {
-		t.Fatalf("expected advisory summary, got %+v", diag)
+	if !strings.Contains(diag.Summary, "do not explain why Apple still reports MISSING_METADATA") {
+		t.Fatalf("expected opaque Apple state summary, got %+v", diag)
 	}
 
 	imageRow, ok := findSubscriptionDiagnosticRow(diag.Rows, "promotional_image")
@@ -479,6 +481,9 @@ func TestValidateSubscriptionsPrefersAdvisoryConclusionOverOpaqueAppleState(t *t
 	if imageRow.Status != DiagnosticStatusNo || imageRow.Blocking {
 		t.Fatalf("expected promotional image finding to stay advisory, got %+v", imageRow)
 	}
+	if !strings.Contains(imageRow.Remediation, "undocumented recalculation attempt") || !strings.Contains(imageRow.Remediation, "1024x1024") {
+		t.Fatalf("expected stuck-state promotional image guidance, got %+v", imageRow)
+	}
 }
 
 func TestValidateSubscriptionsDiagnosticsShowExactMissingTerritories(t *testing.T) {
@@ -487,19 +492,20 @@ func TestValidateSubscriptionsDiagnosticsShowExactMissingTerritories(t *testing.
 		AppAvailableTerritories: []string{"USA", "CAN"},
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA", "CAN"},
-				PriceCount:              1,
-				PriceTerritories:        []string{"USA"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA", "CAN"},
+				PriceCount:                         1,
+				PriceTerritories:                   []string{"USA"},
 			},
 		},
 	}, false)
@@ -538,19 +544,20 @@ func TestValidateSubscriptionsMarksSkippedBuildDiagnosticAsUnverified(t *testing
 		BuildCheckSkipReason:    "build endpoint forbidden",
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA", "CAN"},
-				PriceCount:              2,
-				PriceTerritories:        []string{"USA", "CAN"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA", "CAN"},
+				PriceCount:                         2,
+				PriceTerritories:                   []string{"USA", "CAN"},
 			},
 		},
 	}, false)
@@ -577,19 +584,20 @@ func TestValidateSubscriptionsFallsBackToAppTerritoryCountInDiagnostics(t *testi
 		AvailableTerritories: 2,
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA", "CAN"},
-				PriceCount:              2,
-				PriceTerritories:        []string{"USA", "CAN"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA", "CAN"},
+				PriceCount:                         2,
+				PriceTerritories:                   []string{"USA", "CAN"},
 			},
 		},
 	}, false)
@@ -617,20 +625,21 @@ func TestValidateSubscriptionsTreatsAppOnlyTerritoriesAsAdvisoryInDiagnostics(t 
 		AppAvailableTerritories: []string{"USA", "CAN"},
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA"},
-				HasImage:                true,
-				PriceCount:              1,
-				PriceTerritories:        []string{"USA"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA"},
+				HasImage:                           true,
+				PriceCount:                         1,
+				PriceTerritories:                   []string{"USA"},
 			},
 		},
 	}, false)
@@ -662,20 +671,21 @@ func TestValidateSubscriptionsDoesNotBlockDiagnosticsWhenAppAvailabilityIsMissin
 		AppBuildCount: 1,
 		Subscriptions: []Subscription{
 			{
-				ID:                      "sub-1",
-				Name:                    "Monthly",
-				ProductID:               "com.example.monthly",
-				State:                   "MISSING_METADATA",
-				GroupID:                 "group-1",
-				GroupName:               "Premium",
-				GroupLocalizations:      []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:           []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID:      "shot-1",
-				AvailabilityID:          "avail-1",
-				AvailabilityTerritories: []string{"USA"},
-				HasImage:                true,
-				PriceCount:              1,
-				PriceTerritories:        []string{"USA"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				AvailabilityID:                     "avail-1",
+				AvailabilityTerritories:            []string{"USA"},
+				HasImage:                           true,
+				PriceCount:                         1,
+				PriceTerritories:                   []string{"USA"},
 			},
 		},
 	}, false)
@@ -705,18 +715,19 @@ func TestValidateSubscriptionsSkipsAppCoverageUntilSubscriptionAvailabilityExist
 		AppAvailableTerritories: []string{"USA", "CAN"},
 		Subscriptions: []Subscription{
 			{
-				ID:                 "sub-1",
-				Name:               "Monthly",
-				ProductID:          "com.example.monthly",
-				State:              "MISSING_METADATA",
-				GroupID:            "group-1",
-				GroupName:          "Premium",
-				GroupLocalizations: []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
-				Localizations:      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
-				ReviewScreenshotID: "shot-1",
-				HasImage:           true,
-				PriceCount:         1,
-				PriceTerritories:   []string{"USA"},
+				ID:                                 "sub-1",
+				Name:                               "Monthly",
+				ProductID:                          "com.example.monthly",
+				State:                              "MISSING_METADATA",
+				GroupID:                            "group-1",
+				GroupName:                          "Premium",
+				GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+				Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Unlimited access"}},
+				ReviewScreenshotID:                 "shot-1",
+				ReviewScreenshotAssetDeliveryState: "COMPLETE",
+				HasImage:                           true,
+				PriceCount:                         1,
+				PriceTerritories:                   []string{"USA"},
 			},
 		},
 	}, false)
@@ -752,4 +763,66 @@ func findSubscriptionDiagnosticRow(rows []SubscriptionDiagnosticRow, key string)
 		}
 	}
 	return SubscriptionDiagnosticRow{}, false
+}
+
+func TestReviewScreenshotDiagnosticsRespectAssetDeliveryState(t *testing.T) {
+	tests := []struct {
+		name           string
+		state          string
+		wantStatus     DiagnosticStatus
+		wantConclusion string
+		wantCheckID    string
+		wantText       string
+	}{
+		{name: "complete", state: "COMPLETE", wantStatus: DiagnosticStatusYes, wantConclusion: "opaque_apple_state"},
+		{name: "failed", state: "FAILED", wantStatus: DiagnosticStatusNo, wantConclusion: "known_blocker", wantCheckID: "subscriptions.diagnostics.review_screenshot_failed", wantText: "delete"},
+		{name: "processing", state: "PROCESSING", wantStatus: DiagnosticStatusUnverified, wantConclusion: "unknown", wantCheckID: "subscriptions.diagnostics.review_screenshot_unverified", wantText: "COMPLETE"},
+		{name: "unknown", state: "", wantStatus: DiagnosticStatusUnverified, wantConclusion: "unknown", wantCheckID: "subscriptions.diagnostics.review_screenshot_unverified", wantText: "delivery state"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			report := ValidateSubscriptions(SubscriptionsInput{
+				AppID:         "app-1",
+				AppBuildCount: 1,
+				Subscriptions: []Subscription{{
+					ID:                                 "sub-1",
+					State:                              "MISSING_METADATA",
+					GroupLocalizations:                 []SubscriptionGroupLocalizationInfo{{Locale: "en-US", Name: "Premium"}},
+					Localizations:                      []SubscriptionLocalizationInfo{{Locale: "en-US", Name: "Monthly", Description: "Access"}},
+					ReviewScreenshotID:                 "shot-1",
+					ReviewScreenshotAssetDeliveryState: test.state,
+					AvailabilityID:                     "avail-1",
+					AvailabilityTerritories:            []string{"USA"},
+					PriceCount:                         1,
+					PriceTerritories:                   []string{"USA"},
+					HasImage:                           true,
+				}},
+			}, false)
+
+			if len(report.Diagnostics) != 1 {
+				t.Fatalf("expected one diagnostics result, got %+v", report.Diagnostics)
+			}
+			diagnostic := report.Diagnostics[0]
+			row, ok := findSubscriptionDiagnosticRow(diagnostic.Rows, "review_screenshot")
+			if !ok {
+				t.Fatalf("review screenshot row missing: %+v", diagnostic.Rows)
+			}
+			if row.Status != test.wantStatus || diagnostic.Conclusion != test.wantConclusion {
+				t.Fatalf("row=%+v conclusion=%q, want status=%q conclusion=%q", row, diagnostic.Conclusion, test.wantStatus, test.wantConclusion)
+			}
+			if !strings.Contains(row.Evidence, "asset_delivery_state=") {
+				t.Fatalf("expected delivery-state evidence, got %+v", row)
+			}
+			if test.wantText != "" && !strings.Contains(strings.ToLower(row.Remediation), strings.ToLower(test.wantText)) {
+				t.Fatalf("remediation %q does not contain %q", row.Remediation, test.wantText)
+			}
+			if test.state == "FAILED" && !strings.Contains(strings.ToLower(row.Remediation), "re-upload") {
+				t.Fatalf("failed screenshot remediation must instruct re-upload, got %q", row.Remediation)
+			}
+			if test.wantCheckID != "" && !hasCheckID(report.Checks, test.wantCheckID) {
+				t.Fatalf("expected check %q, got %+v", test.wantCheckID, report.Checks)
+			}
+		})
+	}
 }

--- a/internal/validation/types.go
+++ b/internal/validation/types.go
@@ -67,6 +67,8 @@ type Input struct {
 	AvailabilityID              string
 	AvailableTerritories        int
 	AppAvailableTerritories     []string
+	PricingTerritories          []string
+	PricingTerritoryCount       int
 	AvailabilityFetchSkipReason string
 	PricingCoverageSkipReason   string
 	ScreenshotSets              []ScreenshotSet


### PR DESCRIPTION
## Root cause

App Store Connect requires the complete equalized subscription price matrix independently of the territories where the subscription is available for sale. The web UI sends one compound subscription PATCH containing all 175 price relationships and inline prices. Our setup path created only the base/availability prices, while validation treated availability coverage as sufficient.

A disposable-app probe with otherwise complete metadata remained `MISSING_METADATA` with three prices. Re-saving the same base price as the full 175-territory matrix, without changing localization or availability, immediately changed Apple final state to `READY_TO_SUBMIT`.

## Changes

- atomically materialize the full equalized matrix during `subscriptions setup`
- make `--repair` rebuild and re-save the matrix even when the base price is unchanged
- make same-value `subscriptions prices add --force --territory ...` use the same atomic matrix PATCH
- verify exact price-point coverage against every canonical App Store pricing territory
- expose final Apple state and deep metadata diagnostics from setup
- support group localization and review screenshot completion in setup
- keep sale availability as an independent subset
- avoid suppressing matrix validation when the separate app-availability probe is unavailable

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- targeted validator concurrency regression under `go test -race`
- live disposable app: 175 resolved price territories and `READY_TO_SUBMIT`
- `asc validate subscriptions --app "6759231657" --output json --pretty`: zero errors and zero blocking issues after repair

Temporary subscriptions, group, screenshot, and local diagnostic files were removed after verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic subscription “price matrix” updates with multi-territory normalization, ordering, and deduplication.
  * Enhanced `subscriptions prices add` with `--force` to re-save the full equalized matrix (and added stricter input validation).
  * Expanded `subscriptions setup` with group localization, review screenshot upload/resume, and optional atomic pricing repair.
  * Updated `validate subscriptions` to use App Store pricing territories and surface review screenshot delivery-state details.
* **Bug Fixes**
  * Improved pricing-territory coverage/blocker detection and more accurate skip-reasons across availability and pricing endpoints.
* **Tests**
  * Added/updated coverage for matrix ordering/dedupe, force/repair flows, pricing-territory validation, and screenshot delivery diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->