### PR TITLE
fix(subscriptions): require adjusted equalization filters

### DIFF
--- a/internal/cli/cmdtest/subscriptions_adjusted_equalizations_test.go
+++ b/internal/cli/cmdtest/subscriptions_adjusted_equalizations_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -267,16 +269,46 @@ func TestSubscriptionsPricePointEqualizationsKeepTerritoryInSparseFields(t *test
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			setupAuth(t)
-			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				wantPath := "/v1/subscriptionPricePoints/base-1/" + test.path
 				if req.Method != http.MethodGet || req.URL.Path != wantPath {
-					t.Fatalf("unexpected request: %s %s", req.Method, req.URL)
+					t.Errorf("unexpected request: %s %s", req.Method, req.URL)
+					return
 				}
 				if got, want := req.URL.RawQuery, test.wantQuery.Encode(); got != want {
-					t.Fatalf("query=%q, want %q", got, want)
+					t.Errorf("query=%q, want %q", got, want)
+					return
 				}
-				return jsonResponse(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"point-1"}],"links":{}}`)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"data":[{"type":"subscriptionPricePoints","id":"point-1"}],"links":{}}`)
 			}))
+			t.Cleanup(server.Close)
+
+			transport, ok := server.Client().Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("server transport type = %T, want *http.Transport", server.Client().Transport)
+			}
+			transport = transport.Clone()
+			transport.Proxy = nil
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+			transport.TLSClientConfig.ServerName = "example.com"
+			dialer := &net.Dialer{}
+			transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+			}
+			client, err := asc.NewClientWithHTTPClient(
+				"TEST_KEY",
+				"TEST_ISSUER",
+				os.Getenv("ASC_PRIVATE_KEY_PATH"),
+				&http.Client{Transport: transport},
+			)
+			if err != nil {
+				t.Fatalf("new test client: %v", err)
+			}
+			restore := subscriptionscli.SetPricePointsClientFactory(func() (*asc.Client, error) {
+				return client, nil
+			})
+			t.Cleanup(restore)
 
 			root := RootCommand("1.2.3")
 			root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/subscriptions_adjusted_equalizations_test.go
+++ b/internal/cli/cmdtest/subscriptions_adjusted_equalizations_test.go
@@ -249,10 +249,16 @@ func TestSubscriptionsPricePointEqualizationsKeepTerritoryInSparseFields(t *test
 			name:    "adjusted equalizations territory fields imply include",
 			command: "adjusted-equalizations",
 			path:    "adjustedEqualizations",
-			args:    []string{"--territory-fields", "currency"},
+			args: []string{
+				"--upfront-price-point-id", "upfront-1",
+				"--plan-type", "MONTHLY",
+				"--territory-fields", "currency",
+			},
 			wantQuery: url.Values{
 				"fields[subscriptionPricePoints]": {"customerPrice,territory"},
 				"fields[territories]":             {"currency"},
+				"filter[planType]":                {"MONTHLY"},
+				"filter[upfrontPricePointId]":     {"upfront-1"},
 				"include":                         {"territory"},
 			},
 		},
@@ -324,6 +330,49 @@ func TestSubscriptionsAdjustedEqualizationsUsageErrors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assertUsageExit(t, test.args, test.want)
+		})
+	}
+}
+
+func TestSubscriptionsAdjustedEqualizationsRequiresLiveFiltersBeforeClient(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing upfront price point",
+			args: []string{
+				"subscriptions", "pricing", "price-points", "adjusted-equalizations",
+				"--price-point-id", "base-1",
+				"--plan-type", "MONTHLY",
+			},
+			want: "--upfront-price-point-id is required for adjusted equalizations",
+		},
+		{
+			name: "missing plan type",
+			args: []string{
+				"subscriptions", "pricing", "price-points", "adjusted-equalizations",
+				"--price-point-id", "base-1",
+				"--upfront-price-point-id", "upfront-1",
+			},
+			want: "--plan-type is required for adjusted equalizations",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := subscriptionscli.SetPricePointsClientFactory(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("poison price-points client factory called")
+			})
+			t.Cleanup(restore)
+
+			assertUsageExit(t, test.args, test.want)
+			if clientFactoryCalled {
+				t.Fatal("missing adjusted-equalizations filters reached the price-points client factory")
+			}
 		})
 	}
 }

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -380,10 +380,14 @@ func buildSubscriptionPricePointEqualizationsCommand(name string, adjusted bool)
 	pricePointID := fs.String("price-point-id", "", "Subscription price point ID")
 	territory := fs.String("territory", "", "Filter by territory IDs or names (comma-separated)")
 	subscriptionIDs := fs.String("subscription-id", "", "Filter by subscription IDs (comma-separated)")
-	upfrontPricePointIDs := fs.String("upfront-price-point-id", "", "Filter by upfront price point IDs (comma-separated)")
+	upfrontPricePointIDUsage := "Filter by upfront price point IDs (comma-separated)"
+	if adjusted {
+		upfrontPricePointIDUsage = "Required upfront price point IDs (comma-separated)"
+	}
+	upfrontPricePointIDs := fs.String("upfront-price-point-id", "", upfrontPricePointIDUsage)
 	planTypeUsage := "Filter by plan types (comma-separated)"
 	if adjusted {
-		planTypeUsage = "Filter by plan type: MONTHLY"
+		planTypeUsage = "Required plan type: MONTHLY"
 	}
 	planTypes := fs.String("plan-type", "", planTypeUsage)
 	fields := fs.String("fields", "", "Subscription price point fields (comma-separated)")
