### PR TITLE
fix(iap): support free offer codes

### DIFF
--- a/internal/asc/client_iap_subresources.go
+++ b/internal/asc/client_iap_subresources.go
@@ -1366,23 +1366,26 @@ func (c *Client) CreateInAppPurchaseOfferCode(ctx context.Context, iapID string,
 			Type: ResourceTypeInAppPurchaseOfferPrices,
 			ID:   resourceID,
 		})
-		included = append(included, InAppPurchaseOfferPriceInlineCreateResource{
-			Type: ResourceTypeInAppPurchaseOfferPrices,
-			ID:   resourceID,
-			Relationships: InAppPurchaseOfferPriceInlineRelationships{
-				Territory: Relationship{
-					Data: ResourceData{
-						Type: ResourceTypeTerritories,
-						ID:   territoryID,
-					},
-				},
-				PricePoint: Relationship{
-					Data: ResourceData{
-						Type: ResourceTypeInAppPurchasePricePoints,
-						ID:   pricePointID,
-					},
+		relationships := InAppPurchaseOfferPriceInlineRelationships{
+			Territory: Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeTerritories,
+					ID:   territoryID,
 				},
 			},
+		}
+		if !strings.EqualFold(pricePointID, "FREE") {
+			relationships.PricePoint = &Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeInAppPurchasePricePoints,
+					ID:   pricePointID,
+				},
+			}
+		}
+		included = append(included, InAppPurchaseOfferPriceInlineCreateResource{
+			Type:          ResourceTypeInAppPurchaseOfferPrices,
+			ID:            resourceID,
+			Relationships: relationships,
 		})
 	}
 

--- a/internal/asc/client_iap_subresources_test.go
+++ b/internal/asc/client_iap_subresources_test.go
@@ -820,15 +820,29 @@ func TestCreateInAppPurchaseOfferCode(t *testing.T) {
 		if req.URL.Path != "/v1/inAppPurchaseOfferCodes" {
 			t.Fatalf("expected path /v1/inAppPurchaseOfferCodes, got %s", req.URL.Path)
 		}
-		var payload InAppPurchaseOfferCodeCreateRequest
+		var payload struct {
+			Data     InAppPurchaseOfferCodeCreateData `json:"data"`
+			Included []struct {
+				Relationships struct {
+					Territory  Relationship  `json:"territory"`
+					PricePoint *Relationship `json:"pricePoint"`
+				} `json:"relationships"`
+			} `json:"included"`
+		}
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode payload error: %v", err)
 		}
 		if payload.Data.Relationships.InAppPurchase.Data.ID != "iap-1" {
 			t.Fatalf("expected inAppPurchase ID iap-1, got %q", payload.Data.Relationships.InAppPurchase.Data.ID)
 		}
-		if len(payload.Included) != 1 || payload.Included[0].Relationships.Territory.Data.ID != "USA" {
-			t.Fatalf("expected included territory USA")
+		if len(payload.Included) != 2 || payload.Included[0].Relationships.Territory.Data.ID != "USA" {
+			t.Fatalf("expected included paid territory USA")
+		}
+		if payload.Included[0].Relationships.PricePoint == nil {
+			t.Fatalf("expected paid territory price point")
+		}
+		if payload.Included[1].Relationships.Territory.Data.ID != "CAN" || payload.Included[1].Relationships.PricePoint != nil {
+			t.Fatalf("expected included free territory CAN without a price point")
 		}
 		assertAuthorized(t, req)
 	}, response)
@@ -843,6 +857,10 @@ func TestCreateInAppPurchaseOfferCode(t *testing.T) {
 			{
 				TerritoryID:  "USA",
 				PricePointID: "price-1",
+			},
+			{
+				TerritoryID:  "CAN",
+				PricePointID: "FREE",
 			},
 		},
 	}

