### PR TITLE
docs(commands): harden API 4.4.1 workflows

### DIFF
--- a/commands/age-rating.mdx
+++ b/commands/age-rating.mdx
@@ -1,0 +1,118 @@
+# Age Ratings
+
+> View and update App Store age rating declarations
+
+The `age-rating` command manages the declaration associated with an app, app
+info, or App Store version.
+
+## View a Declaration
+
+Identify the declaration through one app-scoped target:
+
+```bash  theme={null}
+asc age-rating view --app "APP_ID"
+asc age-rating view --app-info-id "APP_INFO_ID"
+asc age-rating view --version-id "APP_STORE_VERSION_ID"
+```
+
+Use `--output json`, `--output table`, or `--output markdown`. Add `--pretty`
+when using JSON interactively. Only one of `--app-info-id` and `--version-id`
+may be supplied; use `--app` when neither direct relationship ID is known.
+
+## Update a Declaration
+
+Target the declaration directly or let the CLI resolve it from the app, app
+info, or version:
+
+```bash  theme={null}
+asc age-rating edit --id "DECLARATION_ID" --gambling false
+asc age-rating edit --app "APP_ID" --kids-age-band FIVE_AND_UNDER
+asc age-rating edit --app-info-id "APP_INFO_ID" --loot-box false
+asc age-rating edit --version-id "APP_STORE_VERSION_ID" --advertising true
+```
+
+Every update flag is sparse: omitted values remain unchanged. Boolean fields
+take explicit `true` or `false`. Common content-frequency fields accept
+`NONE`, `INFREQUENT_OR_MILD`, or `FREQUENT_OR_INTENSE`.
+
+To declare that an app has none of the listed content, reset the declaration to
+safe defaults and then add any exceptions in the same request:
+
+```bash  theme={null}
+asc age-rating edit \
+  --app "APP_ID" \
+  --all-none \
+  --unrestricted-web-access true
+```
+
+## Social Media Fields (API 4.4.1)
+
+App Store Connect API 4.4.1 adds two declaration attributes exposed as these
+flags:
+
+* `--social-media` - The app contains social media features
+* `--social-media-age-restricted` - Those social media features are restricted
+  by age
+
+Apple enforces dependencies that are stricter than the two fields in
+isolation:
+
+* `--social-media true` requires `--user-generated-content true`.
+* `--social-media-age-restricted true` requires `--age-assurance true` and
+  `--social-media true`.
+* Because social media itself requires user-generated content, a complete
+  age-restricted update includes all four true flags.
+
+```bash  theme={null}
+# Enable social media
+asc age-rating edit \
+  --app "APP_ID" \
+  --social-media true \
+  --user-generated-content true
+
+# Enable age-restricted social media with every prerequisite
+asc age-rating edit \
+  --app "APP_ID" \
+  --social-media-age-restricted true \
+  --age-assurance true \
+  --social-media true \
+  --user-generated-content true
+```
+
+Include the prerequisite flags when enabling these attributes unless the
+current declaration already stores them as true. The CLI rejects combinations
+that are provably contradictory before making an HTTP request. When disabling
+a prerequisite, also disable the dependent fields in the same request:
+
+```bash  theme={null}
+asc age-rating edit \
+  --app "APP_ID" \
+  --social-media-age-restricted false \
+  --social-media false \
+  --user-generated-content false
+```
+
+After an update, read the declaration again to verify the stored combination:
+
+```bash  theme={null}
+asc age-rating view --app "APP_ID" --output json --pretty
+```
+
+## Other Update Fields
+
+The command also supports:
+
+* Booleans: `--advertising`, `--age-assurance`, `--gambling`,
+  `--health-or-wellness-topics`, `--loot-box`, `--messaging-and-chat`,
+  `--parental-controls`, `--unrestricted-web-access`, and
+  `--user-generated-content`
+* Content frequencies: `--alcohol-tobacco-drug-use`, `--contests`,
+  `--gambling-simulated`, `--guns-or-other-weapons`, `--horror-fear`,
+  `--mature-suggestive`, `--medical-treatment`, `--profanity-humor`, the
+  sexual-content fields, and the violence fields
+* Overrides: `--age-rating-override-v2`, `--korea-age-rating-override`,
+  `--kids-age-band`, and `--developer-age-rating-info-url`
+
+`--age-rating-override` is deprecated. Use `--age-rating-override-v2` for new
+automation, and run `asc age-rating edit --help` for the current accepted enum
+values before scripting an override.

