### PR TITLE
fix(subscriptions): pluralize relationship limit flags

### DIFF
--- a/docs/design/subscription-relationship-limit-flags.md
+++ b/docs/design/subscription-relationship-limit-flags.md
@@ -1,0 +1,51 @@
+# Subscription relationship limit flags
+
+## Decision
+
+Subscription product and version reads use plural relationship names in both
+App Store Connect JSON:API payloads and query parameters. Their canonical CLI
+flags therefore use the same plural nouns:
+
+- `asc subscriptions list|view --versions-limit`
+- `asc subscriptions versions list|view --images-limit`
+- `asc subscriptions versions list|view --localizations-limit`
+
+The existing singular spellings remain accepted as hidden deprecated aliases.
+Using one writes one migration warning to stderr. Supplying both spellings is a
+usage error, even when their values match. Opaque `--next` URLs remain mutually
+exclusive with relationship-limit flags; an alias is normalized first so the
+error names the canonical plural flag.
+
+## API contract
+
+The affected operations are `GET /v1/subscriptionGroups/{id}/subscriptions`,
+`GET /v1/subscriptions/{id}`, `GET /v1/subscriptions/{id}/versions`, and
+`GET /v1/subscriptionVersions/{id}`. Their OpenAPI query keys remain
+`limit[versions]`, `limit[images]`, and `limit[localizations]`. Responses and
+stdout output are unchanged. Valid limits remain 1 through 50; invalid values
+return a usage error before authentication or HTTP.
+
+## Compatibility and migration
+
+This is a deprecation, not a removal. Existing scripts continue to run while
+receiving a direct replacement command. Generated command documentation remains
+in sync, and live command help lists only the plural flags. Release notes are
+generated from this pull request, whose title and body call out the deprecated
+aliases and exact replacements.
+
+The external ASC workflow skills do not currently use these limit flags. Their
+4.4.1 synchronization pull request should still record the plural names as the
+only recommended spellings and must not add singular examples.
+
+## Verification
+
+RED-GREEN coverage spans all four command leaves, valid and invalid canonical
+values, hidden aliases, one-warning behavior, dual-spelling conflicts, and
+opaque-next conflicts. Existing HTTP tests continue to assert the three exact
+JSON:API query keys. Built-binary checks cover canonical help, alias migration,
+conflicts, stdout/stderr separation, and exit code 2 for usage failures.
+
+An alternative was to remove the singular flags immediately. That would break
+stable scripts and violates the CLI lifecycle. Keeping the singular names as
+the documented interface was also rejected because it disagrees with every
+other 4.4.1 relationship-limit flag and with the API resource names.

--- a/internal/cli/cmdtest/subscription_versions_test.go
+++ b/internal/cli/cmdtest/subscription_versions_test.go
@@ -61,8 +61,10 @@ func TestSubscriptionVersionsListJSON(t *testing.T) {
 			t.Fatalf("run error: %v", err)
 		}
 	})
