### PR TITLE
fix(subscriptions): classify screenshot state conflicts

### DIFF
--- a/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
+++ b/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestSubscriptionsReviewScreenshotCreateSkipsCompleteMatchingAsset(t *testing.T) {
@@ -122,6 +124,9 @@ func TestSubscriptionsReviewScreenshotCreateRejectsConflictingReservationDuringR
 	if err == nil || !strings.Contains(err.Error(), "different incomplete") {
 		t.Fatalf("expected conflicting reservation error, got %v", err)
 	}
+	if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
+	}
 	if stdout != "" || stderr != "" || posts != 1 || reads != 2 {
 		t.Fatalf("unexpected conflict result: reads=%d posts=%d stdout=%q stderr=%q", reads, posts, stdout, stderr)
 	}
@@ -159,6 +164,9 @@ func TestSubscriptionsReviewScreenshotCreateRejectsConflictingCommitDuringReconc
 	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
 	if err == nil || !strings.Contains(err.Error(), "instead of upload reservation") {
 		t.Fatalf("expected conflicting commit error, got %v", err)
+	}
+	if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
 	}
 	if stdout != "" || stderr != "" || puts != 1 || patches != 1 || reads != 2 {
 		t.Fatalf("unexpected conflict result: reads=%d puts=%d patches=%d stdout=%q stderr=%q", reads, puts, patches, stdout, stderr)
@@ -222,6 +230,9 @@ func TestSubscriptionsReviewScreenshotCreateRejectsChangedChecksumDuringPoll(t *
 	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
 	if err == nil || !strings.Contains(err.Error(), "checksum changed") {
 		t.Fatalf("expected checksum race error, got %v", err)
+	}
+	if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
 	}
 	if stdout != "" || stderr != "" || reads != 2 {
 		t.Fatalf("unexpected checksum race result: reads=%d stdout=%q stderr=%q", reads, stdout, stderr)
@@ -351,6 +362,9 @@ func TestSubscriptionsReviewScreenshotCreateRejectsMismatchedCommitResponse(t *t
 	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
 	if err == nil || !strings.Contains(err.Error(), "instead of upload reservation") {
 		t.Fatalf("expected mismatched commit error, got %v", err)
+	}
+	if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
 	}
 	if stdout != "" || stderr != "" || puts != 1 || patches != 1 {
 		t.Fatalf("unexpected mismatched commit result: puts=%d patches=%d stdout=%q stderr=%q", puts, patches, stdout, stderr)
@@ -579,11 +593,12 @@ func TestSubscriptionsReviewScreenshotCreateRejectsUnsafeExistingState(t *testin
 		status   int
 		body     string
 		want     string
+		conflict bool
 	}{
-		{name: "complete conflict", checksum: func(string) string { return "different" }, state: "COMPLETE", want: "different checksum"},
+		{name: "complete conflict", checksum: func(string) string { return "different" }, state: "COMPLETE", want: "different checksum", conflict: true},
 		{name: "failed delivery", checksum: func(value string) string { return value }, state: "FAILED", want: "delivery failed"},
 		{name: "missing operations", checksum: func(string) string { return "" }, state: "", want: "no upload operations"},
-		{name: "incomplete identity mismatch", checksum: func(string) string { return "" }, state: "", ops: true, fileName: "other.png", want: "different incomplete"},
+		{name: "incomplete identity mismatch", checksum: func(string) string { return "" }, state: "", ops: true, fileName: "other.png", want: "different incomplete", conflict: true},
 		{name: "forbidden read", status: http.StatusForbidden, body: `{"errors":[{"status":"403","code":"FORBIDDEN","detail":"denied"}]}`, want: "denied"},
 	}
 
@@ -613,6 +628,11 @@ func TestSubscriptionsReviewScreenshotCreateRejectsUnsafeExistingState(t *testin
 			stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
 			if err == nil || !strings.Contains(err.Error(), tt.want) || stdout != "" || stderr != "" || requests != 1 {
 				t.Fatalf("expected %q: requests=%d stdout=%q stderr=%q err=%v", tt.want, requests, stdout, stderr, err)
+			}
+			if tt.conflict {
+				if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+					t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
+				}
 			}
 		})
 	}

