### PR TITLE
fix(cli): correct help text and stabilize prompt tests

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -30,7 +30,7 @@ func BuildsUploadCommand() *ffcli.Command {
 	buildNumber := fs.String("build-number", "", "CFBundleVersion (e.g., 123, auto-extracted from IPA if not provided)")
 	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS (auto-detected for --pkg)")
 	dryRun := fs.Bool("dry-run", false, "Reserve upload operations without uploading the file")
-	concurrency := fs.Int("concurrency", asc.DefaultUploadConcurrency, fmt.Sprintf("Upload concurrency (default %d)", asc.DefaultUploadConcurrency))
+	concurrency := fs.Int("concurrency", asc.DefaultUploadConcurrency, "Upload concurrency")
 	verifyChecksum := fs.Bool("checksum", false, "Verify upload checksums if provided by API")
 	testNotes := fs.String("test-notes", "", "What to Test notes (requires build processing)")
 	locale := fs.String("locale", "", "Locale for --test-notes (e.g., en-US)")

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -57,6 +58,10 @@ func TestBuildsUploadCommand_HelpShowsConcurrencyDefaultOnce(t *testing.T) {
 	}
 	if count := strings.Count(concurrencyLine, "default"); count != 1 {
 		t.Fatalf("expected one concurrency default annotation, got %q", concurrencyLine)
+	}
+	wantDefault := fmt.Sprintf("(default: %d)", asc.DefaultUploadConcurrency)
+	if !strings.Contains(concurrencyLine, wantDefault) {
+		t.Fatalf("expected concurrency default annotation %q, got %q", wantDefault, concurrencyLine)
 	}
 }
 

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -41,6 +41,25 @@ func TestBuildsListCommand_HelpMentionsCombinedFilters(t *testing.T) {
 	}
 }
 
+func TestBuildsUploadCommand_HelpShowsConcurrencyDefaultOnce(t *testing.T) {
+	cmd := BuildsUploadCommand()
+	usage := cmd.UsageFunc(cmd)
+
+	var concurrencyLine string
+	for line := range strings.SplitSeq(usage, "\n") {
+		if strings.Contains(line, "--concurrency") {
+			concurrencyLine = line
+			break
+		}
+	}
+	if concurrencyLine == "" {
+		t.Fatalf("expected rendered help to include --concurrency, got %q", usage)
+	}
+	if count := strings.Count(concurrencyLine, "default"); count != 1 {
+		t.Fatalf("expected one concurrency default annotation, got %q", concurrencyLine)
+	}
+}
+
 func TestBuildsListCommand_ProcessingStateFlagDescription(t *testing.T) {
 	cmd := BuildsListCommand()
 

--- a/internal/cli/promotedpurchases/promoted_purchases_test.go
+++ b/internal/cli/promotedpurchases/promoted_purchases_test.go
@@ -46,6 +46,26 @@ func TestScopedPromotedPurchasesCommandsUseScopedPaths(t *testing.T) {
 	}
 }
 
+func TestScopedPromotedPurchasesShortUsageShowsAlternativeFlows(t *testing.T) {
+	cmd := scopedPromotedPurchasesCommandForTest()
+
+	listCmd := findDirectSubcommand(cmd, "list")
+	if listCmd == nil {
+		t.Fatal("expected list subcommand")
+	}
+	if !strings.Contains(listCmd.ShortUsage, "(--app APP_ID | --next URL)") {
+		t.Fatalf("list ShortUsage should show app and next alternatives, got %q", listCmd.ShortUsage)
+	}
+
+	linkCmd := findDirectSubcommand(cmd, "link")
+	if linkCmd == nil {
+		t.Fatal("expected link subcommand")
+	}
+	if !strings.Contains(linkCmd.ShortUsage, "--promoted-purchase-id PROMO_ID[,PROMO_ID...] | --clear --confirm") {
+		t.Fatalf("link ShortUsage should show link and clear alternatives, got %q", linkCmd.ShortUsage)
+	}
+}
+
 func TestScopedPromotedPurchasesDetailCommandsUseScopedErrorPrefixes(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))

--- a/internal/cli/promotedpurchases/promoted_purchases_test.go
+++ b/internal/cli/promotedpurchases/promoted_purchases_test.go
@@ -22,10 +22,10 @@ func TestPromotedPurchasesListValidation(t *testing.T) {
 	}
 }
 
