### PR TITLE
fix(search): prioritize canonical workflows

### DIFF
--- a/docs/design/search-ranking-hardening.md
+++ b/docs/design/search-ranking-hardening.md
@@ -47,6 +47,8 @@ RED-GREEN coverage will assert that:
   workflow within a five-result limit;
 - `asc search "upload build app"` keeps the direct `asc builds upload` command
   ahead of broader publish workflows;
+- `asc search "app review"` does not apply a publish-workflow boost to the
+  generic review intent;
 - the built binary emits valid JSON to stdout, nothing to stderr, and exits zero
   for both natural-language queries.
 

--- a/docs/design/search-ranking-hardening.md
+++ b/docs/design/search-ranking-hardening.md
@@ -1,0 +1,61 @@
+# Search ranking hardening
+
+## Placement and current behavior
+
+`asc search` remains in `internal/cli/search` and stays registered as the existing
+top-level utility command. Its invocation and help remain unchanged:
+
+```text
+asc search [flags] <query>
+```
+
+The current scorer treats any query term of three or more characters as a match
+when it appears anywhere inside an indexed token. That makes `ship` match
+`relationships`. It also has no first-class notion of canonical workflows, so
+deep resource commands can outrank `asc publish appstore` for release-oriented
+queries.
+
+## Proposed behavior
+
+- Match indexed fields by exact normalized tokens plus conservative singular and
+  plural stemming.
+- Match hyphenated token components independently, so `app` still matches
+  `app-store-releases` without restoring arbitrary substring behavior.
+- Apply deterministic intent boosts to canonical publish workflows when a query
+  contains both a shipping action and the corresponding App Store or TestFlight
+  subject.
+- Keep fuzzy typo matching as the fallback only when a term has no direct token
+  or stem match.
+
+This change is local-only and does not call an App Store Connect endpoint.
+
+## Compatibility and output
+
+Flags, accepted values, output formats, stdout/stderr placement, exit codes, and
+the JSON response schema remain unchanged. Result ordering, scores, and `matched`
+reasons intentionally change. Existing scripts must not treat scores as stable
+across CLI versions.
+
+## Tests and verification
+
+RED-GREEN coverage will assert that:
+
+- `ship` does not match the `relationships` token;
+- singular queries still match plural command tokens;
+- `asc search "ship app"` ranks `asc publish appstore` first;
+- `asc search "release app"` includes and prioritizes the canonical publish
+  workflow within a five-result limit;
+- the built binary emits valid JSON to stdout, nothing to stderr, and exits zero
+  for both natural-language queries.
+
+Focused package tests, adjacent CLI tests, a `/tmp/asc` build, and the repository
+validation gate cover the remaining regression surface. No live API call is
+needed because ranking is deterministic and offline.
+
+## Alternatives
+
+Blacklisting `relationships` would fix only the reported collision and leave all
+other substring false positives intact. Penalizing deep command paths alone would
+improve some ordering but would neither remove the false match nor reliably route
+shipping language to the documented canonical workflow. Exact token/stem matching
+plus narrow intent boosts fixes both causes without changing the command surface.

--- a/docs/design/search-ranking-hardening.md
+++ b/docs/design/search-ranking-hardening.md
@@ -45,6 +45,8 @@ RED-GREEN coverage will assert that:
 - `asc search "ship app"` ranks `asc publish appstore` first;
 - `asc search "release app"` includes and prioritizes the canonical publish
   workflow within a five-result limit;
+- `asc search "upload build app"` keeps the direct `asc builds upload` command
+  ahead of broader publish workflows;
 - the built binary emits valid JSON to stdout, nothing to stderr, and exits zero
   for both natural-language queries.
 

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -104,6 +104,72 @@ func TestSearchUsesAliasesForAgentVocabulary(t *testing.T) {
 	}
 }
 