--- a/commands/iap.mdx
+++ b/commands/iap.mdx
@@ -619,7 +619,10 @@ echo "Submitted IAP $IAP_ID using version $IAP_VERSION_ID"
 The workflow deliberately stops when several versions or same-locale resources
 exist. Select the intended IDs and resume rather than creating replacements.
 Image and review-screenshot uploads are writes; on a retry, inspect the current
-resources first and skip an upload that already succeeded.
+resources first and skip an upload that already succeeded. Price-schedule
+creation is also an unconditional write: if the script stops after that command
+succeeds, resume at step 6 instead of restarting the script and creating a
+second schedule.
 
 ### Bulk Update Availability
 

--- a/commands/iap.mdx
+++ b/commands/iap.mdx
@@ -71,6 +71,10 @@ commands for new automation.
 asc iap versions list --iap-id "IAP_ID"
 asc iap versions create --iap-id "IAP_ID"
 asc iap versions view --version-id "IAP_VERSION_ID"
+asc iap versions links versions --iap-id "IAP_ID"
+asc iap versions links image --version-id "IAP_VERSION_ID"
+asc iap versions links images --version-id "IAP_VERSION_ID"
+asc iap versions links localizations --version-id "IAP_VERSION_ID"
 asc iap versions localizations list --version-id "IAP_VERSION_ID"
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
 asc iap versions images create --version-id "IAP_VERSION_ID" --file ./promotional.png
@@ -78,9 +82,26 @@ asc iap versions submit --version-id "IAP_VERSION_ID" --submission "REVIEW_SUBMI
 ```
 
 Use the version ID—not the product ID—for v2 localization, image, and review
-submission operations. Update commands distinguish omitted fields, explicit
-values, and explicit clears; use the documented `--clear-*` flags to send JSON
-`null` rather than an empty string.
+submission operations.
+
+<Warning>
+  Resolve and reuse an existing version before running `versions create`.
+  Apple exposes no DELETE operation for IAP versions, and deleting the parent
+  product does not reliably remove a version. An unnecessary create can leave
+  an orphan that the CLI cannot clean up.
+</Warning>
+
+Handle the list result explicitly: create only when it contains zero versions,
+reuse the returned ID when it contains exactly one, and require the operator to
+choose an intended version when it contains more than one. Check the selected
+version's state before changing its metadata; do not guess by taking the first
+array element.
+
+Update commands distinguish omitted fields, explicit values, and explicit
+clears. Although the OpenAPI request schema permits an empty or nullable
+description, the live App Store Connect service rejects both an empty string
+and JSON `null` for IAP-version localization descriptions. Always send a
+non-empty `--description`; do not use `--clear-description` in live workflows.
 
 ## Create In-App Purchase
 
@@ -225,6 +246,12 @@ Manage in-app purchase localizations for different languages and regions. First
 create or resolve an IAP version, then pass its version ID to these commands.
 The product-scoped `asc iap localizations ...` commands are deprecated.
 
+<Warning>
+  Keep at least one complete localization on the version. App Store Connect
+  rejects deletion of the final required localization. Create its replacement
+  first, verify it, and only then delete an older locale.
+</Warning>
+
 ### List Localizations
 
 ```bash  theme={null}
@@ -255,6 +282,10 @@ asc iap versions localizations update \
   --name "Updated Name" \
   --description "Updated description"
 ```
+
+Descriptions must remain non-empty in live App Store Connect. The CLI exposes
+schema-correct clear encoding, but Apple currently rejects an empty or null
+description for this v2 resource.
 
 ### Delete Localization
 
@@ -289,6 +320,35 @@ asc iap versions images delete --image-id "IMAGE_ID" --confirm
 * Size: 1024 x 1024 pixels
 * Color space: RGB
 * Maximum file size: 4MB
+
+### Raw Version Relationship Links
+
+Use linkage commands when you need relationship IDs without fetching the full
+related resources:
+
+```bash  theme={null}
+# All versions related to an IAP product
+asc iap versions links versions \
+  --iap-id "IAP_ID" \
+  --paginate
+
+# Singular primary-image linkage for a version
+asc iap versions links image \
+  --version-id "IAP_VERSION_ID"
+
+# Plural image and localization linkages for a version
+asc iap versions links images \
+  --version-id "IAP_VERSION_ID" \
+  --paginate
+
+asc iap versions links localizations \
+  --version-id "IAP_VERSION_ID" \
+  --paginate
+```
+
+`versions`, `images`, and `localizations` accept `--limit`, `--next`, and
+`--paginate`. The singular `image` linkage accepts only `--version-id` plus
+output flags.
 
 ### Manage Review Screenshots
 
@@ -436,54 +496,130 @@ asc review submissions-submit \
 
 ## Common Workflows
 
-### Create Complete IAP
+### Create a Complete, Version-Safe IAP
 
 ```bash  theme={null}
 #!/bin/bash
