### PR TITLE
apps wall: add Speed Reading - WPM Arena

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1371,6 +1371,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/68/88/12/688812e9-4f3d-ce80-5822-5c55e715b809/default-0-0-1x_U007ephone-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Speed Reading - WPM Arena",
+    "link": "https://apps.apple.com/us/app/speed-reading-wpm-arena/id6757508919?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/07/4c/e6/074ce60c-fca7-5361-ddd9-eff545681cd3/icon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "SpeedReader",
     "link": "https://apps.apple.com/app/id6757832936",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/90/bc/20/90bc2003-d998-ba7a-ce45-66d846d7685f/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Speed Reading - WPM Arena` to the Wall of Apps

## Entry

- App ID: 6757508919
- App: Speed Reading - WPM Arena
- Link: https://apps.apple.com/us/app/speed-reading-wpm-arena/id6757508919?uo=4

## Notes

- Submitted via `asc apps wall submit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787759678&installation_model_id=10418&pr_number=1813&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1813&signature=50aee0059dd37eda9bfc564d6c53826c7699a92549a737b3a3ed834723b633a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **“Speed Reading - WPM Arena”** to the Wall of Apps directory, including its link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->