### PR TITLE
fix(iap): complete 4.4.1 related sparse fields

### DIFF
--- a/commands/iap.mdx
+++ b/commands/iap.mdx
@@ -84,6 +84,11 @@ asc iap versions submit --version-id "IAP_VERSION_ID" --submission "REVIEW_SUBMI
 Use the version ID—not the product ID—for v2 localization, image, and review
 submission operations.
 
+The deprecated product-scoped localization and image read commands remain
+available only for migration. Their list/detail reads accept
+`--iap-fields versions` when the included parent product must expose its
+versions, but new automation should use the version-scoped commands above.
+
 <Warning>
   Resolve and reuse an existing version before running `versions create`.
   Apple exposes no DELETE operation for IAP versions, and deleting the parent
@@ -361,7 +366,9 @@ asc iap review-screenshots create \
   --file "./screenshot.png"
 
 # View review screenshot
-asc iap review-screenshots view --iap-id "IAP_ID"
+asc iap review-screenshots view \
+  --iap-id "IAP_ID" \
+  --iap-fields versions
 
 # Delete review screenshot
 asc iap review-screenshots delete \
@@ -406,11 +413,39 @@ asc iap pricing availabilities view --id "AVAILABILITY_ID"
 
 Promote in-app purchases on your App Store product page.
 
+Promoted-purchase reads support the exact related-resource sparse fields from
+App Store Connect API 4.4.1. `--iap-fields` maps to
+`fields[inAppPurchases]`; `--subscription-fields` maps to
+`fields[subscriptions]`. Selecting either field set automatically includes its
+matching relationship.
+
+### List Promoted Purchases
+
+```bash  theme={null}
+asc iap promoted-purchases list \
+  --app "APP_ID" \
+  --iap-fields versions \
+  --subscription-fields versions
+```
+
 ### View Promoted Purchase
 
 ```bash  theme={null}
-asc iap promoted-purchases view --promoted-purchase-id "PROMO_ID"
+asc iap promoted-purchases view \
+  --promoted-purchase-id "PROMO_ID" \
+  --iap-fields versions \
+  --subscription-fields versions
+
+# Resolve the promoted purchase through its IAP relationship
+asc iap promoted-purchases view \
+  --iap-id "IAP_ID" \
+  --iap-fields versions \
+  --subscription-fields versions
 ```
+
+Provide exactly one of `--promoted-purchase-id` or `--iap-id`. Sparse-field
+flags cannot be combined with `--next` on list commands because the next-page
+URL already owns its query parameters.
 
 ### Create Promoted Purchase
 
@@ -463,7 +498,9 @@ Manage hosted content for in-app purchases.
 
 ```bash  theme={null}
 # View content status
-asc iap content view --iap-id "IAP_ID"
+asc iap content view \
+  --iap-id "IAP_ID" \
+  --iap-fields versions
 ```
 
 ## Submission

--- a/commands/iap.mdx
+++ b/commands/iap.mdx
@@ -449,11 +449,11 @@ asc iap promoted-purchases view \
   --iap-fields versions
 ```
 
-Provide exactly one of `--promoted-purchase-id` or `--iap-id`. The IAP selector
-accepts an ASC resource ID, product ID, or exact current name. Product IDs and
-names require `--app` or `ASC_APP_ID`; a numeric ASC resource ID can be used
-directly without app context. Sparse-field flags cannot be combined with
-`--next` on list commands because the next-page URL already owns its query
+Provide exactly one of `--promoted-purchase-id` or `--iap-id IAP_SELECTOR`.
+`IAP_SELECTOR` accepts an ASC resource ID, product ID, or exact current name.
+Product IDs and names require `--app` or `ASC_APP_ID`; a numeric ASC resource ID
+can be used directly without app context. Sparse-field flags cannot be combined
+with `--next` on list commands because the next-page URL already owns its query
 parameters.
 
 ### Create Promoted Purchase

--- a/commands/iap.mdx
+++ b/commands/iap.mdx
@@ -438,14 +438,23 @@ asc iap promoted-purchases view \
 
 # Resolve the promoted purchase through its IAP relationship
 asc iap promoted-purchases view \
-  --iap-id "IAP_ID" \
+  --iap-id "123456789" \
   --iap-fields versions \
   --subscription-fields versions
+
+# Resolve a product ID or exact current name inside an app
+asc iap promoted-purchases view \
+  --app "APP_ID" \
+  --iap-id "com.example.pro" \
+  --iap-fields versions
 ```
 
-Provide exactly one of `--promoted-purchase-id` or `--iap-id`. Sparse-field
-flags cannot be combined with `--next` on list commands because the next-page
-URL already owns its query parameters.
+Provide exactly one of `--promoted-purchase-id` or `--iap-id`. The IAP selector
+accepts an ASC resource ID, product ID, or exact current name. Product IDs and
+names require `--app` or `ASC_APP_ID`; a numeric ASC resource ID can be used
+directly without app context. Sparse-field flags cannot be combined with
+`--next` on list commands because the next-page URL already owns its query
+parameters.
 
 ### Create Promoted Purchase
 

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -333,7 +333,7 @@ change.
 
 | Contract area | Semantic change | Verification owner | Exact evidence |
 | --- | --- | --- | --- |
-| IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 | `ee40c7b3`; endpoint-specific option and exact query tests |
+| IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 plus the related-resource sparse-field follow-up | `ee40c7b3` plus `client_iap_related_sparse_fields_441_test.go`; all 11 propagated IAP/promoted-purchase GETs now have endpoint-specific options and exact-query tests |
 | Subscription reads | Subscription detail and group-subscription reads gain version includes, sparse fields, and relationship limits; subscription sparse fields gain `versions` across related endpoints | #1779 | `c8f3ab52`; exact query and compatibility tests |
 | Subscription-group reads | Group detail and app-group collection reads gain version includes, sparse fields, and relationship limits; group sparse fields gain `versions` | #1780 | `48d04e0b`; exact query, owner/next validation, and compatibility tests |
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
@@ -517,8 +517,10 @@ payload, output, and compatibility tests):
 - [x] `GET /v1/apps/{id}/appInfos`
 - [x] `GET /v1/ciProducts/{id}/app`
 
-IAP and promoted-purchase propagation (#1777 at `ee40c7b3`; endpoint-exact
-query and response compatibility tests):
+IAP and promoted-purchase propagation (#1777 at `ee40c7b3` plus the
+related-resource sparse-field follow-up; endpoint-exact query and response
+compatibility tests). The follow-up closes the 11 related GETs below while
+preserving #1777's top-level IAP list/detail behavior:
 
 - [x] `GET /v1/apps/{id}/inAppPurchasesV2`
 - [x] `GET /v1/inAppPurchaseAppStoreReviewScreenshots/{id}`

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -83,8 +83,8 @@ separately and has no invented landed `main` commit:
 | Transitive age-rating dependency closure | #1788 | `08003c38` | `9282e82d` | Merged and `main`-gated |
 | Final 4.4.1 coverage ledger | #1789 | `51b3a962` | `d6d8d94b` | Merged and `main`-gated; documentation only |
 | Subscription localization delete-confirmation coverage | #1790 | `49eda126` | `73466720` | Merged; test only |
-| Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only; current #1792 base |
-| Seven-property nullable request fidelity | #1792 | `db3657b6` implementation head | - | Open and pre-merge; no landed `main` SHA |
+| Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only |
+| Seven-property nullable request fidelity | #1792 | `3f7d1449` | `804624cd` | Merged; exact final head landed on `main` |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#50 | `61b9634` | `e5561a9` | Merged; landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
@@ -103,23 +103,21 @@ a value, but not explicit JSON `null`. #1792 is the first implementation to
 preserve all three states for `socialMedia`, `socialMediaAgeRestricted`, the two
 v2 localization `description` properties, v2 group-localization
 `customAppName`, and the two v2 image `uploaded` properties. Its exact audited
-implementation head is
-`db3657b6c6e88ebbf7f0da59137c92df99931e59`. That head also preserves the
+final PR head is
+`3f7d14495fcb3b696692bee4955e36fd2f36c63f`. That head also preserves the
 legacy omission behavior for a whitespace-only `customAppName` while retaining
-explicit JSON `null`. This documentation follow-up is a later commit on the same
-open PR, so `db3657b6` is deliberately recorded as the
-implementation head rather than misrepresented as a self-referential final PR
-head.
+explicit JSON `null`; it landed on `main` as
+`804624cd158d1eb8843d8e0be7cf55bc639da0a1`.
 
-The last fully merged behavior integration before #1792 is `main` commit
-`9282e82d1feebddaaaa3285c658e6960b8a500f3`; #1789 then landed this coverage
-ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and docs-only #1791
-produced the current #1792 base `e902d375`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
+The current fully merged behavior integration is #1792 at `main` commit
+`804624cd158d1eb8843d8e0be7cf55bc639da0a1`; #1789 previously landed this
+coverage ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and
+docs-only #1791 landed at `e902d375`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
 173-contract, 61-modified-schema, and 9-addition/7-deprecation counts are
 unchanged. The recursive built-help comparison from `839c4da6` to `9282e82d`
 found 48 added and 52 changed leaf paths, 100 affected paths total, with zero
-removals; it is historical help-surface evidence, not proof of #1792's nullable
-request encoding.
+removals; it is historical help-surface evidence rather than the nullable
+request-encoding proof, which is carried by #1792's typed tests.
 
 ## Live App Store Connect verification
 
@@ -159,7 +157,7 @@ Live behavior refined four schema-level assumptions:
   localizations, subscription localizations, and subscription images. A runtime
   validator migration was therefore a live-verified no-op, not an assumption.
 
-PR #1792 makes no new live explicit-null claim. It adds typed-client fidelity and
+PR #1792 made no new live explicit-null claim. It added typed-client fidelity and
 table-driven omit/value/null encoding tests only. The existing CLI commands
 continue to send the same concrete values or omissions as before; they do not
 gain a new clear/null flag. No explicit-null request for the age-rating, group
@@ -333,12 +331,12 @@ change.
 
 | Contract area | Semantic change | Verification owner | Exact evidence |
 | --- | --- | --- | --- |
-| IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 plus the related-resource sparse-field follow-up | `ee40c7b3` plus `client_iap_related_sparse_fields_441_test.go`; all 11 propagated IAP/promoted-purchase GETs now have endpoint-specific options and exact-query tests |
+| IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 plus the related-resource sparse-field follow-up | `ee40c7b3` plus `client_iap_related_sparse_fields_441_test.go`; all 11 propagated IAP/promoted-purchase GETs now have endpoint-specific options and exact-query tests; follow-up remains pre-merge until its own PR lands |
 | Subscription reads | Subscription detail and group-subscription reads gain version includes, sparse fields, and relationship limits; subscription sparse fields gain `versions` across related endpoints | #1779 | `c8f3ab52`; exact query and compatibility tests |
 | Subscription-group reads | Group detail and app-group collection reads gain version includes, sparse fields, and relationship limits; group sparse fields gain `versions` | #1780 | `48d04e0b`; exact query, owner/next validation, and compatibility tests |
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
 | Pricing reads | Price-point sparse fields gain `adjustedEqualizations`; existing equalization and price-point relationship operations gain `filter[upfrontPricePointId]` and `filter[planType]` where allowed | #1778 | `39284b0a`; endpoint-specific option, exact query, strict CSV/enums, territory inclusion, opaque-next, ID validation, and aggregation tests |
-| Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 and #1792 | `39284b0a` added the fields and CLI behavior; #1792 implementation head `db3657b6` adds exact omit/value/null request encoding |
+| Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 and #1792 | `39284b0a` added the fields and CLI behavior; #1792 final head `3f7d1449`, landed as `804624cd`, adds exact omit/value/null request encoding |
 | App info reads | `AppInfo.attributes.kidsAgeBand` and `fields[appInfos]=kidsAgeBand` appear as deprecated additions | #1778 | `39284b0a`; generic decoding/output characterization, no new write path |
 | Included-resource unions | IAP, subscription, group, and review-submission responses gain their corresponding version resource discriminators | #1777, #1779, #1780, #1781 | `ee40c7b3`, `c8f3ab52`, `48d04e0b`, `aba35e0a`; typed response and included-resource tests |
 
