### PR TITLE
fix(cli): reject invalid 4.4.1 inputs

### DIFF
--- a/internal/cli/cmdtest/positional_args_4_4_1_test.go
+++ b/internal/cli/cmdtest/positional_args_4_4_1_test.go
@@ -1,0 +1,28 @@
+package cmdtest
+
+import "testing"
+
+func TestChanged441CommandValidationReturnsUsageExit(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "iap list positional", args: []string{"iap", "list", "--app", "app-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "iap view positional", args: []string{"iap", "view", "--id", "iap-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "iap localization update positional", args: []string{"iap", "localizations", "update", "--localization-id", "loc-1", "--name", "Name", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "subscription groups list positional", args: []string{"subscriptions", "groups", "list", "--app", "app-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "subscription groups view positional", args: []string{"subscriptions", "groups", "view", "--id", "group-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "subscriptions list positional", args: []string{"subscriptions", "list", "--group-id", "group-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "subscriptions view positional", args: []string{"subscriptions", "view", "--id", "sub-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "subscription price-points list positional", args: []string{"subscriptions", "pricing", "price-points", "list", "--subscription-id", "sub-1", "unexpected"}, wantErr: "unexpected argument(s): unexpected"},
+		{name: "iap list versions limit", args: []string{"iap", "list", "--app", "app-1", "--versions-limit", "51"}, wantErr: "iap list: --versions-limit must be between 1 and 50"},
+		{name: "iap view versions limit", args: []string{"iap", "view", "--id", "iap-1", "--versions-limit", "51"}, wantErr: "iap view: --versions-limit must be between 1 and 50"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertUsageExit(t, test.args, test.wantErr)
+		})
+	}
+}

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -96,6 +96,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectIAPVersionArgs(args); err != nil {
+				return err
+			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("iap list: %w", err)
 			}
@@ -106,7 +109,7 @@ Examples:
 				return fmt.Errorf("iap list: --limit must be between 1 and 200")
 			}
 			if *versionsLimit != 0 && (*versionsLimit < 1 || *versionsLimit > 50) {
-				return fmt.Errorf("iap list: --versions-limit must be between 1 and 50")
+				return shared.UsageError("iap list: --versions-limit must be between 1 and 50")
 			}
 			if *legacy && strings.TrimSpace(*fields) != "" {
 				return shared.UsageError("iap list: --fields requires the v2 endpoint")
@@ -225,13 +228,16 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectIAPVersionArgs(args); err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*iapID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError()
 			}
 			if *versionsLimit != 0 && (*versionsLimit < 1 || *versionsLimit > 50) {
-				return fmt.Errorf("iap view: --versions-limit must be between 1 and 50")
+				return shared.UsageError("iap view: --versions-limit must be between 1 and 50")
 			}
 			if *legacy && strings.TrimSpace(*fields) != "" {
 				return shared.UsageError("iap view: --fields requires the v2 endpoint")

--- a/internal/cli/iap/localizations.go
+++ b/internal/cli/iap/localizations.go
@@ -173,6 +173,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectIAPVersionArgs(args); err != nil {
+				return err
+			}
 			if err := legacyID.Apply(localizationID); err != nil {
 				return err
 			}
@@ -194,7 +197,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := iapQueryClientFactory()
 			if err != nil {
 				return fmt.Errorf("iap localizations update: %w", err)
 			}

--- a/internal/cli/iap/positional_args_4_4_1_test.go
+++ b/internal/cli/iap/positional_args_4_4_1_test.go
@@ -1,0 +1,90 @@
+package iap
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestChanged441IAPCommandsRejectPositionalArgsBeforeAuth(t *testing.T) {
+	isolateIAPAuth(t)
+
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+	}{
+		{name: "list", command: IAPListCommand, args: []string{"--app", "app-1", "unexpected"}},
+		{name: "view", command: IAPGetCommand, args: []string{"--id", "iap-1", "unexpected"}},
+		{name: "localization update", command: IAPLocalizationsUpdateCommand, args: []string{"--localization-id", "loc-1", "--name", "Name", "unexpected"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			factoryCalled := false
+			previous := iapQueryClientFactory
+			iapQueryClientFactory = func() (*asc.Client, error) {
+				factoryCalled = true
+				return &asc.Client{}, errors.New("poison IAP client factory called")
+			}
+			t.Cleanup(func() { iapQueryClientFactory = previous })
+
+			err := test.command().ParseAndRun(context.Background(), test.args)
+			if err == nil || !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "unexpected argument(s): unexpected") {
+				t.Fatalf("error = %v, want positional usage error", err)
+			}
+			if factoryCalled {
+				t.Fatal("client factory called before positional-argument validation")
+			}
+		})
+	}
+}
+
+func TestChanged441IAPVersionLimitErrorsAreUsageErrorsBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+	}{
+		{name: "list", command: IAPListCommand, args: []string{"--app", "app-1", "--versions-limit", "51"}},
+		{name: "view", command: IAPGetCommand, args: []string{"--id", "iap-1", "--versions-limit", "51"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			factoryCalled := false
+			previous := iapQueryClientFactory
+			iapQueryClientFactory = func() (*asc.Client, error) {
+				factoryCalled = true
+				return &asc.Client{}, errors.New("poison IAP client factory called")
+			}
+			t.Cleanup(func() { iapQueryClientFactory = previous })
+
+			err := test.command().ParseAndRun(context.Background(), test.args)
+			if err == nil || !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "--versions-limit must be between 1 and 50") {
+				t.Fatalf("error = %v, want versions-limit usage error", err)
+			}
+			if factoryCalled {
+				t.Fatal("client factory called before versions-limit validation")
+			}
+		})
+	}
+}
+
+func isolateIAPAuth(t *testing.T) {
+	t.Helper()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", t.TempDir()+"/config.json")
+	for _, key := range []string{
+		"ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+		"ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_STRICT_AUTH",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/cli/subscriptions/positional_args_4_4_1_test.go
+++ b/internal/cli/subscriptions/positional_args_4_4_1_test.go
@@ -1,0 +1,69 @@
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestChanged441SubscriptionCommandsRejectPositionalArgsBeforeAuth(t *testing.T) {
+	isolateSubscriptionAuth(t)
+
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+		group   bool
+		pricing bool
+	}{
+		{name: "groups list", command: SubscriptionsGroupsListCommand, args: []string{"--app", "app-1", "unexpected"}, group: true},
+		{name: "groups view", command: SubscriptionsGroupsGetCommand, args: []string{"--id", "group-1", "unexpected"}, group: true},
+		{name: "list", command: SubscriptionsListCommand, args: []string{"--group-id", "group-1", "unexpected"}},
+		{name: "view", command: SubscriptionsGetCommand, args: []string{"--id", "sub-1", "unexpected"}},
+		{name: "price-points list", command: SubscriptionsPricePointsListCommand, args: []string{"--subscription-id", "sub-1", "unexpected"}, pricing: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			factoryCalled := false
+			factory := &subscriptionQueryClientFactory
+			if test.group {
+				factory = &subscriptionGroupVersionClientFactory
+			} else if test.pricing {
+				factory = &subscriptionPricePointsClientFactory
+			}
+			previous := *factory
+			*factory = func() (*asc.Client, error) {
+				factoryCalled = true
+				return &asc.Client{}, errors.New("poison subscription client factory called")
+			}
+			t.Cleanup(func() { *factory = previous })
+
+			err := test.command().ParseAndRun(context.Background(), test.args)
+			if err == nil || !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "unexpected argument(s): unexpected") {
+				t.Fatalf("error = %v, want positional usage error", err)
+			}
+			if factoryCalled {
+				t.Fatal("client factory called before positional-argument validation")
+			}
+		})
+	}
+}
+
+func isolateSubscriptionAuth(t *testing.T) {
+	t.Helper()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", t.TempDir()+"/config.json")
+	for _, key := range []string{
+		"ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+		"ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_STRICT_AUTH",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -97,6 +97,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions price-points list: %w", err)
 			}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -18,6 +18,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+var subscriptionQueryClientFactory = shared.GetASCClient