--- a/internal/asc/iap_output.go
+++ b/internal/asc/iap_output.go
@@ -250,7 +250,11 @@ func inAppPurchaseOfferPriceRelationshipIDs(raw json.RawMessage) (string, string
 	if err := json.Unmarshal(raw, &relationships); err != nil {
 		return "", "", fmt.Errorf("decode in-app purchase offer price relationships: %w", err)
 	}
-	return relationships.Territory.Data.ID, relationships.PricePoint.Data.ID, nil
+	pricePointID := "FREE"
+	if relationships.PricePoint != nil {
+		pricePointID = relationships.PricePoint.Data.ID
+	}
+	return relationships.Territory.Data.ID, pricePointID, nil
 }
 
 func inAppPurchaseReviewScreenshotRows(resp *InAppPurchaseAppStoreReviewScreenshotResponse) ([]string, [][]string) {

--- a/internal/asc/iap_output_test.go
+++ b/internal/asc/iap_output_test.go
@@ -201,6 +201,26 @@ func TestPrintTable_InAppPurchasePrices(t *testing.T) {
 	}
 }
 
+func TestPrintTable_InAppPurchaseOfferCodeFreePrice(t *testing.T) {
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}}}`)
+	resp := &InAppPurchaseOfferPricesResponse{
+		Data: []Resource[InAppPurchaseOfferPriceAttributes]{
+			{
+				ID:            "offer-price-1",
+				Relationships: relationships,
+			},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(resp)
+	})
+
+	if !strings.Contains(output, "USA") || !strings.Contains(output, "FREE") {
+		t.Fatalf("expected free offer price in output, got: %s", output)
+	}
+}
+
 func TestPrintMarkdown_InAppPurchasePrices(t *testing.T) {
 	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"inAppPurchasePricePoint":{"data":{"type":"inAppPurchasePricePoints","id":"PRICE_POINT_1"}}}`)
 	resp := &InAppPurchasePricesResponse{

--- a/internal/asc/iap_resources.go
+++ b/internal/asc/iap_resources.go
@@ -307,8 +307,8 @@ type InAppPurchaseOfferPriceInlineCreateResource struct {
 }
 
 type InAppPurchaseOfferPriceInlineRelationships struct {
-	Territory  Relationship `json:"territory"`
-	PricePoint Relationship `json:"pricePoint"`
+	Territory  Relationship  `json:"territory"`
+	PricePoint *Relationship `json:"pricePoint,omitempty"`
 }
 
 // Offer code custom codes and one-time use codes.

--- a/internal/cli/cmdtest/iap_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/iap_offer_codes_output_test.go
@@ -68,10 +68,15 @@ func TestIAPOfferCodesCreateUsesDefaultEligibilitiesAndParsedPrices(t *testing.T
 		}
 
 		territoryIDs := make([]string, 0, 2)
-		for _, resource := range included {
+		for index, resource := range included {
 			relationships := resource.(map[string]any)["relationships"].(map[string]any)
 			territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
 			territoryIDs = append(territoryIDs, territory["id"].(string))
+			if index == 1 {
+				if _, exists := relationships["pricePoint"]; exists {
+					t.Fatalf("expected free territory to omit pricePoint relationship")
+				}
+			}
 		}
 		if !slices.Equal(territoryIDs, []string{"USA", "JPN"}) {
 			t.Fatalf("expected normalized territory ids [USA JPN], got %v", territoryIDs)
@@ -93,7 +98,7 @@ func TestIAPOfferCodesCreateUsesDefaultEligibilitiesAndParsedPrices(t *testing.T
 			"iap", "offer-codes", "create",
 			"--iap-id", "9000000001",
 			"--name", "SPRING",
-			"--prices", "usa:pp-us,jpn:pp-jp",
+			"--prices", "usa:pp-us,jpn:FREE",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}

--- a/internal/cli/cmdtest/iap_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/iap_offer_codes_output_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -17,12 +18,7 @@ func TestIAPOfferCodesCreateUsesDefaultEligibilitiesAndParsedPrices(t *testing.T
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
 		}
@@ -83,12 +79,12 @@ func TestIAPOfferCodesCreateUsesDefaultEligibilitiesAndParsedPrices(t *testing.T
 		}
 
 		body := `{"data":{"type":"inAppPurchaseOfferCodes","id":"offer-1","attributes":{"name":"SPRING","active":true}}}`
-		return &http.Response{
-			StatusCode: http.StatusCreated,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
-	})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+	setIAPRelatedTestServerClient(t, server)
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/iap_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/iap_offer_codes_output_test.go
@@ -63,18 +63,27 @@ func TestIAPOfferCodesCreateUsesDefaultEligibilitiesAndParsedPrices(t *testing.T
 			t.Fatalf("expected 2 included price objects, got %d", len(included))
 		}
 
-		territoryIDs := make([]string, 0, 2)
-		for index, resource := range included {
+		territoryIDs := make(map[string]bool, 2)
+		for _, resource := range included {
 			relationships := resource.(map[string]any)["relationships"].(map[string]any)
 			territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
-			territoryIDs = append(territoryIDs, territory["id"].(string))
-			if index == 1 {
+			territoryID := territory["id"].(string)
+			territoryIDs[territoryID] = true
+			switch territoryID {
+			case "USA":
+				pricePoint := relationships["pricePoint"].(map[string]any)["data"].(map[string]any)
+				if pricePoint["id"] != "pp-us" {
+					t.Fatalf("expected USA price point pp-us, got %#v", pricePoint["id"])
+				}
+			case "JPN":
 				if _, exists := relationships["pricePoint"]; exists {
 					t.Fatalf("expected free territory to omit pricePoint relationship")
 				}
+			default:
+				t.Fatalf("unexpected territory %q", territoryID)
 			}
 		}
-		if !slices.Equal(territoryIDs, []string{"USA", "JPN"}) {
+		if !territoryIDs["USA"] || !territoryIDs["JPN"] {
 			t.Fatalf("expected normalized territory ids [USA JPN], got %v", territoryIDs)
 		}
 

--- a/internal/cli/iap/offer_codes.go
+++ b/internal/cli/iap/offer_codes.go
@@ -184,7 +184,7 @@ func IAPOfferCodesCreateCommand() *ffcli.Command {
 	iapID := fs.String("iap-id", "", "In-app purchase ID, product ID, or exact current name")
 	name := fs.String("name", "", "Offer code name")
 	eligibilities := fs.String("eligibilities", "", "Customer eligibilities (comma-separated)")
-	prices := fs.String("prices", "", "Prices: TERRITORY:PRICE_POINT_ID entries (territory accepts alpha-2, alpha-3, or exact English country name)")
+	prices := fs.String("prices", "", "Prices: TERRITORY:PRICE_POINT_ID or TERRITORY:FREE entries (territory accepts alpha-2, alpha-3, or exact English country name)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -195,6 +195,7 @@ func IAPOfferCodesCreateCommand() *ffcli.Command {
 
 Examples:
   asc iap offer-codes create --iap-id "IAP_ID" --name "SPRING" --prices "US:PRICE_POINT_ID"
+  asc iap offer-codes create --iap-id "IAP_ID" --name "GIFT" --prices "US:FREE,CA:FREE"
   asc iap offer-codes create --iap-id "IAP_ID" --name "SPRING" --eligibilities "NON_SPENDER" --prices "France:PRICE_POINT_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,


### PR DESCRIPTION
## Summary

- accept `TERRITORY:FREE` in `iap offer-codes create --prices`
- omit the optional `pricePoint` relationship for free storefront entries
- preserve the existing paid price-point path and update help/tests

## Why

Apple represents a free IAP offer price by including the territory relationship without a `pricePoint`. The CLI previously required every `--prices` value to resolve to a price-point ID, so it could not create free IAP offer codes.

Verified against an authorized IAP by creating a free offer across 175 storefronts and generating a 500-code batch. No offer-code value is included here.

## Test plan

- `make format`
- `make check-docs`
- `make lint`
- focused IAP offer-code tests
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`
- `asc iap offer-codes create --help`

`ASC_BYPASS_KEYCHAIN=1 make test` initially hit the unrelated flaky `TestEmitDoesNotWaitForBlockedSender`; its targeted rerun and the full non-verbose Go test suite passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787511590&installation_model_id=10418&pr_number=1809&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1809&signature=f48cea4788231f5297f486563f4d40d0b6180bd123593fe69010be43acf92a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `TERRITORY:FREE` pricing in in-app purchase offer-code creation; free entries now omit the price-point relationship and include only the territory relationship.
  * Extended CLI help and examples to include `TERRITORY:FREE` usage.

* **Bug Fixes**
  * Improved offer-price output formatting to handle missing price-point data by treating it as free pricing.

* **Tests**
  * Updated and expanded CLI/API request validation for free vs paid territories.
  * Added coverage for table output showing `FREE` for free offers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->