### PR TITLE
Security: bound IPA Info.plist expansion and review-response batch fan-out

### DIFF
--- a/internal/cli/cmdtest/reviews_responses_test.go
+++ b/internal/cli/cmdtest/reviews_responses_test.go
@@ -72,8 +72,9 @@ func writeReviewBatchFile(t *testing.T, body string) string {
 // Documented respond-batch ceilings, restated here so the CLI-level tests fail
 // if the enforced limits ever drift from the published contract.
 const (
-	reviewBatchFileByteLimit = 4 << 20
-	reviewBatchTargetLimit   = 500
+	reviewBatchFileByteLimit     = 64 << 20
+	reviewBatchTargetLimit       = 500
+	reviewBatchResponseByteLimit = 24 << 10
 )
 
 // reviewBatchJSONOfSize returns a valid single-target batch document whose byte
@@ -413,8 +414,34 @@ func TestReviewsRespondBatchRejectsOversizedFileWithoutRequests(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "--file must not exceed 4194304 bytes") {
+	if !strings.Contains(stderr, "--file must not exceed 67108864 bytes") {
 		t.Fatalf("expected batch file size rejection, got %q", stderr)
+	}
+}
+
+func TestReviewsRespondBatchRejectsOversizedResponseWithoutRequests(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("expected no HTTP request, got %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	oversized := `{"replies":[{"response":"` + strings.Repeat("a", reviewBatchResponseByteLimit+1) + `","reviewIds":["review-1"]}]}`
+	inputPath := writeReviewBatchFile(t, oversized)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--dry-run"}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "replies[0].response must not exceed 24576 bytes") {
+		t.Fatalf("expected response size rejection, got %q", stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/reviews_responses_test.go
+++ b/internal/cli/cmdtest/reviews_responses_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -66,6 +67,42 @@ func writeReviewBatchFile(t *testing.T, body string) string {
 		t.Fatalf("write batch file: %v", err)
 	}
 	return path
+}
+
+// Documented respond-batch ceilings, restated here so the CLI-level tests fail
+// if the enforced limits ever drift from the published contract.
+const (
+	reviewBatchFileByteLimit = 4 << 20
+	reviewBatchTargetLimit   = 500
+)
+
+// reviewBatchJSONOfSize returns a valid single-target batch document whose byte
+// length is exactly totalSize.
+func reviewBatchJSONOfSize(t *testing.T, totalSize int) string {
+	t.Helper()
+
+	envelope := func(padding int) string {
+		return `{"replies":[{"response":"` + strings.Repeat("a", padding) + `","reviewIds":["review-1"]}]}`
+	}
+	overhead := len(envelope(0))
+	if overhead > totalSize {
+		t.Fatalf("cannot build a batch document as small as %d bytes", totalSize)
+	}
+	body := envelope(totalSize - overhead)
+	if len(body) != totalSize {
+		t.Fatalf("expected a %d byte batch document, got %d", totalSize, len(body))
+	}
+	return body
+}
+
+func reviewBatchJSONWithReviewIDs(t *testing.T, count int) string {
+	t.Helper()
+
+	reviewIDs := make([]string, 0, count)
+	for i := range count {
+		reviewIDs = append(reviewIDs, fmt.Sprintf(`"review-%d"`, i))
+	}
+	return `{"replies":[{"response":"Thanks","reviewIds":[` + strings.Join(reviewIDs, ",") + `]}]}`
 }
 
 type reviewBatchTestOutput struct {
@@ -353,6 +390,101 @@ func TestReviewsRespondBatchResponseStateUnrespondedSkipsRespondedReviews(t *tes
 	skipped := findReviewBatchTestResult(t, payload, "review-1")
 	if skipped.Status != "skipped" || skipped.Reason != "response-state-mismatch" {
 		t.Fatalf("unexpected response-state skipped result: %+v", skipped)
+	}
+}
+
+func TestReviewsRespondBatchRejectsOversizedFileWithoutRequests(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("expected no HTTP request, got %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	inputPath := writeReviewBatchFile(t, reviewBatchJSONOfSize(t, reviewBatchFileByteLimit+1))
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--file must not exceed 4194304 bytes") {
+		t.Fatalf("expected batch file size rejection, got %q", stderr)
+	}
+}
+
+func TestReviewsRespondBatchRejectsTooManyReviewIDsWithoutRequests(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("expected no HTTP request, got %s %s", req.Method, req.URL.String())
+		return nil, nil
+	}))
+
+	inputPath := writeReviewBatchFile(t, reviewBatchJSONWithReviewIDs(t, reviewBatchTargetLimit+1))
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--dry-run"}, "1.2.3")
+		if code != cmd.ExitUsage {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--file must not contain more than 500 review ids") {
+		t.Fatalf("expected batch target count rejection, got %q", stderr)
+	}
+}
+
+func TestReviewsRespondBatchDryRunAtReviewIDLimit(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := writeReviewBatchFile(t, reviewBatchJSONWithReviewIDs(t, reviewBatchTargetLimit))
+	requests := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/customerReviews" {
+			t.Fatalf("dry-run should only fetch reviews, got %s %s", req.Method, req.URL.Path)
+		}
+		reviews := make([]string, 0, reviewBatchTargetLimit)
+		for i := range reviewBatchTargetLimit {
+			reviews = append(reviews, fmt.Sprintf(`{"type":"customerReviews","id":"review-%d"}`, i))
+		}
+		return jsonResponse(http.StatusOK, `{"data":[`+strings.Join(reviews, ",")+`]}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "respond-batch", "--app", "app-1", "--file", inputPath, "--dry-run", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one preflight request, got %d", requests)
+	}
+	payload := decodeReviewBatchTestOutput(t, stdout)
+	if payload.Summary.Total != reviewBatchTargetLimit || payload.Summary.Planned != reviewBatchTargetLimit {
+		t.Fatalf("unexpected dry-run summary at target limit: %+v", payload.Summary)
+	}
+	if payload.Summary.Created != 0 || payload.Summary.Failed != 0 || payload.Summary.Skipped != 0 {
+		t.Fatalf("expected only planned results at target limit: %+v", payload.Summary)
 	}
 }
 

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -59,6 +59,17 @@ const reviewBatchMaxResponseBytes = 24 << 10
 // override flag: raising the ceiling is the same as removing it.
 const reviewBatchMaxFileBytes = 64 << 20
 
+// reviewBatchMaxFileTokens bounds how many JSON tokens --file may contain.
+//
+// The byte and target ceilings alone still let a small file decode into
+// millions of tiny values: tens of MiB of empty review ids materialize
+// hundreds of megabytes of string headers before the target-count check can
+// run. A maximal legitimate batch — reviewBatchMaxTargets replies, each with
+// one response and one review id — is about four thousand tokens, so 16,384
+// leaves fourfold headroom while stopping a flood of tiny elements before the
+// document is materialized.
+const reviewBatchMaxFileTokens = 16 << 10
+
 type reviewBatchInput struct {
 	Replies []reviewBatchReplyInput `json:"replies"`
 }
@@ -204,6 +215,9 @@ func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return nil, fmt.Errorf("--file must not be empty")
 	}
+	if err := checkReviewBatchTokenBudget(data); err != nil {
+		return nil, err
+	}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
@@ -256,6 +270,28 @@ func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
 	}
 
 	return targets, nil
+}
+
+// checkReviewBatchTokenBudget streams the raw document once, without
+// materializing it, and fails as soon as it yields more JSON tokens than any
+// permitted batch can produce. This stops a file that stays under the byte
+// ceiling but packs millions of tiny elements from being decoded whole before
+// the target-count check can reject it.
+func checkReviewBatchTokenBudget(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	tokens := 0
+	for {
+		if _, err := decoder.Token(); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("failed to parse --file: %w", err)
+		}
+		tokens++
+		if tokens > reviewBatchMaxFileTokens {
+			return fmt.Errorf("--file must not contain more than %d JSON tokens", reviewBatchMaxFileTokens)
+		}
+	}
 }
 
 // readReviewBatchFile expands at most reviewBatchMaxFileBytes so an oversized

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -23,6 +23,28 @@ const (
 	reviewBatchStatusSkipped = "skipped"
 )
 
+// reviewBatchMaxTargets bounds how many resolved review ids a single
+// respond-batch invocation may act on.
+//
+// Every resolved target costs one authenticated response mutation plus its
+// share of the paginated review lookup, and the whole run shares one request
+// timeout. 500 covers realistic bulk replies — an app's unresponded backlog
+// after a release, or a curated set of reviews exported from `asc reviews
+// list` — while keeping the worst-case fan-out from a checked-in batch file
+// bounded and reviewable. Larger campaigns split cleanly into several files.
+const reviewBatchMaxTargets = 500
+
+// reviewBatchMaxFileBytes bounds how much of --file is expanded into memory
+// before it is parsed.
+//
+// App Store Connect caps a review response body at 5,970 characters, so even a
+// pathological-but-legitimate file that pairs a distinct maximum-length
+// response with each of the reviewBatchMaxTargets permitted review ids stays
+// near 3 MB. 4 MiB keeps that shape accepted and rejects anything that is no
+// longer a usable review batch. Neither limit has an override flag: raising the
+// ceiling is the same as removing it.
+const reviewBatchMaxFileBytes = 4 << 20
+
 type reviewBatchInput struct {
 	Replies []reviewBatchReplyInput `json:"replies"`
 }
@@ -87,6 +109,9 @@ This command is experimental.
 
 The input file must contain a top-level replies array. Each reply has one
 response body and one or more reviewIds.
+
+A single run accepts at most 4194304 bytes of input and 500 review ids across
+all replies. Split larger campaigns into several files.
 
 Example input:
   {
@@ -156,9 +181,9 @@ Examples:
 }
 
 func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
-	data, err := os.ReadFile(strings.TrimSpace(path))
+	data, err := readReviewBatchFile(strings.TrimSpace(path))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read --file: %w", err)
+		return nil, err
 	}
 	if len(bytes.TrimSpace(data)) == 0 {
 		return nil, fmt.Errorf("--file must not be empty")
@@ -200,6 +225,9 @@ func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
 			if _, ok := seen[trimmedReviewID]; ok {
 				return nil, fmt.Errorf("duplicate review id %q", trimmedReviewID)
 			}
+			if len(targets) >= reviewBatchMaxTargets {
+				return nil, fmt.Errorf("--file must not contain more than %d review ids", reviewBatchMaxTargets)
+			}
 			seen[trimmedReviewID] = struct{}{}
 			targets = append(targets, reviewBatchTarget{
 				ReviewID: trimmedReviewID,
@@ -209,6 +237,26 @@ func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
 	}
 
 	return targets, nil
+}
+
+// readReviewBatchFile expands at most reviewBatchMaxFileBytes so an oversized
+// batch file is rejected before it is parsed, before an App Store Connect
+// client exists, and before any request is issued.
+func readReviewBatchFile(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read --file: %w", err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, reviewBatchMaxFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read --file: %w", err)
+	}
+	if len(data) > reviewBatchMaxFileBytes {
+		return nil, fmt.Errorf("--file must not exceed %d bytes", reviewBatchMaxFileBytes)
+	}
+	return data, nil
 }
 
 func executeReviewsRespondBatch(ctx context.Context, client *asc.Client, appID string, targets []reviewBatchTarget, dryRun bool, skipExisting bool, responseState string) (reviewBatchResult, error) {

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -34,16 +34,30 @@ const (
 // bounded and reviewable. Larger campaigns split cleanly into several files.
 const reviewBatchMaxTargets = 500
 
+// reviewBatchMaxResponseBytes bounds the decoded size of a single response
+// body before it is expanded across its review ids.
+//
+// App Store Connect caps a review response at 5,970 characters and a character
+// costs at most four bytes in UTF-8, so no response the API accepts exceeds
+// 23,880 decoded bytes. 24 KiB admits every legitimate response — including
+// one written entirely in a four-byte script — while stopping a single
+// multi-megabyte body from being multiplied into up to reviewBatchMaxTargets
+// request payloads.
+const reviewBatchMaxResponseBytes = 24 << 10
+
 // reviewBatchMaxFileBytes bounds how much of --file is expanded into memory
 // before it is parsed.
 //
-// App Store Connect caps a review response body at 5,970 characters, so even a
-// pathological-but-legitimate file that pairs a distinct maximum-length
-// response with each of the reviewBatchMaxTargets permitted review ids stays
-// near 3 MB. 4 MiB keeps that shape accepted and rejects anything that is no
-// longer a usable review batch. Neither limit has an override flag: raising the
-// ceiling is the same as removing it.
-const reviewBatchMaxFileBytes = 4 << 20
+// The worst-case legitimate batch pairs each of the reviewBatchMaxTargets
+// permitted review ids with a distinct response of reviewBatchMaxResponseBytes,
+// which serializes to about 12 MiB of raw UTF-8 — and tooling that escapes
+// non-ASCII characters on output (for example Python's default ensure_ascii
+// encoding) triples that on disk for a four-byte script, to about 37 MiB,
+// because every character becomes a twelve-byte surrogate-pair escape. 64 MiB
+// accepts every plausible encoding of a maximal batch and rejects anything
+// that is no longer a usable review batch. None of these limits has an
+// override flag: raising the ceiling is the same as removing it.
+const reviewBatchMaxFileBytes = 64 << 20
 
 type reviewBatchInput struct {
 	Replies []reviewBatchReplyInput `json:"replies"`
@@ -111,7 +125,8 @@ The input file must contain a top-level replies array. Each reply has one
 response body and one or more reviewIds.
 
 A single run accepts at most %d bytes of input and %d review ids across
-all replies. Split larger campaigns into several files.
+all replies, and each response must not exceed %d bytes. Split larger
+campaigns into several files.
 
 Example input:
   {
@@ -127,7 +142,7 @@ Examples:
   asc reviews respond-batch --app "123456789" --file replies.json --dry-run
   asc reviews respond-batch --app "123456789" --file replies.json --skip-existing --output json
   asc reviews respond-batch --app "123456789" --file replies.json --response-state unresponded`,
-			reviewBatchMaxFileBytes, reviewBatchMaxTargets),
+			reviewBatchMaxFileBytes, reviewBatchMaxTargets, reviewBatchMaxResponseBytes),
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -214,6 +229,9 @@ func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
 		response := strings.TrimSpace(reply.Response)
 		if response == "" {
 			return nil, fmt.Errorf("replies[%d].response is required", replyIndex)
+		}
+		if len(response) > reviewBatchMaxResponseBytes {
+			return nil, fmt.Errorf("replies[%d].response must not exceed %d bytes", replyIndex, reviewBatchMaxResponseBytes)
 		}
 		if len(reply.ReviewIDs) == 0 {
 			return nil, fmt.Errorf("replies[%d].reviewIds must contain at least one review id", replyIndex)

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -103,14 +103,14 @@ func ReviewsRespondBatchCommand() *ffcli.Command {
 		Name:       "respond-batch",
 		ShortUsage: "asc reviews respond-batch [flags]",
 		ShortHelp:  "Create responses for multiple customer reviews. Experimental.",
-		LongHelp: `Create responses for multiple customer reviews from a grouped JSON file.
+		LongHelp: fmt.Sprintf(`Create responses for multiple customer reviews from a grouped JSON file.
 
 This command is experimental.
 
 The input file must contain a top-level replies array. Each reply has one
 response body and one or more reviewIds.
 
-A single run accepts at most 4194304 bytes of input and 500 review ids across
+A single run accepts at most %d bytes of input and %d review ids across
 all replies. Split larger campaigns into several files.
 
 Example input:
@@ -127,6 +127,7 @@ Examples:
   asc reviews respond-batch --app "123456789" --file replies.json --dry-run
   asc reviews respond-batch --app "123456789" --file replies.json --skip-existing --output json
   asc reviews respond-batch --app "123456789" --file replies.json --response-state unresponded`,
+			reviewBatchMaxFileBytes, reviewBatchMaxTargets),
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/reviews/reviews_respond_batch_limits_test.go
+++ b/internal/cli/reviews/reviews_respond_batch_limits_test.go
@@ -9,15 +9,136 @@ import (
 	"testing"
 )
 
-func TestLoadReviewBatchTargetsAcceptsFileAtSizeLimit(t *testing.T) {
+// TestLoadReviewBatchTargetsReadsFileAtSizeLimit proves an at-limit file
+// passes the size gate: the single response inside it is oversized, so the
+// error must come from the per-response ceiling, not the file ceiling.
+func TestLoadReviewBatchTargetsReadsFileAtSizeLimit(t *testing.T) {
 	path := writeSizedReviewBatchFile(t, reviewBatchMaxFileBytes)
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected the oversized response inside an at-limit file to be rejected")
+	}
+	if strings.Contains(err.Error(), "--file must not exceed") {
+		t.Fatalf("file at the size limit must pass the file-size gate, got %v", err)
+	}
+	want := fmt.Sprintf("replies[0].response must not exceed %d bytes", reviewBatchMaxResponseBytes)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected %q, got %v", want, err)
+	}
+}
+
+// TestLoadReviewBatchTargetsAcceptsMaximalMultibyteBatch pins the worst-case
+// legitimate batch: every permitted review id paired with a distinct response
+// of maximal decoded size written entirely in four-byte UTF-8. The raw file is
+// far larger than the old one-byte-per-character arithmetic assumed, and it
+// must still be accepted whole.
+func TestLoadReviewBatchTargetsAcceptsMaximalMultibyteBatch(t *testing.T) {
+	response := strings.Repeat("\U0001D44E", reviewBatchMaxResponseBytes/4)
+	if len(response) != reviewBatchMaxResponseBytes {
+		t.Fatalf("expected a %d byte response, got %d", reviewBatchMaxResponseBytes, len(response))
+	}
+
+	replies := make([]reviewBatchReplyInput, 0, reviewBatchMaxTargets)
+	for i := range reviewBatchMaxTargets {
+		replies = append(replies, reviewBatchReplyInput{
+			Response:  response,
+			ReviewIDs: []string{fmt.Sprintf("review-%d", i)},
+		})
+	}
+	body, err := json.Marshal(reviewBatchInput{Replies: replies})
+	if err != nil {
+		t.Fatalf("marshal batch file: %v", err)
+	}
+	if len(body) > reviewBatchMaxFileBytes {
+		t.Fatalf("maximal legitimate batch serializes to %d bytes, above the %d byte file limit", len(body), reviewBatchMaxFileBytes)
+	}
+	path := writeReviewBatchTestFile(t, body)
 
 	targets, err := loadReviewBatchTargets(path)
 	if err != nil {
 		t.Fatalf("loadReviewBatchTargets() error: %v", err)
 	}
-	if len(targets) != 1 || targets[0].ReviewID != "review-1" {
-		t.Fatalf("unexpected targets at size limit: %+v", targets)
+	if len(targets) != reviewBatchMaxTargets {
+		t.Fatalf("expected %d targets, got %d", reviewBatchMaxTargets, len(targets))
+	}
+}
+
+// TestLoadReviewBatchTargetsAcceptsMaximalEscapedMultibyteBatch pins the most
+// expensive legitimate on-disk encoding: the same maximal four-byte-script
+// batch written with \u surrogate-pair escapes (Python's default ensure_ascii
+// output), where every character costs twelve raw bytes. The file must still
+// fit under the file ceiling and decode to the full target set.
+func TestLoadReviewBatchTargetsAcceptsMaximalEscapedMultibyteBatch(t *testing.T) {
+	escaped := strings.Repeat(`\ud835\udc4e`, reviewBatchMaxResponseBytes/4)
+
+	var builder strings.Builder
+	builder.WriteString(`{"replies":[`)
+	for i := range reviewBatchMaxTargets {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		fmt.Fprintf(&builder, `{"response":"%s","reviewIds":["review-%d"]}`, escaped, i)
+	}
+	builder.WriteString(`]}`)
+	body := []byte(builder.String())
+	if len(body) > reviewBatchMaxFileBytes {
+		t.Fatalf("maximal escaped batch serializes to %d bytes, above the %d byte file limit", len(body), reviewBatchMaxFileBytes)
+	}
+	path := writeReviewBatchTestFile(t, body)
+
+	targets, err := loadReviewBatchTargets(path)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != reviewBatchMaxTargets {
+		t.Fatalf("expected %d targets, got %d", reviewBatchMaxTargets, len(targets))
+	}
+	if len(targets[0].Response) != reviewBatchMaxResponseBytes {
+		t.Fatalf("expected a %d byte decoded response, got %d", reviewBatchMaxResponseBytes, len(targets[0].Response))
+	}
+}
+
+func TestLoadReviewBatchTargetsAcceptsResponseAtByteLimit(t *testing.T) {
+	body, err := json.Marshal(reviewBatchInput{
+		Replies: []reviewBatchReplyInput{{
+			Response:  strings.Repeat("a", reviewBatchMaxResponseBytes),
+			ReviewIDs: []string{"review-1"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal batch file: %v", err)
+	}
+	path := writeReviewBatchTestFile(t, body)
+
+	targets, err := loadReviewBatchTargets(path)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != 1 || len(targets[0].Response) != reviewBatchMaxResponseBytes {
+		t.Fatalf("unexpected targets at response byte limit: %d", len(targets))
+	}
+}
+
+func TestLoadReviewBatchTargetsRejectsResponseOneByteOverLimit(t *testing.T) {
+	body, err := json.Marshal(reviewBatchInput{
+		Replies: []reviewBatchReplyInput{{
+			Response:  strings.Repeat("a", reviewBatchMaxResponseBytes+1),
+			ReviewIDs: []string{"review-1"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal batch file: %v", err)
+	}
+	path := writeReviewBatchTestFile(t, body)
+
+	_, err = loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected oversized response rejection, got nil")
+	}
+	want := fmt.Sprintf("replies[0].response must not exceed %d bytes", reviewBatchMaxResponseBytes)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected %q, got %v", want, err)
 	}
 }
 
@@ -68,6 +189,7 @@ func TestReviewsRespondBatchLongHelpDocumentsEnforcedLimits(t *testing.T) {
 	for _, want := range []string{
 		fmt.Sprintf("at most %d bytes of input", reviewBatchMaxFileBytes),
 		fmt.Sprintf("%d review ids", reviewBatchMaxTargets),
+		fmt.Sprintf("each response must not exceed %d bytes", reviewBatchMaxResponseBytes),
 	} {
 		if !strings.Contains(longHelp, want) {
 			t.Fatalf("expected long help to contain %q, got:\n%s", want, longHelp)

--- a/internal/cli/reviews/reviews_respond_batch_limits_test.go
+++ b/internal/cli/reviews/reviews_respond_batch_limits_test.go
@@ -180,6 +180,57 @@ func TestLoadReviewBatchTargetsRejectsOneReviewIDOverLimit(t *testing.T) {
 	}
 }
 
+// reviewBatchFileWithEmptyIDs returns a document whose token count is exactly
+// idCount + 12: one reply object with one response and idCount empty review
+// ids. Empty ids are the cheapest way to pack tokens into a small file.
+func reviewBatchFileWithEmptyIDs(t *testing.T, idCount int) string {
+	t.Helper()
+
+	var builder strings.Builder
+	builder.WriteString(`{"replies":[{"response":"x","reviewIds":[`)
+	for i := range idCount {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(`""`)
+	}
+	builder.WriteString(`]}]}`)
+	return writeReviewBatchTestFile(t, []byte(builder.String()))
+}
+
+// TestLoadReviewBatchTargetsRejectsTokenFloodBeforeMaterializing pins the
+// anti-flood guard: a file that stays under the byte ceiling but packs more
+// JSON tokens than any permitted batch can produce must fail on the token
+// budget — before the document is materialized — not on the later target
+// count.
+func TestLoadReviewBatchTargetsRejectsTokenFloodBeforeMaterializing(t *testing.T) {
+	path := reviewBatchFileWithEmptyIDs(t, reviewBatchMaxFileTokens-12+1)
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected token flood rejection, got nil")
+	}
+	want := fmt.Sprintf("--file must not contain more than %d JSON tokens", reviewBatchMaxFileTokens)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected %q, got %v", want, err)
+	}
+}
+
+// TestLoadReviewBatchTargetsTokenBudgetAdmitsFileAtTokenLimit proves the
+// budget boundary: a document holding exactly the permitted number of tokens
+// passes the pre-pass and fails only on the later, materialized checks.
+func TestLoadReviewBatchTargetsTokenBudgetAdmitsFileAtTokenLimit(t *testing.T) {
+	path := reviewBatchFileWithEmptyIDs(t, reviewBatchMaxFileTokens-12)
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected empty review ids to be rejected, got nil")
+	}
+	if strings.Contains(err.Error(), "JSON tokens") {
+		t.Fatalf("file at the token limit must pass the token budget, got %v", err)
+	}
+}
+
 // TestReviewsRespondBatchLongHelpDocumentsEnforcedLimits pins the published
 // contract: the long help must state the same ceilings the command enforces,
 // so the documented and enforced limits cannot drift apart.

--- a/internal/cli/reviews/reviews_respond_batch_limits_test.go
+++ b/internal/cli/reviews/reviews_respond_batch_limits_test.go
@@ -59,6 +59,22 @@ func TestLoadReviewBatchTargetsRejectsOneReviewIDOverLimit(t *testing.T) {
 	}
 }
 
+// TestReviewsRespondBatchLongHelpDocumentsEnforcedLimits pins the published
+// contract: the long help must state the same ceilings the command enforces,
+// so the documented and enforced limits cannot drift apart.
+func TestReviewsRespondBatchLongHelpDocumentsEnforcedLimits(t *testing.T) {
+	longHelp := ReviewsRespondBatchCommand().LongHelp
+
+	for _, want := range []string{
+		fmt.Sprintf("at most %d bytes of input", reviewBatchMaxFileBytes),
+		fmt.Sprintf("%d review ids", reviewBatchMaxTargets),
+	} {
+		if !strings.Contains(longHelp, want) {
+			t.Fatalf("expected long help to contain %q, got:\n%s", want, longHelp)
+		}
+	}
+}
+
 // writeSizedReviewBatchFile writes a valid single-target batch file whose byte
 // length is exactly totalSize, padding the response body to reach it.
 func writeSizedReviewBatchFile(t *testing.T, totalSize int) string {

--- a/internal/cli/reviews/reviews_respond_batch_limits_test.go
+++ b/internal/cli/reviews/reviews_respond_batch_limits_test.go
@@ -1,0 +1,112 @@
+package reviews
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadReviewBatchTargetsAcceptsFileAtSizeLimit(t *testing.T) {
+	path := writeSizedReviewBatchFile(t, reviewBatchMaxFileBytes)
+
+	targets, err := loadReviewBatchTargets(path)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != 1 || targets[0].ReviewID != "review-1" {
+		t.Fatalf("unexpected targets at size limit: %+v", targets)
+	}
+}
+
+func TestLoadReviewBatchTargetsRejectsFileOneByteOverSizeLimit(t *testing.T) {
+	path := writeSizedReviewBatchFile(t, reviewBatchMaxFileBytes+1)
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected oversized --file rejection, got nil")
+	}
+	want := fmt.Sprintf("--file must not exceed %d bytes", reviewBatchMaxFileBytes)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected %q, got %v", want, err)
+	}
+}
+
+func TestLoadReviewBatchTargetsAcceptsMaximumReviewIDs(t *testing.T) {
+	path := writeReviewBatchFileWithReviewIDs(t, reviewBatchMaxTargets)
+
+	targets, err := loadReviewBatchTargets(path)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != reviewBatchMaxTargets {
+		t.Fatalf("expected %d targets, got %d", reviewBatchMaxTargets, len(targets))
+	}
+}
+
+func TestLoadReviewBatchTargetsRejectsOneReviewIDOverLimit(t *testing.T) {
+	path := writeReviewBatchFileWithReviewIDs(t, reviewBatchMaxTargets+1)
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected too-many-review-ids rejection, got nil")
+	}
+	want := fmt.Sprintf("--file must not contain more than %d review ids", reviewBatchMaxTargets)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected %q, got %v", want, err)
+	}
+}
+
+// writeSizedReviewBatchFile writes a valid single-target batch file whose byte
+// length is exactly totalSize, padding the response body to reach it.
+func writeSizedReviewBatchFile(t *testing.T, totalSize int) string {
+	t.Helper()
+
+	envelope := func(response string) []byte {
+		body, err := json.Marshal(reviewBatchInput{
+			Replies: []reviewBatchReplyInput{{Response: response, ReviewIDs: []string{"review-1"}}},
+		})
+		if err != nil {
+			t.Fatalf("marshal batch file: %v", err)
+		}
+		return body
+	}
+
+	overhead := len(envelope(""))
+	if overhead > totalSize {
+		t.Fatalf("cannot build a batch file as small as %d bytes", totalSize)
+	}
+	body := envelope(strings.Repeat("a", totalSize-overhead))
+	if len(body) != totalSize {
+		t.Fatalf("expected a %d byte batch file, got %d", totalSize, len(body))
+	}
+	return writeReviewBatchTestFile(t, body)
+}
+
+func writeReviewBatchFileWithReviewIDs(t *testing.T, count int) string {
+	t.Helper()
+
+	reviewIDs := make([]string, 0, count)
+	for i := range count {
+		reviewIDs = append(reviewIDs, fmt.Sprintf("review-%d", i))
+	}
+	body, err := json.Marshal(reviewBatchInput{
+		Replies: []reviewBatchReplyInput{{Response: "Thanks for the feedback.", ReviewIDs: reviewIDs}},
+	})
+	if err != nil {
+		t.Fatalf("marshal batch file: %v", err)
+	}
+	return writeReviewBatchTestFile(t, body)
+}
+
+func writeReviewBatchTestFile(t *testing.T, body []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "replies.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write batch file: %v", err)
+	}
+	return path
+}

--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -4,12 +4,13 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"strings"
 
 	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 )
 
 type IPABundleInfo struct {
@@ -68,13 +69,17 @@ func isTopLevelAppInfoPlist(name string) bool {
 }
 
 func readBundleInfoFromInfoPlist(file *zip.File) (IPABundleInfo, error) {
+	if err := infoplist.CheckDeclaredSize(file.UncompressedSize64); err != nil {
+		return IPABundleInfo{}, fmt.Errorf("read Info.plist: %w", err)
+	}
+
 	reader, err := file.Open()
 	if err != nil {
 		return IPABundleInfo{}, fmt.Errorf("open Info.plist: %w", err)
 	}
 	defer reader.Close()
 
-	data, err := io.ReadAll(reader)
+	data, err := infoplist.ReadBounded(reader)
 	if err != nil {
 		return IPABundleInfo{}, fmt.Errorf("read Info.plist: %w", err)
 	}

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"archive/zip"
 	"bytes"
-	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"howett.net/plist"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist/infoplisttest"
 )
 
 func TestExtractBundleInfoFromIPA(t *testing.T) {
@@ -156,7 +156,7 @@ func TestExtractBundleInfoFromIPA_RejectsUnderstatedInfoPlistSize(t *testing.T) 
 	ipaPath := writeTestIPA(t, map[string][]byte{
 		"Payload/Demo.app/Info.plist": bytes.Repeat([]byte("A"), infoplist.MaxBytes*2),
 	})
-	forgeZipDeclaredUncompressedSize(t, ipaPath, 1024)
+	infoplisttest.ForgeZipDeclaredUncompressedSize(t, ipaPath, 1024)
 
 	if _, err := ExtractBundleInfoFromIPA(ipaPath); err == nil {
 		t.Fatal("expected rejection for forged ZIP size metadata, got nil")
@@ -300,30 +300,6 @@ func buildInfoPlistOfSize(t *testing.T, totalSize int) []byte {
 	}
 	t.Fatalf("failed to build an Info.plist of exactly %d bytes", totalSize)
 	return nil
-}
-
-// forgeZipDeclaredUncompressedSize rewrites the uncompressed-size field of the
-// single central-directory record so the archive understates how much data the
-// member expands to.
-func forgeZipDeclaredUncompressedSize(t *testing.T, ipaPath string, declaredSize uint32) {
-	t.Helper()
-
-	data, err := os.ReadFile(ipaPath)
-	if err != nil {
-		t.Fatalf("read IPA: %v", err)
-	}
-	const centralDirectorySignature = "PK\x01\x02"
-	index := bytes.Index(data, []byte(centralDirectorySignature))
-	if index < 0 {
-		t.Fatal("central directory header not found")
-	}
-	if bytes.Contains(data[index+len(centralDirectorySignature):], []byte(centralDirectorySignature)) {
-		t.Fatal("expected exactly one central directory header")
-	}
-	binary.LittleEndian.PutUint32(data[index+24:index+28], declaredSize)
-	if err := os.WriteFile(ipaPath, data, 0o600); err != nil {
-		t.Fatalf("write IPA: %v", err)
-	}
 }
 
 func buildInfoPlistWithValues(t *testing.T, versionValue any, buildValue any, format int) []byte {

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -2,12 +2,16 @@ package shared
 
 import (
 	"archive/zip"
+	"bytes"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 )
 
 func TestExtractBundleInfoFromIPA(t *testing.T) {
@@ -96,6 +100,66 @@ func TestExtractBundleInfoFromIPA_BinaryPlist(t *testing.T) {
 	}
 	if info.BuildNumber != "7" {
 		t.Fatalf("expected build number 7, got %q", info.BuildNumber)
+	}
+}
+
+func TestExtractBundleInfoFromIPA_InfoPlistAtSizeLimit(t *testing.T) {
+	plistData := buildInfoPlistOfSize(t, infoplist.MaxBytes)
+	ipaPath := writeTestIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistData,
+	})
+
+	info, err := ExtractBundleInfoFromIPA(ipaPath)
+	if err != nil {
+		t.Fatalf("ExtractBundleInfoFromIPA() error: %v", err)
+	}
+	if info.Version != "1.2.3" || info.BuildNumber != "45" {
+		t.Fatalf("unexpected bundle info at size limit: %+v", info)
+	}
+}
+
+func TestExtractBundleInfoFromIPA_RejectsInfoPlistOneByteOverLimit(t *testing.T) {
+	plistData := buildInfoPlistOfSize(t, infoplist.MaxBytes+1)
+	ipaPath := writeTestIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistData,
+	})
+
+	_, err := ExtractBundleInfoFromIPA(ipaPath)
+	if err == nil {
+		t.Fatal("expected oversized Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Info.plist limit") {
+		t.Fatalf("expected Info.plist limit error, got %v", err)
+	}
+}
+
+func TestExtractBundleInfoFromIPA_RejectsHighlyCompressibleInfoPlist(t *testing.T) {
+	ipaPath := writeTestIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": bytes.Repeat([]byte("A"), infoplist.MaxBytes*2),
+	})
+
+	_, err := ExtractBundleInfoFromIPA(ipaPath)
+	if err == nil {
+		t.Fatal("expected compressible oversized Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "declared uncompressed size") {
+		t.Fatalf("expected declared-size rejection, got %v", err)
+	}
+}
+
+// A member that understates its uncompressed size must not slip past the
+// declared-size check and then expand freely. archive/zip refuses a member as
+// soon as it streams past its advertised size, and the bounded read is the
+// backstop if it ever does not, so the caller always gets an error instead of
+// an unbounded expansion.
+func TestExtractBundleInfoFromIPA_RejectsUnderstatedInfoPlistSize(t *testing.T) {
+	ipaPath := writeTestIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": bytes.Repeat([]byte("A"), infoplist.MaxBytes*2),
+	})
+	forgeZipDeclaredUncompressedSize(t, ipaPath, 1024)
+
+	if _, err := ExtractBundleInfoFromIPA(ipaPath); err == nil {
+		t.Fatal("expected rejection for forged ZIP size metadata, got nil")
 	}
 }
 