-func TestScopedPromotedPurchasesDetailCommandsUseScopedPaths(t *testing.T) {
+func TestScopedPromotedPurchasesCommandsUseScopedPaths(t *testing.T) {
 	cmd := scopedPromotedPurchasesCommandForTest()
 
-	for _, name := range []string{"view", "update", "delete"} {
+	for _, name := range []string{"list", "view", "update", "delete", "link"} {
 		t.Run(name, func(t *testing.T) {
 			subcommand := findDirectSubcommand(cmd, name)
 			if subcommand == nil {

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -71,7 +71,7 @@ func configureScopedPromotedPurchasesListCommand(cmd *ffcli.Command, cfg ScopedP
 		return
 	}
 
-	cmd.ShortUsage = fmt.Sprintf("%s list --app APP_ID [flags]", cfg.PathPrefix)
+	cmd.ShortUsage = fmt.Sprintf("%s list (--app APP_ID | --next URL) [flags]", cfg.PathPrefix)
 	cmd.ShortHelp = fmt.Sprintf("List promoted purchases for %s in an app.", cfg.ProductPlural)
 	cmd.LongHelp = fmt.Sprintf(`List promoted purchases for %s in an app.
 
@@ -311,7 +311,7 @@ func configureScopedPromotedPurchasesLinkCommand(cmd *ffcli.Command, cfg ScopedP
 		return
 	}
 
-	cmd.ShortUsage = fmt.Sprintf("%s link --app APP_ID --promoted-purchase-id PROMO_ID[,PROMO_ID...]", cfg.PathPrefix)
+	cmd.ShortUsage = fmt.Sprintf("%s link --app APP_ID (--promoted-purchase-id PROMO_ID[,PROMO_ID...] | --clear --confirm)", cfg.PathPrefix)
 	cmd.ShortHelp = fmt.Sprintf("Link or clear promoted purchases for %s while preserving %s.", cfg.ProductPlural, otherProductPlural(cfg.ProductType))
 	cmd.LongHelp = fmt.Sprintf(`Link or clear promoted purchases for %s on an app.
 

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -71,6 +71,7 @@ func configureScopedPromotedPurchasesListCommand(cmd *ffcli.Command, cfg ScopedP
 		return
 	}
 
+	cmd.ShortUsage = fmt.Sprintf("%s list --app APP_ID [flags]", cfg.PathPrefix)
 	cmd.ShortHelp = fmt.Sprintf("List promoted purchases for %s in an app.", cfg.ProductPlural)
 	cmd.LongHelp = fmt.Sprintf(`List promoted purchases for %s in an app.
 
@@ -310,6 +311,7 @@ func configureScopedPromotedPurchasesLinkCommand(cmd *ffcli.Command, cfg ScopedP
 		return
 	}
 
+	cmd.ShortUsage = fmt.Sprintf("%s link --app APP_ID --promoted-purchase-id PROMO_ID[,PROMO_ID...]", cfg.PathPrefix)
 	cmd.ShortHelp = fmt.Sprintf("Link or clear promoted purchases for %s while preserving %s.", cfg.ProductPlural, otherProductPlural(cfg.ProductType))
 	cmd.LongHelp = fmt.Sprintf(`Link or clear promoted purchases for %s on an app.
 

--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -177,19 +177,17 @@ func TestReadPasswordFromTerminalPropagatesCtrlCAsInterrupt(t *testing.T) {
 		return nil
 	}
 
-	promptSeen := make(chan struct{})
-	readPromptDone := make(chan error, 1)
+	promptResult := make(chan error, 1)
 	go func() {
 		buf := make([]byte, 128)
 		for {
 			n, err := ptmx.Read(buf)
 			if n > 0 && strings.Contains(string(buf[:n]), "Apple Account password:") {
-				close(promptSeen)
-				readPromptDone <- nil
+				promptResult <- nil
 				return
 			}
 			if err != nil {
-				readPromptDone <- err
+				promptResult <- err
 				return
 			}
 		}
@@ -202,9 +200,10 @@ func TestReadPasswordFromTerminalPropagatesCtrlCAsInterrupt(t *testing.T) {
 	}()
 
 	select {
-	case <-promptSeen:
-	case err := <-readPromptDone:
-		t.Fatalf("failed waiting for password prompt: %v", err)
+	case err := <-promptResult:
+		if err != nil {
+			t.Fatalf("failed waiting for password prompt: %v", err)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for password prompt")
 	}
@@ -245,19 +244,17 @@ func TestReadPasswordFromTerminalReturnsPromptInterruptAfterContextCancel(t *tes
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	promptSeen := make(chan struct{})
-	readPromptDone := make(chan error, 1)
+	promptResult := make(chan error, 1)
 	go func() {
 		buf := make([]byte, 128)
 		for {
 			n, err := ptmx.Read(buf)
 			if n > 0 && strings.Contains(string(buf[:n]), "Apple Account password:") {
-				close(promptSeen)
-				readPromptDone <- nil
+				promptResult <- nil
 				return
 			}
 			if err != nil {
-				readPromptDone <- err
+				promptResult <- err
 				return
 			}
 		}
@@ -270,9 +267,10 @@ func TestReadPasswordFromTerminalReturnsPromptInterruptAfterContextCancel(t *tes
 	}()
 
 	select {
-	case <-promptSeen:
-	case err := <-readPromptDone:
-		t.Fatalf("failed waiting for password prompt: %v", err)
+	case err := <-promptResult:
+		if err != nil {
+			t.Fatalf("failed waiting for password prompt: %v", err)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for password prompt")
 	}

--- a/internal/telemetry/spool_test.go
+++ b/internal/telemetry/spool_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const spoolWriterHelperEnv = "ASC_TEST_TELEMETRY_SPOOL_WRITER"
@@ -56,6 +57,16 @@ func TestSpoolRejectsOversizedNewestWithoutEvictingQueue(t *testing.T) {
 		t.Fatalf("append oversized event error = %v, want %v", err, errSpoolRecordTooLarge)
 	}
 	assertSpoolEventIDs(t, store, "event-old")
+}
+
+func TestSpoolLockAlwaysAttemptsUncontendedLock(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), "telemetry-spool.jsonl"))
+	store.lockWait = time.Nanosecond
+
+	if err := store.append(testSpoolRecord("event-01")); err != nil {
+		t.Fatalf("append with uncontended lock error = %v", err)
+	}
+	assertSpoolEventIDs(t, store, "event-01")
 }
 
 func TestSpoolRecoversCorruptAndTruncatedRecords(t *testing.T) {

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -228,11 +228,6 @@ func lockTelemetryFile(path string, wait time.Duration, purpose string) (func(),
 			_ = lockFile.Close()
 			return nil, fmt.Errorf("telemetry: failed to secure %s lock: %w", purpose, err)
 		}
-		if wait > 0 && time.Until(deadline) <= 0 {
-			_ = lockFile.Close()
-			return nil, telemetryLockBusyError(purpose)
-		}
-
 		locked, lockErr := tryLockStateFile(lockFile)
 		if lockErr != nil {
 			_ = lockFile.Close()


### PR DESCRIPTION
## What changed

- render scoped `iap promoted-purchases` and `subscriptions promoted-purchases` usage paths for `list` and `link`
- let the standard flag renderer show the `builds upload --concurrency` default exactly once
- remove ambiguous dual-channel success signaling from the PTY password prompt tests
- always attempt an uncontended telemetry file lock before applying the retry deadline

## Why

The scoped promoted-purchase helpers inherited generic top-level usage strings, which could direct users to commands with different behavior. The upload concurrency description repeated its default because both the flag description and the renderer supplied it.

The latest main workflow also failed in `TestReadPasswordFromTerminalReturnsPromptInterruptAfterContextCancel`. The test made two success signals ready at once, allowing `select` to choose a branch that treated a nil result as failure. A single result channel now represents prompt readiness or a real read error.

The initial PR run then exposed a Windows telemetry spool failure. The 25 ms lock deadline could expire after lock-file setup but before the first lock attempt, causing an uncontended append to be dropped as busy. The lock now always makes one immediate attempt and applies the deadline only to contention retries.

Failing main run: https://github.com/rorkai/App-Store-Connect-CLI/actions/runs/29511191387

## Compatibility

This changes help text and test synchronization only. API requests, command execution, output data, authentication, and exit codes are unchanged.

## Validation

- focused regression tests established RED before the help fixes
- built binary help smoke tests for all four scoped commands and `builds upload`
- 100 repeated PTY prompt test runs
- 10 PTY prompt test runs with the race detector
- 100 repeated telemetry lock and endpoint-spool regression tests
- 10 telemetry race-detector repetitions
- 10 complete short telemetry-package stress runs
- Windows telemetry test-binary compilation
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `asc builds upload --concurrency` help text so the default is displayed clearly and only once.
  * Corrected scoped promoted-purchases command help to consistently show the appropriate command path and required options.
  * Improved telemetry recording behavior when lock wait times are very short.
  * Made password-prompt interruption handling more reliable for cancellation and Ctrl+C scenarios.

* **Tests**
  * Added coverage to verify the updated command help and telemetry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->