### PR TITLE
Detect duplicate screenshot pixels

### DIFF
--- a/internal/cli/assets/assets_screenshots_duplicates.go
+++ b/internal/cli/assets/assets_screenshots_duplicates.go
@@ -1,0 +1,94 @@
+package assets
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"image"
+	"image/color"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"os"
+)
+
+type screenshotPixelDigest [sha256.Size]byte
+
+func decodedScreenshotPixelDigest(path string) (screenshotPixelDigest, error) {
+	img, err := decodeScreenshotPixels(path)
+	if err != nil {
+		return screenshotPixelDigest{}, err
+	}
+
+	bounds := img.Bounds()
+	hasher := sha256.New()
+	var dimensions [16]byte
+	binary.BigEndian.PutUint64(dimensions[0:8], uint64(bounds.Dx()))
+	binary.BigEndian.PutUint64(dimensions[8:16], uint64(bounds.Dy()))
+	_, _ = hasher.Write(dimensions[:])
+
+	row := make([]byte, bounds.Dx()*4)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		normalizeScreenshotPixelRow(row, img, y)
+		_, _ = hasher.Write(row)
+	}
+
+	var digest screenshotPixelDigest
+	copy(digest[:], hasher.Sum(nil))
+	return digest, nil
+}
+
+func decodedScreenshotPixelsEqual(leftPath, rightPath string) (bool, error) {
+	left, err := decodeScreenshotPixels(leftPath)
+	if err != nil {
+		return false, err
+	}
+	right, err := decodeScreenshotPixels(rightPath)
+	if err != nil {
+		return false, err
+	}
+
+	leftBounds := left.Bounds()
+	rightBounds := right.Bounds()
+	if leftBounds.Dx() != rightBounds.Dx() || leftBounds.Dy() != rightBounds.Dy() {
+		return false, nil
+	}
+
+	leftRow := make([]byte, leftBounds.Dx()*4)
+	rightRow := make([]byte, rightBounds.Dx()*4)
+	for offsetY := 0; offsetY < leftBounds.Dy(); offsetY++ {
+		normalizeScreenshotPixelRow(leftRow, left, leftBounds.Min.Y+offsetY)
+		normalizeScreenshotPixelRow(rightRow, right, rightBounds.Min.Y+offsetY)
+		if !bytes.Equal(leftRow, rightRow) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func decodeScreenshotPixels(path string) (image.Image, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	img, _, err := image.Decode(file)
+	if err != nil {
+		return nil, fmt.Errorf("decode image pixels for %q: %w", path, err)
+	}
+	return img, nil
+}
+
+func normalizeScreenshotPixelRow(dst []byte, img image.Image, y int) {
+	bounds := img.Bounds()
+	for offsetX := 0; offsetX < bounds.Dx(); offsetX++ {
+		pixel := color.NRGBAModel.Convert(img.At(bounds.Min.X+offsetX, y)).(color.NRGBA)
+		index := offsetX * 4
+		dst[index] = pixel.R
+		dst[index+1] = pixel.G
+		dst[index+2] = pixel.B
+		dst[index+3] = pixel.A
+	}
+}

--- a/internal/cli/assets/assets_screenshots_duplicates.go
+++ b/internal/cli/assets/assets_screenshots_duplicates.go
@@ -28,7 +28,7 @@ func decodedScreenshotPixelDigest(path string) (screenshotPixelDigest, error) {
 	binary.BigEndian.PutUint64(dimensions[8:16], uint64(bounds.Dy()))
 	_, _ = hasher.Write(dimensions[:])
 
-	row := make([]byte, bounds.Dx()*4)
+	row := make([]byte, bounds.Dx()*8)
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		normalizeScreenshotPixelRow(row, img, y)
 		_, _ = hasher.Write(row)
@@ -55,8 +55,8 @@ func decodedScreenshotPixelsEqual(leftPath, rightPath string) (bool, error) {
 		return false, nil
 	}
 
-	leftRow := make([]byte, leftBounds.Dx()*4)
-	rightRow := make([]byte, rightBounds.Dx()*4)
+	leftRow := make([]byte, leftBounds.Dx()*8)
+	rightRow := make([]byte, rightBounds.Dx()*8)
 	for offsetY := 0; offsetY < leftBounds.Dy(); offsetY++ {
 		normalizeScreenshotPixelRow(leftRow, left, leftBounds.Min.Y+offsetY)
 		normalizeScreenshotPixelRow(rightRow, right, rightBounds.Min.Y+offsetY)
@@ -84,11 +84,11 @@ func decodeScreenshotPixels(path string) (image.Image, error) {
 func normalizeScreenshotPixelRow(dst []byte, img image.Image, y int) {
 	bounds := img.Bounds()
 	for offsetX := 0; offsetX < bounds.Dx(); offsetX++ {
-		pixel := color.NRGBAModel.Convert(img.At(bounds.Min.X+offsetX, y)).(color.NRGBA)
-		index := offsetX * 4
-		dst[index] = pixel.R
-		dst[index+1] = pixel.G
-		dst[index+2] = pixel.B
-		dst[index+3] = pixel.A
+		pixel := color.NRGBA64Model.Convert(img.At(bounds.Min.X+offsetX, y)).(color.NRGBA64)
+		index := offsetX * 8
+		binary.BigEndian.PutUint16(dst[index:index+2], pixel.R)
+		binary.BigEndian.PutUint16(dst[index+2:index+4], pixel.G)
+		binary.BigEndian.PutUint16(dst[index+4:index+6], pixel.B)
+		binary.BigEndian.PutUint16(dst[index+6:index+8], pixel.A)
 	}
 }

--- a/internal/cli/assets/assets_screenshots_validate.go
+++ b/internal/cli/assets/assets_screenshots_validate.go
@@ -35,6 +35,8 @@ type screenshotValidateIssue struct {
 	Severity    string `json:"severity"`
 	FilePath    string `json:"filePath,omitempty"`
 	FileName    string `json:"fileName,omitempty"`
+	DuplicateOf string `json:"duplicateOf,omitempty"`
+	Match       string `json:"match,omitempty"`
 	Message     string `json:"message"`
 	Remediation string `json:"remediation,omitempty"`
 }
@@ -67,7 +69,7 @@ func AssetsScreenshotsValidateCommand() *ffcli.Command {
 
 This preflight mirrors upload file ordering and reports common local problems
 before any App Store Connect mutation happens, including hidden files,
-unreadable assets, and unsupported dimensions.
+unreadable assets, unsupported dimensions, and duplicate decoded pixels.
 
 Examples:
   asc screenshots validate --path "./screenshots" --device-type "IPHONE_65"
@@ -148,6 +150,7 @@ func validateScreenshotAssets(pathValue, displayType string) (*screenshotValidat
 		return result, nil
 	}
 
+	seenPixelDigests := make(map[screenshotPixelDigest][]string, len(paths))
 	for index, filePath := range paths {
 		fileName := filepath.Base(filePath)
 		fileResult := screenshotValidateFile{
@@ -216,6 +219,49 @@ func validateScreenshotAssets(pathValue, displayType string) (*screenshotValidat
 			})
 		}
 
+		if !hasError {
+			digest, err := decodedScreenshotPixelDigest(filePath)
+			if err != nil {
+				hasError = true
+				appendScreenshotValidateIssue(result, screenshotValidateIssue{
+					Code:        "read_failure",
+					Severity:    screenshotValidateSeverityError,
+					FilePath:    filePath,
+					FileName:    fileName,
+					Message:     err.Error(),
+					Remediation: "Replace this file with a valid PNG or JPEG screenshot.",
+				})
+			} else {
+				duplicateOf, err := findDecodedScreenshotDuplicate(filePath, seenPixelDigests[digest])
+				if err != nil {
+					hasError = true
+					appendScreenshotValidateIssue(result, screenshotValidateIssue{
+						Code:        "read_failure",
+						Severity:    screenshotValidateSeverityError,
+						FilePath:    filePath,
+						FileName:    fileName,
+						Message:     err.Error(),
+						Remediation: "Replace this file with a valid PNG or JPEG screenshot.",
+					})
+				} else if duplicateOf != "" {
+					hasError = true
+					duplicateName := filepath.Base(duplicateOf)
+					appendScreenshotValidateIssue(result, screenshotValidateIssue{
+						Code:        "duplicate_content",
+						Severity:    screenshotValidateSeverityError,
+						FilePath:    filePath,
+						FileName:    fileName,
+						DuplicateOf: duplicateName,
+						Match:       "pixels",
+						Message:     fmt.Sprintf("screenshot %q has decoded pixels identical to %q", fileName, duplicateName),
+						Remediation: "Remove one duplicate or replace it with a distinct screenshot before uploading.",
+					})
+				} else {
+					seenPixelDigests[digest] = append(seenPixelDigests[digest], filePath)
+				}
+			}
+		}
+
 		switch {
 		case hasError:
 			fileResult.Status = screenshotValidateSeverityError
@@ -232,6 +278,19 @@ func validateScreenshotAssets(pathValue, displayType string) (*screenshotValidat
 	}
 
 	return result, nil
+}
+
+func findDecodedScreenshotDuplicate(path string, candidates []string) (string, error) {
+	for _, candidate := range candidates {
+		equal, err := decodedScreenshotPixelsEqual(candidate, path)
+		if err != nil {
+			return "", err
+		}
+		if equal {
+			return candidate, nil
+		}
+	}
+	return "", nil
 }
 
 func appendScreenshotValidateIssue(result *screenshotValidateResult, issue screenshotValidateIssue) {

--- a/internal/cli/assets/assets_screenshots_validate.go
+++ b/internal/cli/assets/assets_screenshots_validate.go
@@ -220,46 +220,7 @@ func validateScreenshotAssets(pathValue, displayType string) (*screenshotValidat
 		}
 
 		if !hasError {
-			digest, err := decodedScreenshotPixelDigest(filePath)
-			if err != nil {
-				hasError = true
-				appendScreenshotValidateIssue(result, screenshotValidateIssue{
-					Code:        "read_failure",
-					Severity:    screenshotValidateSeverityError,
-					FilePath:    filePath,
-					FileName:    fileName,
-					Message:     err.Error(),
-					Remediation: "Replace this file with a valid PNG or JPEG screenshot.",
-				})
-			} else {
-				duplicateOf, err := findDecodedScreenshotDuplicate(filePath, seenPixelDigests[digest])
-				if err != nil {
-					hasError = true
-					appendScreenshotValidateIssue(result, screenshotValidateIssue{
-						Code:        "read_failure",
-						Severity:    screenshotValidateSeverityError,
-						FilePath:    filePath,
-						FileName:    fileName,
-						Message:     err.Error(),
-						Remediation: "Replace this file with a valid PNG or JPEG screenshot.",
-					})
-				} else if duplicateOf != "" {
-					hasError = true
-					duplicateName := filepath.Base(duplicateOf)
-					appendScreenshotValidateIssue(result, screenshotValidateIssue{
-						Code:        "duplicate_content",
-						Severity:    screenshotValidateSeverityError,
-						FilePath:    filePath,
-						FileName:    fileName,
-						DuplicateOf: duplicateName,
-						Match:       "pixels",
-						Message:     fmt.Sprintf("screenshot %q has decoded pixels identical to %q", fileName, duplicateName),
-						Remediation: "Remove one duplicate or replace it with a distinct screenshot before uploading.",
-					})
-				} else {
-					seenPixelDigests[digest] = append(seenPixelDigests[digest], filePath)
-				}
-			}
+			hasError = checkDecodedPixelDuplicate(result, filePath, fileName, seenPixelDigests)
 		}
 
 		switch {
@@ -278,6 +239,51 @@ func validateScreenshotAssets(pathValue, displayType string) (*screenshotValidat
 	}
 
 	return result, nil
+}
+
+func checkDecodedPixelDuplicate(result *screenshotValidateResult, filePath, fileName string, seenPixelDigests map[screenshotPixelDigest][]string) bool {
+	digest, err := decodedScreenshotPixelDigest(filePath)
+	if err != nil {
+		appendScreenshotValidateIssue(result, screenshotValidateIssue{
+			Code:        "read_failure",
+			Severity:    screenshotValidateSeverityError,
+			FilePath:    filePath,
+			FileName:    fileName,
+			Message:     err.Error(),
+			Remediation: "Replace this file with a valid PNG or JPEG screenshot.",
+		})
+		return true
+	}
+
+	duplicateOf, err := findDecodedScreenshotDuplicate(filePath, seenPixelDigests[digest])
+	if err != nil {
+		appendScreenshotValidateIssue(result, screenshotValidateIssue{
+			Code:        "read_failure",
+			Severity:    screenshotValidateSeverityError,
+			FilePath:    filePath,
+			FileName:    fileName,
+			Message:     err.Error(),
+			Remediation: "Replace this file with a valid PNG or JPEG screenshot.",
+		})
+		return true
+	}
+	if duplicateOf == "" {
+		seenPixelDigests[digest] = append(seenPixelDigests[digest], filePath)
+		return false
+	}
+
+	duplicateName := filepath.Base(duplicateOf)
+	appendScreenshotValidateIssue(result, screenshotValidateIssue{
+		Code:        "duplicate_content",
+		Severity:    screenshotValidateSeverityError,
+		FilePath:    filePath,
+		FileName:    fileName,
+		DuplicateOf: duplicateName,
+		Match:       "pixels",
+		Message:     fmt.Sprintf("screenshot %q has decoded pixels identical to %q", fileName, duplicateName),
+		Remediation: "Remove one duplicate or replace it with a distinct screenshot before uploading.",
+	})
+	return true
 }
 
 func findDecodedScreenshotDuplicate(path string, candidates []string) (string, error) {

--- a/internal/cli/assets/assets_screenshots_validate_test.go
+++ b/internal/cli/assets/assets_screenshots_validate_test.go
@@ -160,6 +160,24 @@ func TestValidateScreenshotAssetsReportsDecodedPixelDuplicatesDeterministically(
 	}
 }
 
+func TestValidateScreenshotAssetsPreserves16BitSamplesWhenDetectingDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	writeAssetsScreenshotValidatePNG64(t, dir, "01-first.png", 312, 390, color.NRGBA64{R: 0x1201, G: 0x3400, B: 0x5600, A: 0xffff})
+	writeAssetsScreenshotValidatePNG64(t, dir, "02-second.png", 312, 390, color.NRGBA64{R: 0x1202, G: 0x3400, B: 0x5600, A: 0xffff})
+
+	result, err := validateScreenshotAssets(dir, "APP_WATCH_SERIES_3")
+	if err != nil {
+		t.Fatalf("validateScreenshotAssets() error: %v", err)
+	}
+
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected distinct 16-bit samples to pass, got %d error(s): %+v", result.ErrorCount, result.Issues)
+	}
+	if result.ReadyFiles != 2 {
+		t.Fatalf("expected 2 ready files, got %d", result.ReadyFiles)
+	}
+}
+
 func TestRenderScreenshotValidateResultSkipsRedundantAPIDisplayTypeRow(t *testing.T) {
 	result := &screenshotValidateResult{
 		Path:         "/tmp/screenshots",
@@ -239,4 +257,22 @@ func writeAssetsScreenshotValidatePNG(t *testing.T, dir, name string, width, hei
 		t.Fatalf("encode png: %v", err)
 	}
 	return path
+}
+
+func writeAssetsScreenshotValidatePNG64(t *testing.T, dir, name string, width, height int, marker color.NRGBA64) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	img := image.NewNRGBA64(image.Rect(0, 0, width, height))
+	img.SetNRGBA64(0, 0, marker)
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create png: %v", err)
+	}
+	defer file.Close()
+
+	if err := png.Encode(file, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
 }

--- a/internal/cli/assets/assets_screenshots_validate_test.go
+++ b/internal/cli/assets/assets_screenshots_validate_test.go
@@ -1,6 +1,10 @@
 package assets
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,9 +13,9 @@ import (
 
 func TestValidateScreenshotAssetsSortsEntriesAndKeepsHiddenWarningsNonBlocking(t *testing.T) {
 	dir := t.TempDir()
-	writeAssetsTestPNGWithSize(t, dir, "02-details.png", 1242, 2688)
-	writeAssetsTestPNGWithSize(t, dir, "01-home.png", 1242, 2688)
-	writeAssetsTestPNGWithSize(t, dir, ".hidden.png", 1242, 2688)
+	writeAssetsScreenshotValidatePNG(t, dir, "02-details.png", 1242, 2688, color.RGBA{R: 20, A: 255}, png.DefaultCompression)
+	writeAssetsScreenshotValidatePNG(t, dir, "01-home.png", 1242, 2688, color.RGBA{R: 10, A: 255}, png.DefaultCompression)
+	writeAssetsScreenshotValidatePNG(t, dir, ".hidden.png", 1242, 2688, color.RGBA{R: 30, A: 255}, png.DefaultCompression)
 
 	result, err := validateScreenshotAssets(dir, "APP_IPHONE_65")
 	if err != nil {
@@ -45,9 +49,9 @@ func TestValidateScreenshotAssetsSortsEntriesAndKeepsHiddenWarningsNonBlocking(t
 
 func TestValidateScreenshotAssetsMatchesUploadOrdering(t *testing.T) {
 	dir := t.TempDir()
-	writeAssetsTestPNGWithSize(t, dir, "02-details.png", 1242, 2688)
-	writeAssetsTestPNGWithSize(t, dir, "01-home.png", 1242, 2688)
-	writeAssetsTestPNGWithSize(t, dir, ".hidden.png", 1242, 2688)
+	writeAssetsScreenshotValidatePNG(t, dir, "02-details.png", 1242, 2688, color.RGBA{R: 20, A: 255}, png.DefaultCompression)
+	writeAssetsScreenshotValidatePNG(t, dir, "01-home.png", 1242, 2688, color.RGBA{R: 10, A: 255}, png.DefaultCompression)
+	writeAssetsScreenshotValidatePNG(t, dir, ".hidden.png", 1242, 2688, color.RGBA{R: 30, A: 255}, png.DefaultCompression)
 
 	uploadFiles, err := collectAssetFiles(dir)
 	if err != nil {
@@ -103,6 +107,56 @@ func TestValidateScreenshotAssetsReportsUnreadableDotfilesAndDimensionMismatch(t
 	}
 	if !hasScreenshotValidateIssueWithSeverity(result.Issues, "dimension_mismatch", screenshotValidateSeverityError, "03-bad.png") {
 		t.Fatalf("expected dimension mismatch error, got %+v", result.Issues)
+	}
+}
+
+func TestValidateScreenshotAssetsReportsDecodedPixelDuplicatesDeterministically(t *testing.T) {
+	dir := t.TempDir()
+	marker := color.RGBA{R: 10, G: 20, B: 30, A: 255}
+	originalPath := writeAssetsScreenshotValidatePNG(t, dir, "01-original.png", 312, 390, marker, png.BestSpeed)
+	duplicatePath := writeAssetsScreenshotValidatePNG(t, dir, "02-duplicate.png", 312, 390, marker, png.BestCompression)
+	writeAssetsScreenshotValidatePNG(t, dir, "03-another-duplicate.png", 312, 390, marker, png.DefaultCompression)
+	writeAssetsScreenshotValidatePNG(t, dir, "04-distinct.png", 312, 390, color.RGBA{R: 11, G: 20, B: 30, A: 255}, png.DefaultCompression)
+
+	originalBytes, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+	duplicateBytes, err := os.ReadFile(duplicatePath)
+	if err != nil {
+		t.Fatalf("read duplicate: %v", err)
+	}
+	if bytes.Equal(originalBytes, duplicateBytes) {
+		t.Fatal("expected differently encoded PNG files")
+	}
+
+	result, err := validateScreenshotAssets(dir, "APP_WATCH_SERIES_3")
+	if err != nil {
+		t.Fatalf("validateScreenshotAssets() error: %v", err)
+	}
+
+	if result.ErrorCount != 2 {
+		t.Fatalf("expected 2 duplicate errors, got %d (%+v)", result.ErrorCount, result.Issues)
+	}
+	if result.ReadyFiles != 2 {
+		t.Fatalf("expected 2 ready files, got %d", result.ReadyFiles)
+	}
+	if len(result.Files) != 4 {
+		t.Fatalf("expected 4 files, got %d", len(result.Files))
+	}
+	if result.Files[0].Status != "ok" || result.Files[1].Status != "error" || result.Files[2].Status != "error" || result.Files[3].Status != "ok" {
+		t.Fatalf("unexpected file statuses: %+v", result.Files)
+	}
+
+	for _, fileName := range []string{"02-duplicate.png", "03-another-duplicate.png"} {
+		if !hasScreenshotValidateIssueWithSeverity(result.Issues, "duplicate_content", screenshotValidateSeverityError, fileName) {
+			t.Fatalf("expected duplicate-content issue for %s, got %+v", fileName, result.Issues)
+		}
+	}
+	for _, issue := range result.Issues {
+		if issue.Code == "duplicate_content" && !strings.Contains(issue.Message, `"01-original.png"`) {
+			t.Fatalf("expected deterministic original in duplicate message, got %q", issue.Message)
+		}
 	}
 }
 
@@ -165,4 +219,24 @@ func hasScreenshotValidateIssueWithSeverity(issues []screenshotValidateIssue, co
 		}
 	}
 	return false
+}
+
+func writeAssetsScreenshotValidatePNG(t *testing.T, dir, name string, width, height int, marker color.RGBA, compression png.CompressionLevel) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	img.SetRGBA(0, 0, marker)
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create png: %v", err)
+	}
+	defer file.Close()
+
+	encoder := png.Encoder{CompressionLevel: compression}
+	if err := encoder.Encode(file, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return path
 }

--- a/internal/cli/cmdtest/assets_screenshots_validate_test.go
+++ b/internal/cli/cmdtest/assets_screenshots_validate_test.go
@@ -1,9 +1,13 @@
 package cmdtest
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
+	"image"
+	"image/color"
+	"image/png"
 	"io"
 	"os"
 	"path/filepath"
@@ -15,6 +19,7 @@ type screenshotValidateOutput struct {
 	Path         string                          `json:"path"`
 	DisplayType  string                          `json:"displayType"`
 	TotalFiles   int                             `json:"totalFiles"`
+	ReadyFiles   int                             `json:"readyFiles"`
 	ErrorCount   int                             `json:"errorCount"`
 	WarningCount int                             `json:"warningCount"`
 	Files        []screenshotValidateFileOutput  `json:"files"`
@@ -26,13 +31,16 @@ type screenshotValidateFileOutput struct {
 	FileName string `json:"fileName"`
 	Width    int    `json:"width,omitempty"`
 	Height   int    `json:"height,omitempty"`
+	Status   string `json:"status,omitempty"`
 }
 
 type screenshotValidateIssueOutput struct {
-	Code     string `json:"code"`
-	Severity string `json:"severity"`
-	FileName string `json:"fileName,omitempty"`
-	Message  string `json:"message"`
+	Code        string `json:"code"`
+	Severity    string `json:"severity"`
+	FileName    string `json:"fileName,omitempty"`
+	DuplicateOf string `json:"duplicateOf,omitempty"`
+	Match       string `json:"match,omitempty"`
+	Message     string `json:"message"`
 }
 
 func TestScreenshotsHelpListsValidateSubcommand(t *testing.T) {
@@ -51,9 +59,9 @@ func TestScreenshotsHelpListsValidateSubcommand(t *testing.T) {
 
 func TestAssetsScreenshotsValidateOutputReportsOrderingHiddenFilesAndDimensionErrors(t *testing.T) {
 	dir := t.TempDir()
-	writePNG(t, filepath.Join(dir, "02-details.png"), 1242, 2688)
-	writePNG(t, filepath.Join(dir, "01-home.png"), 1242, 2688)
-	writePNG(t, filepath.Join(dir, ".hidden.png"), 1242, 2688)
+	writeScreenshotValidatePNG(t, filepath.Join(dir, "02-details.png"), 1242, 2688, color.RGBA{R: 20, A: 255}, png.DefaultCompression)
+	writeScreenshotValidatePNG(t, filepath.Join(dir, "01-home.png"), 1242, 2688, color.RGBA{R: 10, A: 255}, png.DefaultCompression)
+	writeScreenshotValidatePNG(t, filepath.Join(dir, ".hidden.png"), 1242, 2688, color.RGBA{R: 30, A: 255}, png.DefaultCompression)
 	writePNG(t, filepath.Join(dir, "03-bad.png"), 100, 100)
 
 	root := RootCommand("1.2.3")
@@ -124,6 +132,82 @@ func TestAssetsScreenshotsValidateOutputReportsOrderingHiddenFilesAndDimensionEr
 	}
 }
 
+func TestAssetsScreenshotsValidateReportsDecodedPixelDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "01-original.png")
+	duplicatePath := filepath.Join(dir, "02-duplicate.png")
+	distinctPath := filepath.Join(dir, "03-distinct.png")
+	marker := color.RGBA{R: 10, G: 20, B: 30, A: 255}
+
+	writeScreenshotValidatePNG(t, originalPath, 312, 390, marker, png.BestSpeed)
+	writeScreenshotValidatePNG(t, duplicatePath, 312, 390, marker, png.BestCompression)
+	writeScreenshotValidatePNG(t, distinctPath, 312, 390, color.RGBA{R: 11, G: 20, B: 30, A: 255}, png.DefaultCompression)
+
+	originalBytes, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+	duplicateBytes, err := os.ReadFile(duplicatePath)
+	if err != nil {
+		t.Fatalf("read duplicate: %v", err)
+	}
+	if bytes.Equal(originalBytes, duplicateBytes) {
+		t.Fatal("expected differently encoded PNG files")
+	}
+
+	stdout, stderr, runErr := runRootCommand(t, []string{
+		"screenshots", "validate",
+		"--path", dir,
+		"--device-type", "APP_WATCH_SERIES_3",
+		"--output", "json",
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if runErr == nil {
+		t.Fatal("expected reported validation error, got nil")
+	}
+	if !strings.Contains(runErr.Error(), "screenshots validate: found 1 error(s)") {
+		t.Fatalf("expected one duplicate-content error, got %v", runErr)
+	}
+
+	var result screenshotValidateOutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 error, got %d", result.ErrorCount)
+	}
+	if result.ReadyFiles != 2 {
+		t.Fatalf("expected 2 ready files, got %d", result.ReadyFiles)
+	}
+	if len(result.Files) != 3 || result.Files[1].Status != "error" {
+		t.Fatalf("expected sorted duplicate file to have error status, got %+v", result.Files)
+	}
+
+	var duplicateIssue *screenshotValidateIssueOutput
+	for i := range result.Issues {
+		issue := &result.Issues[i]
+		if issue.Code == "duplicate_content" && issue.FileName == "02-duplicate.png" {
+			duplicateIssue = issue
+			break
+		}
+	}
+	if duplicateIssue == nil {
+		t.Fatalf("expected duplicate-content issue, got %+v", result.Issues)
+	}
+	if duplicateIssue.Severity != "error" {
+		t.Fatalf("expected duplicate error severity, got %q", duplicateIssue.Severity)
+	}
+	if duplicateIssue.DuplicateOf != "01-original.png" {
+		t.Fatalf("expected duplicateOf 01-original.png, got %q", duplicateIssue.DuplicateOf)
+	}
+	if duplicateIssue.Match != "pixels" {
+		t.Fatalf("expected pixel match, got %q", duplicateIssue.Match)
+	}
+}
+
 func hasScreenshotValidateIssue(issues []screenshotValidateIssueOutput, code, severity, fileName string) bool {
 	for _, issue := range issues {
 		if issue.Code == code && issue.Severity == severity && issue.FileName == fileName {
@@ -137,6 +221,24 @@ func TestAssetsScreenshotsValidateHelpUsesCanonicalUsage(t *testing.T) {
 	usage := usageForCommand(t, "screenshots", "validate")
 	if !strings.Contains(usage, `asc screenshots validate --path "./screenshots" --device-type "IPHONE_65"`) {
 		t.Fatalf("expected canonical validate usage, got %q", usage)
+	}
+}
+
+func writeScreenshotValidatePNG(t *testing.T, path string, width, height int, marker color.RGBA, compression png.CompressionLevel) {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	img.SetRGBA(0, 0, marker)
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+	defer file.Close()
+
+	encoder := png.Encoder{CompressionLevel: compression}
+	if err := encoder.Encode(file, img); err != nil {
+		t.Fatalf("encode png: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- detect exact duplicate screenshots by hashing normalized decoded pixels, independent of PNG encoding or compression
- confirm hash candidates byte-for-byte in deterministic upload order and report later matches as blocking `duplicate_content` errors
- expose `duplicateOf` and `match: "pixels"` in structured validation output
- add unit and CLI coverage for differently encoded, pixel-identical PNGs

## Why

Comparing encoded file bytes misses screenshots that render identically but were re-exported or compressed differently. This adds a deterministic local preflight so the same screenshot is not uploaded twice.

## Impact

The existing `asc screenshots validate` command gains this check without new flags or dependencies. It remains local-only and does not mutate App Store Connect. Detection is intentionally exact; perceptually similar screenshots are out of scope.

## Validation

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused asset and CLI duplicate-detection tests after rebasing onto latest `origin/main`
- built-binary smoke test verifying `duplicate_content`, `duplicateOf`, `match`, ready-file counts, and non-zero validation exit
- pre-commit hooks: command docs, formatting, lint, and short test suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787794576&installation_model_id=10418&pr_number=1815&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1815&signature=f02dcec5a95e529f8a497c8d0bafc76973ad89f1648c893ab64ddd3f22192649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The screenshot validation command now detects duplicate images by comparing decoded pixel content, even across different encodings/compression.
  - Duplicate findings are reported as `duplicate_content`, including which screenshot they match and the match type (`pixels`).
  - Validation output now includes per-file status and enhanced details for duplicate relationships.

- **Bug Fixes**
  - Duplicate detection is deterministic, consistently referencing the same canonical screenshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->