### PR TITLE
fix(age-rating): reject stale UGC contradiction

### DIFF
--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -318,6 +318,9 @@ func validateAgeRatingDependencies(attrs asc.AgeRatingDeclarationAttributes) err
 	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.SocialMedia) {
 		return shared.UsageError("--social-media-age-restricted true cannot be combined with --social-media false")
 	}
+	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.UserGeneratedContent) {
+		return shared.UsageError("--social-media-age-restricted true cannot be combined with --user-generated-content false")
+	}
 	return nil
 }
 

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -171,6 +171,20 @@ func TestAgeRatingHelpers(t *testing.T) {
 	}
 }
 
+func TestValidateAgeRatingDependenciesRejectsTransitiveUGCContradiction(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	err := validateAgeRatingDependencies(asc.AgeRatingDeclarationAttributes{
+		AgeAssurance:             &trueValue,
+		SocialMediaAgeRestricted: &trueValue,
+		UserGeneratedContent:     &falseValue,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--social-media-age-restricted true cannot be combined with --user-generated-content false") {
+		t.Fatalf("expected transitive user-generated-content dependency error, got %v", err)
+	}
+}
+
 func TestValidateAgeRatingDependenciesAllowsPartialUpdates(t *testing.T) {
 	trueValue := true
 	falseValue := false

--- a/internal/cli/cmdtest/age_rating_4_4_1_test.go
+++ b/internal/cli/cmdtest/age_rating_4_4_1_test.go
@@ -118,6 +118,15 @@ func TestAgeRatingEditRejectsExplicitDependencyContradictions(t *testing.T) {
 			wantErr: "--social-media-age-restricted true cannot be combined with --social-media false",
 		},
 		{
+			name: "age restricted social media with user generated content disabled",
+			args: []string{
+				"age-rating", "edit", "--id", "age-441",
+				"--social-media-age-restricted", "true",
+				"--user-generated-content", "false",
+			},
+			wantErr: "--social-media-age-restricted true cannot be combined with --user-generated-content false",
+		},
+		{
 			name: "all none materializes conflicting false prerequisites",
 			args: []string{
 				"age-rating", "edit", "--id", "age-441",


### PR DESCRIPTION
## Summary

- reject the transitive age-rating contradiction where `--social-media-age-restricted true` is combined with `--user-generated-content false`, even when `--social-media` is omitted
- preserve valid partial updates whose omitted stored prerequisites can still satisfy App Store Connect
- add CLI and direct validator coverage for both omitted and explicitly enabled age-assurance truth-table cells

## Design and compatibility

This stays in the existing `age-rating edit` validator for `PATCH /v1/ageRatingDeclarations/{id}` (`AgeRatingDeclarationUpdateRequest`). The command shape, flags, help, payload, stdout, and successful exit behavior do not change. The contradictory invocation now fails before auth or HTTP with usage exit code 2.

Fetching server state before validation was considered, but is unnecessary and would add a read side effect. Because age-restricted social media requires social media, and social media requires user-generated content, explicit `userGeneratedContent=false` is contradictory for every possible stored `socialMedia` value.

## TDD evidence

- RED: focused CLI regression expected usage exit 2 but reached auth and exited 3
- GREEN: `ASC_BYPASS_KEYCHAIN=1 GOCACHE=/private/tmp/asc-go-cache go test ./internal/cli/agerating ./internal/cli/cmdtest -run 'TestValidateAgeRatingDependenciesRejectsTransitiveUGCContradiction|TestAgeRatingEditRejectsExplicitDependencyContradictions' -count=1`
- built binary: contradictory invocation exits 2 with `--social-media-age-restricted true cannot be combined with --user-generated-content false`
- repository gates: `make format`, `make check-docs`, `make lint`, and `make test` passed (the sandboxed test run could not bind an `httptest` loopback port; the unrestricted rerun passed)

Follow-up to unresolved review thread `PRRT_kwDOQ9ePjM6RpA1w` on #1782. This PR intentionally does not resolve that historical thread.