-	if stderr != "" {
-		t.Fatalf("stderr = %q", stderr)
+	wantStderr := "Warning: `--image-limit` is deprecated. Use `--images-limit`.\n" +
+		"Warning: `--localization-limit` is deprecated. Use `--localizations-limit`.\n"
+	if stderr != wantStderr {
+		t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
 	}
 	var payload struct {
 		Data []struct {
@@ -85,7 +87,7 @@ func TestSubscriptionVersionsValidationUsesUsageErrors(t *testing.T) {
 	}{
 		{name: "missing version ID", args: []string{"subscriptions", "versions", "view"}, message: "Error: --id is required"},
 		{name: "invalid state", args: []string{"subscriptions", "versions", "list", "--subscription-id", "123456789", "--state", "UNKNOWN"}, message: "invalid --state"},
-		{name: "invalid relationship limit", args: []string{"subscriptions", "versions", "view", "--id", "ver-1", "--image-limit", "51"}, message: "--image-limit must be between 1 and 50"},
+		{name: "invalid relationship limit", args: []string{"subscriptions", "versions", "view", "--id", "ver-1", "--images-limit", "51"}, message: "--images-limit must be between 1 and 50"},
 		{name: "next query conflict", args: []string{"subscriptions", "versions", "list", "--next", "https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/versions?cursor=next", "--state", "APPROVED"}, message: "--next cannot be combined with --state"},
 		{name: "delete confirm", args: []string{"subscriptions", "versions", "images", "delete", "--id", "img-1"}, message: "Error: --confirm is required"},
 	}

--- a/internal/cli/shared/flag_aliases.go
+++ b/internal/cli/shared/flag_aliases.go
@@ -104,11 +104,11 @@ func (f *DeprecatedIntFlagAlias) String() string {
 
 // Set records that the compatibility spelling was explicitly supplied.
 func (f *DeprecatedIntFlagAlias) Set(value string) error {
-	parsed, err := strconv.Atoi(value)
+	parsed, err := strconv.ParseInt(value, 0, strconv.IntSize)
 	if err != nil {
 		return err
 	}
-	f.value = parsed
+	f.value = int(parsed)
 	f.set = true
 	return nil
 }

--- a/internal/cli/shared/flag_aliases.go
+++ b/internal/cli/shared/flag_aliases.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -77,6 +78,84 @@ func (f *DeprecatedStringFlagAlias) canonicalWasSet() bool {
 	set := false
 	f.flagSet.Visit(func(flag *flag.Flag) {
 		if flag.Name == f.canonicalName {
+			set = true
+		}
+	})
+	return set
+}
+
+// DeprecatedIntFlagAlias holds a hidden compatibility spelling for a
+// canonical integer flag and records whether callers supplied it.
+type DeprecatedIntFlagAlias struct {
+	value         int
+	set           bool
+	flagSet       *flag.FlagSet
+	aliasName     string
+	canonicalName string
+}
+
+// String returns the compatibility flag value for flag.Value formatting.
+func (f *DeprecatedIntFlagAlias) String() string {
+	if f == nil {
+		return "0"
+	}
+	return strconv.Itoa(f.value)
+}
+
+// Set records that the compatibility spelling was explicitly supplied.
+func (f *DeprecatedIntFlagAlias) Set(value string) error {
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	f.value = parsed
+	f.set = true
+	return nil
+}
+
+// BindDeprecatedIntFlagAlias accepts a compatibility spelling without
+// advertising it as part of the command's canonical interface.
+func BindDeprecatedIntFlagAlias(fs *flag.FlagSet, aliasName, canonicalName string) *DeprecatedIntFlagAlias {
+	alias := &DeprecatedIntFlagAlias{
+		flagSet:       fs,
+		aliasName:     strings.TrimSpace(aliasName),
+		canonicalName: strings.TrimSpace(canonicalName),
+	}
+	fs.Var(alias, alias.aliasName, fmt.Sprintf("DEPRECATED: use --%s", alias.canonicalName))
+	HideFlagFromHelp(fs.Lookup(alias.aliasName))
+	return alias
+}
+
+// Apply copies a supplied alias into the canonical value, warns about the
+// migration path, and rejects dual spelling before command side effects.
+func (f *DeprecatedIntFlagAlias) Apply(canonical *int) error {
+	if f == nil || !f.set {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Warning: `--%s` is deprecated. Use `--%s`.\n", f.aliasName, f.canonicalName)
+	if f.canonicalWasSet() {
+		return UsageErrorf("--%s conflicts with --%s; use only --%s", f.aliasName, f.canonicalName, f.canonicalName)
+	}
+	if canonical != nil {
+		*canonical = f.value
+	}
+	return nil
+}
+
+// WasProvided reports whether the compatibility spelling was explicitly set.
+func (f *DeprecatedIntFlagAlias) WasProvided() bool {
+	return f != nil && f.set
+}
+
+func (f *DeprecatedIntFlagAlias) canonicalWasSet() bool {
+	if f == nil || f.flagSet == nil {
+		return false
+	}
+
+	set := false
+	f.flagSet.Visit(func(parsed *flag.Flag) {
+		if parsed.Name == f.canonicalName {
 			set = true
 		}
 	})

--- a/internal/cli/shared/flag_aliases_test.go
+++ b/internal/cli/shared/flag_aliases_test.go
@@ -89,3 +89,69 @@ func TestBindDeprecatedStringFlagAliasHidesCompatibilityFlag(t *testing.T) {
 		}
 	}
 }
+
+func TestDeprecatedIntFlagAliasApply(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		want         int
+		wantErr      string
+		warningCount int
+		aliasWasSet  bool
+	}{
+		{name: "canonical only", args: []string{"--canonical", "7"}, want: 7},
+		{name: "alias only", args: []string{"--legacy", "8"}, want: 8, warningCount: 1, aliasWasSet: true},
+		{name: "both spellings conflict", args: []string{"--canonical", "9", "--legacy", "9"}, want: 9, wantErr: "--legacy conflicts with --canonical", warningCount: 1, aliasWasSet: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			canonical := fs.Int("canonical", 0, "Canonical value")
+			alias := BindDeprecatedIntFlagAlias(fs, "legacy", "canonical")
+			if err := fs.Parse(test.args); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+
+			_, stderr := captureOutput(t, func() {
+				err := alias.Apply(canonical)
+				if test.wantErr == "" && err != nil {
+					t.Fatalf("Apply() error: %v", err)
+				}
+				if test.wantErr != "" {
+					if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+						t.Fatalf("Apply() error = %v, want containing %q", err, test.wantErr)
+					}
+					if !errors.Is(err, flag.ErrHelp) {
+						t.Fatalf("Apply() error = %v, want usage error", err)
+					}
+				}
+			})
+
+			if *canonical != test.want {
+				t.Fatalf("canonical value = %d, want %d", *canonical, test.want)
+			}
+			if got := strings.Count(stderr, "Warning: `--legacy` is deprecated. Use `--canonical`."); got != test.warningCount {
+				t.Fatalf("warning count = %d, want %d; stderr=%q", got, test.warningCount, stderr)
+			}
+			if got := alias.WasProvided(); got != test.aliasWasSet {
+				t.Fatalf("WasProvided() = %t, want %t", got, test.aliasWasSet)
+			}
+		})
+	}
+}
+
+func TestBindDeprecatedIntFlagAliasHidesCompatibilityFlag(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	_ = fs.Int("canonical", 0, "Canonical value")
+	BindDeprecatedIntFlagAlias(fs, "legacy", "canonical")
+
+	if fs.Lookup("legacy") == nil {
+		t.Fatal("compatibility flag was not registered")
+	}
+	for _, visible := range VisibleHelpFlags(fs) {
+		if visible.Name == "legacy" {
+			t.Fatal("compatibility flag should be hidden from canonical help")
+		}
+	}
+}

--- a/internal/cli/shared/flag_aliases_test.go
+++ b/internal/cli/shared/flag_aliases_test.go
@@ -141,6 +141,56 @@ func TestDeprecatedIntFlagAliasApply(t *testing.T) {
 	}
 }
 
