### PR TITLE
test(subscriptions): cover localization delete confirmation

### DIFF
--- a/internal/cli/cmdtest/subscription_version_localization_delete_confirm_test.go
+++ b/internal/cli/cmdtest/subscription_version_localization_delete_confirm_test.go
@@ -1,0 +1,49 @@
+package cmdtest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestSubscriptionVersionLocalizationDeleteRequiresConfirmBeforeAuthOrHTTP(t *testing.T) {
+	clearSubscriptionVersionAuth(t)
+
+	clientFactoryCalled := false
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientFactoryCalled = true
+		return nil, errors.New("client factory must not run before confirmation")
+	})
+	t.Cleanup(restore)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"subscriptions", "versions", "localizations", "delete",
+			"--id", "loc-1",
+		}, "1.2.3")
+		if code != rootcmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.HasPrefix(stderr, "Error: --confirm is required\n") {
+		t.Fatalf("stderr = %q, want missing-confirm diagnostic first", stderr)
+	}
+	if strings.Count(stderr, "Error: --confirm is required\n") != 1 {
+		t.Fatalf("stderr = %q, want one missing-confirm diagnostic", stderr)
+	}
+	const usage = "USAGE\n  asc subscriptions versions localizations delete --id \"LOCALIZATION_ID\" --confirm\n"
+	if strings.Count(stderr, usage) != 1 {
+		t.Fatalf("stderr = %q, want command usage once", stderr)
+	}
+	if clientFactoryCalled {
+		t.Fatal("authenticated client factory ran before confirmation")
+	}
+}

--- a/internal/cli/cmdtest/subscription_version_localization_delete_confirm_test.go
+++ b/internal/cli/cmdtest/subscription_version_localization_delete_confirm_test.go
@@ -40,8 +40,11 @@ func TestSubscriptionVersionLocalizationDeleteRequiresConfirmBeforeAuthOrHTTP(t 
 		t.Fatalf("stderr = %q, want one missing-confirm diagnostic", stderr)
 	}
 	const usage = "USAGE\n  asc subscriptions versions localizations delete --id \"LOCALIZATION_ID\" --confirm\n"
-	if strings.Count(stderr, usage) != 1 {
-		t.Fatalf("stderr = %q, want command usage once", stderr)
+	if strings.Count(stderr, "USAGE\n") != 1 {
+		t.Fatalf("stderr = %q, want one usage block", stderr)
+	}
+	if !strings.Contains(stderr, usage) {
+		t.Fatalf("stderr = %q, want localization-delete usage", stderr)
 	}
 	if clientFactoryCalled {
 		t.Fatal("authenticated client factory ran before confirmation")


### PR DESCRIPTION
## Summary

- add CLI-level regression coverage for subscriptions versions localizations delete without --confirm
- assert exit code 2, empty stdout, one missing-confirm diagnostic, and one command usage block
- prove validation stops before authenticated client creation and therefore before HTTP deletion

## Behavior characterized

The existing implementation is correct, so this is characterization coverage rather than a production fix. The built CLI returns exit code 2, prints Error: --confirm is required followed by the command usage, and does not resolve authentication or perform HTTP work.

## Alternatives considered

- A leaf-command unit test would be smaller, but would not cover root-runner exit and usage rendering.
- Changing production code was unnecessary because the requested behavior already works.

## Verification

- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run ^TestSubscriptionVersionLocalizationDeleteRequiresConfirmBeforeAuthOrHTTP$ -count=1
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run SubscriptionVersion\|SubscriptionGroupVersion -count=1
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/subscriptions -count=1
- make format
- make check-docs
- make lint
- make build
- ASC_BYPASS_KEYCHAIN=1 make test

No live App Store Connect mutation was needed or performed because this PR only adds local validation coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CLI coverage to ensure `subscriptions versions localizations delete` fails with `rootcmd.ExitUsage` when `--confirm` is omitted.
  * Verified the command emits the expected single error (`--confirm is required`) along with the correct usage guidance.
  * Confirmed execution stops before any authentication or network activity occurs when confirmation is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->