### PR TITLE
fix(subscriptions): complete API 4.4.1 related sparse fields

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -778,6 +778,39 @@ Current CLI behavior:
   before creating MONTHLY `subscriptionPrices`, as required by Apple.
 * Creates MONTHLY `subscriptionPrices` for each eligible territory at `--price`.
 
+## API 4.4.1 Related Sparse Fields
+
+App Store Connect API 4.4.1 adds version and adjusted-equalization fields to
+existing subscription relationship reads. Use the long-form flag matching the
+related resource:
+
+```bash  theme={null}
+# Include subscription versions with a relationship read
+asc subscriptions offers promotional list \
+  --subscription-id "SUBSCRIPTION_SELECTOR" \
+  --subscription-fields versions
+
+# Include subscription-group versions with deprecated v1 group localizations
+asc subscriptions groups localizations list \
+  --group-id "GROUP_ID" \
+  --group-fields versions
+
+# Include adjusted equalizations with offer prices
+asc subscriptions offers promotional prices \
+  --id "OFFER_ID" \
+  --price-point-fields adjustedEqualizations
+
+# Select adjusted equalizations on a price-point detail read
+asc subscriptions pricing price-points view \
+  --price-point-id "PRICE_POINT_ID" \
+  --fields adjustedEqualizations
+```
+
+Related sparse fields automatically add the required include relationship. Do
+not combine them with `--next`; the next-page URL already contains the server's
+query state. The product-scoped v1 localization and image commands remain
+deprecated: use the version-scoped commands below for writes and new workflows.
+
 Monthly with 12-Month Commitment is available only outside the United States and
 Singapore, requires devices on OS version 26.4 or later, excludes watchOS, and
 requires apps built with SDK 26.5 or later.
@@ -994,6 +1027,13 @@ asc subscriptions promoted-purchases list \
 asc subscriptions promoted-purchases view \
   --promoted-purchase-id "PROMO_ID"
 
+# View the promoted purchase attached to a subscription selector
+asc subscriptions promoted-purchases view \
+  --app "APP_ID" \
+  --subscription-id "SUBSCRIPTION_SELECTOR" \
+  --subscription-fields versions \
+  --iap-fields versions
+
 # Create promoted subscription
 asc subscriptions promoted-purchases create \
   --app "APP_ID" \
@@ -1005,6 +1045,12 @@ asc subscriptions promoted-purchases link \
   --app "APP_ID" \
   --promoted-purchase-id "PROMO_ID"
 ```
+
+Provide exactly one of `--promoted-purchase-id` or
+`--subscription-id SUBSCRIPTION_SELECTOR`. `SUBSCRIPTION_SELECTOR` accepts an
+ASC subscription ID, product ID, or exact current name. Product IDs and names
+require `--app "APP_ID"` or `ASC_APP_ID`. The sparse-field flags automatically
+include the matching `subscription` and `inAppPurchaseV2` relationships.
 
 ## Submission
 

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -520,7 +520,7 @@ payload, output, and compatibility tests):
 IAP and promoted-purchase propagation (#1777 at `ee40c7b3` plus #1793 final
 head `917d719d`, landed as `f6b34d9e`; endpoint-exact query and response
 compatibility tests). #1793 closes 11 of the 13 GETs below while preserving
-#1777's two top-level IAP list/detail behaviors:
+the two top-level IAP list/detail behaviors from #1777:
 
 - [x] `GET /v1/apps/{id}/inAppPurchasesV2`
 - [x] `GET /v1/inAppPurchaseAppStoreReviewScreenshots/{id}`

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -85,6 +85,7 @@ separately and has no invented landed `main` commit:
 | Subscription localization delete-confirmation coverage | #1790 | `49eda126` | `73466720` | Merged; test only |
 | Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only |
 | Seven-property nullable request fidelity | #1792 | `3f7d1449` | `804624cd` | Merged; exact final head landed on `main` |
+| IAP and promoted-purchase related sparse fields | #1793 | `917d719d` | `f6b34d9e` | Merged; exact final head, six resolved threads, and green exact-head gates |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#50 | `61b9634` | `e5561a9` | Merged; landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
@@ -109,10 +110,11 @@ legacy omission behavior for a whitespace-only `customAppName` while retaining
 explicit JSON `null`; it landed on `main` as
 `804624cd158d1eb8843d8e0be7cf55bc639da0a1`.
 
-The current fully merged behavior integration is #1792 at `main` commit
-`804624cd158d1eb8843d8e0be7cf55bc639da0a1`; #1789 previously landed this
-coverage ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and
-docs-only #1791 landed at `e902d375`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
+The current fully merged behavior integration is #1793 at `main` commit
+`f6b34d9e042964673ee39c32fbae4f7aa99fc874`; #1789 previously landed this
+coverage ledger at `d6d8d94b`, test-only #1790 landed at `73466720`,
+docs-only #1791 landed at `e902d375`, and nullable-fidelity #1792 landed at
+`804624cd`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
 173-contract, 61-modified-schema, and 9-addition/7-deprecation counts are
 unchanged. The recursive built-help comparison from `839c4da6` to `9282e82d`
 found 48 added and 52 changed leaf paths, 100 affected paths total, with zero
@@ -331,8 +333,8 @@ change.
 
 | Contract area | Semantic change | Verification owner | Exact evidence |
 | --- | --- | --- | --- |
-| IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 plus the related-resource sparse-field follow-up | `ee40c7b3` plus `client_iap_related_sparse_fields_441_test.go`; all 11 propagated IAP/promoted-purchase GETs now have endpoint-specific options and exact-query tests; follow-up remains pre-merge until its own PR lands |
-| Subscription reads | Subscription detail and group-subscription reads gain version includes, sparse fields, and relationship limits; subscription sparse fields gain `versions` across related endpoints | #1779 | `c8f3ab52`; exact query and compatibility tests |
+| IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 and #1793 | `ee40c7b3`; #1793 final head `917d719d`, landed as `f6b34d9e`, adds all 11 propagated IAP/promoted-purchase GETs with endpoint-exact options, queries, stable owner selection, and response compatibility tests |
+| Subscription reads | Subscription detail and group-subscription reads gain version includes, sparse fields, and relationship limits; subscription sparse fields gain `versions` across related endpoints | #1779 plus the subscription sparse-field follow-up | `c8f3ab52` plus `subscription_sparse_fields_4_4_1_test.go`; exact query, stable owner selection, opaque-pagination, and compatibility tests across all 17 propagated subscription/pricing GETs |
 | Subscription-group reads | Group detail and app-group collection reads gain version includes, sparse fields, and relationship limits; group sparse fields gain `versions` | #1780 | `48d04e0b`; exact query, owner/next validation, and compatibility tests |
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
 | Pricing reads | Price-point sparse fields gain `adjustedEqualizations`; existing equalization and price-point relationship operations gain `filter[upfrontPricePointId]` and `filter[planType]` where allowed | #1778 | `39284b0a`; endpoint-specific option, exact query, strict CSV/enums, territory inclusion, opaque-next, ID validation, and aggregation tests |
@@ -515,9 +517,9 @@ payload, output, and compatibility tests):
 - [x] `GET /v1/apps/{id}/appInfos`
 - [x] `GET /v1/ciProducts/{id}/app`
 
-IAP and promoted-purchase propagation (#1777 at `ee40c7b3` plus the
-related-resource sparse-field follow-up; endpoint-exact query and response
-compatibility tests). The follow-up closes the 11 related GETs below while
+IAP and promoted-purchase propagation (#1777 at `ee40c7b3` plus #1793 final
+head `917d719d`, landed as `f6b34d9e`; endpoint-exact query and response
+compatibility tests). #1793 closes the 11 related GETs below while
 preserving #1777's top-level IAP list/detail behavior:
 
 - [x] `GET /v1/apps/{id}/inAppPurchasesV2`
@@ -819,19 +821,24 @@ documented deprecation window; this goal intentionally stops before release.
 17. #1792 completed all seven nullable request properties at exact final head
     `3f7d14495fcb3b696692bee4955e36fd2f36c63f` and landed on `main` as
     `804624cd158d1eb8843d8e0be7cf55bc639da0a1`.
-18. External workflow skills were audited at exact head `61b9634` and landed as
+18. #1793 completed the IAP and promoted-purchase related sparse-field follow-up
+    at exact final head `917d719df73a8dce9eefd5f378bad5a0562a67c0`
+    and landed on `main` as `f6b34d9e042964673ee39c32fbae4f7aa99fc874`.
+19. External workflow skills were audited at exact head `61b9634` and landed as
     `e5561a9`. All 11 review threads are resolved, and the landed tree passes all
     23 skill validators plus 245 command-example and 716 flag help checks.
-19. Exact CLI `main` `804624cd` is the current fully merged behavior integration
-    through #1792. Its PR head passed integration, Govulncheck, and CodeQL workflows.
-    Its built help has 48 added and 52 changed leaf paths relative to
-    `839c4da6`, with zero removals. Those historical help counts do not replace
-    #1792's typed nullable-encoding tests.
+20. Exact CLI `main` `f6b34d9e` is the current fully merged behavior integration
+    through #1793. Its PR head passed integration, Govulncheck, and CodeQL workflows.
+    The historical built-help audit through #1788 found 48 added and 52 changed
+    leaf paths relative to `839c4da6`, with zero removals; later flag-level help
+    changes are verified by their focused command tests. Those historical
+    counts do not replace #1792's typed nullable-encoding tests.
 
 CLI behavior and lifecycle PRs through #1788, the ledger PR, test-only #1790,
-docs-only #1791, nullable-fidelity #1792, and the companion skills PR are
-merged. This IAP sparse-field follow-up remains pre-merge until its own PR
-lands. No release, tag, or package publication is part of this goal.
+docs-only #1791, nullable-fidelity #1792, IAP sparse-field #1793, and the
+companion skills PR are merged. The subscription and pricing sparse-field
+follow-up is verified by its endpoint ledger and exact-query tests in this
+branch. No release, tag, or package publication is part of this goal.
 
 ### Built help-surface delta
 
@@ -1032,11 +1039,12 @@ pre-merge evidence are separated explicitly:
   read succeeded, all four age fields were restored to `false`, and all four
   review submissions contained zero items. This predates #1792 and is not
   evidence that Apple accepts explicit null for its seven corrected fields.
-- [x] Confirmed the fully merged behavior integration through #1792, `main`
-  `804624cd`, follows green exact-head integration, Govulncheck, and CodeQL
+- [x] Confirmed the fully merged behavior integration through #1793, `main`
+  `f6b34d9e`, follows green exact-head integration, Govulncheck, and CodeQL
   workflows; #1789 previously landed
-  the ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, and docs-only
-  #1791 landed at `e902d375`. Skills `main` `e5561a9` still passes local validation (it has no
+  the ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, docs-only
+  #1791 landed at `e902d375`, and nullable-fidelity #1792 landed at
+  `804624cd`. Skills `main` `e5561a9` still passes local validation (it has no
   configured `main` status or check runs), and the latest release/tag remains
   `3.0.0` at the pre-integration commit `839c4da6`. No release, tag,
   Homebrew/WinGet update, or package publication was performed.

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -86,7 +86,7 @@ separately and has no invented landed `main` commit:
 | Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only |
 | Seven-property nullable request fidelity | #1792 | `3f7d1449` | `804624cd` | Merged; exact final head landed on `main` |
 | IAP and promoted-purchase related sparse fields | #1793 | `917d719d` | `f6b34d9e` | Merged; exact final head, six resolved threads, and green exact-head gates |
-| External ASC workflow skills | rorkai/app-store-connect-cli-skills#50 | `61b9634` | `e5561a9` | Merged; landed tree revalidated |
+| External ASC workflow skills | rorkai/app-store-connect-cli-skills#51 | `d7888b2b4a1a152f8524fc18c99d2d73d1c431fc` | `26b2fa92e612dff3477537f67b44f1bcfedf0fc5` | Merged; exact final head and landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
 endpoint-exact fields, includes, sparse fields, and relationship limits; opaque
@@ -519,8 +519,8 @@ payload, output, and compatibility tests):
 
 IAP and promoted-purchase propagation (#1777 at `ee40c7b3` plus #1793 final
 head `917d719d`, landed as `f6b34d9e`; endpoint-exact query and response
-compatibility tests). #1793 closes the 11 related GETs below while
-preserving #1777's top-level IAP list/detail behavior:
+compatibility tests). #1793 closes 11 of the 13 GETs below while preserving
+#1777's two top-level IAP list/detail behaviors:
 
 - [x] `GET /v1/apps/{id}/inAppPurchasesV2`
 - [x] `GET /v1/inAppPurchaseAppStoreReviewScreenshots/{id}`
@@ -824,9 +824,12 @@ documented deprecation window; this goal intentionally stops before release.
 18. #1793 completed the IAP and promoted-purchase related sparse-field follow-up
     at exact final head `917d719df73a8dce9eefd5f378bad5a0562a67c0`
     and landed on `main` as `f6b34d9e042964673ee39c32fbae4f7aa99fc874`.
-19. External workflow skills were audited at exact head `61b9634` and landed as
-    `e5561a9`. All 11 review threads are resolved, and the landed tree passes all
-    23 skill validators plus 245 command-example and 716 flag help checks.
+19. External workflow skills were audited through
+    rorkai/app-store-connect-cli-skills#51 at exact head
+    `d7888b2b4a1a152f8524fc18c99d2d73d1c431fc` and landed as skills `main`
+    `26b2fa92e612dff3477537f67b44f1bcfedf0fc5`. All three PR #51 review
+    threads are resolved; final-head exact-help validation covered 28 commands
+    and 108 flags with zero failures, and the skill validator passed.
 20. Exact CLI `main` `f6b34d9e` is the current fully merged behavior integration
     through #1793. Its PR head passed integration, Govulncheck, and CodeQL workflows.
     The historical built-help audit through #1788 found 48 added and 52 changed
@@ -1030,10 +1033,12 @@ pre-merge evidence are separated explicitly:
 - [x] Cleaned every disposable resource the API permits and recorded the three
   unavoidable version/localization remnant pairs. All four review submissions
   are empty and age-rating fields were restored.
-- [x] Audited and merged companion workflow-skills PR #50 at exact head
-  `61b9634`, producing skills `main` `e5561a9`; all 11 threads are resolved,
-  all 23 skills validate, and 245 command examples with 716 flags match exact
-  CLI help. No runnable deprecated localization or submission teaching remains.
+- [x] Audited and merged companion workflow-skills PR #51 at exact head
+  `d7888b2b4a1a152f8524fc18c99d2d73d1c431fc`, producing skills `main`
+  `26b2fa92e612dff3477537f67b44f1bcfedf0fc5`; all three threads are resolved,
+  final-head exact-help validation covered 28 commands and 108 flags with zero
+  failures, and the skill validator passed. No runnable deprecated localization
+  or submission teaching remains.
 - [x] Ran the final read-only live smoke on disposable app `6759231657` after
   behavior work through #1788 and the workflow-skill changes merged: the app
   read succeeded, all four age fields were restored to `false`, and all four
@@ -1044,7 +1049,9 @@ pre-merge evidence are separated explicitly:
   workflows; #1789 previously landed
   the ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, docs-only
   #1791 landed at `e902d375`, and nullable-fidelity #1792 landed at
-  `804624cd`. Skills `main` `e5561a9` still passes local validation (it has no
-  configured `main` status or check runs), and the latest release/tag remains
+  `804624cd`. Skills `main`
+  `26b2fa92e612dff3477537f67b44f1bcfedf0fc5` is the landed companion-skills
+  integration (that repository has no configured `main` status or check runs),
+  and the latest release/tag remains
   `3.0.0` at the pre-integration commit `839c4da6`. No release, tag,
   Homebrew/WinGet update, or package publication was performed.

--- a/docs/design/app-store-connect-api-4.4.1-subscription-sparse-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-subscription-sparse-fields.md
@@ -1,0 +1,92 @@
+# App Store Connect API 4.4.1 subscription sparse fields
+
+## Placement and command shape
+
+This slice extends the existing subscription resource, offer, pricing, review,
+and promoted-purchase commands. It does not add a command noun. The one
+previously client-only relationship read is exposed through the established
+scoped view command:
+
+```text
+asc subscriptions promoted-purchases view --subscription-id "SUBSCRIPTION_ID"
+```
+
+Related-resource sparse fields use the existing CLI naming convention:
+
+- `--subscription-fields` maps to `fields[subscriptions]`.
+- `--group-fields` maps to `fields[subscriptionGroups]`.
+- `--price-point-fields` maps to `fields[subscriptionPricePoints]`.
+- `--in-app-purchase-fields` maps to `fields[inAppPurchases]`.
+- `--fields` remains the primary-resource sparse-field flag on
+  `subscriptions pricing price-points view`.
+
+Before this change, the affected commands had no way to request the new sparse
+field values. List commands accepted `--next` but would silently discard any
+new sparse-field options if they were sent through an opaque next URL.
+
+## OpenAPI contract and implementation ledger
+
+Apple's 4.4.1 schema changes only the following parameter enums for this slice.
+All operations return their existing JSON:API response types.
+
+| Done | Method and path | 4.4.1 sparse-field addition | CLI command |
+| --- | --- | --- | --- |
+| [x] | `GET /v1/subscriptionAppStoreReviewScreenshots/{id}` | `fields[subscriptions]=versions` | `subscriptions review screenshots view` |
+| [x] | `GET /v1/subscriptionGroupLocalizations/{id}` | `fields[subscriptionGroups]=versions` | `subscriptions groups localizations view` |
+| [x] | `GET /v1/subscriptionImages/{id}` | `fields[subscriptions]=versions` | `subscriptions images view` |
+| [x] | `GET /v1/subscriptionLocalizations/{id}` | `fields[subscriptions]=versions` | `subscriptions localizations view` |
+| [x] | `GET /v1/subscriptionOfferCodes/{id}` | `fields[subscriptions]=versions` | `subscriptions offers offer-codes view` |
+| [x] | `GET /v1/subscriptionPricePoints/{id}` | `fields[subscriptionPricePoints]=adjustedEqualizations` | `subscriptions pricing price-points view` |
+| [x] | `GET /v1/subscriptionPromotionalOffers/{id}` | `fields[subscriptions]=versions` | `subscriptions offers promotional view` |
+| [x] | `GET /v1/subscriptionGroups/{id}/subscriptionGroupLocalizations` | `fields[subscriptionGroups]=versions` | `subscriptions groups localizations list` |
+| [x] | `GET /v1/subscriptionOfferCodes/{id}/prices` | `fields[subscriptionPricePoints]=adjustedEqualizations` | `subscriptions offers offer-codes prices` |
+| [x] | `GET /v1/subscriptionPromotionalOffers/{id}/prices` | `fields[subscriptionPricePoints]=adjustedEqualizations` | `subscriptions offers promotional prices` |
+| [x] | `GET /v1/subscriptions/{id}/appStoreReviewScreenshot` | `fields[subscriptions]=versions` | `subscriptions review app-store-screenshot view` |
+| [x] | `GET /v1/subscriptions/{id}/images` | `fields[subscriptions]=versions` | `subscriptions images list` |
+| [x] | `GET /v1/subscriptions/{id}/introductoryOffers` | `fields[subscriptions]=versions`; `fields[subscriptionPricePoints]=adjustedEqualizations` | `subscriptions offers introductory list` |
+| [x] | `GET /v1/subscriptions/{id}/offerCodes` | `fields[subscriptions]=versions` | `subscriptions offers offer-codes list` |
+| [ ] | `GET /v1/subscriptions/{id}/promotedPurchase` | `fields[subscriptions]=versions`; `fields[inAppPurchases]=versions` | `subscriptions promoted-purchases view --subscription-id` |
+| [x] | `GET /v1/subscriptions/{id}/promotionalOffers` | `fields[subscriptions]=versions` | `subscriptions offers promotional list` |
+| [x] | `GET /v1/subscriptions/{id}/subscriptionLocalizations` | `fields[subscriptions]=versions` | `subscriptions localizations list` |
+
+The CLI validates every sparse-field value against the exact enum for its
+resource type before client creation. Related sparse fields automatically add
+their required include relationship: `subscription`, `subscriptionGroup`,
+`subscriptionPricePoint`, or `inAppPurchaseV2`. On paginated commands, an
+explicit sparse-field flag conflicts with `--next`; the opaque URL remains the
+only query source.
+
+`subscriptions promoted-purchases view` accepts exactly one of its existing
+`--promoted-purchase-id` selector or the new `--subscription-id` selector. The
+existing direct-resource invocation remains unchanged; relationship sparse
+fields are valid only with `--subscription-id`.
+
+## Output, compatibility, and failure behavior
+
+Output remains the existing TTY-aware JSON/table/Markdown behavior. Successful
+reads exit zero. Invalid sparse fields, explicit empty values, missing IDs, and
+`--next` conflicts are usage errors (exit code 2) written to stderr before auth
+or HTTP. Existing invocations and response models are unchanged. Deprecated v1
+localization and image commands remain available with their existing warnings.
+
+## Verification plan
+
+1. Establish RED with client HTTP tests for all 17 paths and CLI tests for each
+   new flag family, auto-includes, invalid enums, explicit empties, and
+   `--next` conflicts.
+2. Implement endpoint-specific option types and query builders; do not use a
+   universal query map.
+3. Run focused `internal/asc`, `internal/cli/subscriptions`, and `cmdtest`
+   packages, then build a binary and inspect the changed help and exit behavior.
+4. Regenerate `docs/COMMANDS.md`; run format, docs, lint, and the full test gate.
+5. Perform only a safe read-only App Store Connect smoke if credentials and a
+   suitable existing resource are available. No live mutation is required.
+
+## Alternatives considered
+
+- A raw `map[string]string` query escape hatch would be smaller, but it would
+  accept unsupported parameters and silently drift from endpoint-specific
+  OpenAPI truth.
+- Reusing one universal functional-option type across all 17 operations would
+  allow invalid cross-endpoint combinations at compile time. Endpoint-specific
+  option types preserve the API contract while sharing only private builders.

--- a/docs/design/app-store-connect-api-4.4.1-subscription-sparse-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-subscription-sparse-fields.md
@@ -8,7 +8,7 @@ previously client-only relationship read is exposed through the established
 scoped view command:
 
 ```text
