### PR TITLE
perf(output): defer output-renderer registry population to first lookup

### DIFF
--- a/internal/asc/output_registry.go
+++ b/internal/asc/output_registry.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"fmt"
 	"reflect"
+	"sync"
 )
 
 // rowsFunc extracts headers and rows from a typed response value.
@@ -17,6 +18,20 @@ var outputRegistry = map[reflect.Type]rowsFunc{}
 
 // directRenderRegistry maps types that need direct render control (multi-table output).
 var directRenderRegistry = map[reflect.Type]directRenderFunc{}
+
+// outputRegistryOnce guards the lazy one-time population of the registries.
+var outputRegistryOnce sync.Once
+
+// ensureOutputRegistryPopulated populates both registries exactly once, on
+// first lookup. Deferring registration keeps the ~450-type registration cost
+// out of process start for commands that never render registry output.
+// sync.Once makes concurrent first lookups safe.
+func ensureOutputRegistryPopulated() {
+	outputRegistryOnce.Do(func() {
+		registerAllOutputRenderers()
+		registerValidationRenderers()
+	})
+}
 
 func typeForPtr[T any]() reflect.Type {
 	return reflect.TypeFor[*T]()
@@ -343,6 +358,8 @@ func registerDirect[T any](fn func(*T, func([]string, [][]string)) error) {
 // using the provided render function (RenderTable or RenderMarkdown).
 // Falls back to JSON output for unregistered types.
 func renderByRegistry(data any, render func([]string, [][]string)) error {
+	ensureOutputRegistryPopulated()
+
 	t := reflect.TypeOf(data)
 
 	// Check direct render registry first (multi-table types).

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -1,7 +1,11 @@
 package asc
 
-//nolint:gochecknoinits // registry init is the idiomatic way to populate a type map
-func init() {
+// registerAllOutputRenderers populates the output registries with every
+// renderable response type. It runs lazily on first registry lookup (see
+// ensureOutputRegistryPopulated) instead of in a package init function, so
+// commands that never render registry output (for example `asc --version`)
+// do not pay the ~450-type registration cost at process start.
+func registerAllOutputRenderers() {
 	registerRows(feedbackRows)
 	registerRows(crashesRows)
 	registerRowsWithSingleResourceAdapter(reviewsRows)

--- a/internal/asc/output_registry_lazy_test.go
+++ b/internal/asc/output_registry_lazy_test.go
@@ -1,0 +1,84 @@
+package asc
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// registryEntriesAtProcessInit records how many renderers were registered by
+// the time package initialization finished. Test-file init functions run
+// after every non-test init in the package, so this observes the state a
+// freshly started process would have before any registry lookup.
+var registryEntriesAtProcessInit = -1
+
+//nolint:gochecknoinits // required to observe package-init-time registry state
+func init() {
+	registryEntriesAtProcessInit = len(outputRegistry) + len(directRenderRegistry)
+}
+
+func TestOutputRegistryLazyPopulation(t *testing.T) {
+	t.Run("no renderers registered during package init", func(t *testing.T) {
+		if registryEntriesAtProcessInit != 0 {
+			t.Fatalf("expected 0 renderers registered during package init, got %d; registration must stay lazy",
+				registryEntriesAtProcessInit)
+		}
+	})
+
+	t.Run("registry is fully populated after first use", func(t *testing.T) {
+		var gotHeaders []string
+		err := renderByRegistry(&LinkagesResponse{Data: []ResourceData{{Type: "apps", ID: "123"}}},
+			func(headers []string, rows [][]string) {
+				gotHeaders = headers
+			})
+		if err != nil {
+			t.Fatalf("renderByRegistry returned error: %v", err)
+		}
+		if len(gotHeaders) == 0 {
+			t.Fatal("expected registry-backed rendering for LinkagesResponse, got no headers")
+		}
+
+		// Mirrors the "expected minimum total registrations" sanity check:
+		// one lookup must populate the complete registry, not a subset.
+		const minExpected = 460
+		total := len(outputRegistry) + len(directRenderRegistry)
+		if total < minExpected {
+			t.Fatalf("expected at least %d registered types after first use, got %d (rows: %d, direct: %d)",
+				minExpected, total, len(outputRegistry), len(directRenderRegistry))
+		}
+	})
+
+	t.Run("concurrent lookups are safe", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := renderByRegistry(&LinkagesResponse{}, func([]string, [][]string) {})
+				if err != nil {
+					t.Errorf("renderByRegistry returned error: %v", err)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+// BenchmarkRegistryFirstUse measures the one-time registration cost that was
+// previously paid in package init by every process, including commands that
+// never render registry output such as `asc --version`.
+func BenchmarkRegistryFirstUse(b *testing.B) {
+	origOutput, origDirect := outputRegistry, directRenderRegistry
+	defer func() {
+		outputRegistry, directRenderRegistry = origOutput, origDirect
+	}()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		outputRegistry = make(map[reflect.Type]rowsFunc)
+		directRenderRegistry = make(map[reflect.Type]directRenderFunc)
+		registerAllOutputRenderers()
+		registerValidationRenderers()
+	}
+}

--- a/internal/asc/output_registry_test.go
+++ b/internal/asc/output_registry_test.go
@@ -229,13 +229,15 @@ func runOutputRegistryRenderByRegistryScenarios(t *testing.T) {
 }
 
 func runOutputRegistryHelperRegistrations(t *testing.T) {
+	ensureOutputRegistryPopulated()
+
 	t.Run("registry sanity", func(t *testing.T) {
 		t.Run("registries are non-empty", func(t *testing.T) {
 			if len(outputRegistry) == 0 {
-				t.Fatal("output registry is empty; init() may not have run")
+				t.Fatal("output registry is empty; lazy population may not have run")
 			}
 			if len(directRenderRegistry) == 0 {
-				t.Fatal("direct render registry is empty; init() may not have run")
+				t.Fatal("direct render registry is empty; lazy population may not have run")
 			}
 		})
 

--- a/internal/asc/output_validate.go
+++ b/internal/asc/output_validate.go
@@ -7,7 +7,10 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
-func init() {
+// registerValidationRenderers registers direct renderers for validation
+// reports. It runs lazily on first registry lookup alongside
+// registerAllOutputRenderers (see ensureOutputRegistryPopulated).
+func registerValidationRenderers() {
 	registerDirect(func(v *validation.Report, render func([]string, [][]string)) error {
 		h, r := validationSummaryRows(v)
 		render(h, r)


### PR DESCRIPTION
## Audit finding

Startup audit finding #3: `internal/asc/output_registry_init.go` used a package `init()` to eagerly register ~450 row-renderer functions into the global output registries on every process start (~834 allocs / ~0.5ms in the audit; measured here at ~93us, 817 allocs, 84KB per population on an M2 Pro). Since `internal/asc` is imported by essentially every command package, this cost was paid even by `asc --version`. After the lazy command tree (#1727), this was one of the largest remaining fixed startup costs.

## Approach

- Convert the `init()` in `output_registry_init.go` into `registerAllOutputRenderers()` — the registration body is byte-for-byte unchanged.
- Fold the second eager registration site, the `init()` in `output_validate.go` (4 direct renderers for validation reports), into the same lazy path as `registerValidationRenderers()`.
- Populate both registries via `sync.Once` in `ensureOutputRegistryPopulated()`, triggered from `renderByRegistry` — the single lookup path for both registries (used by `PrintTable` and `PrintMarkdown`; verified no other read path exists outside registration-time duplicate checks).

`sync.Once` keeps concurrent first lookups safe. Rendering behavior and output are unchanged: the same registrations run in the same order, just deferred until the first render.

## Expected impact

Commands that never render registry output (`asc --version`, help paths, JSON-only pipes that hit unregistered types via `PrintJSON`) no longer pay the ~450-type registration cost at process start. Commands that do render tables/markdown pay it once, at first render, where it is negligible relative to the network call that produced the data.

## Tests

- New `TestOutputRegistryLazyPopulation`:
  - asserts zero renderers are registered during package init (captured via a test-file `init()`, which runs after all non-test inits — a regression guard against reintroducing eager registration);
  - asserts the registry is fully populated (>= 460 types, mirroring the existing sanity threshold) after the first `renderByRegistry` call;
  - exercises concurrent lookups under `-race`.
- New `BenchmarkRegistryFirstUse` measures the one-time population cost that init() previously imposed on every process: ~93us, 817 allocs/op, 84KB/op.
- Existing registry sanity test updated to trigger lazy population explicitly before asserting completeness.
- Verified: `go build ./...`, `go vet ./...`, `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/asc/`, end-to-end `./internal/cli/cmdtest/` and `./internal/cli/apps/`, `make format`, `make check-docs`; smoke-tested the built binary (`asc --version`, `asc apps list --help`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced startup overhead by deferring output and validation renderer setup until output is first requested.

* **Reliability**
  * Ensured renderer initialization occurs safely during concurrent output operations.

* **Tests**
  * Added coverage and benchmarking for deferred initialization, first-use performance, and concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->