### PR TITLE
fix: pagination cycle guards for hand-rolled loops and temp key cleanup on write failure

### DIFF
--- a/internal/asc/client_game_center.go
+++ b/internal/asc/client_game_center.go
@@ -559,27 +559,23 @@ func (c *Client) DeleteGameCenterLeaderboardLocalization(ctx context.Context, lo
 
 // GetAllGameCenterLeaderboardLocalizations retrieves all leaderboard localizations using automatic pagination.
 func (c *Client) GetAllGameCenterLeaderboardLocalizations(ctx context.Context, leaderboardID string, opts ...GCLeaderboardLocalizationsOption) (*GameCenterLeaderboardLocalizationsResponse, error) {
-	var allData []Resource[GameCenterLeaderboardLocalizationAttributes]
-
-	for {
-		resp, err := c.GetGameCenterLeaderboardLocalizations(ctx, leaderboardID, opts...)
-		if err != nil {
-			return nil, err
-		}
-		allData = append(allData, resp.Data...)
-
-		if resp.Links.Next == "" {
-			break
-		}
-		opts = []GCLeaderboardLocalizationsOption{
-			WithGCLeaderboardLocalizationsNextURL(resp.Links.Next),
-		}
+	firstPage, err := c.GetGameCenterLeaderboardLocalizations(ctx, leaderboardID, opts...)
+	if err != nil {
+		return nil, err
 	}
 
-	return &GameCenterLeaderboardLocalizationsResponse{
-		Data:  allData,
-		Links: Links{Self: ""},
-	}, nil
+	result, err := PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		return c.GetGameCenterLeaderboardLocalizations(ctx, leaderboardID, WithGCLeaderboardLocalizationsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, ok := result.(*GameCenterLeaderboardLocalizationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected paginated response type %T", result)
+	}
+	return resp, nil
 }
 
 // GetGameCenterLeaderboardReleases retrieves the list of releases for a Game Center leaderboard.

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6452,6 +6452,46 @@ func TestResolveCiWorkflowByName_NoMatch(t *testing.T) {
 	}
 }
 
+func TestResolveCiWorkflowByName_FollowsPagination(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/workflows?cursor=abc"
+	client := newTestClient(
+		t, func(req *http.Request) {
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"ciWorkflows","id":"wf-1","attributes":{"name":"Deploy"}}],"links":{"next":"`+next+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"ciWorkflows","id":"wf-2","attributes":{"name":"CI Build"}}]}`),
+	)
+
+	workflow, err := client.ResolveCiWorkflowByName(context.Background(), "prod-1", "ci build")
+	if err != nil {
+		t.Fatalf("ResolveCiWorkflowByName() error: %v", err)
+	}
+	if workflow.ID != "wf-2" {
+		t.Fatalf("expected workflow ID wf-2, got %q", workflow.ID)
+	}
+}
+
+func TestResolveCiWorkflowByName_RejectsRepeatedNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/workflows?cursor=repeat"
+	requests := 0
+	client := newTestClient(
+		t, func(req *http.Request) {
+			requests++
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"ciWorkflows","id":"wf-1","attributes":{"name":"Deploy"}}],"links":{"next":"`+next+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"ciWorkflows","id":"wf-2","attributes":{"name":"Release"}}],"links":{"next":"`+next+`"}}`),
+	)
+
+	_, err := client.ResolveCiWorkflowByName(context.Background(), "prod-1", "ci build")
+	if !errors.Is(err, ErrRepeatedPaginationURL) {
+		t.Fatalf("expected ErrRepeatedPaginationURL, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected repeated next URL to stop after two requests, got %d", requests)
+	}
+}
+
 func TestResolveGitReferenceByName_CanonicalMatch(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"scmGitReferences","id":"ref-1","attributes":{"name":"main","canonicalName":"refs/heads/main","isDeleted":false}}]}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/game_center_leaderboard_localizations_test.go