-asc subscriptions promoted-purchases view --subscription-id "SUBSCRIPTION_ID"
+asc subscriptions promoted-purchases view --app "APP_ID" --subscription-id "SUBSCRIPTION_SELECTOR"
 ```
 
 Related-resource sparse fields use the existing CLI naming convention:
@@ -16,7 +16,7 @@ Related-resource sparse fields use the existing CLI naming convention:
 - `--subscription-fields` maps to `fields[subscriptions]`.
 - `--group-fields` maps to `fields[subscriptionGroups]`.
 - `--price-point-fields` maps to `fields[subscriptionPricePoints]`.
-- `--in-app-purchase-fields` maps to `fields[inAppPurchases]`.
+- `--iap-fields` maps to `fields[inAppPurchases]`.
 - `--fields` remains the primary-resource sparse-field flag on
   `subscriptions pricing price-points view`.
 
@@ -45,7 +45,7 @@ All operations return their existing JSON:API response types.
 | [x] | `GET /v1/subscriptions/{id}/images` | `fields[subscriptions]=versions` | `subscriptions images list` |
 | [x] | `GET /v1/subscriptions/{id}/introductoryOffers` | `fields[subscriptions]=versions`; `fields[subscriptionPricePoints]=adjustedEqualizations` | `subscriptions offers introductory list` |
 | [x] | `GET /v1/subscriptions/{id}/offerCodes` | `fields[subscriptions]=versions` | `subscriptions offers offer-codes list` |
-| [ ] | `GET /v1/subscriptions/{id}/promotedPurchase` | `fields[subscriptions]=versions`; `fields[inAppPurchases]=versions` | `subscriptions promoted-purchases view --subscription-id` |
+| [x] | `GET /v1/subscriptions/{id}/promotedPurchase` | `fields[subscriptions]=versions`; `fields[inAppPurchases]=versions` | `subscriptions promoted-purchases view --subscription-id` |
 | [x] | `GET /v1/subscriptions/{id}/promotionalOffers` | `fields[subscriptions]=versions` | `subscriptions offers promotional list` |
 | [x] | `GET /v1/subscriptions/{id}/subscriptionLocalizations` | `fields[subscriptions]=versions` | `subscriptions localizations list` |
 
@@ -58,8 +58,11 @@ only query source.
 
 `subscriptions promoted-purchases view` accepts exactly one of its existing
 `--promoted-purchase-id` selector or the new `--subscription-id` selector. The
-existing direct-resource invocation remains unchanged; relationship sparse
-fields are valid only with `--subscription-id`.
+new selector accepts an ASC subscription ID, product ID, or exact current name;
+product IDs and names require `--app` or `ASC_APP_ID`. The existing
+direct-resource invocation remains unchanged. Both selector forms accept the
+exact promoted-purchase sparse fields because both underlying endpoints expose
+the same `fields[inAppPurchases]`, `fields[subscriptions]`, and include contract.
 
 ## Output, compatibility, and failure behavior
 
@@ -87,6 +90,8 @@ localization and image commands remain available with their existing warnings.
 - A raw `map[string]string` query escape hatch would be smaller, but it would
   accept unsupported parameters and silently drift from endpoint-specific
   OpenAPI truth.
-- Reusing one universal functional-option type across all 17 operations would
-  allow invalid cross-endpoint combinations at compile time. Endpoint-specific
-  option types preserve the API contract while sharing only private builders.
+- Reusing one universal functional-option type across unrelated operations
+  would allow invalid cross-endpoint combinations at compile time. The
+  implementation keeps endpoint-specific option types and shares only the
+  promoted-purchase option type among the three endpoints whose query contract
+  is identical.

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -22,6 +22,9 @@ func (c *Client) GetSubscriptionLocalizations(ctx context.Context, subscriptionI
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionLocalizations: %w", err)
 		}
+		if subscriptionLocalizationsQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionLocalizations: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionLocalizationsQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -43,8 +46,15 @@ func (c *Client) GetSubscriptionLocalizations(ctx context.Context, subscriptionI
 // GetSubscriptionLocalization retrieves a subscription localization by ID.
 //
 // Deprecated: Use GetSubscriptionLocalizationV2.
-func (c *Client) GetSubscriptionLocalization(ctx context.Context, localizationID string) (*SubscriptionLocalizationResponse, error) {
+func (c *Client) GetSubscriptionLocalization(ctx context.Context, localizationID string, opts ...SubscriptionLocalizationOption) (*SubscriptionLocalizationResponse, error) {
+	query := &subscriptionRelatedFieldsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionLocalizations/%s", strings.TrimSpace(localizationID))
+	if queryString := buildSubscriptionRelatedFieldsQuery("subscriptions", query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -151,6 +161,9 @@ func (c *Client) GetSubscriptionImages(ctx context.Context, subscriptionID strin
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionImages: %w", err)
 		}
+		if subscriptionImagesQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionImages: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionImagesQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -171,8 +184,15 @@ func (c *Client) GetSubscriptionImages(ctx context.Context, subscriptionID strin
 // GetSubscriptionImage retrieves a subscription image by ID.
 //
 // Deprecated: Use GetSubscriptionImageV2.
-func (c *Client) GetSubscriptionImage(ctx context.Context, imageID string) (*SubscriptionImageResponse, error) {
+func (c *Client) GetSubscriptionImage(ctx context.Context, imageID string, opts ...SubscriptionImageOption) (*SubscriptionImageResponse, error) {
+	query := &subscriptionRelatedFieldsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionImages/%s", strings.TrimSpace(imageID))
+	if queryString := buildSubscriptionRelatedFieldsQuery("subscriptions", query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -283,6 +303,9 @@ func (c *Client) GetSubscriptionIntroductoryOffers(ctx context.Context, subscrip
 	if query.nextURL != "" {
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionIntroductoryOffers: %w", err)
+		}
+		if subscriptionIntroductoryOffersQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionIntroductoryOffers: next URL cannot be combined with query options")
 		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionIntroductoryOffersQuery(query); queryString != "" {
@@ -420,6 +443,9 @@ func (c *Client) GetSubscriptionPromotionalOffers(ctx context.Context, subscript
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionPromotionalOffers: %w", err)
 		}
+		if subscriptionPromotionalOffersQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionPromotionalOffers: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionPromotionalOffersQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -438,8 +464,15 @@ func (c *Client) GetSubscriptionPromotionalOffers(ctx context.Context, subscript
 }
 
 // GetSubscriptionPromotionalOffer retrieves a promotional offer by ID.
-func (c *Client) GetSubscriptionPromotionalOffer(ctx context.Context, offerID string) (*SubscriptionPromotionalOfferResponse, error) {
+func (c *Client) GetSubscriptionPromotionalOffer(ctx context.Context, offerID string, opts ...SubscriptionPromotionalOfferOption) (*SubscriptionPromotionalOfferResponse, error) {
+	query := &subscriptionRelatedFieldsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionPromotionalOffers/%s", strings.TrimSpace(offerID))
+	if queryString := buildSubscriptionRelatedFieldsQuery("subscriptions", query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -566,6 +599,9 @@ func (c *Client) GetSubscriptionPromotionalOfferPrices(ctx context.Context, offe
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionPromotionalOfferPrices: %w", err)
 		}
+		if subscriptionPromotionalOfferPricesQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionPromotionalOfferPrices: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionPromotionalOfferPricesQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -630,6 +666,9 @@ func (c *Client) GetSubscriptionOfferCodes(ctx context.Context, subscriptionID s
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionOfferCodes: %w", err)
 		}
+		if subscriptionOfferCodesQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionOfferCodes: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionOfferCodesQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -648,8 +687,15 @@ func (c *Client) GetSubscriptionOfferCodes(ctx context.Context, subscriptionID s
 }
 
 // GetSubscriptionOfferCode retrieves an offer code by ID.
-func (c *Client) GetSubscriptionOfferCode(ctx context.Context, offerCodeID string) (*SubscriptionOfferCodeResponse, error) {
+func (c *Client) GetSubscriptionOfferCode(ctx context.Context, offerCodeID string, opts ...SubscriptionOfferCodeOption) (*SubscriptionOfferCodeResponse, error) {
+	query := &subscriptionRelatedFieldsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionOfferCodes/%s", strings.TrimSpace(offerCodeID))
+	if queryString := buildSubscriptionRelatedFieldsQuery("subscriptions", query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -855,6 +901,9 @@ func (c *Client) GetSubscriptionOfferCodePrices(ctx context.Context, offerCodeID
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionOfferCodePrices: %w", err)
 		}
+		if subscriptionOfferCodePricesQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionOfferCodePrices: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionOfferCodePricesQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -974,12 +1023,19 @@ func (c *Client) GetSubscriptionPricePoints(ctx context.Context, subscriptionID 
 }
 
 // GetSubscriptionPricePoint retrieves a subscription price point by ID.
-func (c *Client) GetSubscriptionPricePoint(ctx context.Context, pricePointID string) (*SubscriptionPricePointResponse, error) {
+func (c *Client) GetSubscriptionPricePoint(ctx context.Context, pricePointID string, opts ...SubscriptionPricePointOption) (*SubscriptionPricePointResponse, error) {
 	pricePointID = strings.TrimSpace(pricePointID)
 	if pricePointID == "" {
 		return nil, fmt.Errorf("pricePointID is required")
 	}
+	query := &subscriptionPricePointDetailQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionPricePoints/%s", pricePointID)
+	if queryString := buildSubscriptionPricePointDetailQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -1182,8 +1238,15 @@ func (c *Client) CreateSubscriptionGroupSubmission(ctx context.Context, groupID 
 }
 
 // GetSubscriptionAppStoreReviewScreenshot retrieves a review screenshot by ID.
-func (c *Client) GetSubscriptionAppStoreReviewScreenshot(ctx context.Context, screenshotID string) (*SubscriptionAppStoreReviewScreenshotResponse, error) {
+func (c *Client) GetSubscriptionAppStoreReviewScreenshot(ctx context.Context, screenshotID string, opts ...SubscriptionAppStoreReviewScreenshotOption) (*SubscriptionAppStoreReviewScreenshotResponse, error) {
+	query := &subscriptionAppStoreReviewScreenshotQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionAppStoreReviewScreenshots/%s", strings.TrimSpace(screenshotID))
+	if queryString := buildSubscriptionAppStoreReviewScreenshotQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -1291,6 +1354,9 @@ func (c *Client) GetSubscriptionGroupLocalizations(ctx context.Context, groupID 
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("subscriptionGroupLocalizations: %w", err)
 		}
+		if subscriptionGroupLocalizationsQueryHasModifiers(query) {
+			return nil, fmt.Errorf("subscriptionGroupLocalizations: next URL cannot be combined with query options")
+		}
 		path = query.nextURL
 	} else if queryString := buildSubscriptionGroupLocalizationsQuery(query); queryString != "" {
 		path += "?" + queryString
@@ -1311,8 +1377,15 @@ func (c *Client) GetSubscriptionGroupLocalizations(ctx context.Context, groupID 
 // GetSubscriptionGroupLocalization retrieves a subscription group localization by ID.
 //
 // Deprecated: Use GetSubscriptionGroupLocalizationV2.
-func (c *Client) GetSubscriptionGroupLocalization(ctx context.Context, localizationID string) (*SubscriptionGroupLocalizationResponse, error) {
+func (c *Client) GetSubscriptionGroupLocalization(ctx context.Context, localizationID string, opts ...SubscriptionGroupLocalizationOption) (*SubscriptionGroupLocalizationResponse, error) {
+	query := &subscriptionRelatedFieldsQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptionGroupLocalizations/%s", strings.TrimSpace(localizationID))
+	if queryString := buildSubscriptionRelatedFieldsQuery("subscriptionGroups", query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_subscriptions.go
+++ b/internal/asc/client_subscriptions.go
@@ -621,13 +621,20 @@ func (c *Client) GetSubscriptionAppStoreReviewScreenshotForSubscription(ctx cont
 }
 
 // GetSubscriptionPromotedPurchase retrieves the promoted purchase for a subscription.
-func (c *Client) GetSubscriptionPromotedPurchase(ctx context.Context, subID string) (*PromotedPurchaseResponse, error) {
+func (c *Client) GetSubscriptionPromotedPurchase(ctx context.Context, subID string, opts ...PromotedPurchaseGetOption) (*PromotedPurchaseResponse, error) {
 	subID = strings.TrimSpace(subID)
 	if subID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
 	}
 
+	query := &promotedPurchaseGetQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
 	path := fmt.Sprintf("/v1/subscriptions/%s/promotedPurchase", subID)
+	if queryString := buildPromotedPurchaseGetQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/subscription_resources_queries.go
+++ b/internal/asc/subscription_resources_queries.go
@@ -69,31 +69,70 @@ type SubscriptionGroupLocalizationsOption func(*subscriptionGroupLocalizationsQu
 // SubscriptionAppStoreReviewScreenshotOption configures the subscription screenshot relationship endpoint.
 type SubscriptionAppStoreReviewScreenshotOption func(*subscriptionAppStoreReviewScreenshotQuery)
 
+// SubscriptionGroupLocalizationOption configures a v1 subscription group localization detail read.
+type SubscriptionGroupLocalizationOption func(*subscriptionRelatedFieldsQuery)
+
+// SubscriptionImageOption configures a v1 subscription image detail read.
+type SubscriptionImageOption func(*subscriptionRelatedFieldsQuery)
+
+// SubscriptionLocalizationOption configures a v1 subscription localization detail read.
+type SubscriptionLocalizationOption func(*subscriptionRelatedFieldsQuery)
+
+// SubscriptionOfferCodeOption configures a subscription offer code detail read.
+type SubscriptionOfferCodeOption func(*subscriptionRelatedFieldsQuery)
+
+// SubscriptionPromotionalOfferOption configures a subscription promotional offer detail read.
+type SubscriptionPromotionalOfferOption func(*subscriptionRelatedFieldsQuery)
+
+// SubscriptionPricePointOption configures a subscription price point detail read.
+type SubscriptionPricePointOption func(*subscriptionPricePointDetailQuery)
+
+type subscriptionRelatedFieldsQuery struct {
+	parentFields []string
+	include      []string
+}
+
+type subscriptionPricePointDetailQuery struct {
+	fields []string
+}
+
 type subscriptionLocalizationsQuery struct {
 	listQuery
-	fields []string
+	fields             []string
+	subscriptionFields []string
+	include            []string
 }
 
 type subscriptionImagesQuery struct {
 	listQuery
+	subscriptionFields []string
+	include            []string
 }
 
 type subscriptionIntroductoryOffersQuery struct {
 	listQuery
-	fields  []string
-	include []string
+	fields             []string
+	subscriptionFields []string
+	pricePointFields   []string
+	include            []string
 }
 
 type subscriptionPromotionalOffersQuery struct {
 	listQuery
+	subscriptionFields []string
+	include            []string
 }
 
 type subscriptionPromotionalOfferPricesQuery struct {
 	listQuery
+	pricePointFields []string
+	include          []string
 }
 
 type subscriptionOfferCodesQuery struct {
 	listQuery
+	subscriptionFields []string
+	include            []string
 }
 
 type subscriptionOfferCodeCustomCodesQuery struct {
@@ -102,6 +141,8 @@ type subscriptionOfferCodeCustomCodesQuery struct {
 
 type subscriptionOfferCodePricesQuery struct {
 	listQuery
+	pricePointFields []string
+	include          []string
 }
 
 type subscriptionPricePointsQuery struct {
@@ -127,11 +168,15 @@ type subscriptionPricesQuery struct {
 
 type subscriptionGroupLocalizationsQuery struct {
 	listQuery
-	fields []string
+	fields      []string
+	groupFields []string
+	include     []string
 }
 
 type subscriptionAppStoreReviewScreenshotQuery struct {
-	fields []string
+	fields             []string
+	subscriptionFields []string
+	include            []string
 }
 
 // WithSubscriptionLocalizationsLimit sets the max number of localizations to return.
@@ -159,6 +204,20 @@ func WithSubscriptionLocalizationsFields(fields []string) SubscriptionLocalizati
 	}
 }
 
+// WithSubscriptionLocalizationsSubscriptionFields sets fields[subscriptions] for included subscriptions.
+func WithSubscriptionLocalizationsSubscriptionFields(fields []string) SubscriptionLocalizationsOption {
+	return func(q *subscriptionLocalizationsQuery) {
+		q.subscriptionFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionLocalizationsInclude sets relationships to include.
+func WithSubscriptionLocalizationsInclude(include []string) SubscriptionLocalizationsOption {
+	return func(q *subscriptionLocalizationsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
 // WithSubscriptionImagesLimit sets the max number of images to return.
 func WithSubscriptionImagesLimit(limit int) SubscriptionImagesOption {
 	return func(q *subscriptionImagesQuery) {
@@ -174,6 +233,20 @@ func WithSubscriptionImagesNextURL(next string) SubscriptionImagesOption {
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithSubscriptionImagesSubscriptionFields sets fields[subscriptions] for included subscriptions.
+func WithSubscriptionImagesSubscriptionFields(fields []string) SubscriptionImagesOption {
+	return func(q *subscriptionImagesQuery) {
+		q.subscriptionFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionImagesInclude sets relationships to include.
+func WithSubscriptionImagesInclude(include []string) SubscriptionImagesOption {
+	return func(q *subscriptionImagesQuery) {
+		q.include = normalizeList(include)
 	}
 }
 
@@ -209,6 +282,20 @@ func WithSubscriptionIntroductoryOffersInclude(include []string) SubscriptionInt
 	}
 }
 
+// WithSubscriptionIntroductoryOffersSubscriptionFields sets fields[subscriptions] for included subscriptions.
+func WithSubscriptionIntroductoryOffersSubscriptionFields(fields []string) SubscriptionIntroductoryOffersOption {
+	return func(q *subscriptionIntroductoryOffersQuery) {
+		q.subscriptionFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionIntroductoryOffersPricePointFields sets fields[subscriptionPricePoints] for included price points.
+func WithSubscriptionIntroductoryOffersPricePointFields(fields []string) SubscriptionIntroductoryOffersOption {
+	return func(q *subscriptionIntroductoryOffersQuery) {
+		q.pricePointFields = normalizeList(fields)
+	}
+}
+
 // WithSubscriptionPromotionalOffersLimit sets the max number of offers to return.
 func WithSubscriptionPromotionalOffersLimit(limit int) SubscriptionPromotionalOffersOption {
 	return func(q *subscriptionPromotionalOffersQuery) {
@@ -224,6 +311,20 @@ func WithSubscriptionPromotionalOffersNextURL(next string) SubscriptionPromotion
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithSubscriptionPromotionalOffersSubscriptionFields sets fields[subscriptions] for included subscriptions.
+func WithSubscriptionPromotionalOffersSubscriptionFields(fields []string) SubscriptionPromotionalOffersOption {
+	return func(q *subscriptionPromotionalOffersQuery) {
+		q.subscriptionFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionPromotionalOffersInclude sets relationships to include.
+func WithSubscriptionPromotionalOffersInclude(include []string) SubscriptionPromotionalOffersOption {
+	return func(q *subscriptionPromotionalOffersQuery) {
+		q.include = normalizeList(include)
 	}
 }
 
@@ -245,6 +346,20 @@ func WithSubscriptionPromotionalOfferPricesNextURL(next string) SubscriptionProm
 	}
 }
 
+// WithSubscriptionPromotionalOfferPricesPricePointFields sets fields[subscriptionPricePoints] for included price points.
+func WithSubscriptionPromotionalOfferPricesPricePointFields(fields []string) SubscriptionPromotionalOfferPricesOption {
+	return func(q *subscriptionPromotionalOfferPricesQuery) {
+		q.pricePointFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionPromotionalOfferPricesInclude sets relationships to include.
+func WithSubscriptionPromotionalOfferPricesInclude(include []string) SubscriptionPromotionalOfferPricesOption {
+	return func(q *subscriptionPromotionalOfferPricesQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
 // WithSubscriptionOfferCodesLimit sets the max number of offer codes to return.
 func WithSubscriptionOfferCodesLimit(limit int) SubscriptionOfferCodesOption {
 	return func(q *subscriptionOfferCodesQuery) {
@@ -260,6 +375,20 @@ func WithSubscriptionOfferCodesNextURL(next string) SubscriptionOfferCodesOption
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithSubscriptionOfferCodesSubscriptionFields sets fields[subscriptions] for included subscriptions.
+func WithSubscriptionOfferCodesSubscriptionFields(fields []string) SubscriptionOfferCodesOption {
+	return func(q *subscriptionOfferCodesQuery) {
+		q.subscriptionFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionOfferCodesInclude sets relationships to include.
+func WithSubscriptionOfferCodesInclude(include []string) SubscriptionOfferCodesOption {
+	return func(q *subscriptionOfferCodesQuery) {
+		q.include = normalizeList(include)
 	}
 }
 
@@ -296,6 +425,20 @@ func WithSubscriptionOfferCodePricesNextURL(next string) SubscriptionOfferCodePr
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
 		}
+	}
+}
+
+// WithSubscriptionOfferCodePricesPricePointFields sets fields[subscriptionPricePoints] for included price points.
+func WithSubscriptionOfferCodePricesPricePointFields(fields []string) SubscriptionOfferCodePricesOption {
+	return func(q *subscriptionOfferCodePricesQuery) {
+		q.pricePointFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionOfferCodePricesInclude sets relationships to include.
+func WithSubscriptionOfferCodePricesInclude(include []string) SubscriptionOfferCodePricesOption {
+	return func(q *subscriptionOfferCodePricesQuery) {
+		q.include = normalizeList(include)
 	}
 }
 
@@ -464,6 +607,20 @@ func WithSubscriptionGroupLocalizationsFields(fields []string) SubscriptionGroup
 	}
 }
 
+// WithSubscriptionGroupLocalizationsGroupFields sets fields[subscriptionGroups] for included groups.
+func WithSubscriptionGroupLocalizationsGroupFields(fields []string) SubscriptionGroupLocalizationsOption {
+	return func(q *subscriptionGroupLocalizationsQuery) {
+		q.groupFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionGroupLocalizationsInclude sets relationships to include.
+func WithSubscriptionGroupLocalizationsInclude(include []string) SubscriptionGroupLocalizationsOption {
+	return func(q *subscriptionGroupLocalizationsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
 // WithSubscriptionAppStoreReviewScreenshotFields limits returned screenshot fields.
 func WithSubscriptionAppStoreReviewScreenshotFields(fields []string) SubscriptionAppStoreReviewScreenshotOption {
 	return func(q *subscriptionAppStoreReviewScreenshotQuery) {
@@ -471,15 +628,112 @@ func WithSubscriptionAppStoreReviewScreenshotFields(fields []string) Subscriptio
 	}
 }
 
+// WithSubscriptionAppStoreReviewScreenshotSubscriptionFields sets fields[subscriptions] for included subscriptions.
+// It is accepted by both screenshot detail and subscription relationship reads.
+func WithSubscriptionAppStoreReviewScreenshotSubscriptionFields(fields []string) SubscriptionAppStoreReviewScreenshotOption {
+	return func(q *subscriptionAppStoreReviewScreenshotQuery) {
+		q.subscriptionFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionAppStoreReviewScreenshotInclude sets relationships to include.
+// It is accepted by both screenshot detail and subscription relationship reads.
+func WithSubscriptionAppStoreReviewScreenshotInclude(include []string) SubscriptionAppStoreReviewScreenshotOption {
+	return func(q *subscriptionAppStoreReviewScreenshotQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithSubscriptionGroupLocalizationGroupFields sets fields[subscriptionGroups] on a group localization detail read.
+func WithSubscriptionGroupLocalizationGroupFields(fields []string) SubscriptionGroupLocalizationOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.parentFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionGroupLocalizationInclude sets relationships to include on a group localization detail read.
+func WithSubscriptionGroupLocalizationInclude(include []string) SubscriptionGroupLocalizationOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithSubscriptionImageSubscriptionFields sets fields[subscriptions] on a subscription image detail read.
+func WithSubscriptionImageSubscriptionFields(fields []string) SubscriptionImageOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.parentFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionImageInclude sets relationships to include on a subscription image detail read.
+func WithSubscriptionImageInclude(include []string) SubscriptionImageOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithSubscriptionLocalizationSubscriptionFields sets fields[subscriptions] on a subscription localization detail read.
+func WithSubscriptionLocalizationSubscriptionFields(fields []string) SubscriptionLocalizationOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.parentFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionLocalizationInclude sets relationships to include on a subscription localization detail read.
+func WithSubscriptionLocalizationInclude(include []string) SubscriptionLocalizationOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithSubscriptionOfferCodeSubscriptionFields sets fields[subscriptions] on an offer code detail read.
+func WithSubscriptionOfferCodeSubscriptionFields(fields []string) SubscriptionOfferCodeOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.parentFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionOfferCodeInclude sets relationships to include on an offer code detail read.
+func WithSubscriptionOfferCodeInclude(include []string) SubscriptionOfferCodeOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithSubscriptionPromotionalOfferSubscriptionFields sets fields[subscriptions] on a promotional offer detail read.
+func WithSubscriptionPromotionalOfferSubscriptionFields(fields []string) SubscriptionPromotionalOfferOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.parentFields = normalizeList(fields)
+	}
+}
+
+// WithSubscriptionPromotionalOfferInclude sets relationships to include on a promotional offer detail read.
+func WithSubscriptionPromotionalOfferInclude(include []string) SubscriptionPromotionalOfferOption {
+	return func(q *subscriptionRelatedFieldsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithSubscriptionPricePointFields sets fields[subscriptionPricePoints] on a price point detail read.
+func WithSubscriptionPricePointFields(fields []string) SubscriptionPricePointOption {
+	return func(q *subscriptionPricePointDetailQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
 func buildSubscriptionLocalizationsQuery(query *subscriptionLocalizationsQuery) string {
 	values := url.Values{}
 	addCSV(values, "fields[subscriptionLocalizations]", query.fields)
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
 
 func buildSubscriptionImagesQuery(query *subscriptionImagesQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -487,6 +741,8 @@ func buildSubscriptionImagesQuery(query *subscriptionImagesQuery) string {
 func buildSubscriptionIntroductoryOffersQuery(query *subscriptionIntroductoryOffersQuery) string {
 	values := url.Values{}
 	addCSV(values, "fields[subscriptionIntroductoryOffers]", query.fields)
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	addCSV(values, "fields[subscriptionPricePoints]", query.pricePointFields)
 	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
@@ -494,18 +750,24 @@ func buildSubscriptionIntroductoryOffersQuery(query *subscriptionIntroductoryOff
 
 func buildSubscriptionPromotionalOffersQuery(query *subscriptionPromotionalOffersQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
 
 func buildSubscriptionPromotionalOfferPricesQuery(query *subscriptionPromotionalOfferPricesQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptionPricePoints]", query.pricePointFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
 
 func buildSubscriptionOfferCodesQuery(query *subscriptionOfferCodesQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -518,6 +780,8 @@ func buildSubscriptionOfferCodeCustomCodesQuery(query *subscriptionOfferCodeCust
 
 func buildSubscriptionOfferCodePricesQuery(query *subscriptionOfferCodePricesQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[subscriptionPricePoints]", query.pricePointFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -560,6 +824,8 @@ func buildSubscriptionPricesQuery(query *subscriptionPricesQuery) string {
 func buildSubscriptionGroupLocalizationsQuery(query *subscriptionGroupLocalizationsQuery) string {
 	values := url.Values{}
 	addCSV(values, "fields[subscriptionGroupLocalizations]", query.fields)
+	addCSV(values, "fields[subscriptionGroups]", query.groupFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -567,5 +833,53 @@ func buildSubscriptionGroupLocalizationsQuery(query *subscriptionGroupLocalizati
 func buildSubscriptionAppStoreReviewScreenshotQuery(query *subscriptionAppStoreReviewScreenshotQuery) string {
 	values := url.Values{}
 	addCSV(values, "fields[subscriptionAppStoreReviewScreenshots]", query.fields)
+	addCSV(values, "fields[subscriptions]", query.subscriptionFields)
+	addCSV(values, "include", query.include)
 	return values.Encode()
+}
+
+func buildSubscriptionRelatedFieldsQuery(parentResource string, query *subscriptionRelatedFieldsQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields["+parentResource+"]", query.parentFields)
+	addCSV(values, "include", query.include)
+	return values.Encode()
+}
+
+func buildSubscriptionPricePointDetailQuery(query *subscriptionPricePointDetailQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[subscriptionPricePoints]", query.fields)
+	return values.Encode()
+}
+
+func subscriptionLocalizationsQueryHasModifiers(query *subscriptionLocalizationsQuery) bool {
+	return query.limit != 0 || len(query.fields) != 0 || len(query.subscriptionFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionImagesQueryHasModifiers(query *subscriptionImagesQuery) bool {
+	return query.limit != 0 || len(query.subscriptionFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionIntroductoryOffersQueryHasModifiers(query *subscriptionIntroductoryOffersQuery) bool {
+	return query.limit != 0 || len(query.fields) != 0 || len(query.subscriptionFields) != 0 ||
+		len(query.pricePointFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionPromotionalOffersQueryHasModifiers(query *subscriptionPromotionalOffersQuery) bool {
+	return query.limit != 0 || len(query.subscriptionFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionPromotionalOfferPricesQueryHasModifiers(query *subscriptionPromotionalOfferPricesQuery) bool {
+	return query.limit != 0 || len(query.pricePointFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionOfferCodesQueryHasModifiers(query *subscriptionOfferCodesQuery) bool {
+	return query.limit != 0 || len(query.subscriptionFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionOfferCodePricesQueryHasModifiers(query *subscriptionOfferCodePricesQuery) bool {
+	return query.limit != 0 || len(query.pricePointFields) != 0 || len(query.include) != 0
+}
+
+func subscriptionGroupLocalizationsQueryHasModifiers(query *subscriptionGroupLocalizationsQuery) bool {
+	return query.limit != 0 || len(query.fields) != 0 || len(query.groupFields) != 0 || len(query.include) != 0
 }

--- a/internal/asc/subscription_sparse_fields_4_4_1_test.go
+++ b/internal/asc/subscription_sparse_fields_4_4_1_test.go
@@ -331,6 +331,23 @@ func TestSubscriptionSparseFields441ExactQueries(t *testing.T) {
 			},
 		},
 		{
+			name: "subscription promoted purchase dual sparse fields",
+			path: "/v1/subscriptions/sub-1/promotedPurchase",
+			wantQuery: url.Values{
+				"fields[inAppPurchases]": {"versions"},
+				"fields[subscriptions]":  {"versions"},
+				"include":                {"inAppPurchaseV2,subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPromotedPurchase(
+					context.Background(), "sub-1",
+					WithPromotedPurchaseIAPFields([]string{"versions"}),
+					WithPromotedPurchaseSubscriptionFields([]string{"versions"}),
+				)
+				return err
+			},
+		},
+		{
 			name: "subscription promotional offers subscription versions",
 			path: "/v1/subscriptions/sub-1/promotionalOffers",
 			wantQuery: url.Values{

--- a/internal/asc/subscription_sparse_fields_4_4_1_test.go
+++ b/internal/asc/subscription_sparse_fields_4_4_1_test.go
@@ -1,0 +1,468 @@
+package asc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionSparseFields441OpenAPILedger(t *testing.T) {
+	t.Parallel()
+
+	type addition struct {
+		parameter string
+		value     string
+	}
+	want := map[string][]addition{
+		"/v1/subscriptionAppStoreReviewScreenshots/{id}":             {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptionGroupLocalizations/{id}":                    {{"fields[subscriptionGroups]", "versions"}},
+		"/v1/subscriptionImages/{id}":                                {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptionLocalizations/{id}":                         {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptionOfferCodes/{id}":                            {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptionPricePoints/{id}":                           {{"fields[subscriptionPricePoints]", "adjustedEqualizations"}},
+		"/v1/subscriptionPromotionalOffers/{id}":                     {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptionGroups/{id}/subscriptionGroupLocalizations": {{"fields[subscriptionGroups]", "versions"}},
+		"/v1/subscriptionOfferCodes/{id}/prices":                     {{"fields[subscriptionPricePoints]", "adjustedEqualizations"}},
+		"/v1/subscriptionPromotionalOffers/{id}/prices":              {{"fields[subscriptionPricePoints]", "adjustedEqualizations"}},
+		"/v1/subscriptions/{id}/appStoreReviewScreenshot":            {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptions/{id}/images":                              {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptions/{id}/introductoryOffers":                  {{"fields[subscriptions]", "versions"}, {"fields[subscriptionPricePoints]", "adjustedEqualizations"}},
+		"/v1/subscriptions/{id}/offerCodes":                          {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptions/{id}/promotedPurchase":                    {{"fields[subscriptions]", "versions"}, {"fields[inAppPurchases]", "versions"}},
+		"/v1/subscriptions/{id}/promotionalOffers":                   {{"fields[subscriptions]", "versions"}},
+		"/v1/subscriptions/{id}/subscriptionLocalizations":           {{"fields[subscriptions]", "versions"}},
+	}
+	if len(want) != 17 {
+		t.Fatalf("ledger paths = %d, want 17", len(want))
+	}
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	schemaPath := filepath.Join(filepath.Dir(sourceFile), "..", "..", "docs", "openapi", "latest.json")
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read OpenAPI schema: %v", err)
+	}
+	var schema struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("decode OpenAPI schema: %v", err)
+	}
+
+	for path, additions := range want {
+		pathJSON, ok := schema.Paths[path]
+		if !ok {
+			t.Errorf("missing GET %s", path)
+			continue
+		}
+		var pathItem struct {
+			Get struct {
+				Parameters []struct {
+					Name   string `json:"name"`
+					Schema struct {
+						Items struct {
+							Enum []string `json:"enum"`
+						} `json:"items"`
+					} `json:"schema"`
+				} `json:"parameters"`
+			} `json:"get"`
+		}
+		if err := json.Unmarshal(pathJSON, &pathItem); err != nil {
+			t.Errorf("decode GET %s: %v", path, err)
+			continue
+		}
+		for _, addition := range additions {
+			found := false
+			for _, parameter := range pathItem.Get.Parameters {
+				if parameter.Name != addition.parameter {
+					continue
+				}
+				found = slices.Contains(parameter.Schema.Items.Enum, addition.value)
+				break
+			}
+			if !found {
+				t.Errorf("GET %s missing %s=%s", path, addition.parameter, addition.value)
+			}
+		}
+	}
+}
+
+func TestSubscriptionSparseFields441ExactQueries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		path      string
+		wantQuery url.Values
+		call      func(*Client) error
+	}{
+		{
+			name: "review screenshot detail subscription versions",
+			path: "/v1/subscriptionAppStoreReviewScreenshots/shot-1",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionAppStoreReviewScreenshot(
+					context.Background(), "shot-1",
+					WithSubscriptionAppStoreReviewScreenshotSubscriptionFields([]string{"versions"}),
+					WithSubscriptionAppStoreReviewScreenshotInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "group localization detail group versions",
+			path: "/v1/subscriptionGroupLocalizations/group-loc-1",
+			wantQuery: url.Values{
+				"fields[subscriptionGroups]": {"versions"},
+				"include":                    {"subscriptionGroup"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionGroupLocalization(
+					context.Background(), "group-loc-1",
+					WithSubscriptionGroupLocalizationGroupFields([]string{"versions"}),
+					WithSubscriptionGroupLocalizationInclude([]string{"subscriptionGroup"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "image detail subscription versions",
+			path: "/v1/subscriptionImages/image-1",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionImage(
+					context.Background(), "image-1",
+					WithSubscriptionImageSubscriptionFields([]string{"versions"}),
+					WithSubscriptionImageInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "localization detail subscription versions",
+			path: "/v1/subscriptionLocalizations/loc-1",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionLocalization(
+					context.Background(), "loc-1",
+					WithSubscriptionLocalizationSubscriptionFields([]string{"versions"}),
+					WithSubscriptionLocalizationInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "offer code detail subscription versions",
+			path: "/v1/subscriptionOfferCodes/code-1",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionOfferCode(
+					context.Background(), "code-1",
+					WithSubscriptionOfferCodeSubscriptionFields([]string{"versions"}),
+					WithSubscriptionOfferCodeInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "price point detail adjusted equalizations",
+			path: "/v1/subscriptionPricePoints/point-1",
+			wantQuery: url.Values{
+				"fields[subscriptionPricePoints]": {"adjustedEqualizations"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPricePoint(
+					context.Background(), "point-1",
+					WithSubscriptionPricePointFields([]string{"adjustedEqualizations"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "promotional offer detail subscription versions",
+			path: "/v1/subscriptionPromotionalOffers/promo-1",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPromotionalOffer(
+					context.Background(), "promo-1",
+					WithSubscriptionPromotionalOfferSubscriptionFields([]string{"versions"}),
+					WithSubscriptionPromotionalOfferInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "group localizations group versions",
+			path: "/v1/subscriptionGroups/group-1/subscriptionGroupLocalizations",
+			wantQuery: url.Values{
+				"fields[subscriptionGroups]": {"versions"},
+				"include":                    {"subscriptionGroup"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionGroupLocalizations(
+					context.Background(), "group-1",
+					WithSubscriptionGroupLocalizationsGroupFields([]string{"versions"}),
+					WithSubscriptionGroupLocalizationsInclude([]string{"subscriptionGroup"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "offer code prices adjusted equalizations",
+			path: "/v1/subscriptionOfferCodes/code-1/prices",
+			wantQuery: url.Values{
+				"fields[subscriptionPricePoints]": {"adjustedEqualizations"},
+				"include":                         {"subscriptionPricePoint"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionOfferCodePrices(
+					context.Background(), "code-1",
+					WithSubscriptionOfferCodePricesPricePointFields([]string{"adjustedEqualizations"}),
+					WithSubscriptionOfferCodePricesInclude([]string{"subscriptionPricePoint"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "promotional offer prices adjusted equalizations",
+			path: "/v1/subscriptionPromotionalOffers/promo-1/prices",
+			wantQuery: url.Values{
+				"fields[subscriptionPricePoints]": {"adjustedEqualizations"},
+				"include":                         {"subscriptionPricePoint"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPromotionalOfferPrices(
+					context.Background(), "promo-1",
+					WithSubscriptionPromotionalOfferPricesPricePointFields([]string{"adjustedEqualizations"}),
+					WithSubscriptionPromotionalOfferPricesInclude([]string{"subscriptionPricePoint"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "subscription screenshot relationship subscription versions",
+			path: "/v1/subscriptions/sub-1/appStoreReviewScreenshot",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionAppStoreReviewScreenshotForSubscription(
+					context.Background(), "sub-1",
+					WithSubscriptionAppStoreReviewScreenshotSubscriptionFields([]string{"versions"}),
+					WithSubscriptionAppStoreReviewScreenshotInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "subscription images subscription versions",
+			path: "/v1/subscriptions/sub-1/images",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionImages(
+					context.Background(), "sub-1",
+					WithSubscriptionImagesSubscriptionFields([]string{"versions"}),
+					WithSubscriptionImagesInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "introductory offers dual sparse fields",
+			path: "/v1/subscriptions/sub-1/introductoryOffers",
+			wantQuery: url.Values{
+				"fields[subscriptions]":           {"versions"},
+				"fields[subscriptionPricePoints]": {"adjustedEqualizations"},
+				"include":                         {"subscription,subscriptionPricePoint"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionIntroductoryOffers(
+					context.Background(), "sub-1",
+					WithSubscriptionIntroductoryOffersSubscriptionFields([]string{"versions"}),
+					WithSubscriptionIntroductoryOffersPricePointFields([]string{"adjustedEqualizations"}),
+					WithSubscriptionIntroductoryOffersInclude([]string{"subscription", "subscriptionPricePoint"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "subscription offer codes subscription versions",
+			path: "/v1/subscriptions/sub-1/offerCodes",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionOfferCodes(
+					context.Background(), "sub-1",
+					WithSubscriptionOfferCodesSubscriptionFields([]string{"versions"}),
+					WithSubscriptionOfferCodesInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "subscription promotional offers subscription versions",
+			path: "/v1/subscriptions/sub-1/promotionalOffers",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPromotionalOffers(
+					context.Background(), "sub-1",
+					WithSubscriptionPromotionalOffersSubscriptionFields([]string{"versions"}),
+					WithSubscriptionPromotionalOffersInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+		{
+			name: "subscription localizations subscription versions",
+			path: "/v1/subscriptions/sub-1/subscriptionLocalizations",
+			wantQuery: url.Values{
+				"fields[subscriptions]": {"versions"},
+				"include":               {"subscription"},
+			},
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionLocalizations(
+					context.Background(), "sub-1",
+					WithSubscriptionLocalizationsSubscriptionFields([]string{"versions"}),
+					WithSubscriptionLocalizationsInclude([]string{"subscription"}),
+				)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Errorf("method = %s, want GET", req.Method)
+				}
+				if req.URL.Path != test.path {
+					t.Errorf("path = %q, want %q", req.URL.Path, test.path)
+				}
+				if got, want := req.URL.Query().Encode(), test.wantQuery.Encode(); got != want {
+					t.Errorf("query = %q, want %q", got, want)
+				}
+			}, jsonResponse(http.StatusOK, `{"data":null}`))
+			if err := test.call(client); err != nil {
+				t.Fatalf("call error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSubscriptionSparseFields441NextURLConflictsBeforeHTTP(t *testing.T) {
+	t.Parallel()
+
+	const next = "https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/images?cursor=next"
+	tests := []struct {
+		name string
+		call func(*Client) error
+	}{
+		{
+			name: "localizations",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionLocalizations(context.Background(), "sub-1", WithSubscriptionLocalizationsNextURL(next), WithSubscriptionLocalizationsSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name: "images",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionImages(context.Background(), "sub-1", WithSubscriptionImagesNextURL(next), WithSubscriptionImagesSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name: "introductory offers",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionIntroductoryOffers(context.Background(), "sub-1", WithSubscriptionIntroductoryOffersNextURL(next), WithSubscriptionIntroductoryOffersPricePointFields([]string{"adjustedEqualizations"}))
+				return err
+			},
+		},
+		{
+			name: "promotional offers",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPromotionalOffers(context.Background(), "sub-1", WithSubscriptionPromotionalOffersNextURL(next), WithSubscriptionPromotionalOffersSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name: "promotional offer prices",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionPromotionalOfferPrices(context.Background(), "promo-1", WithSubscriptionPromotionalOfferPricesNextURL(next), WithSubscriptionPromotionalOfferPricesPricePointFields([]string{"adjustedEqualizations"}))
+				return err
+			},
+		},
+		{
+			name: "offer codes",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionOfferCodes(context.Background(), "sub-1", WithSubscriptionOfferCodesNextURL(next), WithSubscriptionOfferCodesSubscriptionFields([]string{"versions"}))
+				return err
+			},
+		},
+		{
+			name: "offer code prices",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionOfferCodePrices(context.Background(), "code-1", WithSubscriptionOfferCodePricesNextURL(next), WithSubscriptionOfferCodePricesPricePointFields([]string{"adjustedEqualizations"}))
+				return err
+			},
+		},
+		{
+			name: "group localizations",
+			call: func(c *Client) error {
+				_, err := c.GetSubscriptionGroupLocalizations(context.Background(), "group-1", WithSubscriptionGroupLocalizationsNextURL(next), WithSubscriptionGroupLocalizationsGroupFields([]string{"versions"}))
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			requests := 0
+			client := newTestClient(t, func(*http.Request) { requests++ }, jsonResponse(http.StatusOK, `{"data":null}`))
+			err := test.call(client)
+			if err == nil || !strings.Contains(err.Error(), "next URL cannot be combined with query options") {
+				t.Fatalf("error = %v, want next URL conflict", err)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d, want 0", requests)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -479,10 +479,15 @@ func TestIAPRelatedSparseFieldHelp441(t *testing.T) {
 	}
 
 	subscriptionView := findSubcommand(root, "subscriptions", "promoted-purchases", "view")
-	if usage := subscriptionView.UsageFunc(subscriptionView); strings.Contains(usage, "--app") {
-		t.Fatalf("subscription promoted view unexpectedly changed to expose --app: %q", usage)
+	subscriptionUsage := subscriptionView.UsageFunc(subscriptionView)
+	if !strings.Contains(subscriptionUsage, "--subscription-id SUBSCRIPTION_SELECTOR") ||
+		!strings.Contains(subscriptionUsage, "Subscription ID, product ID, or exact current name") ||
+		!strings.Contains(subscriptionUsage, subscriptionLookupAppUsageForTest) {
+		t.Fatalf("subscription promoted view does not expose the stable selector contract: %q", subscriptionUsage)
 	}
 }
+
+const subscriptionLookupAppUsageForTest = "App Store Connect app ID (or ASC_APP_ID env; required when --subscription-id uses a product ID or name)"
 
 func setIAPRelatedTestServerClient(t *testing.T, server *httptest.Server) {
 	t.Helper()

--- a/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
+++ b/internal/cli/cmdtest/iap_related_sparse_fields_441_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -430,6 +431,60 @@ func TestIAPRelatedSparseFieldValidationPrecedesHTTP441(t *testing.T) {
 			}
 			if !strings.Contains(stderr, tt.want) {
 				t.Fatalf("stderr = %q, want %q", stderr, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopedPromotedPurchaseExplicitEmptyFieldsFailBeforeAuth441(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "iap list iap fields", args: []string{"iap", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", ""}, flag: "--iap-fields"},
+		{name: "iap list subscription fields", args: []string{"iap", "promoted-purchases", "list", "--app", "app-1", "--subscription-fields", ""}, flag: "--subscription-fields"},
+		{name: "subscription list iap fields", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--iap-fields", ""}, flag: "--iap-fields"},
+		{name: "subscription list subscription fields", args: []string{"subscriptions", "promoted-purchases", "list", "--app", "app-1", "--subscription-fields", ""}, flag: "--subscription-fields"},
+		{name: "iap view iap fields", args: []string{"iap", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--iap-fields", ""}, flag: "--iap-fields"},
+		{name: "iap view subscription fields", args: []string{"iap", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--subscription-fields", ""}, flag: "--subscription-fields"},
+		{name: "subscription view iap fields", args: []string{"subscriptions", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--iap-fields", ""}, flag: "--iap-fields"},
+		{name: "subscription view subscription fields", args: []string{"subscriptions", "promoted-purchases", "view", "--promoted-purchase-id", "promo-1", "--subscription-fields", ""}, flag: "--subscription-fields"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{
+				"ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH", "ASC_PRIVATE_KEY",
+				"ASC_PRIVATE_KEY_B64", "ASC_PROFILE", "ASC_STRICT_AUTH",
+			} {
+				t.Setenv(key, "")
+			}
+			t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+			requests := 0
+			originalTransport := http.DefaultTransport
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				return nil, nil
+			})
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(tt.args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+			if strings.TrimSpace(stdout) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d, want 0", requests)
+			}
+			if want := tt.flag + " must not be empty"; !strings.Contains(stderr, want) {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
 			}
 		})
 	}

--- a/internal/cli/cmdtest/stable_selector_resolution_test.go
+++ b/internal/cli/cmdtest/stable_selector_resolution_test.go
@@ -390,6 +390,75 @@ func TestSubscriptionReviewScreenshotGetResolvesStableSelectorWithAppFlag(t *tes
 	}
 }
 
+func TestSubscriptionPromotedPurchaseViewResolvesStableSelectorWithAppFlag(t *testing.T) {
+	setupStableSelectorAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet {
+			t.Fatalf("request method = %s, want GET", req.Method)
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/subscriptionGroups":
+			query := req.URL.Query()
+			if len(query) != 1 || len(query["limit"]) != 1 || query["limit"][0] != "200" {
+				t.Fatalf("subscription-group query = %v, want exactly limit=200", query)
+			}
+			return selectorJSONResponse(`{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}]}`), nil
+		case "/v1/subscriptionGroups/group-1/subscriptions":
+			query := req.URL.Query()
+			if len(query) != 2 || len(query["limit"]) != 1 || query["limit"][0] != "200" {
+				t.Fatalf("subscription query = %v, want exactly product filter and limit=200", query)
+			}
+			if got := query["filter[productId]"]; len(got) != 1 || got[0] != "com.example.monthly" {
+				t.Fatalf("product filter = %v, want exactly [com.example.monthly]", got)
+			}
+			return selectorJSONResponse(`{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}]}`), nil
+		case "/v1/subscriptions/sub-1/promotedPurchase":
+			query := req.URL.Query()
+			want := map[string]string{
+				"fields[inAppPurchases]": "versions",
+				"fields[subscriptions]":  "versions",
+				"include":                "inAppPurchaseV2,subscription",
+			}
+			if len(query) != len(want) {
+				t.Fatalf("query = %v, want exactly %v", query, want)
+			}
+			for key, wantValue := range want {
+				if got := query[key]; len(got) != 1 || got[0] != wantValue {
+					t.Fatalf("query[%q] = %v, want exactly [%q]", key, got, wantValue)
+				}
+			}
+			return selectorJSONResponse(`{"data":{"type":"promotedPurchases","id":"promo-1"}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, runErr := runRootCommand(t, []string{
+		"subscriptions", "promoted-purchases", "view",
+		"--app", "app-1",
+		"--subscription-id", "com.example.monthly",
+		"--iap-fields", "versions",
+		"--subscription-fields", "versions",
+	})
+	if runErr != nil {
+		t.Fatalf("expected nil error, got %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requests != 3 || !strings.Contains(stdout, `"id":"promo-1"`) {
+		t.Fatalf("requests=%d stdout=%q", requests, stdout)
+	}
+}
+
 func TestSubscriptionLocalizationsListFallsBackToNumericIDAfterLookupTimeout(t *testing.T) {
 	setupStableSelectorAuth(t)
 	t.Setenv("ASC_APP_ID", "")

--- a/internal/cli/cmdtest/subscription_sparse_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/subscription_sparse_fields_4_4_1_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
@@ -236,47 +237,81 @@ func TestSubscriptionSparseFields441ValidationBeforeClient(t *testing.T) {
 
 func TestSubscriptionSparseFields441NextConflictsBeforeClient(t *testing.T) {
 	const next = "https://api.appstoreconnect.apple.com/v1/subscriptions/123456789/images?cursor=next"
-	tests := []struct {
-		name string
-		args []string
+	commands := []struct {
+		name      string
+		base      []string
+		modifiers [][]string
 	}{
-		{"group localizations", []string{"subscriptions", "groups", "localizations", "list", "--next", next, "--group-fields", "versions"}},
-		{"offer code prices", []string{"subscriptions", "offers", "offer-codes", "prices", "--next", next, "--price-point-fields", "adjustedEqualizations"}},
-		{"promotional offer prices", []string{"subscriptions", "offers", "promotional", "prices", "--next", next, "--price-point-fields", "adjustedEqualizations"}},
-		{"images", []string{"subscriptions", "images", "list", "--next", next, "--subscription-fields", "versions"}},
-		{"introductory offers subscription", []string{"subscriptions", "offers", "introductory", "list", "--next", next, "--subscription-fields", "versions"}},
-		{"introductory offers price point", []string{"subscriptions", "offers", "introductory", "list", "--next", next, "--price-point-fields", "adjustedEqualizations"}},
-		{"offer codes", []string{"subscriptions", "offers", "offer-codes", "list", "--next", next, "--subscription-fields", "versions"}},
-		{"promotional offers", []string{"subscriptions", "offers", "promotional", "list", "--next", next, "--subscription-fields", "versions"}},
-		{"localizations", []string{"subscriptions", "localizations", "list", "--next", next, "--subscription-fields", "versions"}},
+		{
+			name: "group localizations", base: []string{"subscriptions", "groups", "localizations", "list"},
+			modifiers: [][]string{{"--group-id", "group-1"}, {"--limit", "10"}, {"--group-fields", "versions"}},
+		},
+		{
+			name: "images", base: []string{"subscriptions", "images", "list"},
+			modifiers: subscriptionNextModifierFamilies441(),
+		},
+		{
+			name: "localizations", base: []string{"subscriptions", "localizations", "list"},
+			modifiers: subscriptionNextModifierFamilies441(),
+		},
+		{
+			name: "introductory offers", base: []string{"subscriptions", "offers", "introductory", "list"},
+			modifiers: append(subscriptionNextModifierFamilies441(), []string{"--price-point-fields", "adjustedEqualizations"}),
+		},
+		{
+			name: "offer codes", base: []string{"subscriptions", "offers", "offer-codes", "list"},
+			modifiers: subscriptionNextModifierFamilies441(),
+		},
+		{
+			name: "promotional offers", base: []string{"subscriptions", "offers", "promotional", "list"},
+			modifiers: subscriptionNextModifierFamilies441(),
+		},
+		{
+			name: "offer code prices", base: []string{"subscriptions", "offers", "offer-codes", "prices"},
+			modifiers: [][]string{{"--offer-code-id", "code-1"}, {"--limit", "10"}, {"--price-point-fields", "adjustedEqualizations"}},
+		},
+		{
+			name: "promotional offer prices", base: []string{"subscriptions", "offers", "promotional", "prices"},
+			modifiers: [][]string{{"--id", "promo-1"}, {"--limit", "10"}, {"--price-point-fields", "adjustedEqualizations"}},
+		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			clientFactoryCalled := false
-			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
-				clientFactoryCalled = true
-				return nil, errors.New("client factory must not run")
-			})
-			defer restore()
+	for _, command := range commands {
+		for _, modifier := range command.modifiers {
+			modifier := modifier
+			t.Run(command.name+" "+modifier[0], func(t *testing.T) {
+				clientFactoryCalled := false
+				restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+					clientFactoryCalled = true
+					return nil, errors.New("client factory must not run")
+				})
+				defer restore()
 
-			root := RootCommand("1.2.3")
-			root.FlagSet.SetOutput(io.Discard)
-			_, stderr := captureOutput(t, func() {
-				if err := root.Parse(test.args); err != nil {
-					t.Fatalf("parse error: %v", err)
+				args := append(append(append([]string{}, command.base...), "--next", next), modifier...)
+				stdout, stderr := captureOutput(t, func() {
+					if code := cmd.Run(args, "1.2.3"); code != cmd.ExitUsage {
+						t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+					}
+				})
+				if strings.TrimSpace(stdout) != "" {
+					t.Fatalf("stdout = %q, want empty", stdout)
 				}
-				err := root.Run(context.Background())
-				if !errors.Is(err, flag.ErrHelp) {
-					t.Fatalf("error = %v, want usage error", err)
+				if !strings.Contains(stderr, "--next cannot be combined with "+modifier[0]) {
+					t.Fatalf("stderr = %q, want conflict for %s", stderr, modifier[0])
+				}
+				if clientFactoryCalled {
+					t.Fatal("client factory called before validation")
 				}
 			})
-			if !strings.Contains(stderr, "--next cannot be combined") {
-				t.Fatalf("stderr = %q", stderr)
-			}
-			if clientFactoryCalled {
-				t.Fatal("client factory called before validation")
-			}
-		})
+		}
+	}
+}
+
+func subscriptionNextModifierFamilies441() [][]string {
+	return [][]string{
+		{"--subscription-id", "123456789"},
+		{"--app", "app-1"},
+		{"--limit", "10"},
+		{"--subscription-fields", "versions"},
 	}
 }

--- a/internal/cli/cmdtest/subscription_sparse_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/subscription_sparse_fields_4_4_1_test.go
@@ -108,6 +108,22 @@ func TestSubscriptionSparseFields441CommandQueries(t *testing.T) {
 			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
 		},
 		{
+			name: "subscription promoted purchase",
+			args: []string{
+				"subscriptions", "promoted-purchases", "view",
+				"--subscription-id", "123456789",
+				"--iap-fields", "versions",
+				"--subscription-fields", "versions",
+				"--output", "json",
+			},
+			path: "/v1/subscriptions/123456789/promotedPurchase",
+			wantQuery: url.Values{
+				"fields[inAppPurchases]": {"versions"},
+				"fields[subscriptions]":  {"versions"},
+				"include":                {"inAppPurchaseV2,subscription"},
+			},
+		},
+		{
 			name:      "subscription promotional offers",
 			args:      []string{"subscriptions", "offers", "promotional", "list", "--subscription-id", "123456789", "--subscription-fields", "versions", "--output", "json"},
 			path:      "/v1/subscriptions/123456789/promotionalOffers",
@@ -177,6 +193,9 @@ func TestSubscriptionSparseFields441ValidationBeforeClient(t *testing.T) {
 		{"introductory subscription fields", []string{"subscriptions", "offers", "introductory", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
 		{"introductory price point fields", []string{"subscriptions", "offers", "introductory", "list", "--subscription-id", "123456789", "--price-point-fields", "bogus"}, "--price-point-fields must be one of"},
 		{"subscription offer codes", []string{"subscriptions", "offers", "offer-codes", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"subscription promoted purchase invalid iap fields", []string{"subscriptions", "promoted-purchases", "view", "--subscription-id", "123456789", "--iap-fields", "bogus"}, "--iap-fields must be one of"},
+		{"subscription promoted purchase invalid subscription fields", []string{"subscriptions", "promoted-purchases", "view", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"subscription promoted purchase selector conflict", []string{"subscriptions", "promoted-purchases", "view", "--subscription-id", "123456789", "--promoted-purchase-id", "promo-1"}, "--promoted-purchase-id and --subscription-id are mutually exclusive"},
 		{"subscription promotional offers", []string{"subscriptions", "offers", "promotional", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
 		{"subscription localizations", []string{"subscriptions", "localizations", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
 		{"subscription fields reject price point field", []string{"subscriptions", "images", "view", "--id", "image-1", "--subscription-fields", "adjustedEqualizations"}, "--subscription-fields must be one of"},

--- a/internal/cli/cmdtest/subscription_sparse_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/subscription_sparse_fields_4_4_1_test.go
@@ -1,0 +1,263 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestSubscriptionSparseFields441CommandQueries(t *testing.T) {
+	setupAuth(t)
+
+	tests := []struct {
+		name      string
+		args      []string
+		path      string
+		wantQuery url.Values
+	}{
+		{
+			name:      "review screenshot detail",
+			args:      []string{"subscriptions", "review", "screenshots", "view", "--screenshot-id", "shot-1", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionAppStoreReviewScreenshots/shot-1",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "group localization detail",
+			args:      []string{"subscriptions", "groups", "localizations", "view", "--id", "group-loc-1", "--group-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionGroupLocalizations/group-loc-1",
+			wantQuery: url.Values{"fields[subscriptionGroups]": {"versions"}, "include": {"subscriptionGroup"}},
+		},
+		{
+			name:      "image detail",
+			args:      []string{"subscriptions", "images", "view", "--id", "image-1", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionImages/image-1",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "localization detail",
+			args:      []string{"subscriptions", "localizations", "view", "--id", "loc-1", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionLocalizations/loc-1",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "offer code detail",
+			args:      []string{"subscriptions", "offers", "offer-codes", "view", "--offer-code-id", "code-1", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionOfferCodes/code-1",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "price point detail",
+			args:      []string{"subscriptions", "pricing", "price-points", "view", "--price-point-id", "point-1", "--fields", "adjustedEqualizations", "--output", "json"},
+			path:      "/v1/subscriptionPricePoints/point-1",
+			wantQuery: url.Values{"fields[subscriptionPricePoints]": {"adjustedEqualizations"}},
+		},
+		{
+			name:      "promotional offer detail",
+			args:      []string{"subscriptions", "offers", "promotional", "view", "--id", "promo-1", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionPromotionalOffers/promo-1",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "group localizations",
+			args:      []string{"subscriptions", "groups", "localizations", "list", "--group-id", "group-1", "--group-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptionGroups/group-1/subscriptionGroupLocalizations",
+			wantQuery: url.Values{"fields[subscriptionGroups]": {"versions"}, "include": {"subscriptionGroup"}},
+		},
+		{
+			name:      "offer code prices",
+			args:      []string{"subscriptions", "offers", "offer-codes", "prices", "--offer-code-id", "code-1", "--price-point-fields", "adjustedEqualizations", "--output", "json"},
+			path:      "/v1/subscriptionOfferCodes/code-1/prices",
+			wantQuery: url.Values{"fields[subscriptionPricePoints]": {"adjustedEqualizations"}, "include": {"subscriptionPricePoint"}},
+		},
+		{
+			name:      "promotional offer prices",
+			args:      []string{"subscriptions", "offers", "promotional", "prices", "--id", "promo-1", "--price-point-fields", "adjustedEqualizations", "--output", "json"},
+			path:      "/v1/subscriptionPromotionalOffers/promo-1/prices",
+			wantQuery: url.Values{"fields[subscriptionPricePoints]": {"adjustedEqualizations"}, "include": {"subscriptionPricePoint"}},
+		},
+		{
+			name:      "subscription screenshot relationship",
+			args:      []string{"subscriptions", "review", "app-store-screenshot", "view", "--subscription-id", "123456789", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptions/123456789/appStoreReviewScreenshot",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "subscription images",
+			args:      []string{"subscriptions", "images", "list", "--subscription-id", "123456789", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptions/123456789/images",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "introductory offers",
+			args:      []string{"subscriptions", "offers", "introductory", "list", "--subscription-id", "123456789", "--subscription-fields", "versions", "--price-point-fields", "adjustedEqualizations", "--output", "json"},
+			path:      "/v1/subscriptions/123456789/introductoryOffers",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "fields[subscriptionPricePoints]": {"adjustedEqualizations"}, "include": {"subscription,subscriptionPricePoint"}},
+		},
+		{
+			name:      "subscription offer codes",
+			args:      []string{"subscriptions", "offers", "offer-codes", "list", "--subscription-id", "123456789", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptions/123456789/offerCodes",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "subscription promotional offers",
+			args:      []string{"subscriptions", "offers", "promotional", "list", "--subscription-id", "123456789", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptions/123456789/promotionalOffers",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+		{
+			name:      "subscription localizations",
+			args:      []string{"subscriptions", "localizations", "list", "--subscription-id", "123456789", "--subscription-fields", "versions", "--output", "json"},
+			path:      "/v1/subscriptions/123456789/subscriptionLocalizations",
+			wantQuery: url.Values{"fields[subscriptions]": {"versions"}, "include": {"subscription"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useSubscriptionVersionServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != http.MethodGet || req.URL.Path != test.path {
+					reportSubscriptionVersionHandlerError(t, w, "request = %s %s, want GET %s", req.Method, req.URL.Path, test.path)
+					return
+				}
+				if got, want := req.URL.Query().Encode(), test.wantQuery.Encode(); got != want {
+					reportSubscriptionVersionHandlerError(t, w, "query = %q, want %q", got, want)
+					return
+				}
+				body := `{"data":null}`
+				if req.URL.Path == "/v1/subscriptions/123456789/appStoreReviewScreenshot" {
+					body = `{"data":{"type":"subscriptionAppStoreReviewScreenshots","id":"shot-1"}}`
+				}
+				writeSubscriptionVersionJSON(w, http.StatusOK, body)
+			}))
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			if strings.Contains(stderr, "Error:") {
+				t.Fatalf("stderr = %q", stderr)
+			}
+		})
+	}
+}
+
+func TestSubscriptionSparseFields441ValidationBeforeClient(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"review screenshot detail", []string{"subscriptions", "review", "screenshots", "view", "--screenshot-id", "shot-1", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"group localization detail", []string{"subscriptions", "groups", "localizations", "view", "--id", "loc-1", "--group-fields", "bogus"}, "--group-fields must be one of"},
+		{"image detail", []string{"subscriptions", "images", "view", "--id", "image-1", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"localization detail", []string{"subscriptions", "localizations", "view", "--id", "loc-1", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"offer code detail", []string{"subscriptions", "offers", "offer-codes", "view", "--offer-code-id", "code-1", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"price point detail", []string{"subscriptions", "pricing", "price-points", "view", "--price-point-id", "point-1", "--fields", "bogus"}, "--fields must be one of"},
+		{"promotional offer detail", []string{"subscriptions", "offers", "promotional", "view", "--id", "promo-1", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"group localizations", []string{"subscriptions", "groups", "localizations", "list", "--group-id", "group-1", "--group-fields", "bogus"}, "--group-fields must be one of"},
+		{"offer code prices", []string{"subscriptions", "offers", "offer-codes", "prices", "--offer-code-id", "code-1", "--price-point-fields", "bogus"}, "--price-point-fields must be one of"},
+		{"promotional offer prices", []string{"subscriptions", "offers", "promotional", "prices", "--id", "promo-1", "--price-point-fields", "bogus"}, "--price-point-fields must be one of"},
+		{"subscription screenshot relationship", []string{"subscriptions", "review", "app-store-screenshot", "view", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"subscription images", []string{"subscriptions", "images", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"introductory subscription fields", []string{"subscriptions", "offers", "introductory", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"introductory price point fields", []string{"subscriptions", "offers", "introductory", "list", "--subscription-id", "123456789", "--price-point-fields", "bogus"}, "--price-point-fields must be one of"},
+		{"subscription offer codes", []string{"subscriptions", "offers", "offer-codes", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"subscription promotional offers", []string{"subscriptions", "offers", "promotional", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"subscription localizations", []string{"subscriptions", "localizations", "list", "--subscription-id", "123456789", "--subscription-fields", "bogus"}, "--subscription-fields must be one of"},
+		{"subscription fields reject price point field", []string{"subscriptions", "images", "view", "--id", "image-1", "--subscription-fields", "adjustedEqualizations"}, "--subscription-fields must be one of"},
+		{"group fields reject subscription field", []string{"subscriptions", "groups", "localizations", "view", "--id", "loc-1", "--group-fields", "productId"}, "--group-fields must be one of"},
+		{"price point fields reject subscription field", []string{"subscriptions", "offers", "offer-codes", "prices", "--offer-code-id", "code-1", "--price-point-fields", "versions"}, "--price-point-fields must be one of"},
+		{"explicit empty", []string{"subscriptions", "images", "view", "--id", "image-1", "--subscription-fields", ""}, "--subscription-fields must not be empty"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run")
+			})
+			defer restore()
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want usage error", err)
+				}
+			})
+			if !strings.Contains(stderr, test.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.want)
+			}
+			if clientFactoryCalled {
+				t.Fatal("client factory called before validation")
+			}
+		})
+	}
+}
+
+func TestSubscriptionSparseFields441NextConflictsBeforeClient(t *testing.T) {
+	const next = "https://api.appstoreconnect.apple.com/v1/subscriptions/123456789/images?cursor=next"
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"group localizations", []string{"subscriptions", "groups", "localizations", "list", "--next", next, "--group-fields", "versions"}},
+		{"offer code prices", []string{"subscriptions", "offers", "offer-codes", "prices", "--next", next, "--price-point-fields", "adjustedEqualizations"}},
+		{"promotional offer prices", []string{"subscriptions", "offers", "promotional", "prices", "--next", next, "--price-point-fields", "adjustedEqualizations"}},
+		{"images", []string{"subscriptions", "images", "list", "--next", next, "--subscription-fields", "versions"}},
+		{"introductory offers subscription", []string{"subscriptions", "offers", "introductory", "list", "--next", next, "--subscription-fields", "versions"}},
+		{"introductory offers price point", []string{"subscriptions", "offers", "introductory", "list", "--next", next, "--price-point-fields", "adjustedEqualizations"}},
+		{"offer codes", []string{"subscriptions", "offers", "offer-codes", "list", "--next", next, "--subscription-fields", "versions"}},
+		{"promotional offers", []string{"subscriptions", "offers", "promotional", "list", "--next", next, "--subscription-fields", "versions"}},
+		{"localizations", []string{"subscriptions", "localizations", "list", "--next", next, "--subscription-fields", "versions"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run")
+			})
+			defer restore()
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want usage error", err)
+				}
+			})
+			if !strings.Contains(stderr, "--next cannot be combined") {
+				t.Fatalf("stderr = %q", stderr)
+			}
+			if clientFactoryCalled {
+				t.Fatal("client factory called before validation")
+			}
+		})
+	}
+}

--- a/internal/cli/promotedpurchases/scoped_command.go
+++ b/internal/cli/promotedpurchases/scoped_command.go
@@ -124,6 +124,9 @@ Examples:
 		if strings.TrimSpace(next) != "" && (flagWasSet(cmd.FlagSet, "iap-fields") || flagWasSet(cmd.FlagSet, "subscription-fields")) {
 			return shared.UsageErrorf("%s: --next cannot be combined with --iap-fields or --subscription-fields", errorPrefix)
 		}
+		if err := validateExplicitPromotedPurchaseFields(cmd.FlagSet); err != nil {
+			return shared.UsageError(errorPrefix + ": " + err.Error())
+		}
 		iapFields, err := shared.NormalizeSelection(iapFieldsValue, promotedPurchaseIAPFields, "--iap-fields")
 		if err != nil {
 			return shared.UsageError(errorPrefix + ": " + err.Error())
@@ -234,6 +237,9 @@ Examples:
 		if promotedPurchaseID != "" && ownerID != "" {
 			return shared.UsageErrorf("%s: --promoted-purchase-id and --%s are mutually exclusive", errorPrefix, ownerIDFlag)
 		}
+		if err := validateExplicitPromotedPurchaseFields(cmd.FlagSet); err != nil {
+			return shared.UsageError(errorPrefix + ": " + err.Error())
+		}
 		iapFields, err := shared.NormalizeSelection(stringFlagValue(cmd.FlagSet, "iap-fields"), promotedPurchaseIAPFields, "--iap-fields")
 		if err != nil {
 			return shared.UsageError(errorPrefix + ": " + err.Error())
@@ -321,6 +327,15 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 		}
 	})
 	return found
+}
+
+func validateExplicitPromotedPurchaseFields(fs *flag.FlagSet) error {
+	for _, name := range []string{"iap-fields", "subscription-fields"} {
+		if flagWasSet(fs, name) && strings.TrimSpace(stringFlagValue(fs, name)) == "" {
+			return fmt.Errorf("--%s must not be empty", name)
+		}
+	}
+	return nil
 }
 
 func configureScopedPromotedPurchasesUpdateCommand(cmd *ffcli.Command, cfg ScopedPromotedPurchasesCommandConfig) {

--- a/internal/cli/subscriptions/app_store_review_screenshot.go
+++ b/internal/cli/subscriptions/app_store_review_screenshot.go
@@ -41,6 +41,7 @@ func SubscriptionsAppStoreReviewScreenshotGetCommand() *ffcli.Command {
 
 	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
 	appID := addSubscriptionLookupAppFlag(fs)
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -54,6 +55,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, "", "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
@@ -73,7 +78,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(requestCtx, id)
+			resp, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(
+				requestCtx, id,
+				asc.WithSubscriptionAppStoreReviewScreenshotSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionAppStoreReviewScreenshotInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions app-store-review-screenshot view: failed to fetch: %w", err)
 			}

--- a/internal/cli/subscriptions/group_localizations.go
+++ b/internal/cli/subscriptions/group_localizations.go
@@ -52,6 +52,7 @@ func SubscriptionsGroupsLocalizationsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	groupFields := fs.String("group-fields", "", "Included subscription group fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -72,6 +73,10 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions groups localizations list: %w", err)
 			}
+			selectedGroupFields, err := normalizeSparseFieldsFlag(fs, *next, "group-fields", *groupFields, subscriptionGroupFieldsList())
+			if err != nil {
+				return err
+			}
 
 			id := strings.TrimSpace(*groupID)
 			if id == "" && strings.TrimSpace(*next) == "" {
@@ -90,10 +95,15 @@ Examples:
 			opts := []asc.SubscriptionGroupLocalizationsOption{
 				asc.WithSubscriptionGroupLocalizationsLimit(*limit),
 				asc.WithSubscriptionGroupLocalizationsNextURL(*next),
+				asc.WithSubscriptionGroupLocalizationsGroupFields(selectedGroupFields),
+				asc.WithSubscriptionGroupLocalizationsInclude(includeRelationshipForFields(selectedGroupFields, "subscriptionGroup")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionGroupLocalizationsLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionGroupLocalizationsLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionGroupLocalizations(requestCtx, id, paginateOpts...) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
 				if err != nil {
 					return fmt.Errorf("subscriptions groups localizations list: failed to fetch: %w", err)
@@ -124,6 +134,7 @@ func SubscriptionsGroupsLocalizationsGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("groups localizations view", flag.ExitOnError)
 
 	localizationID := fs.String("id", "", "Subscription group localization ID")
+	groupFields := fs.String("group-fields", "", "Included subscription group fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -137,6 +148,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedGroupFields, err := normalizeSparseFieldsFlag(fs, "", "group-fields", *groupFields, subscriptionGroupFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -151,7 +166,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionGroupLocalization(requestCtx, id) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+			resp, err := client.GetSubscriptionGroupLocalization( //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+				requestCtx, id,
+				asc.WithSubscriptionGroupLocalizationGroupFields(selectedGroupFields),
+				asc.WithSubscriptionGroupLocalizationInclude(includeRelationshipForFields(selectedGroupFields, "subscriptionGroup")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions groups localizations view: failed to fetch: %w", err)
 			}

--- a/internal/cli/subscriptions/group_localizations.go
+++ b/internal/cli/subscriptions/group_localizations.go
@@ -73,6 +73,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions groups localizations list: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "group-id", "limit", "group-fields"); err != nil {
+				return err
+			}
 			selectedGroupFields, err := normalizeSparseFieldsFlag(fs, *next, "group-fields", *groupFields, subscriptionGroupFieldsList())
 			if err != nil {
 				return err

--- a/internal/cli/subscriptions/images.go
+++ b/internal/cli/subscriptions/images.go
@@ -73,6 +73,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions images list: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "subscription-id", "app", "limit", "subscription-fields"); err != nil {
+				return err
+			}
 			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
 			if err != nil {
 				return err

--- a/internal/cli/subscriptions/images.go
+++ b/internal/cli/subscriptions/images.go
@@ -52,6 +52,7 @@ func SubscriptionsImagesListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -71,6 +72,10 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions images list: %w", err)
+			}
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
 			}
 
 			id := strings.TrimSpace(*subscriptionID)
@@ -97,10 +102,15 @@ Examples:
 			opts := []asc.SubscriptionImagesOption{
 				asc.WithSubscriptionImagesLimit(*limit),
 				asc.WithSubscriptionImagesNextURL(*next),
+				asc.WithSubscriptionImagesSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionImagesInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionImagesLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionImagesLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionImages(requestCtx, id, paginateOpts...) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
 				if err != nil {
 					return fmt.Errorf("subscriptions images list: failed to fetch: %w", err)
@@ -131,6 +141,7 @@ func SubscriptionsImagesGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("images view", flag.ExitOnError)
 
 	imageID := fs.String("id", "", "Subscription image ID")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -144,6 +155,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, "", "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*imageID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -158,7 +173,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionImage(requestCtx, id) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+			resp, err := client.GetSubscriptionImage( //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+				requestCtx, id,
+				asc.WithSubscriptionImageSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionImageInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions images view: failed to fetch: %w", err)
 			}

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -80,6 +80,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions introductory-offers list: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "subscription-id", "app", "limit", "subscription-fields", "price-point-fields"); err != nil {
+				return err
+			}
 			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
 			if err != nil {
 				return err

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -58,6 +58,8 @@ func SubscriptionsIntroductoryOffersListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
+	pricePointFields := fs.String("price-point-fields", "", "Included subscription price point fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -78,6 +80,16 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions introductory-offers list: %w", err)
 			}
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
+			selectedPricePointFields, err := normalizeSparseFieldsFlag(fs, *next, "price-point-fields", *pricePointFields, subscriptionPricePointFieldsList())
+			if err != nil {
+				return err
+			}
+			include := includeRelationshipForFields(selectedSubscriptionFields, "subscription")
+			include = appendIncludeForFields(include, selectedPricePointFields, "subscriptionPricePoint")
 
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" && strings.TrimSpace(*next) == "" {
@@ -103,10 +115,16 @@ Examples:
 			opts := []asc.SubscriptionIntroductoryOffersOption{
 				asc.WithSubscriptionIntroductoryOffersLimit(*limit),
 				asc.WithSubscriptionIntroductoryOffersNextURL(*next),
+				asc.WithSubscriptionIntroductoryOffersSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionIntroductoryOffersPricePointFields(selectedPricePointFields),
+				asc.WithSubscriptionIntroductoryOffersInclude(include),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionIntroductoryOffersLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionIntroductoryOffersLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionIntroductoryOffers(requestCtx, id, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("subscriptions introductory-offers list: failed to fetch: %w", err)

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -57,6 +57,7 @@ func SubscriptionsLocalizationsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -76,6 +77,10 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions localizations list: %w", err)
+			}
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
 			}
 
 			id := strings.TrimSpace(*subscriptionID)
@@ -102,10 +107,15 @@ Examples:
 			opts := []asc.SubscriptionLocalizationsOption{
 				asc.WithSubscriptionLocalizationsLimit(*limit),
 				asc.WithSubscriptionLocalizationsNextURL(*next),
+				asc.WithSubscriptionLocalizationsSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionLocalizationsInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionLocalizationsLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionLocalizationsLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionLocalizations(requestCtx, id, paginateOpts...) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
 				if err != nil {
 					return fmt.Errorf("subscriptions localizations list: failed to fetch: %w", err)
@@ -136,6 +146,7 @@ func SubscriptionsLocalizationsGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("localizations view", flag.ExitOnError)
 
 	localizationID := fs.String("id", "", "Subscription localization ID")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return shared.DeprecatedCommand(&ffcli.Command{
@@ -149,6 +160,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, "", "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -163,7 +178,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionLocalization(requestCtx, id) //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+			resp, err := client.GetSubscriptionLocalization( //nolint:staticcheck // Compatibility path retained during the App Store Connect API 4.4.1 deprecation window.
+				requestCtx, id,
+				asc.WithSubscriptionLocalizationSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionLocalizationInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions localizations view: failed to fetch: %w", err)
 			}

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -78,6 +78,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions localizations list: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "subscription-id", "app", "limit", "subscription-fields"); err != nil {
+				return err
+			}
 			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
 			if err != nil {
 				return err

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -82,6 +82,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions offer-codes list: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "subscription-id", "app", "limit", "subscription-fields"); err != nil {
+				return err
+			}
 			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
 			if err != nil {
 				return err
@@ -579,6 +582,9 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions offer-codes prices: %w", err)
+			}
+			if err := validateNextExclusiveFlags(fs, *next, "offer-code-id", "limit", "price-point-fields"); err != nil {
+				return err
 			}
 			selectedPricePointFields, err := normalizeSparseFieldsFlag(fs, *next, "price-point-fields", *pricePointFields, subscriptionPricePointFieldsList())
 			if err != nil {

--- a/internal/cli/subscriptions/offer_codes.go
+++ b/internal/cli/subscriptions/offer_codes.go
@@ -60,6 +60,7 @@ func SubscriptionsOfferCodesListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -80,6 +81,10 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions offer-codes list: %w", err)
+			}
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
 			}
 
 			id := strings.TrimSpace(*subscriptionID)
@@ -106,10 +111,15 @@ Examples:
 			opts := []asc.SubscriptionOfferCodesOption{
 				asc.WithSubscriptionOfferCodesLimit(*limit),
 				asc.WithSubscriptionOfferCodesNextURL(*next),
+				asc.WithSubscriptionOfferCodesSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionOfferCodesInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionOfferCodesLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionOfferCodesLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionOfferCodes(requestCtx, id, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("subscriptions offer-codes list: failed to fetch: %w", err)
@@ -176,6 +186,7 @@ func SubscriptionsOfferCodesGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("offer-codes view", flag.ExitOnError)
 
 	offerCodeID := fs.String("offer-code-id", "", "Offer code ID")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -189,6 +200,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, "", "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --offer-code-id is required")
@@ -203,7 +218,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionOfferCode(requestCtx, id)
+			resp, err := client.GetSubscriptionOfferCode(
+				requestCtx, id,
+				asc.WithSubscriptionOfferCodeSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionOfferCodeInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions offer-codes view: failed to fetch: %w", err)
 			}
@@ -541,6 +560,7 @@ func SubscriptionsOfferCodesPricesCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	pricePointFields := fs.String("price-point-fields", "", "Included subscription price point fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -560,6 +580,10 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions offer-codes prices: %w", err)
 			}
+			selectedPricePointFields, err := normalizeSparseFieldsFlag(fs, *next, "price-point-fields", *pricePointFields, subscriptionPricePointFieldsList())
+			if err != nil {
+				return err
+			}
 
 			id := strings.TrimSpace(*offerCodeID)
 			if id == "" && strings.TrimSpace(*next) == "" {
@@ -578,10 +602,15 @@ Examples:
 			opts := []asc.SubscriptionOfferCodePricesOption{
 				asc.WithSubscriptionOfferCodePricesLimit(*limit),
 				asc.WithSubscriptionOfferCodePricesNextURL(*next),
+				asc.WithSubscriptionOfferCodePricesPricePointFields(selectedPricePointFields),
+				asc.WithSubscriptionOfferCodePricesInclude(includeRelationshipForFields(selectedPricePointFields, "subscriptionPricePoint")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionOfferCodePricesLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionOfferCodePricesLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionOfferCodePrices(requestCtx, id, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("subscriptions offer-codes prices: failed to fetch: %w", err)

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -321,6 +321,7 @@ func SubscriptionsPricePointsGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("price-points view", flag.ExitOnError)
 
 	pricePointID := fs.String("price-point-id", "", "Subscription price point ID")
+	fields := fs.String("fields", "", "Subscription price point fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -334,6 +335,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedFields, err := normalizeSparseFieldsFlag(fs, "", "fields", *fields, subscriptionPricePointFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*pricePointID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --price-point-id is required")
@@ -348,7 +353,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionPricePoint(requestCtx, id)
+			resp, err := client.GetSubscriptionPricePoint(requestCtx, id, asc.WithSubscriptionPricePointFields(selectedFields))
 			if err != nil {
 				return fmt.Errorf("subscriptions price-points view: failed to fetch: %w", err)
 			}
@@ -368,14 +373,7 @@ func SubscriptionsPricePointsAdjustedEqualizationsCommand() *ffcli.Command {
 	return buildSubscriptionPricePointEqualizationsCommand("adjusted-equalizations", true)
 }
 
-var subscriptionPricePointFields = []string{
-	"customerPrice",
-	"proceeds",
-	"proceedsYear2",
-	"territory",
-	"equalizations",
-	"adjustedEqualizations",
-}
+var subscriptionPricePointFields = subscriptionPricePointFieldsList()
 
 func buildSubscriptionPricePointEqualizationsCommand(name string, adjusted bool) *ffcli.Command {
 	flagSetName := "price-points " + name

--- a/internal/cli/subscriptions/promoted_purchases.go
+++ b/internal/cli/subscriptions/promoted_purchases.go
@@ -1,8 +1,11 @@
 package subscriptions
 
 import (
+	"context"
+
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/promotedpurchases"
 )
 
@@ -10,13 +13,23 @@ import (
 func SubscriptionsPromotedPurchasesCommand() *ffcli.Command {
 	cmd := promotedpurchases.PromotedPurchasesCommand()
 	if cmd != nil {
+		lookupAppID := addSubscriptionPromotedPurchaseLookupAppFlag(cmd)
 		cmd.ShortUsage = "asc subscriptions promoted-purchases <subcommand> [flags]"
 		promotedpurchases.ConfigureScopedPromotedPurchasesCommand(cmd, promotedpurchases.ScopedPromotedPurchasesCommandConfig{
-			PathPrefix:      "asc subscriptions promoted-purchases",
-			ProductType:     "SUBSCRIPTION",
-			ProductSingular: "a subscription",
-			ProductPlural:   "subscriptions",
-			RootShortHelp:   "Manage promoted purchases for subscriptions.",
+			PathPrefix:         "asc subscriptions promoted-purchases",
+			ProductType:        "SUBSCRIPTION",
+			ProductSingular:    "a subscription",
+			ProductPlural:      "subscriptions",
+			OwnerIDFlag:        "subscription-id",
+			OwnerIDUsage:       "Subscription ID, product ID, or exact current name",
+			OwnerIDPlaceholder: "SUBSCRIPTION_SELECTOR",
+			ResolveOwnerID: func(ctx context.Context, client *asc.Client, selector string) (string, error) {
+				return resolveSubscriptionLookupIDWithTimeout(ctx, client, *lookupAppID, selector)
+			},
+			FetchForOwner: func(ctx context.Context, client *asc.Client, subscriptionID string, opts ...asc.PromotedPurchaseGetOption) (*asc.PromotedPurchaseResponse, error) {
+				return client.GetSubscriptionPromotedPurchase(ctx, subscriptionID, opts...)
+			},
+			RootShortHelp: "Manage promoted purchases for subscriptions.",
 			RootLongHelp: `Manage promoted purchases for subscriptions.
 
 Only promoted purchases attached to subscriptions are listed or modified.
@@ -26,6 +39,7 @@ attached to the app.
 Examples:
   asc subscriptions promoted-purchases list --app "APP_ID"
   asc subscriptions promoted-purchases view --promoted-purchase-id "PROMO_ID"
+  asc subscriptions promoted-purchases view --app "APP_ID" --subscription-id "SUBSCRIPTION_SELECTOR"
   asc subscriptions promoted-purchases create --app "APP_ID" --product-id "SUB_ID" --visible-for-all-users true
   asc subscriptions promoted-purchases update --promoted-purchase-id "PROMO_ID" --enabled false
   asc subscriptions promoted-purchases delete --promoted-purchase-id "PROMO_ID" --confirm
@@ -34,6 +48,16 @@ Examples:
 		configureSubscriptionsPromotedPurchasesCreate(cmd)
 	}
 	return cmd
+}
+
+func addSubscriptionPromotedPurchaseLookupAppFlag(cmd *ffcli.Command) *string {
+	for _, subcommand := range cmd.Subcommands {
+		if subcommand != nil && subcommand.Name == "view" && subcommand.FlagSet != nil {
+			return addSubscriptionLookupAppFlag(subcommand.FlagSet)
+		}
+	}
+	appID := ""
+	return &appID
 }
 
 func configureSubscriptionsPromotedPurchasesCreate(cmd *ffcli.Command) {

--- a/internal/cli/subscriptions/promotional_offers.go
+++ b/internal/cli/subscriptions/promotional_offers.go
@@ -51,6 +51,7 @@ func SubscriptionsPromotionalOffersListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -70,6 +71,10 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions promotional-offers list: %w", err)
+			}
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
 			}
 
 			id := strings.TrimSpace(*subscriptionID)
@@ -96,10 +101,15 @@ Examples:
 			opts := []asc.SubscriptionPromotionalOffersOption{
 				asc.WithSubscriptionPromotionalOffersLimit(*limit),
 				asc.WithSubscriptionPromotionalOffersNextURL(*next),
+				asc.WithSubscriptionPromotionalOffersSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionPromotionalOffersInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionPromotionalOffersLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionPromotionalOffersLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionPromotionalOffers(requestCtx, id, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("subscriptions promotional-offers list: failed to fetch: %w", err)
@@ -130,6 +140,7 @@ func SubscriptionsPromotionalOffersGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("promotional-offers view", flag.ExitOnError)
 
 	offerID := fs.String("id", "", "Promotional offer ID")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -143,6 +154,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, "", "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -157,7 +172,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionPromotionalOffer(requestCtx, id)
+			resp, err := client.GetSubscriptionPromotionalOffer(
+				requestCtx, id,
+				asc.WithSubscriptionPromotionalOfferSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionPromotionalOfferInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions promotional-offers view: failed to fetch: %w", err)
 			}
@@ -368,6 +387,7 @@ func SubscriptionsPromotionalOfferPricesCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	pricePointFields := fs.String("price-point-fields", "", "Included subscription price point fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -388,6 +408,10 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions promotional-offers prices: %w", err)
 			}
+			selectedPricePointFields, err := normalizeSparseFieldsFlag(fs, *next, "price-point-fields", *pricePointFields, subscriptionPricePointFieldsList())
+			if err != nil {
+				return err
+			}
 
 			id := strings.TrimSpace(*offerID)
 			if id == "" && strings.TrimSpace(*next) == "" {
@@ -406,10 +430,15 @@ Examples:
 			opts := []asc.SubscriptionPromotionalOfferPricesOption{
 				asc.WithSubscriptionPromotionalOfferPricesLimit(*limit),
 				asc.WithSubscriptionPromotionalOfferPricesNextURL(*next),
+				asc.WithSubscriptionPromotionalOfferPricesPricePointFields(selectedPricePointFields),
+				asc.WithSubscriptionPromotionalOfferPricesInclude(includeRelationshipForFields(selectedPricePointFields, "subscriptionPricePoint")),
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithSubscriptionPromotionalOfferPricesLimit(200))
+				paginateOpts := opts
+				if strings.TrimSpace(*next) == "" {
+					paginateOpts = append(paginateOpts, asc.WithSubscriptionPromotionalOfferPricesLimit(200))
+				}
 				firstPage, err := client.GetSubscriptionPromotionalOfferPrices(requestCtx, id, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("subscriptions promotional-offers prices: failed to fetch: %w", err)

--- a/internal/cli/subscriptions/promotional_offers.go
+++ b/internal/cli/subscriptions/promotional_offers.go
@@ -72,6 +72,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions promotional-offers list: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "subscription-id", "app", "limit", "subscription-fields"); err != nil {
+				return err
+			}
 			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, *next, "subscription-fields", *subscriptionFields, subscriptionFieldsList())
 			if err != nil {
 				return err
@@ -407,6 +410,9 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions promotional-offers prices: %w", err)
+			}
+			if err := validateNextExclusiveFlags(fs, *next, "id", "limit", "price-point-fields"); err != nil {
+				return err
 			}
 			selectedPricePointFields, err := normalizeSparseFieldsFlag(fs, *next, "price-point-fields", *pricePointFields, subscriptionPricePointFieldsList())
 			if err != nil {

--- a/internal/cli/subscriptions/review_screenshots.go
+++ b/internal/cli/subscriptions/review_screenshots.go
@@ -48,6 +48,7 @@ func SubscriptionsReviewScreenshotsGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("review-screenshots view", flag.ExitOnError)
 
 	screenshotID := fs.String("screenshot-id", "", "Review screenshot ID")
+	subscriptionFields := fs.String("subscription-fields", "", "Included subscription fields (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -61,6 +62,10 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			selectedSubscriptionFields, err := normalizeSparseFieldsFlag(fs, "", "subscription-fields", *subscriptionFields, subscriptionFieldsList())
+			if err != nil {
+				return err
+			}
 			id := strings.TrimSpace(*screenshotID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --screenshot-id is required")
@@ -75,7 +80,11 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionAppStoreReviewScreenshot(requestCtx, id)
+			resp, err := client.GetSubscriptionAppStoreReviewScreenshot(
+				requestCtx, id,
+				asc.WithSubscriptionAppStoreReviewScreenshotSubscriptionFields(selectedSubscriptionFields),
+				asc.WithSubscriptionAppStoreReviewScreenshotInclude(includeRelationshipForFields(selectedSubscriptionFields, "subscription")),
+			)
 			if err != nil {
 				return fmt.Errorf("subscriptions review-screenshots view: failed to fetch: %w", err)
 			}

--- a/internal/cli/subscriptions/sparse_fields_4_4_1.go
+++ b/internal/cli/subscriptions/sparse_fields_4_4_1.go
@@ -14,6 +14,18 @@ func normalizeSparseFieldsFlag(fs *flag.FlagSet, next, name, value string, allow
 	return normalizeSelectionFlag(fs, value, "--"+name, allowed)
 }
 
+func validateNextExclusiveFlags(fs *flag.FlagSet, next string, names ...string) error {
+	if strings.TrimSpace(next) == "" {
+		return nil
+	}
+	for _, name := range names {
+		if flagWasProvided(fs, name) {
+			return shared.UsageErrorf("--next cannot be combined with --%s", name)
+		}
+	}
+	return nil
+}
+
 func includeRelationshipForFields(fields []string, relationship string) []string {
 	if len(fields) == 0 {
 		return nil

--- a/internal/cli/subscriptions/sparse_fields_4_4_1.go
+++ b/internal/cli/subscriptions/sparse_fields_4_4_1.go
@@ -1,0 +1,37 @@
+package subscriptions
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func normalizeSparseFieldsFlag(fs *flag.FlagSet, next, name, value string, allowed []string) ([]string, error) {
+	if strings.TrimSpace(next) != "" && flagWasProvided(fs, name) {
+		return nil, shared.UsageErrorf("--next cannot be combined with --%s", name)
+	}
+	return normalizeSelectionFlag(fs, value, "--"+name, allowed)
+}
+
+func includeRelationshipForFields(fields []string, relationship string) []string {
+	if len(fields) == 0 {
+		return nil
+	}
+	return []string{relationship}
+}
+
+func appendIncludeForFields(include []string, fields []string, relationship string) []string {
+	if len(fields) == 0 || containsString(include, relationship) {
+		return include
+	}
+	return append(include, relationship)
+}
+
+func subscriptionGroupFieldsList() []string {
+	return []string{"referenceName", "subscriptions", "subscriptionGroupLocalizations", "versions"}
+}
+
+func subscriptionPricePointFieldsList() []string {
+	return []string{"customerPrice", "proceeds", "proceedsYear2", "territory", "equalizations", "adjustedEqualizations"}
+}


### PR DESCRIPTION
## Summary

- complete the App Store Connect API 4.4.1 related sparse-field support for all 17 subscription and pricing GET endpoints
- expose exact `versions` fields for subscriptions and subscription groups, `adjustedEqualizations` for subscription price points, and dual subscription/IAP fields for promoted purchases
- extend `subscriptions promoted-purchases view` with the stable subscription selector convention while preserving direct promoted-purchase ID lookup
- keep deprecated v1 localization/image command paths compatible and document migration to the versioned resources; this PR does not remove stable CLI behavior

## CLI contract

- long-form field flags with strict endpoint-specific enums
- required relationship includes are added automatically when related sparse fields are requested
- `--next` conflicts are validated before HTTP on affected list commands
- subscription selectors accept an ASC ID, product ID, or exact current name; product/name lookup requires `--app` or `ASC_APP_ID`

## Verification

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test` (commit hook full short suite passed)
- complete affected packages: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc ./internal/cli/subscriptions ./internal/cli/cmdtest -count=1`
- exact 17-endpoint client query matrix and CLI query matrix
- focused stable-selector, invalid-enum, selector-conflict, and help-contract coverage
- built-binary help and pre-HTTP validation checks

An earlier standalone full-suite run hit one unrelated PTY timing failure in `internal/cli/shared/TestSpinnerEnabled_DisabledWhenStderrNotTTY`; the isolated test passed immediately, and the subsequent commit-hook full suite passed, including `internal/cli/shared`.

## Scope and live testing

- unstacked on merged PR #1793 (`f6b34d9e`)
- no App Store Connect live calls or mutations were performed in this implementation branch; live disposable-app mutation verification remains part of the release-wide parent audit
- no release is requested or performed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded API 4.4.1 sparse-field support across subscriptions, offers, localizations, images, price points, review screenshots, and promoted-purchases with new `--subscription-fields`, `--group-fields`, and `--price-point-fields`.
  * Added scoped promoted-purchase view using a subscription selector, with stable resolution via the app lookup flag.
* **Bug Fixes**
  * Improved validation so `--next` can’t be combined with sparse-field options, and empty/invalid sparse-field inputs fail early (before any network requests).
  * Enforced “exactly one” selector rule for promoted purchase lookup.
* **Documentation**
  * Updated 4.4.1 subscription sparse-field docs, related sparse-field guidance, and the coverage ledger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->