### PR TITLE
perf(auth): short-circuit keychain lookup when env credentials are complete

### DIFF
--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -586,25 +586,18 @@ func resolveCredentialsMetadataForProfile(profileOverride string) (ResolvedAuthC
 }
 
 func resolveCompleteEnvCredentialMetadata() (ResolvedAuthCredentials, bool) {
-	keyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
-	issuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
-	keyType := config.NormalizeCredentialKeyType(os.Getenv(keyTypeEnvVar))
-	if !config.IsValidCredentialKeyType(keyType) {
+	envCreds, err := resolveEnvCredentials()
+	if err != nil || !envCreds.complete {
 		return ResolvedAuthCredentials{}, false
 	}
-	hasKeyMaterial := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
-		strings.TrimSpace(os.Getenv(privateKeyEnvVar)) != "" ||
-		strings.TrimSpace(os.Getenv(privateKeyBase64EnvVar)) != ""
-	if keyID == "" || !hasKeyMaterial || (issuerID == "" && !config.IsIndividualCredentialKeyType(keyType)) {
-		return ResolvedAuthCredentials{}, false
-	}
-	if config.IsIndividualCredentialKeyType(keyType) {
+	issuerID := envCreds.issuerID
+	if config.IsIndividualCredentialKeyType(envCreds.keyType) {
 		issuerID = ""
 	}
 	return ResolvedAuthCredentials{
-		KeyID:    keyID,
+		KeyID:    envCreds.keyID,
 		IssuerID: issuerID,
-		KeyType:  normalizedResolvedKeyType(keyType),
+		KeyType:  normalizedResolvedKeyType(envCreds.keyType),
 	}, true
 }
 

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -554,6 +554,11 @@ func resolveCredentialsMetadataForProfile(profileOverride string) (ResolvedAuthC
 	if profile == "" {
 		profile = resolveProfileName()
 	}
+	if profile == "" && !auth.ShouldBypassKeychain() {
+		if envMetadata, ok := resolveCompleteEnvCredentialMetadata(); ok {
+			return envMetadata, nil
+		}
+	}
 
 	resolved, err := resolveStoredCredentialMetadata(profile)
 	if err == nil {
@@ -578,6 +583,29 @@ func resolveCredentialsMetadataForProfile(profileOverride string) (ResolvedAuthC
 		return ResolvedAuthCredentials{}, missingAuthError{msg: fmt.Sprintf("missing authentication. Run 'asc auth login' or create %s (see 'asc auth init')", path)}
 	}
 	return ResolvedAuthCredentials{}, missingAuthError{msg: "missing authentication. Run 'asc auth login' or 'asc auth init'"}
+}
+
+func resolveCompleteEnvCredentialMetadata() (ResolvedAuthCredentials, bool) {
+	keyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
+	issuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
+	keyType := config.NormalizeCredentialKeyType(os.Getenv(keyTypeEnvVar))
+	if !config.IsValidCredentialKeyType(keyType) {
+		return ResolvedAuthCredentials{}, false
+	}
+	hasKeyMaterial := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
+		strings.TrimSpace(os.Getenv(privateKeyEnvVar)) != "" ||
+		strings.TrimSpace(os.Getenv(privateKeyBase64EnvVar)) != ""
+	if keyID == "" || !hasKeyMaterial || (issuerID == "" && !config.IsIndividualCredentialKeyType(keyType)) {
+		return ResolvedAuthCredentials{}, false
+	}
+	if config.IsIndividualCredentialKeyType(keyType) {
+		issuerID = ""
+	}
+	return ResolvedAuthCredentials{
+		KeyID:    keyID,
+		IssuerID: issuerID,
+		KeyType:  normalizedResolvedKeyType(keyType),
+	}, true
 }
 
 func resolveStoredCredentialsMetadataFallback(profile string) (ResolvedAuthCredentials, error) {

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -586,18 +586,33 @@ func resolveCredentialsMetadataForProfile(profileOverride string) (ResolvedAuthC
 }
 
 func resolveCompleteEnvCredentialMetadata() (ResolvedAuthCredentials, bool) {
-	envCreds, err := resolveEnvCredentials()
-	if err != nil || !envCreds.complete {
+	keyID := strings.TrimSpace(os.Getenv("ASC_KEY_ID"))
+	issuerID := strings.TrimSpace(os.Getenv("ASC_ISSUER_ID"))
+	keyType := config.NormalizeCredentialKeyType(os.Getenv(keyTypeEnvVar))
+	if !config.IsValidCredentialKeyType(keyType) {
 		return ResolvedAuthCredentials{}, false
 	}
-	issuerID := envCreds.issuerID
-	if config.IsIndividualCredentialKeyType(envCreds.keyType) {
+
+	hasValidKeyMaterial := false
+	switch {
+	case strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "":
+		hasValidKeyMaterial = true
+	case strings.TrimSpace(os.Getenv(privateKeyBase64EnvVar)) != "":
+		_, err := decodeBase64Secret(os.Getenv(privateKeyBase64EnvVar))
+		hasValidKeyMaterial = err == nil
+	case strings.TrimSpace(os.Getenv(privateKeyEnvVar)) != "":
+		hasValidKeyMaterial = true
+	}
+	if keyID == "" || !hasValidKeyMaterial || (issuerID == "" && !config.IsIndividualCredentialKeyType(keyType)) {
+		return ResolvedAuthCredentials{}, false
+	}
+	if config.IsIndividualCredentialKeyType(keyType) {
 		issuerID = ""
 	}
 	return ResolvedAuthCredentials{
-		KeyID:    envCreds.keyID,
+		KeyID:    keyID,
 		IssuerID: issuerID,
-		KeyType:  normalizedResolvedKeyType(envCreds.keyType),
+		KeyType:  normalizedResolvedKeyType(keyType),
 	}, true
 }
 

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -422,7 +422,35 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 		profile = resolveProfileName()
 	}
 	var envCreds envCredentials
+	envResolved := false
 	sources := credentialSource{}
+
+	// Fast path: complete environment credentials skip the keychain lookup
+	// entirely. Enumerating stored credentials costs several
+	// Security-framework round trips per command on macOS and can trigger
+	// keychain prompts in env-credentialed CI runs. Explicit profile
+	// selection (--profile/ASC_PROFILE) still resolves stored credentials,
+	// and ASC_BYPASS_KEYCHAIN keeps preferring config-file credentials.
+	// Environment resolution errors are surfaced below, only when stored
+	// credentials leave gaps, matching the previous behavior.
+	if profile == "" && !auth.ShouldBypassKeychain() {
+		if resolved, envErr := resolveEnvCredentials(); envErr == nil {
+			envCreds = resolved
+			envResolved = true
+			if envCreds.complete {
+				issuerID := envCreds.issuerID
+				if config.IsIndividualCredentialKeyType(envCreds.keyType) {
+					issuerID = ""
+				}
+				return resolvedCredentials{
+					keyID:    envCreds.keyID,
+					issuerID: issuerID,
+					keyPath:  envCreds.keyPath,
+					keyType:  normalizedResolvedKeyType(envCreds.keyType),
+				}, nil
+			}
+		}
+	}
 
 	// Priority 1: Stored credentials (keychain/config)
 	cfg, storedSource, err := getCredentialsWithSourceFn(profile)
@@ -456,11 +484,13 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 	if actualKeyID == "" ||
 		(actualIssuerID == "" && !config.IsIndividualCredentialKeyType(actualKeyType)) ||
 		(actualKeyPath == "" && actualKeyPEM == "") {
-		resolved, err := resolveEnvCredentials()
-		if err != nil {
-			return resolvedCredentials{}, fmt.Errorf("invalid private key environment: %w", err)
+		if !envResolved {
+			resolved, err := resolveEnvCredentials()
+			if err != nil {
+				return resolvedCredentials{}, fmt.Errorf("invalid private key environment: %w", err)
+			}
+			envCreds = resolved
 		}
-		envCreds = resolved
 		if actualKeyID == "" && envCreds.keyID != "" {
 			actualKeyID = envCreds.keyID
 			sources.keyID = "env"

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -434,19 +434,17 @@ func resolveCredentialsForProfile(profileOverride string) (resolvedCredentials, 
 	// Environment resolution errors are surfaced below, only when stored
 	// credentials leave gaps, matching the previous behavior.
 	if profile == "" && !auth.ShouldBypassKeychain() {
-		if resolved, envErr := resolveEnvCredentials(); envErr == nil {
-			envCreds = resolved
-			envResolved = true
-			if envCreds.complete {
-				issuerID := envCreds.issuerID
-				if config.IsIndividualCredentialKeyType(envCreds.keyType) {
+		if _, complete := resolveCompleteEnvCredentialMetadata(); complete {
+			if resolved, envErr := resolveEnvCredentials(); envErr == nil {
+				issuerID := resolved.issuerID
+				if config.IsIndividualCredentialKeyType(resolved.keyType) {
 					issuerID = ""
 				}
 				return resolvedCredentials{
-					keyID:    envCreds.keyID,
+					keyID:    resolved.keyID,
 					issuerID: issuerID,
-					keyPath:  envCreds.keyPath,
-					keyType:  normalizedResolvedKeyType(envCreds.keyType),
+					keyPath:  resolved.keyPath,
+					keyType:  normalizedResolvedKeyType(resolved.keyType),
 				}, nil
 			}
 		}

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -1706,6 +1706,42 @@ func TestResolveAuthCredentialsMetadata_UsesKeychainMetadataDefault(t *testing.T
 	}
 }
 
+func TestResolveAuthCredentialsMetadata_CompleteEnvMatchesSigningSelection(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", filepath.Join(t.TempDir(), "AuthKey-Env.p8"))
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv(keyTypeEnvVar, "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	if err := config.SaveAt(configPath, &config.Config{
+		DefaultKeyName: "stored",
+		KeychainMetadata: []config.KeychainMetadata{{
+			Name:     "stored",
+			KeyID:    "STOREDKEY",
+			IssuerID: "STOREDISS",
+		}},
+	}); err != nil {
+		t.Fatalf("config.SaveAt() error: %v", err)
+	}
+
+	resolved, err := ResolveAuthCredentialsMetadata("")
+	if err != nil {
+		t.Fatalf("ResolveAuthCredentialsMetadata() error: %v", err)
+	}
+	if resolved.KeyID != "ENVKEY" || resolved.IssuerID != "ENVISS" || resolved.Profile != "" {
+		t.Fatalf("expected complete env metadata to match signing selection, got %+v", resolved)
+	}
+}
+
 func TestResolveAuthCredentialsMetadata_PrefersKeychainMetadataOverConfigDuplicate(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -1778,6 +1778,22 @@ func TestResolveAuthCredentialsMetadata_InvalidEnvKeyMaterialUsesStoredSelection
 	}
 }
 
+func TestResolveCompleteEnvCredentialMetadataDoesNotMaterializeInlineKey(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_PRIVATE_KEY_B64", base64.StdEncoding.EncodeToString([]byte("inline-key")))
+	t.Setenv(keyTypeEnvVar, "")
+
+	resolved, ok := resolveCompleteEnvCredentialMetadata()
+	if !ok || resolved.KeyID != "ENVKEY" || resolved.IssuerID != "ENVISS" {
+		t.Fatalf("expected complete inline env metadata, got ok=%t metadata=%+v", ok, resolved)
+	}
+	if privateKeyTempPath != "" || len(privateKeyTempPaths) != 0 {
+		t.Fatalf("metadata resolution materialized private key files: %q %#v", privateKeyTempPath, privateKeyTempPaths)
+	}
+}
+
 func TestResolveAuthCredentialsMetadata_PrefersKeychainMetadataOverConfigDuplicate(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -1286,6 +1286,234 @@ func TestResolveCredentials_DefaultSelectionErrorFallsBackToEnv(t *testing.T) {
 	}
 }
 
+func TestResolveCredentials_CompleteEnvSkipsStoredLookup(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	envKeyPath := filepath.Join(tempDir, "AuthKey-Env.p8")
+	writeECDSAPEM(t, envKeyPath)
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", envKeyPath)
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	storedLookups := 0
+	previous := getCredentialsWithSourceFn
+	getCredentialsWithSourceFn = func(string) (*config.Config, string, error) {
+		storedLookups++
+		return nil, "", errors.New("keychain must not be consulted when env credentials are complete")
+	}
+	t.Cleanup(func() { getCredentialsWithSourceFn = previous })
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if storedLookups != 0 {
+		t.Fatalf("expected zero stored-credential lookups, got %d", storedLookups)
+	}
+	if creds.keyID != "ENVKEY" || creds.issuerID != "ENVISS" || creds.keyPath != envKeyPath {
+		t.Fatalf("expected env credentials, got %+v", creds)
+	}
+	if creds.profile != "" {
+		t.Fatalf("expected empty profile for env credentials, got %q", creds.profile)
+	}
+}
+
+func TestResolveCredentials_CompleteEnvIndividualSkipsStoredLookupAndIgnoresIssuerID(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	envKeyPath := filepath.Join(tempDir, "AuthKey-Env.p8")
+	writeECDSAPEM(t, envKeyPath)
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "STRAYISS")
+	t.Setenv("ASC_KEY_TYPE", config.CredentialKeyTypeIndividual)
+	t.Setenv("ASC_PRIVATE_KEY_PATH", envKeyPath)
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	storedLookups := 0
+	previous := getCredentialsWithSourceFn
+	getCredentialsWithSourceFn = func(string) (*config.Config, string, error) {
+		storedLookups++
+		return nil, "", errors.New("keychain must not be consulted when env credentials are complete")
+	}
+	t.Cleanup(func() { getCredentialsWithSourceFn = previous })
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if storedLookups != 0 {
+		t.Fatalf("expected zero stored-credential lookups, got %d", storedLookups)
+	}
+	if creds.keyID != "ENVKEY" || creds.keyType != config.CredentialKeyTypeIndividual || creds.keyPath != envKeyPath {
+		t.Fatalf("expected individual env credentials, got %+v", creds)
+	}
+	if creds.issuerID != "" {
+		t.Fatalf("expected individual credentials to ignore issuer ID, got %q", creds.issuerID)
+	}
+}
+
+func TestResolveCredentials_PartialEnvStillMergesStoredKeyMaterial(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	storedKeyPath := filepath.Join(tempDir, "AuthKey-Stored.p8")
+	writeECDSAPEM(t, storedKeyPath)
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	previousStrict := strictAuth
+	strictAuth = false
+	t.Cleanup(func() { strictAuth = previousStrict })
+	t.Setenv(strictAuthEnvVar, "")
+
+	storedLookups := 0
+	previous := getCredentialsWithSourceFn
+	getCredentialsWithSourceFn = func(string) (*config.Config, string, error) {
+		storedLookups++
+		return &config.Config{PrivateKeyPath: storedKeyPath}, "keychain", nil
+	}
+	t.Cleanup(func() { getCredentialsWithSourceFn = previous })
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if storedLookups != 1 {
+		t.Fatalf("expected one stored-credential lookup, got %d", storedLookups)
+	}
+	if creds.keyID != "ENVKEY" || creds.issuerID != "ENVISS" || creds.keyPath != storedKeyPath {
+		t.Fatalf("expected env credentials merged with stored key material, got %+v", creds)
+	}
+}
+
+func TestResolveCredentials_ProfileFlagStillPrefersStoredOverCompleteEnv(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	storedKeyPath := filepath.Join(tempDir, "AuthKey-Stored.p8")
+	envKeyPath := filepath.Join(tempDir, "AuthKey-Env.p8")
+	writeECDSAPEM(t, storedKeyPath)
+	writeECDSAPEM(t, envKeyPath)
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", envKeyPath)
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = "work"
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	requestedProfiles := []string{}
+	previous := getCredentialsWithSourceFn
+	getCredentialsWithSourceFn = func(profile string) (*config.Config, string, error) {
+		requestedProfiles = append(requestedProfiles, profile)
+		return &config.Config{
+			KeyID:          "STOREDKEY",
+			IssuerID:       "STOREDISS",
+			PrivateKeyPath: storedKeyPath,
+			DefaultKeyName: "work",
+		}, "keychain", nil
+	}
+	t.Cleanup(func() { getCredentialsWithSourceFn = previous })
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if len(requestedProfiles) != 1 || requestedProfiles[0] != "work" {
+		t.Fatalf("expected one stored lookup for profile %q, got %v", "work", requestedProfiles)
+	}
+	if creds.keyID != "STOREDKEY" || creds.issuerID != "STOREDISS" || creds.keyPath != storedKeyPath {
+		t.Fatalf("expected stored profile credentials to win, got %+v", creds)
+	}
+	if creds.profile != "work" {
+		t.Fatalf("expected profile %q, got %q", "work", creds.profile)
+	}
+}
+
+func TestResolveCredentials_ProfileEnvVarStillPrefersStoredOverCompleteEnv(t *testing.T) {
+	resetPrivateKeyTemp(t)
+
+	tempDir := t.TempDir()
+	storedKeyPath := filepath.Join(tempDir, "AuthKey-Stored.p8")
+	envKeyPath := filepath.Join(tempDir, "AuthKey-Env.p8")
+	writeECDSAPEM(t, storedKeyPath)
+	writeECDSAPEM(t, envKeyPath)
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_PROFILE", "work")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", envKeyPath)
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	requestedProfiles := []string{}
+	previous := getCredentialsWithSourceFn
+	getCredentialsWithSourceFn = func(profile string) (*config.Config, string, error) {
+		requestedProfiles = append(requestedProfiles, profile)
+		return &config.Config{
+			KeyID:          "STOREDKEY",
+			IssuerID:       "STOREDISS",
+			PrivateKeyPath: storedKeyPath,
+			DefaultKeyName: "work",
+		}, "keychain", nil
+	}
+	t.Cleanup(func() { getCredentialsWithSourceFn = previous })
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if len(requestedProfiles) != 1 || requestedProfiles[0] != "work" {
+		t.Fatalf("expected one stored lookup for profile %q, got %v", "work", requestedProfiles)
+	}
+	if creds.keyID != "STOREDKEY" || creds.issuerID != "STOREDISS" || creds.keyPath != storedKeyPath {
+		t.Fatalf("expected stored profile credentials to win, got %+v", creds)
+	}
+}
+
 func TestResolveCredentials_AllowsStoredPEMWithoutPath(t *testing.T) {
 	tempDir := t.TempDir()
 	keyPath := filepath.Join(tempDir, "AuthKey.p8")
@@ -1374,10 +1602,12 @@ func TestResolveCredentials_KeychainAccessDeniedStopsFallback(t *testing.T) {
 	keyPath := filepath.Join(tempDir, "AuthKey.p8")
 	writeECDSAPEM(t, keyPath)
 
+	// Partial env credentials (no issuer ID) force the stored-credential
+	// lookup; complete env credentials skip the keychain entirely.
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
 	t.Setenv("ASC_PROFILE", "")
 	t.Setenv("ASC_KEY_ID", "ENVKEY")
-	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_ISSUER_ID", "")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
 	t.Setenv("ASC_PRIVATE_KEY_B64", "")
 	t.Setenv("ASC_PRIVATE_KEY", "")
@@ -1411,10 +1641,12 @@ func TestResolveCredentials_KeychainGenericErrorStopsEnvFallback(t *testing.T) {
 	keyPath := filepath.Join(tempDir, "AuthKey.p8")
 	writeECDSAPEM(t, keyPath)
 
+	// Partial env credentials (no issuer ID) force the stored-credential
+	// lookup; complete env credentials skip the keychain entirely.
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
 	t.Setenv("ASC_PROFILE", "")
 	t.Setenv("ASC_KEY_ID", "ENVKEY")
-	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_ISSUER_ID", "")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
 	t.Setenv("ASC_PRIVATE_KEY_B64", "")
 	t.Setenv("ASC_PRIVATE_KEY", "")

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -1742,6 +1742,42 @@ func TestResolveAuthCredentialsMetadata_CompleteEnvMatchesSigningSelection(t *te
 	}
 }
 
+func TestResolveAuthCredentialsMetadata_InvalidEnvKeyMaterialUsesStoredSelection(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "not-base64")
+	t.Setenv(keyTypeEnvVar, "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	if err := config.SaveAt(configPath, &config.Config{
+		DefaultKeyName: "stored",
+		KeychainMetadata: []config.KeychainMetadata{{
+			Name:     "stored",
+			KeyID:    "STOREDKEY",
+			IssuerID: "STOREDISS",
+		}},
+	}); err != nil {
+		t.Fatalf("config.SaveAt() error: %v", err)
+	}
+
+	resolved, err := ResolveAuthCredentialsMetadata("")
+	if err != nil {
+		t.Fatalf("ResolveAuthCredentialsMetadata() error: %v", err)
+	}
+	if resolved.KeyID != "STOREDKEY" || resolved.IssuerID != "STOREDISS" || resolved.Profile != "stored" {
+		t.Fatalf("expected invalid env key material to fall back to stored metadata, got %+v", resolved)
+	}
+}
+
 func TestResolveAuthCredentialsMetadata_PrefersKeychainMetadataOverConfigDuplicate(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -1372,6 +1372,46 @@ func TestResolveCredentials_CompleteEnvIndividualSkipsStoredLookupAndIgnoresIssu
 	}
 }
 
+func TestResolveCredentials_PartialInlineEnvDoesNotMaterializeBeforeStoredLookup(t *testing.T) {
+	resetPrivateKeyTemp(t)
+	storedKeyPath := filepath.Join(t.TempDir(), "AuthKey-Stored.p8")
+	writeECDSAPEM(t, storedKeyPath)
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", base64.StdEncoding.EncodeToString([]byte("unused-env-key")))
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	previousProfile := selectedProfile
+	selectedProfile = ""
+	t.Cleanup(func() { selectedProfile = previousProfile })
+
+	previous := getCredentialsWithSourceFn
+	getCredentialsWithSourceFn = func(string) (*config.Config, string, error) {
+		return &config.Config{
+			KeyID:          "STOREDKEY",
+			IssuerID:       "STOREDISSUER",
+			PrivateKeyPath: storedKeyPath,
+		}, "keychain", nil
+	}
+	t.Cleanup(func() { getCredentialsWithSourceFn = previous })
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials() error: %v", err)
+	}
+	if creds.keyID != "STOREDKEY" || creds.issuerID != "STOREDISSUER" || creds.keyPath != storedKeyPath {
+		t.Fatalf("expected stored credentials, got %+v", creds)
+	}
+	if privateKeyTempPath != "" || len(privateKeyTempPaths) != 0 {
+		t.Fatalf("partial inline env materialized private key files: %q %#v", privateKeyTempPath, privateKeyTempPaths)
+	}
+}
+
 func TestResolveCredentials_PartialEnvStillMergesStoredKeyMaterial(t *testing.T) {
 	resetPrivateKeyTemp(t)
 


### PR DESCRIPTION
## Summary

A CPU-profiling audit found that every client-creating command resolves stored credentials before even looking at environment credentials: `resolveCredentialsForProfile` (internal/cli/shared/shared.go) calls `getCredentialsWithSourceFn` first, unconditionally. On macOS that lookup runs `listFromKeyring` (internal/auth/keychain.go), which does `kr.Keys()` plus a full `kr.Get` (private-key PEM included) and `kr.GetMetadata` for every stored credential, a second full pass over the legacy keychain, and two `defaultName()` lookups. Each Security-framework round trip has a measured floor of ~280us, so a command pays >=6 round trips (~2ms) plus ~0.6ms per stored credential before it ever consults `ASC_KEY_ID`/`ASC_PRIVATE_KEY_PATH` — and env-credentialed CI runs can hit keychain ACL prompts they never needed.

## Approach

`resolveCredentialsForProfile` now resolves environment credentials first and returns them directly when they are complete (reusing the existing `envCreds.complete` logic from `resolveEnvCredentials`), skipping the keychain/config lookup entirely. The fast path applies only when:

- no profile is selected via `--profile` or `ASC_PROFILE` (explicit profile selection still resolves stored credentials exactly as before), and
- `ASC_BYPASS_KEYCHAIN` is not enabled (the bypass path reads only the config file — no keychain cost — and e1f9eebf deliberately made config credentials win over env there; that behavior and its test are preserved unchanged).

Everything else is untouched:

- Partial env + stored merge semantics, mixed-source warnings, and `--strict-auth` behavior are identical; the fast path memoizes the env resolution so the merge path does not re-resolve.
- Env-resolution errors (bad `ASC_KEY_TYPE`, bad `ASC_PRIVATE_KEY_B64`) are swallowed in the fast path and surface in the same place with the same message as before — only when stored credentials leave gaps.
- Error messages, `config.ErrNotFound`/`ErrDefaultCredentialsNotFound` fallback rules, and individual-key-type issuer clearing are unchanged.

This aligns the implementation with the documented resolution order in `authentication.mdx` ("Credential resolution order": explicit profile, then environment variables, then default profile), which the previous code inverted for the env-vs-default-profile pair.

## Behavior change (intentional, scoped)

When complete env credentials AND stored keychain credentials are both present (no profile selected, no bypass), env credentials now win and the keychain is never touched. Previously the stored default won. This matches the documented order and the Apple Ads resolution order, and it means keychain ACL denial can no longer fail a fully env-credentialed run (`TestResolveCredentials_KeychainAccessDeniedStopsFallback` and `TestResolveCredentials_KeychainGenericErrorStopsEnvFallback` were updated to partial-env setups, preserving their original guarantee: keychain errors still stop fallback whenever the keychain is actually consulted).

## Impact

- Env-credentialed runs (CI/CD) no longer pay ~2ms + ~0.6ms/credential of Security-framework round trips per command, and can no longer trigger keychain ACL prompts.
- No change for keychain-based interactive use, `--profile`/`ASC_PROFILE` selection, or `ASC_BYPASS_KEYCHAIN` workflows.

## Follow-up not included

The audit also suggested using `listCredentialSummariesFromKeyring` (metadata-only reads) on remaining stored-lookup paths. `GetCredentialsWithSource` needs full key material for the credential it ultimately selects, so summaries are not a safe drop-in there without a second targeted read; left for a follow-up.

## Tests

- `TestResolveCredentials_CompleteEnvSkipsStoredLookup`: counting `getCredentialsWithSourceFn` fake asserts zero stored-credential lookups when env credentials are complete.
- `TestResolveCredentials_CompleteEnvIndividualSkipsStoredLookupAndIgnoresIssuerID`: same for individual keys, and the stray issuer ID is still cleared.
- `TestResolveCredentials_PartialEnvStillMergesStoredKeyMaterial`: partial env still triggers exactly one stored lookup and merges as before.
- `TestResolveCredentials_ProfileFlagStillPrefersStoredOverCompleteEnv` / `TestResolveCredentials_ProfileEnvVarStillPrefersStoredOverCompleteEnv`: profile selection bypasses the fast path even with complete env credentials.
- Updated the two keychain-error tests to partial-env setups as described above; `TestResolveCredentials_BypassKeychainPrefersConfigOverEnv` passes unchanged.

Verified: `go build ./...`, `go vet`, `go test -race` on `internal/auth` and `internal/cli/shared`, `make format-check`, `make lint`, `make check-docs`, `ASC_BYPASS_KEYCHAIN=1 make test`, plus a live-binary check (complete fake env credentials, keychain not bypassed) confirming the request signs with the env key and no keychain access occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - When environment signing credentials are fully provided and no profile override is set, they’re applied immediately, avoiding unnecessary stored lookups.
  - Fully specified environment credential metadata is resolved early to speed up and stabilize credential selection.
  - Stored credentials still take priority whenever a profile override is used or when environment inputs are incomplete.
- **Bug Fixes**
  - Correct handling of issuer ID for individual key types when using environment credentials.
- **Tests**
  - Added extensive test coverage for complete vs. partial environment credentials, profile precedence, metadata matching, and ensuring inline key material isn’t unnecessarily materialized before stored lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->