+++ b/internal/asc/game_center_leaderboard_localizations_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -305,5 +306,48 @@ func TestGetGameCenterLeaderboardLocalizations_WithLimit(t *testing.T) {
 	_, err := client.GetGameCenterLeaderboardLocalizations(context.Background(), "lb-123", WithGCLeaderboardLocalizationsLimit(50))
 	if err != nil {
 		t.Fatalf("GetGameCenterLeaderboardLocalizations() error: %v", err)
+	}
+}
+
+func TestGetAllGameCenterLeaderboardLocalizations_FollowsPagination(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/gameCenterLeaderboards/lb-123/localizations?cursor=abc"
+	client := newTestClient(
+		t, func(req *http.Request) {
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"gameCenterLeaderboardLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}],"links":{"next":"`+next+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"gameCenterLeaderboardLocalizations","id":"loc-2","attributes":{"locale":"ja"}}]}`),
+	)
+
+	resp, err := client.GetAllGameCenterLeaderboardLocalizations(context.Background(), "lb-123")
+	if err != nil {
+		t.Fatalf("GetAllGameCenterLeaderboardLocalizations() error: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 localizations, got %d", len(resp.Data))
+	}
+	if resp.Data[0].ID != "loc-1" || resp.Data[1].ID != "loc-2" {
+		t.Fatalf("expected aggregated localizations loc-1 and loc-2, got %q and %q", resp.Data[0].ID, resp.Data[1].ID)
+	}
+}
+
+func TestGetAllGameCenterLeaderboardLocalizations_RejectsRepeatedNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/gameCenterLeaderboards/lb-123/localizations?cursor=repeat"
+	requests := 0
+	client := newTestClient(
+		t, func(req *http.Request) {
+			requests++
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"gameCenterLeaderboardLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}],"links":{"next":"`+next+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"gameCenterLeaderboardLocalizations","id":"loc-2","attributes":{"locale":"ja"}}],"links":{"next":"`+next+`"}}`),
+	)
+
+	_, err := client.GetAllGameCenterLeaderboardLocalizations(context.Background(), "lb-123")
+	if !errors.Is(err, ErrRepeatedPaginationURL) {
+		t.Fatalf("expected ErrRepeatedPaginationURL, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected repeated next URL to stop after two requests, got %d", requests)
 	}
 }

--- a/internal/asc/sandbox.go
+++ b/internal/asc/sandbox.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -203,29 +204,39 @@ func (c *Client) GetSandboxTesters(ctx context.Context, opts ...SandboxTestersOp
 	return &response, nil
 }
 
