### PR TITLE
fix(telemetry): classify metadata validation findings

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -294,6 +294,43 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	}
 }
 
+func TestRun_MetadataValidateFindingsEmitExpectedNegative(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotExitCode int
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+		gotExitCode = exitCode
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"metadata", "validate", "--dir", t.TempDir()}, "1.0.0"); code != ExitError {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitError)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Valid      bool `json:"valid"`
+		ErrorCount int  `json:"errorCount"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if result.Valid || result.ErrorCount != 1 {
+		t.Fatalf("unexpected validation result: %+v", result)
+	}
+	if gotExitCode != ExitError || gotContext.FailureStage != telemetry.FailureStageValidation ||
+		gotContext.OutcomeKind != telemetry.OutcomeExpectedNegative {
+		t.Fatalf("unexpected telemetry: exit=%d context=%+v", gotExitCode, gotContext)
+	}
+}
+
 func TestRun_MissingRequiredFlagsEmitContext(t *testing.T) {
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -98,7 +98,7 @@ Examples:
 			}
 
 			if result.ErrorCount > 0 {
-				return shared.NewReportedError(fmt.Errorf("metadata validate: found %d error(s)", result.ErrorCount))
+				return shared.NewValidationReportedError(fmt.Errorf("metadata validate: found %d error(s)", result.ErrorCount))
 			}
 			return nil
 		},


### PR DESCRIPTION
## Summary

- mark structured `metadata validate` findings as expected validation outcomes in v4 telemetry
- preserve the existing JSON/table report, empty stderr, and exit code 1 contract
- add an end-to-end `Run` regression covering emitted failure stage and outcome kind

## Why

The 12-hour v4 window showed 12 `asc metadata validate` events classified as internal errors. Every event completed in under 100 ms across multiple installs and agent sources. The command already prints a structured validation report, but used the generic reported-error wrapper, causing ordinary metadata findings to be counted as execution failures.

Filesystem and output failures remain internal errors; only already-reported domain validation findings become `expected_negative`.

## Verification

- RED: end-to-end command telemetry emitted `execution` / `internal_error`
- GREEN: the same command emits `validation` / `expected_negative`
- built binary: exit 1, structured invalid report on stdout, empty stderr
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for the `metadata validate` command when validation findings are detected.
  * Validation failures now provide the appropriate failure status while preserving existing error details.

* **Tests**
  * Added coverage confirming JSON output and telemetry accurately reflect expected validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->