+
 // SubscriptionsCommand returns the subscriptions command group.
 func SubscriptionsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("subscriptions", flag.ExitOnError)
@@ -124,6 +126,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("subscriptions groups list: --limit must be between 1 and 200")
 			}
@@ -277,6 +282,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*groupID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -298,7 +306,7 @@ Examples:
 				return shared.UsageError("subscriptions groups view: " + err.Error())
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := subscriptionGroupVersionClientFactory()
 			if err != nil {
 				return fmt.Errorf("subscriptions groups view: %w", err)
 			}
@@ -454,6 +462,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("subscriptions list: --limit must be between 1 and 200")
 			}
@@ -509,7 +520,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := subscriptionQueryClientFactory()
 			if err != nil {
 				return fmt.Errorf("subscriptions list: %w", err)
 			}
@@ -712,6 +723,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectUnexpectedArgs(args); err != nil {
+				return err
+			}
 			if err := legacySubscriptionID.Apply(subID); err != nil {
 				return err
 			}
@@ -736,7 +750,7 @@ Examples:
 				return err
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := subscriptionQueryClientFactory()
 			if err != nil {
 				return fmt.Errorf("subscriptions view: %w", err)
 			}


### PR DESCRIPTION
## What changed

- Reject extra positional arguments in eight existing IAP and subscription commands changed by the App Store Connect API 4.4.1 work.
- Classify the two IAP `--versions-limit` range failures as usage errors.
- Test every failure before auth/client creation and through the root command exit-code path.

## Why

These commands advertise flag-only invocations. An extra token was ignored and the command continued into auth or HTTP. The new IAP versions-limit checks also returned exit 1 while comparable input checks return exit 2.

## Exact integration point

- Base: `6f11d6aae1b02aa9aa09f8f266afb943c8d250ec`
- Head: `fc5f05040ff9f52907c7fd845f9261391d464a12`
- Rebased after #1783 merged; no conflicts.

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/iap ./internal/cli/subscriptions ./internal/cli/cmdtest -run 'TestChanged441.*' -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built `/private/tmp/asc-reject-441-bin`; all ten invalid invocations returned exit 2 before auth with the expected usage text.
- `git diff --check origin/main...HEAD`

No live App Store Connect mutation is applicable to this input-validation PR: every covered path must fail locally before authentication or HTTP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line validation for in-app purchase and subscription commands.
  * Unexpected positional arguments now produce clear usage errors before requests or authentication begin.
  * Invalid `--versions-limit` values now consistently return usage errors.
  * Updated localization and subscription commands to use the appropriate request handling flow.
* **Tests**
  * Added coverage for invalid arguments, validation messages, and preventing unnecessary authentication or client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->