### PR TITLE
feat(pricing): create app availability

### DIFF
--- a/internal/asc/client_pricing.go
+++ b/internal/asc/client_pricing.go
@@ -575,8 +575,8 @@ func (c *Client) GetAppAvailabilityV2TerritoryAvailabilitiesRelationships(ctx co
 	return &response, nil
 }
 
-// CreateAppAvailabilityV2 calls POST /v2/appAvailabilities.
-// Apple documents this endpoint as app pre-order creation, not generic app-availability bootstrap.
+// CreateAppAvailabilityV2 creates an app availability and its inline territory availabilities.
+// It calls POST /v2/appAvailabilities.
 func (c *Client) CreateAppAvailabilityV2(ctx context.Context, appID string, attrs AppAvailabilityV2CreateAttributes) (*AppAvailabilityV2Response, error) {
 	appID = strings.TrimSpace(appID)
 	if appID == "" {

--- a/internal/asc/pricing.go
+++ b/internal/asc/pricing.go
@@ -88,7 +88,6 @@ type AppPriceRelationships struct {
 }
 
 // AppAvailabilityV2CreateAttributes defines inputs for POST /v2/appAvailabilities.
-// Apple documents this endpoint as app pre-order creation, not generic app-availability bootstrap.
 type AppAvailabilityV2CreateAttributes struct {
 	AvailableInNewTerritories *bool                         `json:"availableInNewTerritories,omitempty"`
 	TerritoryAvailabilityIDs  []string                      `json:"-"`

--- a/internal/asc/pricing_test.go
+++ b/internal/asc/pricing_test.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -662,6 +663,30 @@ func TestCreateAppAvailabilityV2(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateAppAvailabilityV2() error: %v", err)
+	}
+}
+
+func TestCreateAppAvailabilityV2_APIError(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		assertAuthorized(t, req)
+		if req.Method != http.MethodPost || req.URL.Path != "/v2/appAvailabilities" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}, jsonResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"ENTITY_ERROR.RELATIONSHIP.INVALID","title":"invalid relationship","detail":"availability already exists"}]}`))
+
+	availableInNewTerritories := true
+	_, err := client.CreateAppAvailabilityV2(context.Background(), "app-1", AppAvailabilityV2CreateAttributes{
+		AvailableInNewTerritories: &availableInNewTerritories,
+		TerritoryAvailabilities: []TerritoryAvailabilityCreate{
+			{TerritoryID: "USA", Available: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict {
+		t.Fatalf("expected wrapped 409 API error, got %v", err)
 	}
 }
 

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -274,23 +274,23 @@ func capabilityRows() []Capability {
 		{
 			Area:         "app-management",
 			Capability:   "Initial app availability bootstrap",
-			Status:       statusClientOnly,
+			Status:       statusCLISupported,
+			Commands:     []string{"asc pricing availability create"},
 			APIResources: []string{"POST /v2/appAvailabilities", "territoryAvailabilities"},
-			Notes:        []string{"The internal client can create appAvailabilityV2 records; stable CLI commands currently update existing availability only."},
-			NextAction:   "Candidate command: asc pricing availability create.",
+			Notes:        []string{"The CLI creates the initial appAvailabilityV2 record with inline territory availability resources."},
 		},
 		{
 			Area:       "app-management",
 			Capability: "App pricing and availability updates",
 			Status:     statusPartial,
-			Commands:   []string{"asc pricing availability view", "asc pricing availability edit", "asc pricing schedule create"},
+			Commands:   []string{"asc pricing availability view", "asc pricing availability create", "asc pricing availability edit", "asc pricing schedule create"},
 			APIResources: []string{
 				"appAvailabilities",
 				"territoryAvailabilities",
 				"appPriceSchedules",
 				"appPricePoints",
 			},
-			Notes: []string{"Existing availability records can be edited; initial bootstrap is tracked separately as client-only."},
+			Notes: []string{"Availability records can be created and edited through the public App Store Connect API."},
 		},
 		{
 			Area:       "metadata",

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1445,9 +1445,9 @@ func TestPricingValidationErrors(t *testing.T) {
 			wantErr: "Error: --available-in-new-territories is required",
 		},
 		{
-			name:    "pricing availability create removed",
+			name:    "pricing availability create missing app",
 			args:    []string{"pricing", "availability", "create"},
-			wantErr: "Pricing availability commands operate on existing availability records.",
+			wantErr: "Error: --app is required",
 		},
 	}
 

--- a/internal/cli/cmdtest/pricing_availability_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_create_test.go
@@ -1,0 +1,148 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	pricingcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/pricing"
+)
+
+func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
+	setupAuth(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if req.Method != http.MethodPost || req.URL.Path != "/v2/appAvailabilities" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+
+		var payload asc.AppAvailabilityV2CreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.Data.Relationships.App.Data.ID != "app-1" {
+			t.Fatalf("expected app-1, got %q", payload.Data.Relationships.App.Data.ID)
+		}
+		if payload.Data.Attributes == nil || payload.Data.Attributes.AvailableInNewTerritories == nil || !*payload.Data.Attributes.AvailableInNewTerritories {
+			t.Fatalf("expected availableInNewTerritories=true, got %#v", payload.Data.Attributes)
+		}
+		if payload.Data.Relationships.TerritoryAvailabilities == nil || len(payload.Data.Relationships.TerritoryAvailabilities.Data) != 2 {
+			t.Fatalf("expected two territory availability relationships, got %#v", payload.Data.Relationships.TerritoryAvailabilities)
+		}
+		if got := payload.Data.Relationships.TerritoryAvailabilities.Data[0].ID; got != "${local-usa}" {
+			t.Fatalf("expected first local ID ${local-usa}, got %q", got)
+		}
+		if len(payload.Included) != 2 {
+			t.Fatalf("expected two inline territory availabilities, got %d", len(payload.Included))
+		}
+		for _, included := range payload.Included {
+			if included.Type != asc.ResourceTypeTerritoryAvailabilities {
+				t.Fatalf("unexpected included type %q", included.Type)
+			}
+			if included.Attributes == nil || !included.Attributes.Available {
+				t.Fatalf("expected included territory to be available, got %#v", included.Attributes)
+			}
+			if included.Relationships == nil || included.Relationships.Territory.Data.ID == "" {
+				t.Fatalf("expected included territory relationship, got %#v", included.Relationships)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"appAvailabilities","id":"app-1","attributes":{"availableInNewTerritories":true}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	restore := pricingcli.SetAvailabilityClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "create",
+			"--app", "app-1",
+			"--territory", "usa,gbr",
+			"--available", "true",
+			"--available-in-new-territories", "true",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected one request, got %d", requestCount)
+	}
+	var output asc.AppAvailabilityV2Response
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("parse stdout JSON: %v; stdout=%q", err, stdout)
+	}
+	if output.Data.ID != "app-1" || !output.Data.Attributes.AvailableInNewTerritories {
+		t.Fatalf("unexpected output: %#v", output.Data)
+	}
+}
+
+func TestPricingAvailabilityCreate_RejectsPositionalArguments(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "create", "extra",
+			"--app", "app-1",
+			"--territory", "USA",
+			"--available", "true",
+			"--available-in-new-territories", "true",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err == nil {
+			t.Fatal("expected positional argument error")
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "pricing availability create does not accept positional arguments") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/pricing_availability_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_create_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	pricingcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/pricing"
 )
@@ -40,6 +41,9 @@ func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
 		}
 		if got := payload.Data.Relationships.TerritoryAvailabilities.Data[0].ID; got != "${local-usa}" {
 			t.Fatalf("expected first local ID ${local-usa}, got %q", got)
+		}
+		if got := payload.Data.Relationships.TerritoryAvailabilities.Data[1].ID; got != "${local-fra}" {
+			t.Fatalf("expected second local ID ${local-fra}, got %q", got)
 		}
 		if len(payload.Included) != 2 {
 			t.Fatalf("expected two inline territory availabilities, got %d", len(payload.Included))
@@ -93,7 +97,7 @@ func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
 		if err := root.Parse([]string{
 			"pricing", "availability", "create",
 			"--app", "app-1",
-			"--territory", "usa,gbr",
+			"--territory", "US,France",
 			"--available", "true",
 			"--available-in-new-territories", "true",
 			"--output", "json",
@@ -117,6 +121,38 @@ func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
 	}
 	if output.Data.ID != "app-1" || !output.Data.Attributes.AvailableInNewTerritories {
 		t.Fatalf("unexpected output: %#v", output.Data)
+	}
+}
+
+func TestPricingAvailabilityCreate_RejectsUnknownTerritory(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "create",
+			"--app", "app-1",
+			"--territory", "Atlantis",
+			"--available", "true",
+			"--available-in-new-territories", "true",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected unknown territory error")
+	}
+	if got := cmd.ExitCodeFromError(runErr); got != cmd.ExitUsage {
+		t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, got)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `territory "Atlantis" could not be mapped`) {
+		t.Fatalf("unexpected stderr: %q", stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/pricing_availability_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_create_test.go
@@ -97,7 +97,7 @@ func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
 		if err := root.Parse([]string{
 			"pricing", "availability", "create",
 			"--app", "app-1",
-			"--territory", "US,France",
+			"--territory", "US,USA,France",
 			"--available", "true",
 			"--available-in-new-territories", "true",
 			"--output", "json",

--- a/internal/cli/cmdtest/pricing_availability_set_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_set_create_test.go
@@ -35,7 +35,7 @@ func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T)
 				"--output", "json",
 			},
 			wantPrefix: `pricing availability edit: app availability not found for app "app-1"; this command only updates existing app availability`,
-			wantHint:   `use the "asc web apps availability create" flow`,
+			wantHint:   `use "asc pricing availability create" first`,
 		},
 		{
 			name: "app-setup availability edit",
@@ -48,7 +48,7 @@ func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T)
 				"--output", "json",
 			},
 			wantPrefix: `app-setup availability edit: app availability not found for app "app-1"; this command only updates existing app availability`,
-			wantHint:   `use the "asc web apps availability create" flow`,
+			wantHint:   `use "asc pricing availability create" first`,
 		},
 	}
 

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -796,7 +796,12 @@ Examples:
 			availableInNewTerritoriesValue := availableInNewTerritories.Value()
 			availableValue := available.Value()
 			territoryAvailabilities := make([]asc.TerritoryAvailabilityCreate, 0, len(territories))
+			seenTerritories := make(map[string]struct{}, len(territories))
 			for _, territoryID := range territories {
+				if _, exists := seenTerritories[territoryID]; exists {
+					continue
+				}
+				seenTerritories[territoryID] = struct{}{}
 				territoryAvailabilities = append(territoryAvailabilities, asc.TerritoryAvailabilityCreate{
 					TerritoryID: territoryID,
 					Available:   availableValue,

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -737,7 +737,7 @@ func PricingAvailabilityCreateCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
 	var availableInNewTerritories shared.OptionalBool
 	fs.Var(&availableInNewTerritories, "available-in-new-territories", "Automatically make app available in new territories: true or false (required)")
-	territory := fs.String("territory", "", "Territory IDs (comma-separated, e.g., USA,GBR,DEU)")
+	territory := fs.String("territory", "", "Territory inputs (comma-separated; accepts alpha-2, alpha-3, or exact English country names, e.g., US,USA,France)")
 	var available shared.OptionalBool
 	fs.Var(&available, "available", "Set availability for specified territories: true or false (required)")
 	output := shared.BindOutputFlags(fs)
@@ -772,7 +772,10 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			territories := shared.SplitCSVUpper(*territory)
+			territories, err := shared.NormalizeASCTerritoryCSV(*territory)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
 			if len(territories) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --territory must include at least one value")
 				return shared.MissingRequiredUsageError()

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -42,6 +42,7 @@ Examples:
   asc pricing schedule automatic-prices --schedule "SCHEDULE_ID"
   asc pricing availability view --app "123456789"
   asc pricing availability view --id "AVAILABILITY_ID"
+  asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --all-territories --available true --available-in-new-territories true
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
@@ -598,17 +599,14 @@ func PricingAvailabilityCommand() *ffcli.Command {
 Examples:
   asc pricing availability view --app "123456789"
   asc pricing availability view --id "AVAILABILITY_ID"
+  asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --all-territories --available true --available-in-new-territories true
-  asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"
-
-Note:
-  Pricing availability commands operate on existing availability records.
-  For initial bootstrap, use App Store Connect or the
-  "asc web apps availability create" flow.`,
+  asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			PricingAvailabilityGetCommand(),
+			PricingAvailabilityCreateCommand(),
 			PricingAvailabilityTerritoryAvailabilitiesCommand(),
 			PricingAvailabilitySetCommand(),
 		},
