### PR TITLE
fix(iap): restore deprecated submit discovery

### DIFF
--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -41,7 +41,7 @@ Examples:
   asc iap offer-codes create --iap-id "IAP_ID" --name "SPRING" --prices "USA:PRICE_POINT_ID"
   asc iap promoted-purchases create --app "APP_ID" --product-id "IAP_ID" --visible-for-all-users true`,
 		FlagSet:   fs,
-		UsageFunc: shared.VisibleUsageFunc,
+		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			IAPListCommand(),
 			IAPVersionsCommand(),

--- a/internal/cli/iap/legacy_4_4_1_deprecation_test.go
+++ b/internal/cli/iap/legacy_4_4_1_deprecation_test.go
@@ -126,6 +126,20 @@ func TestIAP441ParentHelpPromotesVersionScopedResources(t *testing.T) {
 	}
 }
 
+func TestIAP441ParentHelpListsDeprecatedSubmitMigration(t *testing.T) {
+	cmd := IAPCommand()
+	usage := cmd.UsageFunc(cmd)
+	const submitEntry = "\n  submit"
+	const migration = "DEPRECATED: App Store Connect API 4.4.1 replaced this resource. Use `asc review items add --submission \"SUBMISSION_ID\" --item-type inAppPurchaseVersions --item-id \"IAP_VERSION_ID\"`."
+
+	if got := strings.Count(usage, submitEntry); got != 1 {
+		t.Fatalf("submit entry count = %d, want 1; usage = %q", got, usage)
+	}
+	if !strings.Contains(usage, migration) {
+		t.Fatalf("usage = %q, want migration text %q", usage, migration)
+	}
+}
+
 func TestIAPSetupWarnsOnlyForLegacyLocalization(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## What changed

- Render `asc iap --help` with the standard command-group usage function so the deprecated `submit` leaf stays visible during its migration window.
- Add a rendered-help regression that requires one `submit` entry with the exact `asc review items add` replacement command.

## Why

API 4.4.1 marks `asc iap submit` as deprecated, but `VisibleUsageFunc` filtered every deprecated leaf from parent help. The command still ran, yet callers could no longer discover its migration guidance from `asc iap --help`.

No command execution, flags, HTTP behavior, or exit codes changed.

## Verification

- RED before the renderer change: `go test ./internal/cli/iap -run TestIAP441ParentHelpListsDeprecatedSubmitMigration -count=1`
- Focused and adjacent IAP/CLI tests passed.
- `make format`
- `make generate-command-docs` (no generated diff)
- `make check-docs`
- `make lint` (`0 issues`; one unrelated stale-worktree cache warning)
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built the branch binary and confirmed `ASC_BYPASS_KEYCHAIN=1 asc iap --help` prints the deprecated `submit` entry once with the full migration command.

No App Store Connect request was needed because this changes rendered local help only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the in-app purchase command’s help output to display the deprecated submit migration guidance.
  * Clarified the recommended replacement command and submission details for migrating legacy workflows.

* **Tests**
  * Added coverage to ensure the migration guidance appears once in the parent help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->