### PR TITLE
feat(app-clips): expose default experience template on create

### DIFF
--- a/internal/cli/appclips/default_experiences.go
+++ b/internal/cli/appclips/default_experiences.go
@@ -186,6 +186,7 @@ func AppClipDefaultExperiencesCreateCommand() *ffcli.Command {
 	appClipID := fs.String("app-clip-id", "", "App Clip ID")
 	action := fs.String("action", "", "Action (OPEN, VIEW, PLAY)")
 	releaseVersionID := fs.String("release-version-id", "", "Release with App Store version ID")
+	templateID := fs.String("template-id", "", "Existing default experience ID to use as a template")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -194,9 +195,14 @@ func AppClipDefaultExperiencesCreateCommand() *ffcli.Command {
 		ShortHelp:  "Create a default experience.",
 		LongHelp: `Create a default experience.
 
+Use --template-id to clone an existing default experience. Apple copies the
+template's metadata (header image and localizations) onto the new experience,
+so they do not have to be re-uploaded or recreated.
+
 Examples:
   asc app-clips default-experiences create --app-clip-id "CLIP_ID" --action OPEN
-  asc app-clips default-experiences create --app-clip-id "CLIP_ID" --release-version-id "VERSION_ID"`,
+  asc app-clips default-experiences create --app-clip-id "CLIP_ID" --release-version-id "VERSION_ID"
+  asc app-clips default-experiences create --app-clip-id "CLIP_ID" --release-version-id "VERSION_ID" --template-id "CURRENT_EXPERIENCE_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -217,7 +223,7 @@ Examples:
 				}
 			}
 
-			client, err := shared.GetASCClient()
+			client, err := appClipsClientFactory()
 			if err != nil {
 				return fmt.Errorf("app-clips default-experiences create: %w", err)
 			}
@@ -225,7 +231,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.CreateAppClipDefaultExperience(requestCtx, appClipValue, attrs, *releaseVersionID, "")
+			resp, err := client.CreateAppClipDefaultExperience(requestCtx, appClipValue, attrs, *releaseVersionID, *templateID)
 			if err != nil {
 				return fmt.Errorf("app-clips default-experiences create: failed to create: %w", err)
 			}