@@ -400,6 +404,17 @@ func buildSubscriptionPricePointEqualizationsCommand(name string, adjusted bool)
 	}
 	errorPrefix := "subscriptions price-points " + name
 	baseUsage := fmt.Sprintf(`asc subscriptions price-points %s --price-point-id "PRICE_POINT_ID"`, name)
+	subscriptionExample := baseUsage + ` --subscription-id "SUB_ID" --plan-type MONTHLY`
+	requirementHelp := ""
+	if adjusted {
+		baseUsage += ` --upfront-price-point-id "UPFRONT_PRICE_POINT_ID" --plan-type MONTHLY`
+		subscriptionExample = baseUsage + ` --subscription-id "SUB_ID"`
+		requirementHelp = `
+
+Apple's live endpoint requires both --upfront-price-point-id and --plan-type
+MONTHLY for the first page. An opaque --next URL already carries its query and
+does not accept those flags.`
+	}
 
 	cmd := &ffcli.Command{
 		Name:       name,
@@ -409,13 +424,13 @@ func buildSubscriptionPricePointEqualizationsCommand(name string, adjusted bool)
 
 Filters accept comma-separated values and map directly to the App Store Connect
 API. Setting --territory-fields automatically includes the territory relationship
-so the requested metadata is present in returned price points.
+so the requested metadata is present in returned price points.%s
 
 Examples:
   %s
   %s --territory "US,France" --include territory
-  %s --subscription-id "SUB_ID" --plan-type MONTHLY
-  %s --paginate`, adjective, baseUsage, baseUsage, baseUsage, baseUsage),
+  %s
+  %s --paginate`, adjective, requirementHelp, baseUsage, baseUsage, subscriptionExample, baseUsage),
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 	}
@@ -483,6 +498,14 @@ Examples:
 		selectedIncludes, err := normalizeOptionalSelection(fs, "include", *include, []string{"territory"})
 		if err != nil {
 			return shared.UsageError(err.Error())
+		}
+		if adjusted && strings.TrimSpace(*next) == "" {
+			if len(upfrontIDs) == 0 {
+				return shared.UsageError("--upfront-price-point-id is required for adjusted equalizations")
+			}
+			if len(plans) == 0 {
+				return shared.UsageError("--plan-type is required for adjusted equalizations")
+			}
 		}
 		if len(selectedTerritoryFields) != 0 && !containsString(selectedIncludes, "territory") {
 			selectedIncludes = append(selectedIncludes, "territory")

--- a/internal/cli/subscriptions/subscriptions_command_test.go
+++ b/internal/cli/subscriptions/subscriptions_command_test.go
@@ -34,6 +34,16 @@ func TestSubscriptionPricePointEqualizationCommandsExpose441Filters(t *testing.T
 		}
 	}
 
+	adjusted := SubscriptionsPricePointsAdjustedEqualizationsCommand()
+	for _, required := range []string{"--upfront-price-point-id", "--plan-type MONTHLY"} {
+		if !strings.Contains(adjusted.ShortUsage, required) {
+			t.Fatalf("adjusted-equalizations usage must require %s, got %q", required, adjusted.ShortUsage)
+		}
+	}
+	if !strings.Contains(adjusted.LongHelp, "requires both --upfront-price-point-id and --plan-type") {
+		t.Fatalf("adjusted-equalizations help must explain the live filter requirements, got %q", adjusted.LongHelp)
+	}
+
 	parent := SubscriptionsPricePointsCommand()
 	found := false
 	for _, subcommand := range parent.Subcommands {


### PR DESCRIPTION
## What changed

- Require `--upfront-price-point-id` and `--plan-type MONTHLY` for first-page adjusted-equalizations requests.
- Return exit 2 before client construction when either live-required filter is absent.
- Keep opaque `--next` URLs self-contained; owner and query flags remain forbidden with `--next`.
- Update command help, examples, and regression coverage.

## Why

Apple documents both values as optional query filters in the 4.4.1 OpenAPI snapshot, but the live endpoint rejects requests without the pair. A request with neither filter reports a missing required filter; `--plan-type MONTHLY` without an upfront point reports an invalid upfront point. The same request succeeds when both values are present.

The CLI now catches that server requirement before auth or HTTP instead of sending a request that cannot work.

## Verification

RED showed both missing-filter cases reaching the client factory and exiting 1. The new tests make each case exit 2 before client construction, cover the exact query, retain opaque-next pagination, and reject next/filter conflicts.

The review follow-up runs the sparse-field path and query assertions through a TLS `httptest.Server`. Its test transport keeps certificate verification enabled while dialing the local server.

Ran on exact base `b92e560549ae9d314164e686205af1fdf2bea3dd`:

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

A read-only call from the branch binary against the throwaway-account price point succeeded with both required filters and `--limit 1`, returning one item from 174 adjusted equalizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `adjusted-equalizations` command help/usage to clearly mark `--upfront-price-point-id` and `--plan-type MONTHLY` as required, including explicit guidance for first-page requests.
  * Added clearer messaging that required owner flags can’t be combined with `--next`.

* **Bug Fixes**
  * Added upfront validation to error when required live filter flags are missing, preventing invalid requests before contacting the service.
  * Updated adjusted equalizations request filtering to include the corresponding live filters.

* **Tests**
  * Expanded and refactored CLI tests to verify help text, required-filter enforcement, and correct filter inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->