### PR TITLE
fix(xcode): resolve absolute xcconfig groups

### DIFF
--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -703,7 +703,8 @@ func (project *structuredVersionProject) fileReferencePath(referenceID string) (
 		if err != nil {
 			return "", err
 		}
-		if groupPath, err := parent.String("path"); err == nil && groupPath != "" {
+		groupPath, _ := parent.String("path")
+		if groupPath != "" {
 			groupPaths = append([]string{groupPath}, groupPaths...)
 		}
 		parentSourceTree, _ := parent.String("sourceTree")
@@ -712,7 +713,10 @@ func (project *structuredVersionProject) fileReferencePath(referenceID string) (
 			break
 		}
 	}
-	parts := append([]string{project.rootDir}, groupPaths...)
+	parts := append([]string(nil), groupPaths...)
+	if len(parts) == 0 || !filepath.IsAbs(parts[0]) {
+		parts = append([]string{project.rootDir}, parts...)
+	}
 	parts = append(parts, path)
 	return filepath.Clean(filepath.Join(parts...)), nil
 }

--- a/internal/xcode/version_structured_test.go
+++ b/internal/xcode/version_structured_test.go
@@ -838,6 +838,35 @@ func TestStructuredVersion_GroupRelativeXCConfigReference(t *testing.T) {
 	}
 }
 
+func TestStructuredVersion_AbsoluteGroupXCConfigReference(t *testing.T) {
+	project := writeStructuredVersionProject(t, true)
+	configDir := filepath.Join(filepath.Dir(project), "Configs")
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	contents := mustReadVersionTestFile(t, pbxprojPath)
+	old := "path = Configs/App.xcconfig; sourceTree = SOURCE_ROOT;"
+	if count := strings.Count(contents, old); count != 1 {
+		t.Fatalf("expected one App.xcconfig reference, found %d", count)
+	}
+	contents = strings.Replace(contents,
+		old,
+		"path = App.xcconfig; sourceTree = \"<group>\";", 1)
+	old = "AAAAAAAAAAAAAAAAAAAAAAAA /* App.xcconfig */ ="
+	if count := strings.Count(contents, old); count != 1 {
+		t.Fatalf("expected one App.xcconfig object, found %d", count)
+	}
+	contents = strings.Replace(contents,
+		old,
+		"ABABABABABABABABABABABAB /* Configs */ = {isa = PBXGroup; children = (AAAAAAAAAAAAAAAAAAAAAAAA,); path = \""+configDir+"\"; sourceTree = \"<absolute>\"; };\n\t\tAAAAAAAAAAAAAAAAAAAAAAAA /* App.xcconfig */ =", 1)
+	if err := os.WriteFile(pbxprojPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(project) error = %v", err)
+	}
+
+	view := mustGetStructuredVersion(t, project, "App", "Release")
+	if view.Version != "1.2.3" || !strings.HasSuffix(view.VersionSource, "Configs/Shared.xcconfig") {
+		t.Fatalf("absolute-group xcconfig was not resolved: %#v", view)
+	}
+}
+
 func TestStructuredVersion_ScopedBumps(t *testing.T) {
 	t.Run("patch", func(t *testing.T) {
 		project := writeStructuredVersionProject(t, false)


### PR DESCRIPTION
## Summary

- fix relative xcconfig file references beneath an absolute PBXGroup
- avoid prefixing the project root when the resolved parent group chain is already absolute
- add a focused regression alongside the existing group-relative coverage

This fixes the valid unresolved review finding on merged PR #1794.

## Verification

- focused regression was RED before the fix with a duplicated project-root/absolute-group path
- `ASC_BYPASS_KEYCHAIN=1 GOCACHE=/private/tmp/asc-xcconfig-fix-gocache go test ./internal/xcode -count=1`
- `GOCACHE=/private/tmp/asc-xcconfig-fix-gocache make format`
- `GOCACHE=/private/tmp/asc-xcconfig-fix-gocache make check-docs`
- `GOCACHE=/private/tmp/asc-xcconfig-fix-gocache make lint` (0 issues; sandbox cache-write warnings only)
- `ASC_BYPASS_KEYCHAIN=1 GOCACHE=/private/tmp/asc-xcconfig-fix-gocache make test` (green outside the sandbox so httptest could bind loopback ports)

No App Store Connect resources were read or mutated; this is local Xcode project-path resolution only. No release is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how Xcode group paths are built and normalized when resolving configuration file locations using absolute references.
  * Fixed structured version resolution to correctly continue using the shared `.xcconfig` when referenced via an absolute group path.
* **Tests**
  * Added a test to verify version resolution and `VersionSource` for absolute Xcode group references to `App.xcconfig`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->