### PR TITLE
fix(subscriptions): classify setup state mismatches

### DIFF
--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	subscriptionscli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/subscriptions"
 )
@@ -714,6 +715,9 @@ func TestSubscriptionsSetupRejectsMismatchedExistingSubscription(t *testing.T) {
 	if runErr == nil || !strings.Contains(runErr.Error(), "different reference name") {
 		t.Fatalf("expected different reference name error, got %v", runErr)
 	}
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitConflict {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, runErr)
+	}
 
 	var result subscriptionsSetupOutput
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
@@ -1274,6 +1278,9 @@ func TestSubscriptionsSetupRejectsInitialPricePatchWhenExistingPricesMismatch(t 
 		if err == nil || !strings.Contains(err.Error(), "already has prices but none match") {
 			t.Fatalf("expected existing prices mismatch error, got %v", err)
 		}
+		if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+			t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
+		}
 	})
 
 	if requestCount != 2 {
@@ -1333,6 +1340,9 @@ func TestSubscriptionsSetupRejectsStaleExistingAvailabilityBeforeLocalization(t 
 		err := root.Run(context.Background())
 		if err == nil || !strings.Contains(err.Error(), "already has availability") {
 			t.Fatalf("expected stale availability error, got %v", err)
+		}
+		if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+			t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
 		}
 	})
 

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -134,6 +134,22 @@ type subscriptionsSetupVerification struct {
 	MissingPriceTerritories  []string  `json:"missingPriceTerritories,omitempty"`
 }
 
+type subscriptionsSetupConflictError struct {
+	message string
+}
+
+func (e subscriptionsSetupConflictError) Error() string {
+	return e.message
+}
+
+func (e subscriptionsSetupConflictError) Unwrap() error {
+	return asc.ErrConflict
+}
+
+func newSubscriptionsSetupConflictError(format string, args ...any) error {
+	return subscriptionsSetupConflictError{message: fmt.Sprintf(format, args...)}
+}
+
 // SubscriptionsSetupCommand returns the high-level subscriptions bootstrap workflow command.
 func SubscriptionsSetupCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("setup", flag.ExitOnError)