+func TestDeprecatedIntFlagAliasParsingMatchesCanonical(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		want      int
+		wantError bool
+	}{
+		{name: "decimal", value: "42", want: 42},
+		{name: "octal", value: "0664", want: 436},
+		{name: "hexadecimal", value: "0x10", want: 16},
+		{name: "negative hexadecimal", value: "-0x10", want: -16},
+		{name: "invalid octal", value: "08", wantError: true},
+		{name: "invalid text", value: "invalid", wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			canonical := fs.Int("canonical", 0, "Canonical value")
+			alias := BindDeprecatedIntFlagAlias(fs, "legacy", "canonical")
+
+			err := fs.Parse([]string{"--legacy", test.value})
+			if test.wantError {
+				if err == nil {
+					t.Fatal("Parse() error = nil, want invalid integer error")
+				}
+				if alias.WasProvided() {
+					t.Fatal("WasProvided() = true after invalid alias value")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+
+			captureOutput(t, func() {
+				if err := alias.Apply(canonical); err != nil {
+					t.Fatalf("Apply() error: %v", err)
+				}
+			})
+			if *canonical != test.want {
+				t.Fatalf("canonical value = %d, want %d", *canonical, test.want)
+			}
+			if !alias.WasProvided() {
+				t.Fatal("WasProvided() = false after valid alias value")
+			}
+		})
+	}
+}
+
 func TestBindDeprecatedIntFlagAliasHidesCompatibilityFlag(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	_ = fs.Int("canonical", 0, "Canonical value")

--- a/internal/cli/subscriptions/relationship_limit_flags_test.go
+++ b/internal/cli/subscriptions/relationship_limit_flags_test.go
@@ -1,0 +1,234 @@
+package subscriptions
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type relationshipLimitCommandCase struct {
+	name      string
+	command   func() *ffcli.Command
+	baseArgs  []string
+	canonical []string
+	legacy    []string
+}
+
+func relationshipLimitCommandCases() []relationshipLimitCommandCase {
+	return []relationshipLimitCommandCase{
+		{
+			name: "subscriptions list", command: SubscriptionsListCommand,
+			baseArgs:  []string{"--group-id", "group-1"},
+			canonical: []string{"versions-limit"}, legacy: []string{"version-limit"},
+		},
+		{
+			name: "subscriptions view", command: SubscriptionsGetCommand,
+			baseArgs:  []string{"--id", "sub-1"},
+			canonical: []string{"versions-limit"}, legacy: []string{"version-limit"},
+		},
+		{
+			name: "subscription versions list", command: SubscriptionsVersionsListCommand,
+			baseArgs:  []string{"--subscription-id", "sub-1"},
+			canonical: []string{"images-limit", "localizations-limit"}, legacy: []string{"image-limit", "localization-limit"},
+		},
+		{
+			name: "subscription versions view", command: SubscriptionsVersionsViewCommand,
+			baseArgs:  []string{"--id", "version-1"},
+			canonical: []string{"images-limit", "localizations-limit"}, legacy: []string{"image-limit", "localization-limit"},
+		},
+	}
+}
+
+func captureRelationshipLimitStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stderr = writer
+	defer func() { os.Stderr = old }()
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, reader)
+		_ = reader.Close()
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = writer.Close()
+	return <-done
+}
+
+func TestSubscriptionRelationshipLimitsExposePluralCanonicalFlags(t *testing.T) {
+	for _, test := range relationshipLimitCommandCases() {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.command()
+			usage := shared.DefaultUsageFunc(cmd)
+			for index, canonical := range test.canonical {
+				legacy := test.legacy[index]
+				if cmd.FlagSet.Lookup(canonical) == nil {
+					t.Fatalf("expected --%s", canonical)
+				}
+				if !strings.Contains(usage, "--"+canonical) {
+					t.Fatalf("canonical help does not contain --%s: %q", canonical, usage)
+				}
+				if cmd.FlagSet.Lookup(legacy) == nil {
+					t.Fatalf("expected hidden compatibility --%s", legacy)
+				}
+				if strings.Contains(usage, "--"+legacy) {
+					t.Fatalf("canonical help exposes deprecated --%s: %q", legacy, usage)
+				}
+			}
+		})
+	}
+}
+
+func TestSubscriptionRelationshipLimitsCanonicalFlagsReachClientSetup(t *testing.T) {
+	isolateSubscriptionsAuthEnv(t)
+	for _, test := range relationshipLimitCommandCases() {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.command()
+			args := append([]string{}, test.baseArgs...)
+			for index, canonical := range test.canonical {
+				args = append(args, "--"+canonical, string(rune('7'+index)))
+			}
+			if err := cmd.FlagSet.Parse(args); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			stderr := captureRelationshipLimitStderr(t, func() {
+				err := cmd.Exec(context.Background(), nil)
+				if err == nil {
+					t.Fatal("expected isolated client setup to fail")
+				}
+				if errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("canonical flags failed usage validation: %v", err)
+				}
+			})
+			if strings.Contains(stderr, "deprecated") {
+				t.Fatalf("canonical flags emitted a deprecation warning: %q", stderr)
+			}
+		})
+	}
+}
+
+func TestSubscriptionRelationshipLimitAliasesWarnOnce(t *testing.T) {
+	isolateSubscriptionsAuthEnv(t)
+	for _, test := range relationshipLimitCommandCases() {
+		for index, legacy := range test.legacy {
+			canonical := test.canonical[index]
+			t.Run(test.name+" "+legacy, func(t *testing.T) {
+				cmd := test.command()
+				args := append(append([]string{}, test.baseArgs...), "--"+legacy, "7")
+				if err := cmd.FlagSet.Parse(args); err != nil {
+					t.Fatalf("Parse() error: %v", err)
+				}
+				stderr := captureRelationshipLimitStderr(t, func() {
+					err := cmd.Exec(context.Background(), nil)
+					if err == nil {
+						t.Fatal("expected isolated client setup to fail")
+					}
+					if errors.Is(err, flag.ErrHelp) {
+						t.Fatalf("deprecated alias failed transition validation: %v", err)
+					}
+				})
+				warning := "Warning: `--" + legacy + "` is deprecated. Use `--" + canonical + "`."
+				if got := strings.Count(stderr, warning); got != 1 {
+					t.Fatalf("warning count = %d, want 1; stderr=%q", got, stderr)
+				}
+			})
+		}
+	}
+}
+
+func TestSubscriptionRelationshipLimitAliasesConflictWithCanonicalFlags(t *testing.T) {
+	for _, test := range relationshipLimitCommandCases() {
+		for index, legacy := range test.legacy {
+			canonical := test.canonical[index]
+			t.Run(test.name+" "+legacy, func(t *testing.T) {
+				cmd := test.command()
+				args := append(append([]string{}, test.baseArgs...), "--"+canonical, "7", "--"+legacy, "7")
+				if err := cmd.FlagSet.Parse(args); err != nil {
+					t.Fatalf("Parse() error: %v", err)
+				}
+				stderr := captureRelationshipLimitStderr(t, func() {
+					err := cmd.Exec(context.Background(), nil)
+					if !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "--"+legacy+" conflicts with --"+canonical) {
+						t.Fatalf("Exec() error = %v, want alias conflict usage error", err)
+					}
+				})
+				if got := strings.Count(stderr, "Warning: `--"+legacy+"` is deprecated."); got != 1 {
+					t.Fatalf("warning count = %d, want 1; stderr=%q", got, stderr)
+				}
+			})
+		}
+	}
+}
+
+func TestSubscriptionRelationshipLimitsRejectInvalidCanonicalValues(t *testing.T) {
+	for _, test := range relationshipLimitCommandCases() {
+		for _, canonical := range test.canonical {
+			t.Run(test.name+" "+canonical, func(t *testing.T) {
+				cmd := test.command()
+				args := append(append([]string{}, test.baseArgs...), "--"+canonical, "51")
+				if err := cmd.FlagSet.Parse(args); err != nil {
+					t.Fatalf("Parse() error: %v", err)
+				}
+				err := cmd.Exec(context.Background(), nil)
+				if !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "--"+canonical+" must be between 1 and 50") {
+					t.Fatalf("Exec() error = %v, want canonical range usage error", err)
+				}
+			})
+		}
+	}
+}
+
+func TestSubscriptionRelationshipLimitAliasesConflictWithOpaqueNext(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   func() *ffcli.Command
+		legacy    string
+		canonical string
+	}{
+		{name: "subscription versions", command: SubscriptionsListCommand, legacy: "version-limit", canonical: "versions-limit"},
+		{name: "version images", command: SubscriptionsVersionsListCommand, legacy: "image-limit", canonical: "images-limit"},
+		{name: "version localizations", command: SubscriptionsVersionsListCommand, legacy: "localization-limit", canonical: "localizations-limit"},
+	}
+	for _, test := range tests {
+		for _, spelling := range []struct {
+			name         string
+			flag         string
+			warningCount int
+		}{
+			{name: "canonical", flag: test.canonical},
+			{name: "deprecated alias", flag: test.legacy, warningCount: 1},
+		} {
+			t.Run(test.name+" "+spelling.name, func(t *testing.T) {
+				cmd := test.command()
+				if err := cmd.FlagSet.Parse([]string{"--next", "https://api.appstoreconnect.apple.com/v1/example?cursor=next", "--" + spelling.flag, "7"}); err != nil {
+					t.Fatalf("Parse() error: %v", err)
+				}
+				stderr := captureRelationshipLimitStderr(t, func() {
+					err := cmd.Exec(context.Background(), nil)
+					if !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "--next cannot be combined with --"+test.canonical) {
+						t.Fatalf("Exec() error = %v, want canonical opaque-next conflict", err)
+					}
+				})
+				if got := strings.Count(stderr, "Warning: `--"+test.legacy+"` is deprecated."); got != spelling.warningCount {
+					t.Fatalf("warning count = %d, want %d; stderr=%q", got, spelling.warningCount, stderr)
+				}
+			})
+		}
+	}
+}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -443,7 +443,8 @@ func SubscriptionsListCommand() *ffcli.Command {
 	fields := fs.String("fields", "", "Sparse fields for subscriptions")
 	versionFields := fs.String("version-fields", "", "Sparse fields for included subscriptionVersions")
 	include := fs.String("include", "", "Include relationships (supports versions)")
-	versionLimit := fs.Int("version-limit", 0, "Maximum included versions (1-50)")
+	versionsLimit := fs.Int("versions-limit", 0, "Maximum included versions (1-50)")
+	legacyVersionLimit := shared.BindDeprecatedIntFlagAlias(fs, "version-limit", "versions-limit")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -457,11 +458,15 @@ func SubscriptionsListCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions list --group-id "GROUP_ID"
+  asc subscriptions list --group-id "GROUP_ID" --include versions --versions-limit 10
   asc subscriptions list --group-id "GROUP_ID" --paginate
   asc subscriptions list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := legacyVersionLimit.Apply(versionsLimit); err != nil {
+				return err
+			}
 			if err := rejectUnexpectedArgs(args); err != nil {
 				return err
 			}
@@ -471,7 +476,7 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions list: %w", err)
 			}