-# Create a fully configured in-app purchase
+set -euo pipefail
 
 APP_ID="123456789"
 PRODUCT_ID="com.example.app.premium"
+PRICE_POINT_ID="PRICE_POINT_ID"
+PROMOTIONAL_IMAGE="./promo.png"
+REVIEW_SCREENSHOT="./review.png"
 
-# 1. Create IAP
-IAP_RESPONSE=$(asc iap create \
-  --app "$APP_ID" \
-  --type NON_CONSUMABLE \
-  --ref-name "Premium Features" \
-  --product-id "$PRODUCT_ID" \
-  --output json)
+# 1. Resolve the product by exact product ID, or create it once.
+IAP_LIST=$(asc iap list --app "$APP_ID" --paginate --output json)
+IAP_IDS=$(echo "$IAP_LIST" | jq -r --arg product "$PRODUCT_ID" \
+  '.data[] | select(.attributes.productId == $product) | .id')
+IAP_COUNT=$(printf '%s\n' "$IAP_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
 
-IAP_ID=$(echo "$IAP_RESPONSE" | jq -r '.data.id')
+case "$IAP_COUNT" in
+  0)
+    IAP_ID=$(asc iap create \
+      --app "$APP_ID" \
+      --type NON_CONSUMABLE \
+      --ref-name "Premium Features" \
+      --product-id "$PRODUCT_ID" \
+      --output json | jq -r '.data.id')
+    ;;
+  1) IAP_ID="$IAP_IDS" ;;
+  *) echo "Multiple IAPs matched $PRODUCT_ID; choose one explicitly." >&2; exit 1 ;;
+esac
 
-# 2. Create the review-content version
-IAP_VERSION_RESPONSE=$(asc iap versions create \
+# 2. Reuse the sole version. Create only when none exists; never guess when
+# several versions exist because Apple provides no version DELETE endpoint.
+VERSION_LIST=$(asc iap versions list \
   --iap-id "$IAP_ID" \
+  --paginate \
   --output json)
+VERSION_COUNT=$(echo "$VERSION_LIST" | jq '.data | length')
 
-IAP_VERSION_ID=$(echo "$IAP_VERSION_RESPONSE" | jq -r '.data.id')
+case "$VERSION_COUNT" in
+  0)
+    IAP_VERSION_ID=$(asc iap versions create \
+      --iap-id "$IAP_ID" \
+      --output json | jq -r '.data.id')
+    ;;
+  1) IAP_VERSION_ID=$(echo "$VERSION_LIST" | jq -r '.data[0].id') ;;
+  *) echo "Multiple IAP versions exist; choose the intended editable ID." >&2; exit 1 ;;
+esac
 
-# 3. Add version-scoped localization
-asc iap versions localizations create \
+VERSION_STATE=$(asc iap versions view \
   --version-id "$IAP_VERSION_ID" \
-  --locale "en-US" \
-  --name "Premium Features" \
-  --description "Unlock all premium features"
+  --output json | jq -r '.data.attributes.state')
+test "$VERSION_STATE" = "PREPARE_FOR_SUBMISSION" || {
+  echo "Version $IAP_VERSION_ID is not editable: $VERSION_STATE" >&2
+  exit 1
+}
 
-# 4. Upload the version-scoped promotional image
+# 3. Reconcile the required locale. Never clear or empty the description.
+LOCALIZATIONS=$(asc iap versions localizations list \
+  --version-id "$IAP_VERSION_ID" \
+  --paginate \
+  --output json)
+LOCALIZATION_IDS=$(echo "$LOCALIZATIONS" | jq -r \
+  '.data[] | select(.attributes.locale == "en-US") | .id')
+LOCALIZATION_COUNT=$(printf '%s\n' "$LOCALIZATION_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+
+case "$LOCALIZATION_COUNT" in
+  0)
+    asc iap versions localizations create \
+      --version-id "$IAP_VERSION_ID" \
+      --locale "en-US" \
+      --name "Premium Features" \
+      --description "Unlock all premium features"
+    ;;
+  1)
+    asc iap versions localizations update \
+      --localization-id "$LOCALIZATION_IDS" \
+      --name "Premium Features" \
+      --description "Unlock all premium features"
+    ;;
+  *) echo "Multiple en-US localizations exist; resolve them explicitly." >&2; exit 1 ;;
+esac
+
+# 4. Upload version metadata and the product-level App Review screenshot.
 asc iap versions images create \
   --version-id "$IAP_VERSION_ID" \
