### PR TITLE
feat: surface rate limits in API debug logs

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -55,6 +55,7 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - JWTs issued for App Store Connect are valid for 10 minutes (handled internally).
 - Automatic retries apply only to GET/HEAD requests on 429/503 responses; POST/PATCH/DELETE are not retried.
 - Retry-After headers are honored when present; configure retry settings via `ASC_MAX_RETRIES`, `ASC_BASE_DELAY`, `ASC_MAX_DELAY`, `ASC_RETRY_LOG`.
+- `--api-debug` and `ASC_DEBUG=api` log each response's raw `X-Rate-Limit` value to stderr without changing stdout.
 - Some endpoints return 403 when the API key role lacks permission (e.g., finance reports, reviews).
 
 ## Devices

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -229,6 +229,7 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 			"elapsed", elapsed.String(),
 			"content-type", resp.Header.Get("Content-Type"),
 			"content-length", resp.Header.Get("Content-Length"),
+			"x-rate-limit", resp.Header.Get("X-Rate-Limit"),
 		)
 	}
 

--- a/internal/asc/client_http_debug_test.go
+++ b/internal/asc/client_http_debug_test.go
@@ -3,11 +3,38 @@ package asc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 )
+
+func captureHTTPDebugLog(t *testing.T, enabled bool) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	originalLogger := debugLogger
+	debugLogger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return attr
+		},
+	}))
+	t.Cleanup(func() { debugLogger = originalLogger })
+
+	SetDebugOverride(&enabled)
+	SetDebugHTTPOverride(&enabled)
+	t.Cleanup(func() {
+		SetDebugOverride(nil)
+		SetDebugHTTPOverride(nil)
+	})
+
+	return &buf
+}
 
 func TestSanitizeAuthHeader(t *testing.T) {
 	tests := []struct {
@@ -83,26 +110,8 @@ func TestSanitizeURLForLog_RedactsUserInfo(t *testing.T) {
 }
 
 func TestDebugLoggingRedactsSignedQuery(t *testing.T) {
-	var buf bytes.Buffer
-	originalLogger := debugLogger
-	debugLogger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
-			if attr.Key == slog.TimeKey {
-				return slog.Attr{}
-			}
-			return attr
-		},
-	}))
-	t.Cleanup(func() { debugLogger = originalLogger })
-
 	debugEnabled := true
-	SetDebugOverride(&debugEnabled)
-	SetDebugHTTPOverride(&debugEnabled)
-	t.Cleanup(func() {
-		SetDebugOverride(nil)
-		SetDebugHTTPOverride(nil)
-	})
+	buf := captureHTTPDebugLog(t, debugEnabled)
 
 	client := newTestClient(t, nil, jsonResponse(http.StatusOK, `{"data":[]}`))
 	_, err := client.doOnce(context.Background(), http.MethodGet, "https://example.com/path?X-Amz-Signature=abc&foo=bar", nil)
@@ -119,5 +128,66 @@ func TestDebugLoggingRedactsSignedQuery(t *testing.T) {
 	}
 	if !strings.Contains(output, "REDACTED") {
 		t.Fatalf("expected redacted placeholder in %q", output)
+	}
+}
+
+func TestDebugLoggingIncludesRateLimitHeader(t *testing.T) {
+	buf := captureHTTPDebugLog(t, true)
+
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	response.Header.Set("X-Rate-Limit", "user-hour-lim:3500;user-hour-rem:500;")
+	client := newTestClient(t, nil, response)
+
+	data, err := client.doOnce(context.Background(), http.MethodGet, "/v1/apps", nil)
+	if err != nil {
+		t.Fatalf("doOnce() error: %v", err)
+	}
+	if string(data) != `{"data":[]}` {
+		t.Fatalf("doOnce() data = %q, want unchanged response body", data)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `x-rate-limit=user-hour-lim:3500;user-hour-rem:500;`) {
+		t.Fatalf("expected rate limit header in HTTP debug output, got %q", output)
+	}
+}
+
+func TestDebugLoggingIncludesRateLimitHeaderOnError(t *testing.T) {
+	buf := captureHTTPDebugLog(t, true)
+
+	response := jsonResponse(http.StatusTooManyRequests, `{"errors":[{"code":"RATE_LIMIT_EXCEEDED"}]}`)
+	response.Header.Set("X-Rate-Limit", "user-hour-lim:3500;user-hour-rem:0;")
+	client := newTestClient(t, nil, response)
+
+	_, err := client.doOnce(context.Background(), http.MethodGet, "/v1/apps", nil)
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	var retryableErr *RetryableError
+	if !errors.As(err, &retryableErr) {
+		t.Fatalf("expected RetryableError, got %T: %v", err, err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `status=429`) {
+		t.Fatalf("expected HTTP status in debug output, got %q", output)
+	}
+	if !strings.Contains(output, `x-rate-limit=user-hour-lim:3500;user-hour-rem:0;`) {
+		t.Fatalf("expected rate limit header in HTTP error debug output, got %q", output)
+	}
+}
+
+func TestDebugLoggingDisabledDoesNotExposeRateLimitHeader(t *testing.T) {
+	buf := captureHTTPDebugLog(t, false)
+
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	response.Header.Set("X-Rate-Limit", "user-hour-lim:3500;user-hour-rem:500;")
+	client := newTestClient(t, nil, response)
+
+	if _, err := client.doOnce(context.Background(), http.MethodGet, "/v1/apps", nil); err != nil {
+		t.Fatalf("doOnce() error: %v", err)
+	}
+	if output := buf.String(); output != "" {
+		t.Fatalf("expected no HTTP debug output when disabled, got %q", output)
 	}
 }


### PR DESCRIPTION
## Summary

- include App Store Connect's raw `X-Rate-Limit` value in existing HTTP response diagnostics
- preserve normal JSON, table, and Markdown stdout exactly
- cover successful, 429, and disabled-debug behavior
- document `--api-debug` and `ASC_DEBUG=api`

## Why

Apple returns rate-limit capacity and remaining-request information in `X-Rate-Limit`. Surfacing it through the existing API-debug channel provides per-response visibility for retries, pagination, and composite workflows without introducing a redundant flag or changing command data contracts.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused `internal/asc` RED/GREEN coverage
- built `/tmp/asc` and verified both `--api-debug` and `ASC_DEBUG=api`
- read-only live `apps view` against disposable app `6759231657`; stdout remained valid JSON and stderr included Apple's live `X-Rate-Limit` value
- default invocation emitted zero stderr bytes

Closes #1802

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787132786&installation_id=101311810&pr_number=1803&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1803&signature=68969f560847e45f5fac93dc7a1cf81edad8a0db0ca2700c8e50e6b13af348d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API debug logging for raw rate-limit response headers.
  * Debug output now includes rate-limit details for successful and error responses while leaving standard output unchanged.

* **Documentation**
  * Updated authentication and rate-limiting documentation with instructions for enabling this diagnostic information.

* **Tests**
  * Added coverage confirming rate-limit headers appear only when API debugging is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->