### PR TITLE
fix(iap): render free offer code prices

### DIFF
--- a/internal/asc/client_iap_subresources_test.go
+++ b/internal/asc/client_iap_subresources_test.go
@@ -776,7 +776,7 @@ func TestGetInAppPurchaseOfferCodes_UsesNextURL(t *testing.T) {
 	}
 }
 
-func TestGetInAppPurchaseOfferCodePrices_WithLimit(t *testing.T) {
+func TestGetInAppPurchaseOfferCodePrices_WithQuery(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"inAppPurchaseOfferPrices","id":"price-1"}]}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
@@ -788,10 +788,22 @@ func TestGetInAppPurchaseOfferCodePrices_WithLimit(t *testing.T) {
 		if req.URL.Query().Get("limit") != "5" {
 			t.Fatalf("expected limit=5, got %q", req.URL.Query().Get("limit"))
 		}
+		if got := req.URL.Query().Get("fields[inAppPurchaseOfferPrices]"); got != "territory,pricePoint" {
+			t.Fatalf("expected offer price fields, got %q", got)
+		}
+		if got := req.URL.Query().Get("include"); got != "territory,pricePoint" {
+			t.Fatalf("expected offer price include values, got %q", got)
+		}
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetInAppPurchaseOfferCodePrices(context.Background(), "offer-1", WithIAPOfferCodePricesLimit(5)); err != nil {
+	if _, err := client.GetInAppPurchaseOfferCodePrices(
+		context.Background(),
+		"offer-1",
+		WithIAPOfferCodePricesLimit(5),
+		WithIAPOfferCodePricesFields([]string{"territory", "pricePoint"}),
+		WithIAPOfferCodePricesInclude([]string{"territory", "pricePoint"}),
+	); err != nil {
 		t.Fatalf("GetInAppPurchaseOfferCodePrices() error: %v", err)
 	}
 }

--- a/internal/asc/iap_output.go
+++ b/internal/asc/iap_output.go
@@ -251,9 +251,12 @@ func inAppPurchaseOfferPriceRelationshipIDs(raw json.RawMessage) (string, string
 	if err := json.Unmarshal(raw, &relationships); err != nil {
 		return "", "", fmt.Errorf("decode in-app purchase offer price relationships: %w", err)
 	}
-	pricePointID := "FREE"
-	if relationships.PricePoint != nil && strings.TrimSpace(relationships.PricePoint.Data.ID) != "" {
+	pricePointID := ""
+	if relationships.PricePoint != nil {
 		pricePointID = relationships.PricePoint.Data.ID
+		if strings.TrimSpace(pricePointID) == "" {
+			pricePointID = "FREE"
+		}
 	}
 	return relationships.Territory.Data.ID, pricePointID, nil
 }

--- a/internal/asc/iap_output.go
+++ b/internal/asc/iap_output.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // InAppPurchaseDeleteResult represents CLI output for IAP deletions.
@@ -251,7 +252,7 @@ func inAppPurchaseOfferPriceRelationshipIDs(raw json.RawMessage) (string, string
 		return "", "", fmt.Errorf("decode in-app purchase offer price relationships: %w", err)
 	}
 	pricePointID := "FREE"
-	if relationships.PricePoint != nil {
+	if relationships.PricePoint != nil && strings.TrimSpace(relationships.PricePoint.Data.ID) != "" {
 		pricePointID = relationships.PricePoint.Data.ID
 	}
 	return relationships.Territory.Data.ID, pricePointID, nil

--- a/internal/asc/iap_output_test.go
+++ b/internal/asc/iap_output_test.go
@@ -202,7 +202,7 @@ func TestPrintTable_InAppPurchasePrices(t *testing.T) {
 }
 
 func TestPrintTable_InAppPurchaseOfferCodeFreePrice(t *testing.T) {
-	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}}}`)
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"pricePoint":{"data":null}}`)
 	resp := &InAppPurchaseOfferPricesResponse{
 		Data: []Resource[InAppPurchaseOfferPriceAttributes]{
 			{

--- a/internal/asc/iap_output_test.go
+++ b/internal/asc/iap_output_test.go
@@ -221,6 +221,21 @@ func TestPrintTable_InAppPurchaseOfferCodeFreePrice(t *testing.T) {
 	}
 }
 
+func TestInAppPurchaseOfferPriceRelationshipIDs_MissingPricePointIsUnknown(t *testing.T) {
+	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}}}`)
+
+	territoryID, pricePointID, err := inAppPurchaseOfferPriceRelationshipIDs(relationships)
+	if err != nil {
+		t.Fatalf("unexpected relationship decode error: %v", err)
+	}
+	if territoryID != "USA" {
+		t.Fatalf("expected territory USA, got %q", territoryID)
+	}
+	if pricePointID != "" {
+		t.Fatalf("expected an unknown price point when the relationship is absent, got %q", pricePointID)
+	}
+}
+
 func TestPrintMarkdown_InAppPurchasePrices(t *testing.T) {
 	relationships := json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}},"inAppPurchasePricePoint":{"data":{"type":"inAppPurchasePricePoints","id":"PRICE_POINT_1"}}}`)
 	resp := &InAppPurchasePricesResponse{

--- a/internal/asc/iap_queries.go
+++ b/internal/asc/iap_queries.go
@@ -46,6 +46,8 @@ type iapOfferCodeOneTimeUseCodesQuery struct {
 
 type iapOfferCodePricesQuery struct {
 	listQuery
+	fields  []string
+	include []string
 }
 
 type iapAvailabilityTerritoriesQuery struct {
@@ -201,6 +203,20 @@ func WithIAPOfferCodePricesNextURL(next string) IAPOfferCodePricesOption {
 	}
 }
 
+// WithIAPOfferCodePricesFields sets fields[inAppPurchaseOfferPrices].
+func WithIAPOfferCodePricesFields(fields []string) IAPOfferCodePricesOption {
+	return func(q *iapOfferCodePricesQuery) {
+		q.fields = normalizeUniqueList(fields)
+	}
+}
+
+// WithIAPOfferCodePricesInclude sets relationships to include.
+func WithIAPOfferCodePricesInclude(include []string) IAPOfferCodePricesOption {
+	return func(q *iapOfferCodePricesQuery) {
+		q.include = normalizeUniqueList(include)
+	}
+}
+
 func WithIAPAvailabilityTerritoriesLimit(limit int) IAPAvailabilityTerritoriesOption {
 	return func(q *iapAvailabilityTerritoriesQuery) {
 		if limit > 0 {
@@ -337,6 +353,8 @@ func buildIAPOfferCodeOneTimeUseCodesQuery(query *iapOfferCodeOneTimeUseCodesQue
 
 func buildIAPOfferCodePricesQuery(query *iapOfferCodePricesQuery) string {
 	values := url.Values{}
+	addCSV(values, "fields[inAppPurchaseOfferPrices]", query.fields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/cli/cmdtest/iap_next_validation_phase61_test.go
+++ b/internal/cli/cmdtest/iap_next_validation_phase61_test.go
@@ -146,8 +146,8 @@ func TestIAPOfferCodePricesRejectsInvalidNextURLPhase61(t *testing.T) {
 }
 
 func TestIAPOfferCodePricesPaginateFromNextWithoutOfferCodeIDPhase61(t *testing.T) {
-	const firstURL = "https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=AQ&limit=200"
-	const secondURL = "https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=BQ&limit=200"
+	const firstURL = "https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=AQ&fields%5BinAppPurchaseOfferPrices%5D=territory%2CpricePoint&include=territory%2CpricePoint&limit=200"
+	const secondURL = "https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=BQ&fields%5BinAppPurchaseOfferPrices%5D=territory%2CpricePoint&include=territory%2CpricePoint&limit=200"
 
 	firstBody := `{"data":[{"type":"inAppPurchaseOfferPrices","id":"iap-offer-price-next-1"}],"links":{"next":"` + secondURL + `"}}`
 	secondBody := `{"data":[{"type":"inAppPurchaseOfferPrices","id":"iap-offer-price-next-2"}],"links":{"next":""}}`

--- a/internal/cli/cmdtest/iap_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/iap_offer_codes_output_test.go
@@ -129,6 +129,60 @@ func TestIAPOfferCodesCreateUsesDefaultEligibilitiesAndParsedPrices(t *testing.T
 	}
 }
 
+func TestIAPOfferCodePricesRequestsRelationshipsForTableOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/inAppPurchaseOfferCodes/offer-1/prices" {
+			t.Fatalf("expected offer-code prices path, got %s", req.URL.Path)
+		}
+		if got := req.URL.Query().Get("fields[inAppPurchaseOfferPrices]"); got != "territory,pricePoint" {
+			t.Fatalf("expected offer price relationship fields, got %q", got)
+		}
+		if got := req.URL.Query().Get("include"); got != "territory,pricePoint" {
+			t.Fatalf("expected offer price relationships to be included, got %q", got)
+		}
+
+		body := `{"data":[` +
+			`{"type":"inAppPurchaseOfferPrices","id":"paid-1","relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"pricePoint":{"data":{"type":"inAppPurchasePricePoints","id":"pp-us"}}}},` +
+			`{"type":"inAppPurchaseOfferPrices","id":"free-1","relationships":{"territory":{"data":{"type":"territories","id":"CAN"}},"pricePoint":{"data":null}}}` +
+			`]}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+	setIAPRelatedTestServerClient(t, server)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"iap", "offer-codes", "prices",
+			"--offer-code-id", "offer-1",
+			"--output", "table",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"USA", "pp-us", "CAN", "FREE"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected table output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
 func TestIAPOfferCodesCreateReturnsCreateFailure(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/iap_offer_codes_output_test.go
+++ b/internal/cli/cmdtest/iap_offer_codes_output_test.go
@@ -183,6 +183,75 @@ func TestIAPOfferCodePricesRequestsRelationshipsForTableOutput(t *testing.T) {
 	}
 }
 
+func TestIAPOfferCodePricesNextURLPreservesRelationshipsForTableOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if got := req.URL.Query().Get("fields[inAppPurchaseOfferPrices]"); got != "territory,pricePoint" {
+			t.Fatalf("expected offer price relationship fields, got %q", got)
+		}
+		if got := req.URL.Query().Get("include"); got != "territory,pricePoint" {
+			t.Fatalf("expected offer price relationships to be included, got %q", got)
+		}
+
+		var body string
+		switch got := req.URL.Query().Get("cursor"); got {
+		case "legacy":
+			body = `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=page2"}}`
+		case "page2":
+			body = `{"data":[{"type":"inAppPurchaseOfferPrices","id":"free-1","relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"pricePoint":{"data":null}}}],"links":{"next":null}}`
+		default:
+			t.Fatalf("expected legacy or page2 cursor, got %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	nextURL := "https://api.appstoreconnect.apple.com/v1/inAppPurchaseOfferCodes/offer-1/prices?cursor=legacy"
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"iap", "offer-codes", "prices",
+			"--next", nextURL,
+			"--paginate",
+			"--output", "table",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requests != 2 {
+		t.Fatalf("expected two paginated requests, got %d", requests)
+	}
+	for _, want := range []string{"USA", "FREE"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected table output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
 func TestIAPOfferCodesCreateReturnsCreateFailure(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/iap/offer_code_prices.go
+++ b/internal/cli/iap/offer_code_prices.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -56,9 +57,14 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
+			nextURL, err := shared.MergeNextURLQuery(*next, offerCodePricesRelationshipQuery())
+			if err != nil {
+				return fmt.Errorf("iap offer-codes prices: invalid --next URL: %w", err)
+			}
+
 			opts := []asc.IAPOfferCodePricesOption{
 				asc.WithIAPOfferCodePricesLimit(*limit),
-				asc.WithIAPOfferCodePricesNextURL(*next),
+				asc.WithIAPOfferCodePricesNextURL(nextURL),
 				asc.WithIAPOfferCodePricesFields([]string{"territory", "pricePoint"}),
 				asc.WithIAPOfferCodePricesInclude([]string{"territory", "pricePoint"}),
 			}
@@ -71,6 +77,10 @@ Examples:
 				}
 
 				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					nextURL, err := shared.MergeNextURLQuery(nextURL, offerCodePricesRelationshipQuery())
+					if err != nil {
+						return nil, err
+					}
 					return client.GetInAppPurchaseOfferCodePrices(ctx, id, asc.WithIAPOfferCodePricesNextURL(nextURL))
 				})
 				if err != nil {
@@ -87,5 +97,12 @@ Examples:
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
+	}
+}
+
+func offerCodePricesRelationshipQuery() url.Values {
+	return url.Values{
+		"fields[inAppPurchaseOfferPrices]": []string{"territory,pricePoint"},
+		"include":                          []string{"territory,pricePoint"},
 	}
 }

--- a/internal/cli/iap/offer_code_prices.go
+++ b/internal/cli/iap/offer_code_prices.go
@@ -59,6 +59,8 @@ Examples:
 			opts := []asc.IAPOfferCodePricesOption{
 				asc.WithIAPOfferCodePricesLimit(*limit),
 				asc.WithIAPOfferCodePricesNextURL(*next),
+				asc.WithIAPOfferCodePricesFields([]string{"territory", "pricePoint"}),
+				asc.WithIAPOfferCodePricesInclude([]string{"territory", "pricePoint"}),
 			}
 
 			if *paginate {


### PR DESCRIPTION
## Summary

- request `territory` and `pricePoint` relationships when listing IAP offer-code prices
- render both an omitted `pricePoint` relationship and Apple’s live `pricePoint.data: null` shape as `FREE`
- cover the real query and paid/free table output end to end

## Production verification

Verified with the built CLI against the authorized production account’s disposable app:

- app: `6759231657`
- IAP: `6759789699`
- audit offer: `ee2c31ad-80e6-4949-9d77-14efc60e9dda`
- Apple accepted `USA:FREE`
- the live price response contained territory `USA` and `pricePoint.data: null`
- the original command rendered blank territory/price columns because it did not request the relationships
- this follow-up renders `USA` / `FREE`

The audit offer was deactivated after verification. No custom or one-time code batch was generated. Apple exposes no delete endpoint for IAP offer codes, so the inactive audit record remains on the disposable app.

## Validation

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused ASC, IAP, and CLI command tests
- live production create/list/table/deactivate cycle on the disposable app

Follow-up to #1809. This branch is based directly on the merged `main` commit `4f622ca7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `iap offer-codes prices --output table` to request and show territory and price point relationship details, including free price points.
  - Pagination (`--next`) now preserves the same relationship field selection and includes for consistent table output across pages.
- **Bug Fixes**
  - Correctly treats whitespace-only price point IDs as missing, keeping “FREE” labeling accurate when price point data is absent.
- **Tests**
  - Expanded CLI and output coverage to verify query parameters, relationship decoding (including missing pricePoint), and paginated table rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->