--- a/internal/cli/appclips/default_experiences.go
+++ b/internal/cli/appclips/default_experiences.go
@@ -212,6 +212,15 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
+			templateValue := strings.TrimSpace(*templateID)
+			templateProvided := false
+			fs.Visit(func(f *flag.Flag) {
+				templateProvided = templateProvided || f.Name == "template-id"
+			})
+			if templateProvided && templateValue == "" {
+				return fmt.Errorf("app-clips default-experiences create: --template-id must not be empty")
+			}
+
 			var attrs *asc.AppClipDefaultExperienceCreateAttributes
 			if strings.TrimSpace(*action) != "" {
 				actionValue, err := normalizeAppClipAction(*action)
@@ -231,7 +240,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.CreateAppClipDefaultExperience(requestCtx, appClipValue, attrs, *releaseVersionID, *templateID)
+			resp, err := client.CreateAppClipDefaultExperience(requestCtx, appClipValue, attrs, *releaseVersionID, templateValue)
 			if err != nil {
 				return fmt.Errorf("app-clips default-experiences create: failed to create: %w", err)
 			}

--- a/internal/cli/cmdtest/appclips_default_experiences_create_test.go
+++ b/internal/cli/cmdtest/appclips_default_experiences_create_test.go
@@ -1,0 +1,140 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	appclipscli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/appclips"
+)
+
+// newDefaultExperiencesCreateClient points the CLI's App Clips client at srv.
+func newDefaultExperiencesCreateClient(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+
+	serverURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	keyPath := t.TempDir() + "/key.p8"
+	writeECDSAPEM(t, keyPath)
+
+	transport := appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return srv.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	t.Cleanup(appclipscli.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	}))
+}
+
+func TestAppClipsDefaultExperiencesCreateSendsTemplate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/appClipDefaultExperiences" {
+			t.Fatalf("expected path /v1/appClipDefaultExperiences, got %s", r.URL.Path)
+		}
+
+		var payload asc.AppClipDefaultExperienceCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		template := payload.Data.Relationships.AppClipDefaultExperienceTemplate
+		if template == nil {
+			t.Fatal("expected appClipDefaultExperienceTemplate relationship")
+		}
+		if template.Data.ID != "exp-current" {
+			t.Fatalf("expected template id exp-current, got %s", template.Data.ID)
+		}
+		if template.Data.Type != asc.ResourceTypeAppClipDefaultExperiences {
+			t.Fatalf("expected template type %s, got %s", asc.ResourceTypeAppClipDefaultExperiences, template.Data.Type)
+		}
+		if payload.Data.Relationships.ReleaseWithAppStoreVersion.Data.ID != "version-1" {
+			t.Fatalf("expected releaseWithAppStoreVersion id version-1, got %s", payload.Data.Relationships.ReleaseWithAppStoreVersion.Data.ID)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"type":"appClipDefaultExperiences","id":"exp-new"},"links":{}}`))
+	}))
+	defer server.Close()
+
+	newDefaultExperiencesCreateClient(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"app-clips", "default-experiences", "create",
+			"--app-clip-id", "clip-1",
+			"--release-version-id", "version-1",
+			"--template-id", "exp-current",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response asc.AppClipDefaultExperienceResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nstdout=%q", err, stdout)
+	}
+	if response.Data.ID != "exp-new" {
+		t.Fatalf("expected experience id exp-new, got %s", response.Data.ID)
+	}
+}
+
+func TestAppClipsDefaultExperiencesCreateOmitsTemplateWhenNotSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload asc.AppClipDefaultExperienceCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Data.Relationships.AppClipDefaultExperienceTemplate != nil {
+			t.Fatalf("expected no template relationship, got %#v", payload.Data.Relationships.AppClipDefaultExperienceTemplate)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"type":"appClipDefaultExperiences","id":"exp-new"},"links":{}}`))
+	}))
+	defer server.Close()
+
+	newDefaultExperiencesCreateClient(t, server)
+
+	root := RootCommand("1.2.3")
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"app-clips", "default-experiences", "create",
+			"--app-clip-id", "clip-1",
+			"--release-version-id", "version-1",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/appclips_default_experiences_create_test.go
+++ b/internal/cli/cmdtest/appclips_default_experiences_create_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -136,5 +137,46 @@ func TestAppClipsDefaultExperiencesCreateOmitsTemplateWhenNotSet(t *testing.T) {
 
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
+func TestAppClipsDefaultExperiencesCreateRejectsEmptyTemplateWhenSet(t *testing.T) {
+	for _, templateID := range []string{"", "   "} {
+		t.Run("value="+templateID, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"data":{"type":"appClipDefaultExperiences","id":"exp-new"},"links":{}}`))
+			}))
+			defer server.Close()
+
+			newDefaultExperiencesCreateClient(t, server)
+
+			root := RootCommand("1.2.3")
+			var runErr error
+			captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"app-clips", "default-experiences", "create",
+					"--app-clip-id", "clip-1",
+					"--release-version-id", "version-1",
+					"--template-id", templateID,
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected error for explicitly empty --template-id")
+			}
+			if !strings.Contains(runErr.Error(), "--template-id must not be empty") {
+				t.Fatalf("expected empty template error, got %v", runErr)
+			}
+			if requestCount != 0 {
+				t.Fatalf("expected no request, got %d", requestCount)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #1818.

## Problem

`asc app-clips default-experiences create` called the client with a hard-coded empty template ID:

```go
client.CreateAppClipDefaultExperience(requestCtx, appClipValue, attrs, *releaseVersionID, "")
```

So there was no way to reuse the current released experience's metadata when creating a default experience for a new App Store version — even though `CreateAppClipDefaultExperience` already accepts `templateID` and `AppClipDefaultExperienceCreateRelationships.AppClipDefaultExperienceTemplate` already exists (with `omitempty`).

Without it, cloning an experience means downloading the existing header image from Apple's CDN and re-uploading it, plus recreating each localization by hand.

## Change

- Add an optional `--template-id` flag to `app-clips default-experiences create` and forward it to the client, producing the `appClipDefaultExperienceTemplate` relationship.
- Document cloning in the long help and add a third example.
- Resolve the client via `appClipsClientFactory` instead of `shared.GetASCClient()` so the command is testable. The `invocations` commands in the same package already do this, and `SetClientFactory` already exists in `test_hooks.go` — this just brings `create` in line with it.
- Add `internal/cli/cmdtest/appclips_default_experiences_create_test.go`, modelled on `appclips_invocations_create_test.go`.

```bash
asc app-clips default-experiences create \
  --app-clip-id "APP_CLIP_ID" \
  --release-version-id "NEW_VERSION_ID" \
  --template-id "CURRENT_EXPERIENCE_ID"
```

No behaviour change when `--template-id` is omitted: the client already trims the value and only attaches the relationship when it is non-empty.

## Tests

Two command-level tests through the real root command and a stubbed transport:

- `TestAppClipsDefaultExperiencesCreateSendsTemplate` — asserts the request body carries `appClipDefaultExperienceTemplate` with the given id and the `appClipDefaultExperiences` type, alongside `releaseWithAppStoreVersion`.
- `TestAppClipsDefaultExperiencesCreateOmitsTemplateWhenNotSet` — asserts the relationship is absent when the flag isn't passed.

I checked the new coverage actually fails without the fix: forwarding `""` instead of `*templateID` (with the flag still declared, so it compiles) fails with `expected appClipDefaultExperienceTemplate relationship` and passes once restored. I'd initially written this at the client layer instead and it passed with the fix fully reverted, since the client behaviour was already correct — the gap was only in the command.

```
gofmt -l           # clean on both files
go vet ./...       # clean
ASC_BYPASS_KEYCHAIN=1 go test -count=1 ./...
```

Full suite: 91 packages pass. `cmd` and `internal/cli/install` fail on two wall-clock tests — `TestSkillsAutoCheckDoesNotDelayForegroundCommand` and `TestDefaultRunSkillsCheckCommandDoesNotWaitForDescendantPipes`. These fail identically on a clean checkout of `main` under the same full-suite load (same `ok=91 fail=5`) and pass in isolation both with and without this change, so they look like pre-existing load-sensitive flakes rather than anything from this PR. Happy to be told otherwise.

Tested with Go 1.26.5 on darwin/arm64. I haven't exercised `--template-id` against the live API — the request shape is asserted in tests only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787888990&installation_model_id=10418&pr_number=1819&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1819&signature=cd2cdbf3cf5fcaf1e3fccc5eff289cfdc678d9d77c727ac3c7abf698827f327c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cloning an existing App Clip default experience with the `--template-id` option.
  * Updated command help and examples to explain template-based creation.
* **Bug Fixes**
  * Default experience creation now validates that `--template-id` (when set) is non-empty.
  * Creation requests now correctly include the selected template instead of always sending an empty template.
* **Tests**
  * Added CLI integration tests for template inclusion, omission, and empty-template validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->