### PR TITLE
fix(ads): document campaign update envelope

### DIFF
--- a/commands/ads.mdx
+++ b/commands/ads.mdx
@@ -137,7 +137,17 @@ asc ads campaigns list --org "123456" --paginate --output json
 ```
 
 Create or update resources with JSON payload files. The CLI sends the file body
-to Apple without inventing extra field mappings:
+to Apple without inventing extra field mappings. Apple requires campaign update
+payloads to use a `campaign` envelope, so `campaign-update.json` must contain a
+wrapped object such as:
+
+```json  theme={null}
+{
+  "campaign": {
+    "status": "PAUSED"
+  }
+}
+```
 
 ```bash  theme={null}
 asc ads campaigns create --org "123456" --file campaign.json

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -151,7 +151,11 @@ func endpointLongHelp(node *commandNode, path []string) string {
 	if node.spec.RequiresOrg {
 		examples[0] += " --org ORG_ID"
 	}
-	return fmt.Sprintf("%s\n\nEndpoint: %s %s\n\nExamples:\n%s", endpointShortHelp(node), node.spec.Method, node.spec.Path, strings.Join(examples, "\n"))
+	help := fmt.Sprintf("%s\n\nEndpoint: %s %s", endpointShortHelp(node), node.spec.Method, node.spec.Path)
+	if node.spec.BodyType == "UpdateCampaignRequest" {
+		help += "\n\nPayload:\n  Apple requires a \"campaign\" envelope for campaign updates.\n  Example: {\"campaign\":{\"status\":\"PAUSED\"}}"
+	}
+	return help + "\n\nExamples:\n" + strings.Join(examples, "\n")
 }
 
 func endpointGroupHelp(name string) string {

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -70,6 +70,23 @@ func TestAdsCampaignsHelpReadsAsManagementSurface(t *testing.T) {
 	}
 }
 
