### PR TITLE
perf: cache bundle ID to app ID resolution across invocations

### DIFF
--- a/commands/global-flags.mdx
+++ b/commands/global-flags.mdx
@@ -93,6 +93,22 @@ Outputs information about:
 
 **Note**: This flag overrides `ASC_RETRY_LOG` and config file settings when explicitly set.
 
+## Caching Flags
+
+### `--no-cache`
+
+Disable the local app lookup cache for this invocation.
+
+```bash  theme={null}
+asc --no-cache builds list --app "com.example.app"
+```
+
+**Default**: `false`
+
+**Environment variable**: `ASC_NO_CACHE` (accepts `true/false`, `1/0`, `yes/no`, `y/n`, `on/off`)
+
+When you pass `--app` with a bundle ID, the CLI caches the resolved App Store Connect app ID under `~/.asc/cache` for 24 hours so repeated invocations skip an extra API round trip. Use `--no-cache` to force a live lookup, e.g. right after an app was deleted and recreated with the same bundle ID.
+
 ## CI and Reporting Flags
 
 ### `--report`
@@ -160,7 +176,7 @@ When the same setting is configured in multiple places, the CLI uses this priori
 
 ### Boolean Flags
 
-Boolean global flags (`--debug`, `--api-debug`, `--retry-log`, `--strict-auth`, `--version`) can be used without values:
+Boolean global flags (`--debug`, `--api-debug`, `--retry-log`, `--strict-auth`, `--no-cache`, `--version`) can be used without values:
 
 ```bash  theme={null}
 # All of these work
@@ -180,6 +196,7 @@ All global flags have corresponding environment variables for easier configurati
 | `--debug`       | `ASC_DEBUG`          | `true/false`                                   |
 | `--api-debug`   | `ASC_DEBUG`          | `api`                                          |
 | `--retry-log`   | `ASC_RETRY_LOG`      | `true/false`                                   |
+| `--no-cache`    | `ASC_NO_CACHE`       | `true/false`, `1/0`, `yes/no`, `y/n`, `on/off` |
 
 ### Additional Environment Variables
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,6 +25,7 @@ asc <subcommand> [flags]
 
 - `--api-debug` - Enable HTTP debug logging to stderr (redacts sensitive values)
 - `--debug` - Enable debug logging to stderr
+- `--no-cache` - Disable the local app lookup cache (default: false)
 - `--profile` - Use named authentication profile
 - `--report` - Report format for CI output (e.g., junit)
 - `--report-file` - Path to write CI report file

--- a/internal/asc/client_core.go
+++ b/internal/asc/client_core.go
@@ -570,6 +570,17 @@ func newClientWithPrivateKey(keyID, issuerID string, privateKey *ecdsa.PrivateKe
 	}
 }
 
+// IssuerID returns the issuer ID the client authenticates with.
+// It is empty for individual API keys.
+func (c *Client) IssuerID() string {
+	return c.issuerID
+}
+
+// KeyID returns the API key ID the client authenticates with.
+func (c *Client) KeyID() string {
+	return c.keyID
+}
+
 func (c *Client) getMutatingRequestLimiter() chan struct{} {
 	c.mutatingRequestLimiterOnce.Do(func() {
 		if c.mutatingRequestLimiter == nil {

--- a/internal/asc/client_core_auth_test.go
+++ b/internal/asc/client_core_auth_test.go
@@ -26,6 +26,21 @@ func TestNewClientFromPEM(t *testing.T) {
 	}
 }
 
+func TestClientCredentialIdentifierAccessors(t *testing.T) {
+	privateKeyPEM := mustGenerateECDSAPEM(t)
+
+	client, err := NewClientFromPEM("KEY123", "ISS456", privateKeyPEM)
+	if err != nil {
+		t.Fatalf("NewClientFromPEM() error: %v", err)
+	}
+	if got := client.KeyID(); got != "KEY123" {
+		t.Fatalf("KeyID() = %q, want %q", got, "KEY123")
+	}
+	if got := client.IssuerID(); got != "ISS456" {
+		t.Fatalf("IssuerID() = %q, want %q", got, "ISS456")
+	}
+}
+
 func TestNewClientFromPEM_InvalidKey(t *testing.T) {
 	_, err := NewClientFromPEM("KEY123", "ISS456", "not-a-valid-key")
 	if err == nil {

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -205,6 +205,7 @@ Use `asc <command> --help` for subcommands and flags.
 
 - `--api-debug` - HTTP request/response logging (redacted)
 - `--debug` - Debug logging
+- `--no-cache` - Disable the local app lookup cache
 - `--profile` - Use a named authentication profile
 - `--report` - Report format for CI output
 - `--report-file` - Path to write CI report file
@@ -219,6 +220,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `ASC_TIMEOUT`, `ASC_TIMEOUT_SECONDS` - Request timeout
 - `ASC_UPLOAD_TIMEOUT`, `ASC_UPLOAD_TIMEOUT_SECONDS` - Upload timeout
 - `ASC_DEBUG` - Debug output (`api` enables HTTP logs)
+- `ASC_NO_CACHE` - Disable the local app lookup cache
 - `ASC_STOREKIT_KEY_ID`, `ASC_STOREKIT_ISSUER_ID`, `ASC_STOREKIT_PRIVATE_KEY_PATH` - StoreKit In-App Purchase API authentication
 - `ASC_STOREKIT_PRIVATE_KEY`, `ASC_STOREKIT_PRIVATE_KEY_B64` - Inline StoreKit private key alternatives
 - `ASC_STOREKIT_BUNDLE_ID`, `ASC_STOREKIT_ENVIRONMENT`, `ASC_STOREKIT_PROFILE`, `ASC_STOREKIT_STRICT_AUTH` - StoreKit app, environment, profile, and mixed-source auth behavior

--- a/internal/cli/shared/app_lookup.go
+++ b/internal/cli/shared/app_lookup.go
@@ -130,6 +130,12 @@ func ResolveAppIDWithLookup(ctx context.Context, client appLookupClient, appID s
 // bundle ID drops any stale entry so later invocations re-resolve live.
 func resolveAppIDByBundleID(ctx context.Context, client appLookupClient, bundleID string) (string, bool, error) {
 	scope := appLookupCacheScope(client)
+	if scope != "" && appLookupCacheEnabled.Load() && noCacheRequested() {
+		// A bypassed live lookup must not leave an older disk answer available
+		// for the next invocation, even though --no-cache also forbids writing
+		// the newly resolved answer.
+		invalidateCachedAppIDForBundleID(scope, bundleID)
+	}
 	if appID, ok := cachedAppIDForBundleID(scope, bundleID); ok {
 		return appID, true, nil
 	}

--- a/internal/cli/shared/app_lookup.go
+++ b/internal/cli/shared/app_lookup.go
@@ -29,15 +29,12 @@ func ResolveAppIDWithExactLookup(ctx context.Context, client appLookupClient, ap
 		return "", fmt.Errorf("app lookup client is required for non-numeric --app values")
 	}
 
-	byBundle, err := client.GetApps(ctx, asc.WithAppsBundleIDs([]string{resolved}), asc.WithAppsLimit(2))
+	appID, found, err := resolveAppIDByBundleID(ctx, client, resolved)
 	if err != nil {
-		return "", fmt.Errorf("resolve app by bundle ID: %w", err)
+		return "", err
 	}
-	if len(byBundle.Data) == 1 {
-		return strings.TrimSpace(byBundle.Data[0].ID), nil
-	}
-	if len(byBundle.Data) > 1 {
-		return "", fmt.Errorf("multiple apps found for bundle ID %q; use --app with App Store Connect app ID", resolved)
+	if found {
+		return appID, nil
 	}
 
 	nameMatchIDs, err := findExactAppNameMatches(ctx, client, resolved, true)
@@ -81,15 +78,12 @@ func ResolveAppIDWithLookup(ctx context.Context, client appLookupClient, appID s
 		return "", fmt.Errorf("app lookup client is required for non-numeric --app values")
 	}
 
-	byBundle, err := client.GetApps(ctx, asc.WithAppsBundleIDs([]string{resolved}), asc.WithAppsLimit(2))
+	appID, found, err := resolveAppIDByBundleID(ctx, client, resolved)
 	if err != nil {
-		return "", fmt.Errorf("resolve app by bundle ID: %w", err)
+		return "", err
 	}
-	if len(byBundle.Data) == 1 {
-		return strings.TrimSpace(byBundle.Data[0].ID), nil
-	}
-	if len(byBundle.Data) > 1 {
-		return "", fmt.Errorf("multiple apps found for bundle ID %q; use --app with App Store Connect app ID", resolved)
+	if found {
+		return appID, nil
 	}
 
 	nameMatchIDs, err := findExactAppNameMatches(ctx, client, resolved, true)
@@ -128,6 +122,33 @@ func ResolveAppIDWithLookup(ctx context.Context, client appLookupClient, appID s
 		return "", fmt.Errorf("multiple apps found for name %q (%s); use --app with App Store Connect app ID", resolved, strings.Join(fuzzyMatches, ", "))
 	}
 	return "", fmt.Errorf("app %q not found (expected app ID, exact bundle ID, or exact app name)", resolved)
+}
+
+// resolveAppIDByBundleID resolves a value as an exact bundle ID, consulting
+// the cross-invocation disk cache before issuing a live lookup. Successful
+// live resolutions refresh the cache; a live lookup that no longer sees the
+// bundle ID drops any stale entry so later invocations re-resolve live.
+func resolveAppIDByBundleID(ctx context.Context, client appLookupClient, bundleID string) (string, bool, error) {
+	scope := appLookupCacheScope(client)
+	if appID, ok := cachedAppIDForBundleID(scope, bundleID); ok {
+		return appID, true, nil
+	}
+
+	byBundle, err := client.GetApps(ctx, asc.WithAppsBundleIDs([]string{bundleID}), asc.WithAppsLimit(2))
+	if err != nil {
+		return "", false, fmt.Errorf("resolve app by bundle ID: %w", err)
+	}
+	if byBundle != nil && len(byBundle.Data) == 1 {
+		appID := strings.TrimSpace(byBundle.Data[0].ID)
+		storeCachedAppIDForBundleID(scope, bundleID, appID)
+		return appID, true, nil
+	}
+	if byBundle != nil && len(byBundle.Data) > 1 {
+		return "", false, fmt.Errorf("multiple apps found for bundle ID %q; use --app with App Store Connect app ID", bundleID)
+	}
+
+	invalidateCachedAppIDForBundleID(scope, bundleID)
+	return "", false, nil
 }
 
 func findExactAppNameMatches(ctx context.Context, client appLookupClient, name string, useNameFilter bool) ([]string, error) {

--- a/internal/cli/shared/app_lookup_cache.go
+++ b/internal/cli/shared/app_lookup_cache.go
@@ -1,0 +1,214 @@
+package shared
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// The app lookup cache stores successful bundle ID -> app ID resolutions on
+// disk so repeated invocations with --app <bundleID> skip the extra apps-list
+// API round trip. App IDs are effectively immutable, so entries stay valid for
+// a short TTL and every cache failure silently falls back to a live lookup.
+const (
+	appLookupCacheTTL = 24 * time.Hour
+	noCacheEnvVar     = "ASC_NO_CACHE"
+)
+
+// appLookupCacheEntry is the on-disk format of one cached resolution.
+// It never contains key material; scope is derived from non-secret
+// credential identifiers (issuer ID or key ID).
+type appLookupCacheEntry struct {
+	AsOf     time.Time `json:"asOf"`
+	Scope    string    `json:"scope"`
+	BundleID string    `json:"bundleId"`
+	AppID    string    `json:"appId"`
+}
+
+var (
+	// appLookupCacheEnabled is off by default so library callers and tests
+	// stay hermetic; the CLI entrypoint opts in via EnableAppLookupCache.
+	appLookupCacheEnabled atomic.Bool
+	noCache               bool
+
+	noCacheWarnMu sync.Mutex
+	noCacheWarned = map[string]struct{}{}
+
+	appLookupCacheDirOverride   string
+	appLookupCacheDirOverrideMu sync.RWMutex
+)
+
+// EnableAppLookupCache activates the cross-invocation app lookup disk cache.
+// It is called once from the CLI entrypoint.
+func EnableAppLookupCache() {
+	appLookupCacheEnabled.Store(true)
+}
+
+// appLookupCredentialsProvider exposes the non-secret credential identifiers
+// used to scope cache entries to the credentials that resolved them.
+type appLookupCredentialsProvider interface {
+	IssuerID() string
+	KeyID() string
+}
+
+var _ appLookupCredentialsProvider = (*asc.Client)(nil)
+
+// appLookupCacheScope derives the cache scope for a lookup client. It returns
+// an empty scope (cache disabled) when the client does not expose credential
+// identifiers, e.g. test stubs.
+func appLookupCacheScope(client appLookupClient) string {
+	provider, ok := client.(appLookupCredentialsProvider)
+	if !ok {
+		return ""
+	}
+	if issuerID := strings.TrimSpace(provider.IssuerID()); issuerID != "" {
+		return "issuer:" + issuerID
+	}
+	// Individual API keys have no issuer ID; scope by key ID instead.
+	if keyID := strings.TrimSpace(provider.KeyID()); keyID != "" {
+		return "key:" + keyID
+	}
+	return ""
+}
+
+func appLookupCacheActive() bool {
+	return appLookupCacheEnabled.Load() && !noCacheRequested()
+}
+
+func noCacheRequested() bool {
+	if noCache {
+		return true
+	}
+	value := strings.TrimSpace(os.Getenv(noCacheEnvVar))
+	if value == "" {
+		return false
+	}
+	switch strings.ToLower(value) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	case "0", "f", "false", "no", "n", "off":
+		return false
+	default:
+		warnInvalidNoCacheValueOnce(value)
+		return false
+	}
+}
+
+func warnInvalidNoCacheValueOnce(value string) {
+	noCacheWarnMu.Lock()
+	if _, ok := noCacheWarned[value]; ok {
+		noCacheWarnMu.Unlock()
+		return
+	}
+	noCacheWarned[value] = struct{}{}
+	noCacheWarnMu.Unlock()
+
+	fmt.Fprintf(
+		os.Stderr,
+		"Warning: invalid %s value %q (expected true/false, 1/0, yes/no, y/n, or on/off); cache enabled\n",
+		noCacheEnvVar,
+		SanitizeTerminal(value),
+	)
+}
+
+func appLookupCacheDir() (string, error) {
+	appLookupCacheDirOverrideMu.RLock()
+	override := appLookupCacheDirOverride
+	appLookupCacheDirOverrideMu.RUnlock()
+	if override != "" {
+		return override, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".asc", "cache"), nil
+}
+
+func appLookupCachePath(scope, bundleID string) (string, error) {
+	dir, err := appLookupCacheDir()
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256([]byte(scope + "\x00" + bundleID))
+	return filepath.Join(dir, fmt.Sprintf("app-id-%s.json", hex.EncodeToString(digest[:16]))), nil
+}
+
+// cachedAppIDForBundleID returns a cached resolution when the cache is active
+// and holds a fresh, matching entry. Unreadable, corrupt, mismatched, or
+// expired entries are dropped so the caller re-resolves live.
+func cachedAppIDForBundleID(scope, bundleID string) (string, bool) {
+	if scope == "" || !appLookupCacheActive() {
+		return "", false
+	}
+	path, err := appLookupCachePath(scope, bundleID)
+	if err != nil {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+
+	var entry appLookupCacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		_ = os.Remove(path)
+		return "", false
+	}
+	appID := strings.TrimSpace(entry.AppID)
+	if entry.Scope != scope || entry.BundleID != bundleID || appID == "" || time.Since(entry.AsOf) > appLookupCacheTTL {
+		_ = os.Remove(path)
+		return "", false
+	}
+	return appID, true
+}
+
+// storeCachedAppIDForBundleID persists a successful resolution. Write failures
+// are silently ignored; the cache is a best-effort optimization.
+func storeCachedAppIDForBundleID(scope, bundleID, appID string) {
+	if scope == "" || appID == "" || !appLookupCacheActive() {
+		return
+	}
+	path, err := appLookupCachePath(scope, bundleID)
+	if err != nil {
+		return
+	}
+	entry := appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    scope,
+		BundleID: bundleID,
+		AppID:    appID,
+	}
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return
+	}
+	_, _ = writeFileNoSymlinkOverwrite(path, 0o600, ".asc-app-id-*", ".asc-app-id-backup-*", func(file *os.File) (int64, error) {
+		written, err := file.Write(data)
+		return int64(written), err
+	})
+}
+
+// invalidateCachedAppIDForBundleID drops a cached resolution, e.g. when a live
+// lookup shows the app is no longer visible to the credentials. It runs even
+// under --no-cache so stale entries do not outlive a bypassed re-resolution.
+func invalidateCachedAppIDForBundleID(scope, bundleID string) {
+	if scope == "" || !appLookupCacheEnabled.Load() {
+		return
+	}
+	path, err := appLookupCachePath(scope, bundleID)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(path)
+}

--- a/internal/cli/shared/app_lookup_cache_test.go
+++ b/internal/cli/shared/app_lookup_cache_test.go
@@ -459,6 +459,32 @@ func TestAppLookupCacheScope(t *testing.T) {
 	}
 }
 
+func TestResolveAppIDWithLookup_KeyScopedCacheHitSkipsLiveLookup(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	// Individual API keys have no issuer; they cache under the key scope.
+	scope := "key:KEY1"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    scope,
+		BundleID: "com.example.app",
+		AppID:    "app-key-scoped",
+	})
+
+	stub := &scopedAppLookupStub{keyID: "KEY1"}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() cached error: %v", err)
+	}
+	if got != "app-key-scoped" {
+		t.Fatalf("expected cached app-key-scoped, got %q", got)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("expected cache hit without live calls, got %d", stub.calls)
+	}
+}
+
 func TestResolveAppIDWithLookup_RealClientCachesAcrossInvocations(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	enableAppLookupCacheForTest(t)

--- a/internal/cli/shared/app_lookup_cache_test.go
+++ b/internal/cli/shared/app_lookup_cache_test.go
@@ -60,8 +60,9 @@ func cacheFiles(t *testing.T, dir string) []string {
 	return names
 }
 
-func writeCacheEntry(t *testing.T, scope, bundleID string, entry appLookupCacheEntry) string {
+func writeCacheEntry(t *testing.T, bundleID string, entry appLookupCacheEntry) string {
 	t.Helper()
+	scope := "issuer:issuer-a"
 	path, err := appLookupCachePath(scope, bundleID)
 	if err != nil {
 		t.Fatalf("cache path: %v", err)
@@ -185,9 +186,9 @@ func TestResolveAppIDWithLookup_CacheMissForDifferentCredentials(t *testing.T) {
 func TestResolveAppIDWithLookup_ExpiredCacheEntryReResolvesLive(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	enableAppLookupCacheForTest(t)
-
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+
+	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().Add(-appLookupCacheTTL - time.Minute).UTC(),
 		Scope:    scope,
 		BundleID: "com.example.app",
@@ -259,8 +260,7 @@ func TestResolveAppIDWithLookup_ScopeMismatchedEntryIsIgnored(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	enableAppLookupCacheForTest(t)
 
-	scope := "issuer:issuer-a"
-	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    "issuer:issuer-other",
 		BundleID: "com.example.app",
@@ -292,7 +292,7 @@ func TestResolveAppIDWithLookup_NoCacheFlagBypassesCache(t *testing.T) {
 	dir := enableAppLookupCacheForTest(t)
 
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.app",
@@ -336,7 +336,7 @@ func TestResolveAppIDWithLookup_NoCacheEnvBypassesCache(t *testing.T) {
 	t.Setenv(noCacheEnvVar, "1")
 
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.app",
@@ -400,7 +400,7 @@ func TestResolveAppIDWithLookup_DropsEntryWhenAppNoLongerVisible(t *testing.T) {
 	dir := enableAppLookupCacheForTest(t)
 
 	scope := "issuer:issuer-a"
-	path := writeCacheEntry(t, scope, "com.example.gone", appLookupCacheEntry{
+	path := writeCacheEntry(t, "com.example.gone", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.gone",
@@ -530,7 +530,7 @@ func TestCachedAppIDForBundleIDRejectsBundleMismatch(t *testing.T) {
 	enableAppLookupCacheForTest(t)
 
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.other",

--- a/internal/cli/shared/app_lookup_cache_test.go
+++ b/internal/cli/shared/app_lookup_cache_test.go
@@ -60,9 +60,8 @@ func cacheFiles(t *testing.T, dir string) []string {
 	return names
 }
 
-func writeCacheEntry(t *testing.T, bundleID string, entry appLookupCacheEntry) string {
+func writeCacheEntry(t *testing.T, scope, bundleID string, entry appLookupCacheEntry) string {
 	t.Helper()
-	scope := "issuer:issuer-a"
 	path, err := appLookupCachePath(scope, bundleID)
 	if err != nil {
 		t.Fatalf("cache path: %v", err)
@@ -186,9 +185,9 @@ func TestResolveAppIDWithLookup_CacheMissForDifferentCredentials(t *testing.T) {
 func TestResolveAppIDWithLookup_ExpiredCacheEntryReResolvesLive(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	enableAppLookupCacheForTest(t)
-	scope := "issuer:issuer-a"
 
-	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().Add(-appLookupCacheTTL - time.Minute).UTC(),
 		Scope:    scope,
 		BundleID: "com.example.app",
@@ -260,7 +259,8 @@ func TestResolveAppIDWithLookup_ScopeMismatchedEntryIsIgnored(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	enableAppLookupCacheForTest(t)
 
-	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    "issuer:issuer-other",
 		BundleID: "com.example.app",
@@ -292,7 +292,7 @@ func TestResolveAppIDWithLookup_NoCacheFlagBypassesCache(t *testing.T) {
 	dir := enableAppLookupCacheForTest(t)
 
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.app",
@@ -336,7 +336,7 @@ func TestResolveAppIDWithLookup_NoCacheEnvBypassesCache(t *testing.T) {
 	t.Setenv(noCacheEnvVar, "1")
 
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.app",
@@ -400,7 +400,7 @@ func TestResolveAppIDWithLookup_DropsEntryWhenAppNoLongerVisible(t *testing.T) {
 	dir := enableAppLookupCacheForTest(t)
 
 	scope := "issuer:issuer-a"
-	path := writeCacheEntry(t, "com.example.gone", appLookupCacheEntry{
+	path := writeCacheEntry(t, scope, "com.example.gone", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.gone",
@@ -556,7 +556,7 @@ func TestCachedAppIDForBundleIDRejectsBundleMismatch(t *testing.T) {
 	enableAppLookupCacheForTest(t)
 
 	scope := "issuer:issuer-a"
-	writeCacheEntry(t, "com.example.app", appLookupCacheEntry{
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
 		AsOf:     time.Now().UTC(),
 		Scope:    scope,
 		BundleID: "com.example.other",

--- a/internal/cli/shared/app_lookup_cache_test.go
+++ b/internal/cli/shared/app_lookup_cache_test.go
@@ -319,13 +319,14 @@ func TestResolveAppIDWithLookup_NoCacheFlagBypassesCache(t *testing.T) {
 		t.Fatalf("expected live lookup with --no-cache, got %d calls", stub.calls)
 	}
 
-	// The bypassed run must not rewrite the cache.
+	// The bypassed run must not leave the older answer available to a later
+	// cache-enabled invocation.
 	noCache = false
-	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); !ok || cached != "app-cached" {
-		t.Fatalf("expected untouched cache entry app-cached, got %q (ok=%t)", cached, ok)
+	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); ok {
+		t.Fatalf("expected bypassed live lookup to invalidate stale entry, got %q", cached)
 	}
-	if files := cacheFiles(t, dir); len(files) != 1 {
-		t.Fatalf("expected one untouched cache file, got %v", files)
+	if files := cacheFiles(t, dir); len(files) != 0 {
+		t.Fatalf("expected empty cache after bypassed live lookup, got %v", files)
 	}
 }
 
@@ -359,6 +360,38 @@ func TestResolveAppIDWithLookup_NoCacheEnvBypassesCache(t *testing.T) {
 	}
 	if stub.calls != 1 {
 		t.Fatalf("expected live lookup with ASC_NO_CACHE=1, got %d calls", stub.calls)
+	}
+	t.Setenv(noCacheEnvVar, "0")
+	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); ok {
+		t.Fatalf("expected env-bypassed lookup to invalidate stale entry, got %q", cached)
+	}
+}
+
+func TestNoCacheRequestedWarnsOnceForInvalidEnvValue(t *testing.T) {
+	enableAppLookupCacheForTest(t)
+	t.Setenv(noCacheEnvVar, "invalid\x1b[31m")
+
+	noCacheWarnMu.Lock()
+	previousWarnings := noCacheWarned
+	noCacheWarned = map[string]struct{}{}
+	noCacheWarnMu.Unlock()
+	t.Cleanup(func() {
+		noCacheWarnMu.Lock()
+		noCacheWarned = previousWarnings
+		noCacheWarnMu.Unlock()
+	})
+
+	_, stderr := captureOutput(t, func() {
+		if noCacheRequested() {
+			t.Fatal("invalid ASC_NO_CACHE value must keep cache enabled")
+		}
+		_ = noCacheRequested()
+	})
+	if count := strings.Count(stderr, "invalid ASC_NO_CACHE value"); count != 1 {
+		t.Fatalf("expected one invalid-value warning, got %d in %q", count, stderr)
+	}
+	if strings.Contains(stderr, "\x1b") {
+		t.Fatalf("expected warning to sanitize terminal control characters, got %q", stderr)
 	}
 }
 

--- a/internal/cli/shared/app_lookup_cache_test.go
+++ b/internal/cli/shared/app_lookup_cache_test.go
@@ -1,0 +1,510 @@
+package shared
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type scopedAppLookupStub struct {
+	sequenceAppLookupStub
+	issuerID string
+	keyID    string
+}
+
+func (s *scopedAppLookupStub) IssuerID() string { return s.issuerID }
+
+func (s *scopedAppLookupStub) KeyID() string { return s.keyID }
+
+func enableAppLookupCacheForTest(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	appLookupCacheDirOverrideMu.Lock()
+	previousDir := appLookupCacheDirOverride
+	appLookupCacheDirOverride = dir
+	appLookupCacheDirOverrideMu.Unlock()
+
+	previousEnabled := appLookupCacheEnabled.Swap(true)
+	previousNoCache := noCache
+	noCache = false
+	t.Setenv(noCacheEnvVar, "")
+
+	t.Cleanup(func() {
+		appLookupCacheDirOverrideMu.Lock()
+		appLookupCacheDirOverride = previousDir
+		appLookupCacheDirOverrideMu.Unlock()
+		appLookupCacheEnabled.Store(previousEnabled)
+		noCache = previousNoCache
+	})
+	return dir
+}
+
+func cacheFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read cache dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func writeCacheEntry(t *testing.T, scope, bundleID string, entry appLookupCacheEntry) string {
+	t.Helper()
+	path, err := appLookupCachePath(scope, bundleID)
+	if err != nil {
+		t.Fatalf("cache path: %v", err)
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal cache entry: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write cache entry: %v", err)
+	}
+	return path
+}
+
+func TestResolveAppIDWithLookup_CacheHitSkipsLiveLookup(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	dir := enableAppLookupCacheForTest(t)
+
+	first := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-bundle", name: "Bundle App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+		keyID:    "KEY1",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), first, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-bundle" {
+		t.Fatalf("expected app-bundle, got %q", got)
+	}
+	if first.calls != 1 {
+		t.Fatalf("expected one live lookup call, got %d", first.calls)
+	}
+	if files := cacheFiles(t, dir); len(files) != 1 {
+		t.Fatalf("expected one cache file, got %v", files)
+	}
+
+	// A second invocation with the same credentials must resolve from disk.
+	second := &scopedAppLookupStub{issuerID: "issuer-a", keyID: "KEY1"}
+	got, err = ResolveAppIDWithLookup(context.Background(), second, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() cached error: %v", err)
+	}
+	if got != "app-bundle" {
+		t.Fatalf("expected cached app-bundle, got %q", got)
+	}
+	if second.calls != 0 {
+		t.Fatalf("expected cache hit without live calls, got %d", second.calls)
+	}
+}
+
+func TestResolveAppIDWithExactLookup_CacheHitSkipsLiveLookup(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	first := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-exact", name: "Exact App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	if _, err := ResolveAppIDWithExactLookup(context.Background(), first, "com.example.exact"); err != nil {
+		t.Fatalf("ResolveAppIDWithExactLookup() error: %v", err)
+	}
+
+	second := &scopedAppLookupStub{issuerID: "issuer-a"}
+	got, err := ResolveAppIDWithExactLookup(context.Background(), second, "com.example.exact")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithExactLookup() cached error: %v", err)
+	}
+	if got != "app-exact" {
+		t.Fatalf("expected cached app-exact, got %q", got)
+	}
+	if second.calls != 0 {
+		t.Fatalf("expected cache hit without live calls, got %d", second.calls)
+	}
+}
+
+func TestResolveAppIDWithLookup_CacheMissForDifferentCredentials(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	first := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-team-a", name: "Team A App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	if _, err := ResolveAppIDWithLookup(context.Background(), first, "com.example.app"); err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+
+	other := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-team-b", name: "Team B App"}}),
+			},
+		},
+		issuerID: "issuer-b",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), other, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-team-b" {
+		t.Fatalf("expected live app-team-b for other credentials, got %q", got)
+	}
+	if other.calls != 1 {
+		t.Fatalf("expected live lookup for other credentials, got %d calls", other.calls)
+	}
+}
+
+func TestResolveAppIDWithLookup_ExpiredCacheEntryReResolvesLive(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+		AsOf:     time.Now().Add(-appLookupCacheTTL - time.Minute).UTC(),
+		Scope:    scope,
+		BundleID: "com.example.app",
+		AppID:    "app-stale",
+	})
+
+	stub := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-fresh", name: "Fresh App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-fresh" {
+		t.Fatalf("expected live app-fresh after expiry, got %q", got)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected live lookup after expiry, got %d calls", stub.calls)
+	}
+
+	// The refreshed entry must serve later invocations again.
+	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); !ok || cached != "app-fresh" {
+		t.Fatalf("expected refreshed cache entry app-fresh, got %q (ok=%t)", cached, ok)
+	}
+}
+
+func TestResolveAppIDWithLookup_CorruptCacheEntryFallsBackToLiveLookup(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	scope := "issuer:issuer-a"
+	path, err := appLookupCachePath(scope, "com.example.app")
+	if err != nil {
+		t.Fatalf("cache path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt cache entry: %v", err)
+	}
+
+	stub := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-live", name: "Live App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-live" {
+		t.Fatalf("expected live app-live after corrupt cache, got %q", got)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected live lookup after corrupt cache, got %d calls", stub.calls)
+	}
+	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); !ok || cached != "app-live" {
+		t.Fatalf("expected corrupt entry replaced with app-live, got %q (ok=%t)", cached, ok)
+	}
+}
+
+func TestResolveAppIDWithLookup_ScopeMismatchedEntryIsIgnored(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    "issuer:issuer-other",
+		BundleID: "com.example.app",
+		AppID:    "app-wrong-scope",
+	})
+
+	stub := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-live", name: "Live App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-live" {
+		t.Fatalf("expected live app-live for mismatched scope entry, got %q", got)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected live lookup for mismatched scope entry, got %d calls", stub.calls)
+	}
+}
+
+func TestResolveAppIDWithLookup_NoCacheFlagBypassesCache(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	dir := enableAppLookupCacheForTest(t)
+
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    scope,
+		BundleID: "com.example.app",
+		AppID:    "app-cached",
+	})
+
+	noCache = true
+	stub := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-live", name: "Live App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-live" {
+		t.Fatalf("expected live app-live with --no-cache, got %q", got)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected live lookup with --no-cache, got %d calls", stub.calls)
+	}
+
+	// The bypassed run must not rewrite the cache.
+	noCache = false
+	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); !ok || cached != "app-cached" {
+		t.Fatalf("expected untouched cache entry app-cached, got %q (ok=%t)", cached, ok)
+	}
+	if files := cacheFiles(t, dir); len(files) != 1 {
+		t.Fatalf("expected one untouched cache file, got %v", files)
+	}
+}
+
+func TestResolveAppIDWithLookup_NoCacheEnvBypassesCache(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+	t.Setenv(noCacheEnvVar, "1")
+
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    scope,
+		BundleID: "com.example.app",
+		AppID:    "app-cached",
+	})
+
+	stub := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-live", name: "Live App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-live" {
+		t.Fatalf("expected live app-live with ASC_NO_CACHE=1, got %q", got)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected live lookup with ASC_NO_CACHE=1, got %d calls", stub.calls)
+	}
+}
+
+func TestResolveAppIDWithLookup_DropsEntryWhenAppNoLongerVisible(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	dir := enableAppLookupCacheForTest(t)
+
+	scope := "issuer:issuer-a"
+	path := writeCacheEntry(t, scope, "com.example.gone", appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    scope,
+		BundleID: "com.example.gone",
+		AppID:    "app-gone",
+	})
+
+	// Bypass the cached entry so the resolver performs a live lookup that no
+	// longer sees the app; the stale entry must be dropped.
+	noCache = true
+	stub := &scopedAppLookupStub{issuerID: "issuer-a"}
+	_, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.gone")
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected stale cache entry %q to be removed, stat err: %v", filepath.Base(path), statErr)
+	}
+	if files := cacheFiles(t, dir); len(files) != 0 {
+		t.Fatalf("expected empty cache dir after invalidation, got %v", files)
+	}
+}
+
+func TestResolveAppIDWithLookup_UnscopedClientDoesNotWriteCache(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	dir := enableAppLookupCacheForTest(t)
+
+	stub := &sequenceAppLookupStub{
+		responses: []*asc.AppsResponse{
+			appsResponseFromApps([]appFixture{{id: "app-bundle", name: "Bundle App"}}),
+		},
+	}
+	got, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "app-bundle" {
+		t.Fatalf("expected app-bundle, got %q", got)
+	}
+	if files := cacheFiles(t, dir); len(files) != 0 {
+		t.Fatalf("expected no cache files for unscoped client, got %v", files)
+	}
+}
+
+func TestResolveAppIDWithLookup_CacheDisabledByDefault(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	dir := t.TempDir()
+	appLookupCacheDirOverrideMu.Lock()
+	previousDir := appLookupCacheDirOverride
+	appLookupCacheDirOverride = dir
+	appLookupCacheDirOverrideMu.Unlock()
+	t.Cleanup(func() {
+		appLookupCacheDirOverrideMu.Lock()
+		appLookupCacheDirOverride = previousDir
+		appLookupCacheDirOverrideMu.Unlock()
+	})
+
+	stub := &scopedAppLookupStub{
+		sequenceAppLookupStub: sequenceAppLookupStub{
+			responses: []*asc.AppsResponse{
+				appsResponseFromApps([]appFixture{{id: "app-bundle", name: "Bundle App"}}),
+			},
+		},
+		issuerID: "issuer-a",
+	}
+	if _, err := ResolveAppIDWithLookup(context.Background(), stub, "com.example.app"); err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if files := cacheFiles(t, dir); len(files) != 0 {
+		t.Fatalf("expected no cache files while cache is disabled, got %v", files)
+	}
+}
+
+func TestAppLookupCacheScope(t *testing.T) {
+	if scope := appLookupCacheScope(&sequenceAppLookupStub{}); scope != "" {
+		t.Fatalf("expected empty scope for unscoped client, got %q", scope)
+	}
+	if scope := appLookupCacheScope(&scopedAppLookupStub{issuerID: " issuer-a ", keyID: "KEY1"}); scope != "issuer:issuer-a" {
+		t.Fatalf("expected issuer scope, got %q", scope)
+	}
+	if scope := appLookupCacheScope(&scopedAppLookupStub{keyID: "KEY1"}); scope != "key:KEY1" {
+		t.Fatalf("expected key scope for individual keys, got %q", scope)
+	}
+	if scope := appLookupCacheScope(&scopedAppLookupStub{}); scope != "" {
+		t.Fatalf("expected empty scope without identifiers, got %q", scope)
+	}
+}
+
+func TestResolveAppIDWithLookup_RealClientCachesAcrossInvocations(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	enableAppLookupCacheForTest(t)
+
+	requests := 0
+	first := newAppResolutionTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requests++
+		return appResolutionJSONResponse(`{"data":[{"type":"apps","id":"6759231657","attributes":{"name":"Bundle App","bundleId":"com.example.app"}}]}`)
+	})
+	got, err := ResolveAppIDWithLookup(context.Background(), first, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() error: %v", err)
+	}
+	if got != "6759231657" {
+		t.Fatalf("expected 6759231657, got %q", got)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one live HTTP request, got %d", requests)
+	}
+
+	// A fresh client with the same credentials must resolve from disk.
+	second := newAppResolutionTestClient(t, func(req *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected HTTP request %s %s for cached resolution", req.Method, req.URL)
+		return appResolutionJSONResponse(`{"data":[]}`)
+	})
+	got, err = ResolveAppIDWithLookup(context.Background(), second, "com.example.app")
+	if err != nil {
+		t.Fatalf("ResolveAppIDWithLookup() cached error: %v", err)
+	}
+	if got != "6759231657" {
+		t.Fatalf("expected cached 6759231657, got %q", got)
+	}
+}
+
+func TestCachedAppIDForBundleIDRejectsBundleMismatch(t *testing.T) {
+	enableAppLookupCacheForTest(t)
+
+	scope := "issuer:issuer-a"
+	writeCacheEntry(t, scope, "com.example.app", appLookupCacheEntry{
+		AsOf:     time.Now().UTC(),
+		Scope:    scope,
+		BundleID: "com.example.other",
+		AppID:    "app-other",
+	})
+
+	if cached, ok := cachedAppIDForBundleID(scope, "com.example.app"); ok {
+		t.Fatalf("expected mismatched bundle entry to be rejected, got %q", cached)
+	}
+}

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -91,6 +91,7 @@ func BindRootFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(&selectedProfile, "profile", "", "Use named authentication profile")
 	fs.BoolVar(&strictAuth, "strict-auth", false, "Fail when credentials are resolved from multiple sources")
+	fs.BoolVar(&noCache, "no-cache", false, "Disable the local app lookup cache")
 	fs.Var(&retryLog, "retry-log", "Enable retry logging to stderr (overrides ASC_RETRY_LOG/config when set)")
 	fs.Var(&debug, "debug", "Enable debug logging to stderr")
 	fs.Var(&apiDebug, "api-debug", "Enable HTTP debug logging to stderr (redacts sensitive values)")

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
 
@@ -22,6 +23,9 @@ func run(args []string) int {
 	if telemetry.RunMaintenanceWorkerIfRequested(args) {
 		return cmd.ExitSuccess
 	}
+	// Cross-invocation lookup caching is opted into at the binary entrypoint
+	// so tests and library callers stay hermetic by default.
+	shared.EnableAppLookupCache()
 	return cmd.Run(args, versionInfoString())
 }
 


### PR DESCRIPTION
## Motivation

Audit finding (`internal/cli/shared/app_lookup.go`): every invocation with `--app <bundleID>` re-resolves the app ID via a live apps-list request before the command's real work starts, adding a full App Store Connect API round trip to every scripted/CI call — even though bundle ID → app ID mappings are effectively immutable.

## Approach

- **Disk cache**: successful exact-bundle-ID resolutions are stored under the existing `~/.asc/cache` directory (same convention as the tier cache) as one small JSON file per entry, written atomically with `0600` permissions via the existing hardened `writeFileNoSymlinkOverwrite` helper. Entries expire after 24 hours.
- **Scoping**: entries are keyed by issuer ID (or key ID for individual API keys, which have no issuer) plus bundle ID, so different teams/credentials never share entries. `*asc.Client` gained `IssuerID()`/`KeyID()` accessors (non-secret identifiers only — no key material is ever cached).
- **Silent fallback**: any cache error (unreadable, corrupt, expired, scope/bundle mismatch) drops the entry and falls back to the live lookup. A live lookup that no longer sees a cached bundle ID (app deleted / key access revoked) invalidates the stale entry — including under `--no-cache` — so entries self-heal.
- **Opt-out**: new `--no-cache` root flag, or `ASC_NO_CACHE` env var (same truthy grammar as `ASC_STRICT_AUTH`), disables the cache for an invocation (no reads, no writes).
- **Hermetic by default**: the cache activates only at the binary entrypoint (`main.run`), so unit tests, `cmdtest`, and library callers never touch the user's real `~/.asc/cache`.

Name-based `--app` resolution is unchanged; only the exact-bundle-ID branch consults the cache. Numeric app IDs still pass through without any lookup.

## Impact

Repeated `asc <cmd> --app <bundleID>` invocations (the common scripted/CI shape) skip one `GET /v1/apps?filter[bundleId]=…` round trip each — the resolver returns from disk with zero API calls on a warm cache. First use per credential/bundle pair, cache expiry (24h), and `--no-cache` behave exactly as before.

## Tests

- Cache hit serves from disk with zero client calls (`ResolveAppIDWithLookup` and `ResolveAppIDWithExactLookup`).
- Cache miss for different credentials (scope isolation) and mismatched entries.
- Expired entry → live re-resolution + refreshed entry.
- Corrupt cache file → silent live fallback + entry replaced.
- `--no-cache` flag and `ASC_NO_CACHE=1` bypass reads and do not write.
- Stale entry dropped when the live lookup no longer sees the app.
- Unscoped clients (no credential identifiers) and disabled-by-default mode never write cache files.
- Real `*asc.Client` end-to-end over a mocked transport: second invocation resolves with no HTTP request.
- `asc.Client.IssuerID()/KeyID()` accessor coverage.

`go build ./...`, `go vet`, `make format`, `ASC_BYPASS_KEYCHAIN=1 go test ./...`, `make generate-command-docs`, and `make check-docs` all pass. Docs updated: `docs/COMMANDS.md` (regenerated), `commands/global-flags.mdx`, and the embedded `internal/cli/docs/templates/ASC.md` (kept in sync with the root flag set by `TestASCTemplateIncludesAllRootFlags`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-disk app lookup cache that speeds up App Store Connect app ID resolution across invocations for up to 24 hours.
  * Added `--no-cache` and `ASC_NO_CACHE` to bypass the cache for the current run.
* **Documentation**
  * Updated global flags and command reference docs with `--no-cache`, including default behavior and environment variable mapping.
* **Tests**
  * Added automated coverage for cache hit/miss behavior, credential scoping, TTL expiry, corruption handling, and `--no-cache` bypass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->