+// errSandboxTesterFound signals early pagination exit once the tester is located.
+var errSandboxTesterFound = errors.New("sandbox tester found")
+
 // GetSandboxTester retrieves a sandbox tester by ID.
 func (c *Client) GetSandboxTester(ctx context.Context, testerID string) (*SandboxTesterResponse, error) {
-	next := ""
-	for {
-		resp, err := c.GetSandboxTesters(
-			ctx,
-			WithSandboxTestersLimit(200),
-			WithSandboxTestersNextURL(next),
-		)
-		if err != nil {
-			return nil, err
+	firstPage, err := c.GetSandboxTesters(ctx, WithSandboxTestersLimit(200))
+	if err != nil {
+		return nil, err
+	}
+
+	var found *SandboxTesterResponse
+	err = PaginateEach(ctx, firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		return c.GetSandboxTesters(ctx, WithSandboxTestersNextURL(nextURL))
+	}, func(page PaginatedResponse) error {
+		resp, ok := page.(*SandboxTestersResponse)
+		if !ok {
+			return fmt.Errorf("unexpected page type %T", page)
 		}
 		for _, item := range resp.Data {
 			if item.ID == testerID {
-				return &SandboxTesterResponse{Data: item, Links: resp.Links}, nil
+				found = &SandboxTesterResponse{Data: item, Links: resp.Links}
+				return errSandboxTesterFound
 			}
 		}
-		if strings.TrimSpace(resp.Links.Next) == "" {
-			break
-		}
-		next = resp.Links.Next
+		return nil
+	})
+	if err != nil && !errors.Is(err, errSandboxTesterFound) {
+		return nil, err
 	}
-	return nil, fmt.Errorf("sandbox tester not found: %s", testerID)
+	if found == nil {
+		return nil, fmt.Errorf("sandbox tester not found: %s", testerID)
+	}
+	return found, nil
 }
 
 // UpdateSandboxTester updates a sandbox tester by ID.

--- a/internal/asc/sandbox_test.go
+++ b/internal/asc/sandbox_test.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -93,6 +94,46 @@ func TestGetSandboxTester_ByID(t *testing.T) {
 
 	if _, err := client.GetSandboxTester(context.Background(), "tester-1"); err != nil {
 		t.Fatalf("GetSandboxTester() error: %v", err)
+	}
+}
+
+func TestGetSandboxTester_FollowsPagination(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v2/sandboxTesters?cursor=abc"
+	client := newTestClient(
+		t, func(req *http.Request) {
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"sandboxTesters","id":"tester-1","attributes":{"acAccountName":"one@example.com","territory":"USA"}}],"links":{"next":"`+next+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"sandboxTesters","id":"tester-2","attributes":{"acAccountName":"two@example.com","territory":"USA"}}]}`),
+	)
+
+	resp, err := client.GetSandboxTester(context.Background(), "tester-2")
+	if err != nil {
+		t.Fatalf("GetSandboxTester() error: %v", err)
+	}
+	if resp.Data.ID != "tester-2" {
+		t.Fatalf("expected tester-2, got %q", resp.Data.ID)
+	}
+}
+
+func TestGetSandboxTester_RejectsRepeatedNextURL(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v2/sandboxTesters?cursor=repeat"
+	requests := 0
+	client := newTestClient(
+		t, func(req *http.Request) {
+			requests++
+			assertAuthorized(t, req)
+		},
+		jsonResponse(http.StatusOK, `{"data":[{"type":"sandboxTesters","id":"tester-1","attributes":{"acAccountName":"one@example.com","territory":"USA"}}],"links":{"next":"`+next+`"}}`),
+		jsonResponse(http.StatusOK, `{"data":[{"type":"sandboxTesters","id":"tester-2","attributes":{"acAccountName":"two@example.com","territory":"USA"}}],"links":{"next":"`+next+`"}}`),
+	)
+
+	_, err := client.GetSandboxTester(context.Background(), "missing-tester")
+	if !errors.Is(err, ErrRepeatedPaginationURL) {
+		t.Fatalf("expected ErrRepeatedPaginationURL, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected repeated next URL to stop after two requests, got %d", requests)
 	}
 }
 

--- a/internal/asc/xcode_cloud_products.go
+++ b/internal/asc/xcode_cloud_products.go
@@ -621,29 +621,23 @@ func (c *Client) ResolveCiProductForApp(ctx context.Context, appID string) (*CiP
 // ResolveCiWorkflowByName finds a workflow by name for a given product.
 // Returns an error if no workflow or multiple workflows match the name.
 func (c *Client) ResolveCiWorkflowByName(ctx context.Context, productID, workflowName string) (*CiWorkflowResource, error) {
-	var allWorkflows []CiWorkflowResource
-	var nextURL string
-
-	for {
-		var resp *CiWorkflowsResponse
-		var err error
-
-		if nextURL != "" {
-			resp, err = c.GetCiWorkflows(ctx, productID, WithCiWorkflowsNextURL(nextURL))
-		} else {
-			resp, err = c.GetCiWorkflows(ctx, productID, WithCiWorkflowsLimit(200))
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch CI workflows: %w", err)
-		}
-
-		allWorkflows = append(allWorkflows, resp.Data...)
-
-		if resp.Links.Next == "" {
-			break
-		}
-		nextURL = resp.Links.Next
+	firstPage, err := c.GetCiWorkflows(ctx, productID, WithCiWorkflowsLimit(200))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch CI workflows: %w", err)
 	}
+
+	result, err := PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		return c.GetCiWorkflows(ctx, productID, WithCiWorkflowsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch CI workflows: %w", err)
+	}
+
+	workflows, ok := result.(*CiWorkflowsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected paginated response type %T", result)
+	}
+	allWorkflows := workflows.Data
 
 	if len(allWorkflows) == 0 {
 		return nil, fmt.Errorf("no Xcode Cloud workflows found for product %q", productID)

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -955,19 +955,33 @@ func writeTempPrivateKey(data []byte, cacheKey string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := file.Chmod(0o600); err != nil {
-		_ = file.Close()
-		return "", err
-	}
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		return "", err
-	}
-	if err := file.Close(); err != nil {
+	if err := finalizeTempPrivateKey(file, data); err != nil {
 		return "", err
 	}
 	registerTempPrivateKey(file.Name(), cacheKey)
 	return file.Name(), nil
+}
+
+// finalizeTempPrivateKey restricts permissions, writes the key material, and
+// closes the temp file. On any failure it removes the file so partial private
+// key material never lingers on disk.
+func finalizeTempPrivateKey(file *os.File, data []byte) error {
+	fail := func(err error) error {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return fail(err)
+	}
+	if _, err := file.Write(data); err != nil {
+		return fail(err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(file.Name())
+		return err
+	}
+	return nil
 }
 
 func registerTempPrivateKey(path, cacheKey string) {

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -851,6 +851,47 @@ func TestCleanupTempPrivateKeysRemovesFile(t *testing.T) {
 	}
 }
 
+func TestFinalizeTempPrivateKeyRemovesFileOnChmodFailure(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "asc-key-*.p8")
+	if err != nil {
+		t.Fatalf("CreateTemp() error: %v", err)
+	}
+	// Close the handle up front so Chmod fails, exercising the error path.
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+
+	if err := finalizeTempPrivateKey(file, []byte("key-data")); err == nil {
+		t.Fatal("expected finalizeTempPrivateKey to fail on a closed file")
+	}
+	if _, err := os.Stat(file.Name()); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected temp key file to be removed after failure, got %v", err)
+	}
+}
+
+func TestFinalizeTempPrivateKeyRemovesFileOnWriteFailure(t *testing.T) {
+	temp, err := os.CreateTemp(t.TempDir(), "asc-key-*.p8")
+	if err != nil {
+		t.Fatalf("CreateTemp() error: %v", err)
+	}
+	if err := temp.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+
+	// Reopen read-only so Chmod succeeds but Write fails.
+	readOnly, err := os.Open(temp.Name())
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+
+	if err := finalizeTempPrivateKey(readOnly, []byte("key-data")); err == nil {
+		t.Fatal("expected finalizeTempPrivateKey to fail writing to a read-only handle")
+	}
+	if _, err := os.Stat(temp.Name()); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected temp key file to be removed after failure, got %v", err)
+	}
+}
+
 func TestResolvePrivateKeyPathInvalidBase64(t *testing.T) {
 	resetPrivateKeyTemp(t)
 	t.Setenv("ASC_PRIVATE_KEY_PATH", "")


### PR DESCRIPTION
## Motivation

Two small correctness fixes from the recent code audit:

1. **Unguarded pagination loops.** The shared pagination helpers (`PaginateAll`/`PaginateEach` in `internal/asc/client_pagination.go`, and the inline loop in `client_signing.go`) track already-seen `links.next` URLs and fail fast with `ErrRepeatedPaginationURL`. Three hand-rolled loops lacked that guard, so a server responding with a self-referential (or cycling) `next` link would spin them forever:
   - `GetSandboxTester` (`internal/asc/sandbox.go`)
   - `GetAllGameCenterLeaderboardLocalizations` (`internal/asc/client_game_center.go`)
   - `ResolveCiWorkflowByName` (`internal/asc/xcode_cloud_products.go`)
2. **Leaked temp private key material.** In `writeTempPrivateKey` (`internal/cli/shared/shared.go`), a failure in `Chmod`, `Write`, or `Close` returned early after closing the file but never removed it. Since `registerTempPrivateKey` only runs on success, `CleanupTempPrivateKeys` never saw the path either, stranding an `asc-key-*.p8` file (possibly containing partial private key material) on disk.

## Approach

- Routed all three pagination loops through the shared helpers instead of duplicating the guard: `PaginateAll` for the two aggregate-everything loops, and `PaginateEach` with a found-sentinel error for `GetSandboxTester`'s early-exit search. Behavior is unchanged on well-formed responses; a repeated next URL now returns `ErrRepeatedPaginationURL` after the second request instead of looping.
- Extracted the chmod/write/close sequence into `finalizeTempPrivateKey`, which best-effort `os.Remove`s the temp file on any failure before returning the error.

## Impact

- No infinite loop / unbounded memory growth if the API (or a proxy) ever returns a cycling pagination cursor; the CLI fails with a clear error instead of hanging.
- No leftover private key material in the temp directory on error paths.
- No command surface, flag, or help text changes, so no docs regeneration needed.

## Test coverage

- `TestGetSandboxTester_FollowsPagination` / `TestGetSandboxTester_RejectsRepeatedNextURL`
- `TestGetAllGameCenterLeaderboardLocalizations_FollowsPagination` / `..._RejectsRepeatedNextURL`
- `TestResolveCiWorkflowByName_FollowsPagination` / `..._RejectsRepeatedNextURL`

  Each repeated-URL test uses a mock transport returning a self-referential `next` link and asserts `ErrRepeatedPaginationURL` after exactly two requests (no spin).
- `TestFinalizeTempPrivateKeyRemovesFileOnChmodFailure` / `...OnWriteFailure` force the chmod and write error paths (closed / read-only file handle) and assert the temp file is removed.

Verified locally: `go build ./...`, `make lint`, `make format-check`, and `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc/ ./internal/cli/shared/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination across game center localizations, CI workflows, and sandbox testers.
  - Prevented infinite loops when APIs return repeated pagination links.
  - Sandbox tester lookups now stop as soon as the requested tester is found.
  - Temporary private-key files are removed if setup or writing fails.

- **Tests**
  - Added coverage for multi-page results, repeated pagination links, and private-key cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->