-  --file "./promo.png"
+  --file "$PROMOTIONAL_IMAGE"
 
-# 5. Set availability
+asc iap review-screenshots create \
+  --iap-id "$IAP_ID" \
+  --file "$REVIEW_SCREENSHOT"
+
+# 5. Configure availability and pricing.
 asc iap pricing availability set \
   --iap-id "$IAP_ID" \
   --territories "USA,CAN,GBR,AUS"
 
-# 6. Configure pricing (requires price point ID)
-# See pricing documentation for details
+asc iap pricing schedules create \
+  --iap-id "$IAP_ID" \
+  --base-territory "USA" \
+  --prices "$PRICE_POINT_ID"
 
-echo "IAP created with ID: $IAP_ID"
+# 6. Add the version to a fresh review submission and submit it.
+SUBMISSION_ID=$(asc review submissions-create \
+  --app "$APP_ID" \
+  --platform IOS \
+  --output json | jq -r '.data.id')
+
+asc review items add \
+  --submission "$SUBMISSION_ID" \
+  --item-type inAppPurchaseVersions \
+  --item-id "$IAP_VERSION_ID"
+
+asc review submissions-submit \
+  --id "$SUBMISSION_ID" \
+  --confirm
+
+echo "Submitted IAP $IAP_ID using version $IAP_VERSION_ID"
 ```
+
+The workflow deliberately stops when several versions or same-locale resources
+exist. Select the intended IDs and resume rather than creating replacements.
+Image and review-screenshot uploads are writes; on a retry, inspect the current
+resources first and skip an upload that already succeeded.
 
 ### Bulk Update Availability
 

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -1048,6 +1048,7 @@ APP_ID="123456789"
 GROUP_REFERENCE_NAME="Premium"
 PRODUCT_ID="com.example.app.monthly"
 PRICE_POINT_ID="PRICE_POINT_ID"
+PRICE_TERRITORY="USA"
 PROMOTIONAL_IMAGE="./promo.png"
 REVIEW_SCREENSHOT="./review.png"
 
@@ -1197,11 +1198,12 @@ esac
 # 5. Configure pricing, promotional art, and the App Review screenshot.
 asc subscriptions pricing prices set \
   --subscription-id "$SUBSCRIPTION_ID" \
-  --price-point "$PRICE_POINT_ID"
+  --price-point "$PRICE_POINT_ID" \
+  --territory "$PRICE_TERRITORY"
 
 asc subscriptions pricing availability edit \
   --subscription-id "$SUBSCRIPTION_ID" \
-  --territories "USA,CAN,GBR,AUS"
+  --territories "$PRICE_TERRITORY"
 
 asc subscriptions versions images upload \
   --version-id "$SUBSCRIPTION_VERSION_ID" \

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -109,6 +109,13 @@ App Store Connect API 4.4.1 adds discrete review versions for subscription
 groups and version-scoped v2 localizations. The commands live under
 `asc subscriptions groups versions`.
 
+<Warning>
+  List and reuse an existing group version before creating one. The API has no
+  subscription-group-version DELETE operation. Treat zero versions as the only
+  automatic create case, reuse the sole returned ID, and require an explicit
+  choice when several versions exist.
+</Warning>
+
 #### Include Versions with Groups
 
 The existing group list and view commands can include version resources and
@@ -266,8 +273,8 @@ asc subscriptions create \
 
 **Required Flags:**
 
-* `--group` - Subscription group ID
-* `--ref-name` - Reference name
+* `--group-id` - Subscription group ID
+* `--reference-name` - Reference name
 * `--product-id` - Product ID (must match bundle ID prefix)
 
 **Optional Flags:**
@@ -315,7 +322,7 @@ asc subscriptions update \
 
 **Optional Flags:**
 
-* `--ref-name` - New reference name
+* `--reference-name` - New reference name
 * `--subscription-period` - New duration
 * `--family-sharable` - Enable Family Sharing
 
@@ -332,6 +339,13 @@ A subscription version ID is distinct from a subscription product ID. The
 old `asc subscriptions localizations` and `asc subscriptions images` command
 trees remain product-scoped v1 compatibility workflows, but are deprecated.
 Use the commands below for new version-scoped automation.
+
+<Warning>
+  Resolve versions before creating them. Apple exposes no subscription-version
+  DELETE operation, and deleting a parent subscription can leave versions
+  orphaned. Create only for a zero-result list, reuse the ID when exactly one
+  version exists, and stop for explicit selection when several exist.
+</Warning>
 
 The command group covers all 18 new operations: four version operations, six
 localization operations, and eight image operations.
@@ -382,8 +396,16 @@ selectors; the pagination URL is opaque and already contains its query state.
 ### Version Localizations
 
 Version localizations use the API 4.4.1 v2 localization resource. Creation
-requires `--version-id`, `--locale`, and `--name`; `--description` is optional.
-Locale cannot be changed after creation.
+requires `--version-id`, `--locale`, and `--name`; the CLI models
+`--description` as schema-optional. In live App Store Connect, provide a
+non-empty description because Apple rejects both an empty string and JSON
+`null`. Locale cannot be changed after creation.
+
+<Warning>
+  App Store Connect rejects deletion of the final required localization on a
+  subscription version. Create and verify a replacement locale before deleting
+  the old one.
+</Warning>
 
 ```bash  theme={null}
 # List resources or raw relationship linkages
