### PR TITLE
perf(upload): raise default chunk concurrency to 4 and tune upload transport

### DIFF
--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -17,6 +17,18 @@ import (
 	"sync/atomic"
 )
 
+const (
+	// DefaultUploadConcurrency is the number of upload workers used when no
+	// explicit concurrency is configured. App Store Connect upload operations
+	// carry explicit byte offsets, so chunks are safe to upload in parallel.
+	DefaultUploadConcurrency = 4
+
+	// uploadMaxIdleConnsPerHost keeps enough idle connections to the upload
+	// host so concurrent chunk uploads are not throttled by the Go transport
+	// default of 2 idle connections per host.
+	uploadMaxIdleConnsPerHost = 8
+)
+
 // UploadOptions configure how upload operations are executed.
 type UploadOptions struct {
 	Concurrency int
@@ -65,7 +77,11 @@ func WithUploadHTTPClient(client *http.Client) UploadOption {
 func newUploadClient() *http.Client {
 	transport := http.DefaultTransport
 	if base, ok := transport.(*http.Transport); ok {
-		transport = base.Clone()
+		cloned := base.Clone()
+		if cloned.MaxIdleConnsPerHost < uploadMaxIdleConnsPerHost {
+			cloned.MaxIdleConnsPerHost = uploadMaxIdleConnsPerHost
+		}
+		transport = cloned
 	}
 	return &http.Client{
 		Timeout:   ResolveUploadTimeout(),
@@ -83,7 +99,7 @@ func ExecuteUploadOperations(ctx context.Context, filePath string, operations []
 	}
 
 	uploadOpts := UploadOptions{
-		Concurrency: 1,
+		Concurrency: DefaultUploadConcurrency,
 		Client:      newUploadClient(),
 		RetryOpts:   ResolveRetryOptions(),
 	}

--- a/internal/asc/upload_test.go
+++ b/internal/asc/upload_test.go
@@ -94,6 +94,141 @@ func TestExecuteUploadOperations_UploadsSlices(t *testing.T) {
 	}
 }
 
+func TestExecuteUploadOperations_DefaultConcurrencyUploadsChunksInParallel(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.ipa")
+	content := []byte("abcdefgh")
+	if err := os.WriteFile(filePath, content, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	arrived := make(chan struct{}, DefaultUploadConcurrency)
+	allArrived := make(chan struct{})
+	go func() {
+		for i := 0; i < DefaultUploadConcurrency; i++ {
+			<-arrived
+		}
+		close(allArrived)
+	}()
+
+	var mu sync.Mutex
+	received := map[string]string{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		arrived <- struct{}{}
+		// Block until every chunk is in flight simultaneously. This only
+		// completes when the default concurrency dispatches all chunks in
+		// parallel; a serial default would deadlock and hit the timeout.
+		select {
+		case <-allArrived:
+		case <-time.After(5 * time.Second):
+			t.Error("timed out waiting for concurrent chunk uploads; default concurrency appears serial")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		received[r.URL.Path] = string(body)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ops := make([]UploadOperation, 0, DefaultUploadConcurrency)
+	for i := 0; i < DefaultUploadConcurrency; i++ {
+		ops = append(ops, UploadOperation{
+			Method: "PUT",
+			URL:    fmt.Sprintf("%s/op%d", server.URL, i),
+			Length: 2,
+			Offset: int64(i * 2),
+		})
+	}
+
+	// No WithUploadConcurrency option: rely on the default.
+	err := ExecuteUploadOperations(
+		context.Background(), filePath, ops,
+		WithUploadHTTPClient(server.Client()),
+		withUploadRetryOptions(0),
+	)
+	if err != nil {
+		t.Fatalf("ExecuteUploadOperations() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 0; i < DefaultUploadConcurrency; i++ {
+		path := fmt.Sprintf("/op%d", i)
+		want := string(content[i*2 : i*2+2])
+		if received[path] != want {
+			t.Fatalf("expected %s body=%q, got %q", path, want, received[path])
+		}
+	}
+}
+
+func TestExecuteUploadOperations_ConcurrentUploadFailsOnErrorMidBatch(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.ipa")
+	if err := os.WriteFile(filePath, []byte("abcdefghijkl"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		_, _ = io.Copy(io.Discard, r.Body)
+		if r.URL.Path == "/op3" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ops := make([]UploadOperation, 0, 6)
+	for i := 0; i < 6; i++ {
+		ops = append(ops, UploadOperation{
+			Method: "PUT",
+			URL:    fmt.Sprintf("%s/op%d", server.URL, i),
+			Length: 2,
+			Offset: int64(i * 2),
+		})
+	}
+
+	err := ExecuteUploadOperations(
+		context.Background(), filePath, ops,
+		WithUploadHTTPClient(server.Client()),
+		withUploadRetryOptions(0),
+	)
+	if err == nil {
+		t.Fatal("expected mid-batch upload failure to surface an error")
+	}
+	if !strings.Contains(err.Error(), "upload operation 3") {
+		t.Fatalf("expected error to identify failing operation, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected error to include HTTP status, got %v", err)
+	}
+}
+
+func TestNewUploadClient_RaisesMaxIdleConnsPerHost(t *testing.T) {
+	client := newUploadClient()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if transport.MaxIdleConnsPerHost < uploadMaxIdleConnsPerHost {
+		t.Fatalf("expected MaxIdleConnsPerHost >= %d, got %d", uploadMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	}
+	if base, ok := http.DefaultTransport.(*http.Transport); ok && transport == base {
+		t.Fatal("expected upload client transport to be a clone, not http.DefaultTransport")
+	}
+}
+
 func TestExecuteUploadOperations_FailsOnHTTPError(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "app.ipa")

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -30,7 +30,7 @@ func BuildsUploadCommand() *ffcli.Command {
 	buildNumber := fs.String("build-number", "", "CFBundleVersion (e.g., 123, auto-extracted from IPA if not provided)")
 	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS (auto-detected for --pkg)")
 	dryRun := fs.Bool("dry-run", false, "Reserve upload operations without uploading the file")
-	concurrency := fs.Int("concurrency", 1, "Upload concurrency (default 1)")
+	concurrency := fs.Int("concurrency", asc.DefaultUploadConcurrency, fmt.Sprintf("Upload concurrency (default %d)", asc.DefaultUploadConcurrency))
 	verifyChecksum := fs.Bool("checksum", false, "Verify upload checksums if provided by API")
 	testNotes := fs.String("test-notes", "", "What to Test notes (requires build processing)")
 	locale := fs.String("locale", "", "Locale for --test-notes (e.g., en-US)")
@@ -142,8 +142,14 @@ Examples:
 			default:
 				return fmt.Errorf("builds upload: --platform must be IOS, MAC_OS, TV_OS, or VISION_OS")
 			}
+			concurrencySet := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "concurrency" {
+					concurrencySet = true
+				}
+			})
 			if *dryRun {
-				if *concurrency != 1 {
+				if concurrencySet {
 					return fmt.Errorf("builds upload: --concurrency is not supported with --dry-run")
 				}
 				if *verifyChecksum {

--- a/internal/cli/cmdtest/builds_upload_concurrency_test.go
+++ b/internal/cli/cmdtest/builds_upload_concurrency_test.go
@@ -1,0 +1,117 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBuildsUploadDryRunRejectsExplicitConcurrency(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
+	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write ipa fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		return nil, http.ErrUseLastResponse
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "upload",
+			"--app", "123456789",
+			"--ipa", ipaPath,
+			"--version", "1.0.0",
+			"--build-number", "42",
+			"--dry-run",
+			"--concurrency", "2",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected builds upload to fail, got nil")
+	}
+	if !strings.Contains(runErr.Error(), "--concurrency is not supported with --dry-run") {
+		t.Fatalf("expected dry-run concurrency rejection, got %v", runErr)
+	}
+}
+
+func TestBuildsUploadDryRunSucceedsWithDefaultConcurrency(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
+	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write ipa fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var uploadRequests int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":4,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":4,"offset":0,"requestHeaders":[{"name":"Content-Type","value":"application/octet-stream"}]}]}}}`)
+		case req.Method == http.MethodPut:
+			atomic.AddInt32(&uploadRequests, 1)
+			return jsonResponse(http.StatusOK, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, http.ErrUseLastResponse
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "upload",
+			"--app", "123456789",
+			"--ipa", ipaPath,
+			"--version", "1.0.0",
+			"--build-number", "42",
+			"--dry-run",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("expected dry-run to succeed with default concurrency, got %v", runErr)
+	}
+	if !strings.Contains(stdout, "upload-1") {
+		t.Fatalf("expected reserved upload in output, got %q", stdout)
+	}
+	if got := atomic.LoadInt32(&uploadRequests); got != 0 {
+		t.Fatalf("expected no chunk uploads in dry-run, got %d", got)
+	}
+}


### PR DESCRIPTION
## Motivation

A performance audit found that asset/build chunk uploads run serially across the whole CLI:

- `internal/cli/builds/builds_commands.go`: the `builds upload` `--concurrency` flag defaulted to 1.
- `internal/asc/upload.go`: the upload engine's default `Concurrency` was 1.
- Six call sites pass no concurrency option at all, so their chunks always uploaded one at a time: `internal/cli/encryption/encryption.go`, `internal/cli/routingcoverage/routing_coverage.go`, `internal/cli/publish/publish.go`, `internal/cli/subscriptions/review_screenshot_recovery.go`, `internal/cli/backgroundassets/background_assets_upload_files.go`, `internal/cli/reviews/review_attachments.go`.
- `newUploadClient` cloned `http.DefaultTransport` but left `MaxIdleConnsPerHost` at the Go default of 2, so even with a higher concurrency the transport would throttle parallel chunks to the same upload host.

## Safety of parallel chunks

Each App Store Connect `uploadOperation` carries an explicit byte offset, length, and presigned URL, so chunks are independent and completion order does not matter. The commit step (`uploaded=true` PATCH with checksums) only runs after `ExecuteUploadOperations` returns, and that function waits for every worker via `sync.WaitGroup` and verifies the completed count, so the commit can never race an in-flight chunk.

## Changes

- Add `asc.DefaultUploadConcurrency = 4` and use it as the engine default in `ExecuteUploadOperations`. All six option-less call sites pick up the new default with no code change; single-operation uploads are still clamped to 1 worker.
- Default `builds upload --concurrency` to 4 (flag kept, help text derives from the constant). The `--dry-run` guard now rejects an explicitly provided `--concurrency` (via `fs.Visit`) instead of comparing the value against a hardcoded default, so plain `--dry-run` keeps working with the new default.
- Raise `MaxIdleConnsPerHost` to 8 on the dedicated upload client's cloned transport (never lowering a larger ambient value).

## Expected impact

Large IPA/PKG uploads are split into many presigned-URL chunks; uploading 4 at a time overlaps TLS setup and per-request latency, giving up to ~4x faster wall-clock upload on connections with available bandwidth. The idle-connection bump avoids closing and re-dialing connections between chunks.

## Test coverage

- `TestExecuteUploadOperations_DefaultConcurrencyUploadsChunksInParallel`: proves 4 chunks are in flight simultaneously with no explicit concurrency option (deadlocks and fails if the default were serial), and verifies each chunk body lands at the right offset.
- `TestExecuteUploadOperations_ConcurrentUploadFailsOnErrorMidBatch`: a 403 on chunk 3 of 6 under concurrent workers surfaces an error identifying the failing operation.
- `TestNewUploadClient_RaisesMaxIdleConnsPerHost`: the upload client transport is a clone with `MaxIdleConnsPerHost >= 8`.
- `TestBuildsUploadDryRunRejectsExplicitConcurrency` / `TestBuildsUploadDryRunSucceedsWithDefaultConcurrency`: CLI-level coverage of the dry-run flag interaction, including that dry-run performs no chunk PUTs.

`go build ./...`, `go vet`, `make format`, `make check-docs`, and `ASC_BYPASS_KEYCHAIN=1 go test` on `internal/asc`, `internal/cli/builds`, and `internal/cli/cmdtest` all pass. `make generate-command-docs` produced no diff (flag help text is not embedded in docs/COMMANDS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploads now use a default concurrency of four, improving chunk upload performance.
  * Connection handling supports more simultaneous upload requests.

* **Bug Fixes**
  * Dry-run uploads now succeed with the default concurrency while continuing to reject explicitly configured concurrency.
  * Upload failures during concurrent operations are reported correctly.

* **Tests**
  * Added coverage for parallel uploads, failure handling, connection capacity, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->