### PR TITLE
fix(auth): classify invalid private keys as usage errors

### DIFF
--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -636,6 +636,68 @@ func TestAuthTokenConfirmInvalidBooleanExitCode(t *testing.T) {
 	}
 }
 
+func TestAuthLoginInvalidPrivateKeyExitCodes(t *testing.T) {
+	tmpDir := t.TempDir()
+	binaryPath := buildASCBlackboxBinary(t)
+	missingKeyPath := filepath.Join(tmpDir, "missing-key.p8")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "app store connect",
+			args: []string{
+				"auth", "login", "--name", "demo", "--key-id", "KEY", "--issuer-id", "ISS",
+				"--private-key", missingKeyPath, "--bypass-keychain", "--local",
+			},
+		},
+		{
+			name: "apple ads",
+			args: []string{
+				"ads", "auth", "login", "--name", "demo", "--client-id", "CLIENT", "--team-id", "TEAM",
+				"--key-id", "KEY", "--private-key", missingKeyPath, "--bypass-keychain", "--local",
+			},
+		},
+		{
+			name: "storekit",
+			args: []string{
+				"storekit", "auth", "login", "--name", "demo", "--key-id", "KEY", "--issuer-id", "ISS",
+				"--private-key", missingKeyPath, "--bundle-id", "com.example.app", "--bypass-keychain", "--local",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runCmd := exec.Command(binaryPath, test.args...)
+			runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, test.name+"-config.json"))
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			runCmd.Stdout = &stdout
+			runCmd.Stderr = &stderr
+
+			err := runCmd.Run()
+			if err == nil {
+				t.Fatalf("expected invalid private key to fail, got stdout %q", stdout.String())
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
+			}
+			if exitErr.ExitCode() != ExitUsage {
+				t.Fatalf("exit code = %d, want %d; stderr=%q", exitErr.ExitCode(), ExitUsage, stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "invalid private key") {
+				t.Fatalf("stderr = %q, want invalid private key diagnostic", stderr.String())
+			}
+		})
+	}
+}
+
 func TestWebAuthLoginPromptInterruptDoesNotFallBackToUsageError(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryPath := buildASCBlackboxBinary(t)

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -242,23 +243,26 @@ func validateKeyFileForOS(path, goos string) error {
 		return fmt.Errorf("failed to read key file: %w", err)
 	}
 
-	// Parse the PEM block
 	block, _ := pem.Decode(data)
 	if block == nil {
 		return fmt.Errorf("invalid PEM data")
 	}
 
-	// Try to parse as PKCS8 (App Store Connect keys are ECDSA)
+	var privateKey *ecdsa.PrivateKey
 	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
-		if _, ok := key.(*ecdsa.PrivateKey); ok {
-			return nil
+		var ok bool
+		privateKey, ok = key.(*ecdsa.PrivateKey)
+		if !ok {
+			return fmt.Errorf("private key is not ECDSA")
 		}
-		return fmt.Errorf("private key is not ECDSA")
+	} else {
+		privateKey, err = x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("invalid private key format: %w", err)
+		}
 	}
-
-	// Try SEC1 EC private key as fallback
-	if _, err := x509.ParseECPrivateKey(block.Bytes); err != nil {
-		return fmt.Errorf("invalid private key format: %w", err)
+	if privateKey.Curve != elliptic.P256() {
+		return fmt.Errorf("private key must use the P-256 curve")
 	}
 
 	return nil

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -781,6 +781,24 @@ func TestValidateKeyFileSuccess(t *testing.T) {
 	}
 }
 
