### PR TITLE
feat(apps): expose API 4.4.1 sparse app fields

### DIFF
--- a/commands/age-rating.mdx
+++ b/commands/age-rating.mdx
@@ -19,6 +19,17 @@ Use `--output json`, `--output table`, or `--output markdown`. Add `--pretty`
 when using JSON interactively. Only one of `--app-info-id` and `--version-id`
 may be supplied; use `--app` when neither direct relationship ID is known.
 
+API 4.4.1 sparse reads can return only the new social-media attributes:
+
+```bash  theme={null}
+asc age-rating view \
+  --app-info-id "APP_INFO_ID" \
+  --fields socialMedia,socialMediaAgeRestricted
+```
+
+`--fields` accepts `socialMedia` and `socialMediaAgeRestricted`. It is also
+supported when the declaration is resolved through `--app` or `--version-id`.
+
 ## Update a Declaration
 
 Target the declaration directly or let the CLI resolve it from the app, app
@@ -95,7 +106,7 @@ asc age-rating edit \
 After an update, read the declaration again to verify the stored combination:
 
 ```bash  theme={null}
-asc age-rating view --app "APP_ID" --output json --pretty
+asc age-rating view --app "APP_ID" --fields socialMedia,socialMediaAgeRestricted --output json --pretty
 ```
 
 ## Other Update Fields

--- a/commands/app-info.mdx
+++ b/commands/app-info.mdx
@@ -10,6 +10,35 @@ App Info commands manage version-specific metadata like descriptions, keywords, 
 
 ## Commands
 
+### `asc apps info list`
+
+List every app-info record for an app. Use this command to find the app-info ID
+needed by app-info detail and age-rating commands.
+
+<ParamField path="--app" type="string" required>
+  App Store Connect app ID (or `ASC_APP_ID` env variable)
+</ParamField>
+
+<ParamField path="--fields" type="string">
+  Sparse app-info fields. API 4.4.1 supports only `kidsAgeBand`; Apple marks
+  this selector deprecated, so prefer `asc age-rating view` for current
+  age-rating data.
+</ParamField>
+
+<ParamField path="--age-rating-fields" type="string">
+  Sparse fields for the included age-rating declaration. Supported values are
+  `socialMedia` and `socialMediaAgeRestricted`. Supplying this flag
+  automatically includes `ageRatingDeclaration`.
+</ParamField>
+
+```bash  theme={null}
+asc apps info list --app "APP_ID"
+asc apps info list --app "APP_ID" --fields kidsAgeBand
+asc apps info list --app "APP_ID" --fields kidsAgeBand --age-rating-fields socialMedia,socialMediaAgeRestricted
+```
+
+***
+
 ### `asc apps info view`
 
 View app store version localization metadata.
@@ -55,7 +84,19 @@ View app store version localization metadata.
 </ParamField>
 
 <ParamField path="--include" type="string">
-  Include related resources (comma-separated): `ageRatingDeclaration`, `territoryAgeRatings`, `primaryCategory`, `primarySubcategoryOne`, `primarySubcategoryTwo`, `secondaryCategory`, `secondarySubcategoryOne`, `secondarySubcategoryTwo`
+  Include related resources (comma-separated): `app`, `ageRatingDeclaration`, `appInfoLocalizations`, `primaryCategory`, `primarySubcategoryOne`, `primarySubcategoryTwo`, `secondaryCategory`, `secondarySubcategoryOne`, `secondarySubcategoryTwo`
+</ParamField>
+
+<ParamField path="--fields" type="string">
+  Sparse app-info fields. API 4.4.1 supports only `kidsAgeBand`; Apple marks
+  this selector deprecated, so prefer `asc age-rating view` for current
+  age-rating data.
+</ParamField>
+
+<ParamField path="--age-rating-fields" type="string">
+  Sparse fields for the included age-rating declaration. Supported values are
+  `socialMedia` and `socialMediaAgeRestricted`. Supplying this flag
+  automatically includes `ageRatingDeclaration`.
 </ParamField>
 
 **Examples:**
@@ -65,9 +106,28 @@ asc apps info view --app "APP_ID"
 asc apps info view --app "APP_ID" --version "1.2.3" --platform IOS
 asc apps info view --version-id "VERSION_ID"
 asc apps info view --info-id "APP_INFO_ID" --include "ageRatingDeclaration"
-asc apps info view --app "APP_ID" --include "ageRatingDeclaration,territoryAgeRatings"
+asc apps info view --info-id "APP_INFO_ID" --fields kidsAgeBand --age-rating-fields socialMedia
+asc apps info view --app "APP_ID" --include "ageRatingDeclaration,appInfoLocalizations"
 asc apps info view --app "APP_ID" --locale "en-US" --output table
 ```
+
+When an app-info sparse fieldset and relationships are requested together, the
+CLI retains each included relationship in `fields[appInfos]`. For example, the
+combined sparse example above sends
+`fields[appInfos]=kidsAgeBand,ageRatingDeclaration` and
+`include=ageRatingDeclaration`, so App Store Connect does not drop the included
+age-rating declaration.
+
+App-info selectors (`--include`, `--fields`, and `--age-rating-fields`) cannot
+be combined with version-localization selectors such as `--version-id`,
+`--locale`, `--limit`, `--next`, or `--paginate`. Unsupported or empty sparse
+field values are rejected before authentication or HTTP.
+
+<Warning>
+  `kidsAgeBand` remains available because API 4.4.1 publishes it in the
+  app-info sparse-field enum, but Apple marks it deprecated. New workflows
+  should read age-rating data with `asc age-rating view`.
+</Warning>
 
 **Response:**
 
@@ -200,7 +260,7 @@ asc apps info edit --app "123456789" --locale "fr-FR" --copy-from-locale "en-US"
 ### Get metadata with related resources
 
 ```bash  theme={null}
-asc apps info view --app "123456789" --include "ageRatingDeclaration,territoryAgeRatings" --output json
+asc apps info view --app "123456789" --include "ageRatingDeclaration,appInfoLocalizations" --output json
 ```
 
 ## Submit-Required Fields

--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -44,6 +44,16 @@ List apps from App Store Connect.
   Automatically fetch all pages (aggregate results)
 </ParamField>
 
+<ParamField path="--iap-fields" type="string">
+  Sparse fields for included in-app purchases. API 4.4.1 supports `versions`.
+  Supplying this flag automatically includes `inAppPurchases`.
+</ParamField>
+
+<ParamField path="--subscription-group-fields" type="string">
+  Sparse fields for included subscription groups. API 4.4.1 supports
+  `versions`. Supplying this flag automatically includes `subscriptionGroups`.
+</ParamField>
+
 <ParamField path="--output" type="string" default="json">
   Output format: `json`, `table`, `markdown`
 </ParamField>
@@ -56,6 +66,7 @@ asc apps list --bundle-id "com.example.app"
 asc apps list --name "My App"
 asc apps list --limit 10
 asc apps list --sort name
+asc apps list --iap-fields versions --subscription-group-fields versions
 asc apps list --output table
 asc apps list --paginate
 ```
@@ -92,6 +103,16 @@ View app details by ID.
   App Store Connect app ID
 </ParamField>
 
+<ParamField path="--iap-fields" type="string">
+  Sparse fields for included in-app purchases: `versions`. Automatically
+  includes `inAppPurchases`.
+</ParamField>
+
+<ParamField path="--subscription-group-fields" type="string">
+  Sparse fields for included subscription groups: `versions`. Automatically
+  includes `subscriptionGroups`.
+</ParamField>
+
 <ParamField path="--output" type="string" default="json">
   Output format: `json`, `table`
 </ParamField>
@@ -100,6 +121,7 @@ View app details by ID.
 
 ```bash  theme={null}
 asc apps view --id "APP_ID"
+asc apps view --id "APP_ID" --iap-fields versions --subscription-group-fields versions
 asc apps view --id "APP_ID" --output table
 ```
 
@@ -119,6 +141,50 @@ asc apps view --id "APP_ID" --output table
     }
   }
 }
+```
+
+***
+
+### `asc apps info list`
+
+List app-info records for an app. API 4.4.1 adds sparse reads for the app info
+kids age band and the age-rating declaration's social-media fields.
+
+<ParamField path="--app" type="string" required>
+  App Store Connect app ID (or `ASC_APP_ID`)
+</ParamField>
+
+<ParamField path="--fields" type="string">
+  Sparse app-info fields: `kidsAgeBand`
+</ParamField>
+
+<ParamField path="--age-rating-fields" type="string">
+  Sparse fields for the included age-rating declaration:
+  `socialMedia`, `socialMediaAgeRestricted`. Automatically includes
+  `ageRatingDeclaration`.
+</ParamField>
+
+```bash  theme={null}
+asc apps info list --app "APP_ID" --fields kidsAgeBand
+asc apps info list --app "APP_ID" --age-rating-fields socialMedia,socialMediaAgeRestricted
+```
+
+<Note>
+  Apple's production API accepted the API 4.4.1 social-media fields in live
+  testing on July 17, 2026, but still rejected the official
+  `fields[appInfos]=kidsAgeBand` value on app-info detail and collection reads.
+  The CLI exposes the published schema while Apple's rollout catches up.
+</Note>
+
+### `asc apps info view`
+
+Use an app-info ID to request the same sparse fields from one record. These
+app-info flags cannot be combined with version-localization selectors such as
+`--version-id`, `--locale`, `--next`, or `--paginate`.
+
+```bash  theme={null}
+asc apps info view --info-id "APP_INFO_ID" --fields kidsAgeBand
+asc apps info view --info-id "APP_INFO_ID" --age-rating-fields socialMedia,socialMediaAgeRestricted
 ```
 
 ***

--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -44,6 +44,12 @@ List apps from App Store Connect.
   Automatically fetch all pages (aggregate results)
 </ParamField>
 
+<ParamField path="--app-info-fields" type="string">
+  Sparse fields for included app-info records. API 4.4.1 supports the deprecated
+  `kidsAgeBand` selector. Supplying this flag automatically includes `appInfos`.
+  Prefer `asc age-rating view` for current age-rating data.
+</ParamField>
+
 <ParamField path="--iap-fields" type="string">
   Sparse fields for included in-app purchases. API 4.4.1 supports `versions`.
   Supplying this flag automatically includes `inAppPurchases`.
@@ -66,7 +72,7 @@ asc apps list --bundle-id "com.example.app"
 asc apps list --name "My App"
 asc apps list --limit 10
 asc apps list --sort name
-asc apps list --iap-fields versions --subscription-group-fields versions
+asc apps list --app-info-fields kidsAgeBand --iap-fields versions --subscription-group-fields versions
 asc apps list --output table
 asc apps list --paginate
 ```
@@ -103,6 +109,11 @@ View app details by ID.
   App Store Connect app ID
 </ParamField>
 
+<ParamField path="--app-info-fields" type="string">
+  Sparse fields for included app-info records: the deprecated `kidsAgeBand`
+  selector. Automatically includes `appInfos`; prefer `asc age-rating view`.
+</ParamField>
+
 <ParamField path="--iap-fields" type="string">
   Sparse fields for included in-app purchases: `versions`. Automatically
   includes `inAppPurchases`.
@@ -121,7 +132,7 @@ View app details by ID.
 
 ```bash  theme={null}
 asc apps view --id "APP_ID"
-asc apps view --id "APP_ID" --iap-fields versions --subscription-group-fields versions
+asc apps view --id "APP_ID" --app-info-fields kidsAgeBand --iap-fields versions --subscription-group-fields versions
 asc apps view --id "APP_ID" --output table
 ```
 
@@ -155,7 +166,8 @@ kids age band and the age-rating declaration's social-media fields.
 </ParamField>
 
 <ParamField path="--fields" type="string">
-  Sparse app-info fields: `kidsAgeBand`
+  Sparse app-info fields: `kidsAgeBand`. Apple marks this selector deprecated;
+  prefer `asc age-rating view` for current age-rating data.
 </ParamField>
 
 <ParamField path="--age-rating-fields" type="string">
@@ -175,6 +187,13 @@ asc apps info list --app "APP_ID" --age-rating-fields socialMedia,socialMediaAge
   `fields[appInfos]=kidsAgeBand` value on app-info detail and collection reads.
   The CLI exposes the published schema while Apple's rollout catches up.
 </Note>
+
+<Warning>
+  `kidsAgeBand` remains available because it is present in the official API
+  4.4.1 sparse-field enum, but Apple marks it deprecated. New workflows should
+  read the age-rating declaration with `asc age-rating view`; use its `--fields`
+  flag for the API 4.4.1 social-media fields.
+</Warning>
 
 ### `asc apps info view`
 

--- a/commands/localizations.mdx
+++ b/commands/localizations.mdx
@@ -28,6 +28,13 @@ List localization metadata for an app or version.
   Localization type: `version` (default) or `app-info`
 </ParamField>
 
+<ParamField path="--app-info-fields" type="string">
+  Sparse app-info fields for `--type app-info`: the deprecated API 4.4.1
+  `kidsAgeBand` selector. Automatically includes `appInfo`. Prefer
+  `asc age-rating view` for current age-rating data. This flag is rejected for
+  other localization types and cannot be combined with `--next`.
+</ParamField>
+
 <ParamField path="--locale" type="string">
   Filter by locale(s), comma-separated (e.g., en-US,ja)
 </ParamField>
@@ -48,7 +55,7 @@ List localization metadata for an app or version.
 
 ```bash  theme={null}
 asc localizations list --version "VERSION_ID"
-asc localizations list --app "APP_ID" --type app-info
+asc localizations list --app "APP_ID" --type app-info --app-info-fields kidsAgeBand
 asc localizations list --version "VERSION_ID" --locale "en-US,ja"
 asc localizations list --version "VERSION_ID" --paginate
 ```

--- a/commands/xcode-cloud.mdx
+++ b/commands/xcode-cloud.mdx
@@ -149,6 +149,26 @@ asc xcode-cloud build-runs builds --run-id "BUILD_RUN_ID"
 * `--output` - Output format: `json`, `table`, `markdown`
 * `--pretty` - Pretty-print JSON output
 
+### xcode-cloud products app
+
+Get the app related to an Xcode Cloud product. API 4.4.1 can expose the new
+version relationships on included in-app purchases and subscription groups:
+
+```bash  theme={null}
+asc xcode-cloud products app \
+  --id "PRODUCT_ID" \
+  --iap-fields versions \
+  --subscription-group-fields versions
+```
+
+* `--id` - Xcode Cloud product ID (required)
+* `--iap-fields` - Sparse fields for included in-app purchases: `versions`;
+  automatically includes `inAppPurchases`
+* `--subscription-group-fields` - Sparse fields for included subscription
+  groups: `versions`; automatically includes `subscriptionGroups`
+* `--output` - Output format: `json`, `table`, `markdown`
+* `--pretty` - Pretty-print JSON output
+
 ### xcode-cloud actions
 
 List actions for a build run:

--- a/commands/xcode-cloud.mdx
+++ b/commands/xcode-cloud.mdx
@@ -152,16 +152,20 @@ asc xcode-cloud build-runs builds --run-id "BUILD_RUN_ID"
 ### xcode-cloud products app
 
 Get the app related to an Xcode Cloud product. API 4.4.1 can expose the new
-version relationships on included in-app purchases and subscription groups:
+app-info field and version relationships on included resources:
 
 ```bash  theme={null}
 asc xcode-cloud products app \
   --id "PRODUCT_ID" \
+  --app-info-fields kidsAgeBand \
   --iap-fields versions \
   --subscription-group-fields versions
 ```
 
 * `--id` - Xcode Cloud product ID (required)
+* `--app-info-fields` - Sparse fields for included app info: the deprecated
+  `kidsAgeBand` selector; automatically includes `appInfos`. Prefer
+  `asc age-rating view` for current age-rating data
 * `--iap-fields` - Sparse fields for included in-app purchases: `versions`;
   automatically includes `inAppPurchases`
 * `--subscription-group-fields` - Sparse fields for included subscription

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -86,6 +86,7 @@ separately and has no invented landed `main` commit:
 | Hardened public 4.4.1 command workflows | #1791 | `e9c2a0dc` | `e902d375` | Merged; documentation only |
 | Seven-property nullable request fidelity | #1792 | `3f7d1449` | `804624cd` | Merged; exact final head landed on `main` |
 | IAP and promoted-purchase related sparse fields | #1793 | `917d719d` | `f6b34d9e` | Merged; exact final head, six resolved threads, and green exact-head gates |
+| Subscription and pricing related sparse fields | #1795 | `229dc07c` | `5bf2d154` | Merged; exact final head landed on `main` |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#51 | `d7888b2b4a1a152f8524fc18c99d2d73d1c431fc` | `26b2fa92e612dff3477537f67b44f1bcfedf0fc5` | Merged; exact final head and landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
@@ -110,11 +111,12 @@ legacy omission behavior for a whitespace-only `customAppName` while retaining
 explicit JSON `null`; it landed on `main` as
 `804624cd158d1eb8843d8e0be7cf55bc639da0a1`.
 
