### PR TITLE
feat(web): encrypt file-backed web session cache at rest

### DIFF
--- a/authentication.mdx
+++ b/authentication.mdx
@@ -372,9 +372,10 @@ on every invocation.
 `~/.asc/web/` as files encrypted with AES-256-GCM. The encryption key is a
 random secret stored once in your system keychain (macOS Keychain, Windows
 Credential Manager, or Linux Secret Service), so the cookies are never stored
-as cleartext on disk. Existing cleartext session files from older CLI versions
-are migrated to the encrypted format automatically the first time they are
-read.
+as cleartext on disk when that keychain is available. Keychain access errors
+fail persistence instead of silently downgrading protection. Existing cleartext
+session files from older CLI versions are migrated to the encrypted format
+automatically the first time they are read.
 
 **Headless and CI fallback.** When no system keychain is available (or
 `ASC_BYPASS_KEYCHAIN=1` is set), the CLI falls back to the legacy cleartext

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -362,6 +362,40 @@ This removes credentials from both keychain and config files.
   </Accordion>
 </AccordionGroup>
 
+## Web session storage
+
+Commands under `asc web` authenticate with your Apple ID and cache the resulting
+web-session cookies so you do not have to repeat password and two-factor prompts
+on every invocation.
+
+**At-rest protection.** By default the session cache is written to
+`~/.asc/web/` as files encrypted with AES-256-GCM. The encryption key is a
+random secret stored once in your system keychain (macOS Keychain, Windows
+Credential Manager, or Linux Secret Service), so the cookies are never stored
+as cleartext on disk. Existing cleartext session files from older CLI versions
+are migrated to the encrypted format automatically the first time they are
+read.
+
+**Headless and CI fallback.** When no system keychain is available (or
+`ASC_BYPASS_KEYCHAIN=1` is set), the CLI falls back to the legacy cleartext
+format with owner-only file permissions (`0600`) so headless environments keep
+working. You can also opt out of encryption explicitly by pinning the legacy
+backend:
+
+```bash  theme={null}
+# Keep the legacy cleartext file cache (headless/CI escape hatch)
+export ASC_WEB_SESSION_CACHE_BACKEND=file
+```
+
+Other controls:
+
+| Variable                        | Purpose                                                    |
+| ------------------------------- | ---------------------------------------------------------- |
+| `ASC_WEB_SESSION_CACHE`         | Disable the session cache entirely (`0`, `false`, `off`)   |
+| `ASC_WEB_SESSION_CACHE_DIR`     | Override the cache directory (default `~/.asc/web`)        |
+| `ASC_WEB_SESSION_CACHE_BACKEND` | `auto` (encrypted file, default), `file` (legacy cleartext), `keychain`, or `off` |
+| `ASC_BYPASS_KEYCHAIN`           | Skip the keychain; session files fall back to cleartext    |
+
 ## Environment variables reference
 
 | Variable               | Purpose                       | Example                                |

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/99designs/keyring"
@@ -101,6 +102,9 @@ type encryptedSessionEnvelope struct {
 }
 
 var (
+	sessionFileKeyMu      sync.Mutex
+	sessionFileKeyLockDir = defaultSessionFileKeyLockDir
+
 	sessionKeyringOpen = func() (keyring.Keyring, error) {
 		return keyring.Open(keyring.Config{
 			ServiceName:                    webSessionKeyringService,
@@ -165,6 +169,16 @@ func webSessionCacheDir() (string, error) {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
 	return filepath.Join(home, ".asc", "web"), nil
+}
+
+func defaultSessionFileKeyLockDir() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user cache directory: %w", err)
+	}
+	// The encryption key is shared across custom session-cache directories,
+	// so its creation lock must also live at one user-global path.
+	return filepath.Join(cacheDir, "asc"), nil
 }
 
 func legacyIrisSessionCacheEnabled() bool {
@@ -565,28 +579,58 @@ func sessionFileEncryptionDesired() bool {
 }
 
 // loadSessionFileKey returns the keychain-held secret used to encrypt
-// file-backed session caches. When create is true and no secret exists yet, a
-// new random secret is generated and stored. The boolean result is false when
-// the keychain is bypassed or unavailable, in which case callers fall back to
-// the legacy cleartext behavior.
-func loadSessionFileKey(create bool) (string, bool) {
+// file-backed session caches. Only an explicitly bypassed or unavailable
+// keychain permits the documented cleartext fallback; operational keychain
+// failures must not silently downgrade cookie storage.
+func loadSessionFileKey(create bool) (string, bool, error) {
 	if sessionKeychainBypassed() {
-		return "", false
+		return "", false, nil
 	}
 	kr, err := sessionKeyringOpen()
 	if err != nil {
-		return "", false
+		if isKeyringUnavailable(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to open session file keychain: %w", err)
 	}
 	item, err := kr.Get(webSessionFileKeyItem)
-	if err == nil && len(item.Data) > 0 {
-		return string(item.Data), true
+	if err == nil {
+		if len(item.Data) == 0 {
+			return "", false, errors.New("session file encryption key is empty")
+		}
+		return string(item.Data), true, nil
 	}
-	if !errors.Is(err, keyring.ErrKeyNotFound) || !create {
-		return "", false
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		return "", false, fmt.Errorf("failed to read session file encryption key: %w", err)
+	}
+	if !create {
+		return "", false, nil
+	}
+
+	// Keyring Set overwrites existing items, so serialize the first write across
+	// goroutines and processes and re-check after acquiring the lock. Otherwise
+	// concurrent first sessions can be encrypted with different keys.
+	sessionFileKeyMu.Lock()
+	defer sessionFileKeyMu.Unlock()
+	unlock, err := lockSessionFileKeyCreation()
+	if err != nil {
+		return "", false, fmt.Errorf("failed to lock session file encryption key: %w", err)
+	}
+	defer func() { _ = unlock() }()
+
+	item, err = kr.Get(webSessionFileKeyItem)
+	if err == nil {
+		if len(item.Data) == 0 {
+			return "", false, errors.New("session file encryption key is empty")
+		}
+		return string(item.Data), true, nil
+	}
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		return "", false, fmt.Errorf("failed to re-read session file encryption key: %w", err)
 	}
 	secret := make([]byte, webSessionFileKeySize)
 	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
-		return "", false
+		return "", false, fmt.Errorf("failed to generate session file encryption key: %w", err)
 	}
 	encoded := base64.StdEncoding.EncodeToString(secret)
 	if err := kr.Set(keyring.Item{
@@ -594,22 +638,22 @@ func loadSessionFileKey(create bool) (string, bool) {
 		Data:  []byte(encoded),
 		Label: "ASC Web Session File Key",
 	}); err != nil {
-		return "", false
+		return "", false, fmt.Errorf("failed to store session file encryption key: %w", err)
 	}
-	return encoded, true
+	return encoded, true, nil
 }
 
 // encryptSessionPayload encrypts a marshaled persistedSession with a
-// keychain-held secret. It returns ok=false when encryption is not possible
-// (keychain bypassed or unavailable) so callers can fall back to cleartext.
-func encryptSessionPayload(raw []byte) ([]byte, bool) {
-	fileKey, ok := loadSessionFileKey(true)
-	if !ok {
-		return nil, false
+// keychain-held secret. It returns ok=false only for the documented bypassed
+// or unavailable-keychain cases where callers may fall back to cleartext.
+func encryptSessionPayload(raw []byte) ([]byte, bool, error) {
+	fileKey, ok, err := loadSessionFileKey(true)
+	if err != nil || !ok {
+		return nil, false, err
 	}
 	encrypted, err := signing.Encrypt(raw, fileKey)
 	if err != nil {
-		return nil, false
+		return nil, false, fmt.Errorf("failed to encrypt session cache: %w", err)
 	}
 	envelope, err := json.Marshal(encryptedSessionEnvelope{
 		Version: webSessionCacheVersion,
@@ -617,16 +661,19 @@ func encryptSessionPayload(raw []byte) ([]byte, bool) {
 		Data:    base64.StdEncoding.EncodeToString(encrypted),
 	})
 	if err != nil {
-		return nil, false
+		return nil, false, fmt.Errorf("failed to marshal encrypted session cache: %w", err)
 	}
-	return envelope, true
+	return envelope, true, nil
 }
 
 func decryptSessionEnvelope(envelope encryptedSessionEnvelope) (persistedSession, bool, error) {
 	if envelope.Version != webSessionCacheVersion {
 		return persistedSession{}, false, nil
 	}
-	fileKey, ok := loadSessionFileKey(false)
+	fileKey, ok, err := loadSessionFileKey(false)
+	if err != nil {
+		return persistedSession{}, false, err
+	}
 	if !ok {
 		// Encrypted cache without a reachable keychain key behaves like a
 		// cache miss so callers fall through to a fresh login.
@@ -661,8 +708,8 @@ func maybeRewriteSessionFileEncrypted(key string, sess persistedSession) {
 	if err != nil {
 		return
 	}
-	envelope, ok := encryptSessionPayload(raw)
-	if !ok {
+	envelope, ok, err := encryptSessionPayload(raw)
+	if err != nil || !ok {
 		return
 	}
 	_ = writeSessionFileBytes(key, envelope)
@@ -696,7 +743,11 @@ func writeSessionToFile(key string, sess persistedSession) error {
 		return fmt.Errorf("failed to marshal session: %w", err)
 	}
 	if sessionFileEncryptionDesired() {
-		if envelope, ok := encryptSessionPayload(raw); ok {
+		envelope, ok, err := encryptSessionPayload(raw)
+		if err != nil {
+			return err
+		}
+		if ok {
 			raw = envelope
 		}
 	}
@@ -735,7 +786,10 @@ func readSessionFromFile(key string) (persistedSession, bool, error) {
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return persistedSession{}, false, fmt.Errorf("failed to decode session cache: %w", err)
 	}
-	if envelope.Cipher == webSessionFileCipher && envelope.Data != "" {
+	if envelope.Cipher != "" || envelope.Data != "" {
+		if envelope.Cipher != webSessionFileCipher || envelope.Data == "" {
+			return persistedSession{}, false, fmt.Errorf("unsupported encrypted session cache envelope")
+		}
 		return decryptSessionEnvelope(envelope)
 	}
 	var sess persistedSession

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -675,10 +675,7 @@ func decryptSessionEnvelope(envelope encryptedSessionEnvelope) (persistedSession
 		return persistedSession{}, false, nil
 	}
 	fileKey, ok, err := loadSessionFileKey(false)
-	if err != nil {
-		return persistedSession{}, false, err
-	}
-	if !ok {
+	if err != nil || !ok {
 		// Encrypted cache without a reachable keychain key behaves like a
 		// cache miss so callers fall through to a fresh login.
 		return persistedSession{}, false, nil

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -142,21 +142,25 @@ func resolveBackendSelection() backendSelection {
 	if !webSessionCacheEnabled() {
 		return backendSelection{backend: sessionBackendOff}
 	}
+	keychainBypassed := sessionKeychainBypassed()
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(webSessionBackendEnv))) {
 	case "off", "none", "disabled":
 		return backendSelection{backend: sessionBackendOff}
 	case "file":
 		return backendSelection{backend: sessionBackendFile}
 	case "keychain":
+		if keychainBypassed {
+			return backendSelection{backend: sessionBackendFile}
+		}
 		// Allow explicit keychain mode to import sessions from the file cache
 		// so users can switch back after running on the default file-backed mode.
 		return backendSelection{backend: sessionBackendKeychain, fallbackFile: true}
 	case "", "auto":
 		// Default to file-backed web sessions so successful logins can be reused
 		// without recurring per-binary keychain approval prompts.
-		return backendSelection{backend: sessionBackendFile, fallbackKeychain: true}
+		return backendSelection{backend: sessionBackendFile, fallbackKeychain: !keychainBypassed}
 	default:
-		return backendSelection{backend: sessionBackendFile, fallbackKeychain: true}
+		return backendSelection{backend: sessionBackendFile, fallbackKeychain: !keychainBypassed}
 	}
 }
 

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -1239,7 +1239,7 @@ func deleteAllFromKeychain() error {
 		return err
 	}
 	for _, key := range keys {
-		if key == webSessionStoreItem || key == webSessionLastKeyItem || strings.HasPrefix(key, webSessionKeyPrefix) {
+		if key != webSessionFileKeyItem && (key == webSessionStoreItem || key == webSessionLastKeyItem || strings.HasPrefix(key, webSessionKeyPrefix)) {
 			if err := kr.Remove(key); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
 				return err
 			}

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -2,11 +2,14 @@ package web
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -17,6 +20,8 @@ import (
 	"time"
 
 	"github.com/99designs/keyring"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/signing"
 )
 
 const (
@@ -33,6 +38,11 @@ const (
 	webSessionStoreItem      = "asc:web-session:store"
 	webSessionKeyPrefix      = "asc:web-session:"
 	webSessionLastKeyItem    = "asc:web-session:last"
+	webSessionFileKeyItem    = "asc:web-session:file-key"
+
+	webSessionFileCipher     = "aes-256-gcm"
+	webSessionFileKeySize    = 32
+	sessionBypassKeychainEnv = "ASC_BYPASS_KEYCHAIN"
 )
 
 var ErrCachedSessionExpired = errors.New("cached web session expired")
@@ -79,6 +89,15 @@ type pCookie struct {
 type persistedLastSession struct {
 	Version int    `json:"version"`
 	Key     string `json:"key"`
+}
+
+// encryptedSessionEnvelope wraps an AES-256-GCM encrypted persistedSession so
+// web-session cookies are not stored as cleartext on disk. The encryption key
+// is a random secret stored once in the OS keychain (webSessionFileKeyItem).
+type encryptedSessionEnvelope struct {
+	Version int    `json:"version"`
+	Cipher  string `json:"cipher"`
+	Data    string `json:"data"`
 }
 
 var (
@@ -404,7 +423,7 @@ func readLegacySessionStoreFromKeyring(kr keyring.Keyring) (persistedSessionStor
 	}
 	store := newPersistedSessionStore()
 	for _, itemKey := range keys {
-		if !strings.HasPrefix(itemKey, webSessionKeyPrefix) || itemKey == webSessionLastKeyItem || itemKey == webSessionStoreItem {
+		if !strings.HasPrefix(itemKey, webSessionKeyPrefix) || itemKey == webSessionLastKeyItem || itemKey == webSessionStoreItem || itemKey == webSessionFileKeyItem {
 			continue
 		}
 		key := strings.TrimPrefix(itemKey, webSessionKeyPrefix)
@@ -523,18 +542,139 @@ func readSessionFromKeychain(key string) (persistedSession, bool, error) {
 	return sess, true, nil
 }
 
-func writeSessionToFile(key string, sess persistedSession) error {
+func sessionKeychainBypassed() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(sessionBypassKeychainEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// sessionFileEncryptionDesired reports whether file-backed sessions should be
+// encrypted at rest. Users who explicitly select the legacy file backend keep
+// the historical cleartext behavior (documented escape hatch for headless/CI
+// environments without a keychain).
+func sessionFileEncryptionDesired() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(webSessionBackendEnv))) {
+	case "file":
+		return false
+	default:
+		return true
+	}
+}
+
+// loadSessionFileKey returns the keychain-held secret used to encrypt
+// file-backed session caches. When create is true and no secret exists yet, a
+// new random secret is generated and stored. The boolean result is false when
+// the keychain is bypassed or unavailable, in which case callers fall back to
+// the legacy cleartext behavior.
+func loadSessionFileKey(create bool) (string, bool) {
+	if sessionKeychainBypassed() {
+		return "", false
+	}
+	kr, err := sessionKeyringOpen()
+	if err != nil {
+		return "", false
+	}
+	item, err := kr.Get(webSessionFileKeyItem)
+	if err == nil && len(item.Data) > 0 {
+		return string(item.Data), true
+	}
+	if !errors.Is(err, keyring.ErrKeyNotFound) || !create {
+		return "", false
+	}
+	secret := make([]byte, webSessionFileKeySize)
+	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
+		return "", false
+	}
+	encoded := base64.StdEncoding.EncodeToString(secret)
+	if err := kr.Set(keyring.Item{
+		Key:   webSessionFileKeyItem,
+		Data:  []byte(encoded),
+		Label: "ASC Web Session File Key",
+	}); err != nil {
+		return "", false
+	}
+	return encoded, true
+}
+
+// encryptSessionPayload encrypts a marshaled persistedSession with a
+// keychain-held secret. It returns ok=false when encryption is not possible
+// (keychain bypassed or unavailable) so callers can fall back to cleartext.
+func encryptSessionPayload(raw []byte) ([]byte, bool) {
+	fileKey, ok := loadSessionFileKey(true)
+	if !ok {
+		return nil, false
+	}
+	encrypted, err := signing.Encrypt(raw, fileKey)
+	if err != nil {
+		return nil, false
+	}
+	envelope, err := json.Marshal(encryptedSessionEnvelope{
+		Version: webSessionCacheVersion,
+		Cipher:  webSessionFileCipher,
+		Data:    base64.StdEncoding.EncodeToString(encrypted),
+	})
+	if err != nil {
+		return nil, false
+	}
+	return envelope, true
+}
+
+func decryptSessionEnvelope(envelope encryptedSessionEnvelope) (persistedSession, bool, error) {
+	if envelope.Version != webSessionCacheVersion {
+		return persistedSession{}, false, nil
+	}
+	fileKey, ok := loadSessionFileKey(false)
+	if !ok {
+		// Encrypted cache without a reachable keychain key behaves like a
+		// cache miss so callers fall through to a fresh login.
+		return persistedSession{}, false, nil
+	}
+	encrypted, err := base64.StdEncoding.DecodeString(envelope.Data)
+	if err != nil {
+		return persistedSession{}, false, fmt.Errorf("failed to decode session cache: %w", err)
+	}
+	raw, err := signing.Decrypt(encrypted, fileKey)
+	if err != nil {
+		return persistedSession{}, false, fmt.Errorf("failed to decrypt session cache: %w", err)
+	}
+	var sess persistedSession
+	if err := json.Unmarshal(raw, &sess); err != nil {
+		return persistedSession{}, false, fmt.Errorf("failed to decode session cache: %w", err)
+	}
+	if sess.Version != webSessionCacheVersion {
+		return persistedSession{}, false, nil
+	}
+	return sess, true, nil
+}
+
+// maybeRewriteSessionFileEncrypted migrates a legacy cleartext session file to
+// the encrypted format. Best effort: failures leave the readable cleartext
+// file in place.
+func maybeRewriteSessionFileEncrypted(key string, sess persistedSession) {
+	if !sessionFileEncryptionDesired() {
+		return
+	}
+	raw, err := json.Marshal(sess)
+	if err != nil {
+		return
+	}
+	envelope, ok := encryptSessionPayload(raw)
+	if !ok {
+		return
+	}
+	_ = writeSessionFileBytes(key, envelope)
+}
+
+func writeSessionFileBytes(key string, raw []byte) error {
 	dir, err := webSessionCacheDir()
 	if err != nil {
 		return err
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("failed to create session cache dir: %w", err)
-	}
-
-	raw, err := json.Marshal(sess)
-	if err != nil {
-		return fmt.Errorf("failed to marshal session: %w", err)
 	}
 	sessionPath, err := webSessionFilePath(key)
 	if err != nil {
@@ -546,6 +686,22 @@ func writeSessionToFile(key string, sess persistedSession) error {
 	}
 	if err := os.Rename(tmpSessionPath, sessionPath); err != nil {
 		return fmt.Errorf("failed to finalize session cache: %w", err)
+	}
+	return nil
+}
+
+func writeSessionToFile(key string, sess persistedSession) error {
+	raw, err := json.Marshal(sess)
+	if err != nil {
+		return fmt.Errorf("failed to marshal session: %w", err)
+	}
+	if sessionFileEncryptionDesired() {
+		if envelope, ok := encryptSessionPayload(raw); ok {
+			raw = envelope
+		}
+	}
+	if err := writeSessionFileBytes(key, raw); err != nil {
+		return err
 	}
 
 	lastPath, err := webSessionLastFilePath()
@@ -575,6 +731,13 @@ func readSessionFromFile(key string) (persistedSession, bool, error) {
 		}
 		return persistedSession{}, false, err
 	}
+	var envelope encryptedSessionEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return persistedSession{}, false, fmt.Errorf("failed to decode session cache: %w", err)
+	}
+	if envelope.Cipher == webSessionFileCipher && envelope.Data != "" {
+		return decryptSessionEnvelope(envelope)
+	}
 	var sess persistedSession
 	if err := json.Unmarshal(raw, &sess); err != nil {
 		return persistedSession{}, false, fmt.Errorf("failed to decode session cache: %w", err)
@@ -582,6 +745,8 @@ func readSessionFromFile(key string) (persistedSession, bool, error) {
 	if sess.Version != webSessionCacheVersion {
 		return persistedSession{}, false, nil
 	}
+	// Legacy cleartext cache: migrate to the encrypted format once.
+	maybeRewriteSessionFileEncrypted(key, sess)
 	return sess, true, nil
 }
 

--- a/internal/web/session_cache_lock_other.go
+++ b/internal/web/session_cache_lock_other.go
@@ -2,10 +2,10 @@
 
 package web
 
-// lockSessionFileKeyCreation has no cross-process file lock on platforms
-// without flock or LockFileEx support. Key creation is still serialized
-// within the process by sessionFileKeyMu, and the keychain re-check after
-// acquiring the lock keeps the remaining cross-process window narrow.
+import "errors"
+
+// lockSessionFileKeyCreation disables encrypted persistence on platforms where
+// the first key write cannot be made safe across processes.
 func lockSessionFileKeyCreation() (func() error, error) {
-	return func() error { return nil }, nil
+	return nil, errors.New("cross-process session file key locking is unavailable on this platform")
 }

--- a/internal/web/session_cache_lock_other.go
+++ b/internal/web/session_cache_lock_other.go
@@ -1,0 +1,11 @@
+//go:build !windows && !darwin && !linux && !freebsd && !netbsd && !openbsd && !dragonfly
+
+package web
+
+// lockSessionFileKeyCreation has no cross-process file lock on platforms
+// without flock or LockFileEx support. Key creation is still serialized
+// within the process by sessionFileKeyMu, and the keychain re-check after
+// acquiring the lock keeps the remaining cross-process window narrow.
+func lockSessionFileKeyCreation() (func() error, error) {
+	return func() error { return nil }, nil
+}

--- a/internal/web/session_cache_lock_unix.go
+++ b/internal/web/session_cache_lock_unix.go
@@ -1,8 +1,9 @@
-//go:build darwin || linux
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
 
 package web
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,16 +24,29 @@ func lockSessionFileKeyCreation() (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+	if err := flockRetryingEINTR(int(file.Fd()), unix.LOCK_EX); err != nil {
 		_ = file.Close()
 		return nil, err
 	}
 	return func() error {
-		unlockErr := unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		unlockErr := flockRetryingEINTR(int(file.Fd()), unix.LOCK_UN)
 		closeErr := file.Close()
 		if unlockErr != nil {
 			return unlockErr
 		}
 		return closeErr
 	}, nil
+}
+
+// flockRetryingEINTR retries flock when a signal interrupts the blocking
+// wait. The Go runtime's asynchronous preemption signal (SIGURG) routinely
+// interrupts syscalls, so a contended LOCK_EX would otherwise fail spuriously
+// with EINTR in exactly the concurrent-creation scenario the lock exists for.
+func flockRetryingEINTR(fd int, how int) error {
+	for {
+		err := unix.Flock(fd, how)
+		if !errors.Is(err, unix.EINTR) {
+			return err
+		}
+	}
 }

--- a/internal/web/session_cache_lock_unix.go
+++ b/internal/web/session_cache_lock_unix.go
@@ -1,0 +1,38 @@
+//go:build darwin || linux
+
+package web
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockSessionFileKeyCreation() (func() error, error) {
+	dir, err := sessionFileKeyLockDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create session cache dir: %w", err)
+	}
+	path := filepath.Join(dir, ".web-session-file-key.lock")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() error {
+		unlockErr := unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		closeErr := file.Close()
+		if unlockErr != nil {
+			return unlockErr
+		}
+		return closeErr
+	}, nil
+}

--- a/internal/web/session_cache_lock_windows.go
+++ b/internal/web/session_cache_lock_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package web
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockSessionFileKeyCreation() (func() error, error) {
+	dir, err := sessionFileKeyLockDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create session cache dir: %w", err)
+	}
+	path := filepath.Join(dir, ".web-session-file-key.lock")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() error {
+		unlockErr := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+		closeErr := file.Close()
+		if unlockErr != nil {
+			return unlockErr
+		}
+		return closeErr
+	}, nil
+}

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -149,8 +149,13 @@ func TestPersistSessionDefaultBackendWritesFileWithoutKeychain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("keyring keys error: %v", err)
 	}
-	if len(keys) != 0 {
-		t.Fatalf("expected default backend not to write keychain entries, got %#v", keys)
+	for _, key := range keys {
+		// The at-rest encryption key is the only allowed keychain item; the
+		// session cookies themselves must stay out of the keychain in the
+		// default file-backed mode.
+		if key != webSessionFileKeyItem {
+			t.Fatalf("expected default backend not to write keychain session entries, got %#v", keys)
+		}
 	}
 
 	if _, ok, err := readSessionFromFile(webSessionCacheKey("user@example.com")); err != nil {
@@ -2038,4 +2043,327 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func newTestSessionJar(t *testing.T, cookieValue string) *cookiejar.Jar {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New error: %v", err)
+	}
+	targetURL, _ := url.Parse("https://appstoreconnect.apple.com/")
+	jar.SetCookies(targetURL, []*http.Cookie{
+		{Name: "myacinfo", Value: cookieValue, Path: "/", Expires: time.Now().Add(24 * time.Hour)},
+	})
+	return jar
+}
+
+func readRawSessionFile(t *testing.T, key string) []byte {
+	t.Helper()
+	sessionPath, err := webSessionFilePath(key)
+	if err != nil {
+		t.Fatalf("webSessionFilePath error: %v", err)
+	}
+	raw, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("read session file: %v", err)
+	}
+	return raw
+}
+
+func TestWriteSessionToFileEncryptsAtRestByDefault(t *testing.T) {
+	kr := withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	jar := newTestSessionJar(t, "secret-token")
+	if err := PersistSession(&AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: "user@example.com",
+	}); err != nil {
+		t.Fatalf("PersistSession error: %v", err)
+	}
+
+	key := webSessionCacheKey("user@example.com")
+	raw := readRawSessionFile(t, key)
+	if strings.Contains(string(raw), "secret-token") {
+		t.Fatal("expected session file not to contain cleartext cookie values")
+	}
+	var envelope encryptedSessionEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if envelope.Cipher != webSessionFileCipher {
+		t.Fatalf("expected cipher %q, got %q", webSessionFileCipher, envelope.Cipher)
+	}
+	if envelope.Data == "" {
+		t.Fatal("expected non-empty encrypted payload")
+	}
+
+	if _, err := kr.Get(webSessionFileKeyItem); err != nil {
+		t.Fatalf("expected encryption key in keychain, got error: %v", err)
+	}
+
+	sess, ok, err := readSessionFromFile(key)
+	if err != nil {
+		t.Fatalf("readSessionFromFile error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected encrypted session round-trip")
+	}
+	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "secret-token" {
+		t.Fatalf("expected round-tripped cookie value, got %q", got)
+	}
+}
+
+func TestWriteSessionToFileReusesEncryptionKey(t *testing.T) {
+	kr := withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	for _, email := range []string{"first@example.com", "second@example.com"} {
+		jar := newTestSessionJar(t, "token-"+email)
+		if err := PersistSession(&AuthSession{
+			Client:    &http.Client{Jar: jar},
+			UserEmail: email,
+		}); err != nil {
+			t.Fatalf("PersistSession(%s) error: %v", email, err)
+		}
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatalf("keyring keys error: %v", err)
+	}
+	keyItems := 0
+	for _, key := range keys {
+		if key == webSessionFileKeyItem {
+			keyItems++
+		}
+	}
+	if keyItems != 1 {
+		t.Fatalf("expected exactly one encryption key item, got %d (keys: %#v)", keyItems, keys)
+	}
+
+	for _, email := range []string{"first@example.com", "second@example.com"} {
+		sess, ok, err := readSessionFromFile(webSessionCacheKey(email))
+		if err != nil {
+			t.Fatalf("readSessionFromFile(%s) error: %v", email, err)
+		}
+		if !ok {
+			t.Fatalf("expected persisted session for %s", email)
+		}
+		if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "token-"+email {
+			t.Fatalf("expected cookie for %s, got %q", email, got)
+		}
+	}
+}
+
+func TestReadSessionFromFileMigratesLegacyCleartext(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	key := webSessionCacheKey("user@example.com")
+	jar := newTestSessionJar(t, "legacy-token")
+	legacy := serializeCookieJar(jar, "user@example.com")
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy session: %v", err)
+	}
+	sessionPath, err := webSessionFilePath(key)
+	if err != nil {
+		t.Fatalf("webSessionFilePath error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o700); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := os.WriteFile(sessionPath, raw, 0o600); err != nil {
+		t.Fatalf("write legacy session file: %v", err)
+	}
+
+	sess, ok, err := readSessionFromFile(key)
+	if err != nil {
+		t.Fatalf("readSessionFromFile error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected legacy cleartext session to load")
+	}
+	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-token" {
+		t.Fatalf("expected legacy cookie value, got %q", got)
+	}
+
+	rewritten := readRawSessionFile(t, key)
+	if strings.Contains(string(rewritten), "legacy-token") {
+		t.Fatal("expected legacy cleartext file to be rewritten encrypted")
+	}
+	var envelope encryptedSessionEnvelope
+	if err := json.Unmarshal(rewritten, &envelope); err != nil {
+		t.Fatalf("decode rewritten envelope: %v", err)
+	}
+	if envelope.Cipher != webSessionFileCipher {
+		t.Fatalf("expected rewritten cipher %q, got %q", webSessionFileCipher, envelope.Cipher)
+	}
+
+	sess, ok, err = readSessionFromFile(key)
+	if err != nil {
+		t.Fatalf("readSessionFromFile after migration error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected migrated session to load")
+	}
+	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-token" {
+		t.Fatalf("expected migrated cookie value, got %q", got)
+	}
+}
+
+func TestWriteSessionToFileFallsBackToCleartextWithoutKeychain(t *testing.T) {
+	withUnavailableSessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	jar := newTestSessionJar(t, "headless-token")
+	if err := PersistSession(&AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: "user@example.com",
+	}); err != nil {
+		t.Fatalf("PersistSession error: %v", err)
+	}
+
+	key := webSessionCacheKey("user@example.com")
+	raw := readRawSessionFile(t, key)
+	if !strings.Contains(string(raw), "headless-token") {
+		t.Fatal("expected cleartext fallback when no keychain is available")
+	}
+
+	sess, ok, err := readSessionFromFile(key)
+	if err != nil {
+		t.Fatalf("readSessionFromFile error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected fallback session to load")
+	}
+	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "headless-token" {
+		t.Fatalf("expected fallback cookie value, got %q", got)
+	}
+}
+
+func TestWriteSessionToFileHonorsBypassKeychainEnv(t *testing.T) {
+	kr := withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "1")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	jar := newTestSessionJar(t, "bypass-token")
+	if err := PersistSession(&AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: "user@example.com",
+	}); err != nil {
+		t.Fatalf("PersistSession error: %v", err)
+	}
+
+	key := webSessionCacheKey("user@example.com")
+	raw := readRawSessionFile(t, key)
+	if !strings.Contains(string(raw), "bypass-token") {
+		t.Fatal("expected cleartext session when keychain is bypassed")
+	}
+	if _, err := kr.Get(webSessionFileKeyItem); err == nil {
+		t.Fatal("expected no encryption key item when keychain is bypassed")
+	}
+}
+
+func TestExplicitFileBackendKeepsCleartextBehavior(t *testing.T) {
+	kr := withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "file")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	jar := newTestSessionJar(t, "explicit-file-token")
+	if err := PersistSession(&AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: "user@example.com",
+	}); err != nil {
+		t.Fatalf("PersistSession error: %v", err)
+	}
+
+	key := webSessionCacheKey("user@example.com")
+	raw := readRawSessionFile(t, key)
+	if !strings.Contains(string(raw), "explicit-file-token") {
+		t.Fatal("expected explicit file backend to keep legacy cleartext format")
+	}
+	if _, err := kr.Get(webSessionFileKeyItem); err == nil {
+		t.Fatal("expected no encryption key item for the explicit file backend")
+	}
+}
+
+func TestReadEncryptedSessionWithoutKeychainIsCacheMiss(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	jar := newTestSessionJar(t, "portable-token")
+	if err := PersistSession(&AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: "user@example.com",
+	}); err != nil {
+		t.Fatalf("PersistSession error: %v", err)
+	}
+
+	withUnavailableSessionKeyring(t)
+	key := webSessionCacheKey("user@example.com")
+	sess, ok, err := readSessionFromFile(key)
+	if err != nil {
+		t.Fatalf("expected cache miss without keychain, got error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected cache miss without keychain, got session %#v", sess)
+	}
+}
+
+func TestReadLegacySessionStoreFromKeyringSkipsFileKeyItem(t *testing.T) {
+	kr := withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+
+	if err := kr.Set(keyring.Item{
+		Key:  webSessionFileKeyItem,
+		Data: []byte("not-a-session-payload"),
+	}); err != nil {
+		t.Fatalf("seed file key item: %v", err)
+	}
+
+	jar := newTestSessionJar(t, "legacy-keychain-token")
+	key := webSessionCacheKey("user@example.com")
+	raw, err := json.Marshal(serializeCookieJar(jar, "user@example.com"))
+	if err != nil {
+		t.Fatalf("marshal legacy keychain session: %v", err)
+	}
+	if err := kr.Set(keyring.Item{Key: keyringSessionItem(key), Data: raw}); err != nil {
+		t.Fatalf("seed legacy keychain session: %v", err)
+	}
+
+	store, ok, err := readLegacySessionStoreFromKeyring(kr)
+	if err != nil {
+		t.Fatalf("readLegacySessionStoreFromKeyring error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected legacy keychain store to load")
+	}
+	if _, found := store.Sessions[key]; !found {
+		t.Fatal("expected legacy keychain session to survive alongside the file key item")
+	}
+	if _, found := store.Sessions["file-key"]; found {
+		t.Fatal("expected the encryption key item to be excluded from legacy sessions")
+	}
 }

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2567,6 +2567,37 @@ func TestReadEncryptedSessionWithoutKeychainIsCacheMiss(t *testing.T) {
 	}
 }
 
+func TestReadEncryptedSessionSurfacesOperationalKeychainErrors(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	jar := newTestSessionJar(t, "guarded-token")
+	if err := PersistSession(&AuthSession{
+		Client:    &http.Client{Jar: jar},
+		UserEmail: "user@example.com",
+	}); err != nil {
+		t.Fatalf("PersistSession error: %v", err)
+	}
+
+	previous := sessionKeyringOpen
+	sessionKeyringOpen = func() (keyring.Keyring, error) {
+		return &failingSessionKeyring{
+			Keyring: keyring.NewArrayKeyring(nil),
+			getErr:  errors.New("keychain locked"),
+		}, nil
+	}
+	t.Cleanup(func() { sessionKeyringOpen = previous })
+
+	key := webSessionCacheKey("user@example.com")
+	sess, ok, err := readSessionFromFile(key)
+	if err == nil {
+		t.Fatalf("expected operational keychain error to surface, got ok=%v session=%#v", ok, sess)
+	}
+}
+
 func TestReadLegacySessionStoreFromKeyringSkipsFileKeyItem(t *testing.T) {
 	kr := withArraySessionKeyring(t)
 	t.Setenv(sessionBypassKeychainEnv, "0")

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -2634,5 +2635,30 @@ func TestReadLegacySessionStoreFromKeyringSkipsFileKeyItem(t *testing.T) {
 	}
 	if _, found := store.Sessions["file-key"]; found {
 		t.Fatal("expected the encryption key item to be excluded from legacy sessions")
+	}
+}
+
+func TestDeleteAllFromKeychainPreservesSharedFileEncryptionKey(t *testing.T) {
+	kr := withArraySessionKeyring(t)
+	fileKey := []byte("shared-file-encryption-key")
+	if err := kr.Set(keyring.Item{Key: webSessionFileKeyItem, Data: fileKey}); err != nil {
+		t.Fatalf("seed file key item: %v", err)
+	}
+	if err := kr.Set(keyring.Item{Key: keyringSessionItem("session"), Data: []byte("session")}); err != nil {
+		t.Fatalf("seed session item: %v", err)
+	}
+
+	if err := deleteAllFromKeychain(); err != nil {
+		t.Fatalf("deleteAllFromKeychain error: %v", err)
+	}
+	item, err := kr.Get(webSessionFileKeyItem)
+	if err != nil {
+		t.Fatalf("expected shared file encryption key to survive session deletion: %v", err)
+	}
+	if !bytes.Equal(item.Data, fileKey) {
+		t.Fatalf("file key data = %q, want %q", item.Data, fileKey)
+	}
+	if _, err := kr.Get(keyringSessionItem("session")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("expected session item deletion, got %v", err)
 	}
 }

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,9 +20,32 @@ import (
 type countingKeyring struct {
 	keyring.Keyring
 	getCounts map[string]int
+	mu        sync.Mutex
+}
+
+type failingSessionKeyring struct {
+	keyring.Keyring
+	getErr error
+	setErr error
+}
+
+func (kr *failingSessionKeyring) Get(key string) (keyring.Item, error) {
+	if kr.getErr != nil {
+		return keyring.Item{}, kr.getErr
+	}
+	return kr.Keyring.Get(key)
+}
+
+func (kr *failingSessionKeyring) Set(item keyring.Item) error {
+	if kr.setErr != nil {
+		return kr.setErr
+	}
+	return kr.Keyring.Set(item)
 }
 
 func (kr *countingKeyring) Get(key string) (keyring.Item, error) {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
 	kr.getCounts[key]++
 	return kr.Keyring.Get(key)
 }
@@ -31,6 +55,8 @@ func (kr *countingKeyring) GetMetadata(key string) (keyring.Metadata, error) {
 }
 
 func (kr *countingKeyring) Set(item keyring.Item) error {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
 	return kr.Keyring.Set(item)
 }
 
@@ -43,16 +69,23 @@ func (kr *countingKeyring) Keys() ([]string, error) {
 }
 
 func (kr *countingKeyring) ResetCounts() {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
 	kr.getCounts = map[string]int{}
 }
 
 func (kr *countingKeyring) GetCount(key string) int {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
 	return kr.getCounts[key]
 }
 
 func withArraySessionKeyring(t *testing.T) *countingKeyring {
 	t.Helper()
 	prev := sessionKeyringOpen
+	previousLockDir := sessionFileKeyLockDir
+	lockDir := t.TempDir()
+	sessionFileKeyLockDir = func() (string, error) { return lockDir, nil }
 	kr := &countingKeyring{
 		Keyring:   keyring.NewArrayKeyring([]keyring.Item{}),
 		getCounts: map[string]int{},
@@ -62,6 +95,7 @@ func withArraySessionKeyring(t *testing.T) *countingKeyring {
 	}
 	t.Cleanup(func() {
 		sessionKeyringOpen = prev
+		sessionFileKeyLockDir = previousLockDir
 	})
 	return kr
 }
@@ -999,7 +1033,7 @@ func TestTryResumeSessionPersistsRefreshedCookies(t *testing.T) {
 		t.Fatal("expected refreshed session in cache")
 	}
 
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "refreshed-token" {
+	if got := persistedMyACInfoCookieValue(stored); got != "refreshed-token" {
 		t.Fatalf("expected refreshed cookie value, got %q", got)
 	}
 }
@@ -1057,7 +1091,7 @@ func TestTryResumeLastSessionPersistsRefreshedCookies(t *testing.T) {
 	if !ok {
 		t.Fatal("expected refreshed session in cache")
 	}
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "new-token" {
+	if got := persistedMyACInfoCookieValue(stored); got != "new-token" {
 		t.Fatalf("expected refreshed cookie value, got %q", got)
 	}
 }
@@ -1341,7 +1375,7 @@ func TestTryResumeSessionMigratesLegacyIrisFileCache(t *testing.T) {
 	if !ok {
 		t.Fatal("expected migrated session in web cache")
 	}
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-iris-token" {
+	if got := persistedMyACInfoCookieValue(stored); got != "legacy-iris-token" {
 		t.Fatalf("expected migrated legacy cookie value, got %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(legacyDir, "session-"+key+".json")); !os.IsNotExist(err) {
@@ -2017,10 +2051,10 @@ func TestClearLastSessionMarkerDefaultBackendIgnoresUnavailableKeychainFallback(
 	}
 }
 
-func persistedCookieValue(sess persistedSession, baseURL, cookieName string) string {
-	list := sess.Cookies[baseURL]
+func persistedMyACInfoCookieValue(sess persistedSession) string {
+	list := sess.Cookies["https://appstoreconnect.apple.com/"]
 	for _, cookie := range list {
-		if cookie.Name == cookieName {
+		if cookie.Name == "myacinfo" {
 			return cookie.Value
 		}
 	}
@@ -2113,7 +2147,7 @@ func TestWriteSessionToFileEncryptsAtRestByDefault(t *testing.T) {
 	if !ok {
 		t.Fatal("expected encrypted session round-trip")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "secret-token" {
+	if got := persistedMyACInfoCookieValue(sess); got != "secret-token" {
 		t.Fatalf("expected round-tripped cookie value, got %q", got)
 	}
 }
@@ -2157,9 +2191,100 @@ func TestWriteSessionToFileReusesEncryptionKey(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected persisted session for %s", email)
 		}
-		if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "token-"+email {
+		if got := persistedMyACInfoCookieValue(sess); got != "token-"+email {
 			t.Fatalf("expected cookie for %s, got %q", email, got)
 		}
+	}
+}
+
+func TestLoadSessionFileKeySerializesConcurrentCreation(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+
+	const callers = 24
+	keys := make(chan string, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key, ok, err := loadSessionFileKey(true)
+			if err == nil && !ok {
+				err = errors.New("keychain unexpectedly unavailable")
+			}
+			if err != nil {
+				errs <- err
+				return
+			}
+			keys <- key
+		}()
+	}
+	wg.Wait()
+	close(keys)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("loadSessionFileKey error: %v", err)
+	}
+	var expected string
+	for key := range keys {
+		if expected == "" {
+			expected = key
+			continue
+		}
+		if key != expected {
+			t.Fatalf("expected all callers to share one key, got %q and %q", expected, key)
+		}
+	}
+	if expected == "" {
+		t.Fatal("expected a generated encryption key")
+	}
+}
+
+func TestWriteSessionToFileDoesNotDowngradeOnKeychainErrors(t *testing.T) {
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+	previousLockDir := sessionFileKeyLockDir
+	lockDir := t.TempDir()
+	sessionFileKeyLockDir = func() (string, error) { return lockDir, nil }
+	t.Cleanup(func() { sessionFileKeyLockDir = previousLockDir })
+
+	tests := []struct {
+		name string
+		open func() (keyring.Keyring, error)
+	}{
+		{name: "open denied", open: func() (keyring.Keyring, error) {
+			return nil, errors.New("keychain denied")
+		}},
+		{name: "read denied", open: func() (keyring.Keyring, error) {
+			return &failingSessionKeyring{Keyring: keyring.NewArrayKeyring(nil), getErr: errors.New("keychain locked")}, nil
+		}},
+		{name: "write denied", open: func() (keyring.Keyring, error) {
+			return &failingSessionKeyring{Keyring: keyring.NewArrayKeyring(nil), setErr: errors.New("keychain write denied")}, nil
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previous := sessionKeyringOpen
+			sessionKeyringOpen = tt.open
+			t.Cleanup(func() { sessionKeyringOpen = previous })
+
+			key := webSessionCacheKey(tt.name + "@example.com")
+			err := writeSessionToFile(key, serializeCookieJar(newTestSessionJar(t, "secret-token"), tt.name+"@example.com"))
+			if err == nil {
+				t.Fatal("expected keychain error")
+			}
+			path, pathErr := webSessionFilePath(key)
+			if pathErr != nil {
+				t.Fatalf("webSessionFilePath error: %v", pathErr)
+			}
+			if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+				t.Fatalf("expected no cleartext fallback file, stat error: %v", statErr)
+			}
+		})
 	}
 }
 
@@ -2195,7 +2320,7 @@ func TestReadSessionFromFileMigratesLegacyCleartext(t *testing.T) {
 	if !ok {
 		t.Fatal("expected legacy cleartext session to load")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-token" {
+	if got := persistedMyACInfoCookieValue(sess); got != "legacy-token" {
 		t.Fatalf("expected legacy cookie value, got %q", got)
 	}
 
@@ -2218,8 +2343,69 @@ func TestReadSessionFromFileMigratesLegacyCleartext(t *testing.T) {
 	if !ok {
 		t.Fatal("expected migrated session to load")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-token" {
+	if got := persistedMyACInfoCookieValue(sess); got != "legacy-token" {
 		t.Fatalf("expected migrated cookie value, got %q", got)
+	}
+}
+
+func TestReadSessionFromFileKeepsRorkLegacyCacheReadableWithoutKeychain(t *testing.T) {
+	withUnavailableSessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	key := webSessionCacheKey("user@example.com")
+	// This literal mirrors the cache emitted by rorkai #4211 rather than using
+	// the Go serializer, so field-name or timestamp compatibility cannot pass
+	// accidentally through shared implementation assumptions.
+	raw := []byte(`{"version":1,"updated_at":"2026-07-15T00:00:00.000Z","user_email":"user@example.com","cookies":{"https://appstoreconnect.apple.com/":[{"name":"myacinfo","value":"external-2.8-token","path":"/","domain":".apple.com","expires":"2030-07-15T00:00:00.000Z","secure":true,"http_only":true,"same_site":2}]}}`)
+	path, err := webSessionFilePath(key)
+	if err != nil {
+		t.Fatalf("webSessionFilePath error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write Rork legacy cache: %v", err)
+	}
+
+	sess, ok, err := readSessionFromFile(key)
+	if err != nil {
+		t.Fatalf("readSessionFromFile error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected Rork-written ASC 2.8 cache to remain readable")
+	}
+	if got := persistedMyACInfoCookieValue(sess); got != "external-2.8-token" {
+		t.Fatalf("expected Rork legacy cookie, got %q", got)
+	}
+	if rewritten := readRawSessionFile(t, key); !strings.Contains(string(rewritten), "external-2.8-token") {
+		t.Fatal("expected unavailable keychain to leave the compatible legacy cache unchanged")
+	}
+}
+
+func TestReadSessionFromFileRejectsMalformedEncryptedEnvelope(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(sessionBypassKeychainEnv, "0")
+	t.Setenv(webSessionBackendEnv, "")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	key := webSessionCacheKey("user@example.com")
+	path, err := webSessionFilePath(key)
+	if err != nil {
+		t.Fatalf("webSessionFilePath error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":1,"cipher":"future-cipher","data":"ciphertext"}`), 0o600); err != nil {
+		t.Fatalf("write malformed encrypted envelope: %v", err)
+	}
+
+	sess, ok, err := readSessionFromFile(key)
+	if err == nil {
+		t.Fatalf("expected malformed encrypted envelope error, got ok=%v session=%#v", ok, sess)
 	}
 }
 
@@ -2251,7 +2437,7 @@ func TestWriteSessionToFileFallsBackToCleartextWithoutKeychain(t *testing.T) {
 	if !ok {
 		t.Fatal("expected fallback session to load")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "headless-token" {
+	if got := persistedMyACInfoCookieValue(sess); got != "headless-token" {
 		t.Fatalf("expected fallback cookie value, got %q", got)
 	}
 }

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2567,7 +2567,7 @@ func TestReadEncryptedSessionWithoutKeychainIsCacheMiss(t *testing.T) {
 	}
 }
 
-func TestReadEncryptedSessionSurfacesOperationalKeychainErrors(t *testing.T) {
+func TestReadEncryptedSessionTreatsOperationalKeychainErrorsAsCacheMiss(t *testing.T) {
 	withArraySessionKeyring(t)
 	t.Setenv(sessionBypassKeychainEnv, "0")
 	t.Setenv(webSessionCacheEnabledEnv, "1")
@@ -2593,8 +2593,11 @@ func TestReadEncryptedSessionSurfacesOperationalKeychainErrors(t *testing.T) {
 
 	key := webSessionCacheKey("user@example.com")
 	sess, ok, err := readSessionFromFile(key)
-	if err == nil {
-		t.Fatalf("expected operational keychain error to surface, got ok=%v session=%#v", ok, sess)
+	if err != nil {
+		t.Fatalf("expected operational keychain error to behave like a cache miss, got %v", err)
+	}
+	if ok {
+		t.Fatalf("expected cache miss while the encryption key is unreachable, got %#v", sess)
 	}
 }
 

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -999,7 +999,7 @@ func TestTryResumeSessionPersistsRefreshedCookies(t *testing.T) {
 		t.Fatal("expected refreshed session in cache")
 	}
 
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "refreshed-token" {
+	if got := persistedMyacinfoValue(stored); got != "refreshed-token" {
 		t.Fatalf("expected refreshed cookie value, got %q", got)
 	}
 }
@@ -1057,7 +1057,7 @@ func TestTryResumeLastSessionPersistsRefreshedCookies(t *testing.T) {
 	if !ok {
 		t.Fatal("expected refreshed session in cache")
 	}
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "new-token" {
+	if got := persistedMyacinfoValue(stored); got != "new-token" {
 		t.Fatalf("expected refreshed cookie value, got %q", got)
 	}
 }
@@ -1341,7 +1341,7 @@ func TestTryResumeSessionMigratesLegacyIrisFileCache(t *testing.T) {
 	if !ok {
 		t.Fatal("expected migrated session in web cache")
 	}
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-iris-token" {
+	if got := persistedMyacinfoValue(stored); got != "legacy-iris-token" {
 		t.Fatalf("expected migrated legacy cookie value, got %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(legacyDir, "session-"+key+".json")); !os.IsNotExist(err) {
@@ -2017,10 +2017,10 @@ func TestClearLastSessionMarkerDefaultBackendIgnoresUnavailableKeychainFallback(
 	}
 }
 
-func persistedCookieValue(sess persistedSession, baseURL, cookieName string) string {
-	list := sess.Cookies[baseURL]
+func persistedMyacinfoValue(sess persistedSession) string {
+	list := sess.Cookies["https://appstoreconnect.apple.com/"]
 	for _, cookie := range list {
-		if cookie.Name == cookieName {
+		if cookie.Name == "myacinfo" {
 			return cookie.Value
 		}
 	}
@@ -2113,7 +2113,7 @@ func TestWriteSessionToFileEncryptsAtRestByDefault(t *testing.T) {
 	if !ok {
 		t.Fatal("expected encrypted session round-trip")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "secret-token" {
+	if got := persistedMyacinfoValue(sess); got != "secret-token" {
 		t.Fatalf("expected round-tripped cookie value, got %q", got)
 	}
 }
@@ -2157,7 +2157,7 @@ func TestWriteSessionToFileReusesEncryptionKey(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected persisted session for %s", email)
 		}
-		if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "token-"+email {
+		if got := persistedMyacinfoValue(sess); got != "token-"+email {
 			t.Fatalf("expected cookie for %s, got %q", email, got)
 		}
 	}
@@ -2195,7 +2195,7 @@ func TestReadSessionFromFileMigratesLegacyCleartext(t *testing.T) {
 	if !ok {
 		t.Fatal("expected legacy cleartext session to load")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-token" {
+	if got := persistedMyacinfoValue(sess); got != "legacy-token" {
 		t.Fatalf("expected legacy cookie value, got %q", got)
 	}
 
@@ -2218,7 +2218,7 @@ func TestReadSessionFromFileMigratesLegacyCleartext(t *testing.T) {
 	if !ok {
 		t.Fatal("expected migrated session to load")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-token" {
+	if got := persistedMyacinfoValue(sess); got != "legacy-token" {
 		t.Fatalf("expected migrated cookie value, got %q", got)
 	}
 }
@@ -2251,7 +2251,7 @@ func TestWriteSessionToFileFallsBackToCleartextWithoutKeychain(t *testing.T) {
 	if !ok {
 		t.Fatal("expected fallback session to load")
 	}
-	if got := persistedCookieValue(sess, "https://appstoreconnect.apple.com/", "myacinfo"); got != "headless-token" {
+	if got := persistedMyacinfoValue(sess); got != "headless-token" {
 		t.Fatalf("expected fallback cookie value, got %q", got)
 	}
 }

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -17,6 +17,13 @@ import (
 	"github.com/99designs/keyring"
 )
 
+func TestMain(m *testing.M) {
+	// Keychain-specific tests must not inherit a developer or CI bypass; the
+	// individual bypass tests opt in explicitly.
+	_ = os.Unsetenv(sessionBypassKeychainEnv)
+	os.Exit(m.Run())
+}
+
 type countingKeyring struct {
 	keyring.Keyring
 	getCounts map[string]int
@@ -154,6 +161,48 @@ func TestResolveBackendSelectionKeychainFallsBackToFile(t *testing.T) {
 	}
 	if selection.fallbackKeychain {
 		t.Fatal("did not expect keychain backend to fall back to keychain")
+	}
+}
+
+func TestResolveBackendSelectionBypassSuppressesKeychainAccess(t *testing.T) {
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(sessionBypassKeychainEnv, "1")
+
+	for _, backend := range []string{"", "auto", "keychain", "unexpected"} {
+		t.Run(backend, func(t *testing.T) {
+			t.Setenv(webSessionBackendEnv, backend)
+			selection := resolveBackendSelection()
+			if selection.backend != sessionBackendFile {
+				t.Fatalf("expected file backend with keychain bypass, got %v", selection.backend)
+			}
+			if selection.fallbackKeychain || selection.fallbackFile {
+				t.Fatalf("expected no keychain-related fallbacks with bypass, got %#v", selection)
+			}
+		})
+	}
+}
+
+func TestLoadCachedSessionBypassDoesNotOpenKeychainFallback(t *testing.T) {
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "auto")
+	t.Setenv(sessionBypassKeychainEnv, "1")
+	t.Setenv(webSessionCacheDirEnv, t.TempDir())
+
+	previousOpen := sessionKeyringOpen
+	keychainOpened := false
+	sessionKeyringOpen = func() (keyring.Keyring, error) {
+		keychainOpened = true
+		return keyring.NewArrayKeyring(nil), nil
+	}
+	t.Cleanup(func() { sessionKeyringOpen = previousOpen })
+
+	if _, ok, err := LoadCachedSession("user@example.com"); err != nil {
+		t.Fatalf("LoadCachedSession error: %v", err)
+	} else if ok {
+		t.Fatal("expected cache miss without a file-backed session")
+	}
+	if keychainOpened {
+		t.Fatal("expected ASC_BYPASS_KEYCHAIN to suppress keychain fallback")
 	}
 }
 


### PR DESCRIPTION
## Motivation

Security audit finding F1 (Medium): `internal/web/session_cache.go` defaults (`ASC_WEB_SESSION_CACHE_BACKEND` unset/`auto`) to the file backend, which serialized Apple ID web-session cookies (`myacinfo`, DES/trust cookies for `idmsa`/`appstoreconnect`/`gsa.apple.com`) as cleartext JSON at `~/.asc/web/session-<sha256(email)>.json`. Those cookies are a fully authenticated session that bypasses password + 2FA, and while permissions were already `0600`/`0700` with atomic writes, the plaintext blob leaks through backups, file sync, and same-user malware.

## Approach

Keep the file backend as the default (it exists because session blobs can exceed keychain item size limits and to avoid recurring per-binary keychain prompts), but encrypt the blob at rest:

- Session files are now written as a small JSON envelope (`{"version":1,"cipher":"aes-256-gcm","data":"<base64>"}`) whose payload is encrypted with the existing `internal/signing` AES-256-GCM helpers.
- The encryption key is one random 32-byte secret stored a single time in the OS keychain (`asc-web-session` service, item `asc:web-session:file-key`) — well under keychain item size limits; the large cookie blobs stay on disk.
- **Transparent migration**: legacy cleartext session files are read once and rewritten encrypted in place (best effort — a failed rewrite leaves the readable cleartext file untouched).
- **Headless/CI escape hatches (documented)**: when no keychain backend exists or `ASC_BYPASS_KEYCHAIN=1` is set, writes fall back to the legacy cleartext format so headless environments keep working; `ASC_WEB_SESSION_CACHE_BACKEND=file` explicitly pins the historical cleartext behavior.
- **No behavior change for explicit backend selections**: explicit `file` stays cleartext, explicit `keychain` is untouched. Reads always understand both formats regardless of backend selection, so switching backends never strands a session.
- An encrypted file read without a reachable key behaves as a cache miss (fresh login) rather than a hard error; corrupt/undecryptable payloads keep the existing decode-error semantics so the established keychain-fallback paths still apply.
- The new key item is excluded from the legacy keychain session-store scan (it shares the `asc:web-session:` prefix) and is cleaned up by `DeleteAllSessions` via the existing prefix sweep.

## Expected impact

- Default-mode users on machines with a keychain (macOS/Windows/most desktop Linux): session cookies are no longer recoverable from disk artifacts alone; an attacker needs the keychain-held key as well. One-time keychain approval prompt for the key item.
- CI/headless and explicit-`file` users: behavior unchanged.
- Per-operation overhead is one keychain read plus one PBKDF2 derivation (~tens of ms) on session persist/resume — negligible against the network round-trips these flows make.

## Test coverage

New tests in `internal/web/session_cache_test.go` (all pass with and without `ASC_BYPASS_KEYCHAIN=1`):

- encrypted round-trip: raw file contains no cookie cleartext, envelope format verified, decrypts back to the original cookies
- key reuse across multiple accounts (exactly one keychain key item)
- legacy cleartext file migration: loads once, rewritten encrypted, still readable afterwards
- keychain-unavailable fallback writes readable cleartext
- `ASC_BYPASS_KEYCHAIN=1` fallback writes cleartext and creates no key item
- explicit `ASC_WEB_SESSION_CACHE_BACKEND=file` keeps cleartext and creates no key item
- encrypted file + unavailable keychain reads as a cache miss (no hard error)
- legacy keychain session-store scan skips the key item

Validation: `go build ./...`, `go vet`, `make format-check`, `make check-docs`, and full `ASC_BYPASS_KEYCHAIN=1 make test` all green. `authentication.mdx` documents the at-rest behavior and escape hatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypts file-backed web-session cookie cache entries at rest by default (AES-256-GCM), using a key stored in the system keychain.
  * Migrates legacy cleartext session cache files to the encrypted format on first read.
  * Adds configurable cache backend selection and keychain bypass controls, including a documented headless/CI cleartext fallback.
* **Documentation**
  * New “Web session storage” section explaining encryption, migration, fallback behavior, and environment variables (with examples).
* **Bug Fixes / Hardening**
  * Improves safe concurrent key initialization and more resilient handling of malformed cache data and keychain failures.
* **Tests**
  * Expanded coverage for encryption, migration, fallback rules, error handling, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->