+func TestValidateKeyFileRejectsNonP256Curve(t *testing.T) {
+	for _, pkcs8 := range []bool{true, false} {
+		name := "sec1"
+		if pkcs8 {
+			name = "pkcs8"
+		}
+		t.Run(name, func(t *testing.T) {
+			keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+			writeECDSAPEMWithCurve(t, keyPath, 0o600, pkcs8, elliptic.P384())
+
+			err := ValidateKeyFile(keyPath)
+			if err == nil || !strings.Contains(err.Error(), "P-256") {
+				t.Fatalf("ValidateKeyFile() error = %v, want P-256 requirement", err)
+			}
+		})
+	}
+}
+
 func TestValidateKeyFileDirectory(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -1860,9 +1878,13 @@ func TestRemoveCredentials_MissingReturnsErr(t *testing.T) {
 }
 
 func writeECDSAPEM(t *testing.T, path string, mode os.FileMode, pkcs8 bool) {
+	writeECDSAPEMWithCurve(t, path, mode, pkcs8, elliptic.P256())
+}
+
+func writeECDSAPEMWithCurve(t *testing.T, path string, mode os.FileMode, pkcs8 bool, curve elliptic.Curve) {
 	t.Helper()
 
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey() error: %v", err)
 	}

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -106,7 +106,7 @@ Examples:
 			}
 			if !*skipValidation {
 				if err := authsvc.ValidateKeyFile(*privateKey); err != nil {
-					return fmt.Errorf("ads auth login: invalid private key: %w", err)
+					return shared.UsageErrorf("ads auth login: invalid private key: %v", err)
 				}
 			}
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -505,9 +505,8 @@ so commands continue to work even if the original .p8 file is removed.`,
 				return shared.UsageError("--skip-validation and --network are mutually exclusive")
 			}
 
-			// Validate the key file exists and is parseable
 			if err := authsvc.ValidateKeyFile(*keyPath); err != nil {
-				return fmt.Errorf("auth login: invalid private key: %w", err)
+				return shared.UsageErrorf("auth login: invalid private key: %v", err)
 			}
 
 			if !*skipValidation {

--- a/internal/cli/storekit/auth.go
+++ b/internal/cli/storekit/auth.go
@@ -99,7 +99,7 @@ Examples:
 			}
 			if !*skipValidation {
 				if err := authsvc.ValidateKeyFile(cleanPrivateKey); err != nil {
-					return fmt.Errorf("storekit auth login: invalid private key: %w", err)
+					return shared.UsageErrorf("storekit auth login: invalid private key: %v", err)
 				}
 			}
 			credentials := storekitapi.Credentials{


### PR DESCRIPTION
## Summary

- classify missing, malformed, or incompatible private-key input as a usage error for App Store Connect, Apple Ads, and StoreKit login
- reject non-P-256 ECDSA keys during shared local validation for both PKCS#8 and SEC1 encodings
- preserve the existing detailed stderr diagnostic and empty stdout
- add built-binary exit-code coverage plus shared key-curve regression coverage

## Why

The v4 CLI analytics window showed 17 `asc auth login` failures reported as generic internal errors across many local installs, all completing in under 100 ms. A current-main reproduction confirmed that a missing `--private-key` path returns exit 1 even though the failure is detected during local input validation before storage or network activity.

Review also identified that syntactically valid P-384 keys passed the shared file validator and failed later during ES256 signing. All three credential APIs use ES256, so the shared validator now requires P-256 and returns the same usage-class diagnostic before signing.

Only the local key-validation boundary changes to exit 2. Storage, keychain, network, authentication, and API failures retain their existing classifications.

## Testing

- RED/GREEN: `ASC_BYPASS_KEYCHAIN=1 go test ./cmd -run '^TestAuthLoginInvalidPrivateKeyExitCodes$' -count=1`
- RED/GREEN: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/auth -run '^TestValidateKeyFileRejectsNonP256Curve$' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/auth ./internal/cli/auth ./internal/cli/ads ./internal/cli/storekit ./cmd`
- built `/tmp/asc-auth-key-usage` and verified exit 2, empty stdout, and stderr diagnostics for all three commands
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `auth login` private key handling across supported authentication flows by returning a user-facing usage error with an “invalid private key” message and the correct exit code.
  * Ensured these validation failures produce no standard output and emit the expected diagnostic details on standard error.
  * Tightened private key validation to require the P-256 (secp256r1) curve.

* **Tests**
  * Added black-box coverage verifying exit codes and messaging for missing private key files.
  * Added unit coverage rejecting non-P-256 ECDSA keys for both SEC1 and PKCS8 encodings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->