@@ -403,16 +425,11 @@ asc subscriptions versions localizations create \
   --name "Premium" \
   --description "Premium subscription access"
 
-# Set a string value, including an explicitly empty string
+# Update with non-empty live-service values
 asc subscriptions versions localizations update \
   --id "LOCALIZATION_ID" \
   --name "Premium Plus" \
-  --description ""
-
-# Encode JSON null to clear a nullable value
-asc subscriptions versions localizations update \
-  --id "LOCALIZATION_ID" \
-  --clear-description
+  --description "Premium subscription access with family features"
 
 # Delete a localization
 asc subscriptions versions localizations delete \
@@ -423,7 +440,7 @@ asc subscriptions versions localizations delete \
 Localization updates preserve all three OpenAPI states:
 
 * Omit a flag to leave that attribute unchanged.
-* Use `--name` or `--description` to send a string, including `""`.
+* Use `--name` or `--description` to send a string.
 * Use `--clear-name` or `--clear-description` to send JSON `null`.
 
 `--name` and `--clear-name` are mutually exclusive, as are `--description` and
@@ -431,6 +448,11 @@ Localization updates preserve all three OpenAPI states:
 `--include version`, `--version-fields`, `--limit`, `--next`, and `--paginate`;
 `view` supports the corresponding sparse fields and `--include version`
 without pagination.
+
+Those three encodings describe the OpenAPI contract and remain available in
+the CLI. They are not all accepted by the live service: do not send
+`--description ""` or `--clear-description` for subscription-version
+localizations.
 
 ### Version Images
 
@@ -631,6 +653,38 @@ asc subscriptions pricing price-points view \
   --price-point-id "PRICE_POINT_ID"
 ```
 
+### Adjusted Equalizations (API 4.4.1)
+
+List Apple's adjusted MONTHLY equalizations for an upfront subscription price
+point:
+
+```bash  theme={null}
+asc subscriptions pricing price-points adjusted-equalizations \
+  --price-point-id "MONTHLY_PRICE_POINT_ID" \
+  --upfront-price-point-id "UPFRONT_PRICE_POINT_ID" \
+  --plan-type MONTHLY \
+  --include territory \
+  --territory-fields currency \
+  --paginate
+```
+
+For the first page, all three identifiers are required:
+
+* `--price-point-id` - The subscription price point whose adjusted
+  equalizations are being read
+* `--upfront-price-point-id` - Required upfront price point filter; accepts a
+  comma-separated list
+* `--plan-type MONTHLY` - Required plan type; no other value is accepted
+
+Apple's live endpoint rejects the request when the upfront price point or plan
+type is omitted even though the published query schema does not mark both
+filters as required. An opaque `--next` URL already contains its query state;
+when using `--next`, do not repeat these filters or other query selectors.
+
+Optional selectors include `--territory`, `--subscription-id`, `--fields`,
+`--include territory`, `--territory-fields currency`, `--limit`, and
+`--paginate`.
+
 ## Availability
 
 Control which territories can purchase your subscriptions.
@@ -733,6 +787,9 @@ requires apps built with SDK 26.5 or later.
 Manage subscription display names and descriptions through a subscription
 version. The product-scoped `asc subscriptions localizations ...` commands are
 deprecated. Create or resolve a subscription version, then use its version ID.
+Always keep a non-empty description, and do not delete the version's final
+required localization; these live-service rules are stricter than the nullable
+OpenAPI request schema.
 
 ```bash  theme={null}
 # Create localization