-The current fully merged behavior integration is #1793 at `main` commit
-`f6b34d9e042964673ee39c32fbae4f7aa99fc874`; #1789 previously landed this
+The current fully merged behavior integration is #1795 at `main` commit
+`5bf2d1545785a863242a8509bf55cc25d8a4ab49`; #1789 previously landed this
 coverage ledger at `d6d8d94b`, test-only #1790 landed at `73466720`,
 docs-only #1791 landed at `e902d375`, and nullable-fidelity #1792 landed at
-`804624cd`. The 37-path, 47-operation, 47-schema, 102-direct, 71-transitive,
+`804624cd`; IAP sparse-field #1793 landed at `f6b34d9e`. The 37-path,
+47-operation, 47-schema, 102-direct, 71-transitive,
 173-contract, 61-modified-schema, and 9-addition/7-deprecation counts are
 unchanged. The recursive built-help comparison from `839c4da6` to `9282e82d`
 found 48 added and 52 changed leaf paths, 100 affected paths total, with zero
@@ -334,7 +336,7 @@ change.
 | Contract area | Semantic change | Verification owner | Exact evidence |
 | --- | --- | --- | --- |
 | IAP reads | `fields[inAppPurchases]` gains `versions`; IAP detail and app-IAP collection reads gain `include=versions`, `fields[inAppPurchaseVersions]`, and `limit[versions]` | #1777 and #1793 | `ee40c7b3`; #1793 final head `917d719d`, landed as `f6b34d9e`, adds all 11 propagated IAP/promoted-purchase GETs with endpoint-exact options, queries, stable owner selection, and response compatibility tests |
-| Subscription reads | Subscription detail and group-subscription reads gain version includes, sparse fields, and relationship limits; subscription sparse fields gain `versions` across related endpoints | #1779 plus the subscription sparse-field follow-up | `c8f3ab52` plus `subscription_sparse_fields_4_4_1_test.go`; exact query, stable owner selection, opaque-pagination, and compatibility tests across all 17 propagated subscription/pricing GETs |
+| Subscription reads | Subscription detail and group-subscription reads gain version includes, sparse fields, and relationship limits; subscription sparse fields gain `versions` across related endpoints | #1779 and #1795 | `c8f3ab52`; #1795 final head `229dc07c`, landed as `5bf2d154`, adds exact query, stable owner selection, opaque-pagination, and compatibility tests across all 17 propagated subscription/pricing GETs |
 | Subscription-group reads | Group detail and app-group collection reads gain version includes, sparse fields, and relationship limits; group sparse fields gain `versions` | #1780 | `48d04e0b`; exact query, owner/next validation, and compatibility tests |
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
 | Pricing reads | Price-point sparse fields gain `adjustedEqualizations`; existing equalization and price-point relationship operations gain `filter[upfrontPricePointId]` and `filter[planType]` where allowed | #1778 | `39284b0a`; endpoint-specific option, exact query, strict CSV/enums, territory inclusion, opaque-next, ID validation, and aggregation tests |
@@ -830,18 +832,20 @@ documented deprecation window; this goal intentionally stops before release.
     `26b2fa92e612dff3477537f67b44f1bcfedf0fc5`. All three PR #51 review
     threads are resolved; final-head exact-help validation covered 28 commands
     and 108 flags with zero failures, and the skill validator passed.
-20. Exact CLI `main` `f6b34d9e` is the current fully merged behavior integration
-    through #1793. Its PR head passed integration, Govulncheck, and CodeQL workflows.
+20. #1795 completed the subscription and pricing related sparse-field follow-up
+    at exact final head `229dc07c3b999777e9b03dd543f66c3c6898e705`
+    and landed on `main` as `5bf2d1545785a863242a8509bf55cc25d8a4ab49`.
+21. Exact CLI `main` `5bf2d154` is the current fully merged behavior integration
+    through #1795. Its PR head passed integration, Govulncheck, and CodeQL workflows.
     The historical built-help audit through #1788 found 48 added and 52 changed
     leaf paths relative to `839c4da6`, with zero removals; later flag-level help
     changes are verified by their focused command tests. Those historical
     counts do not replace #1792's typed nullable-encoding tests.
 
 CLI behavior and lifecycle PRs through #1788, the ledger PR, test-only #1790,
-docs-only #1791, nullable-fidelity #1792, IAP sparse-field #1793, and the
-companion skills PR are merged. The subscription and pricing sparse-field
-follow-up is verified by its endpoint ledger and exact-query tests in this
-branch. No release, tag, or package publication is part of this goal.
+docs-only #1791, nullable-fidelity #1792, IAP sparse-field #1793,
+subscription/pricing sparse-field #1795, and the companion skills PR are merged.
+No release, tag, or package publication is part of this goal.
 
 ### Built help-surface delta
 
@@ -1044,8 +1048,8 @@ pre-merge evidence are separated explicitly:
   read succeeded, all four age fields were restored to `false`, and all four
   review submissions contained zero items. This predates #1792 and is not
   evidence that Apple accepts explicit null for its seven corrected fields.
-- [x] Confirmed the fully merged behavior integration through #1793, `main`
-  `f6b34d9e`, follows green exact-head integration, Govulncheck, and CodeQL
+- [x] Confirmed the fully merged behavior integration through #1795, `main`
+  `5bf2d154`, follows green exact-head integration, Govulncheck, and CodeQL
   workflows; #1789 previously landed
   the ledger at `d6d8d94b`, test-only #1790 landed at `73466720`, docs-only
   #1791 landed at `e902d375`, and nullable-fidelity #1792 landed at

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -87,6 +87,7 @@ separately and has no invented landed `main` commit:
 | Seven-property nullable request fidelity | #1792 | `3f7d1449` | `804624cd` | Merged; exact final head landed on `main` |
 | IAP and promoted-purchase related sparse fields | #1793 | `917d719d` | `f6b34d9e` | Merged; exact final head, six resolved threads, and green exact-head gates |
 | Subscription and pricing related sparse fields | #1795 | `229dc07c` | `5bf2d154` | Merged; exact final head landed on `main` |
+| App-info related sparse-field query transport | #1796 | — | — | Open; current PR, exact endpoint transport and CLI follow-up |
 | External ASC workflow skills | rorkai/app-store-connect-cli-skills#51 | `d7888b2b4a1a152f8524fc18c99d2d73d1c431fc` | `26b2fa92e612dff3477537f67b44f1bcfedf0fc5` | Merged; exact final head and landed tree revalidated |
 
 The hard audit fixed contract gaps beyond the initial six implementation PRs:
@@ -122,6 +123,10 @@ unchanged. The recursive built-help comparison from `839c4da6` to `9282e82d`
 found 48 added and 52 changed leaf paths, 100 affected paths total, with zero
 removals; it is historical help-surface evidence rather than the nullable
 request-encoding proof, which is carried by #1792's typed tests.
+
+#1796 is an open follow-up. It supplies the operation-specific app-info query
+transport and public CLI validation missing from the merged response-decoding
+work; it is not part of the fully merged integration claim above.
 
 ## Live App Store Connect verification
 
@@ -341,7 +346,7 @@ change.
 | Review submission reads | Review-item sparse fields and includes gain `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion` | #1781 | `aba35e0a`; all four changed GET surfaces, automatic item inclusion, and response round-trip tests |
 | Pricing reads | Price-point sparse fields gain `adjustedEqualizations`; existing equalization and price-point relationship operations gain `filter[upfrontPricePointId]` and `filter[planType]` where allowed | #1778 | `39284b0a`; endpoint-specific option, exact query, strict CSV/enums, territory inclusion, opaque-next, ID validation, and aggregation tests |
 | Age rating reads and update | Age-rating sparse fields and update schema gain `socialMedia` and `socialMediaAgeRestricted` | #1778 and #1792 | `39284b0a` added the fields and CLI behavior; #1792 final head `3f7d1449`, landed as `804624cd`, adds exact omit/value/null request encoding |
-| App info reads | `AppInfo.attributes.kidsAgeBand` and `fields[appInfos]=kidsAgeBand` appear as deprecated additions | #1778 | `39284b0a`; generic decoding/output characterization, no new write path |
+| App info reads | `AppInfo.attributes.kidsAgeBand` and `fields[appInfos]=kidsAgeBand` appear as deprecated additions | #1778 and #1796 | #1778 at `39284b0a` adds response decoding and output characterization; open #1796 adds exact operation-specific query transport, CLI flags and automatic includes, strict validation, and query-cardinality tests across all seven `fields[appInfos]` reads |
 | Included-resource unions | IAP, subscription, group, and review-submission responses gain their corresponding version resource discriminators | #1777, #1779, #1780, #1781 | `ee40c7b3`, `c8f3ab52`, `48d04e0b`, `aba35e0a`; typed response and included-resource tests |
 
 No existing operation changes from nondeprecated to `deprecated: true` in the
@@ -507,8 +512,9 @@ immediate pre-PR base plus 52 changes already reconciled after the 4.4 import.
 Schema-mediated request-contract changes are listed separately after it and do
 not alter this count.
 
-Age rating and app info (#1778 at `39284b0a`; sparse-field, typed-decoder,
-payload, output, and compatibility tests):
+Age rating and app info (#1778 at `39284b0a` covers response decoding and
+update behavior; open #1796 covers exact sparse-query transport, CLI flags,
+and query-cardinality tests):
 
 - [x] `GET /v1/appInfoLocalizations/{id}`
 - [x] `GET /v1/appInfos/{id}`

--- a/docs/design/app-store-connect-api-4.4.1-sparse-app-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-sparse-app-fields.md
@@ -44,9 +44,11 @@ Commands add it deterministically and preserve explicit compatible includes.
 ## Validation and compatibility
 
 The new flags are additive. They validate against the exact new enum members
-before authentication or HTTP. On paginated app lists, `--next` cannot be
-combined with any sparse-field flag because the continuation URL owns the full
-query. Existing invocations and output shapes are unchanged.
+before authentication or HTTP, and explicitly provided empty or whitespace-only
+values are rejected. On paginated app lists and app-info localization reads,
+`--next` cannot be combined with any sparse-field flag, even when that flag's
+explicit value is empty, because the continuation URL owns the full query.
+Existing invocations and output shapes are unchanged.
 
 The typed client keeps operation-specific query structs and functional options;
 there is intentionally no universal query map. Invalid or unsupported values

--- a/docs/design/app-store-connect-api-4.4.1-sparse-app-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-sparse-app-fields.md
@@ -6,7 +6,8 @@ This slice covers eight existing GET operations whose sparse-field enums gained
 new values in App Store Connect API 4.4.1. It extends the existing typed clients
 and the closest existing commands; it does not add a generic query escape hatch.
 
-- `asc apps list` and `asc apps view` accept `--iap-fields versions` and
+- `asc apps list` and `asc apps view` accept
+  `--app-info-fields kidsAgeBand`, `--iap-fields versions`, and
   `--subscription-group-fields versions`, automatically including the matching
   relationship.
 - `asc apps info list` and the app-info form of `asc apps info view` accept
@@ -15,11 +16,18 @@ and the closest existing commands; it does not add a generic query escape hatch.
   including `ageRatingDeclaration`.
 - `asc age-rating view` accepts
   `--fields socialMedia,socialMediaAgeRestricted`.
+- `asc localizations list --type app-info` accepts
+  `--app-info-fields kidsAgeBand`, automatically including `appInfo`.
 - `asc xcode-cloud products app` accepts `--iap-fields versions` and
   `--subscription-group-fields versions`, automatically including the matching
   relationship.
-- The app-info-localization detail and collection operations have typed client
-  options only because there is no direct CLI read command for those resources.
+- The app-info-localization detail operation has typed client options only;
+  the collection operation is exposed by `asc localizations list --type app-info`.
+
+Apple marks `kidsAgeBand` deprecated even though API 4.4.1 adds it to these
+sparse-field enums. The CLI supports the published selector for compatibility,
+labels it deprecated, and guides new workflows to `asc age-rating view` and its
+current age-rating fields.
 
 All flags use the exact OpenAPI field names and comma-separated long-form CLI
 syntax. JSON remains the default non-TTY output and errors remain on stderr.
@@ -30,12 +38,12 @@ syntax. JSON remains the default non-TTY output and errors remain on stderr.
 | --- | --- |
 | `GET /v1/appInfoLocalizations/{id}` | `fields[appInfos]=kidsAgeBand` |
 | `GET /v1/appInfos/{id}` | `fields[appInfos]=kidsAgeBand`; `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` |
-| `GET /v1/apps` | `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
-| `GET /v1/apps/{id}` | `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
+| `GET /v1/apps` | `fields[appInfos]=kidsAgeBand`; `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
+| `GET /v1/apps/{id}` | `fields[appInfos]=kidsAgeBand`; `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
 | `GET /v1/appInfos/{id}/ageRatingDeclaration` | `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` |
 | `GET /v1/appInfos/{id}/appInfoLocalizations` | `fields[appInfos]=kidsAgeBand` |
 | `GET /v1/apps/{id}/appInfos` | `fields[appInfos]=kidsAgeBand`; `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` |
-| `GET /v1/ciProducts/{id}/app` | `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
+| `GET /v1/ciProducts/{id}/app` | `fields[appInfos]=kidsAgeBand`; `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
 
 Relationship sparse fields require the corresponding `include` value:
 `appInfo`, `ageRatingDeclaration`, `inAppPurchases`, or `subscriptionGroups`.
@@ -45,10 +53,12 @@ Commands add it deterministically and preserve explicit compatible includes.
 
 The new flags are additive. They validate against the exact new enum members
 before authentication or HTTP, and explicitly provided empty or whitespace-only
-values are rejected. On paginated app lists and app-info localization reads,
-`--next` cannot be combined with any sparse-field flag, even when that flag's
-explicit value is empty, because the continuation URL owns the full query.
-Existing invocations and output shapes are unchanged.
+values are rejected. `--app-info-fields` is rejected on non-app-info
+localization types rather than silently ignored. On paginated app lists,
+app-info localization reads, and the app-info command's paginated localization
+mode, `--next` cannot be combined with a sparse-field flag, even when that
+flag's explicit value is empty, because the continuation URL owns the full
+query. Existing invocations and output shapes are unchanged.
 
 The typed client keeps operation-specific query structs and functional options;
 there is intentionally no universal query map. Invalid or unsupported values

--- a/docs/design/app-store-connect-api-4.4.1-sparse-app-fields.md
+++ b/docs/design/app-store-connect-api-4.4.1-sparse-app-fields.md
@@ -1,0 +1,88 @@
+# App Store Connect API 4.4.1 sparse app fields
+
+## Placement and command shape
+
+This slice covers eight existing GET operations whose sparse-field enums gained
+new values in App Store Connect API 4.4.1. It extends the existing typed clients
+and the closest existing commands; it does not add a generic query escape hatch.
+
+- `asc apps list` and `asc apps view` accept `--iap-fields versions` and
+  `--subscription-group-fields versions`, automatically including the matching
+  relationship.
+- `asc apps info list` and the app-info form of `asc apps info view` accept
+  `--fields kidsAgeBand`; both accept
+  `--age-rating-fields socialMedia,socialMediaAgeRestricted`, automatically
+  including `ageRatingDeclaration`.
+- `asc age-rating view` accepts
+  `--fields socialMedia,socialMediaAgeRestricted`.
+- `asc xcode-cloud products app` accepts `--iap-fields versions` and
+  `--subscription-group-fields versions`, automatically including the matching
+  relationship.
+- The app-info-localization detail and collection operations have typed client
+  options only because there is no direct CLI read command for those resources.
+
+All flags use the exact OpenAPI field names and comma-separated long-form CLI
+syntax. JSON remains the default non-TTY output and errors remain on stderr.
+
+## Endpoint contract
+
+| Method and path | New 4.4.1 query value |
+| --- | --- |
+| `GET /v1/appInfoLocalizations/{id}` | `fields[appInfos]=kidsAgeBand` |
+| `GET /v1/appInfos/{id}` | `fields[appInfos]=kidsAgeBand`; `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` |
+| `GET /v1/apps` | `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
+| `GET /v1/apps/{id}` | `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
+| `GET /v1/appInfos/{id}/ageRatingDeclaration` | `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` |
+| `GET /v1/appInfos/{id}/appInfoLocalizations` | `fields[appInfos]=kidsAgeBand` |
+| `GET /v1/apps/{id}/appInfos` | `fields[appInfos]=kidsAgeBand`; `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` |
+| `GET /v1/ciProducts/{id}/app` | `fields[inAppPurchases]=versions`; `fields[subscriptionGroups]=versions` |
+
+Relationship sparse fields require the corresponding `include` value:
+`appInfo`, `ageRatingDeclaration`, `inAppPurchases`, or `subscriptionGroups`.
+Commands add it deterministically and preserve explicit compatible includes.
+
+## Validation and compatibility
+
+The new flags are additive. They validate against the exact new enum members
+before authentication or HTTP. On paginated app lists, `--next` cannot be
+combined with any sparse-field flag because the continuation URL owns the full
+query. Existing invocations and output shapes are unchanged.
+
+The typed client keeps operation-specific query structs and functional options;
+there is intentionally no universal query map. Invalid or unsupported values
+cannot be smuggled through the public CLI.
+
+## Verification
+
+RED coverage establishes missing query propagation, strict CLI enums, automatic
+includes, and `--next` conflicts. GREEN coverage asserts exact paths and query
+keys with `httptest`, CLI behavior before auth, and representative command HTTP
+requests. The slice is then checked with focused packages, generated command
+docs, the repository gates, and a read-only live smoke test.
+
+Alternatives rejected:
+
+- A raw `--query` map would expose unsupported values and violate typed command
+  validation.
+- Separate commands for the new fields would duplicate existing resource
+  taxonomy without adding capability.
+
+## Live evidence (July 17, 2026)
+
+Read-only checks used disposable app `6759231657`:
+
+- `fields[inAppPurchases]=versions` and
+  `fields[subscriptionGroups]=versions` with their automatic includes returned
+  `200` from `GET /v1/apps/{id}`.
+- `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted` returned
+  `200` both from the direct age-rating operation and when included from app
+  info detail and collection operations.
+- Apple production returned `400` (`'kidsAgeBand' is not a valid field name`)
+  for the exact official 4.4.1 `fields[appInfos]=kidsAgeBand` query on app info
+  detail and collection operations. The implementation intentionally retains
+  the official OpenAPI contract; this is recorded as an upstream rollout lag,
+  not hidden by client-side fallback.
+- The disposable app has no Xcode Cloud product, so the product-to-app variant
+  remains covered by exact HTTP and CLI transport tests rather than a live call.
+
+No App Store Connect resource was created, changed, or deleted by these checks.