@@ -732,6 +730,89 @@ func isPricingAvailabilityTerritoryAvailabilitiesUsageError(err error) bool {
 		strings.HasPrefix(message, "pricing availability territory-availabilities: --next ")
 }
 
+// PricingAvailabilityCreateCommand returns the availability create subcommand.
+func PricingAvailabilityCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("pricing availability create", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	var availableInNewTerritories shared.OptionalBool
+	fs.Var(&availableInNewTerritories, "available-in-new-territories", "Automatically make app available in new territories: true or false (required)")
+	territory := fs.String("territory", "", "Territory IDs (comma-separated, e.g., USA,GBR,DEU)")
+	var available shared.OptionalBool
+	fs.Var(&available, "available", "Set availability for specified territories: true or false (required)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "asc pricing availability create --app \"APP_ID\" --territory \"USA,GBR\" --available true --available-in-new-territories true",
+		ShortHelp:  "Initialize app availability for territories.",
+		LongHelp: `Initialize app availability for territories.
+
+Creates the initial app availability record and its territory availability
+entries through the public App Store Connect API. Once created, use
+"asc pricing availability edit" to update the record.
+
+Examples:
+  asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
+  asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available false --available-in-new-territories false`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("pricing availability create does not accept positional arguments")
+			}
+
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return shared.MissingRequiredUsageError()
+			}
+			if !availableInNewTerritories.IsSet() {
+				fmt.Fprintln(os.Stderr, "Error: --available-in-new-territories is required (true or false)")
+				return shared.MissingRequiredUsageError()
+			}
+
+			territories := shared.SplitCSVUpper(*territory)
+			if len(territories) == 0 {
+				fmt.Fprintln(os.Stderr, "Error: --territory must include at least one value")
+				return shared.MissingRequiredUsageError()
+			}
+			if !available.IsSet() {
+				fmt.Fprintln(os.Stderr, "Error: --available is required (true or false)")
+				return shared.MissingRequiredUsageError()
+			}
+
+			client, err := pricingAvailabilityClientFactory()
+			if err != nil {
+				return fmt.Errorf("pricing availability create: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			availableInNewTerritoriesValue := availableInNewTerritories.Value()
+			availableValue := available.Value()
+			territoryAvailabilities := make([]asc.TerritoryAvailabilityCreate, 0, len(territories))
+			for _, territoryID := range territories {
+				territoryAvailabilities = append(territoryAvailabilities, asc.TerritoryAvailabilityCreate{
+					TerritoryID: territoryID,
+					Available:   availableValue,
+				})
+			}
+
+			resp, err := client.CreateAppAvailabilityV2(requestCtx, resolvedAppID, asc.AppAvailabilityV2CreateAttributes{
+				AvailableInNewTerritories: &availableInNewTerritoriesValue,
+				TerritoryAvailabilities:   territoryAvailabilities,
+			})
+			if err != nil {
+				return fmt.Errorf("pricing availability create: %w", err)
+			}
+
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+		},
+	}
+}
+
 // PricingAvailabilitySetCommand returns the availability edit subcommand.
 func PricingAvailabilitySetCommand() *ffcli.Command {
 	return shared.NewAvailabilitySetCommand(shared.AvailabilitySetCommandConfig{
@@ -747,8 +828,7 @@ Examples:
 
 Note:
   This command only updates an existing app availability. If the app has no
-  availability record yet, initialize availability in App Store Connect first,
-  or use the "asc web apps availability create" flow.`,
+  availability record yet, use "asc pricing availability create" first.`,
 		ErrorPrefix:                      "pricing availability edit",
 		IncludeAvailableInNewTerritories: true,
 	})

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -279,6 +279,34 @@ func TestPricingAvailabilitySetCommand_MissingFlags(t *testing.T) {
 	}
 }
 