@@ -981,58 +1038,206 @@ asc review submissions-submit \
 
 ## Common Workflows
 
-### Create Complete Subscription Tier
+### Create a Complete, Version-Safe Subscription
 
 ```bash  theme={null}
 #!/bin/bash
-# Create a full subscription tier (monthly, yearly)
+set -euo pipefail
 
 APP_ID="123456789"
-BUNDLE_ID="com.example.app"
+GROUP_REFERENCE_NAME="Premium"
+PRODUCT_ID="com.example.app.monthly"
+PRICE_POINT_ID="PRICE_POINT_ID"
+PROMOTIONAL_IMAGE="./promo.png"
+REVIEW_SCREENSHOT="./review.png"
 
-# 1. Create subscription group
-GROUP_RESPONSE=$(asc subscriptions groups create \
+# 1. Resolve the group by exact reference name, or create it once.
+GROUPS=$(asc subscriptions groups list \
   --app "$APP_ID" \
-  --reference-name "Premium" \
+  --paginate \
   --output json)
+GROUP_IDS=$(echo "$GROUPS" | jq -r --arg name "$GROUP_REFERENCE_NAME" \
+  '.data[] | select(.attributes.referenceName == $name) | .id')
+GROUP_COUNT=$(printf '%s\n' "$GROUP_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
 
-GROUP_ID=$(echo "$GROUP_RESPONSE" | jq -r '.data.id')
+case "$GROUP_COUNT" in
+  0)
+    GROUP_ID=$(asc subscriptions groups create \
+      --app "$APP_ID" \
+      --reference-name "$GROUP_REFERENCE_NAME" \
+      --output json | jq -r '.data.id')
+    ;;
+  1) GROUP_ID="$GROUP_IDS" ;;
+  *) echo "Multiple groups matched $GROUP_REFERENCE_NAME." >&2; exit 1 ;;
+esac
 
-# 2. Create monthly subscription
-MONTHLY_RESPONSE=$(asc subscriptions create \
+# 2. Resolve the subscription by exact product ID, or create it once.
+SUBSCRIPTIONS=$(asc subscriptions list \
   --group-id "$GROUP_ID" \
-  --reference-name "Monthly Premium" \
-  --product-id "${BUNDLE_ID}.monthly" \
-  --subscription-period ONE_MONTH \
+  --paginate \
   --output json)
+SUBSCRIPTION_IDS=$(echo "$SUBSCRIPTIONS" | jq -r --arg product "$PRODUCT_ID" \
+  '.data[] | select(.attributes.productId == $product) | .id')
+SUBSCRIPTION_COUNT=$(printf '%s\n' "$SUBSCRIPTION_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
 
-MONTHLY_ID=$(echo "$MONTHLY_RESPONSE" | jq -r '.data.id')
+case "$SUBSCRIPTION_COUNT" in
+  0)
+    SUBSCRIPTION_ID=$(asc subscriptions create \
+      --group-id "$GROUP_ID" \
+      --reference-name "Monthly Premium" \
+      --product-id "$PRODUCT_ID" \
+      --subscription-period ONE_MONTH \
+      --output json | jq -r '.data.id')
+    ;;
+  1) SUBSCRIPTION_ID="$SUBSCRIPTION_IDS" ;;
+  *) echo "Multiple subscriptions matched $PRODUCT_ID." >&2; exit 1 ;;
+esac
 
-# 3. Create yearly subscription
-YEARLY_RESPONSE=$(asc subscriptions create \
+# 3. Resolve the group version. Never create speculatively: there is no
+# group-version DELETE endpoint.
+GROUP_VERSIONS=$(asc subscriptions groups versions list \
   --group-id "$GROUP_ID" \
-  --reference-name "Yearly Premium" \
-  --product-id "${BUNDLE_ID}.yearly" \
-  --subscription-period ONE_YEAR \
+  --paginate \
   --output json)
+GROUP_VERSION_COUNT=$(echo "$GROUP_VERSIONS" | jq '.data | length')
 
-YEARLY_ID=$(echo "$YEARLY_RESPONSE" | jq -r '.data.id')
+case "$GROUP_VERSION_COUNT" in
+  0)
+    GROUP_VERSION_ID=$(asc subscriptions groups versions create \
+      --group-id "$GROUP_ID" \
+      --output json | jq -r '.data.id')
+    ;;
+  1) GROUP_VERSION_ID=$(echo "$GROUP_VERSIONS" | jq -r '.data[0].id') ;;
+  *) echo "Multiple group versions exist; choose the intended editable ID." >&2; exit 1 ;;
+esac
 
-# 4. Set pricing
+GROUP_VERSION_STATE=$(asc subscriptions groups versions view \
+  --version-id "$GROUP_VERSION_ID" \
+  --output json | jq -r '.data.attributes.state')
+test "$GROUP_VERSION_STATE" = "PREPARE_FOR_SUBMISSION" || {
+  echo "Group version $GROUP_VERSION_ID is not editable: $GROUP_VERSION_STATE" >&2
+  exit 1
+}
+
+# Reconcile the group display name.
+GROUP_LOCALIZATIONS=$(asc subscriptions groups versions localizations list \
+  --version-id "$GROUP_VERSION_ID" \
+  --paginate \
+  --output json)
+GROUP_LOCALIZATION_IDS=$(echo "$GROUP_LOCALIZATIONS" | jq -r \
+  '.data[] | select(.attributes.locale == "en-US") | .id')
+GROUP_LOCALIZATION_COUNT=$(printf '%s\n' "$GROUP_LOCALIZATION_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+
+case "$GROUP_LOCALIZATION_COUNT" in
+  0)
+    asc subscriptions groups versions localizations create \
+      --version-id "$GROUP_VERSION_ID" \
+      --locale "en-US" \
+      --name "Premium"
+    ;;
+  1)
+    asc subscriptions groups versions localizations update \
+      --id "$GROUP_LOCALIZATION_IDS" \
+      --name "Premium"
+    ;;
+  *) echo "Multiple en-US group localizations exist." >&2; exit 1 ;;
+esac
+
+# 4. Resolve the subscription version using the same zero/one/many rule.
+SUBSCRIPTION_VERSIONS=$(asc subscriptions versions list \
+  --subscription-id "$SUBSCRIPTION_ID" \
+  --paginate \
+  --output json)
+SUBSCRIPTION_VERSION_COUNT=$(echo "$SUBSCRIPTION_VERSIONS" | jq '.data | length')
+
+case "$SUBSCRIPTION_VERSION_COUNT" in
+  0)
+    SUBSCRIPTION_VERSION_ID=$(asc subscriptions versions create \
+      --subscription-id "$SUBSCRIPTION_ID" \
+      --output json | jq -r '.data.id')
+    ;;
+  1) SUBSCRIPTION_VERSION_ID=$(echo "$SUBSCRIPTION_VERSIONS" | jq -r '.data[0].id') ;;
+  *) echo "Multiple subscription versions exist; choose the intended editable ID." >&2; exit 1 ;;
+esac
+
+SUBSCRIPTION_VERSION_STATE=$(asc subscriptions versions view \
+  --id "$SUBSCRIPTION_VERSION_ID" \
+  --output json | jq -r '.data.attributes.state')
+test "$SUBSCRIPTION_VERSION_STATE" = "PREPARE_FOR_SUBMISSION" || {
+  echo "Subscription version $SUBSCRIPTION_VERSION_ID is not editable: $SUBSCRIPTION_VERSION_STATE" >&2
+  exit 1
+}
+
+# Reconcile the required locale with a non-empty live-service description.
+LOCALIZATIONS=$(asc subscriptions versions localizations list \
+  --version-id "$SUBSCRIPTION_VERSION_ID" \
+  --paginate \
+  --output json)
+LOCALIZATION_IDS=$(echo "$LOCALIZATIONS" | jq -r \
+  '.data[] | select(.attributes.locale == "en-US") | .id')
+LOCALIZATION_COUNT=$(printf '%s\n' "$LOCALIZATION_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+
+case "$LOCALIZATION_COUNT" in
+  0)
+    asc subscriptions versions localizations create \
+      --version-id "$SUBSCRIPTION_VERSION_ID" \
+      --locale "en-US" \
+      --name "Monthly Premium" \
+      --description "Unlimited premium access, billed monthly"
+    ;;
+  1)
+    asc subscriptions versions localizations update \
+      --id "$LOCALIZATION_IDS" \
+      --name "Monthly Premium" \
+      --description "Unlimited premium access, billed monthly"
+    ;;
+  *) echo "Multiple en-US subscription localizations exist." >&2; exit 1 ;;
+esac
+
+# 5. Configure pricing, promotional art, and the App Review screenshot.
 asc subscriptions pricing prices set \
-  --subscription-id "$MONTHLY_ID" \
-  --tier 5 \
-  --territory "USA"
+  --subscription-id "$SUBSCRIPTION_ID" \
+  --price-point "$PRICE_POINT_ID"
 
-asc subscriptions pricing prices set \
-  --subscription-id "$YEARLY_ID" \
-  --tier 40 \
-  --territory "USA"
+asc subscriptions pricing availability edit \
+  --subscription-id "$SUBSCRIPTION_ID" \
+  --territories "USA,CAN,GBR,AUS"
 
-echo "Created subscription group: $GROUP_ID"
-echo "Monthly subscription: $MONTHLY_ID"
-echo "Yearly subscription: $YEARLY_ID"
+asc subscriptions versions images upload \
+  --version-id "$SUBSCRIPTION_VERSION_ID" \
+  --file "$PROMOTIONAL_IMAGE"
+
+asc subscriptions review screenshots create \
+  --subscription-id "$SUBSCRIPTION_ID" \
+  --file "$REVIEW_SCREENSHOT"
+
+# 6. Submit both typed versions together.
+SUBMISSION_ID=$(asc review submissions-create \
+  --app "$APP_ID" \
+  --platform IOS \
+  --output json | jq -r '.data.id')
+
+asc review items add \
+  --submission "$SUBMISSION_ID" \
+  --item-type subscriptionGroupVersions \
+  --item-id "$GROUP_VERSION_ID"
+
+asc review items add \
+  --submission "$SUBMISSION_ID" \
+  --item-type subscriptionVersions \
+  --item-id "$SUBSCRIPTION_VERSION_ID"
+
+asc review submissions-submit \
+  --id "$SUBMISSION_ID" \
+  --confirm
+
+echo "Submitted subscription $SUBSCRIPTION_ID and group $GROUP_ID"
 ```