@@ -1338,10 +1354,10 @@ func findExistingSubscriptionSetupGroupLocalization(ctx context.Context, client 
 
 func validateExistingSubscriptionSetupGroupLocalization(localization asc.Resource[asc.SubscriptionGroupLocalizationAttributes], opts subscriptionsSetupOptions) error {
 	if strings.TrimSpace(localization.Attributes.Name) != opts.GroupDisplayName {
-		return fmt.Errorf("existing group localization %q has a different name", localization.ID)
+		return newSubscriptionsSetupConflictError("existing group localization %q has a different name", localization.ID)
 	}
 	if opts.GroupCustomAppName != "" && strings.TrimSpace(localization.Attributes.CustomAppName) != opts.GroupCustomAppName {
-		return fmt.Errorf("existing group localization %q has a different custom app name", localization.ID)
+		return newSubscriptionsSetupConflictError("existing group localization %q has a different custom app name", localization.ID)
 	}
 	return nil
 }
@@ -1642,7 +1658,7 @@ func findExistingSubscriptionSetupPrice(ctx context.Context, client *asc.Client,
 }
 
 func mismatchedExistingSubscriptionSetupPriceError(subscriptionID string) error {
-	return fmt.Errorf("existing subscription %q already has prices but none match the requested price point, territory, start date, and upfront plan type; use subscriptions prices add to add the requested price", subscriptionID)
+	return newSubscriptionsSetupConflictError("existing subscription %q already has prices but none match the requested price point, territory, start date, and upfront plan type; use subscriptions prices add to add the requested price", subscriptionID)
 }
 
 func subscriptionSetupPriceMatchesTarget(price asc.Resource[asc.SubscriptionPriceAttributes], pricePointID, territoryID string, attrs asc.SubscriptionPriceCreateAttributes) bool {
@@ -1706,7 +1722,7 @@ func findExistingSubscriptionSetupAvailability(ctx context.Context, client *asc.
 }
 
 func mismatchedExistingSubscriptionSetupAvailabilityError(subscriptionID string) error {
-	return fmt.Errorf("existing subscription %q already has availability but it does not match the requested territories and available-in-new-territories setting; update availability or choose a different product ID", subscriptionID)
+	return newSubscriptionsSetupConflictError("existing subscription %q already has availability but it does not match the requested territories and available-in-new-territories setting; update availability or choose a different product ID", subscriptionID)
 }
 
 func fetchSubscriptionSetupAvailabilityTerritories(ctx context.Context, client *asc.Client, availabilityID string) (map[string]struct{}, []string, error) {
@@ -1752,26 +1768,26 @@ func fetchSubscriptionSetupAvailabilityTerritories(ctx context.Context, client *
 
 func validateExistingSubscriptionSetupSubscription(subscription asc.Resource[asc.SubscriptionAttributes], target asc.SubscriptionCreateAttributes, expectedFamilySharable bool) error {
 	if strings.TrimSpace(subscription.Attributes.Name) != strings.TrimSpace(target.Name) {
-		return fmt.Errorf("existing subscription %q has a different reference name; update it or choose a different product ID", strings.TrimSpace(subscription.ID))
+		return newSubscriptionsSetupConflictError("existing subscription %q has a different reference name; update it or choose a different product ID", strings.TrimSpace(subscription.ID))
 	}
 	if target.SubscriptionPeriod != "" && strings.TrimSpace(subscription.Attributes.SubscriptionPeriod) != strings.TrimSpace(target.SubscriptionPeriod) {
-		return fmt.Errorf("existing subscription %q has a different subscription period; update it or choose a different product ID", strings.TrimSpace(subscription.ID))
+		return newSubscriptionsSetupConflictError("existing subscription %q has a different subscription period; update it or choose a different product ID", strings.TrimSpace(subscription.ID))
 	}
 	if subscription.Attributes.FamilySharable != expectedFamilySharable {
-		return fmt.Errorf("existing subscription %q has a different family sharing setting; update it or choose a different product ID", strings.TrimSpace(subscription.ID))
+		return newSubscriptionsSetupConflictError("existing subscription %q has a different family sharing setting; update it or choose a different product ID", strings.TrimSpace(subscription.ID))
 	}
 	return nil
 }
 
 func validateExistingSubscriptionSetupLocalization(localization asc.Resource[asc.SubscriptionLocalizationAttributes], opts subscriptionsSetupOptions) error {
 	if strings.TrimSpace(localization.Attributes.Locale) != strings.TrimSpace(opts.Locale) {
-		return fmt.Errorf("existing subscription localization %q has a different locale; update it or choose a different locale", strings.TrimSpace(localization.ID))
+		return newSubscriptionsSetupConflictError("existing subscription localization %q has a different locale; update it or choose a different locale", strings.TrimSpace(localization.ID))
 	}
 	if strings.TrimSpace(opts.DisplayName) != "" && strings.TrimSpace(localization.Attributes.Name) != strings.TrimSpace(opts.DisplayName) {
-		return fmt.Errorf("existing subscription localization %q has a different display name; update it or choose a different locale", strings.TrimSpace(localization.ID))
+		return newSubscriptionsSetupConflictError("existing subscription localization %q has a different display name; update it or choose a different locale", strings.TrimSpace(localization.ID))
 	}
 	if strings.TrimSpace(localization.Attributes.Description) != strings.TrimSpace(opts.Description) {
-		return fmt.Errorf("existing subscription localization %q has a different description; update it or choose a different locale", strings.TrimSpace(localization.ID))
+		return newSubscriptionsSetupConflictError("existing subscription localization %q has a different description; update it or choose a different locale", strings.TrimSpace(localization.ID))
 	}
 	return nil
 }

--- a/internal/cli/subscriptions/setup_test.go
+++ b/internal/cli/subscriptions/setup_test.go
@@ -2,6 +2,7 @@ package subscriptions
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -174,6 +175,9 @@ func TestValidateExistingSubscriptionSetupLocalizationComparesEmptyDescription(t
 	if err == nil || !strings.Contains(err.Error(), "different description") {
 		t.Fatalf("expected different description error, got %v", err)
 	}
+	if !errors.Is(err, asc.ErrConflict) {
+		t.Fatalf("expected conflict classification, got %v", err)
+	}
 }
 
 func TestValidateExistingSubscriptionSetupGroupLocalizationIgnoresUnspecifiedCustomAppName(t *testing.T) {
@@ -213,5 +217,8 @@ func TestValidateExistingSubscriptionSetupGroupLocalizationComparesSpecifiedCust
 	err := validateExistingSubscriptionSetupGroupLocalization(localization, opts)
 	if err == nil || !strings.Contains(err.Error(), "different custom app name") {
 		t.Fatalf("expected different custom app name error, got %v", err)
+	}
+	if !errors.Is(err, asc.ErrConflict) {
+		t.Fatalf("expected conflict classification, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Classify deterministic `asc subscriptions setup` mismatches against existing resources as conflicts instead of generic internal errors.

The structured setup result, actionable message, stdout/stderr behavior, and API flow remain unchanged. The command now exits 5 and v4 telemetry records `conflict` when an existing subscription, localization, price, or availability cannot be reconciled with the requested state.

This targets the analytics-ranked `asc subscriptions setup` cluster (30 internal-error events in the reviewed 12-hour window) without reclassifying genuine API, transport, or verification failures.

## Testing

- RED: existing subscription mismatch mapped to exit 1
- GREEN: subscription, price, availability, and localization mismatches map to exit 5
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc-subscriptions-conflict .`
- `/tmp/asc-subscriptions-conflict subscriptions setup --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription setup validation by consistently classifying mismatches and conflicts.
  * CLI commands now return the appropriate conflict exit code when subscription, pricing, availability, or localization details differ.
  * Preserved existing error messages while making conflict outcomes more reliable for automation and command-line workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->