### PR TITLE
fix(asc): preserve OpenAPI nullable request fields

### DIFF
--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -84,7 +84,7 @@ separately and has no invented landed `main` commit:
 | Final 4.4.1 coverage ledger | #1789 | `51b3a962` | `d6d8d94b` | Merged and `main`-gated; documentation only |
 | Subscription localization delete-confirmation coverage | #1790 | `49eda126` | `73466720` | Merged; test only |
 | Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only; current #1792 base |
-| Seven-property nullable request fidelity | #1792 | `f5e447ef` implementation head | - | Open and pre-merge; no landed `main` SHA |
+| Seven-property nullable request fidelity | #1792 | `db3657b6` implementation head | - | Open and pre-merge; no landed `main` SHA |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#50 | `61b9634` | `e5561a9` | Merged; landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
@@ -104,8 +104,10 @@ preserve all three states for `socialMedia`, `socialMediaAgeRestricted`, the two
 v2 localization `description` properties, v2 group-localization
 `customAppName`, and the two v2 image `uploaded` properties. Its exact audited
 implementation head is
-`f5e447efd75fe902fc46570ed8ce19715ab1051c`. This documentation follow-up is a
-later commit on the same open PR, so `f5e447ef` is deliberately recorded as the
+`db3657b6c6e88ebbf7f0da59137c92df99931e59`. That head also preserves the
+legacy omission behavior for a whitespace-only `customAppName` while retaining
+explicit JSON `null`. This documentation follow-up is a later commit on the same
+open PR, so `db3657b6` is deliberately recorded as the
 implementation head rather than misrepresented as a self-referential final PR
 head.
 
@@ -336,7 +338,7 @@ change.
 | Subscription-group reads | Group detail and app-group collection reads gain version includes, sparse fields, and relationship limits; group sparse fields gain `versions` | #1780 | `48d04e0b`; exact query, owner/next validation, and compatibility tests |
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
 | Pricing reads | Price-point sparse fields gain `adjustedEqualizations`; existing equalization and price-point relationship operations gain `filter[upfrontPricePointId]` and `filter[planType]` where allowed | #1778 | `39284b0a`; endpoint-specific option, exact query, strict CSV/enums, territory inclusion, opaque-next, ID validation, and aggregation tests |
-| Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 and #1792 | `39284b0a` added the fields and CLI behavior; #1792 implementation head `f5e447ef` adds exact omit/value/null request encoding |
+| Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 and #1792 | `39284b0a` added the fields and CLI behavior; #1792 implementation head `db3657b6` adds exact omit/value/null request encoding |
 | App info reads | `AppInfo.attributes.kidsAgeBand` and `fields[appInfos]=kidsAgeBand` appear as deprecated additions | #1778 | `39284b0a`; generic decoding/output characterization, no new write path |
 | Included-resource unions | IAP, subscription, group, and review-submission responses gain their corresponding version resource discriminators | #1777, #1779, #1780, #1781 | `ee40c7b3`, `c8f3ab52`, `48d04e0b`, `aba35e0a`; typed response and included-resource tests |
 