+
+This workflow refuses ambiguous version or localization matches rather than
+creating resources that cannot be deleted. Image and review-screenshot uploads
+are writes; inspect their current resources and skip an upload that already
+succeeded before retrying the script.
 
 ### Bulk Price Update
 

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -1052,11 +1052,11 @@ PROMOTIONAL_IMAGE="./promo.png"
 REVIEW_SCREENSHOT="./review.png"
 
 # 1. Resolve the group by exact reference name, or create it once.
-GROUPS=$(asc subscriptions groups list \
+GROUP_LIST=$(asc subscriptions groups list \
   --app "$APP_ID" \
   --paginate \
   --output json)
-GROUP_IDS=$(echo "$GROUPS" | jq -r --arg name "$GROUP_REFERENCE_NAME" \
+GROUP_IDS=$(echo "$GROUP_LIST" | jq -r --arg name "$GROUP_REFERENCE_NAME" \
   '.data[] | select(.attributes.referenceName == $name) | .id')
 GROUP_COUNT=$(printf '%s\n' "$GROUP_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
 

--- a/docs.json
+++ b/docs.json
@@ -80,6 +80,7 @@
             "group": "App Management",
             "pages": [
               "commands/apps",
+              "commands/age-rating",
               "commands/app-tags",
               "commands/app-info",
               "commands/localizations",


### PR DESCRIPTION
## Summary

- correct the documented subscription create and update flag names
- document live API 4.4.1 restrictions for version-localization descriptions and final-localization deletion
- make the complete IAP and subscription examples resolve zero, one, or many versions safely before creating anything
- document the missing IAP relationship-link commands and adjusted-equalization prerequisites
- add a focused age-rating reference for the new social-media fields and their dependency rules

## Safety and compatibility

This is documentation-only. It does not change commands, HTTP behavior, output, lifecycle state, or generated command help. The workflow examples deliberately stop on ambiguous version matches because Apple exposes no DELETE operation for IAP, subscription, or subscription-group versions.

## Verification

- `make format`
- `make check-docs`
  - command docs sync passed
  - 78 command example docs validated
  - repository docs links passed
  - Mintlify validation passed for 80 pages
  - website command paths and flags passed
  - OpenAPI indexes remained current at 1,263 endpoints
- `make lint` (0 issues)
- extracted complete IAP and subscription scripts passed `bash -n`

The full Go suite and live ASC mutations were not repeated: this branch changes only MDX and navigation on exact tested CLI main `d6d8d94b`, and the live-service constraints documented here were already established by the API 4.4.1 mutation audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive age-rating CLI guidance for viewing and updating declarations, including Social Media–related attribute rules and migration from the deprecated override flag to the newer alternative.
  - Updated in-app purchase and subscription command docs with clearer version-safe workflows, relationship-link examples, stronger automation safeguards, and stricter localization/non-empty description requirements.
  - Refreshed subscription CLI examples (including renamed flags) and added guidance for adjusted equalizations/pagination behavior.
  - Included the age-rating command in the command reference navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->