-			if err := validateRelationshipLimit("--version-limit", *versionLimit); err != nil {
+			if err := validateRelationshipLimit("--versions-limit", *versionsLimit); err != nil {
 				return err
 			}
 
@@ -491,7 +496,7 @@ Examples:
 				flagConflict{"--fields", flagWasProvided(fs, "fields")},
 				flagConflict{"--version-fields", flagWasProvided(fs, "version-fields")},
 				flagConflict{"--include", flagWasProvided(fs, "include")},
-				flagConflict{"--version-limit", flagWasProvided(fs, "version-limit")},
+				flagConflict{"--versions-limit", flagWasProvided(fs, "versions-limit") || legacyVersionLimit.WasProvided()},
 				flagConflict{"--limit", flagWasProvided(fs, "limit")},
 			); err != nil {
 				return err
@@ -512,8 +517,8 @@ Examples:
 			if appFlag != "" || (id == "" && nextURL == "") {
 				resolvedAppID = shared.ResolveAppID(*appID)
 			}
-			if resolvedAppID != "" && (strings.TrimSpace(*fields) != "" || strings.TrimSpace(*versionFields) != "" || strings.TrimSpace(*include) != "" || *versionLimit != 0) {
-				return shared.UsageError("--fields, --version-fields, --include, and --version-limit require --group-id")
+			if resolvedAppID != "" && (strings.TrimSpace(*fields) != "" || strings.TrimSpace(*versionFields) != "" || strings.TrimSpace(*include) != "" || *versionsLimit != 0) {
+				return shared.UsageError("--fields, --version-fields, --include, and --versions-limit require --group-id")
 			}
 			if id == "" && resolvedAppID == "" && nextURL == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id or --app is required (or set ASC_APP_ID)")
@@ -542,7 +547,7 @@ Examples:
 				asc.WithSubscriptionsFields(fieldValues),
 				asc.WithSubscriptionsVersionFields(versionFieldValues),
 				asc.WithSubscriptionsInclude(includeValues),
-				asc.WithSubscriptionsVersionLimit(*versionLimit),
+				asc.WithSubscriptionsVersionLimit(*versionsLimit),
 			}
 
 			if *paginate {
@@ -709,7 +714,8 @@ func SubscriptionsGetCommand() *ffcli.Command {
 	fields := fs.String("fields", "", "Sparse fields for subscriptions")
 	versionFields := fs.String("version-fields", "", "Sparse fields for included subscriptionVersions")
 	include := fs.String("include", "", "Include relationships (supports versions)")
-	versionLimit := fs.Int("version-limit", 0, "Maximum included versions (1-50)")
+	versionsLimit := fs.Int("versions-limit", 0, "Maximum included versions (1-50)")
+	legacyVersionLimit := shared.BindDeprecatedIntFlagAlias(fs, "version-limit", "versions-limit")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -719,10 +725,14 @@ func SubscriptionsGetCommand() *ffcli.Command {
 		LongHelp: `View a subscription by ID.
 
 Examples:
-  asc subscriptions view --id "SUB_ID"`,
+  asc subscriptions view --id "SUB_ID"
+  asc subscriptions view --id "SUB_ID" --include versions --versions-limit 10`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := legacyVersionLimit.Apply(versionsLimit); err != nil {
+				return err
+			}
 			if err := rejectUnexpectedArgs(args); err != nil {
 				return err
 			}
@@ -734,7 +744,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError()
 			}
-			if err := validateRelationshipLimit("--version-limit", *versionLimit); err != nil {
+			if err := validateRelationshipLimit("--versions-limit", *versionsLimit); err != nil {
 				return err
 			}
 			fieldValues, err := normalizeSelectionFlag(fs, *fields, "--fields", subscriptionFieldsList())
@@ -763,7 +773,7 @@ Examples:
 				asc.WithSubscriptionFields(fieldValues),
 				asc.WithSubscriptionIncludedVersionFields(versionFieldValues),
 				asc.WithSubscriptionInclude(includeValues),
-				asc.WithSubscriptionVersionLimit(*versionLimit),
+				asc.WithSubscriptionVersionLimit(*versionsLimit),
 			)
 			if err != nil {
 				return fmt.Errorf("subscriptions view: failed to fetch: %w", err)

--- a/internal/cli/subscriptions/versions.go
+++ b/internal/cli/subscriptions/versions.go
@@ -111,8 +111,10 @@ func SubscriptionsVersionsListCommand() *ffcli.Command {
 	imageFields := fs.String("image-fields", "", "Sparse fields for included subscriptionImages")
 	localizationFields := fs.String("localization-fields", "", "Sparse fields for included subscriptionLocalizations")
 	include := fs.String("include", "", "Include relationships: subscription,image,images,localizations")
-	imageLimit := fs.Int("image-limit", 0, "Maximum included images (1-50)")
-	localizationLimit := fs.Int("localization-limit", 0, "Maximum included localizations (1-50)")
+	imagesLimit := fs.Int("images-limit", 0, "Maximum included images (1-50)")
+	legacyImageLimit := shared.BindDeprecatedIntFlagAlias(fs, "image-limit", "images-limit")
+	localizationsLimit := fs.Int("localizations-limit", 0, "Maximum included localizations (1-50)")
+	legacyLocalizationLimit := shared.BindDeprecatedIntFlagAlias(fs, "localization-limit", "localizations-limit")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages")
@@ -123,9 +125,16 @@ func SubscriptionsVersionsListCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions versions list --subscription-id "SUBSCRIPTION_ID"
-  asc subscriptions versions list --subscription-id "SUBSCRIPTION_ID" --state PREPARE_FOR_SUBMISSION --include localizations`,
+  asc subscriptions versions list --subscription-id "SUBSCRIPTION_ID" --state PREPARE_FOR_SUBMISSION --include localizations --localizations-limit 10
+  asc subscriptions versions list --subscription-id "SUBSCRIPTION_ID" --include images --images-limit 10`,
 		FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := legacyImageLimit.Apply(imagesLimit); err != nil {
+				return err
+			}
+			if err := legacyLocalizationLimit.Apply(localizationsLimit); err != nil {
+				return err
+			}
 			if err := rejectUnexpectedArgs(args); err != nil {
 				return err
 			}
@@ -139,13 +148,13 @@ Examples:
 				flagConflict{"--image-fields", flagWasProvided(fs, "image-fields")},
 				flagConflict{"--localization-fields", flagWasProvided(fs, "localization-fields")},
 				flagConflict{"--include", flagWasProvided(fs, "include")},
-				flagConflict{"--image-limit", flagWasProvided(fs, "image-limit")},
-				flagConflict{"--localization-limit", flagWasProvided(fs, "localization-limit")},
+				flagConflict{"--images-limit", flagWasProvided(fs, "images-limit") || legacyImageLimit.WasProvided()},
+				flagConflict{"--localizations-limit", flagWasProvided(fs, "localizations-limit") || legacyLocalizationLimit.WasProvided()},
 				flagConflict{"--limit", flagWasProvided(fs, "limit")},
 			); err != nil {
 				return err
 			}
-			if err := validateVersionListLimits(*limit, *imageLimit, *localizationLimit); err != nil {
+			if err := validateVersionListLimits(*limit, *imagesLimit, *localizationsLimit); err != nil {
 				return err
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
@@ -202,7 +211,7 @@ Examples:
 				asc.WithSubscriptionVersionsImageFields(imageFieldValues),
 				asc.WithSubscriptionVersionsLocalizationFields(localizationFieldValues),
 				asc.WithSubscriptionVersionsInclude(includeValues),
-				asc.WithSubscriptionVersionsImageLimit(*imageLimit), asc.WithSubscriptionVersionsLocalizationLimit(*localizationLimit),
+				asc.WithSubscriptionVersionsImageLimit(*imagesLimit), asc.WithSubscriptionVersionsLocalizationLimit(*localizationsLimit),
 			}
 			resp, err := client.GetSubscriptionVersions(requestCtx, id, opts...)
 			if err != nil {
@@ -231,13 +240,25 @@ func SubscriptionsVersionsViewCommand() *ffcli.Command {
 	imageFields := fs.String("image-fields", "", "Sparse fields for included subscriptionImages")
 	localizationFields := fs.String("localization-fields", "", "Sparse fields for included subscriptionLocalizations")
 	include := fs.String("include", "", "Include relationships: subscription,image,images,localizations")
-	imageLimit := fs.Int("image-limit", 0, "Maximum included images (1-50)")
-	localizationLimit := fs.Int("localization-limit", 0, "Maximum included localizations (1-50)")
+	imagesLimit := fs.Int("images-limit", 0, "Maximum included images (1-50)")
+	legacyImageLimit := shared.BindDeprecatedIntFlagAlias(fs, "image-limit", "images-limit")
+	localizationsLimit := fs.Int("localizations-limit", 0, "Maximum included localizations (1-50)")
+	legacyLocalizationLimit := shared.BindDeprecatedIntFlagAlias(fs, "localization-limit", "localizations-limit")
 	output := shared.BindOutputFlags(fs)
 	return &ffcli.Command{
 		Name: "view", ShortUsage: "asc subscriptions versions view --id \"VERSION_ID\"", ShortHelp: "View a subscription version.",
-		LongHelp: "View a subscription version by ID.", FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
+		LongHelp: `View a subscription version by ID.
+
+Examples:
+  asc subscriptions versions view --id "VERSION_ID"
+  asc subscriptions versions view --id "VERSION_ID" --include images,localizations --images-limit 10 --localizations-limit 10`, FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := legacyImageLimit.Apply(imagesLimit); err != nil {
+				return err
+			}
+			if err := legacyLocalizationLimit.Apply(localizationsLimit); err != nil {
+				return err
+			}
 			if err := rejectUnexpectedArgs(args); err != nil {
 				return err
 			}
@@ -246,10 +267,10 @@ func SubscriptionsVersionsViewCommand() *ffcli.Command {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError("--id")
 			}
-			if err := validateRelationshipLimit("--image-limit", *imageLimit); err != nil {
+			if err := validateRelationshipLimit("--images-limit", *imagesLimit); err != nil {
 				return err
 			}
-			if err := validateRelationshipLimit("--localization-limit", *localizationLimit); err != nil {
+			if err := validateRelationshipLimit("--localizations-limit", *localizationsLimit); err != nil {
 				return err
 			}
 			versionFieldValues, err := normalizeSelectionFlag(fs, *fields, "--fields", subscriptionVersionFieldsList())
@@ -285,8 +306,8 @@ func SubscriptionsVersionsViewCommand() *ffcli.Command {
 				asc.WithSubscriptionVersionImageFields(imageFieldValues),
 				asc.WithSubscriptionVersionLocalizationFields(localizationFieldValues),
 				asc.WithSubscriptionVersionInclude(includeValues),
-				asc.WithSubscriptionVersionImageLimit(*imageLimit),
-				asc.WithSubscriptionVersionLocalizationLimit(*localizationLimit),
+				asc.WithSubscriptionVersionImageLimit(*imagesLimit),
+				asc.WithSubscriptionVersionLocalizationLimit(*localizationsLimit),
 			)
 			if err != nil {
 				return fmt.Errorf("subscriptions versions view: failed to fetch: %w", err)
@@ -399,14 +420,14 @@ func validateRelationshipLimit(name string, limit int) error {
 	return nil
 }
 
-func validateVersionListLimits(limit, imageLimit, localizationLimit int) error {
+func validateVersionListLimits(limit, imagesLimit, localizationsLimit int) error {
 	if err := validatePageLimit(limit); err != nil {
 		return err
 	}
-	if err := validateRelationshipLimit("--image-limit", imageLimit); err != nil {
+	if err := validateRelationshipLimit("--images-limit", imagesLimit); err != nil {
 		return err
 	}
-	return validateRelationshipLimit("--localization-limit", localizationLimit)
+	return validateRelationshipLimit("--localizations-limit", localizationsLimit)
 }
 
 type flagConflict struct {


### PR DESCRIPTION
## What changed

- Makes --versions-limit, --images-limit, and --localizations-limit the documented relationship-limit flags for subscription and subscription-version commands.
- Keeps --version-limit, --image-limit, and --localization-limit as hidden deprecated compatibility aliases.
- Each legacy alias prints exactly one migration warning. Using both spellings is a usage error, even when both values match.
- Preserves opaque --next validation and names the canonical plural flag in conflicts.
- Leaves App Store Connect request parameters unchanged: limit[versions], limit[images], and limit[localizations].

Covered leaves: subscriptions list, subscriptions view, subscriptions versions list, and subscriptions versions view.

## Compatibility lifecycle

The singular spellings remain functional, hidden aliases in this release. They warn once and point callers to the plural spelling; they are not removed here. The design note records the transition and expected future removal path.

The external ASC skills currently contain no uses of these flags. The 4.4.1 skills follow-up should document only the canonical plural spellings.

## Verification

Final branch base: 1cc9facee96c7f16297a5561101bccf5fcc314d4

Exact head: ddc18dcbedbd2cf5cab48d759a1347cd0186c3b3

Post-rebase verification:

- make format
- focused relationship-limit and positional-validation tests
- make check-docs
- make lint (0 issues)
- ASC_BYPASS_KEYCHAIN=1 make test
- built the exact head with go build
- manually checked plural help, hidden aliases, exactly-one-warning behavior, dual-spelling conflicts, range errors, opaque-next conflicts, and composition with positional-argument rejection

Before opening this PR, the exact base commit's Main Branch integration, Govulncheck, and CodeQL workflows were all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added canonical plural relationship-limit flags for subscription versions, images, and localizations.
  * Updated subscription versions list and view commands to use the plural flags for limiting returned related resources.

* **Bug Fixes**
  * Kept the previous singular flags as hidden deprecated aliases that still work, emitting a single deprecation warning per use.
  * Improved validation for out-of-range limits, flag conflicts, and incompatible use with the cursor option (`--next`).

* **Documentation**
  * Updated command help/examples to show the new canonical plural flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->