+func TestSearchPrioritizesCanonicalPublishWorkflowForNaturalLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    []string
+		expected string
+	}{
+		{name: "ship app", query: []string{"ship", "app"}, expected: "asc publish appstore"},
+		{name: "release app", query: []string{"release", "app"}, expected: "asc publish appstore"},
+		{name: "ship beta", query: []string{"ship", "beta"}, expected: "asc publish testflight"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				args := []string{"search", "--output", "json", "--limit", "5"}
+				args = append(args, test.query...)
+				code = rootcmd.Run(args, "1.2.3")
+			})
+
+			if code != 0 {
+				t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var response searchResponse
+			if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+				t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+			}
+			if len(response.Results) == 0 {
+				t.Fatalf("expected search results, got %#v", response)
+			}
+			if response.Results[0].Command != test.expected {
+				t.Fatalf("expected canonical publish workflow %q first, got %#v", test.expected, response.Results)
+			}
+		})
+	}
+}
+
+func TestSearchKeepsExactBuildUploadAheadOfBroaderPublishWorkflows(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "--limit", "5", "upload", "build"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if len(response.Results) == 0 {
+		t.Fatalf("expected search results, got %#v", response)
+	}
+	if response.Results[0].Command != "asc builds upload" {
+		t.Fatalf("expected exact build upload command first, got %#v", response.Results)
+	}
+}
+
 func TestSearchUsesTypoToleranceAsFallback(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -146,27 +146,36 @@ func TestSearchPrioritizesCanonicalPublishWorkflowForNaturalLanguage(t *testing.
 }
 
 func TestSearchKeepsExactBuildUploadAheadOfBroaderPublishWorkflows(t *testing.T) {
-	var code int
-	stdout, stderr := captureOutput(t, func() {
-		code = rootcmd.Run([]string{"search", "--output", "json", "--limit", "5", "upload", "build"}, "1.2.3")
-	})
+	for _, query := range [][]string{
+		{"upload", "build"},
+		{"upload", "build", "app"},
+	} {
+		t.Run(strings.Join(query, " "), func(t *testing.T) {
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				args := []string{"search", "--output", "json", "--limit", "5"}
+				args = append(args, query...)
+				code = rootcmd.Run(args, "1.2.3")
+			})
 
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
-	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
+			if code != 0 {
+				t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
 
-	var response searchResponse
-	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
-		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
-	}
-	if len(response.Results) == 0 {
-		t.Fatalf("expected search results, got %#v", response)
-	}
-	if response.Results[0].Command != "asc builds upload" {
-		t.Fatalf("expected exact build upload command first, got %#v", response.Results)
+			var response searchResponse
+			if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+				t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+			}
+			if len(response.Results) == 0 {
+				t.Fatalf("expected search results, got %#v", response)
+			}
+			if response.Results[0].Command != "asc builds upload" {
+				t.Fatalf("expected exact build upload command first, got %#v", response.Results)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -179,6 +179,31 @@ func TestSearchKeepsExactBuildUploadAheadOfBroaderPublishWorkflows(t *testing.T)
 	}
 }
 
+func TestSearchDoesNotRouteGenericAppReviewToPublishWorkflow(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "--limit", "5", "app", "review"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if len(response.Results) == 0 {
+		t.Fatalf("expected search results, got %#v", response)
+	}
+	if response.Results[0].Command == "asc publish appstore" {
+		t.Fatalf("expected a review-specific command ahead of the publish workflow, got %#v", response.Results)
+	}
+}
+
 func TestSearchUsesTypoToleranceAsFallback(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -66,7 +66,7 @@ type canonicalIntentRule struct {
 var canonicalIntentRules = []canonicalIntentRule{
 	{
 		command:  "asc publish appstore",
-		actions:  []string{"ship", "shipping", "publish", "release", "submit", "submission", "review", "upload"},
+		actions:  []string{"ship", "shipping", "publish", "release", "submit", "submission", "upload"},
 		subjects: []string{"app", "appstore", "store"},
 		reason:   "canonical:appstore-publish",
 	},

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -16,7 +16,10 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared/suggest"
 )
 
-const defaultLimit = 10
+const (
+	defaultLimit         = 10
+	canonicalIntentBoost = 300
+)
 
 var tokenPattern = regexp.MustCompile(`[a-z0-9][a-z0-9-]*`)
 
@@ -38,17 +41,41 @@ type SearchResult struct {
 }
 
 type commandDoc struct {
-	Command     string
-	Summary     string
-	Usage       string
-	LongHelp    string
-	Examples    []string
-	Flags       []string
-	PathTokens  []string
-	TextTokens  []string
-	FlagTokens  []string
-	AllTokens   []string
-	CommandRank int
+	Command       string
+	Summary       string
+	Usage         string
+	Examples      []string
+	PathTokens    []string
+	SummaryTokens []string
+	UsageTokens   []string
+	ExampleTokens []string
+	HelpTokens    []string
+	TextTokens    []string
+	FlagTokens    []string
+	AllTokens     []string
+	CommandRank   int
+}
+
+type canonicalIntentRule struct {
+	command  string
+	actions  []string
+	subjects []string
+	reason   string
+}
+
+var canonicalIntentRules = []canonicalIntentRule{
+	{
+		command:  "asc publish appstore",
+		actions:  []string{"ship", "shipping", "publish", "release", "submit", "submission", "review", "upload"},
+		subjects: []string{"app", "appstore", "store"},
+		reason:   "canonical:appstore-publish",
+	},
+	{
+		command:  "asc publish testflight",
+		actions:  []string{"ship", "shipping", "publish", "release", "distribute", "distribution", "upload"},
+		subjects: []string{"beta", "testflight"},
+		reason:   "canonical:testflight-publish",
+	},
 }
 
 type scoredResult struct {
@@ -266,22 +293,31 @@ func collectCommandDoc(docs *[]commandDoc, cmd *ffcli.Command, parents []string)
 	examples := extractExamples(longHelp)
 	flags := commandFlags(cmd)
 	pathTokens := uniqueTokens(strings.Join(pathParts[1:], " "))
-	textTokens := uniqueTokens(strings.Join([]string{summary, usage, longHelp, strings.Join(examples, " ")}, " "))
+	summaryTokens := uniqueTokens(summary)
+	usageTokens := uniqueTokens(usage)
+	exampleTokens := uniqueTokens(strings.Join(examples, " "))
+	helpTokens := uniqueTokens(longHelp)
+	textTokens := append([]string{}, summaryTokens...)
+	textTokens = append(textTokens, usageTokens...)
+	textTokens = append(textTokens, exampleTokens...)
+	textTokens = uniqueStrings(append(textTokens, helpTokens...))
 	flagTokens := uniqueTokens(strings.Join(flags, " "))
 
 	all := append(append(append([]string{}, pathTokens...), textTokens...), flagTokens...)
 	*docs = append(*docs, commandDoc{
-		Command:     command,
-		Summary:     summary,
-		Usage:       usage,
-		LongHelp:    longHelp,
-		Examples:    examples,
-		Flags:       flags,
-		PathTokens:  pathTokens,
-		TextTokens:  textTokens,
-		FlagTokens:  flagTokens,
-		AllTokens:   uniqueStrings(all),
-		CommandRank: len(pathParts),
+		Command:       command,
+		Summary:       summary,
+		Usage:         usage,
+		Examples:      examples,
+		PathTokens:    pathTokens,
+		SummaryTokens: summaryTokens,
+		UsageTokens:   usageTokens,
+		ExampleTokens: exampleTokens,
+		HelpTokens:    helpTokens,
+		TextTokens:    textTokens,
+		FlagTokens:    flagTokens,
+		AllTokens:     uniqueStrings(all),
+		CommandRank:   len(pathParts),
 	})
 
 	nextParents := append(append([]string{}, parents...), cmd.Name)
@@ -347,7 +383,7 @@ func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {
 		}
 
 		for _, alias := range aliasesFor(token) {
-			if alias == token {
+			if sameSearchStem(alias, token) {
 				continue
 			}
 			aliasScore, aliasReasons := scoreTerm(doc, alias, "alias:"+token)
@@ -360,6 +396,11 @@ func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {
 				addReason(&reasons, seenReasons, reason)
 			}
 		}
+	}
+
+	if boost, reason := canonicalBoostFor(doc.Command, queryTokens); boost > 0 {
+		score += boost
+		addReason(&reasons, seenReasons, reason)
 	}
 
 	return score, reasons
@@ -382,15 +423,11 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 		score += 60
 		reasons = append(reasons, reason, "command:"+term)
 	}
-	if strings.Contains(strings.ToLower(doc.Command), term) && !tokenContains(doc.PathTokens, term) {
-		score += 40
-		reasons = append(reasons, reason, "command:"+term)
-	}
-	if strings.Contains(strings.ToLower(doc.Summary), term) {
+	if tokenContains(doc.SummaryTokens, term) {
 		score += 35
 		reasons = append(reasons, reason, "summary:"+term)
 	}
-	if strings.Contains(strings.ToLower(doc.Usage), term) {
+	if tokenContains(doc.UsageTokens, term) {
 		score += 25
 		reasons = append(reasons, reason, "usage:"+term)
 	}
@@ -398,11 +435,11 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 		score += 20
 		reasons = append(reasons, reason, "flag:"+term)
 	}
-	if strings.Contains(strings.ToLower(strings.Join(doc.Examples, "\n")), term) {
+	if tokenContains(doc.ExampleTokens, term) {
 		score += 18
 		reasons = append(reasons, reason, "example:"+term)
 	}
-	if strings.Contains(strings.ToLower(doc.LongHelp), term) {
+	if tokenContains(doc.HelpTokens, term) {
 		score += 10
 		reasons = append(reasons, reason, "help:"+term)
 	}
@@ -418,6 +455,27 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 	}
 
 	return score, uniqueStrings(reasons)
+}
+
+func canonicalBoostFor(command string, queryTokens []string) (int, string) {
+	for _, rule := range canonicalIntentRules {
+		if command != rule.command {
+			continue
+		}
+		if tokenContainsAny(queryTokens, rule.actions) && tokenContainsAny(queryTokens, rule.subjects) {
+			return canonicalIntentBoost, rule.reason
+		}
+	}
+	return 0, ""
+}
+
+func tokenContainsAny(tokens, terms []string) bool {
+	for _, term := range terms {
+		if tokenContains(tokens, term) {
+			return true
+		}
+	}
+	return false
 }
 
 func aliasesFor(token string) []string {
@@ -529,11 +587,63 @@ func uniqueTokens(text string) []string {
 
 func tokenContains(tokens []string, term string) bool {
 	for _, token := range tokens {
-		if token == term {
+		if searchTokensMatch(token, term) {
 			return true
 		}
-		if len(term) >= 3 && strings.Contains(token, term) {
+	}
+	return false
+}
+
+func searchTokensMatch(token, term string) bool {
+	token = strings.ToLower(strings.TrimSpace(token))
+	term = strings.ToLower(strings.TrimSpace(term))
+	if token == "" || term == "" {
+		return false
+	}
+	if token == term {
+		return true
+	}
+
+	termForms := searchTokenForms(term)
+	tokenParts := strings.Split(token, "-")
+	for _, tokenPart := range tokenParts {
+		if searchTokenFormsOverlap(searchTokenForms(tokenPart), termForms) {
 			return true
+		}
+	}
+	return false
+}
+
+func sameSearchStem(left, right string) bool {
+	left = strings.ToLower(strings.TrimSpace(left))
+	right = strings.ToLower(strings.TrimSpace(right))
+	return left != "" && right != "" && searchTokenFormsOverlap(searchTokenForms(left), searchTokenForms(right))
+}
+
+func searchTokenForms(token string) []string {
+	forms := []string{token}
+	if len(token) > 4 && strings.HasSuffix(token, "ies") {
+		forms = append(forms, strings.TrimSuffix(token, "ies")+"y")
+		return uniqueStrings(forms)
+	}
+	if len(token) > 3 && strings.HasSuffix(token, "es") {
+		forms = append(forms, strings.TrimSuffix(token, "es"))
+	}
+	if len(token) > 3 && strings.HasSuffix(token, "s") &&
+		!strings.HasSuffix(token, "ss") &&
+		!strings.HasSuffix(token, "us") &&
+		!strings.HasSuffix(token, "is") {
+		forms = append(forms, strings.TrimSuffix(token, "s"))
+	}
+	return uniqueStrings(forms)
+}
+
+func searchTokenFormsOverlap(left, right []string) bool {
+	for _, leftForm := range left {
+		for _, rightForm := range right {
+			if leftForm == rightForm {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -458,6 +458,10 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 }
 
 func canonicalBoostFor(command string, queryTokens []string) (int, string) {
+	if tokenContains(queryTokens, "upload") && tokenContains(queryTokens, "build") {
+		return 0, ""
+	}
+
 	for _, rule := range canonicalIntentRules {
 		if command != rule.command {
 			continue

--- a/internal/cli/search/search_test.go
+++ b/internal/cli/search/search_test.go
@@ -36,13 +36,16 @@ func TestScoreTermDoesNotStackExactCommandAndPathTokenScores(t *testing.T) {
 
 func TestScoreTermDoesNotStackExactCommandWithSelfReferentialHelpText(t *testing.T) {
 	doc := commandDoc{
-		Command:    "asc search",
-		Summary:    "Search asc commands and examples.",
-		Usage:      "asc search [flags] <query>",
-		LongHelp:   "Search asc commands and examples.\n\nExamples:\n  asc search \"external testers\"",
-		Examples:   []string{`asc search "external testers"`},
-		PathTokens: []string{"search"},
-		FlagTokens: []string{"search"},
+		Command:       "asc search",
+		Summary:       "Search asc commands and examples.",
+		Usage:         "asc search [flags] <query>",
+		Examples:      []string{`asc search "external testers"`},
+		PathTokens:    []string{"search"},
+		SummaryTokens: []string{"search"},
+		UsageTokens:   []string{"search"},
+		ExampleTokens: []string{"search"},
+		HelpTokens:    []string{"search"},
+		FlagTokens:    []string{"search"},
 	}
 
 	score, matched := scoreTerm(doc, "search", "query:search")
@@ -86,5 +89,37 @@ func TestScoreCommandDocsIgnoresLeadingASCToken(t *testing.T) {
 	}
 	if slices.Contains(results[0].result.Matched, "command:asc") {
 		t.Fatalf("expected leading asc token to be ignored, got matches %v", results[0].result.Matched)
+	}
+}
+
+func TestTokenContainsDoesNotMatchSubstringInsideToken(t *testing.T) {
+	if tokenContains([]string{"relationships"}, "ship") {
+		t.Fatal("expected ship not to match relationships")
+	}
+	if tokenContains([]string{"real"}, "zzzz-not-real") {
+		t.Fatal("expected a hyphenated query not to match one of its components")
+	}
+}
+
+func TestTokenContainsMatchesSingularPluralAndHyphenatedComponents(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens []string
+		term   string
+	}{
+		{name: "singular query", tokens: []string{"builds"}, term: "build"},
+		{name: "plural query", tokens: []string{"build"}, term: "builds"},
+		{name: "ies plural", tokens: []string{"categories"}, term: "category"},
+		{name: "es plural", tokens: []string{"classes"}, term: "class"},
+		{name: "singular ending s", tokens: []string{"statuses"}, term: "status"},
+		{name: "hyphenated component", tokens: []string{"app-store-releases"}, term: "app"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !tokenContains(test.tokens, test.term) {
+				t.Fatalf("expected %q to match tokens %v", test.term, test.tokens)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- replace substring search matching with exact tokens and conservative singular/plural matching
- prioritize canonical App Store and TestFlight publish workflows for natural-language shipping intents
- add regression coverage for `ship app`, `release app`, `ship beta`, and exact `upload build`

## Why

`asc search "ship app"` ranked `asc apps info relationships` because `ship` matched inside `relationships`. `release app` also failed to surface the canonical publish workflow in the first five results.

## Impact

The command shape, JSON schema, stdout/stderr behavior, and exit codes are unchanged. Search ordering, scores, and match reasons intentionally change.

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary checks for `ship app`, `release app`, and `upload build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787219463&installation_model_id=10418&pr_number=1807&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1807&signature=1a4f38e37e6cecec0b0f8f8810cf53d3196c5a9fbe196550c8a390dda80c1c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Search Improvements**
  * Enhanced CLI search ranking to prioritize canonical publishing workflows for natural-language “ship/release” queries.
  * Ensures exact “build upload” matches rank above broader publish-related results.
  * Improved token matching using normalization with singular/plural handling and hyphenated component support; avoids unintended substring matches and tightens fallback behavior.

* **Documentation**
  * Added a design note outlining the search ranking hardening approach and verification expectations.

* **Tests**
  * Added/updated unit and CLI tests to confirm ordering and prevent substring-inside-token matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->