@@ -369,7 +371,7 @@ remained at the immediate pre-PR base.
 Still different before the 4.4.1 schema PR:
 
 - [x] `AgeRatingDeclaration` - two social-media Boolean attributes (#1778, `39284b0a`)
-- [x] `AgeRatingDeclarationUpdateRequest` - two social-media update attributes added in #1778 (`39284b0a`); exact omit/value/null fidelity first implemented in #1792 at `f5e447ef`
+- [x] `AgeRatingDeclarationUpdateRequest` - two social-media update attributes added in #1778 (`39284b0a`); exact omit/value/null fidelity first implemented in #1792 at `db3657b6`
 - [x] `AppInfo` - deprecated `kidsAgeBand` read attribute (#1778, `39284b0a`)
 - [x] `InAppPurchaseV2` - versions relationship (#1777, `ee40c7b3`)
 - [x] `InAppPurchaseV2Response` - included IAP-version discriminator (#1777, `ee40c7b3`)
@@ -448,13 +450,13 @@ round-trip tests):
 - [x] `InAppPurchaseVersionImagesLinkagesResponse`
 - [x] `InAppPurchaseVersionLocalizationsLinkagesResponse`
 - [x] `InAppPurchaseLocalizationV2`
-- [x] `InAppPurchaseLocalizationV2CreateRequest` - nullable create description completed by #1792 at `f5e447ef`
+- [x] `InAppPurchaseLocalizationV2CreateRequest` - nullable create description completed by #1792 at `db3657b6`
 - [x] `InAppPurchaseLocalizationV2UpdateRequest`
 - [x] `InAppPurchaseLocalizationV2Response`
 - [x] `InAppPurchaseLocalizationsV2Response`
 - [x] `InAppPurchaseImageV2`
 - [x] `InAppPurchaseImageV2CreateRequest`
-- [x] `InAppPurchaseImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `f5e447ef`
+- [x] `InAppPurchaseImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `db3657b6`
 - [x] `InAppPurchaseImageV2Response`
 - [x] `InAppPurchaseImagesV2Response`
 
@@ -470,13 +472,13 @@ and round-trip tests):
 - [x] `SubscriptionVersionImagesLinkagesResponse`
 - [x] `SubscriptionVersionLocalizationsLinkagesResponse`
 - [x] `SubscriptionLocalizationV2`
-- [x] `SubscriptionLocalizationV2CreateRequest` - nullable create description completed by #1792 at `f5e447ef`
+- [x] `SubscriptionLocalizationV2CreateRequest` - nullable create description completed by #1792 at `db3657b6`
 - [x] `SubscriptionLocalizationV2UpdateRequest`
 - [x] `SubscriptionLocalizationV2Response`
 - [x] `SubscriptionLocalizationsV2Response`
 - [x] `SubscriptionImageV2`
 - [x] `SubscriptionImageV2CreateRequest`
-- [x] `SubscriptionImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `f5e447ef`
+- [x] `SubscriptionImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `db3657b6`
 - [x] `SubscriptionImageV2Response`
 - [x] `SubscriptionImagesV2Response`
 
@@ -490,7 +492,7 @@ request/response and round-trip tests):
 - [x] `SubscriptionGroupVersionsLinkagesResponse`
 - [x] `SubscriptionGroupVersionLocalizationsLinkagesResponse`
 - [x] `SubscriptionGroupLocalizationV2`
-- [x] `SubscriptionGroupLocalizationV2CreateRequest` - nullable custom app name completed by #1792 at `f5e447ef`
+- [x] `SubscriptionGroupLocalizationV2CreateRequest` - nullable custom app name completed by #1792 at `db3657b6`
 - [x] `SubscriptionGroupLocalizationV2UpdateRequest`
 - [x] `SubscriptionGroupLocalizationV2Response`
 - [x] `SubscriptionGroupLocalizationsV2Response`
@@ -747,11 +749,11 @@ after the original 4.4 import (31):
 | 2 | Discrete subscription versions and their localizations/promotional images | #1779 | 18-operation ledger, CLI/HTTP/upload tests | Implemented at `c8f3ab52` |
 | 3 | Discrete subscription-group versions and their localizations | #1780 | 10-operation ledger and CLI/HTTP tests | Implemented at `48d04e0b` |
 | 4 | Submit all three version types through review-submission items | #1777 and #1781 | Three exact relationship payload tests plus built-command tests | Implemented at `ee40c7b3` and `aba35e0a` |
-| 5 | Version-scoped v2 IAP localizations and images | #1777 and #1792 | CRUD/upload coverage from #1777; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `ee40c7b3`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
-| 6 | Version-scoped v2 subscription localizations and images | #1779 and #1792 | CRUD/upload coverage from #1779; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `c8f3ab52`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
-| 7 | Version-scoped v2 subscription-group localizations | #1780 and #1792 | CRUD coverage from #1780; #1792 table-tests `customAppName` omission/value/null encoding | Feature implementation at `48d04e0b`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
+| 5 | Version-scoped v2 IAP localizations and images | #1777 and #1792 | CRUD/upload coverage from #1777; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `ee40c7b3`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
+| 6 | Version-scoped v2 subscription localizations and images | #1779 and #1792 | CRUD/upload coverage from #1779; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `c8f3ab52`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
+| 7 | Version-scoped v2 subscription-group localizations | #1780 and #1792 | CRUD coverage from #1780; #1792 table-tests `customAppName` omission/value/null encoding, including whitespace omission | Feature implementation at `48d04e0b`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
 | 8 | Adjusted subscription equalizations and new filters | #1778 | Exact query/response, option-scope, strict-CSV/enum, territory-inclusion, opaque-next, ID-validation, and aggregation tests | Implemented at `39284b0a` |
-| 9 | `socialMedia` and `socialMediaAgeRestricted` age-rating attributes | #1778 and #1792 | Payload/output/help coverage from #1778; #1792 table-tests omission/value/null encoding for both update fields | Feature implementation at `39284b0a`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
+| 9 | `socialMedia` and `socialMediaAgeRestricted` age-rating attributes | #1778 and #1792 | Payload/output/help coverage from #1778; #1792 table-tests omission/value/null encoding for both update fields | Feature implementation at `39284b0a`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
 
 ## Deprecation and migration ledger
 
@@ -815,7 +817,7 @@ documented deprecation window; this goal intentionally stops before release.
     `e9c2a0dc` and landed as `e902d375`; that docs-only commit is the current
     base of #1792.
 17. #1792 first completes all seven nullable request properties at exact
-    implementation head `f5e447efd75fe902fc46570ed8ce19715ab1051c`.
+    implementation head `db3657b6c6e88ebbf7f0da59137c92df99931e59`.
     The PR remains open and pre-merge, this ledger change is a later docs-only
     commit on that PR, and no landed `main` SHA is claimed.
 18. External workflow skills were audited at exact head `61b9634` and landed as
@@ -991,7 +993,7 @@ pre-merge evidence are separated explicitly:
   discoverable typed command/client surfaces.
 - [x] Classified all 102 direct plus 71 transitive operation-contract changes:
   173 unique existing-operation contracts with no missing or extra ledger item.
-- [x] On #1792 implementation head `f5e447ef`, mapped all 47 added and 61
+- [x] On #1792 implementation head `db3657b6`, mapped all 47 added and 61
   modified schemas to typed models, documented generic decoding, or an
   already-reconciled schema-only disposition. This includes table-driven
   omission/value/null encoding for the seven nullable properties missed by the
@@ -1006,7 +1008,7 @@ pre-merge evidence are separated explicitly:
   producing `main` `9282e82d`; its integration, Govulncheck, and CodeQL
   workflows passed.
 - [ ] #1792 remains open and pre-merge. Its implementation head is
-  `f5e447efd75fe902fc46570ed8ce19715ab1051c`; there is no landed `main` SHA or
+  `db3657b6c6e88ebbf7f0da59137c92df99931e59`; there is no landed `main` SHA or
   post-merge workflow result to record yet.
 - [x] Deprecated all 29 public legacy leaves with one exact warning and direct
   migration help, added conditional setup warnings, and documented all 33

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -82,7 +82,8 @@ separately and has no invented landed `main` commit:
 | Deprecated IAP submit discoverability | #1787 | `04b52a62` | `38fa9b5f` | Merged and `main`-gated |
 | Transitive age-rating dependency closure | #1788 | `08003c38` | `9282e82d` | Merged and `main`-gated |
 | Final 4.4.1 coverage ledger | #1789 | `51b3a962` | `d6d8d94b` | Merged and `main`-gated; documentation only |
-| Subscription localization delete-confirmation coverage | #1790 | `49eda126` | `73466720` | Merged; test only; current #1792 base |
+| Subscription localization delete-confirmation coverage | #1790 | `49eda126` | `73466720` | Merged; test only |
+| Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only; current #1792 base |
 | Seven-property nullable request fidelity | #1792 | `f5e447ef` implementation head | - | Open and pre-merge; no landed `main` SHA |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#50 | `61b9634` | `e5561a9` | Merged; landed tree revalidated |
 
@@ -110,8 +111,8 @@ head.
 
 The last fully merged behavior integration before #1792 is `main` commit
 `9282e82d1feebddaaaa3285c658e6960b8a500f3`; #1789 then landed this coverage
-ledger at `d6d8d94b`, and test-only #1790 produced the current #1792 base
-`73466720`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
+ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and docs-only #1791
+produced the current #1792 base `e902d375`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
 173-contract, 61-modified-schema, and 9-addition/7-deprecation counts are
 unchanged. The recursive built-help comparison from `839c4da6` to `9282e82d`
 found 48 added and 52 changed leaf paths, 100 affected paths total, with zero
@@ -809,24 +810,27 @@ documented deprecation window; this goal intentionally stops before release.
 14. The final coverage ledger was audited at #1789 head `51b3a962` and landed
     as `d6d8d94b` without changing CLI behavior.
 15. Subscription localization delete-confirmation coverage was audited at
-    #1790 head `49eda126` and landed as `73466720`; it is test-only and is the
+    #1790 head `49eda126` and landed as `73466720`; it is test-only.
+16. Hardened public 4.4.1 command workflows were audited at #1791 head
+    `e9c2a0dc` and landed as `e902d375`; that docs-only commit is the current
     base of #1792.
-16. #1792 first completes all seven nullable request properties at exact
+17. #1792 first completes all seven nullable request properties at exact
     implementation head `f5e447efd75fe902fc46570ed8ce19715ab1051c`.
     The PR remains open and pre-merge, this ledger change is a later docs-only
     commit on that PR, and no landed `main` SHA is claimed.
-17. External workflow skills were audited at exact head `61b9634` and landed as
+18. External workflow skills were audited at exact head `61b9634` and landed as
     `e5561a9`. All 11 review threads are resolved, and the landed tree passes all
     23 skill validators plus 245 command-example and 716 flag help checks.
-18. Exact CLI `main` `9282e82d` is the last fully merged behavior integration
+19. Exact CLI `main` `9282e82d` is the last fully merged behavior integration
     before #1792 and has green integration, Govulncheck, and CodeQL workflows.
     Its built help has 48 added and 52 changed leaf paths relative to
     `839c4da6`, with zero removals. Those workflows and help counts do not prove
     #1792's still-pre-merge nullable encoding.
 
 CLI behavior and lifecycle PRs through #1788, the ledger PR, test-only #1790,
-and the companion skills PR are merged. #1792 remains the nullable-fidelity
-closeout gate. No release, tag, or package publication is part of this goal.
+docs-only #1791, and the companion skills PR are merged. #1792 remains the
+nullable-fidelity closeout gate. No release, tag, or package publication is
+part of this goal.
 
 ### Built help-surface delta
 
@@ -1029,8 +1033,8 @@ pre-merge evidence are separated explicitly:
   evidence that Apple accepts explicit null for its seven corrected fields.
 - [x] Confirmed the last fully merged behavior integration, `main` `9282e82d`,
   has green integration, Govulncheck, and CodeQL workflows; #1789 later landed
-  the ledger at `d6d8d94b`, and test-only #1790 produced #1792's base
-  `73466720`. Skills `main` `e5561a9` still passes local validation (it has no
+  the ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and docs-only
+  #1791 produced #1792's base `e902d375`. Skills `main` `e5561a9` still passes local validation (it has no
   configured `main` status or check runs), and the latest release/tag remains
   `3.0.0` at the pre-integration commit `839c4da6`. No release, tag,
   Homebrew/WinGet update, or package publication was performed.

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -159,7 +159,7 @@ Live behavior refined four schema-level assumptions:
   localizations, subscription localizations, and subscription images. A runtime
   validator migration was therefore a live-verified no-op, not an assumption.
 
-#1792 makes no new live explicit-null claim. It adds typed-client fidelity and
+PR #1792 makes no new live explicit-null claim. It adds typed-client fidelity and
 table-driven omit/value/null encoding tests only. The existing CLI commands
 continue to send the same concrete values or omissions as before; they do not
 gain a new clear/null flag. No explicit-null request for the age-rating, group

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -61,9 +61,10 @@ top-level contract changes.
 
 ## Current effort and status
 
-The CLI pull requests landed sequentially after exact-head audit. Every landed
-CLI `main` commit below passed its exact post-merge integration, Govulncheck, and
-CodeQL workflows before the next PR advanced:
+The CLI pull requests landed sequentially after exact-head audit. Rows marked
+`main`-gated passed their post-merge integration, Govulncheck, and CodeQL
+workflows before the next behavior PR advanced. Open work is identified
+separately and has no invented landed `main` commit:
 
 | Scope | Pull request | Reference head | Landed `main` commit | Status |
 | --- | --- | --- | --- | --- |
@@ -80,11 +81,14 @@ CodeQL workflows before the next PR advanced:
 | Legacy 4.4.1 resource deprecation transition | #1786 | `1ef32153` | `a00985b2` | Merged and `main`-gated |
 | Deprecated IAP submit discoverability | #1787 | `04b52a62` | `38fa9b5f` | Merged and `main`-gated |
 | Transitive age-rating dependency closure | #1788 | `08003c38` | `9282e82d` | Merged and `main`-gated |
+| Final 4.4.1 coverage ledger | #1789 | `51b3a962` | `d6d8d94b` | Merged and `main`-gated; documentation only |
+| Subscription localization delete-confirmation coverage | #1790 | `49eda126` | `73466720` | Merged; test only; current #1792 base |
+| Seven-property nullable request fidelity | #1792 | `f5e447ef` implementation head | - | Open and pre-merge; no landed `main` SHA |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#50 | `61b9634` | `e5561a9` | Merged; landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
-nullable request encoding; endpoint-exact fields, includes, sparse fields, and
-relationship limits; opaque continuation URLs; next-aware argument
+endpoint-exact fields, includes, sparse fields, and relationship limits; opaque
+continuation URLs; next-aware argument
 exclusivity; review-response links and metadata; positional-argument rejection;
 age-rating prerequisite declarations; adjusted-equalization required filters;
 exact deprecation warnings and migration guidance; and rendered parent-help
@@ -92,12 +96,27 @@ discoverability for all 29 deprecated leaves. A post-merge thread audit found
 the final transitive age-rating contradiction omitted by #1782; #1788 added
 both sparse-update regression cases, landed green, and closed that thread.
 
-The definitive CLI integration is `main` commit
-`9282e82d1feebddaaaa3285c658e6960b8a500f3`. It preserves the exact 37-path,
-47-operation, 47-schema, 102-direct, 71-transitive, 173-contract,
-61-modified-schema, and 9-addition/7-deprecation counts. A recursive built-help
-comparison from `839c4da6` to `9282e82d` found 48 added and 52 changed leaf
-paths, 100 affected paths total, with zero removals.
+The later cross-verification found one remaining typed-request gap: seven
+properties marked optional and nullable by OpenAPI could represent omission and
+a value, but not explicit JSON `null`. #1792 is the first implementation to
+preserve all three states for `socialMedia`, `socialMediaAgeRestricted`, the two
+v2 localization `description` properties, v2 group-localization
+`customAppName`, and the two v2 image `uploaded` properties. Its exact audited
+implementation head is
+`f5e447efd75fe902fc46570ed8ce19715ab1051c`. This documentation follow-up is a
+later commit on the same open PR, so `f5e447ef` is deliberately recorded as the
+implementation head rather than misrepresented as a self-referential final PR
+head.
+
+The last fully merged behavior integration before #1792 is `main` commit
+`9282e82d1feebddaaaa3285c658e6960b8a500f3`; #1789 then landed this coverage
+ledger at `d6d8d94b`, and test-only #1790 produced the current #1792 base
+`73466720`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
+173-contract, 61-modified-schema, and 9-addition/7-deprecation counts are
+unchanged. The recursive built-help comparison from `839c4da6` to `9282e82d`
+found 48 added and 52 changed leaf paths, 100 affected paths total, with zero
+removals; it is historical help-surface evidence, not proof of #1792's nullable
+request encoding.
 
 ## Live App Store Connect verification
 
@@ -136,6 +155,14 @@ Live behavior refined four schema-level assumptions:
 - Five retained validator v1 reads returned the same IDs for v2-created group
   localizations, subscription localizations, and subscription images. A runtime
   validator migration was therefore a live-verified no-op, not an assumption.
+
+#1792 makes no new live explicit-null claim. It adds typed-client fidelity and
+table-driven omit/value/null encoding tests only. The existing CLI commands
+continue to send the same concrete values or omissions as before; they do not
+gain a new clear/null flag. No explicit-null request for the age-rating, group
+localization, or image-upload fields was sent to App Store Connect for #1792,
+and the earlier live rejection of null localization descriptions remains the
+only live null evidence.
 
 Cleanup was verified by ID. Image resources, secondary localizations, review
 items, and temporary group-version resources were deleted where the API permits
@@ -308,7 +335,7 @@ change.
 | Subscription-group reads | Group detail and app-group collection reads gain version includes, sparse fields, and relationship limits; group sparse fields gain `versions` | #1780 | `48d04e0b`; exact query, owner/next validation, and compatibility tests |
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
 | Pricing reads | Price-point sparse fields gain `adjustedEqualizations`; existing equalization and price-point relationship operations gain `filter[upfrontPricePointId]` and `filter[planType]` where allowed | #1778 | `39284b0a`; endpoint-specific option, exact query, strict CSV/enums, territory inclusion, opaque-next, ID validation, and aggregation tests |
-| Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 | `39284b0a`; payload, output, help, and exit-behavior tests |
+| Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 and #1792 | `39284b0a` added the fields and CLI behavior; #1792 implementation head `f5e447ef` adds exact omit/value/null request encoding |
 | App info reads | `AppInfo.attributes.kidsAgeBand` and `fields[appInfos]=kidsAgeBand` appear as deprecated additions | #1778 | `39284b0a`; generic decoding/output characterization, no new write path |
 | Included-resource unions | IAP, subscription, group, and review-submission responses gain their corresponding version resource discriminators | #1777, #1779, #1780, #1781 | `ee40c7b3`, `c8f3ab52`, `48d04e0b`, `aba35e0a`; typed response and included-resource tests |
 
@@ -341,7 +368,7 @@ remained at the immediate pre-PR base.
 Still different before the 4.4.1 schema PR:
 
 - [x] `AgeRatingDeclaration` - two social-media Boolean attributes (#1778, `39284b0a`)
-- [x] `AgeRatingDeclarationUpdateRequest` - two nullable social-media update attributes (#1778, `39284b0a`)
+- [x] `AgeRatingDeclarationUpdateRequest` - two social-media update attributes added in #1778 (`39284b0a`); exact omit/value/null fidelity first implemented in #1792 at `f5e447ef`
 - [x] `AppInfo` - deprecated `kidsAgeBand` read attribute (#1778, `39284b0a`)
 - [x] `InAppPurchaseV2` - versions relationship (#1777, `ee40c7b3`)
 - [x] `InAppPurchaseV2Response` - included IAP-version discriminator (#1777, `ee40c7b3`)
@@ -420,13 +447,13 @@ round-trip tests):
 - [x] `InAppPurchaseVersionImagesLinkagesResponse`
 - [x] `InAppPurchaseVersionLocalizationsLinkagesResponse`
 - [x] `InAppPurchaseLocalizationV2`
-- [x] `InAppPurchaseLocalizationV2CreateRequest`
+- [x] `InAppPurchaseLocalizationV2CreateRequest` - nullable create description completed by #1792 at `f5e447ef`
 - [x] `InAppPurchaseLocalizationV2UpdateRequest`
 - [x] `InAppPurchaseLocalizationV2Response`
 - [x] `InAppPurchaseLocalizationsV2Response`
 - [x] `InAppPurchaseImageV2`
 - [x] `InAppPurchaseImageV2CreateRequest`
-- [x] `InAppPurchaseImageV2UpdateRequest`
+- [x] `InAppPurchaseImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `f5e447ef`
 - [x] `InAppPurchaseImageV2Response`
 - [x] `InAppPurchaseImagesV2Response`
 
@@ -442,13 +469,13 @@ and round-trip tests):
 - [x] `SubscriptionVersionImagesLinkagesResponse`
 - [x] `SubscriptionVersionLocalizationsLinkagesResponse`
 - [x] `SubscriptionLocalizationV2`
-- [x] `SubscriptionLocalizationV2CreateRequest`
+- [x] `SubscriptionLocalizationV2CreateRequest` - nullable create description completed by #1792 at `f5e447ef`
 - [x] `SubscriptionLocalizationV2UpdateRequest`
 - [x] `SubscriptionLocalizationV2Response`
 - [x] `SubscriptionLocalizationsV2Response`
 - [x] `SubscriptionImageV2`
 - [x] `SubscriptionImageV2CreateRequest`
-- [x] `SubscriptionImageV2UpdateRequest`
+- [x] `SubscriptionImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `f5e447ef`
 - [x] `SubscriptionImageV2Response`
 - [x] `SubscriptionImagesV2Response`
 
@@ -462,7 +489,7 @@ request/response and round-trip tests):
 - [x] `SubscriptionGroupVersionsLinkagesResponse`
 - [x] `SubscriptionGroupVersionLocalizationsLinkagesResponse`
 - [x] `SubscriptionGroupLocalizationV2`
-- [x] `SubscriptionGroupLocalizationV2CreateRequest`
+- [x] `SubscriptionGroupLocalizationV2CreateRequest` - nullable custom app name completed by #1792 at `f5e447ef`
 - [x] `SubscriptionGroupLocalizationV2UpdateRequest`
 - [x] `SubscriptionGroupLocalizationV2Response`
 - [x] `SubscriptionGroupLocalizationsV2Response`
@@ -719,11 +746,11 @@ after the original 4.4 import (31):
 | 2 | Discrete subscription versions and their localizations/promotional images | #1779 | 18-operation ledger, CLI/HTTP/upload tests | Implemented at `c8f3ab52` |
 | 3 | Discrete subscription-group versions and their localizations | #1780 | 10-operation ledger and CLI/HTTP tests | Implemented at `48d04e0b` |
 | 4 | Submit all three version types through review-submission items | #1777 and #1781 | Three exact relationship payload tests plus built-command tests | Implemented at `ee40c7b3` and `aba35e0a` |
-| 5 | Version-scoped v2 IAP localizations and images | #1777 | CRUD, explicit-null, and upload lifecycle tests | Implemented at `ee40c7b3` |
-| 6 | Version-scoped v2 subscription localizations and images | #1779 | CRUD, explicit-null, and upload lifecycle tests | Implemented at `c8f3ab52` |
-| 7 | Version-scoped v2 subscription-group localizations | #1780 | CRUD tests including `customAppName` | Implemented at `48d04e0b` |
+| 5 | Version-scoped v2 IAP localizations and images | #1777 and #1792 | CRUD/upload coverage from #1777; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `ee40c7b3`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
+| 6 | Version-scoped v2 subscription localizations and images | #1779 and #1792 | CRUD/upload coverage from #1779; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `c8f3ab52`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
+| 7 | Version-scoped v2 subscription-group localizations | #1780 and #1792 | CRUD coverage from #1780; #1792 table-tests `customAppName` omission/value/null encoding | Feature implementation at `48d04e0b`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
 | 8 | Adjusted subscription equalizations and new filters | #1778 | Exact query/response, option-scope, strict-CSV/enum, territory-inclusion, opaque-next, ID-validation, and aggregation tests | Implemented at `39284b0a` |
-| 9 | `socialMedia` and `socialMediaAgeRestricted` age-rating attributes | #1778 | Payload, output, help, and exit-behavior tests | Implemented at `39284b0a` |
+| 9 | `socialMedia` and `socialMediaAgeRestricted` age-rating attributes | #1778 and #1792 | Payload/output/help coverage from #1778; #1792 table-tests omission/value/null encoding for both update fields | Feature implementation at `39284b0a`; complete nullable request fidelity at #1792 implementation head `f5e447ef` (pre-merge) |
 
 ## Deprecation and migration ledger
 
@@ -779,16 +806,27 @@ documented deprecation window; this goal intentionally stops before release.
 13. The final transitive age-rating dependency was audited at #1788 head
     `08003c38` and landed as `9282e82d`; the historical #1782 thread was then
     resolved with exact-main evidence.
-14. External workflow skills were audited at exact head `61b9634` and landed as
+14. The final coverage ledger was audited at #1789 head `51b3a962` and landed
+    as `d6d8d94b` without changing CLI behavior.
+15. Subscription localization delete-confirmation coverage was audited at
+    #1790 head `49eda126` and landed as `73466720`; it is test-only and is the
+    base of #1792.
+16. #1792 first completes all seven nullable request properties at exact
+    implementation head `f5e447efd75fe902fc46570ed8ce19715ab1051c`.
+    The PR remains open and pre-merge, this ledger change is a later docs-only
+    commit on that PR, and no landed `main` SHA is claimed.
+17. External workflow skills were audited at exact head `61b9634` and landed as
     `e5561a9`. All 11 review threads are resolved, and the landed tree passes all
     23 skill validators plus 245 command-example and 716 flag help checks.
-15. Exact CLI `main` `9282e82d` has green integration, Govulncheck, and CodeQL
-    workflows. Its built help has 48 added and 52 changed leaf paths relative
-    to `839c4da6`, with zero removals.
+18. Exact CLI `main` `9282e82d` is the last fully merged behavior integration
+    before #1792 and has green integration, Govulncheck, and CodeQL workflows.
+    Its built help has 48 added and 52 changed leaf paths relative to
+    `839c4da6`, with zero removals. Those workflows and help counts do not prove
+    #1792's still-pre-merge nullable encoding.
 
-All CLI behavior and lifecycle PRs and the companion skills PR are merged. This
-final ledger's review and merge remain the repository closeout gate. No release,
-tag, or package publication is part of this goal.
+CLI behavior and lifecycle PRs through #1788, the ledger PR, test-only #1790,
+and the companion skills PR are merged. #1792 remains the nullable-fidelity
+closeout gate. No release, tag, or package publication is part of this goal.
 
 ### Built help-surface delta
 
@@ -936,8 +974,9 @@ ASC_BYPASS_KEYCHAIN=1 make test
 
 ## Final omission audit
 
-The integration closeout independently repeated these checks rather than
-trusting the per-PR reports:
+The merged closeout through #1789 independently repeated these checks rather
+than trusting the per-PR reports. The later nullable-fidelity finding and its
+pre-merge evidence are separated explicitly:
 
 - [x] Re-downloaded Apple's official OpenAPI zip and verified the artifact and
   extracted JSON hashes against the repository snapshot.
@@ -948,8 +987,11 @@ trusting the per-PR reports:
   discoverable typed command/client surfaces.
 - [x] Classified all 102 direct plus 71 transitive operation-contract changes:
   173 unique existing-operation contracts with no missing or extra ledger item.
-- [x] Mapped all 47 added and 61 modified schemas to typed models, documented
-  generic decoding, or an already-reconciled schema-only disposition.
+- [x] On #1792 implementation head `f5e447ef`, mapped all 47 added and 61
+  modified schemas to typed models, documented generic decoding, or an
+  already-reconciled schema-only disposition. This includes table-driven
+  omission/value/null encoding for the seven nullable properties missed by the
+  earlier merged closeout.
 - [x] Mapped all nine release-note additions and seven deprecated families to
   commands, compatibility treatment, tests, and migration guidance.
 - [x] Exercised all 100 changed or new leaf help paths: 48 additions and 52
@@ -959,6 +1001,9 @@ trusting the per-PR reports:
 - [x] Sequentially merged all 13 exact audited CLI heads through #1788,
   producing `main` `9282e82d`; its integration, Govulncheck, and CodeQL
   workflows passed.
+- [ ] #1792 remains open and pre-merge. Its implementation head is
+  `f5e447efd75fe902fc46570ed8ce19715ab1051c`; there is no landed `main` SHA or
+  post-merge workflow result to record yet.
 - [x] Deprecated all 29 public legacy leaves with one exact warning and direct
   migration help, added conditional setup warnings, and documented all 33
   exported legacy client methods without deleting stable behavior.
@@ -978,11 +1023,14 @@ trusting the per-PR reports:
   all 23 skills validate, and 245 command examples with 716 flags match exact
   CLI help. No runnable deprecated localization or submission teaching remains.
 - [x] Ran the final read-only live smoke on disposable app `6759231657` after
-  all behavior and workflow-skill changes merged: the app read succeeded, all
-  four age fields were restored to `false`, and all four review submissions
-  contained zero items.
-- [x] Confirmed definitive behavior `main` `9282e82d` has green integration,
-  Govulncheck, and CodeQL workflows; skills `main` `e5561a9` still passes local
-  validation (it has no configured `main` status or check runs); and the latest
-  release/tag remains `3.0.0` at the pre-integration commit `839c4da6`. No
-  release, tag, Homebrew/WinGet update, or package publication was performed.
+  behavior work through #1788 and the workflow-skill changes merged: the app
+  read succeeded, all four age fields were restored to `false`, and all four
+  review submissions contained zero items. This predates #1792 and is not
+  evidence that Apple accepts explicit null for its seven corrected fields.
+- [x] Confirmed the last fully merged behavior integration, `main` `9282e82d`,
+  has green integration, Govulncheck, and CodeQL workflows; #1789 later landed
+  the ledger at `d6d8d94b`, and test-only #1790 produced #1792's base
+  `73466720`. Skills `main` `e5561a9` still passes local validation (it has no
+  configured `main` status or check runs), and the latest release/tag remains
+  `3.0.0` at the pre-integration commit `839c4da6`. No release, tag,
+  Homebrew/WinGet update, or package publication was performed.

--- a/internal/asc/age_rating.go
+++ b/internal/asc/age_rating.go
@@ -9,17 +9,17 @@ import (
 // AgeRatingDeclarationAttributes describes the age rating declaration attributes.
 type AgeRatingDeclarationAttributes struct {
 	// Boolean content descriptors
-	Advertising              *bool `json:"advertising,omitempty"`
-	Gambling                 *bool `json:"gambling,omitempty"`
-	HealthOrWellnessTopics   *bool `json:"healthOrWellnessTopics,omitempty"`
-	LootBox                  *bool `json:"lootBox,omitempty"`
-	MessagingAndChat         *bool `json:"messagingAndChat,omitempty"`
-	ParentalControls         *bool `json:"parentalControls,omitempty"`
-	AgeAssurance             *bool `json:"ageAssurance,omitempty"`
-	SocialMedia              *bool `json:"socialMedia,omitempty"`
-	SocialMediaAgeRestricted *bool `json:"socialMediaAgeRestricted,omitempty"`
-	UnrestrictedWebAccess    *bool `json:"unrestrictedWebAccess,omitempty"`
-	UserGeneratedContent     *bool `json:"userGeneratedContent,omitempty"`
+	Advertising              *bool         `json:"advertising,omitempty"`
+	Gambling                 *bool         `json:"gambling,omitempty"`
+	HealthOrWellnessTopics   *bool         `json:"healthOrWellnessTopics,omitempty"`
+	LootBox                  *bool         `json:"lootBox,omitempty"`
+	MessagingAndChat         *bool         `json:"messagingAndChat,omitempty"`
+	ParentalControls         *bool         `json:"parentalControls,omitempty"`
+	AgeAssurance             *bool         `json:"ageAssurance,omitempty"`
+	SocialMedia              *NullableBool `json:"socialMedia,omitempty"`
+	SocialMediaAgeRestricted *NullableBool `json:"socialMediaAgeRestricted,omitempty"`
+	UnrestrictedWebAccess    *bool         `json:"unrestrictedWebAccess,omitempty"`
+	UserGeneratedContent     *bool         `json:"userGeneratedContent,omitempty"`
 
 	// Enum content descriptors (NONE, INFREQUENT_OR_MILD, FREQUENT_OR_INTENSE)
 	AlcoholTobaccoOrDrugUseOrReferences         *string `json:"alcoholTobaccoOrDrugUseOrReferences,omitempty"`

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -3865,10 +3865,10 @@ func TestUpdateAgeRatingDeclaration(t *testing.T) {
 		if payload.Data.Attributes.Gambling == nil || !*payload.Data.Attributes.Gambling {
 			t.Fatalf("expected gambling=true in request")
 		}
-		if payload.Data.Attributes.SocialMedia == nil || !*payload.Data.Attributes.SocialMedia {
+		if payload.Data.Attributes.SocialMedia == nil || payload.Data.Attributes.SocialMedia.Value == nil || !*payload.Data.Attributes.SocialMedia.Value {
 			t.Fatalf("expected socialMedia=true in request")
 		}
-		if payload.Data.Attributes.SocialMediaAgeRestricted == nil || *payload.Data.Attributes.SocialMediaAgeRestricted {
+		if payload.Data.Attributes.SocialMediaAgeRestricted == nil || payload.Data.Attributes.SocialMediaAgeRestricted.Value == nil || *payload.Data.Attributes.SocialMediaAgeRestricted.Value {
 			t.Fatalf("expected socialMediaAgeRestricted=false in request")
 		}
 		assertAuthorized(t, req)
@@ -3876,8 +3876,8 @@ func TestUpdateAgeRatingDeclaration(t *testing.T) {
 
 	attrs := AgeRatingDeclarationAttributes{
 		Gambling:                 func() *bool { value := true; return &value }(),
-		SocialMedia:              func() *bool { value := true; return &value }(),
-		SocialMediaAgeRestricted: func() *bool { value := false; return &value }(),
+		SocialMedia:              &NullableBool{Value: func() *bool { value := true; return &value }()},
+		SocialMediaAgeRestricted: &NullableBool{Value: func() *bool { value := false; return &value }()},
 	}
 	if _, err := client.UpdateAgeRatingDeclaration(context.Background(), "age-3", attrs); err != nil {
 		t.Fatalf("UpdateAgeRatingDeclaration() error: %v", err)

--- a/internal/asc/client_iap_versions.go
+++ b/internal/asc/client_iap_versions.go
@@ -463,7 +463,7 @@ func (c *Client) GetInAppPurchaseVersionLocalizationsRelationships(ctx context.C
 	return c.getResourceLinkages(ctx, versionID, "localizations", "versionID", "/v1/inAppPurchaseVersions/%s/relationships/%s", "inAppPurchaseVersionLocalizationsRelationships", opts...)
 }
 
-func (c *Client) CreateInAppPurchaseLocalizationV2(ctx context.Context, versionID string, attrs InAppPurchaseLocalizationCreateAttributes) (*InAppPurchaseLocalizationResponse, error) {
+func (c *Client) CreateInAppPurchaseLocalizationV2(ctx context.Context, versionID string, attrs InAppPurchaseLocalizationV2CreateAttributes) (*InAppPurchaseLocalizationResponse, error) {
 	versionID = strings.TrimSpace(versionID)
 	if versionID == "" {
 		return nil, fmt.Errorf("versionID is required")

--- a/internal/asc/client_iap_versions_test.go
+++ b/internal/asc/client_iap_versions_test.go
@@ -163,7 +163,7 @@ func TestInAppPurchaseVersionEndpoints(t *testing.T) {
 			responseBody: `{"data":{"type":"inAppPurchaseLocalizations","id":"loc-1"}}`,
 			wantBody:     `{"data":{"type":"inAppPurchaseLocalizations","attributes":{"name":"Name","locale":"en-US"},"relationships":{"version":{"data":{"type":"inAppPurchaseVersions","id":"version-1"}}}}}`,
 			call: func(c *Client) error {
-				_, err := c.CreateInAppPurchaseLocalizationV2(context.Background(), "version-1", InAppPurchaseLocalizationCreateAttributes{Name: "Name", Locale: "en-US"})
+				_, err := c.CreateInAppPurchaseLocalizationV2(context.Background(), "version-1", InAppPurchaseLocalizationV2CreateAttributes{Name: "Name", Locale: "en-US"})
 				return err
 			},
 		},
@@ -224,7 +224,7 @@ func TestInAppPurchaseVersionEndpoints(t *testing.T) {
 			responseBody: `{"data":{"type":"inAppPurchaseImages","id":"image-1"}}`,
 			wantBody:     `{"data":{"type":"inAppPurchaseImages","id":"image-1","attributes":{"uploaded":true}}}`,
 			call: func(c *Client) error {
-				_, err := c.UpdateInAppPurchaseImageV2(context.Background(), "image-1", InAppPurchaseImageV2UpdateAttributes{Uploaded: &uploaded})
+				_, err := c.UpdateInAppPurchaseImageV2(context.Background(), "image-1", InAppPurchaseImageV2UpdateAttributes{Uploaded: &NullableBool{Value: &uploaded}})
 				return err
 			},
 		},

--- a/internal/asc/client_subscription_group_versions.go
+++ b/internal/asc/client_subscription_group_versions.go
@@ -263,7 +263,10 @@ func (c *Client) CreateSubscriptionGroupLocalizationV2(ctx context.Context, vers
 	}
 	attrs.Name = strings.TrimSpace(attrs.Name)
 	attrs.Locale = strings.TrimSpace(attrs.Locale)
-	attrs.CustomAppName = strings.TrimSpace(attrs.CustomAppName)
+	if attrs.CustomAppName != nil && attrs.CustomAppName.Value != nil {
+		trimmed := strings.TrimSpace(*attrs.CustomAppName.Value)
+		attrs.CustomAppName = &NullableString{Value: &trimmed}
+	}
 	if attrs.Name == "" {
 		return nil, fmt.Errorf("name is required")
 	}

--- a/internal/asc/client_subscription_group_versions.go
+++ b/internal/asc/client_subscription_group_versions.go
@@ -265,7 +265,11 @@ func (c *Client) CreateSubscriptionGroupLocalizationV2(ctx context.Context, vers
 	attrs.Locale = strings.TrimSpace(attrs.Locale)
 	if attrs.CustomAppName != nil && attrs.CustomAppName.Value != nil {
 		trimmed := strings.TrimSpace(*attrs.CustomAppName.Value)
-		attrs.CustomAppName = &NullableString{Value: &trimmed}
+		if trimmed == "" {
+			attrs.CustomAppName = nil
+		} else {
+			attrs.CustomAppName = &NullableString{Value: &trimmed}
+		}
 	}
 	if attrs.Name == "" {
 		return nil, fmt.Errorf("name is required")

--- a/internal/asc/client_subscription_group_versions_test.go
+++ b/internal/asc/client_subscription_group_versions_test.go
@@ -94,7 +94,8 @@ func TestSubscriptionGroupVersionEndpoints(t *testing.T) {
 			responseBody: `{"data":{"type":"subscriptionGroupLocalizations","id":"loc-1"}}`,
 			bodyContains: []string{`"version":{"data":{"type":"subscriptionGroupVersions","id":"version-1"}}`, `"name":"Premium"`, `"locale":"en-US"`, `"customAppName":"Example"`},
 			call: func(c *Client) error {
-				_, err := c.CreateSubscriptionGroupLocalizationV2(context.Background(), "version-1", SubscriptionGroupLocalizationV2CreateAttributes{Name: "Premium", Locale: "en-US", CustomAppName: "Example"})
+				customAppName := "Example"
+				_, err := c.CreateSubscriptionGroupLocalizationV2(context.Background(), "version-1", SubscriptionGroupLocalizationV2CreateAttributes{Name: "Premium", Locale: "en-US", CustomAppName: &NullableString{Value: &customAppName}})
 				return err
 			},
 		},

--- a/internal/asc/client_subscription_group_versions_test.go
+++ b/internal/asc/client_subscription_group_versions_test.go
@@ -33,6 +33,59 @@ func TestCreateSubscriptionGroupVersionUsesRequiredGroupRelationship(t *testing.
 	}
 }
 
+func TestCreateSubscriptionGroupLocalizationV2CustomAppNameEncoding(t *testing.T) {
+	whitespace := " \t\n "
+	tests := []struct {
+		name        string
+		customName  *NullableString
+		wantPresent bool
+		wantValue   string
+	}{
+		{
+			name:        "whitespace omitted",
+			customName:  &NullableString{Value: &whitespace},
+			wantPresent: false,
+		},
+		{
+			name:        "explicit null preserved",
+			customName:  &NullableString{},
+			wantPresent: true,
+			wantValue:   "null",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				var payload struct {
+					Data struct {
+						Attributes map[string]json.RawMessage `json:"attributes"`
+					} `json:"data"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
+				}
+				got, present := payload.Data.Attributes["customAppName"]
+				if present != test.wantPresent {
+					t.Fatalf("customAppName presence = %t, want %t; payload: %s", present, test.wantPresent, got)
+				}
+				if present && string(got) != test.wantValue {
+					t.Fatalf("customAppName = %s, want %s", got, test.wantValue)
+				}
+			}, jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionGroupLocalizations","id":"loc-1"}}`))
+
+			_, err := client.CreateSubscriptionGroupLocalizationV2(context.Background(), "version-1", SubscriptionGroupLocalizationV2CreateAttributes{
+				Name:          "Premium",
+				Locale:        "en-US",
+				CustomAppName: test.customName,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestSubscriptionGroupVersionEndpoints(t *testing.T) {
 	updatedName := "Premium Plus"
 	cleared := NullableString{Value: nil}

--- a/internal/asc/iap_versions.go
+++ b/internal/asc/iap_versions.go
@@ -34,9 +34,16 @@ type InAppPurchaseLocalizationV2CreateRelationships struct {
 	Version Relationship `json:"version"`
 }
 
+// InAppPurchaseLocalizationV2CreateAttributes describes version-scoped localization create attributes.
+type InAppPurchaseLocalizationV2CreateAttributes struct {
+	Name        string          `json:"name"`
+	Locale      string          `json:"locale"`
+	Description *NullableString `json:"description,omitempty"`
+}
+
 type InAppPurchaseLocalizationV2CreateData struct {
 	Type          ResourceType                                   `json:"type"`
-	Attributes    InAppPurchaseLocalizationCreateAttributes      `json:"attributes"`
+	Attributes    InAppPurchaseLocalizationV2CreateAttributes    `json:"attributes"`
 	Relationships InAppPurchaseLocalizationV2CreateRelationships `json:"relationships"`
 }
 
@@ -88,7 +95,7 @@ type InAppPurchaseImageV2CreateRequest struct {
 }
 
 type InAppPurchaseImageV2UpdateAttributes struct {
-	Uploaded *bool `json:"uploaded,omitempty"`
+	Uploaded *NullableBool `json:"uploaded,omitempty"`
 }
 
 type InAppPurchaseImageV2UpdateData struct {

--- a/internal/asc/openapi_441_nullable_encoding_test.go
+++ b/internal/asc/openapi_441_nullable_encoding_test.go
@@ -1,0 +1,170 @@
+package asc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func nullableEncodingTestPtr[T any](value T) *T {
+	return &value
+}
+
+func assertNullableAttributeEncoding(t *testing.T, request any, key, want string, present bool) {
+	t.Helper()
+
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var payload struct {
+		Data struct {
+			Attributes map[string]json.RawMessage `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	got, ok := payload.Data.Attributes[key]
+	if ok != present {
+		t.Fatalf("%s presence = %t in %s, want %t", key, ok, encoded, present)
+	}
+	if present && string(got) != want {
+		t.Fatalf("%s JSON = %s, want %s", key, got, want)
+	}
+}
+
+func TestAgeRatingDeclarationNewFieldsNullableEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		key   string
+		attrs AgeRatingDeclarationAttributes
+		want  string
+		set   bool
+	}{
+		{name: "social media omitted", key: "socialMedia", attrs: AgeRatingDeclarationAttributes{}},
+		{name: "social media value", key: "socialMedia", attrs: AgeRatingDeclarationAttributes{SocialMedia: &NullableBool{Value: nullableEncodingTestPtr(true)}}, want: "true", set: true},
+		{name: "social media null", key: "socialMedia", attrs: AgeRatingDeclarationAttributes{SocialMedia: &NullableBool{}}, want: "null", set: true},
+		{name: "restricted omitted", key: "socialMediaAgeRestricted", attrs: AgeRatingDeclarationAttributes{}},
+		{name: "restricted value", key: "socialMediaAgeRestricted", attrs: AgeRatingDeclarationAttributes{SocialMediaAgeRestricted: &NullableBool{Value: nullableEncodingTestPtr(false)}}, want: "false", set: true},
+		{name: "restricted null", key: "socialMediaAgeRestricted", attrs: AgeRatingDeclarationAttributes{SocialMediaAgeRestricted: &NullableBool{}}, want: "null", set: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assertNullableAttributeEncoding(t, AgeRatingDeclarationUpdateRequest{Data: AgeRatingDeclarationUpdateData{
+				Type: ResourceTypeAgeRatingDeclarations, ID: "age-1", Attributes: test.attrs,
+			}}, test.key, test.want, test.set)
+		})
+	}
+}
+
+func TestVersionScopedCreateFieldsNullableEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		request any
+		key     string
+		want    string
+		set     bool
+	}{
+		{
+			name: "iap description omitted",
+			request: InAppPurchaseLocalizationV2CreateRequest{Data: InAppPurchaseLocalizationV2CreateData{
+				Type: ResourceTypeInAppPurchaseLocalizations, Attributes: InAppPurchaseLocalizationV2CreateAttributes{Name: "Name", Locale: "en-US"},
+			}},
+			key: "description",
+		},
+		{
+			name: "iap description value",
+			request: InAppPurchaseLocalizationV2CreateRequest{Data: InAppPurchaseLocalizationV2CreateData{
+				Type: ResourceTypeInAppPurchaseLocalizations, Attributes: InAppPurchaseLocalizationV2CreateAttributes{Name: "Name", Locale: "en-US", Description: &NullableString{Value: nullableEncodingTestPtr("Details")}},
+			}},
+			key: "description", want: `"Details"`, set: true,
+		},
+		{
+			name: "iap description null",
+			request: InAppPurchaseLocalizationV2CreateRequest{Data: InAppPurchaseLocalizationV2CreateData{
+				Type: ResourceTypeInAppPurchaseLocalizations, Attributes: InAppPurchaseLocalizationV2CreateAttributes{Name: "Name", Locale: "en-US", Description: &NullableString{}},
+			}},
+			key: "description", want: "null", set: true,
+		},
+		{
+			name: "subscription description omitted",
+			request: SubscriptionLocalizationV2CreateRequest{Data: SubscriptionLocalizationV2CreateData{
+				Type: ResourceTypeSubscriptionLocalizations, Attributes: SubscriptionLocalizationV2CreateAttributes{Name: "Pro", Locale: "en-US"},
+			}},
+			key: "description",
+		},
+		{
+			name: "subscription description value",
+			request: SubscriptionLocalizationV2CreateRequest{Data: SubscriptionLocalizationV2CreateData{
+				Type: ResourceTypeSubscriptionLocalizations, Attributes: SubscriptionLocalizationV2CreateAttributes{Name: "Pro", Locale: "en-US", Description: &NullableString{Value: nullableEncodingTestPtr("Details")}},
+			}},
+			key: "description", want: `"Details"`, set: true,
+		},
+		{
+			name: "subscription description null",
+			request: SubscriptionLocalizationV2CreateRequest{Data: SubscriptionLocalizationV2CreateData{
+				Type: ResourceTypeSubscriptionLocalizations, Attributes: SubscriptionLocalizationV2CreateAttributes{Name: "Pro", Locale: "en-US", Description: &NullableString{}},
+			}},
+			key: "description", want: "null", set: true,
+		},
+		{
+			name: "group custom app name omitted",
+			request: SubscriptionGroupLocalizationV2CreateRequest{Data: SubscriptionGroupLocalizationV2CreateData{
+				Type: ResourceTypeSubscriptionGroupLocalizations, Attributes: SubscriptionGroupLocalizationV2CreateAttributes{Name: "Premium", Locale: "en-US"},
+			}},
+			key: "customAppName",
+		},
+		{
+			name: "group custom app name value",
+			request: SubscriptionGroupLocalizationV2CreateRequest{Data: SubscriptionGroupLocalizationV2CreateData{
+				Type: ResourceTypeSubscriptionGroupLocalizations, Attributes: SubscriptionGroupLocalizationV2CreateAttributes{Name: "Premium", Locale: "en-US", CustomAppName: &NullableString{Value: nullableEncodingTestPtr("Example")}},
+			}},
+			key: "customAppName", want: `"Example"`, set: true,
+		},
+		{
+			name: "group custom app name null",
+			request: SubscriptionGroupLocalizationV2CreateRequest{Data: SubscriptionGroupLocalizationV2CreateData{
+				Type: ResourceTypeSubscriptionGroupLocalizations, Attributes: SubscriptionGroupLocalizationV2CreateAttributes{Name: "Premium", Locale: "en-US", CustomAppName: &NullableString{}},
+			}},
+			key: "customAppName", want: "null", set: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assertNullableAttributeEncoding(t, test.request, test.key, test.want, test.set)
+		})
+	}
+}
+
+func TestVersionScopedImageUploadedNullableEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		request any
+		want    string
+		set     bool
+	}{
+		{name: "iap omitted", request: InAppPurchaseImageV2UpdateRequest{Data: InAppPurchaseImageV2UpdateData{Type: ResourceTypeInAppPurchaseImages, ID: "image-1"}}},
+		{name: "iap value", request: InAppPurchaseImageV2UpdateRequest{Data: InAppPurchaseImageV2UpdateData{Type: ResourceTypeInAppPurchaseImages, ID: "image-1", Attributes: &InAppPurchaseImageV2UpdateAttributes{Uploaded: &NullableBool{Value: nullableEncodingTestPtr(true)}}}}, want: "true", set: true},
+		{name: "iap null", request: InAppPurchaseImageV2UpdateRequest{Data: InAppPurchaseImageV2UpdateData{Type: ResourceTypeInAppPurchaseImages, ID: "image-1", Attributes: &InAppPurchaseImageV2UpdateAttributes{Uploaded: &NullableBool{}}}}, want: "null", set: true},
+		{name: "subscription omitted", request: SubscriptionImageV2UpdateRequest{Data: SubscriptionImageV2UpdateData{Type: ResourceTypeSubscriptionImages, ID: "image-1"}}},
+		{name: "subscription value", request: SubscriptionImageV2UpdateRequest{Data: SubscriptionImageV2UpdateData{Type: ResourceTypeSubscriptionImages, ID: "image-1", Attributes: SubscriptionImageV2UpdateAttributes{Uploaded: &NullableBool{Value: nullableEncodingTestPtr(false)}}}}, want: "false", set: true},
+		{name: "subscription null", request: SubscriptionImageV2UpdateRequest{Data: SubscriptionImageV2UpdateData{Type: ResourceTypeSubscriptionImages, ID: "image-1", Attributes: SubscriptionImageV2UpdateAttributes{Uploaded: &NullableBool{}}}}, want: "null", set: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assertNullableAttributeEncoding(t, test.request, "uploaded", test.want, test.set)
+		})
+	}
+}

--- a/internal/asc/output_age_rating.go
+++ b/internal/asc/output_age_rating.go
@@ -36,8 +36,8 @@ func ageRatingFields(resp *AgeRatingDeclarationResponse) []ageRatingField {
 		{Name: "Messaging and Chat", Value: formatOptionalBool(attrs.MessagingAndChat)},
 		{Name: "Parental Controls", Value: formatOptionalBool(attrs.ParentalControls)},
 		{Name: "Age Assurance", Value: formatOptionalBool(attrs.AgeAssurance)},
-		{Name: "Social Media", Value: formatOptionalBool(attrs.SocialMedia)},
-		{Name: "Social Media Age Restricted", Value: formatOptionalBool(attrs.SocialMediaAgeRestricted)},
+		{Name: "Social Media", Value: formatOptionalBool(nullableBoolPointer(attrs.SocialMedia))},
+		{Name: "Social Media Age Restricted", Value: formatOptionalBool(nullableBoolPointer(attrs.SocialMediaAgeRestricted))},
 		{Name: "Unrestricted Web Access", Value: formatOptionalBool(attrs.UnrestrictedWebAccess)},
 		{Name: "User-Generated Content", Value: formatOptionalBool(attrs.UserGeneratedContent)},
 		// Enum content descriptors
@@ -69,6 +69,13 @@ func formatOptionalBool(value *bool) string {
 		return "-"
 	}
 	return strconv.FormatBool(*value)
+}
+
+func nullableBoolPointer(value *NullableBool) *bool {
+	if value == nil {
+		return nil
+	}
+	return value.Value
 }
 
 func formatOptionalString(value *string) string {

--- a/internal/asc/output_age_rating_test.go
+++ b/internal/asc/output_age_rating_test.go
@@ -13,8 +13,8 @@ func TestPrintTableAgeRatingIncludesSocialMediaFields(t *testing.T) {
 			ID:   "age-441",
 			Type: ResourceTypeAgeRatingDeclarations,
 			Attributes: AgeRatingDeclarationAttributes{
-				SocialMedia:              &socialMedia,
-				SocialMediaAgeRestricted: &ageRestricted,
+				SocialMedia:              &NullableBool{Value: &socialMedia},
+				SocialMediaAgeRestricted: &NullableBool{Value: &ageRestricted},
 			},
 		},
 	}

--- a/internal/asc/subscription_group_versions.go
+++ b/internal/asc/subscription_group_versions.go
@@ -37,9 +37,9 @@ type SubscriptionGroupVersionCreateRequest struct {
 
 // SubscriptionGroupLocalizationV2CreateAttributes describes version-scoped localization attributes.
 type SubscriptionGroupLocalizationV2CreateAttributes struct {
-	Name          string `json:"name"`
-	CustomAppName string `json:"customAppName,omitempty"`
-	Locale        string `json:"locale"`
+	Name          string          `json:"name"`
+	CustomAppName *NullableString `json:"customAppName,omitempty"`
+	Locale        string          `json:"locale"`
 }
 
 // SubscriptionGroupLocalizationV2UpdateAttributes describes nullable v2 updates.

--- a/internal/asc/subscription_versions.go
+++ b/internal/asc/subscription_versions.go
@@ -52,9 +52,9 @@ type SubscriptionLocalizationV2Attributes struct {
 
 // SubscriptionLocalizationV2CreateAttributes describes localization create attributes.
 type SubscriptionLocalizationV2CreateAttributes struct {
-	Name        string  `json:"name"`
-	Locale      string  `json:"locale"`
-	Description *string `json:"description,omitempty"`
+	Name        string          `json:"name"`
+	Locale      string          `json:"locale"`
+	Description *NullableString `json:"description,omitempty"`
 }
 
 // SubscriptionLocalizationV2UpdateAttributes describes localization update attributes.
@@ -110,7 +110,7 @@ type SubscriptionImageV2CreateAttributes struct {
 
 // SubscriptionImageV2UpdateAttributes describes the upload commit state.
 type SubscriptionImageV2UpdateAttributes struct {
-	Uploaded *bool `json:"uploaded,omitempty"`
+	Uploaded *NullableBool `json:"uploaded,omitempty"`
 }
 
 // SubscriptionImageV2CreateData is the data portion of an image create request.

--- a/internal/asc/subscription_versions_http_test.go
+++ b/internal/asc/subscription_versions_http_test.go
@@ -217,7 +217,7 @@ func TestSubscriptionLocalizationV2Mutations(t *testing.T) {
 		jsonResponse(http.StatusNoContent, ``),
 	)
 	ctx := context.Background()
-	if _, err := client.CreateSubscriptionLocalizationV2(ctx, "ver-1", SubscriptionLocalizationV2CreateAttributes{Name: "Pro", Locale: "en-US", Description: &description}); err != nil {
+	if _, err := client.CreateSubscriptionLocalizationV2(ctx, "ver-1", SubscriptionLocalizationV2CreateAttributes{Name: "Pro", Locale: "en-US", Description: &NullableString{Value: &description}}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := client.UpdateSubscriptionLocalizationV2(ctx, "loc-1", SubscriptionLocalizationV2UpdateAttributes{
@@ -312,7 +312,7 @@ func TestSubscriptionImageV2Mutations(t *testing.T) {
 				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 					t.Fatal(err)
 				}
-				if payload.Data.Attributes.Uploaded == nil || !*payload.Data.Attributes.Uploaded {
+				if payload.Data.Attributes.Uploaded == nil || payload.Data.Attributes.Uploaded.Value == nil || !*payload.Data.Attributes.Uploaded.Value {
 					t.Fatalf("expected uploaded=true: %+v", payload)
 				}
 			case http.MethodDelete:
@@ -332,7 +332,7 @@ func TestSubscriptionImageV2Mutations(t *testing.T) {
 		t.Fatal(err)
 	}
 	uploaded := true
-	if _, err := client.UpdateSubscriptionImageV2(ctx, "img-1", SubscriptionImageV2UpdateAttributes{Uploaded: &uploaded}); err != nil {
+	if _, err := client.UpdateSubscriptionImageV2(ctx, "img-1", SubscriptionImageV2UpdateAttributes{Uploaded: &NullableBool{Value: &uploaded}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := client.DeleteSubscriptionImageV2(ctx, "img-1"); err != nil {
@@ -466,7 +466,7 @@ func TestSubscriptionVersionClientRequiredValuesFailBeforeRequest(t *testing.T) 
 		}},
 		{name: "get image ID", call: func() error { _, err := client.GetSubscriptionImageV2(context.Background(), " "); return err }},
 		{name: "update image ID", call: func() error {
-			_, err := client.UpdateSubscriptionImageV2(context.Background(), " ", SubscriptionImageV2UpdateAttributes{Uploaded: &falseValue})
+			_, err := client.UpdateSubscriptionImageV2(context.Background(), " ", SubscriptionImageV2UpdateAttributes{Uploaded: &NullableBool{Value: &falseValue}})
 			return err
 		}},
 		{name: "delete image ID", call: func() error { return client.DeleteSubscriptionImageV2(context.Background(), " ") }},

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -309,16 +309,16 @@ Examples:
 }
 
 func validateAgeRatingDependencies(attrs asc.AgeRatingDeclarationAttributes) error {
-	if boolIsTrue(attrs.SocialMedia) && boolIsFalse(attrs.UserGeneratedContent) {
+	if boolIsTrue(nullableBoolValue(attrs.SocialMedia)) && boolIsFalse(attrs.UserGeneratedContent) {
 		return shared.UsageError("--social-media true cannot be combined with --user-generated-content false")
 	}
-	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.AgeAssurance) {
+	if boolIsTrue(nullableBoolValue(attrs.SocialMediaAgeRestricted)) && boolIsFalse(attrs.AgeAssurance) {
 		return shared.UsageError("--social-media-age-restricted true cannot be combined with --age-assurance false")
 	}
-	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.SocialMedia) {
+	if boolIsTrue(nullableBoolValue(attrs.SocialMediaAgeRestricted)) && boolIsFalse(nullableBoolValue(attrs.SocialMedia)) {
 		return shared.UsageError("--social-media-age-restricted true cannot be combined with --social-media false")
 	}
-	if boolIsTrue(attrs.SocialMediaAgeRestricted) && boolIsFalse(attrs.UserGeneratedContent) {
+	if boolIsTrue(nullableBoolValue(attrs.SocialMediaAgeRestricted)) && boolIsFalse(attrs.UserGeneratedContent) {
 		return shared.UsageError("--social-media-age-restricted true cannot be combined with --user-generated-content false")
 	}
 	return nil
@@ -330,6 +330,13 @@ func boolIsTrue(value *bool) bool {
 
 func boolIsFalse(value *bool) bool {
 	return value != nil && !*value
+}
+
+func nullableBoolValue(value *asc.NullableBool) *bool {
+	if value == nil {
+		return nil
+	}
+	return value.Value
 }
 
 func fetchAgeRatingDeclaration(ctx context.Context, client *asc.Client, appID, appInfoID, versionID string) (*asc.AgeRatingDeclarationResponse, error) {
@@ -381,8 +388,6 @@ func buildAgeRatingAttributes(values map[string]string) (asc.AgeRatingDeclaratio
 		{"messaging-and-chat", &attrs.MessagingAndChat},
 		{"parental-controls", &attrs.ParentalControls},
 		{"age-assurance", &attrs.AgeAssurance},
-		{"social-media", &attrs.SocialMedia},
-		{"social-media-age-restricted", &attrs.SocialMediaAgeRestricted},
 		{"unrestricted-web-access", &attrs.UnrestrictedWebAccess},
 		{"user-generated-content", &attrs.UserGeneratedContent},
 	}
@@ -392,6 +397,22 @@ func buildAgeRatingAttributes(values map[string]string) (asc.AgeRatingDeclaratio
 			return attrs, err
 		}
 		*f.dest = val
+	}
+	nullableBoolFields := []struct {
+		flag string
+		dest **asc.NullableBool
+	}{
+		{"social-media", &attrs.SocialMedia},
+		{"social-media-age-restricted", &attrs.SocialMediaAgeRestricted},
+	}
+	for _, f := range nullableBoolFields {
+		val, err := shared.ParseOptionalBoolFlag("--"+f.flag, values[f.flag])
+		if err != nil {
+			return attrs, err
+		}
+		if val != nil {
+			*f.dest = &asc.NullableBool{Value: val}
+		}
 	}
 
 	// Enum content descriptors (NONE, INFREQUENT_OR_MILD, FREQUENT_OR_INTENSE)

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -93,10 +93,10 @@ func TestAgeRatingHelpers(t *testing.T) {
 	if attrs.Gambling == nil || *attrs.Gambling != true {
 		t.Fatal("expected gambling=true")
 	}
-	if attrs.SocialMedia == nil || !*attrs.SocialMedia {
+	if attrs.SocialMedia == nil || attrs.SocialMedia.Value == nil || !*attrs.SocialMedia.Value {
 		t.Fatal("expected social-media=true")
 	}
-	if attrs.SocialMediaAgeRestricted == nil || *attrs.SocialMediaAgeRestricted {
+	if attrs.SocialMediaAgeRestricted == nil || attrs.SocialMediaAgeRestricted.Value == nil || *attrs.SocialMediaAgeRestricted.Value {
 		t.Fatal("expected social-media-age-restricted=false")
 	}
 
@@ -177,7 +177,7 @@ func TestValidateAgeRatingDependenciesRejectsTransitiveUGCContradiction(t *testi
 
 	err := validateAgeRatingDependencies(asc.AgeRatingDeclarationAttributes{
 		AgeAssurance:             &trueValue,
-		SocialMediaAgeRestricted: &trueValue,
+		SocialMediaAgeRestricted: &asc.NullableBool{Value: &trueValue},
 		UserGeneratedContent:     &falseValue,
 	})
 	if err == nil || !strings.Contains(err.Error(), "--social-media-age-restricted true cannot be combined with --user-generated-content false") {
@@ -195,20 +195,20 @@ func TestValidateAgeRatingDependenciesAllowsPartialUpdates(t *testing.T) {
 	}{
 		{
 			name:  "social media may rely on stored user generated content",
-			attrs: asc.AgeRatingDeclarationAttributes{SocialMedia: &trueValue},
+			attrs: asc.AgeRatingDeclarationAttributes{SocialMedia: &asc.NullableBool{Value: &trueValue}},
 		},
 		{
 			name: "age restriction may rely on stored prerequisites",
 			attrs: asc.AgeRatingDeclarationAttributes{
-				SocialMediaAgeRestricted: &trueValue,
+				SocialMediaAgeRestricted: &asc.NullableBool{Value: &trueValue},
 			},
 		},
 		{
 			name: "all prerequisites explicitly enabled",
 			attrs: asc.AgeRatingDeclarationAttributes{
 				AgeAssurance:             &trueValue,
-				SocialMedia:              &trueValue,
-				SocialMediaAgeRestricted: &trueValue,
+				SocialMedia:              &asc.NullableBool{Value: &trueValue},
+				SocialMediaAgeRestricted: &asc.NullableBool{Value: &trueValue},
 				UserGeneratedContent:     &trueValue,
 			},
 		},
@@ -216,7 +216,7 @@ func TestValidateAgeRatingDependenciesAllowsPartialUpdates(t *testing.T) {
 			name: "unrelated false fields",
 			attrs: asc.AgeRatingDeclarationAttributes{
 				AgeAssurance:         &falseValue,
-				SocialMedia:          &falseValue,
+				SocialMedia:          &asc.NullableBool{Value: &falseValue},
 				UserGeneratedContent: &falseValue,
 			},
 		},
@@ -248,8 +248,8 @@ func TestApplyAllNoneDefaultsSetsAllContentDescriptors(t *testing.T) {
 		"messaging-and-chat":          attrs.MessagingAndChat,
 		"parental-controls":           attrs.ParentalControls,
 		"age-assurance":               attrs.AgeAssurance,
-		"social-media":                attrs.SocialMedia,
-		"social-media-age-restricted": attrs.SocialMediaAgeRestricted,
+		"social-media":                nullableBoolValue(attrs.SocialMedia),
+		"social-media-age-restricted": nullableBoolValue(attrs.SocialMediaAgeRestricted),
 		"unrestricted-web-access":     attrs.UnrestrictedWebAccess,
 		"user-generated-content":      attrs.UserGeneratedContent,
 	}

--- a/internal/cli/cmdtest/age_rating_4_4_1_test.go
+++ b/internal/cli/cmdtest/age_rating_4_4_1_test.go
@@ -23,10 +23,10 @@ func TestAgeRatingEditSendsSocialMediaFields(t *testing.T) {
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode payload: %v", err)
 		}
-		if payload.Data.Attributes.SocialMedia == nil || !*payload.Data.Attributes.SocialMedia {
+		if payload.Data.Attributes.SocialMedia == nil || payload.Data.Attributes.SocialMedia.Value == nil || !*payload.Data.Attributes.SocialMedia.Value {
 			t.Fatalf("expected socialMedia=true, got %#v", payload.Data.Attributes.SocialMedia)
 		}
-		if payload.Data.Attributes.SocialMediaAgeRestricted == nil || *payload.Data.Attributes.SocialMediaAgeRestricted {
+		if payload.Data.Attributes.SocialMediaAgeRestricted == nil || payload.Data.Attributes.SocialMediaAgeRestricted.Value == nil || *payload.Data.Attributes.SocialMediaAgeRestricted.Value {
 			t.Fatalf("expected socialMediaAgeRestricted=false, got %#v", payload.Data.Attributes.SocialMediaAgeRestricted)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -70,10 +70,10 @@ func TestAgeRatingEditSendsSocialMediaFields(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
 		t.Fatalf("parse stdout: %v; stdout=%q", err, stdout)
 	}
-	if response.Data.Attributes.SocialMedia == nil || !*response.Data.Attributes.SocialMedia {
+	if response.Data.Attributes.SocialMedia == nil || response.Data.Attributes.SocialMedia.Value == nil || !*response.Data.Attributes.SocialMedia.Value {
 		t.Fatalf("expected socialMedia=true output, got %#v", response.Data.Attributes.SocialMedia)
 	}
-	if response.Data.Attributes.SocialMediaAgeRestricted == nil || *response.Data.Attributes.SocialMediaAgeRestricted {
+	if response.Data.Attributes.SocialMediaAgeRestricted == nil || response.Data.Attributes.SocialMediaAgeRestricted.Value == nil || *response.Data.Attributes.SocialMediaAgeRestricted.Value {
 		t.Fatalf("expected socialMediaAgeRestricted=false output, got %#v", response.Data.Attributes.SocialMediaAgeRestricted)
 	}
 }

--- a/internal/cli/cmdtest/subscription_versions_test.go
+++ b/internal/cli/cmdtest/subscription_versions_test.go
@@ -323,7 +323,7 @@ func TestSubscriptionVersionImageUploadLifecycle(t *testing.T) {
 				reportSubscriptionVersionHandlerError(t, w, "decode commit body: %v", err)
 				return
 			}
-			if payload.Data.ID != "img-1" || payload.Data.Attributes.Uploaded == nil || !*payload.Data.Attributes.Uploaded {
+			if payload.Data.ID != "img-1" || payload.Data.Attributes.Uploaded == nil || payload.Data.Attributes.Uploaded.Value == nil || !*payload.Data.Attributes.Uploaded.Value {
 				reportSubscriptionVersionHandlerError(t, w, "commit payload = %+v", payload)
 				return
 			}

--- a/internal/cli/iap/version_images.go
+++ b/internal/cli/iap/version_images.go
@@ -127,7 +127,7 @@ func IAPVersionImagesCreateCommand() *ffcli.Command {
 				return fmt.Errorf("iap versions images create: upload failed for reserved image %q: %w", reservedID, err)
 			}
 			uploaded := true
-			if _, err := client.UpdateInAppPurchaseImageV2(requestCtx, reservedID, asc.InAppPurchaseImageV2UpdateAttributes{Uploaded: &uploaded}); err != nil {
+			if _, err := client.UpdateInAppPurchaseImageV2(requestCtx, reservedID, asc.InAppPurchaseImageV2UpdateAttributes{Uploaded: &asc.NullableBool{Value: &uploaded}}); err != nil {
 				return fmt.Errorf("iap versions images create: failed to commit upload for reserved image %q: %w", reservedID, err)
 			}
 			resp, err := client.GetInAppPurchaseImageV2(requestCtx, reservedID)
@@ -204,7 +204,7 @@ func IAPVersionImagesUpdateCommand() *ffcli.Command {
 			}
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
-			resp, err := client.UpdateInAppPurchaseImageV2(requestCtx, value, asc.InAppPurchaseImageV2UpdateAttributes{Uploaded: &uploadedValue})
+			resp, err := client.UpdateInAppPurchaseImageV2(requestCtx, value, asc.InAppPurchaseImageV2UpdateAttributes{Uploaded: &asc.NullableBool{Value: &uploadedValue}})
 			if err != nil {
 				return fmt.Errorf("iap versions images update: failed to update: %w", err)
 			}

--- a/internal/cli/iap/version_localizations.go
+++ b/internal/cli/iap/version_localizations.go
@@ -131,7 +131,11 @@ func IAPVersionLocalizationsCreateCommand() *ffcli.Command {
 			}
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
-			resp, err := client.CreateInAppPurchaseLocalizationV2(requestCtx, vid, asc.InAppPurchaseLocalizationCreateAttributes{Name: nameValue, Locale: localeValue, Description: strings.TrimSpace(*description)})
+			attrs := asc.InAppPurchaseLocalizationV2CreateAttributes{Name: nameValue, Locale: localeValue}
+			if descriptionValue := strings.TrimSpace(*description); descriptionValue != "" {
+				attrs.Description = &asc.NullableString{Value: &descriptionValue}
+			}
+			resp, err := client.CreateInAppPurchaseLocalizationV2(requestCtx, vid, attrs)
 			if err != nil {
 				return fmt.Errorf("iap versions localizations create: failed to create: %w", err)
 			}

--- a/internal/cli/subscriptions/group_version_localizations.go
+++ b/internal/cli/subscriptions/group_version_localizations.go
@@ -156,9 +156,11 @@ func SubscriptionsGroupsVersionLocalizationsCreateCommand() *ffcli.Command {
 			}
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
-			resp, err := client.CreateSubscriptionGroupLocalizationV2(requestCtx, vid, asc.SubscriptionGroupLocalizationV2CreateAttributes{
-				Name: nameValue, Locale: localeValue, CustomAppName: strings.TrimSpace(*customAppName),
-			})
+			attrs := asc.SubscriptionGroupLocalizationV2CreateAttributes{Name: nameValue, Locale: localeValue}
+			if customNameValue := strings.TrimSpace(*customAppName); customNameValue != "" {
+				attrs.CustomAppName = &asc.NullableString{Value: &customNameValue}
+			}
+			resp, err := client.CreateSubscriptionGroupLocalizationV2(requestCtx, vid, attrs)
 			if err != nil {
 				return fmt.Errorf("subscriptions groups versions localizations create: failed to create: %w", err)
 			}

--- a/internal/cli/subscriptions/version_images.go
+++ b/internal/cli/subscriptions/version_images.go
@@ -314,7 +314,7 @@ func SubscriptionsVersionImagesUploadCommand() *ffcli.Command {
 				return fmt.Errorf("subscriptions versions images upload: upload failed for reserved image %s: %w", reservation.Data.ID, err)
 			}
 			uploaded := true
-			resp, err := client.UpdateSubscriptionImageV2(requestCtx, reservation.Data.ID, asc.SubscriptionImageV2UpdateAttributes{Uploaded: &uploaded})
+			resp, err := client.UpdateSubscriptionImageV2(requestCtx, reservation.Data.ID, asc.SubscriptionImageV2UpdateAttributes{Uploaded: &asc.NullableBool{Value: &uploaded}})
 			if err != nil {
 				return fmt.Errorf("subscriptions versions images upload: failed to commit reserved image %s: %w", reservation.Data.ID, err)
 			}
@@ -352,7 +352,7 @@ func SubscriptionsVersionImagesUpdateCommand() *ffcli.Command {
 			}
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
-			resp, err := client.UpdateSubscriptionImageV2(requestCtx, imageID, asc.SubscriptionImageV2UpdateAttributes{Uploaded: &value})
+			resp, err := client.UpdateSubscriptionImageV2(requestCtx, imageID, asc.SubscriptionImageV2UpdateAttributes{Uploaded: &asc.NullableBool{Value: &value}})
 			if err != nil {
 				return fmt.Errorf("subscriptions versions images update: failed to update: %w", err)
 			}

--- a/internal/cli/subscriptions/version_localizations.go
+++ b/internal/cli/subscriptions/version_localizations.go
@@ -267,7 +267,7 @@ func SubscriptionsVersionLocalizationsCreateCommand() *ffcli.Command {
 			}
 			attrs := asc.SubscriptionLocalizationV2CreateAttributes{Name: nameValue, Locale: localeValue}
 			if description.set {
-				attrs.Description = &description.value
+				attrs.Description = &asc.NullableString{Value: &description.value}
 			}
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/validate/age_rating_test.go
+++ b/internal/cli/validate/age_rating_test.go
@@ -11,8 +11,8 @@ func TestMapAgeRatingDeclarationIncludesSocialMediaFields(t *testing.T) {
 	falseValue := false
 
 	mapped := mapAgeRatingDeclaration(asc.AgeRatingDeclarationAttributes{
-		SocialMedia:              &trueValue,
-		SocialMediaAgeRestricted: &falseValue,
+		SocialMedia:              &asc.NullableBool{Value: &trueValue},
+		SocialMediaAgeRestricted: &asc.NullableBool{Value: &falseValue},
 	})
 
 	if mapped.SocialMedia == nil || !*mapped.SocialMedia {

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -360,8 +360,8 @@ func mapAgeRatingDeclaration(attrs asc.AgeRatingDeclarationAttributes) *validati
 		MessagingAndChat:                    attrs.MessagingAndChat,
 		ParentalControls:                    attrs.ParentalControls,
 		AgeAssurance:                        attrs.AgeAssurance,
-		SocialMedia:                         attrs.SocialMedia,
-		SocialMediaAgeRestricted:            attrs.SocialMediaAgeRestricted,
+		SocialMedia:                         nullableAgeRatingBool(attrs.SocialMedia),
+		SocialMediaAgeRestricted:            nullableAgeRatingBool(attrs.SocialMediaAgeRestricted),
 		UnrestrictedWebAccess:               attrs.UnrestrictedWebAccess,
 		UserGeneratedContent:                attrs.UserGeneratedContent,
 		AlcoholTobaccoOrDrugUseOrReferences: attrs.AlcoholTobaccoOrDrugUseOrReferences,
@@ -383,4 +383,11 @@ func mapAgeRatingDeclaration(attrs asc.AgeRatingDeclarationAttributes) *validati
 		KoreaAgeRatingOverride:    attrs.KoreaAgeRatingOverride,
 		DeveloperAgeRatingInfoURL: attrs.DeveloperAgeRatingInfoURL,
 	}
+}
+
+func nullableAgeRatingBool(value *asc.NullableBool) *bool {
+	if value == nil {
+		return nil
+	}
+	return value.Value
 }


### PR DESCRIPTION
## Summary

- preserve the OpenAPI 4.4.1 omit/value/null distinction for seven nullable request properties
- add a v2-specific in-app-purchase localization create model so the released legacy v1 model remains compatible
- adapt existing CLI call sites without changing flags, help, or their current wire values

## Schema contract

The checked-in 4.4.1 snapshot marks these optional request properties as `nullable: true`:

- `AgeRatingDeclarationUpdateRequest`: `socialMedia`, `socialMediaAgeRestricted`
- `InAppPurchaseLocalizationV2CreateRequest`: `description`
- `SubscriptionLocalizationV2CreateRequest`: `description`
- `SubscriptionGroupLocalizationV2CreateRequest`: `customAppName`
- `InAppPurchaseImageV2UpdateRequest`: `uploaded`
- `SubscriptionImageV2UpdateRequest`: `uploaded`

The typed models now encode a nil wrapper pointer as omitted, a populated wrapper as its value, and a non-nil wrapper with a nil value as explicit JSON `null`.

## Compatibility

- no new or changed commands, flags, output formats, or exit codes
- current CLI values serialize exactly as before
- legacy `InAppPurchaseLocalizationCreateAttributes` is unchanged; v2 uses `InAppPurchaseLocalizationV2CreateAttributes`
- the affected 4.4.1 v2/new typed fields have not shipped in the latest 3.0.0 release

## Verification

- established RED on all seven fields before changing the models
- added table-driven omit/value/null request-encoding coverage
- focused nullable encoding tests: pass
- adjacent `internal/asc`, age-rating, validation, IAP, subscriptions, and command tests: pass
- repository-wide compile: pass
- `make format`: pass
- `make check-docs`: pass
- `make lint`: pass
- `ASC_BYPASS_KEYCHAIN=1 make test`: pass
- built `/private/tmp/asc-null-fidelity`; all six affected command help paths exit 0 with unchanged usage

## Live verification

Not run. This change only corrects deterministic JSON request encoding and makes no new App Store Connect behavior claim. No App Store Connect resources were created, changed, submitted, or deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved nullable/optional handling for age-rating and version-scoped fields, preserving “omitted” vs “explicit null” vs “value” encoding.
  * Updated V2 localization and image update payloads to correctly represent optional descriptions, custom app names, and upload completion status.

* **Bug Fixes**
  * Prevented unintended inclusion of empty optional inputs in request payloads.
  * Refined age-rating dependency validation and output rendering for nullable social media flags.

* **Tests**
  * Added and updated encoding-focused tests to verify omit/value/null JSON behavior across relevant request types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->