### PR TITLE
fix(age-rating): reject explicit social media contradictions

### DIFF
--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -187,11 +187,17 @@ func AgeRatingEditCommand() *ffcli.Command {
 Use --all-none to set all ratings to their safe defaults (NONE/false) in one
 command, then override individual fields as needed.
 
+App Store Connect accepts --social-media true only when user-generated content
+is true. It accepts --social-media-age-restricted true only when age assurance
+and social media are both true. Include the matching prerequisite flags when
+enabling these fields unless the declaration already stores them as true.
+
 Examples:
   asc age-rating edit --app APP_ID --all-none
   asc age-rating edit --app APP_ID --all-none --unrestricted-web-access true
   asc age-rating edit --id DECLARATION_ID --gambling false --kids-age-band FIVE_AND_UNDER
-  asc age-rating edit --app APP_ID --violence-realistic FREQUENT_OR_INTENSE --unrestricted-web-access true`,
+  asc age-rating edit --app APP_ID --social-media true --user-generated-content true
+  asc age-rating edit --app APP_ID --social-media-age-restricted true --age-assurance true --social-media true --user-generated-content true`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -269,6 +275,9 @@ Examples:
 			if err != nil {
 				return err
 			}
+			if err := validateAgeRatingDependencies(attributes); err != nil {
+				return err
+			}
 
 			if !hasAgeRatingUpdates(attributes) {
 				return fmt.Errorf("age-rating edit: at least one update flag is required")
@@ -297,6 +306,27 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func validateAgeRatingDependencies(attrs asc.AgeRatingDeclarationAttributes) error {
+	if boolIsTrue(attrs.SocialMedia) && boolIsFalse(attrs.UserGeneratedContent) {
+		return shared.UsageError("--social-media true cannot be combined with --user-generated-content false")
+	}
+	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.AgeAssurance) {
+		return shared.UsageError("--social-media-age-restricted true cannot be combined with --age-assurance false")
+	}
+	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.SocialMedia) {
+		return shared.UsageError("--social-media-age-restricted true cannot be combined with --social-media false")
+	}
+	return nil
+}
+
+func boolIsTrue(value *bool) bool {
+	return value != nil && *value
+}
+
+func boolIsFalse(value *bool) bool {
+	return value != nil && !*value
 }
 
 func fetchAgeRatingDeclaration(ctx context.Context, client *asc.Client, appID, appInfoID, versionID string) (*asc.AgeRatingDeclarationResponse, error) {

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -171,6 +171,52 @@ func TestAgeRatingHelpers(t *testing.T) {
 	}
 }
 
+func TestValidateAgeRatingDependenciesAllowsPartialUpdates(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name  string
+		attrs asc.AgeRatingDeclarationAttributes
+	}{
+		{
+			name:  "social media may rely on stored user generated content",
+			attrs: asc.AgeRatingDeclarationAttributes{SocialMedia: &trueValue},
+		},
+		{
+			name: "age restriction may rely on stored prerequisites",
+			attrs: asc.AgeRatingDeclarationAttributes{
+				SocialMediaAgeRestricted: &trueValue,
+			},
+		},
+		{
+			name: "all prerequisites explicitly enabled",
+			attrs: asc.AgeRatingDeclarationAttributes{
+				AgeAssurance:             &trueValue,
+				SocialMedia:              &trueValue,
+				SocialMediaAgeRestricted: &trueValue,
+				UserGeneratedContent:     &trueValue,
+			},
+		},
+		{
+			name: "unrelated false fields",
+			attrs: asc.AgeRatingDeclarationAttributes{
+				AgeAssurance:         &falseValue,
+				SocialMedia:          &falseValue,
+				UserGeneratedContent: &falseValue,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateAgeRatingDependencies(test.attrs); err != nil {
+				t.Fatalf("unexpected dependency error: %v", err)
+			}
+		})
+	}
+}
+
 func TestApplyAllNoneDefaultsSetsAllContentDescriptors(t *testing.T) {
 	values := map[string]string{}
 	applyAllNoneDefaults(values)

--- a/internal/cli/cmdtest/age_rating_4_4_1_test.go
+++ b/internal/cli/cmdtest/age_rating_4_4_1_test.go
@@ -83,3 +83,54 @@ func TestAgeRatingEditInvalidSocialMediaReturnsUsageExit(t *testing.T) {
 		"age-rating", "edit", "--id", "age-441", "--social-media", "sometimes",
 	}, "--social-media must be true or false")
 }
+
+func TestAgeRatingEditRejectsExplicitDependencyContradictions(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "social media with user generated content disabled",
+			args: []string{
+				"age-rating", "edit", "--id", "age-441",
+				"--social-media", "true",
+				"--user-generated-content", "false",
+			},
+			wantErr: "--social-media true cannot be combined with --user-generated-content false",
+		},
+		{
+			name: "age restricted social media with age assurance disabled",
+			args: []string{
+				"age-rating", "edit", "--id", "age-441",
+				"--social-media-age-restricted", "true",
+				"--age-assurance", "false",
+			},
+			wantErr: "--social-media-age-restricted true cannot be combined with --age-assurance false",
+		},
+		{
+			name: "age restricted social media with social media disabled",
+			args: []string{
+				"age-rating", "edit", "--id", "age-441",
+				"--social-media-age-restricted", "true",
+				"--social-media", "false",
+			},
+			wantErr: "--social-media-age-restricted true cannot be combined with --social-media false",
+		},
+		{
+			name: "all none materializes conflicting false prerequisites",
+			args: []string{
+				"age-rating", "edit", "--id", "age-441",
+				"--all-none",
+				"--social-media", "true",
+			},
+			wantErr: "--social-media true cannot be combined with --user-generated-content false",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertUsageExit(t, test.args, test.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## What changed

`asc age-rating edit` now returns usage exit 2 before auth or HTTP when one
PATCH contains a contradiction that App Store Connect rejects:

- `--social-media true --user-generated-content false`
- `--social-media-age-restricted true --age-assurance false`
- `--social-media-age-restricted true --social-media false`

Partial updates still work. A command may set `--social-media true` without a
user-generated-content flag because the declaration may already store
user-generated content as true. The same rule applies when enabling
age-restricted social media without repeating prerequisites that are already
true on the server.

The extended help explains those server-state requirements and gives complete
enablement examples. `--all-none` participates in validation because it writes
explicit false values into the PATCH.

## Why this boundary

Fetching the declaration before every edit would add a network request and
still leave a race before PATCH. Requiring every companion flag would reject
valid partial updates, so this change checks only contradictions present in the
outgoing request.

## Live proof

Tested against disposable app `6759231657` before writing the local checks.
App Store Connect rejected `socialMedia=true` with
`userGeneratedContent=false`, and it rejected
`socialMediaAgeRestricted=true` when either `ageAssurance` or `socialMedia`
was false. The complete true combination succeeded; the declaration was then
restored to its original values.

## Verification

- RED: the new black-box cases reached auth and returned exit 3 before the fix.
- Focused `agerating` and `cmdtest` suites pass, including partial PATCH cases.
- `make format`, `make check-docs`, and `make lint` pass; lint reports 0 issues.
- `ASC_BYPASS_KEYCHAIN=1 make test` passes on exact base `1aad4a75`.

No release is part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for incompatible age-rating options.
  - The `age-rating edit` command now reports usage errors when social media settings conflict with required content or age-assurance settings.
  - Updated help text to clarify prerequisite requirements for related flags.

- **Tests**
  - Added coverage for valid partial updates and rejected combinations of age-rating options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->