--- a/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
+++ b/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
@@ -133,43 +133,57 @@ func TestSubscriptionsReviewScreenshotCreateRejectsConflictingReservationDuringR
 }
 
 func TestSubscriptionsReviewScreenshotCreateRejectsConflictingCommitDuringReconciliation(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_MAX_RETRIES", "0")
-	path, content, _ := writeSubscriptionReviewScreenshotFixture(t)
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	reads := 0
-	puts := 0
-	patches := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
-			reads++
-			if reads == 1 {
-				return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
-			}
-			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-2", filepath.Base(path), int64(len(content)), "different", "PROCESSING", false)), nil
-		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
-			puts++
-			return jsonHTTPResponse(http.StatusOK, ``), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
-			patches++
-			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
-		default:
-			t.Fatalf("conflicting commit must stop recovery: %s %s", req.Method, req.URL.Path)
-			return nil, nil
-		}
-	})
+	tests := []struct {
+		name             string
+		readbackID       string
+		readbackChecksum string
+		want             string
+	}{
+		{name: "reservation replaced", readbackID: "shot-2", readbackChecksum: "different", want: "instead of upload reservation"},
+		{name: "checksum changed", readbackID: "shot-1", readbackChecksum: "different", want: "checksum changed while committing upload"},
+	}
 