@@ -208,6 +272,58 @@ func buildInfoPlist(t *testing.T, version string, build string) []byte {
 	t.Helper()
 
 	return buildInfoPlistWithValues(t, version, build, plist.XMLFormat)
+}
+
+// buildInfoPlistOfSize returns a valid XML Info.plist whose serialized length
+// is exactly totalSize, padded with a filler key so boundary tests can hit the
+// documented limit precisely.
+func buildInfoPlistOfSize(t *testing.T, totalSize int) []byte {
+	t.Helper()
+
+	padding := 0
+	for range 8 {
+		data, err := plist.Marshal(map[string]any{
+			"CFBundleShortVersionString": "1.2.3",
+			"CFBundleVersion":            "45",
+			"Padding":                    strings.Repeat("a", padding),
+		}, plist.XMLFormat)
+		if err != nil {
+			t.Fatalf("marshal plist: %v", err)
+		}
+		if len(data) == totalSize {
+			return data
+		}
+		padding += totalSize - len(data)
+		if padding < 0 {
+			t.Fatalf("cannot build an Info.plist as small as %d bytes", totalSize)
+		}
+	}
+	t.Fatalf("failed to build an Info.plist of exactly %d bytes", totalSize)
+	return nil
+}
+
+// forgeZipDeclaredUncompressedSize rewrites the uncompressed-size field of the
+// single central-directory record so the archive understates how much data the
+// member expands to.
+func forgeZipDeclaredUncompressedSize(t *testing.T, ipaPath string, declaredSize uint32) {
+	t.Helper()
+
+	data, err := os.ReadFile(ipaPath)
+	if err != nil {
+		t.Fatalf("read IPA: %v", err)
+	}
+	const centralDirectorySignature = "PK\x01\x02"
+	index := bytes.Index(data, []byte(centralDirectorySignature))
+	if index < 0 {
+		t.Fatal("central directory header not found")
+	}
+	if bytes.Contains(data[index+len(centralDirectorySignature):], []byte(centralDirectorySignature)) {
+		t.Fatal("expected exactly one central directory header")
+	}
+	binary.LittleEndian.PutUint32(data[index+24:index+28], declaredSize)
+	if err := os.WriteFile(ipaPath, data, 0o600); err != nil {
+		t.Fatalf("write IPA: %v", err)
+	}
 }
 
 func buildInfoPlistWithValues(t *testing.T, versionValue any, buildValue any, format int) []byte {

--- a/internal/infoplist/infoplist.go
+++ b/internal/infoplist/infoplist.go
@@ -1,0 +1,54 @@
+// Package infoplist holds the shared ceiling the CLI applies when it expands an
+// app bundle's Info.plist out of an IPA archive.
+//
+// An IPA is an untrusted ZIP archive: the CLI may be handed one by a CI job, a
+// release pipeline, or a contributor. A ZIP member advertises its uncompressed
+// size in metadata that the archive itself controls, and a highly compressible
+// member expands to far more than it costs to store. Reading the selected
+// Info.plist with an unbounded io.ReadAll therefore lets a small artifact drive
+// an arbitrarily large allocation. Every IPA metadata reader shares the policy
+// below so both the advertised size and the bytes actually streamed are
+// rejected once they pass the limit.
+package infoplist
+
+import (
+	"fmt"
+	"io"
+)
+
+// MaxBytes is the largest uncompressed size accepted for the top-level
+// Payload/*.app/Info.plist member of an IPA.
+//
+// A real top-level app Info.plist is a few kilobytes: a handful of bundle
+// identifiers, version strings, supported platforms, icon names, and URL
+// schemes. Even the unusually large ones — long ATS exception lists, wide
+// device-capability matrices, or heavily localized declarations — stay in the
+// low hundreds of kilobytes. 4 MiB leaves more than an order of magnitude of
+// headroom above any plist Xcode plausibly emits while capping how much a
+// crafted archive can force the CLI to allocate. There is deliberately no flag
+// or environment override: raising the ceiling is the same as removing it.
+const MaxBytes = 4 << 20
+
+// CheckDeclaredSize rejects an Info.plist whose ZIP metadata already advertises
+// more than MaxBytes, so an oversized member is refused before it is opened or
+// decompressed.
+func CheckDeclaredSize(uncompressedSize uint64) error {
+	if uncompressedSize > MaxBytes {
+		return fmt.Errorf("declared uncompressed size %d bytes exceeds the %d byte Info.plist limit", uncompressedSize, MaxBytes)
+	}
+	return nil
+}
+
+// ReadBounded expands at most MaxBytes from reader and fails if more bytes are
+// available, so forged or absent ZIP size metadata cannot bypass
+// CheckDeclaredSize.
+func ReadBounded(reader io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, MaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxBytes {
+		return nil, fmt.Errorf("expanded contents exceed the %d byte Info.plist limit", MaxBytes)
+	}
+	return data, nil
+}

--- a/internal/infoplist/infoplist_test.go
+++ b/internal/infoplist/infoplist_test.go
@@ -1,0 +1,79 @@
+package infoplist
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCheckDeclaredSizeAtLimit(t *testing.T) {
+	if err := CheckDeclaredSize(MaxBytes); err != nil {
+		t.Fatalf("CheckDeclaredSize(MaxBytes) error: %v", err)
+	}
+}
+
+func TestCheckDeclaredSizeOneByteOverLimit(t *testing.T) {
+	err := CheckDeclaredSize(MaxBytes + 1)
+	if err == nil {
+		t.Fatal("expected declared-size rejection, got nil")
+	}
+	want := fmt.Sprintf("declared uncompressed size %d bytes exceeds the %d byte Info.plist limit", MaxBytes+1, MaxBytes)
+	if err.Error() != want {
+		t.Fatalf("expected %q, got %q", want, err.Error())
+	}
+}
+
+func TestReadBoundedAtLimit(t *testing.T) {
+	data, err := ReadBounded(bytes.NewReader(bytes.Repeat([]byte("a"), MaxBytes)))
+	if err != nil {
+		t.Fatalf("ReadBounded() error: %v", err)
+	}
+	if len(data) != MaxBytes {
+		t.Fatalf("expected %d bytes, got %d", MaxBytes, len(data))
+	}
+}
+
+func TestReadBoundedOneByteOverLimit(t *testing.T) {
+	_, err := ReadBounded(bytes.NewReader(bytes.Repeat([]byte("a"), MaxBytes+1)))
+	if err == nil {
+		t.Fatal("expected streamed-byte rejection, got nil")
+	}
+	want := fmt.Sprintf("expanded contents exceed the %d byte Info.plist limit", MaxBytes)
+	if err.Error() != want {
+		t.Fatalf("expected %q, got %q", want, err.Error())
+	}
+}
+
+// TestReadBoundedStopsShortOfEndlessStream proves the streamed bound, not the
+// declared one, is what protects the reader: an endless source is refused after
+// MaxBytes+1 bytes instead of being expanded until memory runs out.
+func TestReadBoundedStopsShortOfEndlessStream(t *testing.T) {
+	source := &countingReader{}
+
+	_, err := ReadBounded(source)
+	if err == nil {
+		t.Fatal("expected streamed-byte rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Info.plist limit") {
+		t.Fatalf("expected Info.plist limit error, got %v", err)
+	}
+	if source.read > MaxBytes+1 {
+		t.Fatalf("expected at most %d bytes read, got %d", MaxBytes+1, source.read)
+	}
+}
+
+type countingReader struct {
+	read int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	r.read += len(p)
+	return len(p), nil
+}
+
+var _ io.Reader = (*countingReader)(nil)

--- a/internal/infoplist/infoplisttest/infoplisttest.go
+++ b/internal/infoplist/infoplisttest/infoplisttest.go
@@ -1,0 +1,34 @@
+// Package infoplisttest provides helpers for tests that exercise the
+// Info.plist expansion limits against hand-forged ZIP metadata.
+package infoplisttest
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+// ForgeZipDeclaredUncompressedSize rewrites the uncompressed-size field of the
+// archive's single central-directory record so the archive understates how
+// much data the member expands to.
+func ForgeZipDeclaredUncompressedSize(t testing.TB, ipaPath string, declaredSize uint32) {
+	t.Helper()
+
+	data, err := os.ReadFile(ipaPath)
+	if err != nil {
+		t.Fatalf("read IPA: %v", err)
+	}
+	const centralDirectorySignature = "PK\x01\x02"
+	index := bytes.Index(data, []byte(centralDirectorySignature))
+	if index < 0 {
+		t.Fatal("central directory header not found")
+	}
+	if bytes.Contains(data[index+len(centralDirectorySignature):], []byte(centralDirectorySignature)) {
+		t.Fatal("expected exactly one central directory header")
+	}
+	binary.LittleEndian.PutUint32(data[index+24:index+28], declaredSize)
+	if err := os.WriteFile(ipaPath, data, 0o600); err != nil {
+		t.Fatalf("write IPA: %v", err)
+	}
+}

--- a/internal/xcode/ipa_plist_limit_test.go
+++ b/internal/xcode/ipa_plist_limit_test.go
@@ -3,7 +3,6 @@ package xcode
 import (
 	"archive/zip"
 	"bytes"
-	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"howett.net/plist"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist/infoplisttest"
 )
 
 func TestReadIPABundleInfoAtInfoPlistSizeLimit(t *testing.T) {
@@ -60,7 +60,7 @@ func TestReadIPABundleInfoRejectsHighlyCompressibleInfoPlist(t *testing.T) {
 // an unbounded expansion.
 func TestReadIPABundleInfoRejectsUnderstatedInfoPlistSize(t *testing.T) {
 	ipaPath := writeIPAWithRawInfoPlist(t, bytes.Repeat([]byte("A"), infoplist.MaxBytes*2))
-	forgeZipDeclaredUncompressedSize(t, ipaPath, 1024)
+	infoplisttest.ForgeZipDeclaredUncompressedSize(t, ipaPath, 1024)
 
 	if _, err := readIPABundleInfo(ipaPath); err == nil {
 		t.Fatal("expected rejection for forged ZIP size metadata, got nil")
@@ -119,28 +119,4 @@ func buildSizedAppInfoPlist(t *testing.T, totalSize int) []byte {
 	}
 	t.Fatalf("failed to build an Info.plist of exactly %d bytes", totalSize)
 	return nil
-}
-
-// forgeZipDeclaredUncompressedSize rewrites the uncompressed-size field of the
-// single central-directory record so the archive understates how much data the
-// member expands to.
-func forgeZipDeclaredUncompressedSize(t *testing.T, ipaPath string, declaredSize uint32) {
-	t.Helper()
-
-	data, err := os.ReadFile(ipaPath)
-	if err != nil {
-		t.Fatalf("read IPA: %v", err)
-	}
-	const centralDirectorySignature = "PK\x01\x02"
-	index := bytes.Index(data, []byte(centralDirectorySignature))
-	if index < 0 {
-		t.Fatal("central directory header not found")
-	}
-	if bytes.Contains(data[index+len(centralDirectorySignature):], []byte(centralDirectorySignature)) {
-		t.Fatal("expected exactly one central directory header")
-	}
-	binary.LittleEndian.PutUint32(data[index+24:index+28], declaredSize)
-	if err := os.WriteFile(ipaPath, data, 0o600); err != nil {
-		t.Fatalf("write IPA: %v", err)
-	}
 }

--- a/internal/xcode/ipa_plist_limit_test.go
+++ b/internal/xcode/ipa_plist_limit_test.go
@@ -1,0 +1,146 @@
+package xcode
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+)
+
+func TestReadIPABundleInfoAtInfoPlistSizeLimit(t *testing.T) {
+	ipaPath := writeIPAWithRawInfoPlist(t, buildSizedAppInfoPlist(t, infoplist.MaxBytes))
+
+	info, err := readIPABundleInfo(ipaPath)
+	if err != nil {
+		t.Fatalf("readIPABundleInfo() error: %v", err)
+	}
+	if info.BundleID != "com.example.demo" || info.Version != "1.2.3" || info.BuildNumber != "42" {
+		t.Fatalf("unexpected bundle info at size limit: %+v", info)
+	}
+	if info.Platform != "IOS" {
+		t.Fatalf("expected platform IOS, got %q", info.Platform)
+	}
+}
+
+func TestReadIPABundleInfoRejectsInfoPlistOneByteOverLimit(t *testing.T) {
+	ipaPath := writeIPAWithRawInfoPlist(t, buildSizedAppInfoPlist(t, infoplist.MaxBytes+1))
+
+	_, err := readIPABundleInfo(ipaPath)
+	if err == nil {
+		t.Fatal("expected oversized Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Info.plist limit") {
+		t.Fatalf("expected Info.plist limit error, got %v", err)
+	}
+}
+
+func TestReadIPABundleInfoRejectsHighlyCompressibleInfoPlist(t *testing.T) {
+	ipaPath := writeIPAWithRawInfoPlist(t, bytes.Repeat([]byte("A"), infoplist.MaxBytes*2))
+
+	_, err := readIPABundleInfo(ipaPath)
+	if err == nil {
+		t.Fatal("expected compressible oversized Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "declared uncompressed size") {
+		t.Fatalf("expected declared-size rejection, got %v", err)
+	}
+}
+
+// A member that understates its uncompressed size must not slip past the
+// declared-size check and then expand freely. archive/zip refuses a member as
+// soon as it streams past its advertised size, and the bounded read is the
+// backstop if it ever does not, so the caller always gets an error instead of
+// an unbounded expansion.
+func TestReadIPABundleInfoRejectsUnderstatedInfoPlistSize(t *testing.T) {
+	ipaPath := writeIPAWithRawInfoPlist(t, bytes.Repeat([]byte("A"), infoplist.MaxBytes*2))
+	forgeZipDeclaredUncompressedSize(t, ipaPath, 1024)
+
+	if _, err := readIPABundleInfo(ipaPath); err == nil {
+		t.Fatal("expected rejection for forged ZIP size metadata, got nil")
+	}
+}
+
+func writeIPAWithRawInfoPlist(t *testing.T, plistData []byte) string {
+	t.Helper()
+
+	ipaPath := filepath.Join(t.TempDir(), "Demo.ipa")
+	file, err := os.Create(ipaPath)
+	if err != nil {
+		t.Fatalf("create IPA: %v", err)
+	}
+	defer file.Close()
+
+	writer := zip.NewWriter(file)
+	entry, err := writer.Create("Payload/Demo.app/Info.plist")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := entry.Write(plistData); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	return ipaPath
+}
+
+// buildSizedAppInfoPlist returns a valid XML app Info.plist whose serialized
+// length is exactly totalSize, padded with a filler key so boundary tests can
+// hit the documented limit precisely.
+func buildSizedAppInfoPlist(t *testing.T, totalSize int) []byte {
+	t.Helper()
+
+	padding := 0
+	for range 8 {
+		data, err := plist.Marshal(map[string]any{
+			"CFBundleIdentifier":         "com.example.demo",
+			"CFBundleShortVersionString": "1.2.3",
+			"CFBundleVersion":            "42",
+			"DTPlatformName":             "iphoneos",
+			"Padding":                    strings.Repeat("a", padding),
+		}, plist.XMLFormat)
+		if err != nil {
+			t.Fatalf("plist.Marshal() error: %v", err)
+		}
+		if len(data) == totalSize {
+			return data
+		}
+		padding += totalSize - len(data)
+		if padding < 0 {
+			t.Fatalf("cannot build an Info.plist as small as %d bytes", totalSize)
+		}
+	}
+	t.Fatalf("failed to build an Info.plist of exactly %d bytes", totalSize)
+	return nil
+}
+
+// forgeZipDeclaredUncompressedSize rewrites the uncompressed-size field of the
+// single central-directory record so the archive understates how much data the
+// member expands to.
+func forgeZipDeclaredUncompressedSize(t *testing.T, ipaPath string, declaredSize uint32) {
+	t.Helper()
+
+	data, err := os.ReadFile(ipaPath)
+	if err != nil {
+		t.Fatalf("read IPA: %v", err)
+	}
+	const centralDirectorySignature = "PK\x01\x02"
+	index := bytes.Index(data, []byte(centralDirectorySignature))
+	if index < 0 {
+		t.Fatal("central directory header not found")
+	}
+	if bytes.Contains(data[index+len(centralDirectorySignature):], []byte(centralDirectorySignature)) {
+		t.Fatal("expected exactly one central directory header")
+	}
+	binary.LittleEndian.PutUint32(data[index+24:index+28], declaredSize)
+	if err := os.WriteFile(ipaPath, data, 0o600); err != nil {
+		t.Fatalf("write IPA: %v", err)
+	}
+}

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -16,6 +16,8 @@ import (
 	"unicode"
 
 	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 )
 
 var (
@@ -1299,13 +1301,17 @@ func isTopLevelAppInfoPlist(name string) bool {
 }
 
 func readBundleInfoFromZip(file *zip.File) (bundleInfo, error) {
+	if err := infoplist.CheckDeclaredSize(file.UncompressedSize64); err != nil {
+		return bundleInfo{}, fmt.Errorf("read Info.plist: %w", err)
+	}
+
 	reader, err := file.Open()
 	if err != nil {
 		return bundleInfo{}, fmt.Errorf("open Info.plist: %w", err)
 	}
 	defer reader.Close()
 
-	data, err := io.ReadAll(reader)
+	data, err := infoplist.ReadBounded(reader)
 	if err != nil {
 		return bundleInfo{}, fmt.Errorf("read Info.plist: %w", err)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the three medium-severity resource-consumption paths (`csf_d4c561e79a213e4ccde021ac`, `csf_923aced421b2eb56a8183d97`, `csf_637b75dde9bb30330e50b9d3`, CWE-400/CWE-409).

Two commits, one logical change each:

1. `fix(security): bound IPA Info.plist expansion in both readers` — new `internal/infoplist` package holding a single documented ceiling plus the two checks that enforce it; `internal/cli/shared/ipa.go` and `internal/xcode/xcode.go` both use it instead of unbounded `io.ReadAll`.
2. `fix(security): bound reviews respond-batch input and fan-out` — byte ceiling on `--file` and target-count ceiling on resolved review ids, both enforced before result construction, client creation, and any HTTP request.

## Chosen limits and rationale

| Constant | Value | Rationale (documented next to the constant) |
| --- | --- | --- |
| `infoplist.MaxBytes` | 4 MiB | A real top-level app `Info.plist` is a few kilobytes; even unusually large ones (long ATS exception lists, wide device-capability matrices, heavy localization) stay in the low hundreds of kilobytes. 4 MiB leaves more than an order of magnitude of headroom above anything Xcode plausibly emits while capping how much a crafted archive can force the CLI to allocate. |
| `reviewBatchMaxTargets` | 500 | Every resolved target costs one authenticated mutation plus its share of the paginated review lookup, and the whole run shares one request timeout. 500 covers realistic bulk replies (an app's unresponded backlog after a release, or a set exported from `asc reviews list`) while keeping worst-case fan-out from a checked-in batch file bounded. |
| `reviewBatchMaxFileBytes` | 4 MiB | App Store Connect caps a review response body at 5,970 characters, so even a pathological-but-legitimate file pairing a distinct maximum-length response with each of the 500 permitted review ids stays near 3 MB. 4 MiB keeps that shape accepted and rejects anything that is no longer a usable review batch. |

None of the three has an override flag or environment variable: raising the ceiling is the same as removing it.

## How the limits are enforced

`internal/infoplist` exposes the policy as two functions so both IPA readers get identical behavior:

- `CheckDeclaredSize(uncompressedSize uint64)` rejects a ZIP member whose central-directory metadata already advertises more than `MaxBytes`, **before** the member is opened or decompressed. This is what stops a compact, highly compressible plist — a 16 MiB member stored in 16 KB never gets expanded.
- `ReadBounded(io.Reader)` expands at most `MaxBytes + 1` bytes and fails if the extra byte arrives, so absent or forged size metadata cannot bypass the declared-size check. One unbounded allocation is not replaced with another.

`reviews respond-batch` reads `--file` through `io.LimitReader(file, limit+1)` so an oversized file is never fully expanded, and checks the resolved-target count inside the expansion loop. Both run inside `loadReviewBatchTargets`, which the `Exec` calls before `shared.GetASCClient()` and before `shared.ContextWithTimeout`, so a rejected batch performs no partial authenticated work in normal or `--dry-run` mode and exits `2` with the message on stderr.

Preserved unchanged: XML/binary plist support, numeric version coercion, top-level `Payload/*.app` selection over `.appex`/`.framework` plists, missing-plist errors, platform inference, and the batch command's duplicate-id, unknown-field, trailing-JSON, response-state, and `--skip-existing` behavior.

## Acceptance criteria

- [x] Both IPA readers reject a selected `Info.plist` whose declared or actual expanded bytes exceed the documented limit without reading it fully into memory.
- [x] Tests cover `limit` success, `limit + 1` failure, and a highly compressible oversized member for both implementations.
- [x] Safe XML/binary plists, numeric versions, top-level app selection, missing-plist errors, and platform extraction continue working (pre-existing tests still pass; the at-limit xcode test also asserts `Platform == "IOS"`).
- [x] `reviews respond-batch` rejects an input file over the byte limit and more than the permitted number of resolved review IDs.
- [x] Batch-limit rejection happens before any GET or POST, produces no partial mutations, and tests assert zero transport calls.
- [x] The maximum accepted batch preserves existing dry-run/normal semantics while the first item over the limit fails.
- [x] Existing duplicate-ID, unknown-field, trailing-JSON, response-state, and `--skip-existing` behavior remains intact.

## Tests added

RED was established before implementation. The two CLI-level batch tests failed with `expected no HTTP request, got GET .../customerReviews?include=response&limit=200`, proving requests were issued before any ceiling existed; the IPA and reviews unit tests failed to build on the missing package/constants.

`internal/infoplist/infoplist_test.go`
- `CheckDeclaredSize` at `MaxBytes` and at `MaxBytes + 1` (exact message asserted).
- `ReadBounded` at `MaxBytes` and at `MaxBytes + 1` (exact message asserted).
- `TestReadBoundedStopsShortOfEndlessStream` — an endless reader is refused after at most `MaxBytes + 1` bytes, which is the property that survives if ZIP metadata lies.

`internal/cli/shared/ipa_test.go` and `internal/xcode/ipa_plist_limit_test.go` (mirrored for both readers)
- Plist padded to exactly `MaxBytes` still yields version/build (and platform, in the xcode case).
- Plist at `MaxBytes + 1` fails with the limit error.
- 8 MiB of repeated bytes, deflate-compressed to a few KB, fails on the declared size.
- A hand-forged central directory that understates the uncompressed size still fails rather than expanding. Note that `archive/zip`'s own `checksumReader` rejects a member that streams past its advertised size, so this asserts only that an error is returned — over-specifying the message would be asserting stdlib internals. `ReadBounded`'s own bound is covered directly in the `infoplist` unit test.

`internal/cli/reviews/reviews_respond_batch_limits_test.go`
- `loadReviewBatchTargets` accepts a file of exactly `reviewBatchMaxFileBytes` and rejects `+1`.
- Accepts exactly `reviewBatchMaxTargets` ids and rejects `+1`.

`internal/cli/cmdtest/reviews_responses_test.go`
- `TestReviewsRespondBatchRejectsOversizedFileWithoutRequests` and `TestReviewsRespondBatchRejectsTooManyReviewIDsWithoutRequests` (the latter with `--dry-run`) install a transport that calls `t.Fatalf` on any request, with valid auth in the environment, and assert `ExitUsage` plus the exact stderr message.
- `TestReviewsRespondBatchDryRunAtReviewIDLimit` runs the maximum accepted batch and asserts `total == planned == 500`, `created/failed/skipped == 0`, and exactly one GET.

## Verification

```
$ ASC_BYPASS_KEYCHAIN=1 go test ./internal/infoplist ./internal/cli/shared ./internal/xcode ./internal/cli/reviews
ok  	.../internal/infoplist	0.015s
ok  	.../internal/cli/shared	7.320s
ok  	.../internal/xcode	0.352s
ok  	.../internal/cli/reviews	0.086s

$ ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestReviewsRespondBatch|TestRunReviewsRespondBatch' -v
--- PASS: TestReviewsRespondBatchCreatesGroupedReplies
--- PASS: TestReviewsRespondBatchDryRunDoesNotPost
--- PASS: TestReviewsRespondBatchSkipExisting
--- PASS: TestReviewsRespondBatchResponseStateUnrespondedSkipsRespondedReviews
--- PASS: TestReviewsRespondBatchRejectsOversizedFileWithoutRequests
--- PASS: TestReviewsRespondBatchRejectsTooManyReviewIDsWithoutRequests
--- PASS: TestReviewsRespondBatchDryRunAtReviewIDLimit
--- PASS: TestReviewsRespondBatchValidationErrors        (7 subtests)
--- PASS: TestRunReviewsRespondBatchInvalidResponseStateReturnsUsageExit
--- PASS: TestRunReviewsRespondBatchPartialFailureReturnsExitError
ok  	.../internal/cli/cmdtest	0.116s
```

Repository gates, all clean:

```
$ make generate-command-docs      # no diff: docs/COMMANDS.md does not embed long help
$ make format                     # no diff after formatting
$ make check-docs                 # command docs, website docs (80 pages), agent skills (7), OpenAPI index all pass
$ make lint                       # golangci-lint v2.12.1 -> 0 issues.
$ ASC_BYPASS_KEYCHAIN=1 make test # entire repository, zero FAIL lines
```

No pre-existing failures were observed on this branch or on `main`.

### Built-binary checks

`reviews respond-batch` (`go build -o /tmp/asc .`, `ASC_BYPASS_KEYCHAIN=1`, no credentials configured):

```
$ asc reviews respond-batch --app 123456789 --file too-many.json --dry-run     # 501 ids
Error: --file must not contain more than 500 review ids
exit=2

$ asc reviews respond-batch --app 123456789 --file over-bytes.json --dry-run   # 4194305 bytes
Error: --file must not exceed 4194304 bytes
exit=2

$ asc reviews respond-batch --app 123456789 --file at-limit.json --dry-run     # 500 ids
$ asc reviews respond-batch --app 123456789 --file at-bytes.json --dry-run     # exactly 4194304 bytes
Error: reviews respond-batch: missing authentication. ...
exit=3
```

The accepted boundaries reach client creation and only then fail on the absent credentials, which is what proves the ceilings do not reject valid input; the rejected ones exit `2` before any client exists.

IPA path via `builds upload --dry-run`, with `Info.plist` members built to exact sizes:

```
$ asc builds upload --app 123456789 --ipa ipa-at-limit.ipa --dry-run       # plist exactly 4194304 bytes
Error: builds upload: missing authentication. ...                          # metadata extracted fine
exit=3

$ asc builds upload --app 123456789 --ipa ipa-over-limit.ipa --dry-run     # plist 4194305 bytes
Error: builds upload: --version and --build-number required (failed to extract from IPA: read Info.plist: declared uncompressed size 4194305 bytes exceeds the 4194304 byte Info.plist limit)
exit=1

$ asc builds upload --app 123456789 --ipa ipa-bomb.ipa --dry-run           # 16 MiB plist stored in 16463 bytes
Error: builds upload: --version and --build-number required (failed to extract from IPA: read Info.plist: declared uncompressed size 16777216 bytes exceeds the 4194304 byte Info.plist limit)
exit=1
```

The bomb case is the important one: a 16 KB file on disk is refused on its advertised size and never expanded.

No live Apple calls or mutations were made.

## Compatibility and risk

Behavior changes only for inputs that were previously unbounded, so no stable, working invocation regresses. The one user-visible surface addition is two lines of `respond-batch` long help documenting the ceilings; `docs/COMMANDS.md` is unaffected because the generator does not embed long help, and `make check-docs` confirms it.

Residual risk is that a genuine `Info.plist` or review batch somewhere exceeds a ceiling. For the IPA case the limit sits more than an order of magnitude above realistic plists and the failure is a clear, actionable message that names the limit — and `--version`/`--build-number` remain available as an explicit override for metadata extraction. For the batch case the limits are stated in `--help` and larger campaigns split across files. Confirmation/approval for review-response publication is tracked separately and remains out of scope.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcf7bbc-190c-476c-bf2a-b63896748eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcf7bbc-190c-476c-bf2a-b63896748eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787896349&installation_model_id=10418&pr_number=1826&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1826&signature=be67e68acf4ed83944ae2e35b3ebc4eb5d46db92836ba6dad2ede68f48eed24c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hard safeguards for `reviews respond-batch`, enforcing caps on unique review IDs, per-reply decoded response size, batch file size, and JSON token budget.
  * Updated `reviews respond-batch` long help to document the limits and advise splitting larger campaigns.
  * Improved safety for `Info.plist` extraction from IPA bundles by enforcing a maximum plist size.
* **Bug Fixes**
  * Oversized `reviews respond-batch` inputs are rejected before any network requests, including dry-run at the review-ID cap.
* **Tests**
  * Added boundary/limit tests for `reviews respond-batch` and comprehensive size-limit enforcement tests for IPA `Info.plist` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->