@@ -371,7 +369,7 @@ remained at the immediate pre-PR base.
 Still different before the 4.4.1 schema PR:
 
 - [x] `AgeRatingDeclaration` - two social-media Boolean attributes (#1778, `39284b0a`)
-- [x] `AgeRatingDeclarationUpdateRequest` - two social-media update attributes added in #1778 (`39284b0a`); exact omit/value/null fidelity first implemented in #1792 at `db3657b6`
+- [x] `AgeRatingDeclarationUpdateRequest` - two social-media update attributes added in #1778 (`39284b0a`); exact omit/value/null fidelity landed from #1792 at `804624cd`
 - [x] `AppInfo` - deprecated `kidsAgeBand` read attribute (#1778, `39284b0a`)
 - [x] `InAppPurchaseV2` - versions relationship (#1777, `ee40c7b3`)
 - [x] `InAppPurchaseV2Response` - included IAP-version discriminator (#1777, `ee40c7b3`)
@@ -450,13 +448,13 @@ round-trip tests):
 - [x] `InAppPurchaseVersionImagesLinkagesResponse`
 - [x] `InAppPurchaseVersionLocalizationsLinkagesResponse`
 - [x] `InAppPurchaseLocalizationV2`
-- [x] `InAppPurchaseLocalizationV2CreateRequest` - nullable create description completed by #1792 at `db3657b6`
+- [x] `InAppPurchaseLocalizationV2CreateRequest` - nullable create description completed by #1792, landed at `804624cd`
 - [x] `InAppPurchaseLocalizationV2UpdateRequest`
 - [x] `InAppPurchaseLocalizationV2Response`
 - [x] `InAppPurchaseLocalizationsV2Response`
 - [x] `InAppPurchaseImageV2`
 - [x] `InAppPurchaseImageV2CreateRequest`
-- [x] `InAppPurchaseImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `db3657b6`
+- [x] `InAppPurchaseImageV2UpdateRequest` - nullable uploaded state completed by #1792, landed at `804624cd`
 - [x] `InAppPurchaseImageV2Response`
 - [x] `InAppPurchaseImagesV2Response`
 
@@ -472,13 +470,13 @@ and round-trip tests):
 - [x] `SubscriptionVersionImagesLinkagesResponse`
 - [x] `SubscriptionVersionLocalizationsLinkagesResponse`
 - [x] `SubscriptionLocalizationV2`
-- [x] `SubscriptionLocalizationV2CreateRequest` - nullable create description completed by #1792 at `db3657b6`
+- [x] `SubscriptionLocalizationV2CreateRequest` - nullable create description completed by #1792, landed at `804624cd`
 - [x] `SubscriptionLocalizationV2UpdateRequest`
 - [x] `SubscriptionLocalizationV2Response`
 - [x] `SubscriptionLocalizationsV2Response`
 - [x] `SubscriptionImageV2`
 - [x] `SubscriptionImageV2CreateRequest`
-- [x] `SubscriptionImageV2UpdateRequest` - nullable uploaded state completed by #1792 at `db3657b6`
+- [x] `SubscriptionImageV2UpdateRequest` - nullable uploaded state completed by #1792, landed at `804624cd`
 - [x] `SubscriptionImageV2Response`
 - [x] `SubscriptionImagesV2Response`
 
@@ -492,7 +490,7 @@ request/response and round-trip tests):
 - [x] `SubscriptionGroupVersionsLinkagesResponse`
 - [x] `SubscriptionGroupVersionLocalizationsLinkagesResponse`
 - [x] `SubscriptionGroupLocalizationV2`
-- [x] `SubscriptionGroupLocalizationV2CreateRequest` - nullable custom app name completed by #1792 at `db3657b6`
+- [x] `SubscriptionGroupLocalizationV2CreateRequest` - nullable custom app name completed by #1792, landed at `804624cd`
 - [x] `SubscriptionGroupLocalizationV2UpdateRequest`
 - [x] `SubscriptionGroupLocalizationV2Response`
 - [x] `SubscriptionGroupLocalizationsV2Response`
@@ -751,11 +749,11 @@ after the original 4.4 import (31):
 | 2 | Discrete subscription versions and their localizations/promotional images | #1779 | 18-operation ledger, CLI/HTTP/upload tests | Implemented at `c8f3ab52` |
 | 3 | Discrete subscription-group versions and their localizations | #1780 | 10-operation ledger and CLI/HTTP tests | Implemented at `48d04e0b` |
 | 4 | Submit all three version types through review-submission items | #1777 and #1781 | Three exact relationship payload tests plus built-command tests | Implemented at `ee40c7b3` and `aba35e0a` |
-| 5 | Version-scoped v2 IAP localizations and images | #1777 and #1792 | CRUD/upload coverage from #1777; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `ee40c7b3`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
-| 6 | Version-scoped v2 subscription localizations and images | #1779 and #1792 | CRUD/upload coverage from #1779; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `c8f3ab52`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
-| 7 | Version-scoped v2 subscription-group localizations | #1780 and #1792 | CRUD coverage from #1780; #1792 table-tests `customAppName` omission/value/null encoding, including whitespace omission | Feature implementation at `48d04e0b`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
+| 5 | Version-scoped v2 IAP localizations and images | #1777 and #1792 | CRUD/upload coverage from #1777; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `ee40c7b3`; complete nullable request fidelity landed from #1792 at `804624cd` |
+| 6 | Version-scoped v2 subscription localizations and images | #1779 and #1792 | CRUD/upload coverage from #1779; #1792 table-tests create-description and image-upload omission/value/null encoding | Feature implementation at `c8f3ab52`; complete nullable request fidelity landed from #1792 at `804624cd` |
+| 7 | Version-scoped v2 subscription-group localizations | #1780 and #1792 | CRUD coverage from #1780; #1792 table-tests `customAppName` omission/value/null encoding, including whitespace omission | Feature implementation at `48d04e0b`; complete nullable request fidelity landed from #1792 at `804624cd` |
 | 8 | Adjusted subscription equalizations and new filters | #1778 | Exact query/response, option-scope, strict-CSV/enum, territory-inclusion, opaque-next, ID-validation, and aggregation tests | Implemented at `39284b0a` |
-| 9 | `socialMedia` and `socialMediaAgeRestricted` age-rating attributes | #1778 and #1792 | Payload/output/help coverage from #1778; #1792 table-tests omission/value/null encoding for both update fields | Feature implementation at `39284b0a`; complete nullable request fidelity at #1792 implementation head `db3657b6` (pre-merge) |
+| 9 | `socialMedia` and `socialMediaAgeRestricted` age-rating attributes | #1778 and #1792 | Payload/output/help coverage from #1778; #1792 table-tests omission/value/null encoding for both update fields | Feature implementation at `39284b0a`; complete nullable request fidelity landed from #1792 at `804624cd` |
 
 ## Deprecation and migration ledger
 
@@ -816,25 +814,24 @@ documented deprecation window; this goal intentionally stops before release.
 15. Subscription localization delete-confirmation coverage was audited at
     #1790 head `49eda126` and landed as `73466720`; it is test-only.
 16. Hardened public 4.4.1 command workflows were audited at #1791 head
-    `e9c2a0dc` and landed as `e902d375`; that docs-only commit is the current
-    base of #1792.
-17. #1792 first completes all seven nullable request properties at exact
-    implementation head `db3657b6c6e88ebbf7f0da59137c92df99931e59`.
-    The PR remains open and pre-merge, this ledger change is a later docs-only
-    commit on that PR, and no landed `main` SHA is claimed.
+    `e9c2a0dc` and landed as `e902d375`; that docs-only commit became the base
+    for #1792.
+17. #1792 completed all seven nullable request properties at exact final head
+    `3f7d14495fcb3b696692bee4955e36fd2f36c63f` and landed on `main` as
+    `804624cd158d1eb8843d8e0be7cf55bc639da0a1`.
 18. External workflow skills were audited at exact head `61b9634` and landed as
     `e5561a9`. All 11 review threads are resolved, and the landed tree passes all
     23 skill validators plus 245 command-example and 716 flag help checks.
-19. Exact CLI `main` `9282e82d` is the last fully merged behavior integration
-    before #1792 and has green integration, Govulncheck, and CodeQL workflows.
+19. Exact CLI `main` `804624cd` is the current fully merged behavior integration
+    through #1792. Its PR head passed integration, Govulncheck, and CodeQL workflows.
     Its built help has 48 added and 52 changed leaf paths relative to
-    `839c4da6`, with zero removals. Those workflows and help counts do not prove
-    #1792's still-pre-merge nullable encoding.
+    `839c4da6`, with zero removals. Those historical help counts do not replace
+    #1792's typed nullable-encoding tests.
 
 CLI behavior and lifecycle PRs through #1788, the ledger PR, test-only #1790,
-docs-only #1791, and the companion skills PR are merged. #1792 remains the
-nullable-fidelity closeout gate. No release, tag, or package publication is
-part of this goal.
+docs-only #1791, nullable-fidelity #1792, and the companion skills PR are
+merged. This IAP sparse-field follow-up remains pre-merge until its own PR
+lands. No release, tag, or package publication is part of this goal.
 
 ### Built help-surface delta
 
@@ -995,7 +992,7 @@ pre-merge evidence are separated explicitly:
   discoverable typed command/client surfaces.
 - [x] Classified all 102 direct plus 71 transitive operation-contract changes:
   173 unique existing-operation contracts with no missing or extra ledger item.
-- [x] On #1792 implementation head `db3657b6`, mapped all 47 added and 61
+- [x] On #1792 final head `3f7d1449`, landed as `804624cd`, mapped all 47 added and 61
   modified schemas to typed models, documented generic decoding, or an
   already-reconciled schema-only disposition. This includes table-driven
   omission/value/null encoding for the seven nullable properties missed by the
@@ -1009,9 +1006,9 @@ pre-merge evidence are separated explicitly:
 - [x] Sequentially merged all 13 exact audited CLI heads through #1788,
   producing `main` `9282e82d`; its integration, Govulncheck, and CodeQL
   workflows passed.
-- [ ] #1792 remains open and pre-merge. Its implementation head is
-  `db3657b6c6e88ebbf7f0da59137c92df99931e59`; there is no landed `main` SHA or
-  post-merge workflow result to record yet.
+- [x] #1792 merged from exact final head
+  `3f7d14495fcb3b696692bee4955e36fd2f36c63f` and landed on `main` as
+  `804624cd158d1eb8843d8e0be7cf55bc639da0a1`.
 - [x] Deprecated all 29 public legacy leaves with one exact warning and direct
   migration help, added conditional setup warnings, and documented all 33
   exported legacy client methods without deleting stable behavior.
@@ -1035,10 +1032,11 @@ pre-merge evidence are separated explicitly:
   read succeeded, all four age fields were restored to `false`, and all four
   review submissions contained zero items. This predates #1792 and is not
   evidence that Apple accepts explicit null for its seven corrected fields.
-- [x] Confirmed the last fully merged behavior integration, `main` `9282e82d`,
-  has green integration, Govulncheck, and CodeQL workflows; #1789 later landed
+- [x] Confirmed the fully merged behavior integration through #1792, `main`
+  `804624cd`, follows green exact-head integration, Govulncheck, and CodeQL
+  workflows; #1789 previously landed
   the ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and docs-only
-  #1791 produced #1792's base `e902d375`. Skills `main` `e5561a9` still passes local validation (it has no
+  #1791 landed at `e902d375`. Skills `main` `e5561a9` still passes local validation (it has no
   configured `main` status or check runs), and the latest release/tag remains
   `3.0.0` at the pre-integration commit `839c4da6`. No release, tag,
   Homebrew/WinGet update, or package publication was performed.

--- a/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
@@ -1,4 +1,4 @@
-# App Store Connect API 4.4.1 IAP related sparse fields
+# App Store Connect API 4.4.1 IAP-related sparse fields
 
 ## Placement and command shape
 

--- a/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
@@ -14,12 +14,14 @@ The public additions are endpoint-specific sparse-field flags:
 - `asc iap promoted-purchases list|view ... --iap-fields versions --subscription-fields versions`
 - `asc subscriptions promoted-purchases list|view ... --iap-fields versions --subscription-fields versions`
 
-The IAP-scoped promoted-purchase view also accepts
-`--iap-id IAP_ID` as an alternative to `--promoted-purchase-id PROMO_ID` and
-uses `/v2/inAppPurchases/{id}/promotedPurchase`. Exactly one selector is
-required. The shared scoped-command hook is owner-agnostic so the subscription
-slice can add its symmetric relationship selector without duplicating command
-logic.
+The IAP-scoped promoted-purchase view also accepts `--iap-id IAP_SELECTOR` as
+an alternative to `--promoted-purchase-id PROMO_ID` and uses
+`/v2/inAppPurchases/{id}/promotedPurchase`. The selector follows the established
+IAP convention: an ASC resource ID passes through directly, while a product ID
+or exact current name is resolved inside `--app` or `ASC_APP_ID`. Exactly one
+selector is required. The shared scoped-command hook is owner-agnostic so the
+subscription slice can add its symmetric relationship selector and resolver
+without duplicating command logic.
 
 Both promoted-purchase command scopes expose both related-product sparse-field
 flags because their shared API operations permit both fieldsets. The deprecated

--- a/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
@@ -11,8 +11,8 @@ The public additions are endpoint-specific sparse-field flags:
 - `asc iap content view ... --iap-fields versions`
 - `asc iap images list|view ... --iap-fields versions`
 - `asc iap localizations list ... --iap-fields versions`
-- `asc iap promoted-purchases list|view ... --iap-fields versions`
-- `asc subscriptions promoted-purchases list|view ... --subscription-fields versions`
+- `asc iap promoted-purchases list|view ... --iap-fields versions --subscription-fields versions`
+- `asc subscriptions promoted-purchases list|view ... --iap-fields versions --subscription-fields versions`
 
 The IAP-scoped promoted-purchase view also accepts
 `--iap-id IAP_ID` as an alternative to `--promoted-purchase-id PROMO_ID` and
@@ -21,9 +21,10 @@ required. The shared scoped-command hook is owner-agnostic so the subscription
 slice can add its symmetric relationship selector without duplicating command
 logic.
 
-The current help for these commands has no related-product sparse-field flag.
-The deprecated product-scoped image and localization commands remain available
-and retain their existing warnings and migration guidance.
+Both promoted-purchase command scopes expose both related-product sparse-field
+flags because their shared API operations permit both fieldsets. The deprecated
+product-scoped image and localization commands remain available and retain
+their existing warnings and migration guidance.
 
 ## Exact API contracts
 
@@ -73,7 +74,8 @@ deprecated warning surface. The changed help will regenerate
 After focused tests, validation is `make format`, `make check-docs`,
 `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`, plus built-binary help and
 error-stream checks. A read-only live smoke is optional; no mutation is needed
-to validate query construction.
+to validate query construction. The public IAP command page documents the
+long-form flags and owner selector against the built help.
 
 ## Alternatives
 

--- a/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-iap-related-sparse-fields.md
@@ -1,0 +1,84 @@
+# App Store Connect API 4.4.1 IAP related sparse fields
+
+## Placement and command shape
+
+This compatibility slice extends the existing IAP subresource and scoped
+promoted-purchase commands. It does not add a command group or registry entry.
+
+The public additions are endpoint-specific sparse-field flags:
+
+- `asc iap review-screenshots view ... --iap-fields versions`
+- `asc iap content view ... --iap-fields versions`
+- `asc iap images list|view ... --iap-fields versions`
+- `asc iap localizations list ... --iap-fields versions`
+- `asc iap promoted-purchases list|view ... --iap-fields versions`
+- `asc subscriptions promoted-purchases list|view ... --subscription-fields versions`
+
+The IAP-scoped promoted-purchase view also accepts
+`--iap-id IAP_ID` as an alternative to `--promoted-purchase-id PROMO_ID` and
+uses `/v2/inAppPurchases/{id}/promotedPurchase`. Exactly one selector is
+required. The shared scoped-command hook is owner-agnostic so the subscription
+slice can add its symmetric relationship selector without duplicating command
+logic.
+
+The current help for these commands has no related-product sparse-field flag.
+The deprecated product-scoped image and localization commands remain available
+and retain their existing warnings and migration guidance.
+
+## Exact API contracts
+
+The 4.4.1 OpenAPI snapshot adds `versions` to `fields[inAppPurchases]` on these
+GET operations:
+
+- `/v1/inAppPurchaseAppStoreReviewScreenshots/{id}`
+- `/v1/inAppPurchaseContents/{id}`
+- `/v1/inAppPurchaseImages/{id}`
+- `/v1/inAppPurchaseLocalizations/{id}`
+- `/v1/promotedPurchases/{id}`
+- `/v1/apps/{id}/promotedPurchases`
+- `/v2/inAppPurchases/{id}/appStoreReviewScreenshot`
+- `/v2/inAppPurchases/{id}/content`
+- `/v2/inAppPurchases/{id}/images`
+- `/v2/inAppPurchases/{id}/inAppPurchaseLocalizations`
+- `/v2/inAppPurchases/{id}/promotedPurchase`
+
+The three promoted-purchase operations also add `versions` to
+`fields[subscriptions]`. Sparse fields are useful only when their related
+resource is included, so the client builders automatically add the exact
+relationship: `inAppPurchaseV2` for screenshots, content, localizations, and
+promoted purchases; `inAppPurchase` for images; and `subscription` for
+subscription fields. Callers may also request the endpoint's exact include
+set explicitly through typed options.
+
+Responses remain the existing JSON:API response types, including `included`,
+`links`, and `meta`. The commands continue to write data to stdout and errors
+to stderr with the existing output defaults.
+
+## Validation and compatibility
+
+CLI sparse-field values are checked against the endpoint's exact OpenAPI enum
+before authentication, ID resolution, or HTTP. List commands reject combining
+`--next` with sparse-field flags because the opaque next URL already owns its
+query. Invalid selections and next conflicts are usage errors. Deprecated
+commands are extended in place rather than removed.
+
+## RED-GREEN and verification
+
+RED coverage will assert exact query strings for all eleven client methods,
+including automatic includes and both promoted-purchase fieldsets. CLI tests
+will cover successful flags, invalid enums, opaque-next conflicts, and the
+deprecated warning surface. The changed help will regenerate
+`docs/COMMANDS.md`.
+
+After focused tests, validation is `make format`, `make check-docs`,
+`make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`, plus built-binary help and
+error-stream checks. A read-only live smoke is optional; no mutation is needed
+to validate query construction.
+
+## Alternatives
+
+A universal arbitrary-query map would be smaller but would accept unsupported
+keys and values on unrelated endpoints. Extending only the top-level IAP reads
+would also miss the exact 4.4.1 propagation change. Dedicated typed option
+families keep the allowed query surface aligned with each endpoint while
+preserving existing method and command compatibility.

--- a/internal/asc/client_iap_related_sparse_fields_441_test.go
+++ b/internal/asc/client_iap_related_sparse_fields_441_test.go
@@ -1,0 +1,207 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestIAPRelatedReadsPropagateVersionSparseFields441(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		response  string
+		wantQuery map[string]string
+		invoke    func(context.Context, *Client) error
+	}{
+		{
+			name:     "review screenshot detail",
+			path:     "/v1/inAppPurchaseAppStoreReviewScreenshots/shot-1",
+			response: `{"data":{"type":"inAppPurchaseAppStoreReviewScreenshots","id":"shot-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseAppStoreReviewScreenshot(ctx, "shot-1", WithIAPReviewScreenshotIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "review screenshot relationship",
+			path:     "/v2/inAppPurchases/iap-1/appStoreReviewScreenshot",
+			response: `{"data":{"type":"inAppPurchaseAppStoreReviewScreenshots","id":"shot-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseAppStoreReviewScreenshotForIAP(ctx, "iap-1", WithIAPReviewScreenshotIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "content detail",
+			path:     "/v1/inAppPurchaseContents/content-1",
+			response: `{"data":{"type":"inAppPurchaseContents","id":"content-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseContentByID(ctx, "content-1", WithIAPContentIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "content relationship",
+			path:     "/v2/inAppPurchases/iap-1/content",
+			response: `{"data":{"type":"inAppPurchaseContents","id":"content-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseContent(ctx, "iap-1", WithIAPContentIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "image detail",
+			path:     "/v1/inAppPurchaseImages/image-1",
+			response: `{"data":{"type":"inAppPurchaseImages","id":"image-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchase",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseImage(ctx, "image-1", WithIAPImageIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "images relationship",
+			path:     "/v2/inAppPurchases/iap-1/images",
+			response: `{"data":[]}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchase",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseImages(ctx, "iap-1", WithIAPImagesIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "localization detail",
+			path:     "/v1/inAppPurchaseLocalizations/localization-1",
+			response: `{"data":{"type":"inAppPurchaseLocalizations","id":"localization-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseLocalization(ctx, "localization-1", WithIAPLocalizationIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "localizations relationship",
+			path:     "/v2/inAppPurchases/iap-1/inAppPurchaseLocalizations",
+			response: `{"data":[]}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchaseLocalizations(ctx, "iap-1", WithIAPLocalizationsIAPFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "promoted purchase detail",
+			path:     "/v1/promotedPurchases/promo-1",
+			response: `{"data":{"type":"promotedPurchases","id":"promo-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"fields[subscriptions]":  "versions",
+				"include":                "inAppPurchaseV2,subscription",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetPromotedPurchase(ctx, "promo-1", WithPromotedPurchaseIAPFields([]string{"versions"}), WithPromotedPurchaseSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "app promoted purchases",
+			path:     "/v1/apps/app-1/promotedPurchases",
+			response: `{"data":[]}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"fields[subscriptions]":  "versions",
+				"include":                "inAppPurchaseV2,subscription",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetAppPromotedPurchases(ctx, "app-1", WithPromotedPurchasesIAPFields([]string{"versions"}), WithPromotedPurchasesSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name:     "iap promoted purchase relationship",
+			path:     "/v2/inAppPurchases/iap-1/promotedPurchase",
+			response: `{"data":{"type":"promotedPurchases","id":"promo-1"}}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"fields[subscriptions]":  "versions",
+				"include":                "inAppPurchaseV2,subscription",
+			},
+			invoke: func(ctx context.Context, client *Client) error {
+				_, err := client.GetInAppPurchasePromotedPurchase(ctx, "iap-1", WithPromotedPurchaseIAPFields([]string{"versions"}), WithPromotedPurchaseSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", req.Method)
+				}
+				if req.URL.Path != tt.path {
+					t.Fatalf("path = %q, want %q", req.URL.Path, tt.path)
+				}
+				if len(req.URL.Query()) != len(tt.wantQuery) {
+					t.Fatalf("query = %v, want exactly %v", req.URL.Query(), tt.wantQuery)
+				}
+				for key, want := range tt.wantQuery {
+					if got := req.URL.Query().Get(key); got != want {
+						t.Fatalf("query %s = %q, want %q", key, got, want)
+					}
+				}
+			}, jsonResponse(http.StatusOK, tt.response))
+
+			if err := tt.invoke(context.Background(), client); err != nil {
+				t.Fatalf("invoke() error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIAPRelatedSparseFieldsExplicitIncludesAreDeduplicated441(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		if got := req.URL.Query().Get("include"); got != "inAppPurchaseV2" {
+			t.Fatalf("include = %q, want inAppPurchaseV2", got)
+		}
+	}, jsonResponse(http.StatusOK, `{"data":{"type":"inAppPurchaseContents","id":"content-1"}}`))
+
+	_, err := client.GetInAppPurchaseContent(
+		context.Background(),
+		"iap-1",
+		WithIAPContentInclude([]string{"inAppPurchaseV2"}),
+		WithIAPContentIAPFields([]string{"versions"}),
+	)
+	if err != nil {
+		t.Fatalf("GetInAppPurchaseContent() error: %v", err)
+	}
+}

--- a/internal/asc/client_iap_related_sparse_fields_441_test.go
+++ b/internal/asc/client_iap_related_sparse_fields_441_test.go
@@ -175,8 +175,9 @@ func TestIAPRelatedReadsPropagateVersionSparseFields441(t *testing.T) {
 					t.Fatalf("query = %v, want exactly %v", req.URL.Query(), tt.wantQuery)
 				}
 				for key, want := range tt.wantQuery {
-					if got := req.URL.Query().Get(key); got != want {
-						t.Fatalf("query %s = %q, want %q", key, got, want)
+					values := req.URL.Query()[key]
+					if len(values) != 1 || values[0] != want {
+						t.Fatalf("query %s = %v, want exactly [%q]", key, values, want)
 					}
 				}
 			}, jsonResponse(http.StatusOK, tt.response))
@@ -190,8 +191,9 @@ func TestIAPRelatedReadsPropagateVersionSparseFields441(t *testing.T) {
 
 func TestIAPRelatedSparseFieldsExplicitIncludesAreDeduplicated441(t *testing.T) {
 	client := newTestClient(t, func(req *http.Request) {
-		if got := req.URL.Query().Get("include"); got != "inAppPurchaseV2" {
-			t.Fatalf("include = %q, want inAppPurchaseV2", got)
+		values := req.URL.Query()["include"]
+		if len(values) != 1 || values[0] != "inAppPurchaseV2" {
+			t.Fatalf("include = %v, want exactly [inAppPurchaseV2]", values)
 		}
 	}, jsonResponse(http.StatusOK, `{"data":{"type":"inAppPurchaseContents","id":"content-1"}}`))
 

--- a/internal/asc/client_iap_subresources.go
+++ b/internal/asc/client_iap_subresources.go
@@ -116,13 +116,20 @@ func (c *Client) DeleteInAppPurchaseLocalization(ctx context.Context, localizati
 // GetInAppPurchaseLocalization retrieves an IAP localization by ID.
 //
 // Deprecated: Use GetInAppPurchaseLocalizationV2.
-func (c *Client) GetInAppPurchaseLocalization(ctx context.Context, localizationID string) (*InAppPurchaseLocalizationResponse, error) {
+func (c *Client) GetInAppPurchaseLocalization(ctx context.Context, localizationID string, opts ...IAPLocalizationOption) (*InAppPurchaseLocalizationResponse, error) {
 	localizationID = strings.TrimSpace(localizationID)
 	if localizationID == "" {
 		return nil, fmt.Errorf("localizationID is required")
 	}
 
+	query := &iapLocalizationQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/inAppPurchaseLocalizations/%s", localizationID)
+	if queryString := buildIAPLocalizationQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -176,13 +183,20 @@ func (c *Client) GetInAppPurchaseImages(ctx context.Context, iapID string, opts 
 // GetInAppPurchaseImage retrieves an in-app purchase image by ID.
 //
 // Deprecated: Use GetInAppPurchaseImageV2.
-func (c *Client) GetInAppPurchaseImage(ctx context.Context, imageID string) (*InAppPurchaseImageResponse, error) {
+func (c *Client) GetInAppPurchaseImage(ctx context.Context, imageID string, opts ...IAPImageOption) (*InAppPurchaseImageResponse, error) {
 	imageID = strings.TrimSpace(imageID)
 	if imageID == "" {
 		return nil, fmt.Errorf("imageID is required")
 	}
 
+	query := &iapImageQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/inAppPurchaseImages/%s", imageID)
+	if queryString := buildIAPImageQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -298,13 +312,20 @@ func (c *Client) DeleteInAppPurchaseImage(ctx context.Context, imageID string) e
 }
 
 // GetInAppPurchaseAppStoreReviewScreenshotForIAP retrieves the review screenshot for an IAP.
-func (c *Client) GetInAppPurchaseAppStoreReviewScreenshotForIAP(ctx context.Context, iapID string) (*InAppPurchaseAppStoreReviewScreenshotResponse, error) {
+func (c *Client) GetInAppPurchaseAppStoreReviewScreenshotForIAP(ctx context.Context, iapID string, opts ...IAPReviewScreenshotOption) (*InAppPurchaseAppStoreReviewScreenshotResponse, error) {
 	iapID = strings.TrimSpace(iapID)
 	if iapID == "" {
 		return nil, fmt.Errorf("iapID is required")
 	}
 
+	query := &iapReviewScreenshotQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v2/inAppPurchases/%s/appStoreReviewScreenshot", iapID)
+	if queryString := buildIAPReviewScreenshotQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -319,13 +340,20 @@ func (c *Client) GetInAppPurchaseAppStoreReviewScreenshotForIAP(ctx context.Cont
 }
 
 // GetInAppPurchaseAppStoreReviewScreenshot retrieves a review screenshot by ID.
-func (c *Client) GetInAppPurchaseAppStoreReviewScreenshot(ctx context.Context, screenshotID string) (*InAppPurchaseAppStoreReviewScreenshotResponse, error) {
+func (c *Client) GetInAppPurchaseAppStoreReviewScreenshot(ctx context.Context, screenshotID string, opts ...IAPReviewScreenshotOption) (*InAppPurchaseAppStoreReviewScreenshotResponse, error) {
 	screenshotID = strings.TrimSpace(screenshotID)
 	if screenshotID == "" {
 		return nil, fmt.Errorf("screenshotID is required")
 	}
 
+	query := &iapReviewScreenshotQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/inAppPurchaseAppStoreReviewScreenshots/%s", screenshotID)
+	if queryString := buildIAPReviewScreenshotQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -568,13 +596,20 @@ func (c *Client) CreateInAppPurchaseAvailability(ctx context.Context, iapID stri
 }
 
 // GetInAppPurchaseContent retrieves the content resource for an IAP.
-func (c *Client) GetInAppPurchaseContent(ctx context.Context, iapID string) (*InAppPurchaseContentResponse, error) {
+func (c *Client) GetInAppPurchaseContent(ctx context.Context, iapID string, opts ...IAPContentOption) (*InAppPurchaseContentResponse, error) {
 	iapID = strings.TrimSpace(iapID)
 	if iapID == "" {
 		return nil, fmt.Errorf("iapID is required")
 	}
 
+	query := &iapContentQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v2/inAppPurchases/%s/content", iapID)
+	if queryString := buildIAPContentQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -589,13 +624,20 @@ func (c *Client) GetInAppPurchaseContent(ctx context.Context, iapID string) (*In
 }
 
 // GetInAppPurchaseContentByID retrieves an in-app purchase content resource by ID.
-func (c *Client) GetInAppPurchaseContentByID(ctx context.Context, contentID string) (*InAppPurchaseContentResponse, error) {
+func (c *Client) GetInAppPurchaseContentByID(ctx context.Context, contentID string, opts ...IAPContentOption) (*InAppPurchaseContentResponse, error) {
 	contentID = strings.TrimSpace(contentID)
 	if contentID == "" {
 		return nil, fmt.Errorf("contentID is required")
 	}
 
+	query := &iapContentQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/inAppPurchaseContents/%s", contentID)
+	if queryString := buildIAPContentQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -738,13 +780,20 @@ func (c *Client) GetInAppPurchasePriceScheduleByID(ctx context.Context, schedule
 }
 
 // GetInAppPurchasePromotedPurchase retrieves the promoted purchase for an in-app purchase.
-func (c *Client) GetInAppPurchasePromotedPurchase(ctx context.Context, iapID string) (*PromotedPurchaseResponse, error) {
+func (c *Client) GetInAppPurchasePromotedPurchase(ctx context.Context, iapID string, opts ...PromotedPurchaseGetOption) (*PromotedPurchaseResponse, error) {
 	iapID = strings.TrimSpace(iapID)
 	if iapID == "" {
 		return nil, fmt.Errorf("iapID is required")
 	}
 
+	query := &promotedPurchaseGetQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v2/inAppPurchases/%s/promotedPurchase", iapID)
+	if queryString := buildPromotedPurchaseGetQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_promoted_purchases.go
+++ b/internal/asc/client_promoted_purchases.go
@@ -99,9 +99,16 @@ func (c *Client) SetAppPromotedPurchases(ctx context.Context, appID string, prom
 }
 
 // GetPromotedPurchase retrieves a promoted purchase by ID.
-func (c *Client) GetPromotedPurchase(ctx context.Context, promotedPurchaseID string) (*PromotedPurchaseResponse, error) {
+func (c *Client) GetPromotedPurchase(ctx context.Context, promotedPurchaseID string, opts ...PromotedPurchaseGetOption) (*PromotedPurchaseResponse, error) {
 	promotedPurchaseID = strings.TrimSpace(promotedPurchaseID)
+	query := &promotedPurchaseGetQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/promotedPurchases/%s", promotedPurchaseID)
+	if queryString := buildPromotedPurchaseGetQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_query_commerce.go
+++ b/internal/asc/client_query_commerce.go
@@ -29,6 +29,9 @@ type winBackOfferPricesQuery struct {
 
 type promotedPurchasesQuery struct {
 	listQuery
+	iapFields          []string
+	subscriptionFields []string
+	include            []string
 }
 
 type territoryAvailabilitiesQuery struct {
@@ -58,6 +61,11 @@ type appPriceSchedulePricesQuery struct {
 func buildPromotedPurchasesQuery(query *promotedPurchasesQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	include := includeWhenFieldsSelected(query.include, "inAppPurchaseV2", query.iapFields)
+	include = includeWhenFieldsSelected(include, "subscription", query.subscriptionFields)
+	addCSV(values, "include", include)
 	return values.Encode()
 }
 
@@ -283,6 +291,21 @@ func WithPromotedPurchasesNextURL(next string) PromotedPurchasesOption {
 			q.nextURL = strings.TrimSpace(next)
 		}
 	}
+}
+
+// WithPromotedPurchasesIAPFields sets fields[inAppPurchases] for included IAPs.
+func WithPromotedPurchasesIAPFields(fields []string) PromotedPurchasesOption {
+	return func(q *promotedPurchasesQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithPromotedPurchasesSubscriptionFields sets fields[subscriptions] for included subscriptions.
+func WithPromotedPurchasesSubscriptionFields(fields []string) PromotedPurchasesOption {
+	return func(q *promotedPurchasesQuery) { q.subscriptionFields = normalizeUniqueList(fields) }
+}
+
+// WithPromotedPurchasesInclude sets the exact promoted-purchase relationship include set.
+func WithPromotedPurchasesInclude(include []string) PromotedPurchasesOption {
+	return func(q *promotedPurchasesQuery) { q.include = normalizeUniqueList(include) }
 }
 
 // WithTerritoryAvailabilitiesLimit sets the max number of territory availabilities to return.

--- a/internal/asc/iap.go
+++ b/internal/asc/iap.go
@@ -142,6 +142,8 @@ type inAppPurchaseGetQuery struct {
 
 type iapLocalizationsQuery struct {
 	listQuery
+	iapFields []string
+	include   []string
 }
 
 // WithIAPLimit sets the max number of IAPs to return.
@@ -242,6 +244,16 @@ func WithIAPLocalizationsNextURL(next string) IAPLocalizationsOption {
 	}
 }
 
+// WithIAPLocalizationsIAPFields sets fields[inAppPurchases] for included IAPs.
+func WithIAPLocalizationsIAPFields(fields []string) IAPLocalizationsOption {
+	return func(q *iapLocalizationsQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithIAPLocalizationsInclude sets the exact localization relationship include set.
+func WithIAPLocalizationsInclude(include []string) IAPLocalizationsOption {
+	return func(q *iapLocalizationsQuery) { q.include = normalizeUniqueList(include) }
+}
+
 func buildInAppPurchasesQuery(query *inAppPurchasesQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
@@ -270,5 +282,7 @@ func buildInAppPurchaseGetQuery(query *inAppPurchaseGetQuery) string {
 func buildIAPLocalizationsQuery(query *iapLocalizationsQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "include", includeWhenFieldsSelected(query.include, "inAppPurchaseV2", query.iapFields))
 	return values.Encode()
 }

--- a/internal/asc/iap_queries.go
+++ b/internal/asc/iap_queries.go
@@ -20,6 +20,8 @@ type (
 
 type iapImagesQuery struct {
 	listQuery
+	iapFields []string
+	include   []string
 }
 
 type iapOfferCodesQuery struct {
@@ -81,6 +83,16 @@ func WithIAPImagesNextURL(next string) IAPImagesOption {
 			q.nextURL = strings.TrimSpace(next)
 		}
 	}
+}
+
+// WithIAPImagesIAPFields sets fields[inAppPurchases] for included IAPs.
+func WithIAPImagesIAPFields(fields []string) IAPImagesOption {
+	return func(q *iapImagesQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithIAPImagesInclude sets the exact image relationship include set.
+func WithIAPImagesInclude(include []string) IAPImagesOption {
+	return func(q *iapImagesQuery) { q.include = normalizeUniqueList(include) }
 }
 
 func WithIAPOfferCodesLimit(limit int) IAPOfferCodesOption {
@@ -288,6 +300,8 @@ func WithIAPPriceScheduleAutomaticPricesLimit(limit int) IAPPriceScheduleOption 
 func buildIAPImagesQuery(query *iapImagesQuery) string {
 	values := url.Values{}
 	addLimit(values, query.limit)
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "include", includeWhenFieldsSelected(query.include, "inAppPurchase", query.iapFields))
 	return values.Encode()
 }
 

--- a/internal/asc/iap_related_queries.go
+++ b/internal/asc/iap_related_queries.go
@@ -1,0 +1,144 @@
+package asc
+
+import "net/url"
+
+// IAPReviewScreenshotOption configures review screenshot detail and related-resource reads.
+type IAPReviewScreenshotOption func(*iapReviewScreenshotQuery)
+
+// IAPContentOption configures content detail and related-resource reads.
+type IAPContentOption func(*iapContentQuery)
+
+// IAPImageOption configures a legacy in-app purchase image detail read.
+type IAPImageOption func(*iapImageQuery)
+
+// IAPLocalizationOption configures a legacy in-app purchase localization detail read.
+type IAPLocalizationOption func(*iapLocalizationQuery)
+
+// PromotedPurchaseGetOption configures promoted purchase detail and related-resource reads.
+type PromotedPurchaseGetOption func(*promotedPurchaseGetQuery)
+
+type iapReviewScreenshotQuery struct {
+	iapFields []string
+	include   []string
+}
+
+type iapContentQuery struct {
+	iapFields []string
+	include   []string
+}
+
+type iapImageQuery struct {
+	iapFields []string
+	include   []string
+}
+
+type iapLocalizationQuery struct {
+	iapFields []string
+	include   []string
+}
+
+type promotedPurchaseGetQuery struct {
+	iapFields          []string
+	subscriptionFields []string
+	include            []string
+}
+
+// WithIAPReviewScreenshotIAPFields sets fields[inAppPurchases] for included IAPs.
+func WithIAPReviewScreenshotIAPFields(fields []string) IAPReviewScreenshotOption {
+	return func(q *iapReviewScreenshotQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithIAPReviewScreenshotInclude sets the exact screenshot relationship include set.
+func WithIAPReviewScreenshotInclude(include []string) IAPReviewScreenshotOption {
+	return func(q *iapReviewScreenshotQuery) { q.include = normalizeUniqueList(include) }
+}
+
+// WithIAPContentIAPFields sets fields[inAppPurchases] for included IAPs.
+func WithIAPContentIAPFields(fields []string) IAPContentOption {
+	return func(q *iapContentQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithIAPContentInclude sets the exact content relationship include set.
+func WithIAPContentInclude(include []string) IAPContentOption {
+	return func(q *iapContentQuery) { q.include = normalizeUniqueList(include) }
+}
+
+// WithIAPImageIAPFields sets fields[inAppPurchases] for an included IAP.
+func WithIAPImageIAPFields(fields []string) IAPImageOption {
+	return func(q *iapImageQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithIAPImageInclude sets the exact image relationship include set.
+func WithIAPImageInclude(include []string) IAPImageOption {
+	return func(q *iapImageQuery) { q.include = normalizeUniqueList(include) }
+}
+
+// WithIAPLocalizationIAPFields sets fields[inAppPurchases] for an included IAP.
+func WithIAPLocalizationIAPFields(fields []string) IAPLocalizationOption {
+	return func(q *iapLocalizationQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithIAPLocalizationInclude sets the exact localization relationship include set.
+func WithIAPLocalizationInclude(include []string) IAPLocalizationOption {
+	return func(q *iapLocalizationQuery) { q.include = normalizeUniqueList(include) }
+}
+
+// WithPromotedPurchaseIAPFields sets fields[inAppPurchases] for an included IAP.
+func WithPromotedPurchaseIAPFields(fields []string) PromotedPurchaseGetOption {
+	return func(q *promotedPurchaseGetQuery) { q.iapFields = normalizeUniqueList(fields) }
+}
+
+// WithPromotedPurchaseSubscriptionFields sets fields[subscriptions] for an included subscription.
+func WithPromotedPurchaseSubscriptionFields(fields []string) PromotedPurchaseGetOption {
+	return func(q *promotedPurchaseGetQuery) { q.subscriptionFields = normalizeUniqueList(fields) }
+}
+
+// WithPromotedPurchaseInclude sets the exact promoted-purchase relationship include set.
+func WithPromotedPurchaseInclude(include []string) PromotedPurchaseGetOption {
+	return func(q *promotedPurchaseGetQuery) { q.include = normalizeUniqueList(include) }
+}
+
+func buildIAPReviewScreenshotQuery(query *iapReviewScreenshotQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "include", includeWhenFieldsSelected(query.include, "inAppPurchaseV2", query.iapFields))
+	return values.Encode()
+}
+
+func buildIAPContentQuery(query *iapContentQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "include", includeWhenFieldsSelected(query.include, "inAppPurchaseV2", query.iapFields))
+	return values.Encode()
+}
+
+func buildIAPImageQuery(query *iapImageQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "include", includeWhenFieldsSelected(query.include, "inAppPurchase", query.iapFields))
+	return values.Encode()
+}
+
+func buildIAPLocalizationQuery(query *iapLocalizationQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "include", includeWhenFieldsSelected(query.include, "inAppPurchaseV2", query.iapFields))
+	return values.Encode()
+}
+
+func buildPromotedPurchaseGetQuery(query *promotedPurchaseGetQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.iapFields)
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	include := includeWhenFieldsSelected(query.include, "inAppPurchaseV2", query.iapFields)
+	include = includeWhenFieldsSelected(include, "subscription", query.subscriptionFields)
+	addCSV(values, "include", include)
+	return values.Encode()
+}
+
+func includeWhenFieldsSelected(include []string, relationship string, fields []string) []string {
+	if len(fields) == 0 {
+		return normalizeUniqueList(include)
+	}
+	return normalizeUniqueList(append(append([]string{}, include...), relationship))
+}

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -1,6 +1,7 @@
 package cmdtest
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,8 +19,8 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 		path         string
 		wantQuery    map[string]string
 		response     string
-		relationship string
-		resourceType string
+		wantDataID   string
+		wantIncluded string
 	}{
 		{
 			name: "content", args: []string{"iap", "content", "view", "--content-id", "content-1", "--iap-fields", "versions", "--output", "json"},
@@ -36,7 +37,7 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 				"fields[subscriptions]":  "versions",
 				"include":                "inAppPurchaseV2,subscription",
 			},
-			relationship: "inAppPurchaseV2", resourceType: "inAppPurchases",
+			wantDataID: "promo-iap", wantIncluded: "inAppPurchases:iap-1",
 		},
 		{
 			name: "subscription promoted list", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", "versions", "--subscription-fields", "versions", "--output", "json"},
@@ -45,7 +46,7 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 				"fields[subscriptions]":  "versions",
 				"include":                "inAppPurchaseV2,subscription",
 			},
-			relationship: "subscription", resourceType: "subscriptions",
+			wantDataID: "promo-subscription", wantIncluded: "subscriptions:subscription-1",
 		},
 	}
 
@@ -68,8 +69,13 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 				}
 				body := tt.response
 				if body == "" {
-					body = "{\"data\":[{\"type\":\"promotedPurchases\",\"id\":\"promo-1\",\"relationships\":{\"" +
-						tt.relationship + "\":{\"data\":{\"type\":\"" + tt.resourceType + "\",\"id\":\"product-1\"}}}}]}"
+					body = `{"data":[` +
+						`{"type":"promotedPurchases","id":"promo-iap","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}}}},` +
+						`{"type":"promotedPurchases","id":"promo-subscription","relationships":{"subscription":{"data":{"type":"subscriptions","id":"subscription-1"}}}}` +
+						`],"included":[` +
+						`{"type":"inAppPurchases","id":"iap-1","attributes":{"versions":"iap-version"}},` +
+						`{"type":"subscriptions","id":"subscription-1","attributes":{"versions":"subscription-version"}}` +
+						`]}`
 				}
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(body))
@@ -87,6 +93,26 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 			}
 			if !strings.Contains(stdout, "\"data\"") {
 				t.Fatalf("stdout = %q, want JSON response; stderr=%q", stdout, stderr)
+			}
+			if tt.wantDataID != "" {
+				var output struct {
+					Data []struct {
+						ID string `json:"id"`
+					} `json:"data"`
+					Included []struct {
+						Type string `json:"type"`
+						ID   string `json:"id"`
+					} `json:"included"`
+				}
+				if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+					t.Fatalf("decode stdout: %v; stdout=%q stderr=%q", err, stdout, stderr)
+				}
+				if len(output.Data) != 1 || output.Data[0].ID != tt.wantDataID {
+					t.Fatalf("data = %+v, want only %q", output.Data, tt.wantDataID)
+				}
+				if len(output.Included) != 1 || output.Included[0].Type+":"+output.Included[0].ID != tt.wantIncluded {
+					t.Fatalf("included = %+v, want only %q", output.Included, tt.wantIncluded)
+				}
 			}
 		})
 	}
@@ -133,6 +159,102 @@ func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
 	})
 	if requests != 1 || !strings.Contains(stdout, "\"id\":\"promo-1\"") {
 		t.Fatalf("requests=%d stdout=%q stderr=%q", requests, stdout, stderr)
+	}
+}
+
+func TestPromotedPurchasePaginatedScopedListsPruneIncluded441(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      []string
+		wantDataID   string
+		wantIncluded string
+		wantVersion  string
+	}{
+		{
+			name: "iap scope", command: []string{"iap", "promoted-purchases", "list"},
+			wantDataID: "promo-iap", wantIncluded: "inAppPurchases:iap-1", wantVersion: "iap-version",
+		},
+		{
+			name: "subscription scope", command: []string{"subscriptions", "promoted-purchases", "list"},
+			wantDataID: "promo-subscription", wantIncluded: "subscriptions:subscription-1", wantVersion: "subscription-version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSubmitCreateAuth(t)
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requests++
+				if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/promotedPurchases" {
+					t.Fatalf("request = %s %s, want promoted-purchases GET", req.Method, req.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if req.URL.Query().Get("cursor") == "next" {
+					if len(req.URL.Query()) != 1 {
+						t.Fatalf("next query = %v, want opaque cursor only", req.URL.Query())
+					}
+					_, _ = w.Write([]byte(`{"data":[{"type":"promotedPurchases","id":"promo-subscription","relationships":{"subscription":{"data":{"type":"subscriptions","id":"subscription-1"}}}}],"included":[{"type":"subscriptions","id":"subscription-1","attributes":{"versions":["subscription-version"],"name":"Subscription"}}]}`))
+					return
+				}
+
+				wantFirstQuery := map[string]string{
+					"fields[inAppPurchases]": "versions",
+					"fields[subscriptions]":  "versions",
+					"include":                "inAppPurchaseV2,subscription",
+					"limit":                  "200",
+				}
+				if len(req.URL.Query()) != len(wantFirstQuery) {
+					t.Fatalf("first query = %v, want exactly %v", req.URL.Query(), wantFirstQuery)
+				}
+				for key, want := range wantFirstQuery {
+					if got := req.URL.Query().Get(key); got != want {
+						t.Fatalf("first query %s = %q, want %q", key, got, want)
+					}
+				}
+				body := `{"data":[{"type":"promotedPurchases","id":"promo-iap","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}}}}],"included":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"IAP","versions":["iap-version"]}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps/app-1/promotedPurchases?cursor=next"}}`
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+			setIAPRelatedTestServerClient(t, server)
+
+			args := append(append([]string{}, tt.command...), "--app", "app-1", "--iap-fields", "versions", "--subscription-fields", "versions", "--paginate", "--output", "json")
+			exitCode := -1
+			stdout, stderr := captureOutput(t, func() {
+				exitCode = cmd.Run(args, "1.2.3")
+			})
+			if exitCode != cmd.ExitSuccess {
+				t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", exitCode, cmd.ExitSuccess, stdout, stderr)
+			}
+			if requests != 2 {
+				t.Fatalf("requests = %d, want two pages", requests)
+			}
+
+			var output struct {
+				Data []struct {
+					ID string `json:"id"`
+				} `json:"data"`
+				Included []struct {
+					Type       string `json:"type"`
+					ID         string `json:"id"`
+					Attributes struct {
+						Versions []string `json:"versions"`
+					} `json:"attributes"`
+				} `json:"included"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatalf("decode stdout: %v; stdout=%q stderr=%q", err, stdout, stderr)
+			}
+			if len(output.Data) != 1 || output.Data[0].ID != tt.wantDataID {
+				t.Fatalf("data = %+v, want only %q", output.Data, tt.wantDataID)
+			}
+			if len(output.Included) != 1 || output.Included[0].Type+":"+output.Included[0].ID != tt.wantIncluded {
+				t.Fatalf("included = %+v, want only %q", output.Included, tt.wantIncluded)
+			}
+			if len(output.Included[0].Attributes.Versions) != 1 || output.Included[0].Attributes.Versions[0] != tt.wantVersion {
+				t.Fatalf("included attributes = %+v, want version %q", output.Included[0].Attributes, tt.wantVersion)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -59,14 +59,7 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 				if req.Method != http.MethodGet || req.URL.Path != tt.path {
 					t.Fatalf("request = %s %s, want GET %s", req.Method, req.URL.Path, tt.path)
 				}
-				if len(req.URL.Query()) != len(tt.wantQuery) {
-					t.Fatalf("query = %v, want exactly %v", req.URL.Query(), tt.wantQuery)
-				}
-				for key, want := range tt.wantQuery {
-					if got := req.URL.Query().Get(key); got != want {
-						t.Fatalf("%s = %q, want %q", key, got, want)
-					}
-				}
+				assertExactQueryValues441(t, req, tt.wantQuery)
 				body := tt.response
 				if body == "" {
 					body = `{"data":[` +
@@ -120,6 +113,7 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 
 func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
 	setupSubmitCreateAuth(t)
+	t.Setenv("ASC_APP_ID", "")
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requests++
@@ -131,14 +125,7 @@ func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
 			"fields[subscriptions]":  "versions",
 			"include":                "inAppPurchaseV2,subscription",
 		}
-		if len(req.URL.Query()) != len(wantQuery) {
-			t.Fatalf("query = %v, want exactly %v", req.URL.Query(), wantQuery)
-		}
-		for key, want := range wantQuery {
-			if got := req.URL.Query().Get(key); got != want {
-				t.Fatalf("%s = %q, want %q", key, got, want)
-			}
-		}
+		assertExactQueryValues441(t, req, wantQuery)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte("{\"data\":{\"type\":\"promotedPurchases\",\"id\":\"promo-1\"}}"))
 	}))
@@ -160,6 +147,160 @@ func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
 	if requests != 1 || !strings.Contains(stdout, "\"id\":\"promo-1\"") {
 		t.Fatalf("requests=%d stdout=%q stderr=%q", requests, stdout, stderr)
 	}
+}
+
+func TestIAPPromotedPurchaseViewResolvesStableSelector441(t *testing.T) {
+	tests := []struct {
+		name         string
+		selector     string
+		useAppEnv    bool
+		wantRequests int
+	}{
+		{name: "product ID via ASC_APP_ID", selector: "com.example.pro", useAppEnv: true, wantRequests: 2},
+		{name: "exact current name", selector: "Premium", wantRequests: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSubmitCreateAuth(t)
+			if tt.useAppEnv {
+				t.Setenv("ASC_APP_ID", "app-1")
+			} else {
+				t.Setenv("ASC_APP_ID", "")
+			}
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requests++
+				w.Header().Set("Content-Type", "application/json")
+				switch req.URL.Path {
+				case "/v1/apps/app-1/inAppPurchasesV2":
+					productValues := req.URL.Query()["filter[productId]"]
+					nameValues := req.URL.Query()["filter[name]"]
+					if len(productValues) == 1 {
+						assertExactQueryValues441(t, req, map[string]string{"filter[productId]": tt.selector, "limit": "200"})
+						if tt.selector == "com.example.pro" {
+							_, _ = w.Write([]byte(`{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Premium","productId":"com.example.pro"}}]}`))
+							return
+						}
+						_, _ = w.Write([]byte(`{"data":[]}`))
+						return
+					}
+					if len(nameValues) == 1 {
+						assertExactQueryValues441(t, req, map[string]string{"filter[name]": tt.selector, "limit": "200"})
+						_, _ = w.Write([]byte(`{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Premium","productId":"com.example.other"}}]}`))
+						return
+					}
+					t.Fatalf("unexpected lookup query: %v", req.URL.Query())
+				case "/v2/inAppPurchases/iap-1/promotedPurchase":
+					assertExactQueryValues441(t, req, map[string]string{
+						"fields[inAppPurchases]": "versions",
+						"include":                "inAppPurchaseV2",
+					})
+					_, _ = w.Write([]byte(`{"data":{"type":"promotedPurchases","id":"promo-1"}}`))
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+			}))
+			defer server.Close()
+			setIAPRelatedTestServerClient(t, server)
+
+			args := []string{
+				"iap", "promoted-purchases", "view",
+				"--iap-id", tt.selector,
+				"--iap-fields", "versions",
+				"--output", "json",
+			}
+			if !tt.useAppEnv {
+				args = append(args, "--app", "app-1")
+			}
+			stdout, stderr := captureOutput(t, func() {
+				code := cmd.Run(args, "1.2.3")
+				if code != cmd.ExitSuccess {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+				}
+			})
+			if requests != tt.wantRequests || !strings.Contains(stdout, `"id":"promo-1"`) {
+				t.Fatalf("requests=%d stdout=%q stderr=%q", requests, stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestIAPPromotedPurchaseViewStableSelectorErrors441(t *testing.T) {
+	t.Run("missing app", func(t *testing.T) {
+		setupSubmitCreateAuth(t)
+		t.Setenv("ASC_APP_ID", "")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}))
+		defer server.Close()
+		setIAPRelatedTestServerClient(t, server)
+
+		stdout, stderr := captureOutput(t, func() {
+			if code := cmd.Run([]string{"iap", "promoted-purchases", "view", "--iap-id", "com.example.pro"}, "1.2.3"); code != cmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+			}
+		})
+		if strings.TrimSpace(stdout) != "" || !strings.Contains(stderr, "--app is required (or set ASC_APP_ID) when --iap-id is a product ID or name") {
+			t.Fatalf("stdout=%q stderr=%q", stdout, stderr)
+		}
+	})
+
+	t.Run("ambiguous name", func(t *testing.T) {
+		setupSubmitCreateAuth(t)
+		requests := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			requests++
+			w.Header().Set("Content-Type", "application/json")
+			if req.URL.Path != "/v1/apps/app-1/inAppPurchasesV2" {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+			if req.URL.Query().Get("filter[productId]") == "Premium" {
+				assertExactQueryValues441(t, req, map[string]string{"filter[productId]": "Premium", "limit": "200"})
+				_, _ = w.Write([]byte(`{"data":[]}`))
+				return
+			}
+			assertExactQueryValues441(t, req, map[string]string{"filter[name]": "Premium", "limit": "200"})
+			_, _ = w.Write([]byte(`{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Premium","productId":"com.example.one"}},{"type":"inAppPurchases","id":"iap-2","attributes":{"name":"Premium","productId":"com.example.two"}}]}`))
+		}))
+		defer server.Close()
+		setIAPRelatedTestServerClient(t, server)
+
+		_, stderr := captureOutput(t, func() {
+			if code := cmd.Run([]string{"iap", "promoted-purchases", "view", "--app", "app-1", "--iap-id", "Premium"}, "1.2.3"); code == cmd.ExitSuccess {
+				t.Fatal("expected ambiguity failure")
+			}
+		})
+		if requests != 2 || !strings.Contains(stderr, "Use the explicit ASC ID to disambiguate") {
+			t.Fatalf("requests=%d stderr=%q", requests, stderr)
+		}
+	})
+
+	t.Run("lookup API error", func(t *testing.T) {
+		setupSubmitCreateAuth(t)
+		requests := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			requests++
+			if req.URL.Path != "/v1/apps/app-1/inAppPurchasesV2" {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+			assertExactQueryValues441(t, req, map[string]string{"filter[productId]": "com.example.pro", "limit": "200"})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"403","code":"FORBIDDEN.REQUIRED_ROLE","detail":"forbidden"}]}`))
+		}))
+		defer server.Close()
+		setIAPRelatedTestServerClient(t, server)
+
+		_, stderr := captureOutput(t, func() {
+			if code := cmd.Run([]string{"iap", "promoted-purchases", "view", "--app", "app-1", "--iap-id", "com.example.pro"}, "1.2.3"); code == cmd.ExitSuccess {
+				t.Fatal("expected lookup error")
+			}
+		})
+		if requests != 1 || !strings.Contains(stderr, "resolve in-app purchase by product ID") {
+			t.Fatalf("requests=%d stderr=%q", requests, stderr)
+		}
+	})
 }
 
 func TestPromotedPurchasePaginatedScopedListsPruneIncluded441(t *testing.T) {
@@ -191,9 +332,7 @@ func TestPromotedPurchasePaginatedScopedListsPruneIncluded441(t *testing.T) {
 				}
 				w.Header().Set("Content-Type", "application/json")
 				if req.URL.Query().Get("cursor") == "next" {
-					if len(req.URL.Query()) != 1 {
-						t.Fatalf("next query = %v, want opaque cursor only", req.URL.Query())
-					}
+					assertExactQueryValues441(t, req, map[string]string{"cursor": "next"})
 					_, _ = w.Write([]byte(`{"data":[{"type":"promotedPurchases","id":"promo-subscription","relationships":{"subscription":{"data":{"type":"subscriptions","id":"subscription-1"}}}}],"included":[{"type":"subscriptions","id":"subscription-1","attributes":{"versions":["subscription-version"],"name":"Subscription"}}]}`))
 					return
 				}
@@ -204,14 +343,7 @@ func TestPromotedPurchasePaginatedScopedListsPruneIncluded441(t *testing.T) {
 					"include":                "inAppPurchaseV2,subscription",
 					"limit":                  "200",
 				}
-				if len(req.URL.Query()) != len(wantFirstQuery) {
-					t.Fatalf("first query = %v, want exactly %v", req.URL.Query(), wantFirstQuery)
-				}
-				for key, want := range wantFirstQuery {
-					if got := req.URL.Query().Get(key); got != want {
-						t.Fatalf("first query %s = %q, want %q", key, got, want)
-					}
-				}
+				assertExactQueryValues441(t, req, wantFirstQuery)
 				body := `{"data":[{"type":"promotedPurchases","id":"promo-iap","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}}}}],"included":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"IAP","versions":["iap-version"]}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps/app-1/promotedPurchases?cursor=next"}}`
 				_, _ = w.Write([]byte(body))
 			}))
@@ -273,6 +405,7 @@ func TestIAPRelatedSparseFieldValidationPrecedesHTTP441(t *testing.T) {
 		{name: "localizations next conflict", args: []string{"iap", "localizations", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
 		{name: "iap promoted next conflict", args: []string{"iap", "promoted-purchases", "list", "--next", next, "--subscription-fields", "versions"}, want: "--next cannot be combined with --iap-fields or --subscription-fields"},
 		{name: "subscription promoted next conflict", args: []string{"subscriptions", "promoted-purchases", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields or --subscription-fields"},
+		{name: "promoted view missing selector", args: []string{"iap", "promoted-purchases", "view"}, want: "--promoted-purchase-id or --iap-id is required"},
 		{name: "promoted view selector conflict", args: []string{"iap", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--iap-id", "123"}, want: "--promoted-purchase-id and --iap-id are mutually exclusive"},
 	}
 
@@ -323,6 +456,20 @@ func TestIAPRelatedSparseFieldHelp441(t *testing.T) {
 			t.Fatalf("help for %v does not contain %s: %q", tt.path, tt.flag, usage)
 		}
 	}
+
+	iapView := findSubcommand(root, "iap", "promoted-purchases", "view")
+	iapUsage := iapView.UsageFunc(iapView)
+	if !strings.Contains(iapUsage, "In-app purchase ID, product ID, or exact current name") {
+		t.Fatalf("IAP promoted view help does not describe stable selectors: %q", iapUsage)
+	}
+	if !strings.Contains(iapUsage, "App Store Connect app ID (or ASC_APP_ID env; required when --iap-id uses a product ID or name)") {
+		t.Fatalf("IAP promoted view help does not describe app lookup context: %q", iapUsage)
+	}
+
+	subscriptionView := findSubcommand(root, "subscriptions", "promoted-purchases", "view")
+	if usage := subscriptionView.UsageFunc(subscriptionView); strings.Contains(usage, "--app") {
+		t.Fatalf("subscription promoted view unexpectedly changed to expose --app: %q", usage)
+	}
 }
 
 func setIAPRelatedTestServerClient(t *testing.T, server *httptest.Server) {
@@ -332,4 +479,18 @@ func setIAPRelatedTestServerClient(t *testing.T, server *httptest.Server) {
 		return client, nil
 	})
 	t.Cleanup(restore)
+}
+
+func assertExactQueryValues441(t *testing.T, req *http.Request, want map[string]string) {
+	t.Helper()
+	query := req.URL.Query()
+	if len(query) != len(want) {
+		t.Fatalf("query = %v, want exactly %v", query, want)
+	}
+	for key, wantValue := range want {
+		values, ok := query[key]
+		if !ok || len(values) != 1 || values[0] != wantValue {
+			t.Fatalf("query[%q] = %v, want exactly [%q]", key, values, wantValue)
+		}
+	}
 }

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -1,0 +1,190 @@
+package cmdtest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		path         string
+		fieldKey     string
+		include      string
+		response     string
+		relationship string
+		resourceType string
+	}{
+		{
+			name: "content", args: []string{"iap", "content", "view", "--content-id", "content-1", "--iap-fields", "versions", "--output", "json"},
+			path: "/v1/inAppPurchaseContents/content-1", fieldKey: "fields[inAppPurchases]", include: "inAppPurchaseV2",
+			response: "{\"data\":{\"type\":\"inAppPurchaseContents\",\"id\":\"content-1\"}}",
+		},
+		{
+			name: "iap promoted list", args: []string{"iap", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", "versions", "--output", "json"},
+			path: "/v1/apps/app-1/promotedPurchases", fieldKey: "fields[inAppPurchases]", include: "inAppPurchaseV2",
+			relationship: "inAppPurchaseV2", resourceType: "inAppPurchases",
+		},
+		{
+			name: "subscription promoted list", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--subscription-fields", "versions", "--output", "json"},
+			path: "/v1/apps/app-1/promotedPurchases", fieldKey: "fields[subscriptions]", include: "subscription",
+			relationship: "subscription", resourceType: "subscriptions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSubmitCreateAuth(t)
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requests++
+				if req.Method != http.MethodGet || req.URL.Path != tt.path {
+					t.Fatalf("request = %s %s, want GET %s", req.Method, req.URL.Path, tt.path)
+				}
+				if got := req.URL.Query().Get(tt.fieldKey); got != "versions" {
+					t.Fatalf("%s = %q, want versions", tt.fieldKey, got)
+				}
+				if got := req.URL.Query().Get("include"); got != tt.include {
+					t.Fatalf("include = %q, want %q", got, tt.include)
+				}
+				if len(req.URL.Query()) != 2 {
+					t.Fatalf("query = %v, want exactly sparse field and include", req.URL.Query())
+				}
+				body := tt.response
+				if body == "" {
+					body = "{\"data\":[{\"type\":\"promotedPurchases\",\"id\":\"promo-1\",\"relationships\":{\"" +
+						tt.relationship + "\":{\"data\":{\"type\":\"" + tt.resourceType + "\",\"id\":\"product-1\"}}}}]}"
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+			setIAPRelatedTestServerClient(t, server)
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(tt.args, "1.2.3"); code != cmd.ExitSuccess {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+				}
+			})
+			if requests != 1 {
+				t.Fatalf("requests = %d, want 1", requests)
+			}
+			if !strings.Contains(stdout, "\"data\"") {
+				t.Fatalf("stdout = %q, want JSON response; stderr=%q", stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
+	setupSubmitCreateAuth(t)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v2/inAppPurchases/123456789/promotedPurchase" {
+			t.Fatalf("request = %s %s, want relationship GET", req.Method, req.URL.Path)
+		}
+		if got := req.URL.Query().Get("fields[inAppPurchases]"); got != "versions" {
+			t.Fatalf("fields[inAppPurchases] = %q, want versions", got)
+		}
+		if got := req.URL.Query().Get("include"); got != "inAppPurchaseV2" {
+			t.Fatalf("include = %q, want inAppPurchaseV2", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"data\":{\"type\":\"promotedPurchases\",\"id\":\"promo-1\"}}"))
+	}))
+	defer server.Close()
+	setIAPRelatedTestServerClient(t, server)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"iap", "promoted-purchases", "view",
+			"--iap-id", "123456789",
+			"--iap-fields", "versions",
+			"--output", "json",
+		}, "1.2.3")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitSuccess)
+		}
+	})
+	if requests != 1 || !strings.Contains(stdout, "\"id\":\"promo-1\"") {
+		t.Fatalf("requests=%d stdout=%q stderr=%q", requests, stdout, stderr)
+	}
+}
+
+func TestIAPRelatedSparseFieldValidationPrecedesHTTP441(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v2/inAppPurchases/123/images?cursor=next"
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "invalid iap fields", args: []string{"iap", "content", "view", "--content-id", "content-1", "--iap-fields", "notAField"}, want: "--iap-fields must be one of"},
+		{name: "invalid subscription fields", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--subscription-fields", "notAField"}, want: "--subscription-fields must be one of"},
+		{name: "images next conflict", args: []string{"iap", "images", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
+		{name: "localizations next conflict", args: []string{"iap", "localizations", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
+		{name: "iap promoted next conflict", args: []string{"iap", "promoted-purchases", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
+		{name: "subscription promoted next conflict", args: []string{"subscriptions", "promoted-purchases", "list", "--next", next, "--subscription-fields", "versions"}, want: "--next cannot be combined with --subscription-fields"},
+		{name: "promoted view selector conflict", args: []string{"iap", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--iap-id", "123"}, want: "--promoted-purchase-id and --iap-id are mutually exclusive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(tt.args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+			if strings.TrimSpace(stdout) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, tt.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, tt.want)
+			}
+		})
+	}
+}
+
+func TestIAPRelatedSparseFieldHelp441(t *testing.T) {
+	root := RootCommand("1.2.3")
+	tests := []struct {
+		path []string
+		flag string
+	}{
+		{path: []string{"iap", "review-screenshots", "view"}, flag: "--iap-fields"},
+		{path: []string{"iap", "content", "view"}, flag: "--iap-fields"},
+		{path: []string{"iap", "images", "list"}, flag: "--iap-fields"},
+		{path: []string{"iap", "images", "view"}, flag: "--iap-fields"},
+		{path: []string{"iap", "localizations", "list"}, flag: "--iap-fields"},
+		{path: []string{"iap", "promoted-purchases", "list"}, flag: "--iap-fields"},
+		{path: []string{"iap", "promoted-purchases", "view"}, flag: "--iap-id"},
+		{path: []string{"iap", "promoted-purchases", "view"}, flag: "--iap-fields"},
+		{path: []string{"subscriptions", "promoted-purchases", "list"}, flag: "--subscription-fields"},
+		{path: []string{"subscriptions", "promoted-purchases", "view"}, flag: "--subscription-fields"},
+	}
+	for _, tt := range tests {
+		command := findSubcommand(root, tt.path...)
+		if command == nil {
+			t.Fatalf("command %v not found", tt.path)
+		}
+		if usage := command.UsageFunc(command); !strings.Contains(usage, tt.flag) {
+			t.Fatalf("help for %v does not contain %s: %q", tt.path, tt.flag, usage)
+		}
+	}
+}
+
+func setIAPRelatedTestServerClient(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	client := newReviewTestServerClient(t, server)
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+}

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -16,25 +16,35 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 		name         string
 		args         []string
 		path         string
-		fieldKey     string
-		include      string
+		wantQuery    map[string]string
 		response     string
 		relationship string
 		resourceType string
 	}{
 		{
 			name: "content", args: []string{"iap", "content", "view", "--content-id", "content-1", "--iap-fields", "versions", "--output", "json"},
-			path: "/v1/inAppPurchaseContents/content-1", fieldKey: "fields[inAppPurchases]", include: "inAppPurchaseV2",
+			path: "/v1/inAppPurchaseContents/content-1", wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"include":                "inAppPurchaseV2",
+			},
 			response: "{\"data\":{\"type\":\"inAppPurchaseContents\",\"id\":\"content-1\"}}",
 		},
 		{
-			name: "iap promoted list", args: []string{"iap", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", "versions", "--output", "json"},
-			path: "/v1/apps/app-1/promotedPurchases", fieldKey: "fields[inAppPurchases]", include: "inAppPurchaseV2",
+			name: "iap promoted list", args: []string{"iap", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", "versions", "--subscription-fields", "versions", "--output", "json"},
+			path: "/v1/apps/app-1/promotedPurchases", wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"fields[subscriptions]":  "versions",
+				"include":                "inAppPurchaseV2,subscription",
+			},
 			relationship: "inAppPurchaseV2", resourceType: "inAppPurchases",
 		},
 		{
-			name: "subscription promoted list", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--subscription-fields", "versions", "--output", "json"},
-			path: "/v1/apps/app-1/promotedPurchases", fieldKey: "fields[subscriptions]", include: "subscription",
+			name: "subscription promoted list", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", "versions", "--subscription-fields", "versions", "--output", "json"},
+			path: "/v1/apps/app-1/promotedPurchases", wantQuery: map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"fields[subscriptions]":  "versions",
+				"include":                "inAppPurchaseV2,subscription",
+			},
 			relationship: "subscription", resourceType: "subscriptions",
 		},
 	}
@@ -48,14 +58,13 @@ func TestIAPRelatedSparseFieldFlagsSendExactQueries441(t *testing.T) {
 				if req.Method != http.MethodGet || req.URL.Path != tt.path {
 					t.Fatalf("request = %s %s, want GET %s", req.Method, req.URL.Path, tt.path)
 				}
-				if got := req.URL.Query().Get(tt.fieldKey); got != "versions" {
-					t.Fatalf("%s = %q, want versions", tt.fieldKey, got)
+				if len(req.URL.Query()) != len(tt.wantQuery) {
+					t.Fatalf("query = %v, want exactly %v", req.URL.Query(), tt.wantQuery)
 				}
-				if got := req.URL.Query().Get("include"); got != tt.include {
-					t.Fatalf("include = %q, want %q", got, tt.include)
-				}
-				if len(req.URL.Query()) != 2 {
-					t.Fatalf("query = %v, want exactly sparse field and include", req.URL.Query())
+				for key, want := range tt.wantQuery {
+					if got := req.URL.Query().Get(key); got != want {
+						t.Fatalf("%s = %q, want %q", key, got, want)
+					}
 				}
 				body := tt.response
 				if body == "" {
@@ -91,11 +100,18 @@ func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
 		if req.Method != http.MethodGet || req.URL.Path != "/v2/inAppPurchases/123456789/promotedPurchase" {
 			t.Fatalf("request = %s %s, want relationship GET", req.Method, req.URL.Path)
 		}
-		if got := req.URL.Query().Get("fields[inAppPurchases]"); got != "versions" {
-			t.Fatalf("fields[inAppPurchases] = %q, want versions", got)
+		wantQuery := map[string]string{
+			"fields[inAppPurchases]": "versions",
+			"fields[subscriptions]":  "versions",
+			"include":                "inAppPurchaseV2,subscription",
 		}
-		if got := req.URL.Query().Get("include"); got != "inAppPurchaseV2" {
-			t.Fatalf("include = %q, want inAppPurchaseV2", got)
+		if len(req.URL.Query()) != len(wantQuery) {
+			t.Fatalf("query = %v, want exactly %v", req.URL.Query(), wantQuery)
+		}
+		for key, want := range wantQuery {
+			if got := req.URL.Query().Get(key); got != want {
+				t.Fatalf("%s = %q, want %q", key, got, want)
+			}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte("{\"data\":{\"type\":\"promotedPurchases\",\"id\":\"promo-1\"}}"))
@@ -108,6 +124,7 @@ func TestIAPPromotedPurchaseViewByOwnerSendsRelationshipQuery441(t *testing.T) {
 			"iap", "promoted-purchases", "view",
 			"--iap-id", "123456789",
 			"--iap-fields", "versions",
+			"--subscription-fields", "versions",
 			"--output", "json",
 		}, "1.2.3")
 		if code != cmd.ExitSuccess {
@@ -128,10 +145,12 @@ func TestIAPRelatedSparseFieldValidationPrecedesHTTP441(t *testing.T) {
 	}{
 		{name: "invalid iap fields", args: []string{"iap", "content", "view", "--content-id", "content-1", "--iap-fields", "notAField"}, want: "--iap-fields must be one of"},
 		{name: "invalid subscription fields", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--subscription-fields", "notAField"}, want: "--subscription-fields must be one of"},
+		{name: "invalid cross-scope iap fields", args: []string{"subscriptions", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--iap-fields", "notAField"}, want: "--iap-fields must be one of"},
+		{name: "invalid cross-scope subscription fields", args: []string{"iap", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--subscription-fields", "notAField"}, want: "--subscription-fields must be one of"},
 		{name: "images next conflict", args: []string{"iap", "images", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
 		{name: "localizations next conflict", args: []string{"iap", "localizations", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
-		{name: "iap promoted next conflict", args: []string{"iap", "promoted-purchases", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields"},
-		{name: "subscription promoted next conflict", args: []string{"subscriptions", "promoted-purchases", "list", "--next", next, "--subscription-fields", "versions"}, want: "--next cannot be combined with --subscription-fields"},
+		{name: "iap promoted next conflict", args: []string{"iap", "promoted-purchases", "list", "--next", next, "--subscription-fields", "versions"}, want: "--next cannot be combined with --iap-fields or --subscription-fields"},
+		{name: "subscription promoted next conflict", args: []string{"subscriptions", "promoted-purchases", "list", "--next", next, "--iap-fields", "versions"}, want: "--next cannot be combined with --iap-fields or --subscription-fields"},
 		{name: "promoted view selector conflict", args: []string{"iap", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--iap-id", "123"}, want: "--promoted-purchase-id and --iap-id are mutually exclusive"},
 	}
 
@@ -164,9 +183,13 @@ func TestIAPRelatedSparseFieldHelp441(t *testing.T) {
 		{path: []string{"iap", "images", "view"}, flag: "--iap-fields"},
 		{path: []string{"iap", "localizations", "list"}, flag: "--iap-fields"},
 		{path: []string{"iap", "promoted-purchases", "list"}, flag: "--iap-fields"},
+		{path: []string{"iap", "promoted-purchases", "list"}, flag: "--subscription-fields"},
 		{path: []string{"iap", "promoted-purchases", "view"}, flag: "--iap-id"},
 		{path: []string{"iap", "promoted-purchases", "view"}, flag: "--iap-fields"},
+		{path: []string{"iap", "promoted-purchases", "view"}, flag: "--subscription-fields"},
+		{path: []string{"subscriptions", "promoted-purchases", "list"}, flag: "--iap-fields"},
 		{path: []string{"subscriptions", "promoted-purchases", "list"}, flag: "--subscription-fields"},
+		{path: []string{"subscriptions", "promoted-purchases", "view"}, flag: "--iap-fields"},
 		{path: []string{"subscriptions", "promoted-purchases", "view"}, flag: "--subscription-fields"},
 	}
 	for _, tt := range tests {

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -171,6 +171,9 @@ func TestIAPPromotedPurchaseViewResolvesStableSelector441(t *testing.T) {
 			requests := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				requests++
+				if req.Method != http.MethodGet {
+					t.Fatalf("request method = %s, want GET", req.Method)
+				}
 				w.Header().Set("Content-Type", "application/json")
 				switch req.URL.Path {
 				case "/v1/apps/app-1/inAppPurchasesV2":
@@ -251,6 +254,9 @@ func TestIAPPromotedPurchaseViewStableSelectorErrors441(t *testing.T) {
 		requests := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			requests++
+			if req.Method != http.MethodGet {
+				t.Fatalf("request method = %s, want GET", req.Method)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			if req.URL.Path != "/v1/apps/app-1/inAppPurchasesV2" {
 				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -281,6 +287,9 @@ func TestIAPPromotedPurchaseViewStableSelectorErrors441(t *testing.T) {
 		requests := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			requests++
+			if req.Method != http.MethodGet {
+				t.Fatalf("request method = %s, want GET", req.Method)
+			}
 			if req.URL.Path != "/v1/apps/app-1/inAppPurchasesV2" {
 				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 			}
@@ -464,6 +473,9 @@ func TestIAPRelatedSparseFieldHelp441(t *testing.T) {
 	}
 	if !strings.Contains(iapUsage, "App Store Connect app ID (or ASC_APP_ID env; required when --iap-id uses a product ID or name)") {
 		t.Fatalf("IAP promoted view help does not describe app lookup context: %q", iapUsage)
+	}
+	if !strings.Contains(iapUsage, "--iap-id IAP_SELECTOR") || !strings.Contains(iapUsage, `--iap-id "IAP_SELECTOR"`) {
+		t.Fatalf("IAP promoted view help does not use the stable-selector placeholder: %q", iapUsage)
 	}
 
 	subscriptionView := findSubcommand(root, "subscriptions", "promoted-purchases", "view")

--- a/internal/cli/iap/content.go
+++ b/internal/cli/iap/content.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -41,6 +42,7 @@ func IAPContentGetCommand() *ffcli.Command {
 	appID := addIAPLookupAppFlag(fs)
 	iapID := fs.String("iap-id", "", "In-app purchase ID, product ID, or exact current name")
 	contentID := fs.String("content-id", "", "In-app purchase content ID")
+	iapFields := fs.String("iap-fields", "", "fields[inAppPurchases] for the included in-app purchase (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -64,6 +66,10 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --iap-id and --content-id are mutually exclusive")
 				return flag.ErrHelp
 			}
+			fieldValues, err := shared.NormalizeSelection(*iapFields, iapVersionIAPFields, "--iap-fields")
+			if err != nil {
+				return shared.UsageError("iap content view: " + err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -74,7 +80,7 @@ Examples:
 				requestCtx, cancel := shared.ContextWithTimeout(ctx)
 				defer cancel()
 
-				resp, err := client.GetInAppPurchaseContentByID(requestCtx, contentValue)
+				resp, err := client.GetInAppPurchaseContentByID(requestCtx, contentValue, asc.WithIAPContentIAPFields(fieldValues))
 				if err != nil {
 					return fmt.Errorf("iap content view: failed to fetch: %w", err)
 				}
@@ -90,7 +96,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetInAppPurchaseContent(requestCtx, iapValue)
+			resp, err := client.GetInAppPurchaseContent(requestCtx, iapValue, asc.WithIAPContentIAPFields(fieldValues))
 			if err != nil {
 				return fmt.Errorf("iap content view: failed to fetch: %w", err)
 			}

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -512,6 +512,7 @@ func IAPLocalizationsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	iapFields := fs.String("iap-fields", "", "fields[inAppPurchases] for included in-app purchases (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -526,6 +527,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectIAPVersionNextFlagConflicts(fs, *next, "iap localizations list", "iap-fields"); err != nil {
+				return err
+			}
 			resolvedID := strings.TrimSpace(*iapID)
 			if resolvedID == "" {
 				resolvedID = strings.TrimSpace(*legacyID)
@@ -539,6 +543,10 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("iap localizations list: %w", err)
+			}
+			fieldValues, err := shared.NormalizeSelection(*iapFields, iapVersionIAPFields, "--iap-fields")
+			if err != nil {
+				return shared.UsageError("iap localizations list: " + err.Error())
 			}
 
 			client, err := shared.GetASCClient()
@@ -559,6 +567,7 @@ Examples:
 			opts := []asc.IAPLocalizationsOption{
 				asc.WithIAPLocalizationsLimit(*limit),
 				asc.WithIAPLocalizationsNextURL(*next),
+				asc.WithIAPLocalizationsIAPFields(fieldValues),
 			}
 
 			if *paginate {

--- a/internal/cli/iap/images.go
+++ b/internal/cli/iap/images.go
@@ -54,6 +54,7 @@ func IAPImagesListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	iapFields := fs.String("iap-fields", "", "fields[inAppPurchases] for included in-app purchases (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -68,11 +69,18 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectIAPVersionNextFlagConflicts(fs, *next, "iap images list", "iap-fields"); err != nil {
+				return err
+			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("iap images list: --limit must be between 1 and 200")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("iap images list: %w", err)
+			}
+			fieldValues, err := shared.NormalizeSelection(*iapFields, iapVersionIAPFields, "--iap-fields")
+			if err != nil {
+				return shared.UsageError("iap images list: " + err.Error())
 			}
 
 			iapValue := strings.TrimSpace(*iapID)
@@ -99,6 +107,7 @@ Examples:
 			opts := []asc.IAPImagesOption{
 				asc.WithIAPImagesLimit(*limit),
 				asc.WithIAPImagesNextURL(*next),
+				asc.WithIAPImagesIAPFields(fieldValues),
 			}
 
 			if *paginate {
@@ -133,6 +142,7 @@ func IAPImagesGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("images view", flag.ExitOnError)
 
 	imageID := fs.String("image-id", "", "Image ID")
+	iapFields := fs.String("iap-fields", "", "fields[inAppPurchases] for the included in-app purchase (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -151,6 +161,10 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --image-id is required")
 				return shared.MissingRequiredUsageError()
 			}
+			fieldValues, err := shared.NormalizeSelection(*iapFields, iapVersionIAPFields, "--iap-fields")
+			if err != nil {
+				return shared.UsageError("iap images view: " + err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -160,7 +174,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetInAppPurchaseImage(requestCtx, imageValue) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+			resp, err := client.GetInAppPurchaseImage(requestCtx, imageValue, asc.WithIAPImageIAPFields(fieldValues)) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
 			if err != nil {
 				return fmt.Errorf("iap images view: failed to fetch: %w", err)
 			}

--- a/internal/cli/iap/promoted_purchases.go
+++ b/internal/cli/iap/promoted_purchases.go
@@ -13,6 +13,7 @@ import (
 func IAPPromotedPurchasesCommand() *ffcli.Command {
 	cmd := promotedpurchases.PromotedPurchasesCommand()
 	if cmd != nil {
+		lookupAppID := addIAPPromotedPurchaseLookupAppFlag(cmd)
 		cmd.ShortUsage = "asc iap promoted-purchases <subcommand> [flags]"
 		promotedpurchases.ConfigureScopedPromotedPurchasesCommand(cmd, promotedpurchases.ScopedPromotedPurchasesCommandConfig{
 			PathPrefix:      "asc iap promoted-purchases",
@@ -20,7 +21,10 @@ func IAPPromotedPurchasesCommand() *ffcli.Command {
 			ProductSingular: "an in-app purchase",
 			ProductPlural:   "in-app purchases",
 			OwnerIDFlag:     "iap-id",
-			OwnerIDUsage:    "In-app purchase ID",
+			OwnerIDUsage:    "In-app purchase ID, product ID, or exact current name",
+			ResolveOwnerID: func(ctx context.Context, client *asc.Client, selector string) (string, error) {
+				return resolveIAPLookupIDWithTimeout(ctx, client, *lookupAppID, selector)
+			},
 			FetchForOwner: func(ctx context.Context, client *asc.Client, iapID string, opts ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error) {
 				return client.GetInAppPurchasePromotedPurchase(ctx, iapID, opts...)
 			},
@@ -42,6 +46,16 @@ Examples:
 		configureIAPPromotedPurchasesCreate(cmd)
 	}
 	return cmd
+}
+
+func addIAPPromotedPurchaseLookupAppFlag(cmd *ffcli.Command) *string {
+	for _, subcommand := range cmd.Subcommands {
+		if subcommand != nil && subcommand.Name == "view" && subcommand.FlagSet != nil {
+			return addIAPLookupAppFlag(subcommand.FlagSet)
+		}
+	}
+	appID := ""
+	return &appID
 }
 
 func configureIAPPromotedPurchasesCreate(cmd *ffcli.Command) {

--- a/internal/cli/iap/promoted_purchases.go
+++ b/internal/cli/iap/promoted_purchases.go
@@ -1,8 +1,11 @@
 package iap
 
 import (
+	"context"
+
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/promotedpurchases"
 )
 
@@ -16,7 +19,12 @@ func IAPPromotedPurchasesCommand() *ffcli.Command {
 			ProductType:     "IN_APP_PURCHASE",
 			ProductSingular: "an in-app purchase",
 			ProductPlural:   "in-app purchases",
-			RootShortHelp:   "Manage promoted purchases for in-app purchases.",
+			OwnerIDFlag:     "iap-id",
+			OwnerIDUsage:    "In-app purchase ID",
+			FetchForOwner: func(ctx context.Context, client *asc.Client, iapID string, opts ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error) {
+				return client.GetInAppPurchasePromotedPurchase(ctx, iapID, opts...)
+			},
+			RootShortHelp: "Manage promoted purchases for in-app purchases.",
 			RootLongHelp: `Manage promoted purchases for in-app purchases.
 
 Only promoted purchases attached to in-app purchases are listed or modified.

--- a/internal/cli/iap/promoted_purchases.go
+++ b/internal/cli/iap/promoted_purchases.go
@@ -16,12 +16,13 @@ func IAPPromotedPurchasesCommand() *ffcli.Command {
 		lookupAppID := addIAPPromotedPurchaseLookupAppFlag(cmd)
 		cmd.ShortUsage = "asc iap promoted-purchases <subcommand> [flags]"
 		promotedpurchases.ConfigureScopedPromotedPurchasesCommand(cmd, promotedpurchases.ScopedPromotedPurchasesCommandConfig{
-			PathPrefix:      "asc iap promoted-purchases",
-			ProductType:     "IN_APP_PURCHASE",
-			ProductSingular: "an in-app purchase",
-			ProductPlural:   "in-app purchases",
-			OwnerIDFlag:     "iap-id",
-			OwnerIDUsage:    "In-app purchase ID, product ID, or exact current name",
+			PathPrefix:         "asc iap promoted-purchases",
+			ProductType:        "IN_APP_PURCHASE",
+			ProductSingular:    "an in-app purchase",
+			ProductPlural:      "in-app purchases",
+			OwnerIDFlag:        "iap-id",
+			OwnerIDUsage:       "In-app purchase ID, product ID, or exact current name",
+			OwnerIDPlaceholder: "IAP_SELECTOR",
 			ResolveOwnerID: func(ctx context.Context, client *asc.Client, selector string) (string, error) {
 				return resolveIAPLookupIDWithTimeout(ctx, client, *lookupAppID, selector)
 			},

--- a/internal/cli/iap/review_screenshots.go
+++ b/internal/cli/iap/review_screenshots.go
@@ -52,6 +52,7 @@ func IAPReviewScreenshotsGetCommand() *ffcli.Command {
 	iapID := fs.String("iap-id", "", "In-app purchase ID, product ID, or exact current name")
 	appID := addIAPLookupAppFlag(fs)
 	screenshotID := fs.String("screenshot-id", "", "Review screenshot ID")
+	iapFields := fs.String("iap-fields", "", "fields[inAppPurchases] for the included in-app purchase (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -72,6 +73,10 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --iap-id or --screenshot-id is required")
 				return shared.MissingRequiredUsageError()
 			}
+			fieldValues, err := shared.NormalizeSelection(*iapFields, iapVersionIAPFields, "--iap-fields")
+			if err != nil {
+				return shared.UsageError("iap review-screenshots view: " + err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -82,7 +87,7 @@ Examples:
 				requestCtx, cancel := shared.ContextWithTimeout(ctx)
 				defer cancel()
 
-				resp, err := client.GetInAppPurchaseAppStoreReviewScreenshot(requestCtx, screenshotValue)
+				resp, err := client.GetInAppPurchaseAppStoreReviewScreenshot(requestCtx, screenshotValue, asc.WithIAPReviewScreenshotIAPFields(fieldValues))
 				if err != nil {
 					return fmt.Errorf("iap review-screenshots view: failed to fetch: %w", err)
 				}
@@ -97,7 +102,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetInAppPurchaseAppStoreReviewScreenshotForIAP(requestCtx, iapValue)
+			resp, err := client.GetInAppPurchaseAppStoreReviewScreenshotForIAP(requestCtx, iapValue, asc.WithIAPReviewScreenshotIAPFields(fieldValues))
 			if err != nil {
 				return fmt.Errorf("iap review-screenshots view: failed to fetch: %w", err)
 			}

--- a/internal/cli/promotedpurchases/promoted_purchases_test.go
+++ b/internal/cli/promotedpurchases/promoted_purchases_test.go
@@ -2,6 +2,7 @@ package promotedpurchases
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"path/filepath"
@@ -101,6 +102,64 @@ func TestScopedPromotedPurchasesDetailCommandsUseScopedErrorPrefixes(t *testing.
 			wantPrefix := "iap promoted-purchases " + tt.name + ":"
 			if !strings.HasPrefix(err.Error(), wantPrefix) {
 				t.Fatalf("expected error prefix %q, got %q", wantPrefix, err.Error())
+			}
+		})
+	}
+}
+
+func TestFilterPromotedPurchaseIncludedPreservesRetainedResourcesAndOrder(t *testing.T) {
+	included := json.RawMessage(`[{"type":"inAppPurchases","id":"iap-2","attributes":{"versions":["v2"],"name":"Second"}},{"type":"subscriptions","id":"subscription-1","attributes":{"versions":["subscription-version"]}},{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"First","versions":["v1"]}}]`)
+	retained := map[string]struct{}{
+		promotedPurchaseProductResourceKey(promotedPurchaseScope{productType: promotedPurchaseProductTypeInAppPurchase, productID: "iap-1"}): {},
+		promotedPurchaseProductResourceKey(promotedPurchaseScope{productType: promotedPurchaseProductTypeInAppPurchase, productID: "iap-2"}): {},
+	}
+
+	got, err := filterPromotedPurchaseIncluded(included, retained)
+	if err != nil {
+		t.Fatalf("filterPromotedPurchaseIncluded() error: %v", err)
+	}
+	want := `[{"type":"inAppPurchases","id":"iap-2","attributes":{"versions":["v2"],"name":"Second"}},{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"First","versions":["v1"]}}]`
+	if string(got) != want {
+		t.Fatalf("included = %s, want exact retained attributes and order %s", got, want)
+	}
+}
+
+func TestFilterPromotedPurchaseIncludedNilAndNullAreNoOps(t *testing.T) {
+	tests := []struct {
+		name     string
+		included json.RawMessage
+	}{
+		{name: "nil"},
+		{name: "null", included: json.RawMessage("null")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterPromotedPurchaseIncluded(tt.included, nil)
+			if err != nil {
+				t.Fatalf("filterPromotedPurchaseIncluded() error: %v", err)
+			}
+			if string(got) != string(tt.included) {
+				t.Fatalf("included = %q, want unchanged %q", got, tt.included)
+			}
+		})
+	}
+}
+
+func TestFilterPromotedPurchaseIncludedRejectsMissingIdentifiers(t *testing.T) {
+	tests := []struct {
+		name     string
+		included json.RawMessage
+	}{
+		{name: "missing type", included: json.RawMessage(`[{"id":"iap-1","attributes":{"name":"Premium"}}]`)},
+		{name: "missing id", included: json.RawMessage(`[{"type":"inAppPurchases","attributes":{"name":"Premium"}}]`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := filterPromotedPurchaseIncluded(tt.included, nil)
+			if err == nil || !strings.Contains(err.Error(), "missing type or id") {
+				t.Fatalf("error = %v, want missing type or id", err)
 			}
 		})
 	}

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -24,6 +24,24 @@ type ScopedPromotedPurchasesCommandConfig struct {
 	ProductPlural   string
 	RootShortHelp   string
 	RootLongHelp    string
+	OwnerIDFlag     string
+	OwnerIDUsage    string
+	FetchForOwner   func(context.Context, *asc.Client, string, ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error)
+}
+
+var promotedPurchaseIAPFields = []string{
+	"name", "productId", "inAppPurchaseType", "state", "reviewNote", "familySharable",
+	"contentHosting", "inAppPurchaseLocalizations", "pricePoints", "content",
+	"appStoreReviewScreenshot", "promotedPurchase", "iapPriceSchedule",
+	"inAppPurchaseAvailability", "images", "offerCodes", "versions",
+}
+
+var promotedPurchaseSubscriptionFields = []string{
+	"name", "productId", "familySharable", "state", "subscriptionPeriod", "reviewNote",
+	"groupLevel", "subscriptionLocalizations", "appStoreReviewScreenshot", "group",
+	"introductoryOffers", "promotionalOffers", "offerCodes", "prices", "pricePoints",
+	"promotedPurchase", "subscriptionAvailability", "winBackOffers", "images",
+	"planAvailabilities", "versions",
 }
 
 type promotedPurchaseScope struct {
@@ -70,6 +88,8 @@ func configureScopedPromotedPurchasesListCommand(cmd *ffcli.Command, cfg ScopedP
 	if cmd == nil || cmd.FlagSet == nil {
 		return
 	}
+	fieldsFlag, fieldsAllowed := scopedPromotedPurchaseFields(cfg.ProductType)
+	bindStringFlagIfMissing(cmd.FlagSet, fieldsFlag, promotedPurchaseFieldsUsage(fieldsFlag))
 
 	cmd.ShortUsage = fmt.Sprintf("%s list (--app APP_ID | --next URL) [flags]", cfg.PathPrefix)
 	cmd.ShortHelp = fmt.Sprintf("List promoted purchases for %s in an app.", cfg.ProductPlural)
@@ -78,11 +98,13 @@ func configureScopedPromotedPurchasesListCommand(cmd *ffcli.Command, cfg ScopedP
 Examples:
   %s list --app "APP_ID"
   %s list --app "APP_ID" --limit 10
-  %s list --app "APP_ID" --paginate`, cfg.ProductPlural, cfg.PathPrefix, cfg.PathPrefix, cfg.PathPrefix)
+  %s list --app "APP_ID" --%s versions
+  %s list --app "APP_ID" --paginate`, cfg.ProductPlural, cfg.PathPrefix, cfg.PathPrefix, cfg.PathPrefix, fieldsFlag, cfg.PathPrefix)
 
 	cmd.Exec = func(ctx context.Context, args []string) error {
 		limit := intFlagValue(cmd.FlagSet, "limit")
 		next := stringFlagValue(cmd.FlagSet, "next")
+		fieldsValue := stringFlagValue(cmd.FlagSet, fieldsFlag)
 		paginate := boolFlagValue(cmd.FlagSet, "paginate")
 		output := stringFlagValue(cmd.FlagSet, "output")
 		pretty := boolFlagValue(cmd.FlagSet, "pretty")
@@ -95,6 +117,13 @@ Examples:
 		}
 		if err := shared.ValidateNextURL(next); err != nil {
 			return fmt.Errorf("%s: %w", errorPrefix, err)
+		}
+		if strings.TrimSpace(next) != "" && flagWasSet(cmd.FlagSet, fieldsFlag) {
+			return shared.UsageErrorf("%s: --next cannot be combined with --%s", errorPrefix, fieldsFlag)
+		}
+		fields, err := shared.NormalizeSelection(fieldsValue, fieldsAllowed, "--"+fieldsFlag)
+		if err != nil {
+			return shared.UsageError(errorPrefix + ": " + err.Error())
 		}
 		if appID == "" && strings.TrimSpace(next) == "" {
 			fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
@@ -112,6 +141,7 @@ Examples:
 		opts := []asc.PromotedPurchasesOption{
 			asc.WithPromotedPurchasesLimit(limit),
 			asc.WithPromotedPurchasesNextURL(next),
+			scopedPromotedPurchasesFieldsOption(cfg.ProductType, fields),
 		}
 
 		if paginate {
@@ -154,21 +184,47 @@ func configureScopedPromotedPurchasesViewCommand(cmd *ffcli.Command, cfg ScopedP
 	if cmd == nil || cmd.FlagSet == nil {
 		return
 	}
+	fieldsFlag, fieldsAllowed := scopedPromotedPurchaseFields(cfg.ProductType)
+	bindStringFlagIfMissing(cmd.FlagSet, fieldsFlag, promotedPurchaseFieldsUsage(fieldsFlag))
+	ownerIDFlag := strings.TrimSpace(cfg.OwnerIDFlag)
+	if ownerIDFlag != "" {
+		bindStringFlagIfMissing(cmd.FlagSet, ownerIDFlag, cfg.OwnerIDUsage)
+	}
 
-	cmd.ShortUsage = fmt.Sprintf("%s view --promoted-purchase-id PROMO_ID", cfg.PathPrefix)
+	if ownerIDFlag == "" {
+		cmd.ShortUsage = fmt.Sprintf("%s view --promoted-purchase-id PROMO_ID", cfg.PathPrefix)
+	} else {
+		cmd.ShortUsage = fmt.Sprintf("%s view (--promoted-purchase-id PROMO_ID | --%s PRODUCT_ID) [flags]", cfg.PathPrefix, ownerIDFlag)
+	}
 	cmd.ShortHelp = fmt.Sprintf("View a promoted purchase for %s by ID.", cfg.ProductSingular)
 	cmd.LongHelp = fmt.Sprintf(`View a promoted purchase for %s by ID.
 
 Examples:
-  %s view --promoted-purchase-id "PROMO_ID"`, cfg.ProductSingular, cfg.PathPrefix)
+  %s view --promoted-purchase-id "PROMO_ID"
+  %s view --promoted-purchase-id "PROMO_ID" --%s versions`, cfg.ProductSingular, cfg.PathPrefix, cfg.PathPrefix, fieldsFlag)
+	if ownerIDFlag != "" {
+		cmd.LongHelp += fmt.Sprintf("\n  %s view --%s \"PRODUCT_ID\" --%s versions", cfg.PathPrefix, ownerIDFlag, fieldsFlag)
+	}
 
 	cmd.Exec = func(ctx context.Context, args []string) error {
 		promotedPurchaseID := strings.TrimSpace(stringFlagValue(cmd.FlagSet, "promoted-purchase-id"))
+		ownerID := strings.TrimSpace(stringFlagValue(cmd.FlagSet, ownerIDFlag))
 		errorPrefix := promotedPurchasesCommandErrorPrefix(cfg, "view")
 
-		if promotedPurchaseID == "" {
-			fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
+		if promotedPurchaseID == "" && ownerID == "" {
+			if ownerIDFlag == "" {
+				fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: --promoted-purchase-id or --%s is required\n", ownerIDFlag)
+			}
 			return shared.MissingRequiredUsageError()
+		}
+		if promotedPurchaseID != "" && ownerID != "" {
+			return shared.UsageErrorf("%s: --promoted-purchase-id and --%s are mutually exclusive", errorPrefix, ownerIDFlag)
+		}
+		fields, err := shared.NormalizeSelection(stringFlagValue(cmd.FlagSet, fieldsFlag), fieldsAllowed, "--"+fieldsFlag)
+		if err != nil {
+			return shared.UsageError(errorPrefix + ": " + err.Error())
 		}
 
 		client, err := shared.GetASCClient()
@@ -178,12 +234,26 @@ Examples:
 
 		requestCtx, cancel := shared.ContextWithTimeout(ctx)
 		defer cancel()
+		getOpts := []asc.PromotedPurchaseGetOption{scopedPromotedPurchaseFieldsGetOption(cfg.ProductType, fields)}
+
+		if ownerID != "" {
+			if cfg.FetchForOwner == nil {
+				return fmt.Errorf("%s: --%s is not supported", errorPrefix, ownerIDFlag)
+			}
+			resp, err := cfg.FetchForOwner(requestCtx, client, ownerID, getOpts...)
+			if err != nil {
+				return fmt.Errorf("%s: failed to fetch: %w", errorPrefix, err)
+			}
+			output := stringFlagValue(cmd.FlagSet, "output")
+			pretty := boolFlagValue(cmd.FlagSet, "pretty")
+			return shared.PrintOutput(resp, output, pretty)
+		}
 
 		if err := validatePromotedPurchaseScope(requestCtx, client, promotedPurchaseID, cfg, "view"); err != nil {
 			return err
 		}
 
-		resp, err := client.GetPromotedPurchase(requestCtx, promotedPurchaseID)
+		resp, err := client.GetPromotedPurchase(requestCtx, promotedPurchaseID, getOpts...)
 		if err != nil {
 			return fmt.Errorf("%s: failed to fetch: %w", errorPrefix, err)
 		}
@@ -192,6 +262,62 @@ Examples:
 		pretty := boolFlagValue(cmd.FlagSet, "pretty")
 		return shared.PrintOutput(resp, output, pretty)
 	}
+}
+
+func scopedPromotedPurchaseFields(productType promotedPurchaseProductType) (string, []string) {
+	switch productType {
+	case promotedPurchaseProductTypeInAppPurchase:
+		return "iap-fields", promotedPurchaseIAPFields
+	case promotedPurchaseProductTypeSubscription:
+		return "subscription-fields", promotedPurchaseSubscriptionFields
+	default:
+		return "product-fields", nil
+	}
+}
+
+func scopedPromotedPurchasesFieldsOption(productType promotedPurchaseProductType, fields []string) asc.PromotedPurchasesOption {
+	if productType == promotedPurchaseProductTypeSubscription {
+		return asc.WithPromotedPurchasesSubscriptionFields(fields)
+	}
+	return asc.WithPromotedPurchasesIAPFields(fields)
+}
+
+func scopedPromotedPurchaseFieldsGetOption(productType promotedPurchaseProductType, fields []string) asc.PromotedPurchaseGetOption {
+	if productType == promotedPurchaseProductTypeSubscription {
+		return asc.WithPromotedPurchaseSubscriptionFields(fields)
+	}
+	return asc.WithPromotedPurchaseIAPFields(fields)
+}
+
+func promotedPurchaseFieldsUsage(flagName string) string {
+	switch flagName {
+	case "iap-fields":
+		return "fields[inAppPurchases] for included in-app purchases (comma-separated)"
+	case "subscription-fields":
+		return "fields[subscriptions] for included subscriptions (comma-separated)"
+	default:
+		return "Sparse fields for included products (comma-separated)"
+	}
+}
+
+func bindStringFlagIfMissing(fs *flag.FlagSet, name, usage string) {
+	if fs == nil || strings.TrimSpace(name) == "" || fs.Lookup(name) != nil {
+		return
+	}
+	fs.String(name, "", usage)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	if fs == nil || strings.TrimSpace(name) == "" {
+		return false
+	}
+	found := false
+	fs.Visit(func(parsed *flag.Flag) {
+		if parsed.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 func configureScopedPromotedPurchasesUpdateCommand(cmd *ffcli.Command, cfg ScopedPromotedPurchasesCommandConfig) {

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -88,8 +88,8 @@ func configureScopedPromotedPurchasesListCommand(cmd *ffcli.Command, cfg ScopedP
 	if cmd == nil || cmd.FlagSet == nil {
 		return
 	}
-	fieldsFlag, fieldsAllowed := scopedPromotedPurchaseFields(cfg.ProductType)
-	bindStringFlagIfMissing(cmd.FlagSet, fieldsFlag, promotedPurchaseFieldsUsage(fieldsFlag))
+	bindStringFlagIfMissing(cmd.FlagSet, "iap-fields", promotedPurchaseFieldsUsage("iap-fields"))
+	bindStringFlagIfMissing(cmd.FlagSet, "subscription-fields", promotedPurchaseFieldsUsage("subscription-fields"))
 
 	cmd.ShortUsage = fmt.Sprintf("%s list (--app APP_ID | --next URL) [flags]", cfg.PathPrefix)
 	cmd.ShortHelp = fmt.Sprintf("List promoted purchases for %s in an app.", cfg.ProductPlural)
@@ -98,13 +98,14 @@ func configureScopedPromotedPurchasesListCommand(cmd *ffcli.Command, cfg ScopedP
 Examples:
   %s list --app "APP_ID"
   %s list --app "APP_ID" --limit 10
-  %s list --app "APP_ID" --%s versions
-  %s list --app "APP_ID" --paginate`, cfg.ProductPlural, cfg.PathPrefix, cfg.PathPrefix, cfg.PathPrefix, fieldsFlag, cfg.PathPrefix)
+  %s list --app "APP_ID" --iap-fields versions --subscription-fields versions
+  %s list --app "APP_ID" --paginate`, cfg.ProductPlural, cfg.PathPrefix, cfg.PathPrefix, cfg.PathPrefix, cfg.PathPrefix)
 
 	cmd.Exec = func(ctx context.Context, args []string) error {
 		limit := intFlagValue(cmd.FlagSet, "limit")
 		next := stringFlagValue(cmd.FlagSet, "next")
-		fieldsValue := stringFlagValue(cmd.FlagSet, fieldsFlag)
+		iapFieldsValue := stringFlagValue(cmd.FlagSet, "iap-fields")
+		subscriptionFieldsValue := stringFlagValue(cmd.FlagSet, "subscription-fields")
 		paginate := boolFlagValue(cmd.FlagSet, "paginate")
 		output := stringFlagValue(cmd.FlagSet, "output")
 		pretty := boolFlagValue(cmd.FlagSet, "pretty")
@@ -118,10 +119,14 @@ Examples:
 		if err := shared.ValidateNextURL(next); err != nil {
 			return fmt.Errorf("%s: %w", errorPrefix, err)
 		}
-		if strings.TrimSpace(next) != "" && flagWasSet(cmd.FlagSet, fieldsFlag) {
-			return shared.UsageErrorf("%s: --next cannot be combined with --%s", errorPrefix, fieldsFlag)
+		if strings.TrimSpace(next) != "" && (flagWasSet(cmd.FlagSet, "iap-fields") || flagWasSet(cmd.FlagSet, "subscription-fields")) {
+			return shared.UsageErrorf("%s: --next cannot be combined with --iap-fields or --subscription-fields", errorPrefix)
 		}
-		fields, err := shared.NormalizeSelection(fieldsValue, fieldsAllowed, "--"+fieldsFlag)
+		iapFields, err := shared.NormalizeSelection(iapFieldsValue, promotedPurchaseIAPFields, "--iap-fields")
+		if err != nil {
+			return shared.UsageError(errorPrefix + ": " + err.Error())
+		}
+		subscriptionFields, err := shared.NormalizeSelection(subscriptionFieldsValue, promotedPurchaseSubscriptionFields, "--subscription-fields")
 		if err != nil {
 			return shared.UsageError(errorPrefix + ": " + err.Error())
 		}
@@ -141,7 +146,8 @@ Examples:
 		opts := []asc.PromotedPurchasesOption{
 			asc.WithPromotedPurchasesLimit(limit),
 			asc.WithPromotedPurchasesNextURL(next),
-			scopedPromotedPurchasesFieldsOption(cfg.ProductType, fields),
+			asc.WithPromotedPurchasesIAPFields(iapFields),
+			asc.WithPromotedPurchasesSubscriptionFields(subscriptionFields),
 		}
 
 		if paginate {
@@ -184,8 +190,8 @@ func configureScopedPromotedPurchasesViewCommand(cmd *ffcli.Command, cfg ScopedP
 	if cmd == nil || cmd.FlagSet == nil {
 		return
 	}
-	fieldsFlag, fieldsAllowed := scopedPromotedPurchaseFields(cfg.ProductType)
-	bindStringFlagIfMissing(cmd.FlagSet, fieldsFlag, promotedPurchaseFieldsUsage(fieldsFlag))
+	bindStringFlagIfMissing(cmd.FlagSet, "iap-fields", promotedPurchaseFieldsUsage("iap-fields"))
+	bindStringFlagIfMissing(cmd.FlagSet, "subscription-fields", promotedPurchaseFieldsUsage("subscription-fields"))
 	ownerIDFlag := strings.TrimSpace(cfg.OwnerIDFlag)
 	if ownerIDFlag != "" {
 		bindStringFlagIfMissing(cmd.FlagSet, ownerIDFlag, cfg.OwnerIDUsage)
@@ -201,9 +207,9 @@ func configureScopedPromotedPurchasesViewCommand(cmd *ffcli.Command, cfg ScopedP
 
 Examples:
   %s view --promoted-purchase-id "PROMO_ID"
-  %s view --promoted-purchase-id "PROMO_ID" --%s versions`, cfg.ProductSingular, cfg.PathPrefix, cfg.PathPrefix, fieldsFlag)
+  %s view --promoted-purchase-id "PROMO_ID" --iap-fields versions --subscription-fields versions`, cfg.ProductSingular, cfg.PathPrefix, cfg.PathPrefix)
 	if ownerIDFlag != "" {
-		cmd.LongHelp += fmt.Sprintf("\n  %s view --%s \"PRODUCT_ID\" --%s versions", cfg.PathPrefix, ownerIDFlag, fieldsFlag)
+		cmd.LongHelp += fmt.Sprintf("\n  %s view --%s \"PRODUCT_ID\" --iap-fields versions --subscription-fields versions", cfg.PathPrefix, ownerIDFlag)
 	}
 
 	cmd.Exec = func(ctx context.Context, args []string) error {
@@ -222,7 +228,11 @@ Examples:
 		if promotedPurchaseID != "" && ownerID != "" {
 			return shared.UsageErrorf("%s: --promoted-purchase-id and --%s are mutually exclusive", errorPrefix, ownerIDFlag)
 		}
-		fields, err := shared.NormalizeSelection(stringFlagValue(cmd.FlagSet, fieldsFlag), fieldsAllowed, "--"+fieldsFlag)
+		iapFields, err := shared.NormalizeSelection(stringFlagValue(cmd.FlagSet, "iap-fields"), promotedPurchaseIAPFields, "--iap-fields")
+		if err != nil {
+			return shared.UsageError(errorPrefix + ": " + err.Error())
+		}
+		subscriptionFields, err := shared.NormalizeSelection(stringFlagValue(cmd.FlagSet, "subscription-fields"), promotedPurchaseSubscriptionFields, "--subscription-fields")
 		if err != nil {
 			return shared.UsageError(errorPrefix + ": " + err.Error())
 		}
@@ -234,7 +244,10 @@ Examples:
 
 		requestCtx, cancel := shared.ContextWithTimeout(ctx)
 		defer cancel()
-		getOpts := []asc.PromotedPurchaseGetOption{scopedPromotedPurchaseFieldsGetOption(cfg.ProductType, fields)}
+		getOpts := []asc.PromotedPurchaseGetOption{
+			asc.WithPromotedPurchaseIAPFields(iapFields),
+			asc.WithPromotedPurchaseSubscriptionFields(subscriptionFields),
+		}
 
 		if ownerID != "" {
 			if cfg.FetchForOwner == nil {
@@ -262,31 +275,6 @@ Examples:
 		pretty := boolFlagValue(cmd.FlagSet, "pretty")
 		return shared.PrintOutput(resp, output, pretty)
 	}
-}
-
-func scopedPromotedPurchaseFields(productType promotedPurchaseProductType) (string, []string) {
-	switch productType {
-	case promotedPurchaseProductTypeInAppPurchase:
-		return "iap-fields", promotedPurchaseIAPFields
-	case promotedPurchaseProductTypeSubscription:
-		return "subscription-fields", promotedPurchaseSubscriptionFields
-	default:
-		return "product-fields", nil
-	}
-}
-
-func scopedPromotedPurchasesFieldsOption(productType promotedPurchaseProductType, fields []string) asc.PromotedPurchasesOption {
-	if productType == promotedPurchaseProductTypeSubscription {
-		return asc.WithPromotedPurchasesSubscriptionFields(fields)
-	}
-	return asc.WithPromotedPurchasesIAPFields(fields)
-}
-
-func scopedPromotedPurchaseFieldsGetOption(productType promotedPurchaseProductType, fields []string) asc.PromotedPurchaseGetOption {
-	if productType == promotedPurchaseProductTypeSubscription {
-		return asc.WithPromotedPurchaseSubscriptionFields(fields)
-	}
-	return asc.WithPromotedPurchaseIAPFields(fields)
 }
 
 func promotedPurchaseFieldsUsage(flagName string) string {

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -18,16 +18,17 @@ import (
 // ScopedPromotedPurchasesCommandConfig customizes a promoted-purchases command tree
 // to a single product family while preserving the shared generic implementation.
 type ScopedPromotedPurchasesCommandConfig struct {
-	PathPrefix      string
-	ProductType     promotedPurchaseProductType
-	ProductSingular string
-	ProductPlural   string
-	RootShortHelp   string
-	RootLongHelp    string
-	OwnerIDFlag     string
-	OwnerIDUsage    string
-	ResolveOwnerID  func(context.Context, *asc.Client, string) (string, error)
-	FetchForOwner   func(context.Context, *asc.Client, string, ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error)
+	PathPrefix         string
+	ProductType        promotedPurchaseProductType
+	ProductSingular    string
+	ProductPlural      string
+	RootShortHelp      string
+	RootLongHelp       string
+	OwnerIDFlag        string
+	OwnerIDUsage       string
+	OwnerIDPlaceholder string
+	ResolveOwnerID     func(context.Context, *asc.Client, string) (string, error)
+	FetchForOwner      func(context.Context, *asc.Client, string, ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error)
 }
 
 var promotedPurchaseIAPFields = []string{
@@ -194,6 +195,10 @@ func configureScopedPromotedPurchasesViewCommand(cmd *ffcli.Command, cfg ScopedP
 	bindStringFlagIfMissing(cmd.FlagSet, "iap-fields", promotedPurchaseFieldsUsage("iap-fields"))
 	bindStringFlagIfMissing(cmd.FlagSet, "subscription-fields", promotedPurchaseFieldsUsage("subscription-fields"))
 	ownerIDFlag := strings.TrimSpace(cfg.OwnerIDFlag)
+	ownerIDPlaceholder := strings.TrimSpace(cfg.OwnerIDPlaceholder)
+	if ownerIDPlaceholder == "" {
+		ownerIDPlaceholder = "PRODUCT_ID"
+	}
 	if ownerIDFlag != "" {
 		bindStringFlagIfMissing(cmd.FlagSet, ownerIDFlag, cfg.OwnerIDUsage)
 	}
@@ -201,7 +206,7 @@ func configureScopedPromotedPurchasesViewCommand(cmd *ffcli.Command, cfg ScopedP
 	if ownerIDFlag == "" {
 		cmd.ShortUsage = fmt.Sprintf("%s view --promoted-purchase-id PROMO_ID", cfg.PathPrefix)
 	} else {
-		cmd.ShortUsage = fmt.Sprintf("%s view (--promoted-purchase-id PROMO_ID | --%s PRODUCT_ID) [flags]", cfg.PathPrefix, ownerIDFlag)
+		cmd.ShortUsage = fmt.Sprintf("%s view (--promoted-purchase-id PROMO_ID | --%s %s) [flags]", cfg.PathPrefix, ownerIDFlag, ownerIDPlaceholder)
 	}
 	cmd.ShortHelp = fmt.Sprintf("View a promoted purchase for %s by ID.", cfg.ProductSingular)
 	cmd.LongHelp = fmt.Sprintf(`View a promoted purchase for %s by ID.
@@ -210,7 +215,7 @@ Examples:
   %s view --promoted-purchase-id "PROMO_ID"
   %s view --promoted-purchase-id "PROMO_ID" --iap-fields versions --subscription-fields versions`, cfg.ProductSingular, cfg.PathPrefix, cfg.PathPrefix)
 	if ownerIDFlag != "" {
-		cmd.LongHelp += fmt.Sprintf("\n  %s view --%s \"PRODUCT_ID\" --iap-fields versions --subscription-fields versions", cfg.PathPrefix, ownerIDFlag)
+		cmd.LongHelp += fmt.Sprintf("\n  %s view --%s \"%s\" --iap-fields versions --subscription-fields versions", cfg.PathPrefix, ownerIDFlag, ownerIDPlaceholder)
 	}
 
 	cmd.Exec = func(ctx context.Context, args []string) error {

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -26,6 +26,7 @@ type ScopedPromotedPurchasesCommandConfig struct {
 	RootLongHelp    string
 	OwnerIDFlag     string
 	OwnerIDUsage    string
+	ResolveOwnerID  func(context.Context, *asc.Client, string) (string, error)
 	FetchForOwner   func(context.Context, *asc.Client, string, ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error)
 }
 
@@ -242,8 +243,6 @@ Examples:
 			return fmt.Errorf("%s: %w", errorPrefix, err)
 		}
 
-		requestCtx, cancel := shared.ContextWithTimeout(ctx)
-		defer cancel()
 		getOpts := []asc.PromotedPurchaseGetOption{
 			asc.WithPromotedPurchaseIAPFields(iapFields),
 			asc.WithPromotedPurchaseSubscriptionFields(subscriptionFields),
@@ -253,6 +252,15 @@ Examples:
 			if cfg.FetchForOwner == nil {
 				return fmt.Errorf("%s: --%s is not supported", errorPrefix, ownerIDFlag)
 			}
+			if cfg.ResolveOwnerID != nil {
+				ownerID, err = cfg.ResolveOwnerID(ctx, client, ownerID)
+				if err != nil {
+					return err
+				}
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
 			resp, err := cfg.FetchForOwner(requestCtx, client, ownerID, getOpts...)
 			if err != nil {
 				return fmt.Errorf("%s: failed to fetch: %w", errorPrefix, err)
@@ -262,6 +270,8 @@ Examples:
 			return shared.PrintOutput(resp, output, pretty)
 		}
 
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
 		if err := validatePromotedPurchaseScope(requestCtx, client, promotedPurchaseID, cfg, "view"); err != nil {
 			return err
 		}

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -517,6 +517,7 @@ func filterPromotedPurchasesByProductType(ctx context.Context, client *asc.Clien
 	}
 
 	filtered := resp.Data[:0]
+	retainedProducts := make(map[string]struct{}, len(resp.Data))
 	for _, item := range resp.Data {
 		scope, err := promotedPurchaseScopeForResource(ctx, client, item)
 		if err != nil {
@@ -524,10 +525,59 @@ func filterPromotedPurchasesByProductType(ctx context.Context, client *asc.Clien
 		}
 		if scope.productType == productType {
 			filtered = append(filtered, item)
+			retainedProducts[promotedPurchaseProductResourceKey(scope)] = struct{}{}
 		}
 	}
 	resp.Data = filtered
+
+	included, err := filterPromotedPurchaseIncluded(resp.Included, retainedProducts)
+	if err != nil {
+		return err
+	}
+	resp.Included = included
 	return nil
+}
+
+func promotedPurchaseProductResourceKey(scope promotedPurchaseScope) string {
+	resourceType := asc.ResourceTypeInAppPurchases
+	if scope.productType == promotedPurchaseProductTypeSubscription {
+		resourceType = asc.ResourceTypeSubscriptions
+	}
+	return string(resourceType) + "\x00" + scope.productID
+}
+
+func filterPromotedPurchaseIncluded(included json.RawMessage, retainedProducts map[string]struct{}) (json.RawMessage, error) {
+	if len(included) == 0 || string(included) == "null" {
+		return included, nil
+	}
+
+	var resources []json.RawMessage
+	if err := json.Unmarshal(included, &resources); err != nil {
+		return nil, fmt.Errorf("parse promoted purchase included resources: %w", err)
+	}
+
+	filtered := make([]json.RawMessage, 0, len(resources))
+	for _, resource := range resources {
+		var identifier struct {
+			Type asc.ResourceType `json:"type"`
+			ID   string           `json:"id"`
+		}
+		if err := json.Unmarshal(resource, &identifier); err != nil {
+			return nil, fmt.Errorf("parse promoted purchase included resource: %w", err)
+		}
+		if strings.TrimSpace(string(identifier.Type)) == "" || strings.TrimSpace(identifier.ID) == "" {
+			return nil, fmt.Errorf("parse promoted purchase included resource: missing type or id")
+		}
+		if _, ok := retainedProducts[string(identifier.Type)+"\x00"+identifier.ID]; ok {
+			filtered = append(filtered, resource)
+		}
+	}
+
+	encoded, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, fmt.Errorf("encode promoted purchase included resources: %w", err)
+	}
+	return encoded, nil
 }
 
 func collectPreservedPromotedPurchaseIDs(ctx context.Context, client *asc.Client, appID string, scopedType promotedPurchaseProductType) ([]string, error) {


### PR DESCRIPTION
## Summary

- propagate App Store Connect API 4.4.1 versions sparse fields across all 11 affected IAP and promoted-purchase GET operations
- add endpoint-exact typed options, exact enum validation, relationship auto-includes, include deduplication, and opaque-next conflict handling
- expose both --iap-fields and --subscription-fields wherever promoted-purchase reads permit them
- add iap promoted-purchases view --iap-id as an exact alternative to --promoted-purchase-id
- preserve deprecated IAP image/localization commands and their migration warnings
- document the long-form command surface and reconcile the merged #1792 ledger provenance

## Compatibility

Existing client method calls remain source-compatible through variadic typed options. Deprecated stable commands are retained; no stable behavior is removed. Invalid sparse values and selector/next conflicts fail as usage errors before authentication or HTTP.

## Verification

- all 11 exact GET paths have typed HTTP tests asserting method, path, exact query cardinality, sparse fields, and automatic includes
- command HTTP tests cover dual promoted fieldsets, owner lookup, validation, next conflicts, help, and deprecation behavior
- focused post-rebase tests passed for internal/asc, internal/cli/iap, internal/cli/promotedpurchases, and internal/cli/cmdtest
- make format passed
- make check-docs passed, including website command validation
- make lint passed with 0 issues
- make build passed
- built help verified for both IAP and subscription promoted list/view commands
- required commit-hook docs, website, format, lint, and short suite passed
- full ASC_BYPASS_KEYCHAIN=1 make test passed before the final rebase; the post-rebase main delta was the audited nullable/docs merge and focused plus hook suites passed afterward

## Live verification

No App Store Connect resource was created, changed, submitted, or deleted for this PR. Query construction is covered by exact local HTTP tests. Live disposable-app mutation remains part of the coordinated release-wide audit, not this isolated sparse-field PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--iap-fields` to IAP localization, images, content, and review screenshot commands to select related `inAppPurchases` fields (including `versions`).
  - Added `--iap-fields` and `--subscription-fields` to scoped promoted-purchases list/view commands for relationship-aware sparse output.

- **Bug Fixes / Improvements**
  - Enforced sparse-field validation, including rejecting incompatible `--next` usage.
  - Improved relationship/include handling so results and `include` output match the selected fieldsets.

- **Documentation**
  - Clarified App Store Connect IAP v2 migration behavior and expanded sparse-field examples across related resources.

- **Tests**
  - Expanded CLI and API request/query validation for sparse-field correctness, pagination constraints, and include handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->