-	stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
-	if err == nil || !strings.Contains(err.Error(), "instead of upload reservation") {
-		t.Fatalf("expected conflicting commit error, got %v", err)
-	}
-	if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
-		t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
-	}
-	if stdout != "" || stderr != "" || puts != 1 || patches != 1 || reads != 2 {
-		t.Fatalf("unexpected conflict result: reads=%d puts=%d patches=%d stdout=%q stderr=%q", reads, puts, patches, stdout, stderr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_MAX_RETRIES", "0")
+			path, content, _ := writeSubscriptionReviewScreenshotFixture(t)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			reads := 0
+			puts := 0
+			patches := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
+					reads++
+					if reads == 1 {
+						return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), "", "", true)), nil
+					}
+					return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse(tt.readbackID, filepath.Base(path), int64(len(content)), tt.readbackChecksum, "PROCESSING", false)), nil
+				case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+					puts++
+					return jsonHTTPResponse(http.StatusOK, ``), nil
+				case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
+					patches++
+					return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"ambiguous"}]}`), nil
+				default:
+					t.Fatalf("conflicting commit must stop recovery: %s %s", req.Method, req.URL.Path)
+					return nil, nil
+				}
+			})
+
+			stdout, stderr, err := runSubscriptionReviewScreenshotCreate(t, path)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected conflicting commit error containing %q, got %v", tt.want, err)
+			}
+			if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitConflict {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitConflict, err)
+			}
+			if stdout != "" || stderr != "" || puts != 1 || patches != 1 || reads != 2 {
+				t.Fatalf("unexpected conflict result: reads=%d puts=%d patches=%d stdout=%q stderr=%q", reads, puts, patches, stdout, stderr)
+			}
+		})
 	}
 }
 
@@ -596,6 +610,7 @@ func TestSubscriptionsReviewScreenshotCreateRejectsUnsafeExistingState(t *testin
 		conflict bool
 	}{
 		{name: "complete conflict", checksum: func(string) string { return "different" }, state: "COMPLETE", want: "different checksum", conflict: true},
+		{name: "processing checksum conflict", checksum: func(string) string { return "different" }, state: "PROCESSING", want: "different checksum", conflict: true},
 		{name: "failed delivery", checksum: func(value string) string { return value }, state: "FAILED", want: "delivery failed"},
 		{name: "missing operations", checksum: func(string) string { return "" }, state: "", want: "no upload operations"},
 		{name: "incomplete identity mismatch", checksum: func(string) string { return "" }, state: "", ops: true, fileName: "other.png", want: "different incomplete", conflict: true},

--- a/internal/cli/subscriptions/review_screenshot_recovery.go
+++ b/internal/cli/subscriptions/review_screenshot_recovery.go
@@ -24,6 +24,22 @@ type subscriptionReviewScreenshotTarget struct {
 	Checksum string
 }
 
+type subscriptionReviewScreenshotConflictError struct {
+	message string
+}
+
+func (e subscriptionReviewScreenshotConflictError) Error() string {
+	return e.message
+}
+
+func (e subscriptionReviewScreenshotConflictError) Unwrap() error {
+	return asc.ErrConflict
+}
+
+func newSubscriptionReviewScreenshotConflictError(format string, args ...any) error {
+	return subscriptionReviewScreenshotConflictError{message: fmt.Sprintf(format, args...)}
+}
+
 var subscriptionReviewScreenshotFields = []string{
 	"fileName",
 	"fileSize",
@@ -98,14 +114,14 @@ func createOrResumeSubscriptionReviewScreenshot(ctx context.Context, client *asc
 				return candidate, false, readErr
 			}
 			if strings.TrimSpace(candidate.Data.ID) != strings.TrimSpace(reservation.Data.ID) {
-				return candidate, false, fmt.Errorf("subscription now references screenshot %q instead of upload reservation %q", candidate.Data.ID, reservation.Data.ID)
+				return candidate, false, newSubscriptionReviewScreenshotConflictError("subscription now references screenshot %q instead of upload reservation %q", candidate.Data.ID, reservation.Data.ID)
 			}
 			remoteChecksum := strings.TrimSpace(candidate.Data.Attributes.SourceFileChecksum)
 			if remoteChecksum == "" {
 				return candidate, false, nil
 			}
 			if !strings.EqualFold(remoteChecksum, target.Checksum) {
-				return candidate, false, fmt.Errorf("subscription review screenshot checksum changed while committing upload")
+				return candidate, false, newSubscriptionReviewScreenshotConflictError("subscription review screenshot checksum changed while committing upload")
 			}
 			return candidate, true, nil
 		},
@@ -115,7 +131,7 @@ func createOrResumeSubscriptionReviewScreenshot(ctx context.Context, client *asc
 	}
 	if committed != nil && strings.TrimSpace(committed.Data.ID) != "" {
 		if strings.TrimSpace(committed.Data.ID) != strings.TrimSpace(reservation.Data.ID) {
-			return nil, fmt.Errorf("upload commit returned screenshot %q instead of upload reservation %q", committed.Data.ID, reservation.Data.ID)
+			return nil, newSubscriptionReviewScreenshotConflictError("upload commit returned screenshot %q instead of upload reservation %q", committed.Data.ID, reservation.Data.ID)
 		}
 		reservation = committed
 	}
@@ -156,12 +172,12 @@ func subscriptionReviewScreenshotReservationMatches(resp *asc.SubscriptionAppSto
 		if strings.EqualFold(remoteChecksum, target.Checksum) {
 			return true, nil
 		}
-		return false, fmt.Errorf("subscription already has a review screenshot with a different checksum")
+		return false, newSubscriptionReviewScreenshotConflictError("subscription already has a review screenshot with a different checksum")
 	}
 	if attrs.FileName == target.FileName && attrs.FileSize == target.FileSize {
 		return true, nil
 	}
-	return false, fmt.Errorf("subscription already has a different incomplete review screenshot reservation")
+	return false, newSubscriptionReviewScreenshotConflictError("subscription already has a different incomplete review screenshot reservation")
 }
 
 func classifySubscriptionReviewScreenshot(resp *asc.SubscriptionAppStoreReviewScreenshotResponse, target subscriptionReviewScreenshotTarget) (subscriptionReviewScreenshotAction, error) {
@@ -180,16 +196,16 @@ func classifySubscriptionReviewScreenshot(resp *asc.SubscriptionAppStoreReviewSc
 		if sameChecksum {
 			return subscriptionReviewScreenshotSkip, nil
 		}
-		return "", fmt.Errorf("subscription already has a complete review screenshot with a different checksum")
+		return "", newSubscriptionReviewScreenshotConflictError("subscription already has a complete review screenshot with a different checksum")
 	}
 	if remoteChecksum != "" {
 		if !sameChecksum {
-			return "", fmt.Errorf("subscription already has a review screenshot with a different checksum")
+			return "", newSubscriptionReviewScreenshotConflictError("subscription already has a review screenshot with a different checksum")
 		}
 		return subscriptionReviewScreenshotPoll, nil
 	}
 	if attrs.FileName != target.FileName || attrs.FileSize != target.FileSize {
-		return "", fmt.Errorf("subscription already has a different incomplete review screenshot reservation")
+		return "", newSubscriptionReviewScreenshotConflictError("subscription already has a different incomplete review screenshot reservation")
 	}
 	if len(attrs.UploadOperations) == 0 {
 		return "", fmt.Errorf("matching incomplete review screenshot has no upload operations")

--- a/internal/cli/subscriptions/review_screenshots.go
+++ b/internal/cli/subscriptions/review_screenshots.go
@@ -277,7 +277,7 @@ func waitForSubscriptionReviewScreenshotDelivery(ctx context.Context, client *as
 			case "COMPLETE":
 				actualChecksum := strings.TrimSpace(resp.Data.Attributes.SourceFileChecksum)
 				if !strings.EqualFold(actualChecksum, strings.TrimSpace(expectedChecksum)) {
-					return struct{}{}, false, fmt.Errorf("screenshot %s checksum changed while waiting for delivery", screenshotID)
+					return struct{}{}, false, newSubscriptionReviewScreenshotConflictError("screenshot %s checksum changed while waiting for delivery", screenshotID)
 				}
 				verifiedResp = resp
 				return struct{}{}, true, nil


### PR DESCRIPTION
```mermaid
flowchart TD
    A["Create or resume a subscription review screenshot"] --> B{"Does the server state still match this upload?"}
    B -- "yes" --> C["Continue upload, commit, or delivery polling"]
    B -- "no" --> D["Return the existing mismatch message with a conflict exit"]
    C --> E{"Did the API, file, upload, delivery, or timeout fail?"}
    E -- "yes" --> F["Keep the existing error classification"]
    E -- "no" --> G["Return the verified screenshot"]

    classDef new fill:#16a34a,color:#fff,stroke:#15803d
    class D new