--- a/internal/asc/age_rating.go
+++ b/internal/asc/age_rating.go
@@ -94,8 +94,16 @@ type AgeRatingDeclarationUpdateRequest struct {
 }
 
 // GetAgeRatingDeclarationForAppInfo retrieves the age rating declaration for an app info.
-func (c *Client) GetAgeRatingDeclarationForAppInfo(ctx context.Context, appInfoID string) (*AgeRatingDeclarationResponse, error) {
+func (c *Client) GetAgeRatingDeclarationForAppInfo(ctx context.Context, appInfoID string, opts ...AgeRatingDeclarationOption) (*AgeRatingDeclarationResponse, error) {
+	query := &ageRatingDeclarationQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	path := fmt.Sprintf("/v1/appInfos/%s/ageRatingDeclaration", appInfoID)
+	if queryString := buildAgeRatingDeclarationQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -113,12 +121,12 @@ func (c *Client) GetAgeRatingDeclarationForAppInfo(ctx context.Context, appInfoI
 //
 // Apple removed the version-scoped endpoint in API 4.3, so this now resolves the
 // backing app info and retrieves the declaration from the supported app-info path.
-func (c *Client) GetAgeRatingDeclarationForAppStoreVersion(ctx context.Context, versionID string) (*AgeRatingDeclarationResponse, error) {
+func (c *Client) GetAgeRatingDeclarationForAppStoreVersion(ctx context.Context, versionID string, opts ...AgeRatingDeclarationOption) (*AgeRatingDeclarationResponse, error) {
 	appInfoID, err := c.ResolveAppInfoIDForAppStoreVersion(ctx, versionID)
 	if err != nil {
 		return nil, err
 	}
-	return c.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID)
+	return c.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID, opts...)
 }
 
 // UpdateAgeRatingDeclaration updates an age rating declaration by ID.

--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1616,13 +1616,21 @@ func (c *Client) UpdateAppInfoLocalizationFields(ctx context.Context, localizati
 }
 
 // GetAppInfoLocalization retrieves an app info localization by ID.
-func (c *Client) GetAppInfoLocalization(ctx context.Context, localizationID string) (*AppInfoLocalizationResponse, error) {
+func (c *Client) GetAppInfoLocalization(ctx context.Context, localizationID string, opts ...AppInfoLocalizationOption) (*AppInfoLocalizationResponse, error) {
+	query := &appInfoLocalizationQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	localizationID = strings.TrimSpace(localizationID)
 	if localizationID == "" {
 		return nil, fmt.Errorf("localizationID is required")
 	}
 
 	path := fmt.Sprintf("/v1/appInfoLocalizations/%s", localizationID)
+	if queryString := buildAppInfoLocalizationQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_apps.go
+++ b/internal/asc/client_apps.go
@@ -101,8 +101,21 @@ func (c *Client) GetApps(ctx context.Context, opts ...AppsOption) (*AppsResponse
 
 // GetApp retrieves a single app by ID.
 func (c *Client) GetApp(ctx context.Context, appID string) (*AppResponse, error) {
+	return c.GetAppWithOptions(ctx, appID)
+}
+
+// GetAppWithOptions retrieves a single app by ID with sparse fields and includes.
+func (c *Client) GetAppWithOptions(ctx context.Context, appID string, opts ...AppOption) (*AppResponse, error) {
+	query := &appQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	appID = strings.TrimSpace(appID)
 	path := fmt.Sprintf("/v1/apps/%s", appID)
+	if queryString := buildAppQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_query_apps.go
+++ b/internal/asc/client_query_apps.go
@@ -12,6 +12,7 @@ type appsQuery struct {
 	bundleIDs               []string
 	names                   []string
 	skus                    []string
+	appInfoFields           []string
 	inAppPurchaseFields     []string
 	subscriptionGroupFields []string
 	include                 []string
@@ -106,6 +107,7 @@ func buildAppsQuery(query *appsQuery) string {
 	if query.sort != "" {
 		values.Set("sort", query.sort)
 	}
+	addCSV(values, "fields[appInfos]", query.appInfoFields)
 	addCSV(values, "fields[inAppPurchases]", query.inAppPurchaseFields)
 	addCSV(values, "fields[subscriptionGroups]", query.subscriptionGroupFields)
 	addCSV(values, "include", query.include)
@@ -451,6 +453,13 @@ func WithAppsSKUs(skus []string) AppsOption {
 func WithAppsInAppPurchaseFields(fields []string) AppsOption {
 	return func(q *appsQuery) {
 		q.inAppPurchaseFields = normalizeList(fields)
+	}
+}
+
+// WithAppsAppInfoFields sets fields[appInfos].
+func WithAppsAppInfoFields(fields []string) AppsOption {
+	return func(q *appsQuery) {
+		q.appInfoFields = normalizeList(fields)
 	}
 }
 

--- a/internal/asc/client_query_apps.go
+++ b/internal/asc/client_query_apps.go
@@ -8,10 +8,13 @@ import (
 
 type appsQuery struct {
 	listQuery
-	sort      string
-	bundleIDs []string
-	names     []string
-	skus      []string
+	sort                    string
+	bundleIDs               []string
+	names                   []string
+	skus                    []string
+	inAppPurchaseFields     []string
+	subscriptionGroupFields []string
+	include                 []string
 }
 
 type appSearchKeywordsQuery struct {
@@ -103,6 +106,9 @@ func buildAppsQuery(query *appsQuery) string {
 	if query.sort != "" {
 		values.Set("sort", query.sort)
 	}
+	addCSV(values, "fields[inAppPurchases]", query.inAppPurchaseFields)
+	addCSV(values, "fields[subscriptionGroups]", query.subscriptionGroupFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -438,6 +444,27 @@ func WithAppsNames(names []string) AppsOption {
 func WithAppsSKUs(skus []string) AppsOption {
 	return func(q *appsQuery) {
 		q.skus = normalizeList(skus)
+	}
+}
+
+// WithAppsInAppPurchaseFields sets fields[inAppPurchases].
+func WithAppsInAppPurchaseFields(fields []string) AppsOption {
+	return func(q *appsQuery) {
+		q.inAppPurchaseFields = normalizeList(fields)
+	}
+}
+
+// WithAppsSubscriptionGroupFields sets fields[subscriptionGroups].
+func WithAppsSubscriptionGroupFields(fields []string) AppsOption {
+	return func(q *appsQuery) {
+		q.subscriptionGroupFields = normalizeList(fields)
+	}
+}
+
+// WithAppsInclude includes related resources in app collection responses.
+func WithAppsInclude(include []string) AppsOption {
+	return func(q *appsQuery) {
+		q.include = normalizeList(include)
 	}
 }
 

--- a/internal/asc/client_query_sparse_app_fields.go
+++ b/internal/asc/client_query_sparse_app_fields.go
@@ -1,0 +1,112 @@
+package asc
+
+import (
+	"net/url"
+)
+
+type appQuery struct {
+	inAppPurchaseFields     []string
+	subscriptionGroupFields []string
+	include                 []string
+}
+
+type appInfoLocalizationQuery struct {
+	appInfoFields []string
+	include       []string
+}
+
+type ageRatingDeclarationQuery struct {
+	fields []string
+}
+
+type ciProductAppQuery struct {
+	inAppPurchaseFields     []string
+	subscriptionGroupFields []string
+	include                 []string
+}
+
+// AppOption configures an app detail request.
+type AppOption func(*appQuery)
+
+// AppInfoLocalizationOption configures an app info localization detail request.
+type AppInfoLocalizationOption func(*appInfoLocalizationQuery)
+
+// AgeRatingDeclarationOption configures an age rating declaration read request.
+type AgeRatingDeclarationOption func(*ageRatingDeclarationQuery)
+
+// CiProductAppOption configures the app request for a CI product.
+type CiProductAppOption func(*ciProductAppQuery)
+
+func buildAppQuery(query *appQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.inAppPurchaseFields)
+	addCSV(values, "fields[subscriptionGroups]", query.subscriptionGroupFields)
+	addCSV(values, "include", query.include)
+	return values.Encode()
+}
+
+func buildAppInfoLocalizationQuery(query *appInfoLocalizationQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[appInfos]", query.appInfoFields)
+	addCSV(values, "include", query.include)
+	return values.Encode()
+}
+
+func buildAgeRatingDeclarationQuery(query *ageRatingDeclarationQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[ageRatingDeclarations]", query.fields)
+	return values.Encode()
+}
+
+func buildCiProductAppQuery(query *ciProductAppQuery) string {
+	values := url.Values{}
+	addCSV(values, "fields[inAppPurchases]", query.inAppPurchaseFields)
+	addCSV(values, "fields[subscriptionGroups]", query.subscriptionGroupFields)
+	addCSV(values, "include", query.include)
+	return values.Encode()
+}
+
+// WithAppInAppPurchaseFields sets fields[inAppPurchases].
+func WithAppInAppPurchaseFields(fields []string) AppOption {
+	return func(q *appQuery) { q.inAppPurchaseFields = normalizeList(fields) }
+}
+
+// WithAppSubscriptionGroupFields sets fields[subscriptionGroups].
+func WithAppSubscriptionGroupFields(fields []string) AppOption {
+	return func(q *appQuery) { q.subscriptionGroupFields = normalizeList(fields) }
+}
+
+// WithAppInclude includes related resources in an app detail response.
+func WithAppInclude(include []string) AppOption {
+	return func(q *appQuery) { q.include = normalizeList(include) }
+}
+
+// WithAppInfoLocalizationAppInfoFields sets fields[appInfos].
+func WithAppInfoLocalizationAppInfoFields(fields []string) AppInfoLocalizationOption {
+	return func(q *appInfoLocalizationQuery) { q.appInfoFields = normalizeList(fields) }
+}
+
+// WithAppInfoLocalizationInclude includes related resources.
+func WithAppInfoLocalizationInclude(include []string) AppInfoLocalizationOption {
+	return func(q *appInfoLocalizationQuery) { q.include = normalizeList(include) }
+}
+
+// WithAgeRatingDeclarationFields sets fields[ageRatingDeclarations].
+func WithAgeRatingDeclarationFields(fields []string) AgeRatingDeclarationOption {
+	return func(q *ageRatingDeclarationQuery) { q.fields = normalizeList(fields) }
+}
+
+// WithCiProductAppInAppPurchaseFields sets fields[inAppPurchases].
+func WithCiProductAppInAppPurchaseFields(fields []string) CiProductAppOption {
+	return func(q *ciProductAppQuery) { q.inAppPurchaseFields = normalizeList(fields) }
+}
+
+// WithCiProductAppSubscriptionGroupFields sets fields[subscriptionGroups].
+func WithCiProductAppSubscriptionGroupFields(fields []string) CiProductAppOption {
+	return func(q *ciProductAppQuery) { q.subscriptionGroupFields = normalizeList(fields) }
+}
+
+// WithCiProductAppInclude includes related resources in the app response.
+func WithCiProductAppInclude(include []string) CiProductAppOption {
+	return func(q *ciProductAppQuery) { q.include = normalizeList(include) }
+}

--- a/internal/asc/client_query_sparse_app_fields.go
+++ b/internal/asc/client_query_sparse_app_fields.go
@@ -5,6 +5,7 @@ import (
 )
 
 type appQuery struct {
+	appInfoFields           []string
 	inAppPurchaseFields     []string
 	subscriptionGroupFields []string
 	include                 []string
@@ -20,6 +21,7 @@ type ageRatingDeclarationQuery struct {
 }
 
 type ciProductAppQuery struct {
+	appInfoFields           []string
 	inAppPurchaseFields     []string
 	subscriptionGroupFields []string
 	include                 []string
@@ -39,6 +41,7 @@ type CiProductAppOption func(*ciProductAppQuery)
 
 func buildAppQuery(query *appQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[appInfos]", query.appInfoFields)
 	addCSV(values, "fields[inAppPurchases]", query.inAppPurchaseFields)
 	addCSV(values, "fields[subscriptionGroups]", query.subscriptionGroupFields)
 	addCSV(values, "include", query.include)
@@ -60,6 +63,7 @@ func buildAgeRatingDeclarationQuery(query *ageRatingDeclarationQuery) string {
 
 func buildCiProductAppQuery(query *ciProductAppQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[appInfos]", query.appInfoFields)
 	addCSV(values, "fields[inAppPurchases]", query.inAppPurchaseFields)
 	addCSV(values, "fields[subscriptionGroups]", query.subscriptionGroupFields)
 	addCSV(values, "include", query.include)
@@ -69,6 +73,11 @@ func buildCiProductAppQuery(query *ciProductAppQuery) string {
 // WithAppInAppPurchaseFields sets fields[inAppPurchases].
 func WithAppInAppPurchaseFields(fields []string) AppOption {
 	return func(q *appQuery) { q.inAppPurchaseFields = normalizeList(fields) }
+}
+
+// WithAppAppInfoFields sets fields[appInfos].
+func WithAppAppInfoFields(fields []string) AppOption {
+	return func(q *appQuery) { q.appInfoFields = normalizeList(fields) }
 }
 
 // WithAppSubscriptionGroupFields sets fields[subscriptionGroups].
@@ -99,6 +108,11 @@ func WithAgeRatingDeclarationFields(fields []string) AgeRatingDeclarationOption 
 // WithCiProductAppInAppPurchaseFields sets fields[inAppPurchases].
 func WithCiProductAppInAppPurchaseFields(fields []string) CiProductAppOption {
 	return func(q *ciProductAppQuery) { q.inAppPurchaseFields = normalizeList(fields) }
+}
+
+// WithCiProductAppAppInfoFields sets fields[appInfos].
+func WithCiProductAppAppInfoFields(fields []string) CiProductAppOption {
+	return func(q *ciProductAppQuery) { q.appInfoFields = normalizeList(fields) }
 }
 
 // WithCiProductAppSubscriptionGroupFields sets fields[subscriptionGroups].

--- a/internal/asc/client_query_versions.go
+++ b/internal/asc/client_query_versions.go
@@ -61,12 +61,16 @@ type appStoreVersionLocalizationsQuery struct {
 
 type appInfoLocalizationsQuery struct {
 	listQuery
-	locales []string
+	locales       []string
+	appInfoFields []string
+	include       []string
 }
 
 type appInfoQuery struct {
-	include            []string
-	localizationsLimit int
+	fields                     []string
+	ageRatingDeclarationFields []string
+	include                    []string
+	localizationsLimit         int
 }
 
 type territoryAgeRatingsQuery struct {
@@ -242,12 +246,16 @@ func buildAppStoreVersionLocalizationsQuery(query *appStoreVersionLocalizationsQ
 func buildAppInfoLocalizationsQuery(query *appInfoLocalizationsQuery) string {
 	values := url.Values{}
 	addCSV(values, "filter[locale]", query.locales)
+	addCSV(values, "fields[appInfos]", query.appInfoFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }
 
 func buildAppInfoQuery(query *appInfoQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[appInfos]", query.fields)
+	addCSV(values, "fields[ageRatingDeclarations]", query.ageRatingDeclarationFields)
 	addCSV(values, "include", query.include)
 	if query.localizationsLimit > 0 {
 		values.Set("limit[appInfoLocalizations]", strconv.Itoa(query.localizationsLimit))
@@ -791,6 +799,34 @@ func WithAppInfoLocalizationsNextURL(next string) AppInfoLocalizationsOption {
 func WithAppInfoLocalizationLocales(locales []string) AppInfoLocalizationsOption {
 	return func(q *appInfoLocalizationsQuery) {
 		q.locales = normalizeList(locales)
+	}
+}
+
+// WithAppInfoLocalizationsAppInfoFields sets fields[appInfos].
+func WithAppInfoLocalizationsAppInfoFields(fields []string) AppInfoLocalizationsOption {
+	return func(q *appInfoLocalizationsQuery) {
+		q.appInfoFields = normalizeList(fields)
+	}
+}
+
+// WithAppInfoLocalizationsInclude includes related resources.
+func WithAppInfoLocalizationsInclude(include []string) AppInfoLocalizationsOption {
+	return func(q *appInfoLocalizationsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithAppInfoFields sets fields[appInfos].
+func WithAppInfoFields(fields []string) AppInfoOption {
+	return func(q *appInfoQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
+// WithAppInfoAgeRatingDeclarationFields sets fields[ageRatingDeclarations].
+func WithAppInfoAgeRatingDeclarationFields(fields []string) AppInfoOption {
+	return func(q *appInfoQuery) {
+		q.ageRatingDeclarationFields = normalizeList(fields)
 	}
 }
 

--- a/internal/asc/client_query_versions.go
+++ b/internal/asc/client_query_versions.go
@@ -254,9 +254,16 @@ func buildAppInfoLocalizationsQuery(query *appInfoLocalizationsQuery) string {
 
 func buildAppInfoQuery(query *appInfoQuery) string {
 	values := url.Values{}
-	addCSV(values, "fields[appInfos]", query.fields)
+	include := normalizeUniqueList(query.include)
+	fields := normalizeUniqueList(query.fields)
+	if len(fields) > 0 {
+		// A primary sparse fieldset must retain every included relationship or
+		// ASC can omit the linkage and included resource from the response.
+		fields = normalizeUniqueList(append(fields, include...))
+	}
+	addCSV(values, "fields[appInfos]", fields)
 	addCSV(values, "fields[ageRatingDeclarations]", query.ageRatingDeclarationFields)
-	addCSV(values, "include", query.include)
+	addCSV(values, "include", include)
 	if query.localizationsLimit > 0 {
 		values.Set("limit[appInfoLocalizations]", strconv.Itoa(query.localizationsLimit))
 	}

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -1032,18 +1032,35 @@ func TestBuildAppStoreVersionQuery(t *testing.T) {
 
 func TestBuildAppInfoQuery(t *testing.T) {
 	query := &appInfoQuery{}
-	WithAppInfoInclude([]string{"ageRatingDeclaration", "territoryAgeRatings"})(query)
+	WithAppInfoInclude([]string{"ageRatingDeclaration", "primaryCategory"})(query)
 	WithAppInfoLocalizationsIncludeLimit(50)(query)
 
 	values, err := url.ParseQuery(buildAppInfoQuery(query))
 	if err != nil {
 		t.Fatalf("failed to parse query: %v", err)
 	}
-	if got := values.Get("include"); got != "ageRatingDeclaration,territoryAgeRatings" {
-		t.Fatalf("expected include=ageRatingDeclaration,territoryAgeRatings, got %q", got)
+	if got := values.Get("include"); got != "ageRatingDeclaration,primaryCategory" {
+		t.Fatalf("expected include=ageRatingDeclaration,primaryCategory, got %q", got)
 	}
 	if got := values.Get("limit[appInfoLocalizations]"); got != "50" {
 		t.Fatalf("expected localization include limit 50, got %q", got)
+	}
+}
+
+func TestBuildAppInfoQueryAddsIncludedRelationshipsToSparseFields(t *testing.T) {
+	query := &appInfoQuery{}
+	WithAppInfoFields([]string{"kidsAgeBand", "ageRatingDeclaration"})(query)
+	WithAppInfoInclude([]string{"ageRatingDeclaration", "primaryCategory", "ageRatingDeclaration"})(query)
+
+	values, err := url.ParseQuery(buildAppInfoQuery(query))
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+	if got := values["fields[appInfos]"]; len(got) != 1 || got[0] != "kidsAgeBand,ageRatingDeclaration,primaryCategory" {
+		t.Fatalf("fields[appInfos] = %q, want one ordered, deduplicated value", got)
+	}
+	if got := values["include"]; len(got) != 1 || got[0] != "ageRatingDeclaration,primaryCategory" {
+		t.Fatalf("include = %q, want one ordered, deduplicated value", got)
 	}
 }
 

--- a/internal/asc/openapi_441_sparse_app_fields_test.go
+++ b/internal/asc/openapi_441_sparse_app_fields_test.go
@@ -1,0 +1,188 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestOpenAPI441SparseAppFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantPath  string
+		wantQuery map[string]string
+		response  string
+		call      func(*Client) error
+	}{
+		{
+			name:     "app info localization detail",
+			wantPath: "/v1/appInfoLocalizations/loc-1",
+			wantQuery: map[string]string{
+				"fields[appInfos]": "kidsAgeBand",
+				"include":          "appInfo",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetAppInfoLocalization(
+					context.Background(), "loc-1",
+					WithAppInfoLocalizationAppInfoFields([]string{"kidsAgeBand"}),
+					WithAppInfoLocalizationInclude([]string{"appInfo"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "app info detail",
+			wantPath: "/v1/appInfos/info-1",
+			wantQuery: map[string]string{
+				"fields[appInfos]":              "kidsAgeBand",
+				"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted",
+				"include":                       "ageRatingDeclaration",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetAppInfo(
+					context.Background(), "info-1",
+					WithAppInfoFields([]string{"kidsAgeBand"}),
+					WithAppInfoAgeRatingDeclarationFields([]string{"socialMedia", "socialMediaAgeRestricted"}),
+					WithAppInfoInclude([]string{"ageRatingDeclaration"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "apps list",
+			wantPath: "/v1/apps",
+			response: `{"data":[]}`,
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]":     "versions",
+				"fields[subscriptionGroups]": "versions",
+				"include":                    "inAppPurchases,subscriptionGroups",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetApps(
+					context.Background(),
+					WithAppsInAppPurchaseFields([]string{"versions"}),
+					WithAppsSubscriptionGroupFields([]string{"versions"}),
+					WithAppsInclude([]string{"inAppPurchases", "subscriptionGroups"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "app detail",
+			wantPath: "/v1/apps/app-1",
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]":     "versions",
+				"fields[subscriptionGroups]": "versions",
+				"include":                    "inAppPurchases,subscriptionGroups",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetAppWithOptions(
+					context.Background(), "app-1",
+					WithAppInAppPurchaseFields([]string{"versions"}),
+					WithAppSubscriptionGroupFields([]string{"versions"}),
+					WithAppInclude([]string{"inAppPurchases", "subscriptionGroups"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "age rating for app info",
+			wantPath: "/v1/appInfos/info-1/ageRatingDeclaration",
+			wantQuery: map[string]string{
+				"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetAgeRatingDeclarationForAppInfo(
+					context.Background(), "info-1",
+					WithAgeRatingDeclarationFields([]string{"socialMedia", "socialMediaAgeRestricted"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "app info localizations",
+			wantPath: "/v1/appInfos/info-1/appInfoLocalizations",
+			response: `{"data":[]}`,
+			wantQuery: map[string]string{
+				"fields[appInfos]": "kidsAgeBand",
+				"include":          "appInfo",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetAppInfoLocalizations(
+					context.Background(), "info-1",
+					WithAppInfoLocalizationsAppInfoFields([]string{"kidsAgeBand"}),
+					WithAppInfoLocalizationsInclude([]string{"appInfo"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "app infos",
+			wantPath: "/v1/apps/app-1/appInfos",
+			response: `{"data":[]}`,
+			wantQuery: map[string]string{
+				"fields[appInfos]":              "kidsAgeBand",
+				"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted",
+				"include":                       "ageRatingDeclaration",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetAppInfos(
+					context.Background(), "app-1",
+					WithAppInfoFields([]string{"kidsAgeBand"}),
+					WithAppInfoAgeRatingDeclarationFields([]string{"socialMedia", "socialMediaAgeRestricted"}),
+					WithAppInfoInclude([]string{"ageRatingDeclaration"}),
+				)
+				return err
+			},
+		},
+		{
+			name:     "ci product app",
+			wantPath: "/v1/ciProducts/product-1/app",
+			wantQuery: map[string]string{
+				"fields[inAppPurchases]":     "versions",
+				"fields[subscriptionGroups]": "versions",
+				"include":                    "inAppPurchases,subscriptionGroups",
+			},
+			call: func(client *Client) error {
+				_, err := client.GetCiProductApp(
+					context.Background(), "product-1",
+					WithCiProductAppInAppPurchaseFields([]string{"versions"}),
+					WithCiProductAppSubscriptionGroupFields([]string{"versions"}),
+					WithCiProductAppInclude([]string{"inAppPurchases", "subscriptionGroups"}),
+				)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", req.Method)
+				}
+				if req.URL.Path != test.wantPath {
+					t.Fatalf("path = %q, want %q", req.URL.Path, test.wantPath)
+				}
+				query := req.URL.Query()
+				for key, want := range test.wantQuery {
+					if got := query.Get(key); got != want {
+						t.Errorf("query %s = %q, want %q", key, got, want)
+					}
+				}
+				if len(query) != len(test.wantQuery) {
+					t.Errorf("query = %v, want exactly %v", query, test.wantQuery)
+				}
+			}, jsonResponse(http.StatusOK, func() string {
+				if test.response != "" {
+					return test.response
+				}
+				return `{"data":{"type":"apps","id":"1"}}`
+			}()))
+
+			if err := test.call(client); err != nil {
+				t.Fatalf("call error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/asc/openapi_441_sparse_app_fields_test.go
+++ b/internal/asc/openapi_441_sparse_app_fields_test.go
@@ -53,16 +53,18 @@ func TestOpenAPI441SparseAppFields(t *testing.T) {
 			wantPath: "/v1/apps",
 			response: `{"data":[]}`,
 			wantQuery: map[string]string{
+				"fields[appInfos]":           "kidsAgeBand",
 				"fields[inAppPurchases]":     "versions",
 				"fields[subscriptionGroups]": "versions",
-				"include":                    "inAppPurchases,subscriptionGroups",
+				"include":                    "appInfos,inAppPurchases,subscriptionGroups",
 			},
 			call: func(client *Client) error {
 				_, err := client.GetApps(
 					context.Background(),
+					WithAppsAppInfoFields([]string{"kidsAgeBand"}),
 					WithAppsInAppPurchaseFields([]string{"versions"}),
 					WithAppsSubscriptionGroupFields([]string{"versions"}),
-					WithAppsInclude([]string{"inAppPurchases", "subscriptionGroups"}),
+					WithAppsInclude([]string{"appInfos", "inAppPurchases", "subscriptionGroups"}),
 				)
 				return err
 			},
@@ -71,16 +73,18 @@ func TestOpenAPI441SparseAppFields(t *testing.T) {
 			name:     "app detail",
 			wantPath: "/v1/apps/app-1",
 			wantQuery: map[string]string{
+				"fields[appInfos]":           "kidsAgeBand",
 				"fields[inAppPurchases]":     "versions",
 				"fields[subscriptionGroups]": "versions",
-				"include":                    "inAppPurchases,subscriptionGroups",
+				"include":                    "appInfos,inAppPurchases,subscriptionGroups",
 			},
 			call: func(client *Client) error {
 				_, err := client.GetAppWithOptions(
 					context.Background(), "app-1",
+					WithAppAppInfoFields([]string{"kidsAgeBand"}),
 					WithAppInAppPurchaseFields([]string{"versions"}),
 					WithAppSubscriptionGroupFields([]string{"versions"}),
-					WithAppInclude([]string{"inAppPurchases", "subscriptionGroups"}),
+					WithAppInclude([]string{"appInfos", "inAppPurchases", "subscriptionGroups"}),
 				)
 				return err
 			},
@@ -139,16 +143,18 @@ func TestOpenAPI441SparseAppFields(t *testing.T) {
 			name:     "ci product app",
 			wantPath: "/v1/ciProducts/product-1/app",
 			wantQuery: map[string]string{
+				"fields[appInfos]":           "kidsAgeBand",
 				"fields[inAppPurchases]":     "versions",
 				"fields[subscriptionGroups]": "versions",
-				"include":                    "inAppPurchases,subscriptionGroups",
+				"include":                    "appInfos,inAppPurchases,subscriptionGroups",
 			},
 			call: func(client *Client) error {
 				_, err := client.GetCiProductApp(
 					context.Background(), "product-1",
+					WithCiProductAppAppInfoFields([]string{"kidsAgeBand"}),
 					WithCiProductAppInAppPurchaseFields([]string{"versions"}),
 					WithCiProductAppSubscriptionGroupFields([]string{"versions"}),
-					WithCiProductAppInclude([]string{"inAppPurchases", "subscriptionGroups"}),
+					WithCiProductAppInclude([]string{"appInfos", "inAppPurchases", "subscriptionGroups"}),
 				)
 				return err
 			},
@@ -166,8 +172,13 @@ func TestOpenAPI441SparseAppFields(t *testing.T) {
 				}
 				query := req.URL.Query()
 				for key, want := range test.wantQuery {
-					if got := query.Get(key); got != want {
-						t.Errorf("query %s = %q, want %q", key, got, want)
+					got, ok := query[key]
+					if !ok {
+						t.Errorf("query is missing %s", key)
+						continue
+					}
+					if len(got) != 1 || got[0] != want {
+						t.Errorf("query %s = %q, want exactly [%q]", key, got, want)
 					}
 				}
 				if len(query) != len(test.wantQuery) {

--- a/internal/asc/openapi_441_sparse_app_fields_test.go
+++ b/internal/asc/openapi_441_sparse_app_fields_test.go
@@ -34,7 +34,7 @@ func TestOpenAPI441SparseAppFields(t *testing.T) {
 			name:     "app info detail",
 			wantPath: "/v1/appInfos/info-1",
 			wantQuery: map[string]string{
-				"fields[appInfos]":              "kidsAgeBand",
+				"fields[appInfos]":              "kidsAgeBand,ageRatingDeclaration",
 				"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted",
 				"include":                       "ageRatingDeclaration",
 			},
@@ -125,7 +125,7 @@ func TestOpenAPI441SparseAppFields(t *testing.T) {
 			wantPath: "/v1/apps/app-1/appInfos",
 			response: `{"data":[]}`,
 			wantQuery: map[string]string{
-				"fields[appInfos]":              "kidsAgeBand",
+				"fields[appInfos]":              "kidsAgeBand,ageRatingDeclaration",
 				"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted",
 				"include":                       "ageRatingDeclaration",
 			},

--- a/internal/asc/xcode_cloud_products.go
+++ b/internal/asc/xcode_cloud_products.go
@@ -377,8 +377,16 @@ func (c *Client) GetCiProduct(ctx context.Context, productID string) (*CiProduct
 }
 
 // GetCiProductApp retrieves the app for a CI product.
-func (c *Client) GetCiProductApp(ctx context.Context, productID string) (*AppResponse, error) {
+func (c *Client) GetCiProductApp(ctx context.Context, productID string, opts ...CiProductAppOption) (*AppResponse, error) {
+	query := &ciProductAppQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	path := fmt.Sprintf("/v1/ciProducts/%s/app", productID)
+	if queryString := buildCiProductAppQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -123,6 +123,11 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
+			fieldsProvided := false
+			fs.Visit(func(f *flag.Flag) { fieldsProvided = fieldsProvided || f.Name == "fields" })
+			if fieldsProvided && len(fieldValues) == 0 {
+				return shared.UsageError("--fields must not be empty")
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -53,6 +53,11 @@ var kidsAgeBandValues = []string{
 	"NINE_TO_ELEVEN",
 }
 
+var ageRatingSparseFields441 = []string{
+	"socialMedia",
+	"socialMediaAgeRestricted",
+}
+
 // AgeRatingCommand returns the age rating command with subcommands.
 func AgeRatingCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("age-rating", flag.ExitOnError)
@@ -86,6 +91,7 @@ func AgeRatingViewCommand() *ffcli.Command {
 	appID := fs.String("app", os.Getenv("ASC_APP_ID"), "App ID (required unless --app-info-id or --version-id is provided)")
 	appInfoID := fs.String("app-info-id", "", "App info ID (optional)")
 	versionID := fs.String("version-id", "", "App Store version ID (optional)")
+	fields := fs.String("fields", "", "Sparse fields: socialMedia, socialMediaAgeRestricted")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -97,6 +103,7 @@ func AgeRatingViewCommand() *ffcli.Command {
 Examples:
   asc age-rating view --app APP_ID
   asc age-rating view --app-info-id APP_INFO_ID
+  asc age-rating view --app-info-id APP_INFO_ID --fields socialMedia,socialMediaAgeRestricted
   asc age-rating view --version-id VERSION_ID`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -112,6 +119,10 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()
 			}
+			fieldValues, err := shared.NormalizeSelection(*fields, ageRatingSparseFields441, "--fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -121,7 +132,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := fetchAgeRatingDeclaration(requestCtx, client, appValue, appInfoValue, versionValue)
+			resp, err := fetchAgeRatingDeclaration(requestCtx, client, appValue, appInfoValue, versionValue, fieldValues)
 			if err != nil {
 				return fmt.Errorf("age-rating view: %w", err)
 			}
@@ -339,12 +350,13 @@ func nullableBoolValue(value *asc.NullableBool) *bool {
 	return value.Value
 }
 
-func fetchAgeRatingDeclaration(ctx context.Context, client *asc.Client, appID, appInfoID, versionID string) (*asc.AgeRatingDeclarationResponse, error) {
+func fetchAgeRatingDeclaration(ctx context.Context, client *asc.Client, appID, appInfoID, versionID string, fields []string) (*asc.AgeRatingDeclarationResponse, error) {
+	opts := []asc.AgeRatingDeclarationOption{asc.WithAgeRatingDeclarationFields(fields)}
 	switch {
 	case appInfoID != "":
-		return client.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID)
+		return client.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID, opts...)
 	case versionID != "":
-		return client.GetAgeRatingDeclarationForAppStoreVersion(ctx, versionID)
+		return client.GetAgeRatingDeclarationForAppStoreVersion(ctx, versionID, opts...)
 	default:
 		appInfos, err := client.GetAppInfos(ctx, appID)
 		if err != nil {
@@ -357,12 +369,12 @@ func fetchAgeRatingDeclaration(ctx context.Context, client *asc.Client, appID, a
 		if strings.TrimSpace(appInfoID) == "" {
 			return nil, fmt.Errorf("app info id is empty for app %s", appID)
 		}
-		return client.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID)
+		return client.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID, opts...)
 	}
 }
 
 func resolveAgeRatingDeclarationID(ctx context.Context, client *asc.Client, appID, appInfoID, versionID string) (string, error) {
-	resp, err := fetchAgeRatingDeclaration(ctx, client, appID, appInfoID, versionID)
+	resp, err := fetchAgeRatingDeclaration(ctx, client, appID, appInfoID, versionID, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -87,7 +87,7 @@ Examples:
   asc apps info view --info-id "APP_INFO_ID" --fields kidsAgeBand
   asc apps info view --info-id "APP_INFO_ID" --age-rating-fields socialMedia,socialMediaAgeRestricted
   asc apps info view --info-id "APP_INFO_ID" --include "ageRatingDeclaration"
-  asc apps info view --app "APP_ID" --include "ageRatingDeclaration,territoryAgeRatings"
+  asc apps info view --app "APP_ID" --include "appInfoLocalizations,primaryCategory"
   asc apps info view --app "APP_ID" --locale "en-US" --output table`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -67,7 +67,7 @@ func AppsInfoViewCommand() *ffcli.Command {
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	include := fs.String("include", "", "Include related resources: "+strings.Join(appInfoIncludeList(), ", "))
-	fields := fs.String("fields", "", "Sparse app info fields: kidsAgeBand")
+	fields := fs.String("fields", "", "Sparse app info fields: kidsAgeBand (deprecated by Apple; prefer asc age-rating view)")
 	ageRatingFields := fs.String("age-rating-fields", "", "Sparse fields for included age rating declaration: socialMedia, socialMediaAgeRestricted")
 	output := shared.BindOutputFlags(fs)
 

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -102,6 +102,11 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return shared.UsageError(err.Error())
 			}
+			if strings.TrimSpace(*next) != "" {
+				if flagName, ok := appFlagWasProvided(fs, "fields", "age-rating-fields"); ok {
+					return shared.UsageErrorf("--next cannot be combined with %s", flagName)
+				}
+			}
 			if strings.TrimSpace(*version) != "" && strings.TrimSpace(*versionID) != "" {
 				return shared.UsageError("--version and --version-id are mutually exclusive")
 			}
@@ -116,11 +121,11 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			fieldValues, err := normalizeSparseField(*fields, appInfoSparseFields441, "--fields")
+			fieldValues, err := normalizeSparseField(fs, *fields, appInfoSparseFields441, "--fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			ageRatingFieldValues, err := normalizeSparseField(*ageRatingFields, ageRatingSparseFields441, "--age-rating-fields")
+			ageRatingFieldValues, err := normalizeSparseField(fs, *ageRatingFields, ageRatingSparseFields441, "--age-rating-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}

--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -67,6 +67,8 @@ func AppsInfoViewCommand() *ffcli.Command {
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	include := fs.String("include", "", "Include related resources: "+strings.Join(appInfoIncludeList(), ", "))
+	fields := fs.String("fields", "", "Sparse app info fields: kidsAgeBand")
+	ageRatingFields := fs.String("age-rating-fields", "", "Sparse fields for included age rating declaration: socialMedia, socialMediaAgeRestricted")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -82,6 +84,8 @@ Examples:
   asc apps info view --app "APP_ID"
   asc apps info view --app "APP_ID" --version "1.2.3" --platform IOS
   asc apps info view --version-id "VERSION_ID"
+  asc apps info view --info-id "APP_INFO_ID" --fields kidsAgeBand
+  asc apps info view --info-id "APP_INFO_ID" --age-rating-fields socialMedia,socialMediaAgeRestricted
   asc apps info view --info-id "APP_INFO_ID" --include "ageRatingDeclaration"
   asc apps info view --app "APP_ID" --include "ageRatingDeclaration,territoryAgeRatings"
   asc apps info view --app "APP_ID" --locale "en-US" --output table`,
@@ -112,8 +116,20 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			if infoIDValue != "" && len(includeValues) == 0 {
-				fmt.Fprintln(os.Stderr, "Error: --info-id requires --include")
+			fieldValues, err := normalizeSparseField(*fields, appInfoSparseFields441, "--fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			ageRatingFieldValues, err := normalizeSparseField(*ageRatingFields, ageRatingSparseFields441, "--age-rating-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if len(ageRatingFieldValues) > 0 {
+				includeValues = addInclude(includeValues, "ageRatingDeclaration")
+			}
+			appInfoMode := len(includeValues) > 0 || len(fieldValues) > 0
+			if infoIDValue != "" && !appInfoMode {
+				fmt.Fprintln(os.Stderr, "Error: --info-id requires --include, --fields, or --age-rating-fields")
 				return flag.ErrHelp
 			}
 
@@ -133,7 +149,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			if len(includeValues) > 0 {
+			if appInfoMode {
 				if strings.TrimSpace(*versionID) != "" ||
 					strings.TrimSpace(*version) != "" ||
 					strings.TrimSpace(*platform) != "" ||
@@ -142,7 +158,13 @@ Examples:
 					*limit != 0 ||
 					strings.TrimSpace(*next) != "" ||
 					*paginate {
-					fmt.Fprintln(os.Stderr, "Error: --include cannot be used with version localization flags")
+					flagName := "--include"
+					if len(fieldValues) > 0 {
+						flagName = "--fields"
+					} else if len(ageRatingFieldValues) > 0 {
+						flagName = "--age-rating-fields"
+					}
+					fmt.Fprintf(os.Stderr, "Error: %s cannot be used with version localization flags\n", flagName)
 					return flag.ErrHelp
 				}
 			}
@@ -155,13 +177,18 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			if len(includeValues) > 0 {
+			if appInfoMode {
 				appInfoIDValue, err := shared.ResolveAppInfoID(requestCtx, client, resolvedAppID, infoIDValue)
 				if err != nil {
 					return fmt.Errorf("apps info view: %w", err)
 				}
 
-				resp, err := client.GetAppInfo(requestCtx, appInfoIDValue, asc.WithAppInfoInclude(includeValues))
+				resp, err := client.GetAppInfo(
+					requestCtx, appInfoIDValue,
+					asc.WithAppInfoFields(fieldValues),
+					asc.WithAppInfoAgeRatingDeclarationFields(ageRatingFieldValues),
+					asc.WithAppInfoInclude(includeValues),
+				)
 				if err != nil {
 					return fmt.Errorf("apps info view: %w", err)
 				}

--- a/internal/cli/apps/app_info_include.go
+++ b/internal/cli/apps/app_info_include.go
@@ -8,8 +8,9 @@ func normalizeAppInfoInclude(value string) ([]string, error) {
 
 func appInfoIncludeList() []string {
 	return []string{
+		"app",
 		"ageRatingDeclaration",
-		"territoryAgeRatings",
+		"appInfoLocalizations",
 		"primaryCategory",
 		"primarySubcategoryOne",
 		"primarySubcategoryTwo",

--- a/internal/cli/apps/app_infos.go
+++ b/internal/cli/apps/app_infos.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -16,6 +17,8 @@ func AppsInfoListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("apps info list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	fields := fs.String("fields", "", "Sparse app info fields: kidsAgeBand")
+	ageRatingFields := fs.String("age-rating-fields", "", "Sparse fields for included age rating declaration: socialMedia, socialMediaAgeRestricted")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -30,6 +33,8 @@ found" errors in other commands.
 
 Examples:
   asc apps info list --app "APP_ID"
+  asc apps info list --app "APP_ID" --fields kidsAgeBand
+  asc apps info list --app "APP_ID" --age-rating-fields socialMedia,socialMediaAgeRestricted
   asc apps info list --app "APP_ID" --output table
   asc apps info list --app "APP_ID" --output markdown`,
 		FlagSet:   fs,
@@ -40,6 +45,14 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()
 			}
+			fieldValues, err := normalizeSparseField(*fields, appInfoSparseFields441, "--fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			ageRatingFieldValues, err := normalizeSparseField(*ageRatingFields, ageRatingSparseFields441, "--age-rating-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -49,7 +62,16 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetAppInfos(requestCtx, resolvedAppID)
+			includeValues := []string{}
+			if len(ageRatingFieldValues) > 0 {
+				includeValues = addInclude(includeValues, "ageRatingDeclaration")
+			}
+			resp, err := client.GetAppInfos(
+				requestCtx, resolvedAppID,
+				asc.WithAppInfoFields(fieldValues),
+				asc.WithAppInfoAgeRatingDeclarationFields(ageRatingFieldValues),
+				asc.WithAppInfoInclude(includeValues),
+			)
 			if err != nil {
 				return fmt.Errorf("apps info list: failed to fetch: %w", err)
 			}

--- a/internal/cli/apps/app_infos.go
+++ b/internal/cli/apps/app_infos.go
@@ -45,11 +45,11 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()
 			}
-			fieldValues, err := normalizeSparseField(*fields, appInfoSparseFields441, "--fields")
+			fieldValues, err := normalizeSparseField(fs, *fields, appInfoSparseFields441, "--fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			ageRatingFieldValues, err := normalizeSparseField(*ageRatingFields, ageRatingSparseFields441, "--age-rating-fields")
+			ageRatingFieldValues, err := normalizeSparseField(fs, *ageRatingFields, ageRatingSparseFields441, "--age-rating-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}

--- a/internal/cli/apps/app_infos.go
+++ b/internal/cli/apps/app_infos.go
@@ -17,7 +17,7 @@ func AppsInfoListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("apps info list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	fields := fs.String("fields", "", "Sparse app info fields: kidsAgeBand")
+	fields := fs.String("fields", "", "Sparse app info fields: kidsAgeBand (deprecated by Apple; prefer asc age-rating view)")
 	ageRatingFields := fs.String("age-rating-fields", "", "Sparse fields for included age rating declaration: socialMedia, socialMediaAgeRestricted")
 	output := shared.BindOutputFlags(fs)
 

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *string, name *string, sku *string, sort *string, limit *int, next *string, paginate *bool, iapFields *string, subscriptionGroupFields *string) {
+func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *string, name *string, sku *string, sort *string, limit *int, next *string, paginate *bool, appInfoFields *string, iapFields *string, subscriptionGroupFields *string) {
 	output = shared.BindOutputFlags(fs)
 	bundleID = fs.String("bundle-id", "", "Filter by bundle ID(s), comma-separated")
 	name = fs.String("name", "", "Filter by app name(s), comma-separated")
@@ -22,6 +22,7 @@ func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *strin
 	limit = fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next = fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate = fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	appInfoFields = fs.String("app-info-fields", "", "Sparse fields for included app info records: kidsAgeBand (deprecated by Apple; prefer asc age-rating view)")
 	iapFields = fs.String("iap-fields", "", "Sparse fields for included in-app purchases: versions")
 	subscriptionGroupFields = fs.String("subscription-group-fields", "", "Sparse fields for included subscription groups: versions")
 	return
@@ -31,7 +32,7 @@ func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *strin
 func AppsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("apps", flag.ExitOnError)
 
-	output, bundleID, name, sku, sort, limit, next, paginate, iapFields, subscriptionGroupFields := appsListFlags(fs)
+	output, bundleID, name, sku, sort, limit, next, paginate, appInfoFields, iapFields, subscriptionGroupFields := appsListFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "apps",
@@ -59,7 +60,7 @@ Examples:
   asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
   asc apps --limit 10
   asc apps --sort name
-  asc apps --iap-fields versions --subscription-group-fields versions
+  asc apps --app-info-fields kidsAgeBand --iap-fields versions --subscription-group-fields versions
   asc apps --output table
   asc apps --next "<links.next>"
   asc apps --paginate`,
@@ -90,7 +91,7 @@ Examples:
 				fmt.Fprintf(os.Stderr, "Error: unknown subcommand %q\n", subcommand)
 				return flag.ErrHelp
 			}
-			return appsList(ctx, fs, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate, *iapFields, *subscriptionGroupFields)
+			return appsList(ctx, fs, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate, *appInfoFields, *iapFields, *subscriptionGroupFields)
 		},
 	}
 }
@@ -99,7 +100,7 @@ Examples:
 func AppsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("apps list", flag.ExitOnError)
 
-	output, bundleID, name, sku, sort, limit, next, paginate, iapFields, subscriptionGroupFields := appsListFlags(fs)
+	output, bundleID, name, sku, sort, limit, next, paginate, appInfoFields, iapFields, subscriptionGroupFields := appsListFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "list",
@@ -113,14 +114,14 @@ Examples:
   asc apps list --name "My App"
   asc apps list --limit 10
   asc apps list --sort name
-  asc apps list --iap-fields versions --subscription-group-fields versions
+  asc apps list --app-info-fields kidsAgeBand --iap-fields versions --subscription-group-fields versions
   asc apps list --output table
   asc apps list --next "<links.next>"
   asc apps list --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			return appsList(ctx, fs, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate, *iapFields, *subscriptionGroupFields)
+			return appsList(ctx, fs, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate, *appInfoFields, *iapFields, *subscriptionGroupFields)
 		},
 	}
 }
@@ -131,6 +132,7 @@ func AppsGetCommand() *ffcli.Command {
 
 	id := fs.String("id", "", "App Store Connect app ID")
 	legacyAppID := shared.BindDeprecatedStringFlagAlias(fs, "app", "id")
+	appInfoFields := fs.String("app-info-fields", "", "Sparse fields for included app info records: kidsAgeBand (deprecated by Apple; prefer asc age-rating view)")
 	iapFields := fs.String("iap-fields", "", "Sparse fields for included in-app purchases: versions")
 	subscriptionGroupFields := fs.String("subscription-group-fields", "", "Sparse fields for included subscription groups: versions")
 	output := shared.BindOutputFlags(fs)
@@ -143,7 +145,7 @@ func AppsGetCommand() *ffcli.Command {
 
 Examples:
   asc apps view --id "APP_ID"
-  asc apps view --id "APP_ID" --iap-fields versions --subscription-group-fields versions
+  asc apps view --id "APP_ID" --app-info-fields kidsAgeBand --iap-fields versions --subscription-group-fields versions
   asc apps view --id "APP_ID" --output table`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -155,6 +157,10 @@ Examples:
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError()
+			}
+			appInfoFieldValues, err := normalizeSparseField(fs, *appInfoFields, appInfoSparseFields441, "--app-info-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
 			}
 			iapFieldValues, err := normalizeSparseField(fs, *iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
 			if err != nil {
@@ -174,6 +180,9 @@ Examples:
 			defer cancel()
 
 			includeValues := []string{}
+			if len(appInfoFieldValues) > 0 {
+				includeValues = addInclude(includeValues, "appInfos")
+			}
 			if len(iapFieldValues) > 0 {
 				includeValues = addInclude(includeValues, "inAppPurchases")
 			}
@@ -181,6 +190,7 @@ Examples:
 				includeValues = addInclude(includeValues, "subscriptionGroups")
 			}
 			opts := []asc.AppOption{
+				asc.WithAppAppInfoFields(appInfoFieldValues),
 				asc.WithAppInAppPurchaseFields(iapFieldValues),
 				asc.WithAppSubscriptionGroupFields(groupFieldValues),
 				asc.WithAppInclude(includeValues),
@@ -265,7 +275,7 @@ Examples:
 	}
 }
 
-func appsList(ctx context.Context, fs *flag.FlagSet, output string, pretty bool, bundleID string, name string, sku string, sort string, limit int, next string, paginate bool, iapFields string, subscriptionGroupFields string) error {
+func appsList(ctx context.Context, fs *flag.FlagSet, output string, pretty bool, bundleID string, name string, sku string, sort string, limit int, next string, paginate bool, appInfoFields string, iapFields string, subscriptionGroupFields string) error {
 	if limit != 0 && (limit < 1 || limit > 200) {
 		return fmt.Errorf("apps: --limit must be between 1 and 200")
 	}
@@ -276,10 +286,14 @@ func appsList(ctx context.Context, fs *flag.FlagSet, output string, pretty bool,
 		return fmt.Errorf("apps: %w", err)
 	}
 	if strings.TrimSpace(next) != "" {
-		if flagName, ok := appFlagWasProvided(fs, "iap-fields", "subscription-group-fields"); ok {
+		if flagName, ok := appFlagWasProvided(fs, "app-info-fields", "iap-fields", "subscription-group-fields"); ok {
 			fmt.Fprintf(os.Stderr, "Error: --next cannot be combined with %s\n", flagName)
 			return flag.ErrHelp
 		}
+	}
+	appInfoFieldValues, err := normalizeSparseField(fs, appInfoFields, appInfoSparseFields441, "--app-info-fields")
+	if err != nil {
+		return shared.UsageError(err.Error())
 	}
 	iapFieldValues, err := normalizeSparseField(fs, iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
 	if err != nil {
@@ -304,10 +318,14 @@ func appsList(ctx context.Context, fs *flag.FlagSet, output string, pretty bool,
 		asc.WithAppsSKUs(shared.SplitCSV(sku)),
 		asc.WithAppsLimit(limit),
 		asc.WithAppsNextURL(next),
+		asc.WithAppsAppInfoFields(appInfoFieldValues),
 		asc.WithAppsInAppPurchaseFields(iapFieldValues),
 		asc.WithAppsSubscriptionGroupFields(groupFieldValues),
 	}
 	includeValues := []string{}
+	if len(appInfoFieldValues) > 0 {
+		includeValues = addInclude(includeValues, "appInfos")
+	}
 	if len(iapFieldValues) > 0 {
 		includeValues = addInclude(includeValues, "inAppPurchases")
 	}

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *string, name *string, sku *string, sort *string, limit *int, next *string, paginate *bool) {
+func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *string, name *string, sku *string, sort *string, limit *int, next *string, paginate *bool, iapFields *string, subscriptionGroupFields *string) {
 	output = shared.BindOutputFlags(fs)
 	bundleID = fs.String("bundle-id", "", "Filter by bundle ID(s), comma-separated")
 	name = fs.String("name", "", "Filter by app name(s), comma-separated")
@@ -22,6 +22,8 @@ func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *strin
 	limit = fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next = fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate = fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	iapFields = fs.String("iap-fields", "", "Sparse fields for included in-app purchases: versions")
+	subscriptionGroupFields = fs.String("subscription-group-fields", "", "Sparse fields for included subscription groups: versions")
 	return
 }
 
@@ -29,7 +31,7 @@ func appsListFlags(fs *flag.FlagSet) (output shared.OutputFlags, bundleID *strin
 func AppsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("apps", flag.ExitOnError)
 
-	output, bundleID, name, sku, sort, limit, next, paginate := appsListFlags(fs)
+	output, bundleID, name, sku, sort, limit, next, paginate, iapFields, subscriptionGroupFields := appsListFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "apps",
@@ -57,6 +59,7 @@ Examples:
   asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
   asc apps --limit 10
   asc apps --sort name
+  asc apps --iap-fields versions --subscription-group-fields versions
   asc apps --output table
   asc apps --next "<links.next>"
   asc apps --paginate`,
@@ -87,7 +90,7 @@ Examples:
 				fmt.Fprintf(os.Stderr, "Error: unknown subcommand %q\n", subcommand)
 				return flag.ErrHelp
 			}
-			return appsList(ctx, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate)
+			return appsList(ctx, fs, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate, *iapFields, *subscriptionGroupFields)
 		},
 	}
 }
@@ -96,7 +99,7 @@ Examples:
 func AppsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("apps list", flag.ExitOnError)
 
-	output, bundleID, name, sku, sort, limit, next, paginate := appsListFlags(fs)
+	output, bundleID, name, sku, sort, limit, next, paginate, iapFields, subscriptionGroupFields := appsListFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "list",
@@ -110,13 +113,14 @@ Examples:
   asc apps list --name "My App"
   asc apps list --limit 10
   asc apps list --sort name
+  asc apps list --iap-fields versions --subscription-group-fields versions
   asc apps list --output table
   asc apps list --next "<links.next>"
   asc apps list --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			return appsList(ctx, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate)
+			return appsList(ctx, fs, *output.Output, *output.Pretty, *bundleID, *name, *sku, *sort, *limit, *next, *paginate, *iapFields, *subscriptionGroupFields)
 		},
 	}
 }
@@ -127,6 +131,8 @@ func AppsGetCommand() *ffcli.Command {
 
 	id := fs.String("id", "", "App Store Connect app ID")
 	legacyAppID := shared.BindDeprecatedStringFlagAlias(fs, "app", "id")
+	iapFields := fs.String("iap-fields", "", "Sparse fields for included in-app purchases: versions")
+	subscriptionGroupFields := fs.String("subscription-group-fields", "", "Sparse fields for included subscription groups: versions")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -137,6 +143,7 @@ func AppsGetCommand() *ffcli.Command {
 
 Examples:
   asc apps view --id "APP_ID"
+  asc apps view --id "APP_ID" --iap-fields versions --subscription-group-fields versions
   asc apps view --id "APP_ID" --output table`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -149,6 +156,14 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError()
 			}
+			iapFieldValues, err := normalizeSparseField(*iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			groupFieldValues, err := normalizeSparseField(*subscriptionGroupFields, appSubscriptionGroupSparseFields441, "--subscription-group-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -158,7 +173,19 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			app, err := client.GetApp(requestCtx, idValue)
+			includeValues := []string{}
+			if len(iapFieldValues) > 0 {
+				includeValues = addInclude(includeValues, "inAppPurchases")
+			}
+			if len(groupFieldValues) > 0 {
+				includeValues = addInclude(includeValues, "subscriptionGroups")
+			}
+			opts := []asc.AppOption{
+				asc.WithAppInAppPurchaseFields(iapFieldValues),
+				asc.WithAppSubscriptionGroupFields(groupFieldValues),
+				asc.WithAppInclude(includeValues),
+			}
+			app, err := client.GetAppWithOptions(requestCtx, idValue, opts...)
 			if err != nil {
 				return fmt.Errorf("apps view: failed to fetch: %w", err)
 			}
@@ -238,7 +265,7 @@ Examples:
 	}
 }
 
-func appsList(ctx context.Context, output string, pretty bool, bundleID string, name string, sku string, sort string, limit int, next string, paginate bool) error {
+func appsList(ctx context.Context, fs *flag.FlagSet, output string, pretty bool, bundleID string, name string, sku string, sort string, limit int, next string, paginate bool, iapFields string, subscriptionGroupFields string) error {
 	if limit != 0 && (limit < 1 || limit > 200) {
 		return fmt.Errorf("apps: --limit must be between 1 and 200")
 	}
@@ -247,6 +274,20 @@ func appsList(ctx context.Context, output string, pretty bool, bundleID string, 
 	}
 	if err := shared.ValidateSort(sort, "name", "-name", "bundleId", "-bundleId"); err != nil {
 		return fmt.Errorf("apps: %w", err)
+	}
+	if strings.TrimSpace(next) != "" {
+		if flagName, ok := appFlagWasProvided(fs, "iap-fields", "subscription-group-fields"); ok {
+			fmt.Fprintf(os.Stderr, "Error: --next cannot be combined with %s\n", flagName)
+			return flag.ErrHelp
+		}
+	}
+	iapFieldValues, err := normalizeSparseField(iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
+	if err != nil {
+		return shared.UsageError(err.Error())
+	}
+	groupFieldValues, err := normalizeSparseField(subscriptionGroupFields, appSubscriptionGroupSparseFields441, "--subscription-group-fields")
+	if err != nil {
+		return shared.UsageError(err.Error())
 	}
 
 	client, err := shared.GetASCClient()
@@ -263,7 +304,17 @@ func appsList(ctx context.Context, output string, pretty bool, bundleID string, 
 		asc.WithAppsSKUs(shared.SplitCSV(sku)),
 		asc.WithAppsLimit(limit),
 		asc.WithAppsNextURL(next),
+		asc.WithAppsInAppPurchaseFields(iapFieldValues),
+		asc.WithAppsSubscriptionGroupFields(groupFieldValues),
 	}
+	includeValues := []string{}
+	if len(iapFieldValues) > 0 {
+		includeValues = addInclude(includeValues, "inAppPurchases")
+	}
+	if len(groupFieldValues) > 0 {
+		includeValues = addInclude(includeValues, "subscriptionGroups")
+	}
+	opts = append(opts, asc.WithAppsInclude(includeValues))
 	if strings.TrimSpace(sort) != "" {
 		opts = append(opts, asc.WithAppsSort(sort))
 	}

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -156,11 +156,11 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError()
 			}
-			iapFieldValues, err := normalizeSparseField(*iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
+			iapFieldValues, err := normalizeSparseField(fs, *iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			groupFieldValues, err := normalizeSparseField(*subscriptionGroupFields, appSubscriptionGroupSparseFields441, "--subscription-group-fields")
+			groupFieldValues, err := normalizeSparseField(fs, *subscriptionGroupFields, appSubscriptionGroupSparseFields441, "--subscription-group-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
@@ -281,11 +281,11 @@ func appsList(ctx context.Context, fs *flag.FlagSet, output string, pretty bool,
 			return flag.ErrHelp
 		}
 	}
-	iapFieldValues, err := normalizeSparseField(iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
+	iapFieldValues, err := normalizeSparseField(fs, iapFields, appInAppPurchaseSparseFields441, "--iap-fields")
 	if err != nil {
 		return shared.UsageError(err.Error())
 	}
-	groupFieldValues, err := normalizeSparseField(subscriptionGroupFields, appSubscriptionGroupSparseFields441, "--subscription-group-fields")
+	groupFieldValues, err := normalizeSparseField(fs, subscriptionGroupFields, appSubscriptionGroupSparseFields441, "--subscription-group-fields")
 	if err != nil {
 		return shared.UsageError(err.Error())
 	}

--- a/internal/cli/apps/helpers_normalization_test.go
+++ b/internal/cli/apps/helpers_normalization_test.go
@@ -1,6 +1,7 @@
 package apps
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -22,9 +23,15 @@ func TestNormalizeInclude(t *testing.T) {
 		},
 		{
 			name:    "valid",
-			input:   "ageRatingDeclaration,territoryAgeRatings",
+			input:   "ageRatingDeclaration,appInfoLocalizations",
 			allowed: appInfoIncludeList(),
 			wantLen: 2,
+		},
+		{
+			name:    "unsupported territory age ratings",
+			input:   "territoryAgeRatings",
+			allowed: appInfoIncludeList(),
+			wantErr: true,
 		},
 		{
 			name:    "invalid option",
@@ -50,6 +57,23 @@ func TestNormalizeInclude(t *testing.T) {
 				t.Fatalf("expected %d values, got %d", test.wantLen, len(got))
 			}
 		})
+	}
+}
+
+func TestAppInfoIncludeListMatchesOpenAPI441(t *testing.T) {
+	want := []string{
+		"app",
+		"ageRatingDeclaration",
+		"appInfoLocalizations",
+		"primaryCategory",
+		"primarySubcategoryOne",
+		"primarySubcategoryTwo",
+		"secondaryCategory",
+		"secondarySubcategoryOne",
+		"secondarySubcategoryTwo",
+	}
+	if got := appInfoIncludeList(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("appInfoIncludeList() = %v, want exact OpenAPI 4.4.1 enum %v", got, want)
 	}
 }
 

--- a/internal/cli/apps/sparse_fields_4_4_1.go
+++ b/internal/cli/apps/sparse_fields_4_4_1.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -18,8 +19,15 @@ var appInAppPurchaseSparseFields441 = []string{"versions"}
 
 var appSubscriptionGroupSparseFields441 = []string{"versions"}
 
-func normalizeSparseField(value string, allowed []string, flagName string) ([]string, error) {
-	return shared.NormalizeSelection(value, allowed, flagName)
+func normalizeSparseField(fs *flag.FlagSet, value string, allowed []string, flagName string) ([]string, error) {
+	values, err := shared.NormalizeSelection(value, allowed, flagName)
+	if err != nil {
+		return nil, err
+	}
+	if _, provided := appFlagWasProvided(fs, strings.TrimPrefix(flagName, "--")); provided && len(values) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", flagName)
+	}
+	return values, nil
 }
 
 func addInclude(values []string, include string) []string {

--- a/internal/cli/apps/sparse_fields_4_4_1.go
+++ b/internal/cli/apps/sparse_fields_4_4_1.go
@@ -1,0 +1,41 @@
+package apps
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+var appInfoSparseFields441 = []string{"kidsAgeBand"}
+
+var ageRatingSparseFields441 = []string{
+	"socialMedia",
+	"socialMediaAgeRestricted",
+}
+
+var appInAppPurchaseSparseFields441 = []string{"versions"}
+
+var appSubscriptionGroupSparseFields441 = []string{"versions"}
+
+func normalizeSparseField(value string, allowed []string, flagName string) ([]string, error) {
+	return shared.NormalizeSelection(value, allowed, flagName)
+}
+
+func addInclude(values []string, include string) []string {
+	if !shared.HasInclude(values, include) {
+		values = append(values, include)
+	}
+	return values
+}
+
+func appFlagWasProvided(fs *flag.FlagSet, names ...string) (string, bool) {
+	provided := make(map[string]bool, len(names))
+	fs.Visit(func(f *flag.Flag) { provided[f.Name] = true })
+	for _, name := range names {
+		if provided[name] {
+			return "--" + strings.TrimPrefix(name, "--"), true
+		}
+	}
+	return "", false
+}

--- a/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
@@ -1,0 +1,155 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSparseAppFieldFlagsValidateBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"apps list iap", []string{"apps", "list", "--iap-fields", "name"}, "--iap-fields must be one of: versions"},
+		{"apps view group", []string{"apps", "view", "--id", "app-1", "--subscription-group-fields", "subscriptions"}, "--subscription-group-fields must be one of: versions"},
+		{"app infos list fields", []string{"apps", "info", "list", "--app", "app-1", "--fields", "state"}, "--fields must be one of: kidsAgeBand"},
+		{"app info view age rating", []string{"apps", "info", "view", "--info-id", "info-1", "--age-rating-fields", "gambling"}, "--age-rating-fields must be one of"},
+		{"app info fields conflict with version", []string{"apps", "info", "view", "--app", "app-1", "--version-id", "version-1", "--fields", "kidsAgeBand"}, "--fields cannot be used with version localization flags"},
+		{"app info age rating fields conflict with next", []string{"apps", "info", "view", "--app", "app-1", "--next", "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations?cursor=next", "--age-rating-fields", "socialMedia"}, "--age-rating-fields cannot be used with version localization flags"},
+		{"age rating view", []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", "gambling"}, "--fields must be one of"},
+		{"xcode cloud product app", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", "name"}, "--iap-fields must be one of: versions"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, test.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.want)
+			}
+		})
+	}
+}
+
+func TestAppsListSparseFieldsConflictWithNextBeforeAuth(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/apps?cursor=next"
+	for _, flagName := range []string{"--iap-fields", "--subscription-group-fields"} {
+		t.Run(flagName, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{"apps", "list", "--next", next, flagName, ""}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if !strings.Contains(stderr, "--next cannot be combined with "+flagName) {
+				t.Fatalf("stderr = %q", stderr)
+			}
+		})
+	}
+}
+
+func TestSparseAppFieldCommandsSendExactQueries(t *testing.T) {
+	setupAuth(t)
+	tests := []struct {
+		name      string
+		args      []string
+		wantPath  string
+		wantQuery map[string]string
+		response  string
+	}{
+		{
+			name: "apps list", args: []string{"apps", "list", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
+			wantPath: "/v1/apps", response: `{"data":[]}`,
+			wantQuery: map[string]string{"fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "inAppPurchases,subscriptionGroups"},
+		},
+		{
+			name: "apps view", args: []string{"apps", "view", "--id", "app-1", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
+			wantPath: "/v1/apps/app-1", response: `{"data":{"type":"apps","id":"app-1"}}`,
+			wantQuery: map[string]string{"fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "inAppPurchases,subscriptionGroups"},
+		},
+		{
+			name: "app infos list", args: []string{"apps", "info", "list", "--app", "app-1", "--fields", "kidsAgeBand", "--age-rating-fields", "socialMedia,socialMediaAgeRestricted", "--output", "json"},
+			wantPath: "/v1/apps/app-1/appInfos", response: `{"data":[]}`,
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted", "include": "ageRatingDeclaration"},
+		},
+		{
+			name: "app info view", args: []string{"apps", "info", "view", "--info-id", "info-1", "--fields", "kidsAgeBand", "--age-rating-fields", "socialMedia", "--output", "json"},
+			wantPath: "/v1/appInfos/info-1", response: `{"data":{"type":"appInfos","id":"info-1"}}`,
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[ageRatingDeclarations]": "socialMedia", "include": "ageRatingDeclaration"},
+		},
+		{
+			name: "age rating view", args: []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", "socialMedia,socialMediaAgeRestricted", "--output", "json"},
+			wantPath: "/v1/appInfos/info-1/ageRatingDeclaration", response: `{"data":{"type":"ageRatingDeclarations","id":"age-1"}}`,
+			wantQuery: map[string]string{"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted"},
+		},
+		{
+			name: "xcode cloud product app", args: []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
+			wantPath: "/v1/ciProducts/product-1/app", response: `{"data":{"type":"apps","id":"app-1"}}`,
+			wantQuery: map[string]string{"fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "inAppPurchases,subscriptionGroups"},
+		},
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if req.Method != http.MethodGet || req.URL.Path != test.wantPath {
+					t.Fatalf("request = %s %s, want GET %s", req.Method, req.URL.Path, test.wantPath)
+				}
+				query := req.URL.Query()
+				for key, want := range test.wantQuery {
+					if got := query.Get(key); got != want {
+						t.Errorf("query %s = %q, want %q", key, got, want)
+					}
+				}
+				if len(query) != len(test.wantQuery) {
+					t.Errorf("query = %v, want exactly %v", query, test.wantQuery)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(test.response)), Header: http.Header{"Content-Type": []string{"application/json"}}}, nil
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			if calls != 1 {
+				t.Fatalf("calls = %d, want 1", calls)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
@@ -22,6 +22,7 @@ func TestSparseAppFieldFlagsValidateBeforeAuth(t *testing.T) {
 		{"apps view group", []string{"apps", "view", "--id", "app-1", "--subscription-group-fields", "subscriptions"}, "--subscription-group-fields must be one of: versions"},
 		{"app infos list fields", []string{"apps", "info", "list", "--app", "app-1", "--fields", "state"}, "--fields must be one of: kidsAgeBand"},
 		{"app info view age rating", []string{"apps", "info", "view", "--info-id", "info-1", "--age-rating-fields", "gambling"}, "--age-rating-fields must be one of"},
+		{"app info view unsupported include", []string{"apps", "info", "view", "--info-id", "info-1", "--include", "territoryAgeRatings"}, "--include must be one of: app, ageRatingDeclaration, appInfoLocalizations, primaryCategory"},
 		{"app info fields conflict with version", []string{"apps", "info", "view", "--app", "app-1", "--version-id", "version-1", "--fields", "kidsAgeBand"}, "--fields cannot be used with version localization flags"},
 		{"app info age rating fields conflict with next", []string{"apps", "info", "view", "--app", "app-1", "--next", "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations?cursor=next", "--age-rating-fields", "socialMedia"}, "--next cannot be combined with --age-rating-fields"},
 		{"age rating view", []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", "gambling"}, "--fields must be one of"},
@@ -204,12 +205,12 @@ func TestSparseAppFieldCommandsSendExactQueries(t *testing.T) {
 		{
 			name: "app infos list", args: []string{"apps", "info", "list", "--app", "app-1", "--fields", "kidsAgeBand", "--age-rating-fields", "socialMedia,socialMediaAgeRestricted", "--output", "json"},
 			wantPath: "/v1/apps/app-1/appInfos", response: `{"data":[]}`,
-			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted", "include": "ageRatingDeclaration"},
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand,ageRatingDeclaration", "fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted", "include": "ageRatingDeclaration"},
 		},
 		{
 			name: "app info view", args: []string{"apps", "info", "view", "--info-id", "info-1", "--fields", "kidsAgeBand", "--age-rating-fields", "socialMedia", "--output", "json"},
 			wantPath: "/v1/appInfos/info-1", response: `{"data":{"type":"appInfos","id":"info-1"}}`,
-			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[ageRatingDeclarations]": "socialMedia", "include": "ageRatingDeclaration"},
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand,ageRatingDeclaration", "fields[ageRatingDeclarations]": "socialMedia", "include": "ageRatingDeclaration"},
 		},
 		{
 			name: "age rating view", args: []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", "socialMedia,socialMediaAgeRestricted", "--output", "json"},
@@ -300,5 +301,15 @@ func TestSparseAppFieldHelp441(t *testing.T) {
 	}
 	if usage := localizations.UsageFunc(localizations); !strings.Contains(usage, "--app-info-fields") {
 		t.Fatalf("help for [localizations list] does not contain --app-info-fields: %q", usage)
+	}
+
+	appInfoView := findSubcommand(root, "apps", "info", "view")
+	if appInfoView == nil {
+		t.Fatal("command [apps info view] not found")
+	}
+	usage := appInfoView.UsageFunc(appInfoView)
+	wantIncludes := "app, ageRatingDeclaration, appInfoLocalizations, primaryCategory, primarySubcategoryOne, primarySubcategoryTwo, secondaryCategory, secondarySubcategoryOne, secondarySubcategoryTwo"
+	if !strings.Contains(usage, wantIncludes) || strings.Contains(usage, "territoryAgeRatings") {
+		t.Fatalf("help for [apps info view] does not teach exact app-info includes: %q", usage)
 	}
 }

--- a/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
@@ -22,7 +22,7 @@ func TestSparseAppFieldFlagsValidateBeforeAuth(t *testing.T) {
 		{"app infos list fields", []string{"apps", "info", "list", "--app", "app-1", "--fields", "state"}, "--fields must be one of: kidsAgeBand"},
 		{"app info view age rating", []string{"apps", "info", "view", "--info-id", "info-1", "--age-rating-fields", "gambling"}, "--age-rating-fields must be one of"},
 		{"app info fields conflict with version", []string{"apps", "info", "view", "--app", "app-1", "--version-id", "version-1", "--fields", "kidsAgeBand"}, "--fields cannot be used with version localization flags"},
-		{"app info age rating fields conflict with next", []string{"apps", "info", "view", "--app", "app-1", "--next", "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations?cursor=next", "--age-rating-fields", "socialMedia"}, "--age-rating-fields cannot be used with version localization flags"},
+		{"app info age rating fields conflict with next", []string{"apps", "info", "view", "--app", "app-1", "--next", "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations?cursor=next", "--age-rating-fields", "socialMedia"}, "--next cannot be combined with --age-rating-fields"},
 		{"age rating view", []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", "gambling"}, "--fields must be one of"},
 		{"xcode cloud product app", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", "name"}, "--iap-fields must be one of: versions"},
 	}
@@ -50,6 +50,48 @@ func TestSparseAppFieldFlagsValidateBeforeAuth(t *testing.T) {
 	}
 }
 
+func TestSparseAppFieldFlagsRejectExplicitEmptyBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"apps list iap empty", []string{"apps", "list", "--iap-fields", ""}, "--iap-fields must not be empty"},
+		{"apps list group whitespace", []string{"apps", "list", "--subscription-group-fields", " \t"}, "--subscription-group-fields must not be empty"},
+		{"apps view iap whitespace", []string{"apps", "view", "--id", "app-1", "--iap-fields", " \t"}, "--iap-fields must not be empty"},
+		{"apps view group empty", []string{"apps", "view", "--id", "app-1", "--subscription-group-fields", ""}, "--subscription-group-fields must not be empty"},
+		{"app infos list fields empty", []string{"apps", "info", "list", "--app", "app-1", "--fields", ""}, "--fields must not be empty"},
+		{"app infos list age rating whitespace", []string{"apps", "info", "list", "--app", "app-1", "--age-rating-fields", " \t"}, "--age-rating-fields must not be empty"},
+		{"app info view fields whitespace", []string{"apps", "info", "view", "--info-id", "info-1", "--fields", " \t"}, "--fields must not be empty"},
+		{"app info view age rating empty", []string{"apps", "info", "view", "--info-id", "info-1", "--age-rating-fields", ""}, "--age-rating-fields must not be empty"},
+		{"age rating view fields empty", []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", ""}, "--fields must not be empty"},
+		{"xcode cloud product app iap empty", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", ""}, "--iap-fields must not be empty"},
+		{"xcode cloud product app group whitespace", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--subscription-group-fields", " \t"}, "--subscription-group-fields must not be empty"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, test.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.want)
+			}
+		})
+	}
+}
+
 func TestAppsListSparseFieldsConflictWithNextBeforeAuth(t *testing.T) {
 	next := "https://api.appstoreconnect.apple.com/v1/apps?cursor=next"
 	for _, flagName := range []string{"--iap-fields", "--subscription-group-fields"} {
@@ -58,6 +100,27 @@ func TestAppsListSparseFieldsConflictWithNextBeforeAuth(t *testing.T) {
 			root.FlagSet.SetOutput(io.Discard)
 			_, stderr := captureOutput(t, func() {
 				if err := root.Parse([]string{"apps", "list", "--next", next, flagName, ""}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if !strings.Contains(stderr, "--next cannot be combined with "+flagName) {
+				t.Fatalf("stderr = %q", stderr)
+			}
+		})
+	}
+}
+
+func TestAppInfoSparseFieldsConflictWithNextBeforeAuth(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations?cursor=next"
+	for _, flagName := range []string{"--fields", "--age-rating-fields"} {
+		t.Run(flagName, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{"apps", "info", "view", "--app", "app-1", "--next", next, flagName, ""}); err != nil {
 					t.Fatalf("parse error: %v", err)
 				}
 				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {

--- a/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
+++ b/internal/cli/cmdtest/sparse_app_fields_4_4_1_test.go
@@ -18,13 +18,16 @@ func TestSparseAppFieldFlagsValidateBeforeAuth(t *testing.T) {
 		want string
 	}{
 		{"apps list iap", []string{"apps", "list", "--iap-fields", "name"}, "--iap-fields must be one of: versions"},
+		{"apps list app info", []string{"apps", "list", "--app-info-fields", "state"}, "--app-info-fields must be one of: kidsAgeBand"},
 		{"apps view group", []string{"apps", "view", "--id", "app-1", "--subscription-group-fields", "subscriptions"}, "--subscription-group-fields must be one of: versions"},
 		{"app infos list fields", []string{"apps", "info", "list", "--app", "app-1", "--fields", "state"}, "--fields must be one of: kidsAgeBand"},
 		{"app info view age rating", []string{"apps", "info", "view", "--info-id", "info-1", "--age-rating-fields", "gambling"}, "--age-rating-fields must be one of"},
 		{"app info fields conflict with version", []string{"apps", "info", "view", "--app", "app-1", "--version-id", "version-1", "--fields", "kidsAgeBand"}, "--fields cannot be used with version localization flags"},
 		{"app info age rating fields conflict with next", []string{"apps", "info", "view", "--app", "app-1", "--next", "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations?cursor=next", "--age-rating-fields", "socialMedia"}, "--next cannot be combined with --age-rating-fields"},
 		{"age rating view", []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", "gambling"}, "--fields must be one of"},
+		{"app info localizations", []string{"localizations", "list", "--type", "app-info", "--app", "app-1", "--app-info", "info-1", "--app-info-fields", "state"}, "--app-info-fields must be one of: kidsAgeBand"},
 		{"xcode cloud product app", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", "name"}, "--iap-fields must be one of: versions"},
+		{"xcode cloud product app app info", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--app-info-fields", "state"}, "--app-info-fields must be one of: kidsAgeBand"},
 	}
 
 	for _, test := range tests {
@@ -58,16 +61,61 @@ func TestSparseAppFieldFlagsRejectExplicitEmptyBeforeAuth(t *testing.T) {
 		want string
 	}{
 		{"apps list iap empty", []string{"apps", "list", "--iap-fields", ""}, "--iap-fields must not be empty"},
+		{"apps list app info empty", []string{"apps", "list", "--app-info-fields", ""}, "--app-info-fields must not be empty"},
 		{"apps list group whitespace", []string{"apps", "list", "--subscription-group-fields", " \t"}, "--subscription-group-fields must not be empty"},
 		{"apps view iap whitespace", []string{"apps", "view", "--id", "app-1", "--iap-fields", " \t"}, "--iap-fields must not be empty"},
 		{"apps view group empty", []string{"apps", "view", "--id", "app-1", "--subscription-group-fields", ""}, "--subscription-group-fields must not be empty"},
+		{"apps view app info empty", []string{"apps", "view", "--id", "app-1", "--app-info-fields", ""}, "--app-info-fields must not be empty"},
 		{"app infos list fields empty", []string{"apps", "info", "list", "--app", "app-1", "--fields", ""}, "--fields must not be empty"},
 		{"app infos list age rating whitespace", []string{"apps", "info", "list", "--app", "app-1", "--age-rating-fields", " \t"}, "--age-rating-fields must not be empty"},
 		{"app info view fields whitespace", []string{"apps", "info", "view", "--info-id", "info-1", "--fields", " \t"}, "--fields must not be empty"},
 		{"app info view age rating empty", []string{"apps", "info", "view", "--info-id", "info-1", "--age-rating-fields", ""}, "--age-rating-fields must not be empty"},
 		{"age rating view fields empty", []string{"age-rating", "view", "--app-info-id", "info-1", "--fields", ""}, "--fields must not be empty"},
+		{"app info localizations fields empty", []string{"localizations", "list", "--type", "app-info", "--app", "app-1", "--app-info", "info-1", "--app-info-fields", ""}, "--app-info-fields must not be empty"},
 		{"xcode cloud product app iap empty", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", ""}, "--iap-fields must not be empty"},
 		{"xcode cloud product app group whitespace", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--subscription-group-fields", " \t"}, "--subscription-group-fields must not be empty"},
+		{"xcode cloud product app app info empty", []string{"xcode-cloud", "products", "app", "--id", "product-1", "--app-info-fields", ""}, "--app-info-fields must not be empty"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, test.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.want)
+			}
+		})
+	}
+}
+
+func TestAppInfoLocalizationSparseFieldsRejectNextAndOtherTypesBeforeAuth(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appInfos/info-1/appInfoLocalizations?cursor=next"
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "next conflict",
+			args: []string{"localizations", "list", "--type", "app-info", "--app", "app-1", "--next", next, "--app-info-fields", ""},
+			want: "--next cannot be combined with --app-info-fields",
+		},
+		{
+			name: "version type",
+			args: []string{"localizations", "list", "--version", "version-1", "--app-info-fields", "kidsAgeBand"},
+			want: "--app-info-fields requires --type app-info",
+		},
 	}
 
 	for _, test := range tests {
@@ -94,7 +142,7 @@ func TestSparseAppFieldFlagsRejectExplicitEmptyBeforeAuth(t *testing.T) {
 
 func TestAppsListSparseFieldsConflictWithNextBeforeAuth(t *testing.T) {
 	next := "https://api.appstoreconnect.apple.com/v1/apps?cursor=next"
-	for _, flagName := range []string{"--iap-fields", "--subscription-group-fields"} {
+	for _, flagName := range []string{"--app-info-fields", "--iap-fields", "--subscription-group-fields"} {
 		t.Run(flagName, func(t *testing.T) {
 			root := RootCommand("1.2.3")
 			root.FlagSet.SetOutput(io.Discard)
@@ -144,14 +192,14 @@ func TestSparseAppFieldCommandsSendExactQueries(t *testing.T) {
 		response  string
 	}{
 		{
-			name: "apps list", args: []string{"apps", "list", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
+			name: "apps list", args: []string{"apps", "list", "--app-info-fields", "kidsAgeBand", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
 			wantPath: "/v1/apps", response: `{"data":[]}`,
-			wantQuery: map[string]string{"fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "inAppPurchases,subscriptionGroups"},
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "appInfos,inAppPurchases,subscriptionGroups"},
 		},
 		{
-			name: "apps view", args: []string{"apps", "view", "--id", "app-1", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
+			name: "apps view", args: []string{"apps", "view", "--id", "app-1", "--app-info-fields", "kidsAgeBand", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
 			wantPath: "/v1/apps/app-1", response: `{"data":{"type":"apps","id":"app-1"}}`,
-			wantQuery: map[string]string{"fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "inAppPurchases,subscriptionGroups"},
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "appInfos,inAppPurchases,subscriptionGroups"},
 		},
 		{
 			name: "app infos list", args: []string{"apps", "info", "list", "--app", "app-1", "--fields", "kidsAgeBand", "--age-rating-fields", "socialMedia,socialMediaAgeRestricted", "--output", "json"},
@@ -169,9 +217,14 @@ func TestSparseAppFieldCommandsSendExactQueries(t *testing.T) {
 			wantQuery: map[string]string{"fields[ageRatingDeclarations]": "socialMedia,socialMediaAgeRestricted"},
 		},
 		{
-			name: "xcode cloud product app", args: []string{"xcode-cloud", "products", "app", "--id", "product-1", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
+			name: "app info localizations", args: []string{"localizations", "list", "--type", "app-info", "--app", "app-1", "--app-info", "info-1", "--app-info-fields", "kidsAgeBand", "--output", "json"},
+			wantPath: "/v1/appInfos/info-1/appInfoLocalizations", response: `{"data":[]}`,
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "include": "appInfo"},
+		},
+		{
+			name: "xcode cloud product app", args: []string{"xcode-cloud", "products", "app", "--id", "product-1", "--app-info-fields", "kidsAgeBand", "--iap-fields", "versions", "--subscription-group-fields", "versions", "--output", "json"},
 			wantPath: "/v1/ciProducts/product-1/app", response: `{"data":{"type":"apps","id":"app-1"}}`,
-			wantQuery: map[string]string{"fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "inAppPurchases,subscriptionGroups"},
+			wantQuery: map[string]string{"fields[appInfos]": "kidsAgeBand", "fields[inAppPurchases]": "versions", "fields[subscriptionGroups]": "versions", "include": "appInfos,inAppPurchases,subscriptionGroups"},
 		},
 	}
 
@@ -187,8 +240,13 @@ func TestSparseAppFieldCommandsSendExactQueries(t *testing.T) {
 				}
 				query := req.URL.Query()
 				for key, want := range test.wantQuery {
-					if got := query.Get(key); got != want {
-						t.Errorf("query %s = %q, want %q", key, got, want)
+					got, ok := query[key]
+					if !ok {
+						t.Errorf("query is missing %s", key)
+						continue
+					}
+					if len(got) != 1 || got[0] != want {
+						t.Errorf("query %s = %q, want exactly [%q]", key, got, want)
 					}
 				}
 				if len(query) != len(test.wantQuery) {
@@ -214,5 +272,33 @@ func TestSparseAppFieldCommandsSendExactQueries(t *testing.T) {
 				t.Fatalf("calls = %d, want 1", calls)
 			}
 		})
+	}
+}
+
+func TestSparseAppFieldHelp441(t *testing.T) {
+	root := RootCommand("1.2.3")
+	for _, path := range [][]string{
+		{"apps", "list"},
+		{"apps", "view"},
+		{"xcode-cloud", "products", "app"},
+	} {
+		command := findSubcommand(root, path...)
+		if command == nil {
+			t.Fatalf("command %v not found", path)
+		}
+		usage := command.UsageFunc(command)
+		for _, flagName := range []string{"--app-info-fields", "--iap-fields", "--subscription-group-fields"} {
+			if !strings.Contains(usage, flagName) {
+				t.Errorf("help for %v does not contain %s: %q", path, flagName, usage)
+			}
+		}
+	}
+
+	localizations := findSubcommand(root, "localizations", "list")
+	if localizations == nil {
+		t.Fatal("command [localizations list] not found")
+	}
+	if usage := localizations.UsageFunc(localizations); !strings.Contains(usage, "--app-info-fields") {
+		t.Fatalf("help for [localizations list] does not contain --app-info-fields: %q", usage)
 	}
 }

--- a/internal/cli/localizations/localizations.go
+++ b/internal/cli/localizations/localizations.go
@@ -61,6 +61,7 @@ func LocalizationsListCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	appInfoID := fs.String("app-info", "", "App Info ID (optional override)")
 	locType := fs.String("type", shared.LocalizationTypeVersion, "Localization type: version (default) or app-info")
+	appInfoFields := fs.String("app-info-fields", "", "Sparse app info fields for app-info localizations: kidsAgeBand (deprecated; prefer age-rating data)")
 	locale := fs.String("locale", "", "Filter by locale(s), comma-separated")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -75,7 +76,7 @@ func LocalizationsListCommand() *ffcli.Command {
 
 Examples:
   asc localizations list --version "VERSION_ID"
-  asc localizations list --app "APP_ID" --type app-info
+  asc localizations list --app "APP_ID" --type app-info --app-info-fields kidsAgeBand
   asc localizations list --version "VERSION_ID" --locale "en-US,ja"
   asc localizations list --version "VERSION_ID" --paginate`,
 		FlagSet:   fs,
@@ -94,6 +95,21 @@ Examples:
 			normalizedType, err := shared.NormalizeLocalizationType(*locType)
 			if err != nil {
 				return fmt.Errorf("localizations list: %w", err)
+			}
+			appInfoFieldsProvided := false
+			fs.Visit(func(f *flag.Flag) { appInfoFieldsProvided = appInfoFieldsProvided || f.Name == "app-info-fields" })
+			if strings.TrimSpace(*next) != "" && appInfoFieldsProvided {
+				return shared.UsageError("--next cannot be combined with --app-info-fields")
+			}
+			appInfoFieldValues, err := shared.NormalizeSelection(*appInfoFields, []string{"kidsAgeBand"}, "--app-info-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if appInfoFieldsProvided && len(appInfoFieldValues) == 0 {
+				return shared.UsageError("--app-info-fields must not be empty")
+			}
+			if appInfoFieldsProvided && normalizedType != shared.LocalizationTypeAppInfo {
+				return shared.UsageError("--app-info-fields requires --type app-info")
 			}
 
 			locales := shared.SplitCSV(*locale)
@@ -166,6 +182,13 @@ Examples:
 				opts := []asc.AppInfoLocalizationsOption{
 					asc.WithAppInfoLocalizationsLimit(*limit),
 					asc.WithAppInfoLocalizationsNextURL(*next),
+				}
+				if len(appInfoFieldValues) > 0 {
+					opts = append(
+						opts,
+						asc.WithAppInfoLocalizationsAppInfoFields(appInfoFieldValues),
+						asc.WithAppInfoLocalizationsInclude([]string{"appInfo"}),
+					)
 				}
 				if len(locales) > 0 {
 					opts = append(opts, asc.WithAppInfoLocalizationLocales(locales))

--- a/internal/cli/xcodecloud/sparse_app_fields_4_4_1.go
+++ b/internal/cli/xcodecloud/sparse_app_fields_4_4_1.go
@@ -1,10 +1,29 @@
 package xcodecloud
 
-import "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
 
 var ciProductAppInAppPurchaseSparseFields441 = []string{"versions"}
 
 var ciProductAppSubscriptionGroupSparseFields441 = []string{"versions"}
+
+func normalizeCiProductAppSparseField(fs *flag.FlagSet, value string, allowed []string, flagName string) ([]string, error) {
+	values, err := shared.NormalizeSelection(value, allowed, flagName)
+	if err != nil {
+		return nil, err
+	}
+	provided := false
+	fs.Visit(func(f *flag.Flag) { provided = provided || f.Name == strings.TrimPrefix(flagName, "--") })
+	if provided && len(values) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", flagName)
+	}
+	return values, nil
+}
 
 func addCiProductAppInclude(values []string, include string) []string {
 	if !shared.HasInclude(values, include) {

--- a/internal/cli/xcodecloud/sparse_app_fields_4_4_1.go
+++ b/internal/cli/xcodecloud/sparse_app_fields_4_4_1.go
@@ -12,6 +12,8 @@ var ciProductAppInAppPurchaseSparseFields441 = []string{"versions"}
 
 var ciProductAppSubscriptionGroupSparseFields441 = []string{"versions"}
 
+var ciProductAppInfoSparseFields441 = []string{"kidsAgeBand"}
+
 func normalizeCiProductAppSparseField(fs *flag.FlagSet, value string, allowed []string, flagName string) ([]string, error) {
 	values, err := shared.NormalizeSelection(value, allowed, flagName)
 	if err != nil {

--- a/internal/cli/xcodecloud/sparse_app_fields_4_4_1.go
+++ b/internal/cli/xcodecloud/sparse_app_fields_4_4_1.go
@@ -1,0 +1,14 @@
+package xcodecloud
+
+import "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+
+var ciProductAppInAppPurchaseSparseFields441 = []string{"versions"}
+
+var ciProductAppSubscriptionGroupSparseFields441 = []string{"versions"}
+
+func addCiProductAppInclude(values []string, include string) []string {
+	if !shared.HasInclude(values, include) {
+		values = append(values, include)
+	}
+	return values
+}

--- a/internal/cli/xcodecloud/xcode_cloud_extras.go
+++ b/internal/cli/xcodecloud/xcode_cloud_extras.go
@@ -122,11 +122,11 @@ Examples:
 			if idValue == "" {
 				return shared.UsageError("--id is required")
 			}
-			iapFieldValues, err := shared.NormalizeSelection(*iapFields, ciProductAppInAppPurchaseSparseFields441, "--iap-fields")
+			iapFieldValues, err := normalizeCiProductAppSparseField(fs, *iapFields, ciProductAppInAppPurchaseSparseFields441, "--iap-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			groupFieldValues, err := shared.NormalizeSelection(*subscriptionGroupFields, ciProductAppSubscriptionGroupSparseFields441, "--subscription-group-fields")
+			groupFieldValues, err := normalizeCiProductAppSparseField(fs, *subscriptionGroupFields, ciProductAppSubscriptionGroupSparseFields441, "--subscription-group-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}

--- a/internal/cli/xcodecloud/xcode_cloud_extras.go
+++ b/internal/cli/xcodecloud/xcode_cloud_extras.go
@@ -99,26 +99,64 @@ Examples:
 }
 
 func XcodeCloudProductsAppCommand() *ffcli.Command {
-	return shared.BuildIDGetCommand(shared.IDGetCommandConfig{
-		FlagSetName: "app",
-		Name:        "app",
-		ShortUsage:  "asc xcode-cloud products app --id \"PRODUCT_ID\"",
-		ShortHelp:   "Get the app for a product.",
+	fs := flag.NewFlagSet("app", flag.ExitOnError)
+	id := fs.String("id", "", "Product ID")
+	iapFields := fs.String("iap-fields", "", "Sparse fields for included in-app purchases: versions")
+	subscriptionGroupFields := fs.String("subscription-group-fields", "", "Sparse fields for included subscription groups: versions")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "app",
+		ShortUsage: "asc xcode-cloud products app --id \"PRODUCT_ID\"",
+		ShortHelp:  "Get the app for a product.",
 		LongHelp: `Get the app for a product.
 
 Examples:
   asc xcode-cloud products app --id "PRODUCT_ID"
+  asc xcode-cloud products app --id "PRODUCT_ID" --iap-fields versions
   asc xcode-cloud products app --id "PRODUCT_ID" --output table`,
-		IDFlag:      "id",
-		IDUsage:     "Product ID",
-		ErrorPrefix: "xcode-cloud products app",
-		ContextTimeout: func(ctx context.Context) (context.Context, context.CancelFunc) {
-			return contextWithXcodeCloudTimeout(ctx, 0)
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			idValue := strings.TrimSpace(*id)
+			if idValue == "" {
+				return shared.UsageError("--id is required")
+			}
+			iapFieldValues, err := shared.NormalizeSelection(*iapFields, ciProductAppInAppPurchaseSparseFields441, "--iap-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			groupFieldValues, err := shared.NormalizeSelection(*subscriptionGroupFields, ciProductAppSubscriptionGroupSparseFields441, "--subscription-group-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products app: %w", err)
+			}
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, 0)
+			defer cancel()
+
+			includeValues := []string{}
+			if len(iapFieldValues) > 0 {
+				includeValues = addCiProductAppInclude(includeValues, "inAppPurchases")
+			}
+			if len(groupFieldValues) > 0 {
+				includeValues = addCiProductAppInclude(includeValues, "subscriptionGroups")
+			}
+			resp, err := client.GetCiProductApp(
+				requestCtx, idValue,
+				asc.WithCiProductAppInAppPurchaseFields(iapFieldValues),
+				asc.WithCiProductAppSubscriptionGroupFields(groupFieldValues),
+				asc.WithCiProductAppInclude(includeValues),
+			)
+			if err != nil {
+				return fmt.Errorf("xcode-cloud products app: failed to fetch: %w", err)
+			}
+			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
-		Fetch: func(ctx context.Context, client *asc.Client, id string) (any, error) {
-			return client.GetCiProductApp(ctx, id)
-		},
-	})
+	}
 }
 
 func XcodeCloudProductsBuildRunsCommand() *ffcli.Command {

--- a/internal/cli/xcodecloud/xcode_cloud_extras.go
+++ b/internal/cli/xcodecloud/xcode_cloud_extras.go
@@ -101,6 +101,7 @@ Examples:
 func XcodeCloudProductsAppCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("app", flag.ExitOnError)
 	id := fs.String("id", "", "Product ID")
+	appInfoFields := fs.String("app-info-fields", "", "Sparse fields for included app info records: kidsAgeBand (deprecated; prefer age-rating data)")
 	iapFields := fs.String("iap-fields", "", "Sparse fields for included in-app purchases: versions")
 	subscriptionGroupFields := fs.String("subscription-group-fields", "", "Sparse fields for included subscription groups: versions")
 	output := shared.BindOutputFlags(fs)
@@ -113,7 +114,7 @@ func XcodeCloudProductsAppCommand() *ffcli.Command {
 
 Examples:
   asc xcode-cloud products app --id "PRODUCT_ID"
-  asc xcode-cloud products app --id "PRODUCT_ID" --iap-fields versions
+  asc xcode-cloud products app --id "PRODUCT_ID" --app-info-fields kidsAgeBand --iap-fields versions
   asc xcode-cloud products app --id "PRODUCT_ID" --output table`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -121,6 +122,10 @@ Examples:
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				return shared.UsageError("--id is required")
+			}
+			appInfoFieldValues, err := normalizeCiProductAppSparseField(fs, *appInfoFields, ciProductAppInfoSparseFields441, "--app-info-fields")
+			if err != nil {
+				return shared.UsageError(err.Error())
 			}
 			iapFieldValues, err := normalizeCiProductAppSparseField(fs, *iapFields, ciProductAppInAppPurchaseSparseFields441, "--iap-fields")
 			if err != nil {
@@ -139,6 +144,9 @@ Examples:
 			defer cancel()
 
 			includeValues := []string{}
+			if len(appInfoFieldValues) > 0 {
+				includeValues = addCiProductAppInclude(includeValues, "appInfos")
+			}
 			if len(iapFieldValues) > 0 {
 				includeValues = addCiProductAppInclude(includeValues, "inAppPurchases")
 			}
@@ -147,6 +155,7 @@ Examples:
 			}
 			resp, err := client.GetCiProductApp(
 				requestCtx, idValue,
+				asc.WithCiProductAppAppInfoFields(appInfoFieldValues),
 				asc.WithCiProductAppInAppPurchaseFields(iapFieldValues),
 				asc.WithCiProductAppSubscriptionGroupFields(groupFieldValues),
 				asc.WithCiProductAppInclude(includeValues),


### PR DESCRIPTION
## Summary

- expose the App Store Connect API 4.4.1 sparse-field additions on the exact eight affected app GET operations
- add strict long-form CLI flags with deterministic relationship includes, explicit-empty rejection, and opaque `--next` exclusivity
- document the command surface, exact endpoint contract, landed 4.4.1 integration provenance, and read-only live evidence

## Exact endpoint coverage

1. `GET /v1/appInfoLocalizations/{id}`
2. `GET /v1/appInfos/{id}`
3. `GET /v1/apps`
4. `GET /v1/apps/{id}`
5. `GET /v1/appInfos/{id}/ageRatingDeclaration`
6. `GET /v1/appInfos/{id}/appInfoLocalizations`
7. `GET /v1/apps/{id}/appInfos`
8. `GET /v1/ciProducts/{id}/app`

The slice adds only the endpoint-supported values:

- `fields[appInfos]=kidsAgeBand`
- `fields[ageRatingDeclarations]=socialMedia,socialMediaAgeRestricted`
- `fields[inAppPurchases]=versions`
- `fields[subscriptionGroups]=versions`

Relationship fields automatically add the required `appInfo`, `ageRatingDeclaration`, `inAppPurchases`, or `subscriptionGroups` include. The client keeps operation-specific option types rather than adding a generic query map.

## CLI behavior

- `asc apps list` / `asc apps view`: `--app-info-fields kidsAgeBand`, `--iap-fields versions`, `--subscription-group-fields versions`
- `asc apps info list` / app-info mode of `asc apps info view`: `--fields kidsAgeBand`, `--age-rating-fields socialMedia,socialMediaAgeRestricted`
- `asc age-rating view`: `--fields socialMedia,socialMediaAgeRestricted`
- `asc localizations list --type app-info`: `--app-info-fields kidsAgeBand`
- `asc xcode-cloud products app`: `--app-info-fields kidsAgeBand`, `--iap-fields versions`, `--subscription-group-fields versions`

Every new sparse flag validates before authentication or HTTP and rejects an explicitly supplied empty or whitespace-only value. List continuation modes reject sparse flags with `--next`, including explicit-empty flags, because the continuation URL owns the query. The localization flag is also rejected outside `--type app-info`.

Apple marks `kidsAgeBand` deprecated. The CLI retains the official 4.4.1 selector for compatibility, labels it deprecated in help and docs, and directs new workflows to `asc age-rating view`.

## Verification

- focused exact client path/query tests
- focused CLI validation, auto-include, output, and exact HTTP query tests
- `make format`
- `make build`
- `make check-docs`
- isolated-cache `make lint` (`0 issues`)
- `ASC_BYPASS_KEYCHAIN=1 go test ./...` outside the network sandbox so existing `httptest` packages could bind loopback
- exact built help audit for all seven affected command paths
- repository commit hooks: docs, command docs, format, lint, and short test suite passed

## Live App Store Connect evidence

Earlier read-only checks used disposable app `6759231657`:

- app IAP/subscription-group `versions` sparse fields with their includes returned `200`
- direct and included age-rating sparse fields returned `200`
- Apple production returned `400` (`'kidsAgeBand' is not a valid field name`) for the official 4.4.1 `fields[appInfos]=kidsAgeBand` query on app-info detail and collection operations; the CLI retains the published OpenAPI contract and records this as an upstream rollout mismatch
- the disposable app has no Xcode Cloud product, so that route is verified by exact client and CLI HTTP tests

No App Store Connect resource was created, changed, submitted, or deleted. No additional live call or mutation was performed after rebasing onto exact `main` `5bf2d1545785a863242a8509bf55cc25d8a4ab49`.

No release, tag, or package publication is part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API 4.4.1 sparse-field support across apps, apps list/view, app info list/view, age-rating view, app-info localizations list, and Xcode Cloud product apps (social-media age-rating, kids age-band where applicable, in-app purchases, and subscription groups).
* **Bug Fixes**
  * Improved validation for empty/unsupported values and blocked incompatible flag combinations, including `--next` conflicts; updated which related resources are auto-included.
* **Documentation**
  * Refreshed command docs with new `--fields`/`--age-rating-fields` and sparse-field examples, including tightened verification/readback guidance and kids-age-band deprecation notes.
* **Tests**
  * Added coverage for sparse-field query construction and pre/post-authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->