+func TestAdsCampaignUpdateHelpDocumentsRequiredEnvelope(t *testing.T) {
+	root := AdsCommand()
+	update := findCommand(root, "campaigns", "update")
+	if update == nil {
+		t.Fatal("missing campaigns update command")
+	}
+
+	for _, want := range []string{
+		`Apple requires a "campaign" envelope for campaign updates.`,
+		`{"campaign":{"status":"PAUSED"}}`,
+	} {
+		if !strings.Contains(update.LongHelp, want) {
+			t.Fatalf("campaigns update LongHelp = %q, want %q", update.LongHelp, want)
+		}
+	}
+}
+
 func TestCollectQueryValidatesEndpointSpecificLimitsAndEnums(t *testing.T) {
 	customReports, _ := appleads.EndpointByCommandPath("impression-share-reports", "list")
 	fs, flags := bindEndpointFlags(customReports, "test")

--- a/internal/cli/cmdtest/ads_docs_examples_test.go
+++ b/internal/cli/cmdtest/ads_docs_examples_test.go
@@ -215,7 +215,7 @@ func writeAdsGuidePayloads(t *testing.T, dir string) map[string]string {
 
 	files := map[string]string{
 		"campaign.json":              `{"name":"Brand Campaign","status":"PAUSED"}`,
-		"campaign-update.json":       `{"status":"PAUSED"}`,
+		"campaign-update.json":       `{"campaign":{"status":"PAUSED"}}`,
 		"ad-group.json":              `{"name":"Brand Ad Group","status":"PAUSED"}`,
 		"ad.json":                    `{"name":"Brand Ad","status":"PAUSED"}`,
 		"selector.json":              `{"conditions":[{"field":"deleted","operator":"EQUALS","values":["false"]}],"pagination":{"offset":0,"limit":100}}`,

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -388,6 +390,76 @@ func TestAdsAuthDiscoverContinuesWhenOptionalOrgConfigIsInvalid(t *testing.T) {
 	}
 }
 
+func TestAdsCampaignUpdateSendsRequiredEnvelope(t *testing.T) {
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_ORG_ID", "987654")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	campaignUpdate := writeAdsEvalPayload(t, "campaign-update.json", `{"campaign":{"status":"PAUSED"}}`)
+	requests := newRequestLog(1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests.Add(req.Method + " " + req.URL.RequestURI())
+		if req.Method != http.MethodPut || req.URL.Path != "/api/v5/campaigns/1001" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer ACCESS" {
+			t.Errorf("Authorization = %q, want Bearer ACCESS", got)
+		}
+		if got := req.Header.Get("X-AP-Context"); got != "orgId=987654" {
+			t.Errorf("X-AP-Context = %q, want orgId=987654", got)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Errorf("decode campaign update body: %v", err)
+		}
+		campaign, ok := body["campaign"].(map[string]any)
+		if !ok {
+			t.Errorf("campaign update body = %#v, want campaign envelope", body)
+		} else if got := campaign["status"]; got != "PAUSED" {
+			t.Errorf("campaign update status = %#v, want PAUSED", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"id":1001,"status":"PAUSED"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	transport, ok := server.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("server transport type = %T, want *http.Transport", server.Client().Transport)
+	}
+	transport = transport.Clone()
+	transport.Proxy = nil
+	transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.ServerName = "example.com"
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	installDefaultTransport(t, transport)
+
+	stdout, stderr, err := runAdsEvalCommand(
+		t,
+		"ads", "campaigns", "update",
+		"--campaign", "1001",
+		"--file", campaignUpdate,
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("campaign update error: %v\nstderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("campaign update stderr = %q, want empty", stderr)
+	}
+	if got := requests.Snapshot(); len(got) != 1 || got[0] != "PUT /api/v5/campaigns/1001" {
+		t.Fatalf("requests = %q, want one campaign update", got)
+	}
+	if !strings.Contains(stdout, `"status":"PAUSED"`) {
+		t.Fatalf("campaign update stdout = %q, want paused response", stdout)
+	}
+}
+
 func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
 	t.Setenv("ASC_ADS_ORG_ID", "987654")
@@ -398,7 +470,7 @@ func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 	keywords := writeAdsEvalPayload(t, "keywords.json", `[{"text":"example keyword","matchType":"EXACT","status":"PAUSED"}]`)
 	keywordIDs := writeAdsEvalPayload(t, "keyword-ids.json", `[111111111]`)
 
-	log := newRequestLog(4)
+	log := newRequestLog(5)
 	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		assertAdsEvalBearer(t, req)
 		assertAdsEvalOrg(t, req)
@@ -412,14 +484,6 @@ func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 			}
 			return adsJSONResponse(200, `{"data":{"id":1001}}`), nil
 		case req.Method == http.MethodPut && req.URL.Path == "/api/v5/campaigns/1001":
-			body := readAdsEvalJSONBody(t, req)
-			campaign, ok := body["campaign"].(map[string]any)
-			if !ok {
-				t.Fatalf("campaign update body = %#v, want campaign envelope", body)
-			}
-			if got := campaign["status"]; got != "PAUSED" {
-				t.Fatalf("campaign update status = %#v, want PAUSED", got)
-			}
 			return adsJSONResponse(200, `{"data":{"id":1001,"status":"PAUSED"}}`), nil
 		case req.Method == http.MethodPost && req.URL.Path == "/api/v5/campaigns/1001/adgroups/2002/targetingkeywords/bulk":
 			items := readAdsEvalJSONArrayBody(t, req)

--- a/internal/cli/cmdtest/ads_eval_test.go
+++ b/internal/cli/cmdtest/ads_eval_test.go
@@ -394,7 +394,7 @@ func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
 
 	campaignCreate := writeAdsEvalPayload(t, "campaign-create.json", `{"name":"ASC CLI Eval Campaign","status":"PAUSED"}`)
-	campaignUpdate := writeAdsEvalPayload(t, "campaign-update.json", `{"status":"PAUSED"}`)
+	campaignUpdate := writeAdsEvalPayload(t, "campaign-update.json", `{"campaign":{"status":"PAUSED"}}`)
 	keywords := writeAdsEvalPayload(t, "keywords.json", `[{"text":"example keyword","matchType":"EXACT","status":"PAUSED"}]`)
 	keywordIDs := writeAdsEvalPayload(t, "keyword-ids.json", `[111111111]`)
 
@@ -413,7 +413,11 @@ func TestAdsAgentMutationEvalWorkflow(t *testing.T) {
 			return adsJSONResponse(200, `{"data":{"id":1001}}`), nil
 		case req.Method == http.MethodPut && req.URL.Path == "/api/v5/campaigns/1001":
 			body := readAdsEvalJSONBody(t, req)
-			if got := body["status"]; got != "PAUSED" {
+			campaign, ok := body["campaign"].(map[string]any)
+			if !ok {
+				t.Fatalf("campaign update body = %#v, want campaign envelope", body)
+			}
+			if got := campaign["status"]; got != "PAUSED" {
 				t.Fatalf("campaign update status = %#v, want PAUSED", got)
 			}
 			return adsJSONResponse(200, `{"data":{"id":1001,"status":"PAUSED"}}`), nil


### PR DESCRIPTION
## Summary

- document Apple's required `campaign` JSON envelope in `asc ads campaigns update --help`
- add a concrete wrapped payload to the Apple Ads command guide
- correct the documentation and mutation-eval fixtures to use and assert the real `UpdateCampaignRequest` shape
- preserve the existing verbatim `--file` contract; no payload auto-wrapping or raw API behavior changes

## Root cause

The endpoint metadata and internal architecture notes knew that `UpdateCampaignRequest` uses a `campaign` envelope, but the generated command help exposed only a generic `--file payload.json` example. Two test fixtures also modeled the update as a flat object, reinforcing a request shape that Apple rejects with `UNRECOGNIZED_PROPERTY`.

## Validation

- RED: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/ads -run TestAdsCampaignUpdateHelpDocumentsRequiredEnvelope -count=1`
- GREEN: focused Apple Ads help, guide, and mutation-eval tests
- `make generate-command-docs` (no generated diff)
- `make format`
- `make check-docs`
- `make lint` (`0 issues`)
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built `/tmp/asc-issue-1816` and verified `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-issue-1816 ads campaigns update --help`
- commit hooks passed website docs, command docs, formatting, lint, and the short suite

No live Apple Ads campaign or account was mutated.

Closes #1816

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787891020&installation_model_id=10418&pr_number=1820&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1820&signature=3bd1b036442840884273500924e9f66d4ef13613c773d63e496167314959eccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Apple Ads campaign update requests must use a top-level `campaign` envelope.
  * Added/updated examples to show `campaign.status` in the correct wrapped JSON format.

* **CLI Improvements**
  * Enhanced `ads campaigns update` long help to explicitly document the required `campaign` envelope and provide a concrete payload example.
  * Updated campaign update requests to send the wrapped payload structure.

* **Tests**
  * Added coverage to verify help text includes the envelope requirement and that update requests include the correct wrapped JSON body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->