+func TestPricingAvailabilityCreateCommand_MissingFlags(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing app", args: []string{"--territory", "USA", "--available", "true", "--available-in-new-territories", "true"}},
+		{name: "missing territory", args: []string{"--app", "APP", "--available", "true", "--available-in-new-territories", "true"}},
+		{name: "invalid territory csv", args: []string{"--app", "APP", "--territory", ",,,", "--available", "true", "--available-in-new-territories", "true"}},
+		{name: "missing available", args: []string{"--app", "APP", "--territory", "USA", "--available-in-new-territories", "true"}},
+		{name: "missing available in new territories", args: []string{"--app", "APP", "--territory", "USA", "--available", "true"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := PricingAvailabilityCreateCommand()
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			}
+		})
+	}
+}
+
 func TestPricingAvailabilitySetCommand_HasAvailableInNewTerritoriesFlag(t *testing.T) {
 	cmd := PricingAvailabilitySetCommand()
 
@@ -287,18 +315,19 @@ func TestPricingAvailabilitySetCommand_HasAvailableInNewTerritoriesFlag(t *testi
 	}
 }
 
-func TestPricingAvailabilityCommand_UsesExistingAvailabilitySurface(t *testing.T) {
+func TestPricingAvailabilityCommand_RegistersCreate(t *testing.T) {
 	cmd := PricingAvailabilityCommand()
 
 	for _, subcommand := range cmd.Subcommands {
 		if subcommand.Name == "create" {
-			t.Fatal("did not expect pricing availability create to be registered")
+			if !strings.Contains(cmd.LongHelp, "pricing availability create") {
+				t.Fatalf("expected availability help to mention create, got %q", cmd.LongHelp)
+			}
+			return
 		}
 	}
 
-	if !strings.Contains(cmd.LongHelp, `"asc web apps availability create"`) {
-		t.Fatalf("expected pricing availability help to point at web bootstrap flow, got %q", cmd.LongHelp)
-	}
+	t.Fatal("expected pricing availability create to be registered")
 }
 
 func TestPricingAvailabilitySetCommand_HelpMentionsAllTerritories(t *testing.T) {
@@ -325,6 +354,7 @@ func TestPricingCommands_DefaultOutputJSON(t *testing.T) {
 		{"schedule manual-prices", PricingScheduleManualPricesCommand},
 		{"schedule automatic-prices", PricingScheduleAutomaticPricesCommand},
 		{"availability get", PricingAvailabilityGetCommand},
+		{"availability create", PricingAvailabilityCreateCommand},
 		{"availability territory-availabilities", PricingAvailabilityTerritoryAvailabilitiesCommand},
 		{"availability set", PricingAvailabilitySetCommand},
 	}

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -279,18 +281,46 @@ func TestPricingAvailabilitySetCommand_MissingFlags(t *testing.T) {
 	}
 }
 
+func capturePricingStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = originalStderr
+	}()
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return string(output)
+}
+
 func TestPricingAvailabilityCreateCommand_MissingFlags(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 
 	tests := []struct {
-		name string
-		args []string
+		name       string
+		args       []string
+		wantStderr string
 	}{
-		{name: "missing app", args: []string{"--territory", "USA", "--available", "true", "--available-in-new-territories", "true"}},
-		{name: "missing territory", args: []string{"--app", "APP", "--available", "true", "--available-in-new-territories", "true"}},
-		{name: "invalid territory csv", args: []string{"--app", "APP", "--territory", ",,,", "--available", "true", "--available-in-new-territories", "true"}},
-		{name: "missing available", args: []string{"--app", "APP", "--territory", "USA", "--available-in-new-territories", "true"}},
-		{name: "missing available in new territories", args: []string{"--app", "APP", "--territory", "USA", "--available", "true"}},
+		{name: "missing app", args: []string{"--territory", "USA", "--available", "true", "--available-in-new-territories", "true"}, wantStderr: "--app is required"},
+		{name: "missing territory", args: []string{"--app", "APP", "--available", "true", "--available-in-new-territories", "true"}, wantStderr: "--territory must include at least one value"},
+		{name: "invalid territory csv", args: []string{"--app", "APP", "--territory", ",,,", "--available", "true", "--available-in-new-territories", "true"}, wantStderr: "--territory must include at least one value"},
+		{name: "missing available", args: []string{"--app", "APP", "--territory", "USA", "--available-in-new-territories", "true"}, wantStderr: "--available is required"},
+		{name: "missing available in new territories", args: []string{"--app", "APP", "--territory", "USA", "--available", "true"}, wantStderr: "--available-in-new-territories is required"},
 	}
 
 	for _, test := range tests {
@@ -300,8 +330,13 @@ func TestPricingAvailabilityCreateCommand_MissingFlags(t *testing.T) {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
-			if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
-				t.Fatalf("expected flag.ErrHelp, got %v", err)
+			stderr := capturePricingStderr(t, func() {
+				if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected flag.ErrHelp, got %v", err)
+				}
+			})
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr)
 			}
 		})
 	}

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -99,7 +99,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				if isAppAvailabilityMissing(err) {
 					return NewErrorWithCause(
 						fmt.Errorf(
-							"%s: app availability not found for app %q; this command only updates existing app availability, so initialize availability in App Store Connect first or use the \"asc web apps availability create\" flow: %w",
+							"%s: app availability not found for app %q; this command only updates existing app availability, so use \"asc pricing availability create\" first: %w",
 							config.ErrorPrefix,
 							resolvedAppID,
 							asc.ErrNotFound,


### PR DESCRIPTION
## Summary

- expose `asc pricing availability create` as a stable public-API command
- create inline `territoryAvailabilities` with `${local-id}` identifiers through `POST /v2/appAvailabilities`
- keep `pricing availability edit` update-only and route missing-record guidance to the new command
- update capability reporting from client-only to CLI-supported

## Why

Apple titles the endpoint around app pre-orders, but its create schema also accepts ordinary territory availability entries. A controlled live test confirmed the generic bootstrap path:

- app `6787681270` initially returned 404 for `appAvailabilityV2`
- the app had no current price
- `POST /v2/appAvailabilities` returned HTTP 201
- the resulting record contained 175 available territories, zero pre-order territories, and zero release dates

This removes the need to mint a JWT manually or use the App Store Connect web-session bootstrap flow.

## Usage

```sh
asc pricing availability create \
  --app "123456789" \
  --territory "USA,GBR,DEU" \
  --available true \
  --available-in-new-territories true
```

Creation is one-shot. If availability already exists, Apple returns a conflict; use `asc pricing availability edit` for subsequent changes.

## Validation

- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built `/tmp/asc-create-pricing-availability` and verified help plus missing-input exit code 2
- CLI HTTP test asserts method, path, inline local IDs, territory relationships, attributes, and JSON output
- client test asserts API conflict propagation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `asc pricing availability create` to create app availability records, including in-territory and new-territory availability settings.
  - Updated `pricing availability` help/examples and added command registration for the new `create` subcommand.

- **Bug Fixes**
  - Improved user-facing guidance when availability records are missing to direct users to `asc pricing availability create`.
  - Added clearer handling for `pricing availability create` validation failures and surfaced API conflict errors with HTTP status.

- **Tests**
  - Added CLI and API error test coverage for successful requests, flag/argument validation, unknown territory handling, and HTTP 409 error unwrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->