```

Every successful path still verifies the same reservation identity and checksum before returning the screenshot.

## Summary

- classify deterministic reservation identity and checksum mismatches as conflicts (exit 5)
- preserve the existing error text and output behavior
- leave API, file, upload, failed-delivery, and timeout errors unchanged

The v4 analytics stream recorded 15 internal failures for `subscriptions review screenshots create`. Existing reconciliation fixtures reproduced the affected state-race branches as generic exit 1; they now produce the actionable conflict exit.

## Testing

- `PATH=/Users/rudrank/go/bin:$PATH make format`
- `PATH=/Users/rudrank/go/bin:$PATH make check-docs`
- `PATH=/Users/rudrank/go/bin:$PATH make lint`
- `ASC_BYPASS_KEYCHAIN=1 PATH=/Users/rudrank/go/bin:$PATH make test`
- `go build -o /tmp/asc-subscription-screenshot-conflicts .`
- `/tmp/asc-subscription-screenshot-conflicts subscriptions review screenshots create --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription review screenshot recovery and delivery error handling to consistently classify conflicts.
  * Conflicting screenshot IDs and checksum mismatches (including reservation/incomplete-state variations) now produce uniform conflict responses.
* **Tests**
  * Expanded CLI test coverage to verify conflict scenarios return the correct CLI exit code while preserving existing error-message and request expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->