### PR TITLE
Security: redact credentials at output/error boundaries and isolate helper environments

### DIFF
--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -924,8 +924,10 @@ func TestWebAuthLoginPromptInterruptSkipsSkillsAutoCheck(t *testing.T) {
 
 	markerPath := filepath.Join(tmpDir, "skills-check-ran")
 	scriptPath := filepath.Join(scriptDir, "skills")
+	// Marker paths are baked into the script: helper processes receive an
+	// allowlisted environment, so arbitrary test variables cannot reach them.
 	script := "#!/bin/sh\n" +
-		"printf 'ran' > \"$SKILLS_MARKER\"\n" +
+		"printf 'ran' > '" + markerPath + "'\n" +
 		"sleep 2\n" +
 		"printf 'update available\\n'\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
@@ -941,7 +943,6 @@ func TestWebAuthLoginPromptInterruptSkipsSkillsAutoCheck(t *testing.T) {
 		"ASC_IRIS_SESSION_CACHE=0",
 		"ASC_SKILLS_AUTO_CHECK=1",
 		"CI=",
-		"SKILLS_MARKER="+markerPath,
 		"PATH="+scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 	)
 	runCmd.Env = env
@@ -1031,10 +1032,12 @@ func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
 		}
 	})
 	scriptPath := filepath.Join(scriptDir, "skills")
+	// Marker paths are baked into the script: helper processes receive an
+	// allowlisted environment, so arbitrary test variables cannot reach them.
 	script := "#!/bin/sh\n" +
-		"printf 'ran' > \"$SKILLS_MARKER\"\n" +
+		"printf 'ran' > '" + markerPath + "'\n" +
 		"sleep 10 &\n" +
-		"printf '%s' \"$!\" > \"$SKILLS_SLEEP_PID\"\n" +
+		"printf '%s' \"$!\" > '" + sleepPIDPath + "'\n" +
 		"printf '2 updates available\\n'\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("failed to write fake skills command: %v", err)
@@ -1045,8 +1048,6 @@ func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
 		isolatedCLITestEnv(configPath),
 		"ASC_SKILLS_AUTO_CHECK=1",
 		"CI=",
-		"SKILLS_MARKER="+markerPath,
-		"SKILLS_SLEEP_PID="+sleepPIDPath,
 		"PATH="+scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 	)
 

--- a/concepts/error-handling.mdx
+++ b/concepts/error-handling.mdx
@@ -141,6 +141,29 @@ asc apps list --output json | jq '.data[0].id'
 asc apps view --id APP_ID > output.json 2> errors.log
 ```
 
+### Credentials in Error Messages
+
+Errors never repeat the credential-bearing parts of a URL. Asset upload
+failures — Game Center images, App Clip assets, screenshots, previews — report
+the scheme, host, and path of the presigned URL but drop its userinfo, query
+values, and fragment, so an expired or refused upload cannot print the signature
+or token:
+
+```
+Error: upload operation 0: upload request failed for https://upload.example.com/v1/assets/chunk-1 (timeout)
+```
+
+`asc notify slack` reports only the scheme and host, because the webhook path is
+itself the secret:
+
+```
+Error: notify slack: failed to send: webhook POST failed for https://hooks.slack.com
+```
+
+The failure class (`timeout`, `canceled`) and the HTTP status of non-transport
+failures are preserved, and the underlying error stays wrapped so programmatic
+inspection keeps working.
+
 ## Handling Errors in Scripts
 
 ### Exit Code Checks

--- a/concepts/output-formats.mdx
+++ b/concepts/output-formats.mdx
@@ -90,6 +90,51 @@ Example output:
   The `--pretty` flag only works with `--output json`. Using `--pretty` with `table` or `markdown` returns an error.
 </Warning>
 
+## Sensitive Values
+
+Secrets are withheld from output by default. Commands that read or write App
+Store or TestFlight review information replace a non-empty
+`demoAccountPassword` with `(redacted)` before rendering, in every format:
+
+```bash  theme={null}
+asc review details-get --id "DETAIL_ID" --output json
+```
+
+```json  theme={null}
+{"data":{"type":"appStoreReviewDetails","id":"DETAIL_ID","attributes":{"demoAccountName":"reviewer@example.com","demoAccountPassword":"(redacted)","demoAccountRequired":true}}}
+```
+
+This applies to `asc review details-get`, `asc review details-for-version`,
+`asc review details-create`, `asc review details-update`,
+`asc testflight review view`, `asc testflight review edit`, and
+`asc migrate import` (including `--dry-run`).
+
+Redaction affects only what is printed. Passwords you pass with
+`--demo-account-password` are still sent to App Store Connect, and
+`asc migrate import` still uploads and compares the real value read from
+`review_information/demo_password.txt`.
+
+### Opting in with `--include-sensitive`
+
+When you genuinely need the returned password — for example to verify a
+rotation — add `--include-sensitive`:
+
+```bash  theme={null}
+asc review details-get --id "DETAIL_ID" --output json --include-sensitive
+```
+
+The flag applies to that one invocation only, defaults to `false`, and has no
+environment-variable equivalent, so a secret can never become visible because
+of ambient configuration. Each use writes a warning to stderr because printed
+secrets persist in shell history, CI logs, and terminal scrollback.
+
+<Warning>
+  Before this change, `demoAccountPassword` was emitted verbatim in JSON output,
+  and `asc migrate import` also printed it in table and Markdown output. If a
+  script depended on reading the password back, add `--include-sensitive`
+  explicitly and make sure the surrounding logs are not retained.
+</Warning>
+
 ## Format Examples
 
 ### Table Format

--- a/concepts/output-formats.mdx
+++ b/concepts/output-formats.mdx
@@ -126,7 +126,9 @@ asc review details-get --id "DETAIL_ID" --output json --include-sensitive
 The flag applies to that one invocation only, defaults to `false`, and has no
 environment-variable equivalent, so a secret can never become visible because
 of ambient configuration. Each use writes a warning to stderr because printed
-secrets persist in shell history, CI logs, and terminal scrollback.
+secrets persist in shell history, CI logs, and terminal scrollback. The flag
+is currently experimental: its name and placement may still change before it
+becomes stable.
 
 <Warning>
   Before this change, `demoAccountPassword` was emitted verbatim in JSON output,

--- a/internal/asc/assets_upload.go
+++ b/internal/asc/assets_upload.go
@@ -61,7 +61,7 @@ func UploadAssetFromFile(ctx context.Context, file *os.File, fileSize int64, ope
 		reader := io.NewSectionReader(file, op.Offset, op.Length)
 		req, err := http.NewRequestWithContext(ctx, method, op.URL, reader)
 		if err != nil {
-			return fmt.Errorf("upload operation %d: %w", i, err)
+			return fmt.Errorf("upload operation %d: %w", i, newSanitizedUploadError("create upload request", op.URL, err))
 		}
 		req.ContentLength = op.Length
 		for _, header := range op.RequestHeaders {
@@ -70,7 +70,7 @@ func UploadAssetFromFile(ctx context.Context, file *os.File, fileSize int64, ope
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return fmt.Errorf("upload operation %d failed: %w", i, err)
+			return fmt.Errorf("upload operation %d: %w", i, newSanitizedUploadError("upload request", op.URL, err))
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()

--- a/internal/asc/assets_upload_redaction_test.go
+++ b/internal/asc/assets_upload_redaction_test.go
@@ -1,0 +1,140 @@
+package asc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The sentinels stand in for the capability-bearing parts of a presigned URL.
+const (
+	presignedSignatureSentinel = "asc-red-sentinel-presigned-sig-8e15fa"
+	presignedTokenSentinel     = "asc-red-sentinel-presigned-token-c40d27"
+	presignedUserinfoSentinel  = "asc-red-sentinel-presigned-userinfo-5a9b36"
+)
+
+type failingUploadTransport struct {
+	err     error
+	request *http.Request
+}
+
+func (t *failingUploadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.request = req
+	return nil, t.err
+}
+
+func writeUploadFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "asset.bin")
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func presignedUploadURL() string {
+	return "https://" + presignedUserinfoSentinel + ":secret@upload.example.com/v1/assets/chunk-1" +
+		"?X-Amz-Signature=" + presignedSignatureSentinel +
+		"&token=" + presignedTokenSentinel +
+		"#" + presignedTokenSentinel
+}
+
+func assertNoPresignedCredentials(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an upload error")
+	}
+	message := err.Error()
+	for _, sentinel := range []string{presignedSignatureSentinel, presignedTokenSentinel, presignedUserinfoSentinel} {
+		if strings.Contains(message, sentinel) {
+			t.Fatalf("upload error leaked presigned credentials: %q", message)
+		}
+	}
+	if !strings.Contains(message, "upload.example.com") {
+		t.Fatalf("upload error dropped safe operation context: %q", message)
+	}
+}
+
+func TestUploadAssetFromFileSanitizesTransportErrorURL(t *testing.T) {
+	path := writeUploadFixture(t)
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer file.Close()
+
+	transportErr := errors.New("dial tcp: connection refused")
+	transport := &failingUploadTransport{err: transportErr}
+	t.Cleanup(swapUploadTransport(t, transport))
+
+	uploadErr := UploadAssetFromFile(context.Background(), file, 3, []UploadOperation{
+		{Method: http.MethodPut, URL: presignedUploadURL(), Length: 3, Offset: 0},
+	})
+
+	assertNoPresignedCredentials(t, uploadErr)
+	if !strings.Contains(uploadErr.Error(), "upload operation 0") {
+		t.Fatalf("upload error dropped the operation index: %q", uploadErr.Error())
+	}
+	if !errors.Is(uploadErr, transportErr) {
+		t.Fatalf("errors.Is lost the wrapped transport error: %v", uploadErr)
+	}
+	if transport.request == nil || transport.request.URL.Query().Get("X-Amz-Signature") != presignedSignatureSentinel {
+		t.Fatal("the real presigned URL must still be used for the request")
+	}
+}
+
+func TestUploadAssetFromFileSanitizesTimeoutErrorURL(t *testing.T) {
+	path := writeUploadFixture(t)
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer file.Close()
+
+	transport := &failingUploadTransport{err: context.DeadlineExceeded}
+	t.Cleanup(swapUploadTransport(t, transport))
+
+	uploadErr := UploadAssetFromFile(context.Background(), file, 3, []UploadOperation{
+		{Method: http.MethodPut, URL: presignedUploadURL(), Length: 3, Offset: 0},
+	})
+
+	assertNoPresignedCredentials(t, uploadErr)
+	if !errors.Is(uploadErr, context.DeadlineExceeded) {
+		t.Fatalf("errors.Is lost the deadline classification: %v", uploadErr)
+	}
+	if !strings.Contains(uploadErr.Error(), "timeout") {
+		t.Fatalf("upload error dropped timeout context: %q", uploadErr.Error())
+	}
+}
+
+func TestExecuteUploadOperationsSanitizesTransportErrorURL(t *testing.T) {
+	path := writeUploadFixture(t)
+
+	transportErr := errors.New("tls: handshake failure")
+	client := &http.Client{Transport: &failingUploadTransport{err: transportErr}}
+
+	uploadErr := ExecuteUploadOperations(
+		context.Background(),
+		path,
+		[]UploadOperation{{Method: http.MethodPost, URL: presignedUploadURL(), Length: 3, Offset: 0}},
+		WithUploadHTTPClient(client),
+	)
+
+	assertNoPresignedCredentials(t, uploadErr)
+	if !errors.Is(uploadErr, transportErr) {
+		t.Fatalf("errors.Is lost the wrapped transport error: %v", uploadErr)
+	}
+}
+
+func swapUploadTransport(t *testing.T, transport http.RoundTripper) func() {
+	t.Helper()
+	original := http.DefaultTransport
+	http.DefaultTransport = transport
+	return func() {
+		http.DefaultTransport = original
+	}
+}

--- a/internal/asc/review_redaction.go
+++ b/internal/asc/review_redaction.go
@@ -1,0 +1,74 @@
+package asc
+
+import "strings"
+
+// RedactedValuePlaceholder marks a secret that was withheld from output. It is
+// deliberately not a valid App Store Connect value so a redacted payload can
+// never be mistaken for a usable credential.
+const RedactedValuePlaceholder = "(redacted)"
+
+// RedactSecret returns the placeholder for any non-empty secret and leaves
+// empty values untouched so absent fields stay absent in rendered output.
+func RedactSecret(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return value
+	}
+	return RedactedValuePlaceholder
+}
+
+// RedactAppStoreReviewDetailAttributes returns a presentation-safe copy of App
+// Store review detail attributes.
+func RedactAppStoreReviewDetailAttributes(attrs AppStoreReviewDetailAttributes) AppStoreReviewDetailAttributes {
+	attrs.DemoAccountPassword = RedactSecret(attrs.DemoAccountPassword)
+	return attrs
+}
+
+// RedactBetaAppReviewDetailAttributes returns a presentation-safe copy of
+// TestFlight beta app review detail attributes.
+func RedactBetaAppReviewDetailAttributes(attrs BetaAppReviewDetailAttributes) BetaAppReviewDetailAttributes {
+	attrs.DemoAccountPassword = RedactSecret(attrs.DemoAccountPassword)
+	return attrs
+}
+
+// RedactAppStoreReviewDetailResponse returns a presentation-safe copy of a
+// single App Store review detail response. The argument is left unmodified so
+// callers keep the real password for requests, comparison, and validation.
+func RedactAppStoreReviewDetailResponse(resp *AppStoreReviewDetailResponse) *AppStoreReviewDetailResponse {
+	return redactSingleResponse(resp, RedactAppStoreReviewDetailAttributes)
+}
+
+// RedactBetaAppReviewDetailResponse returns a presentation-safe copy of a
+// single TestFlight beta app review detail response.
+func RedactBetaAppReviewDetailResponse(resp *BetaAppReviewDetailResponse) *BetaAppReviewDetailResponse {
+	return redactSingleResponse(resp, RedactBetaAppReviewDetailAttributes)
+}
+
+// RedactBetaAppReviewDetailsResponse returns a presentation-safe copy of a
+// TestFlight beta app review details list response.
+func RedactBetaAppReviewDetailsResponse(resp *BetaAppReviewDetailsResponse) *BetaAppReviewDetailsResponse {
+	return redactListResponse(resp, RedactBetaAppReviewDetailAttributes)
+}
+
+func redactSingleResponse[T any](resp *SingleResponse[T], redact func(T) T) *SingleResponse[T] {
+	if resp == nil {
+		return nil
+	}
+	safe := *resp
+	safe.Data.Attributes = redact(safe.Data.Attributes)
+	return &safe
+}
+
+func redactListResponse[T any](resp *Response[T], redact func(T) T) *Response[T] {
+	if resp == nil {
+		return nil
+	}
+	safe := *resp
+	if len(resp.Data) > 0 {
+		safe.Data = make([]Resource[T], len(resp.Data))
+		copy(safe.Data, resp.Data)
+		for i := range safe.Data {
+			safe.Data[i].Attributes = redact(safe.Data[i].Attributes)
+		}
+	}
+	return &safe
+}

--- a/internal/asc/review_redaction.go
+++ b/internal/asc/review_redaction.go
@@ -1,16 +1,16 @@
 package asc
 
-import "strings"
-
 // RedactedValuePlaceholder marks a secret that was withheld from output. It is
 // deliberately not a valid App Store Connect value so a redacted payload can
 // never be mistaken for a usable credential.
 const RedactedValuePlaceholder = "(redacted)"
 
-// RedactSecret returns the placeholder for any non-empty secret and leaves
-// empty values untouched so absent fields stay absent in rendered output.
+// RedactSecret returns the placeholder for any non-empty secret and leaves the
+// empty value untouched so absent fields stay absent in rendered output. The
+// API permits an unconstrained string, so even a whitespace-only value is
+// treated as a credential.
 func RedactSecret(value string) string {
-	if strings.TrimSpace(value) == "" {
+	if value == "" {
 		return value
 	}
 	return RedactedValuePlaceholder

--- a/internal/asc/review_redaction_test.go
+++ b/internal/asc/review_redaction_test.go
@@ -1,0 +1,95 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const reviewRedactionSentinel = "asc-red-sentinel-asc-demo-pw-2ad57e"
+
+func TestRedactSecretPreservesEmptyValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty stays empty", value: "", want: ""},
+		{name: "whitespace stays whitespace", value: "   ", want: "   "},
+		{name: "secret becomes placeholder", value: reviewRedactionSentinel, want: RedactedValuePlaceholder},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RedactSecret(test.value); got != test.want {
+				t.Fatalf("RedactSecret(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestRedactAppStoreReviewDetailResponseLeavesOriginalIntact(t *testing.T) {
+	original := &AppStoreReviewDetailResponse{}
+	original.Data.ID = "detail-1"
+	original.Data.Attributes = AppStoreReviewDetailAttributes{
+		DemoAccountName:     "reviewer@example.com",
+		DemoAccountPassword: reviewRedactionSentinel,
+		Notes:               "Reviewer notes",
+	}
+
+	safe := RedactAppStoreReviewDetailResponse(original)
+
+	if original.Data.Attributes.DemoAccountPassword != reviewRedactionSentinel {
+		t.Fatalf("original password was mutated to %q", original.Data.Attributes.DemoAccountPassword)
+	}
+	if safe.Data.Attributes.DemoAccountPassword != RedactedValuePlaceholder {
+		t.Fatalf("redacted password = %q, want %q", safe.Data.Attributes.DemoAccountPassword, RedactedValuePlaceholder)
+	}
+	if safe.Data.ID != "detail-1" || safe.Data.Attributes.DemoAccountName != "reviewer@example.com" {
+		t.Fatalf("redaction dropped non-sensitive fields: %+v", safe.Data)
+	}
+
+	encoded, err := json.Marshal(safe)
+	if err != nil {
+		t.Fatalf("marshal redacted response: %v", err)
+	}
+	if strings.Contains(string(encoded), reviewRedactionSentinel) {
+		t.Fatalf("serialized redacted response leaked the sentinel: %s", encoded)
+	}
+}
+
+func TestRedactBetaAppReviewDetailsResponseCopiesEveryResource(t *testing.T) {
+	original := &BetaAppReviewDetailsResponse{
+		Data: []Resource[BetaAppReviewDetailAttributes]{
+			{ID: "detail-1", Attributes: BetaAppReviewDetailAttributes{DemoAccountPassword: reviewRedactionSentinel}},
+			{ID: "detail-2", Attributes: BetaAppReviewDetailAttributes{DemoAccountName: "reviewer@example.com"}},
+		},
+	}
+
+	safe := RedactBetaAppReviewDetailsResponse(original)
+
+	if original.Data[0].Attributes.DemoAccountPassword != reviewRedactionSentinel {
+		t.Fatal("redaction mutated the original list response")
+	}
+	if safe.Data[0].Attributes.DemoAccountPassword != RedactedValuePlaceholder {
+		t.Fatalf("first resource password = %q, want placeholder", safe.Data[0].Attributes.DemoAccountPassword)
+	}
+	if safe.Data[1].Attributes.DemoAccountPassword != "" {
+		t.Fatalf("empty password became %q, want empty", safe.Data[1].Attributes.DemoAccountPassword)
+	}
+	if safe.Data[1].Attributes.DemoAccountName != "reviewer@example.com" {
+		t.Fatalf("redaction dropped non-sensitive fields: %+v", safe.Data[1])
+	}
+}
+
+func TestRedactResponseHelpersHandleNil(t *testing.T) {
+	if got := RedactAppStoreReviewDetailResponse(nil); got != nil {
+		t.Fatalf("RedactAppStoreReviewDetailResponse(nil) = %v, want nil", got)
+	}
+	if got := RedactBetaAppReviewDetailResponse(nil); got != nil {
+		t.Fatalf("RedactBetaAppReviewDetailResponse(nil) = %v, want nil", got)
+	}
+	if got := RedactBetaAppReviewDetailsResponse(nil); got != nil {
+		t.Fatalf("RedactBetaAppReviewDetailsResponse(nil) = %v, want nil", got)
+	}
+}

--- a/internal/asc/review_redaction_test.go
+++ b/internal/asc/review_redaction_test.go
@@ -8,14 +8,16 @@ import (
 
 const reviewRedactionSentinel = "asc-red-sentinel-asc-demo-pw-2ad57e"
 
-func TestRedactSecretPreservesEmptyValues(t *testing.T) {
+func TestRedactSecretPreservesOnlyTheEmptyValue(t *testing.T) {
 	tests := []struct {
 		name  string
 		value string
 		want  string
 	}{
 		{name: "empty stays empty", value: "", want: ""},
-		{name: "whitespace stays whitespace", value: "   ", want: "   "},
+		// The API permits an unconstrained string, so a whitespace-only
+		// password is still a credential and must not pass through verbatim.
+		{name: "whitespace-only is still a secret", value: "   ", want: RedactedValuePlaceholder},
 		{name: "secret becomes placeholder", value: reviewRedactionSentinel, want: RedactedValuePlaceholder},
 	}
 

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -10,11 +10,12 @@ import (
 	"hash"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/urlsanitize"
 )
 
 const (
@@ -42,19 +43,6 @@ type UploadOption func(*UploadOptions)
 type uploadTask struct {
 	index int
 	op    UploadOperation
-}
-
-type sanitizedUploadError struct {
-	message string
-	err     error
-}
-
-func (e *sanitizedUploadError) Error() string {
-	return e.message
-}
-
-func (e *sanitizedUploadError) Unwrap() error {
-	return e.err
 }
 
 // WithUploadConcurrency sets the number of concurrent upload workers.
@@ -287,21 +275,11 @@ func executeUploadOperation(ctx context.Context, file *os.File, task uploadTask,
 	return nil
 }
 
+// newSanitizedUploadError is the single upload-error boundary: presigned upload
+// URLs carry their capability in userinfo, query, and fragment, and net/http
+// renders the whole URL in its own error text.
 func newSanitizedUploadError(operation, rawURL string, err error) error {
-	safeURL := sanitizeURLForLog(rawURL)
-	parsedURL, parseErr := url.Parse(safeURL)
-	if parseErr != nil {
-		safeURL = "[REDACTED]"
-	} else {
-		parsedURL.RawQuery = ""
-		parsedURL.ForceQuery = false
-		parsedURL.Fragment = ""
-		safeURL = parsedURL.String()
-	}
-	return &sanitizedUploadError{
-		message: fmt.Sprintf("%s failed for %s", operation, safeURL),
-		err:     err,
-	}
+	return urlsanitize.NewTransportError(operation, urlsanitize.RedactURLForError(rawURL), err)
 }
 
 // VerifySourceFileChecksums computes and compares checksums provided by the API.

--- a/internal/cli/cmdtest/migrate_import_credentials_test.go
+++ b/internal/cli/cmdtest/migrate_import_credentials_test.go
@@ -1,0 +1,113 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/migrate"
+)
+
+const migrateDemoPasswordSentinel = "asc-red-sentinel-migrate-demo-pw-71ce40"
+
+func setupMigrateReviewFixture(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	reviewDir := filepath.Join(root, "metadata", "review_information")
+	if err := os.MkdirAll(reviewDir, 0o755); err != nil {
+		t.Fatalf("mkdir review_information: %v", err)
+	}
+	writeFile(t, filepath.Join(reviewDir, "first_name.txt"), "Rita")
+	writeFile(t, filepath.Join(reviewDir, "email_address.txt"), "rita@example.com")
+	writeFile(t, filepath.Join(reviewDir, "demo_user.txt"), "reviewer@example.com")
+	writeFile(t, filepath.Join(reviewDir, "demo_password.txt"), migrateDemoPasswordSentinel)
+	writeFile(t, filepath.Join(reviewDir, "demo_required.txt"), "true")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+}
+
+func runMigrateImportDryRun(t *testing.T, extraArgs ...string) (string, string) {
+	t.Helper()
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	args := append([]string{
+		"migrate", "import",
+		"--app", "APP_ID",
+		"--version-id", "VERSION_ID",
+		"--dry-run",
+	}, extraArgs...)
+
+	return captureOutput(t, func() {
+		if err := rootCmd.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := rootCmd.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+}
+
+func TestMigrateImportDryRunRedactsDemoAccountPasswordInEveryFormat(t *testing.T) {
+	formats := []struct {
+		name string
+		args []string
+	}{
+		{name: "json", args: []string{"--output", "json"}},
+		{name: "pretty json", args: []string{"--output", "json", "--pretty"}},
+		{name: "table", args: []string{"--output", "table"}},
+		{name: "markdown", args: []string{"--output", "markdown"}},
+	}
+
+	for _, format := range formats {
+		t.Run(format.name, func(t *testing.T) {
+			setupMigrateReviewFixture(t)
+
+			stdout, stderr := runMigrateImportDryRun(t, format.args...)
+
+			assertNoSentinel(t, "stdout", migrateDemoPasswordSentinel, stdout)
+			assertNoSentinel(t, "stderr", migrateDemoPasswordSentinel, stderr)
+			if !strings.Contains(stdout, redactedDemoPasswordText) {
+				t.Fatalf("expected %q placeholder in output, got %q", redactedDemoPasswordText, stdout)
+			}
+			if !strings.Contains(stdout, "reviewer@example.com") {
+				t.Fatalf("expected non-sensitive review fields to survive redaction, got %q", stdout)
+			}
+		})
+	}
+}
+
+func TestMigrateImportDryRunIncludesDemoAccountPasswordWithIncludeSensitive(t *testing.T) {
+	setupMigrateReviewFixture(t)
+
+	stdout, stderr := runMigrateImportDryRun(t, "--output", "json", "--include-sensitive")
+
+	var result migrate.MigrateImportResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal result: %v\nstdout=%s", err, stdout)
+	}
+	if result.ReviewInformation == nil || result.ReviewInformation.DemoAccountPassword == nil {
+		t.Fatal("expected review information with a demo account password")
+	}
+	if *result.ReviewInformation.DemoAccountPassword != migrateDemoPasswordSentinel {
+		t.Fatalf("expected real password with --include-sensitive, got %q", *result.ReviewInformation.DemoAccountPassword)
+	}
+	if !strings.Contains(stderr, includeSensitiveWarningText) {
+		t.Fatalf("expected plaintext-secret warning on stderr, got %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/review_credentials_redaction_test.go
+++ b/internal/cli/cmdtest/review_credentials_redaction_test.go
@@ -13,29 +13,32 @@ import (
 // Unique sentinels make a leak unambiguous: no fixture, help text, or unrelated
 // field can produce these strings by accident.
 const (
-	appStoreDemoPasswordSentinel  = "asc-red-sentinel-appstore-demo-pw-9f31c7"
+	appStoreDemoPasswordSentinel   = "asc-red-sentinel-appstore-demo-pw-9f31c7"
 	testFlightDemoPasswordSentinel = "asc-red-sentinel-testflight-demo-pw-4b82ad"
-	redactedDemoPasswordText      = "(redacted)"
-	includeSensitiveWarningText   = "Warning: --include-sensitive prints secrets"
+	redactedDemoPasswordText       = "(redacted)"
+	includeSensitiveWarningText    = "Warning: --include-sensitive prints secrets"
 )
 
-func appStoreReviewDetailJSON(password string) string {
+func appStoreReviewDetailJSON() string {
 	return `{"data":{"type":"appStoreReviewDetails","id":"detail-1","attributes":{` +
 		`"contactFirstName":"Dev","contactLastName":"Support","contactEmail":"dev@example.com",` +
-		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com","demoAccountPassword":"` + password + `",` +
+		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com",` +
+		`"demoAccountPassword":"` + appStoreDemoPasswordSentinel + `",` +
 		`"notes":"Reviewer notes"}}}`
 }
 
-func betaAppReviewDetailsJSON(password string) string {
+func betaAppReviewDetailsJSON() string {
 	return `{"data":[{"type":"betaAppReviewDetails","id":"detail-1","attributes":{` +
 		`"contactFirstName":"Dev","contactLastName":"Support","contactEmail":"dev@example.com",` +
-		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com","demoAccountPassword":"` + password + `",` +
+		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com",` +
+		`"demoAccountPassword":"` + testFlightDemoPasswordSentinel + `",` +
 		`"notes":"Reviewer notes"}}],"links":{"self":"https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails"}}`
 }
 
-func betaAppReviewDetailJSON(password string) string {
+func betaAppReviewDetailJSON() string {
 	return `{"data":{"type":"betaAppReviewDetails","id":"detail-1","attributes":{` +
-		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com","demoAccountPassword":"` + password + `"}}}`
+		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com",` +
+		`"demoAccountPassword":"` + testFlightDemoPasswordSentinel + `"}}}`
 }
 
 func assertNoSentinel(t *testing.T, label, sentinel, content string) {
@@ -64,7 +67,7 @@ func TestReviewDetailsGetRedactsDemoAccountPasswordInEveryFormat(t *testing.T) {
 				if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreReviewDetails/detail-1" {
 					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 				}
-				return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+				return jsonResponse(http.StatusOK, appStoreReviewDetailJSON())
 			})
 
 			root := RootCommand("1.2.3")
@@ -98,7 +101,7 @@ func TestReviewDetailsGetIncludesDemoAccountPasswordWithIncludeSensitive(t *test
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	stubTransport(t, func(req *http.Request) (*http.Response, error) {
-		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON())
 	})
 
 	root := RootCommand("1.2.3")
@@ -143,7 +146,7 @@ func TestReviewDetailsForVersionRedactsDemoAccountPassword(t *testing.T) {
 		if req.URL.Path != "/v1/appStoreVersions/version-1/appStoreReviewDetail" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
-		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON())
 	})
 
 	root := RootCommand("1.2.3")
@@ -181,7 +184,7 @@ func TestReviewDetailsCreateSendsPasswordButRedactsResponse(t *testing.T) {
 		if strings.Contains(string(payload), `"demoAccountPassword":"`+appStoreDemoPasswordSentinel+`"`) {
 			sentRealPassword = true
 		}
-		return jsonResponse(http.StatusCreated, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+		return jsonResponse(http.StatusCreated, appStoreReviewDetailJSON())
 	})
 
 	root := RootCommand("1.2.3")
@@ -226,7 +229,7 @@ func TestReviewDetailsUpdateSendsPasswordButRedactsResponse(t *testing.T) {
 		if strings.Contains(string(payload), `"demoAccountPassword":"`+appStoreDemoPasswordSentinel+`"`) {
 			sentRealPassword = true
 		}
-		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON())
 	})
 
 	root := RootCommand("1.2.3")
@@ -257,7 +260,7 @@ func TestTestFlightReviewViewRedactsDemoAccountPassword(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	stubTransport(t, func(req *http.Request) (*http.Response, error) {
-		return jsonResponse(http.StatusOK, betaAppReviewDetailsJSON(testFlightDemoPasswordSentinel))
+		return jsonResponse(http.StatusOK, betaAppReviewDetailsJSON())
 	})
 
 	root := RootCommand("1.2.3")
@@ -295,7 +298,7 @@ func TestTestFlightReviewEditSendsPasswordButRedactsResponse(t *testing.T) {
 		if strings.Contains(string(payload), `"demoAccountPassword":"`+testFlightDemoPasswordSentinel+`"`) {
 			sentRealPassword = true
 		}
-		return jsonResponse(http.StatusOK, betaAppReviewDetailJSON(testFlightDemoPasswordSentinel))
+		return jsonResponse(http.StatusOK, betaAppReviewDetailJSON())
 	})
 
 	root := RootCommand("1.2.3")
@@ -326,7 +329,7 @@ func TestTestFlightReviewViewIncludesDemoAccountPasswordWithIncludeSensitive(t *
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	stubTransport(t, func(req *http.Request) (*http.Response, error) {
-		return jsonResponse(http.StatusOK, betaAppReviewDetailsJSON(testFlightDemoPasswordSentinel))
+		return jsonResponse(http.StatusOK, betaAppReviewDetailsJSON())
 	})
 
 	root := RootCommand("1.2.3")

--- a/internal/cli/cmdtest/review_credentials_redaction_test.go
+++ b/internal/cli/cmdtest/review_credentials_redaction_test.go
@@ -1,0 +1,364 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Unique sentinels make a leak unambiguous: no fixture, help text, or unrelated
+// field can produce these strings by accident.
+const (
+	appStoreDemoPasswordSentinel  = "asc-red-sentinel-appstore-demo-pw-9f31c7"
+	testFlightDemoPasswordSentinel = "asc-red-sentinel-testflight-demo-pw-4b82ad"
+	redactedDemoPasswordText      = "(redacted)"
+	includeSensitiveWarningText   = "Warning: --include-sensitive prints secrets"
+)
+
+func appStoreReviewDetailJSON(password string) string {
+	return `{"data":{"type":"appStoreReviewDetails","id":"detail-1","attributes":{` +
+		`"contactFirstName":"Dev","contactLastName":"Support","contactEmail":"dev@example.com",` +
+		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com","demoAccountPassword":"` + password + `",` +
+		`"notes":"Reviewer notes"}}}`
+}
+
+func betaAppReviewDetailsJSON(password string) string {
+	return `{"data":[{"type":"betaAppReviewDetails","id":"detail-1","attributes":{` +
+		`"contactFirstName":"Dev","contactLastName":"Support","contactEmail":"dev@example.com",` +
+		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com","demoAccountPassword":"` + password + `",` +
+		`"notes":"Reviewer notes"}}],"links":{"self":"https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails"}}`
+}
+
+func betaAppReviewDetailJSON(password string) string {
+	return `{"data":{"type":"betaAppReviewDetails","id":"detail-1","attributes":{` +
+		`"demoAccountRequired":true,"demoAccountName":"reviewer@example.com","demoAccountPassword":"` + password + `"}}}`
+}
+
+func assertNoSentinel(t *testing.T, label, sentinel, content string) {
+	t.Helper()
+	if strings.Contains(content, sentinel) {
+		t.Fatalf("%s leaked the demo account password sentinel: %q", label, content)
+	}
+}
+
+func TestReviewDetailsGetRedactsDemoAccountPasswordInEveryFormat(t *testing.T) {
+	formats := []struct {
+		name string
+		args []string
+	}{
+		{name: "json", args: []string{"--output", "json"}},
+		{name: "pretty json", args: []string{"--output", "json", "--pretty"}},
+		{name: "table", args: []string{"--output", "table"}},
+		{name: "markdown", args: []string{"--output", "markdown"}},
+	}
+
+	for _, format := range formats {
+		t.Run(format.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			stubTransport(t, func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreReviewDetails/detail-1" {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+				}
+				return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			args := append([]string{"review", "details-get", "--id", "detail-1"}, format.args...)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			assertNoSentinel(t, "stdout", appStoreDemoPasswordSentinel, stdout)
+			assertNoSentinel(t, "stderr", appStoreDemoPasswordSentinel, stderr)
+			if !strings.Contains(stdout, "detail-1") {
+				t.Fatalf("expected detail id in output, got %q", stdout)
+			}
+			if format.name == "json" || format.name == "pretty json" {
+				if !strings.Contains(stdout, redactedDemoPasswordText) {
+					t.Fatalf("expected %q placeholder in output, got %q", redactedDemoPasswordText, stdout)
+				}
+			}
+		})
+	}
+}
+
+func TestReviewDetailsGetIncludesDemoAccountPasswordWithIncludeSensitive(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"review", "details-get",
+			"--id", "detail-1",
+			"--output", "json",
+			"--include-sensitive",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var payload struct {
+		Data struct {
+			Attributes struct {
+				DemoAccountPassword string `json:"demoAccountPassword"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	if payload.Data.Attributes.DemoAccountPassword != appStoreDemoPasswordSentinel {
+		t.Fatalf("expected real password with --include-sensitive, got %q", payload.Data.Attributes.DemoAccountPassword)
+	}
+	if !strings.Contains(stderr, includeSensitiveWarningText) {
+		t.Fatalf("expected plaintext-secret warning on stderr, got %q", stderr)
+	}
+}
+
+func TestReviewDetailsForVersionRedactsDemoAccountPassword(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/appStoreVersions/version-1/appStoreReviewDetail" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"review", "details-for-version", "--version-id", "version-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	assertNoSentinel(t, "stdout", appStoreDemoPasswordSentinel, stdout)
+	assertNoSentinel(t, "stderr", appStoreDemoPasswordSentinel, stderr)
+	if !strings.Contains(stdout, redactedDemoPasswordText) {
+		t.Fatalf("expected redaction placeholder, got %q", stdout)
+	}
+}
+
+func TestReviewDetailsCreateSendsPasswordButRedactsResponse(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	sentRealPassword := false
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/appStoreReviewDetails" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if strings.Contains(string(payload), `"demoAccountPassword":"`+appStoreDemoPasswordSentinel+`"`) {
+			sentRealPassword = true
+		}
+		return jsonResponse(http.StatusCreated, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"review", "details-create",
+			"--version-id", "version-1",
+			"--output", "json",
+			"--demo-account-required=true",
+			"--demo-account-name", "reviewer@example.com",
+			"--demo-account-password", appStoreDemoPasswordSentinel,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !sentRealPassword {
+		t.Fatal("expected the create request payload to carry the explicitly supplied password")
+	}
+	assertNoSentinel(t, "stdout", appStoreDemoPasswordSentinel, stdout)
+	assertNoSentinel(t, "stderr", appStoreDemoPasswordSentinel, stderr)
+}
+
+func TestReviewDetailsUpdateSendsPasswordButRedactsResponse(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	sentRealPassword := false
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreReviewDetails/detail-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if strings.Contains(string(payload), `"demoAccountPassword":"`+appStoreDemoPasswordSentinel+`"`) {
+			sentRealPassword = true
+		}
+		return jsonResponse(http.StatusOK, appStoreReviewDetailJSON(appStoreDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"review", "details-update",
+			"--id", "detail-1",
+			"--output", "json",
+			"--demo-account-password", appStoreDemoPasswordSentinel,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !sentRealPassword {
+		t.Fatal("expected the update request payload to carry the explicitly supplied password")
+	}
+	assertNoSentinel(t, "stdout", appStoreDemoPasswordSentinel, stdout)
+	assertNoSentinel(t, "stderr", appStoreDemoPasswordSentinel, stderr)
+}
+
+func TestTestFlightReviewViewRedactsDemoAccountPassword(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, betaAppReviewDetailsJSON(testFlightDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "review", "view", "--app", "app-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	assertNoSentinel(t, "stdout", testFlightDemoPasswordSentinel, stdout)
+	assertNoSentinel(t, "stderr", testFlightDemoPasswordSentinel, stderr)
+	if !strings.Contains(stdout, redactedDemoPasswordText) {
+		t.Fatalf("expected redaction placeholder, got %q", stdout)
+	}
+}
+
+func TestTestFlightReviewEditSendsPasswordButRedactsResponse(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	sentRealPassword := false
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		if strings.Contains(string(payload), `"demoAccountPassword":"`+testFlightDemoPasswordSentinel+`"`) {
+			sentRealPassword = true
+		}
+		return jsonResponse(http.StatusOK, betaAppReviewDetailJSON(testFlightDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "review", "edit",
+			"--id", "detail-1",
+			"--output", "json",
+			"--demo-account-password", testFlightDemoPasswordSentinel,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !sentRealPassword {
+		t.Fatal("expected the update request payload to carry the explicitly supplied password")
+	}
+	assertNoSentinel(t, "stdout", testFlightDemoPasswordSentinel, stdout)
+	assertNoSentinel(t, "stderr", testFlightDemoPasswordSentinel, stderr)
+}
+
+func TestTestFlightReviewViewIncludesDemoAccountPasswordWithIncludeSensitive(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, betaAppReviewDetailsJSON(testFlightDemoPasswordSentinel))
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "review", "view",
+			"--app", "app-1",
+			"--output", "json",
+			"--include-sensitive",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, testFlightDemoPasswordSentinel) {
+		t.Fatalf("expected real password with --include-sensitive, got %q", stdout)
+	}
+	if !strings.Contains(stderr, includeSensitiveWarningText) {
+		t.Fatalf("expected plaintext-secret warning on stderr, got %q", stderr)
+	}
+}
+
+func stubTransport(t *testing.T, fn roundTripFunc) {
+	t.Helper()
+	original := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+	http.DefaultTransport = fn
+}

--- a/internal/cli/install/skills_check.go
+++ b/internal/cli/install/skills_check.go
@@ -584,7 +584,7 @@ func skillsOutputHasUpdates(output string) bool {
 func defaultRunSkillsCheckCommand(ctx context.Context) (string, error) {
 	skillsPath, err := lookupSkillsCheckCLI("skills")
 	if err == nil && !shouldSkipProjectLocalSkillsBinary(skillsPath) {
-		return runSkillsCheckProcess(ctx, skillsPath, []string{"check"}, nil)
+		return runSkillsCheckProcess(ctx, skillsPath, []string{"check"}, skillsCheckHelperEnvironment(os.Environ()))
 	}
 
 	npxPath, err := lookupNpx("npx")
@@ -596,7 +596,7 @@ func defaultRunSkillsCheckCommand(ctx context.Context) (string, error) {
 		ctx,
 		npxPath,
 		[]string{"--offline", "--yes", "skills", "check"},
-		append(os.Environ(), "npm_config_offline=true"),
+		append(skillsCheckHelperEnvironment(os.Environ()), "npm_config_offline=true"),
 	)
 	if runErr != nil && isUnavailableSkillsCheckOutput(output) {
 		return output, errSkillsCheckUnavailable

--- a/internal/cli/install/skills_check_env.go
+++ b/internal/cli/install/skills_check_env.go
@@ -162,9 +162,9 @@ func skillsCheckProxyEnvName(key string) (string, bool) {
 // hierarchical proxy URL is reduced to its scheme, host, and port: userinfo,
 // path, query, and fragment can all carry credentials. The common schemeless
 // host:port form is forwarded verbatim only when it contains none of "@", "?",
-// or "#", because without those separators the value has no structured place
-// for a credential. Anything else is dropped entirely: a credential position
-// that cannot be proven safe is not forwarded.
+// "#", or "/", because without those separators the value has no structured
+// place for a credential. Anything else is dropped entirely: a credential
+// position that cannot be proven safe is not forwarded.
 func sanitizeSkillsCheckProxyValue(canonicalName, value string) (string, bool) {
 	if canonicalName == "NO_PROXY" {
 		return value, true
@@ -177,7 +177,7 @@ func sanitizeSkillsCheckProxyValue(canonicalName, value string) (string, bool) {
 		safe := url.URL{Scheme: parsed.Scheme, Host: parsed.Host}
 		return safe.String(), true
 	}
-	if !strings.ContainsAny(trimmed, "@?#") {
+	if !strings.ContainsAny(trimmed, "@?#/") {
 		return value, true
 	}
 	return "", false

--- a/internal/cli/install/skills_check_env.go
+++ b/internal/cli/install/skills_check_env.go
@@ -1,0 +1,113 @@
+package install
+
+import (
+	"runtime"
+	"strings"
+)
+
+// The automatic skills update check launches a detached worker plus a
+// PATH-resolved `skills` or `npx` helper, so none of them may inherit the
+// caller's credentials. The environment is built from an allowlist rather than
+// a secret denylist: an unrecognized variable is dropped instead of judged.
+//
+// Only variables that executable discovery, the OS loader, and language
+// runtimes genuinely need are forwarded.
+var skillsCheckSharedEnvAllowlist = []string{
+	"HOME",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"PATH",
+	"TEMP",
+	"TMP",
+	"TMPDIR",
+	"TZ",
+}
+
+var skillsCheckUnixEnvAllowlist = []string{
+	"LOGNAME",
+	"SHELL",
+	"USER",
+	"XDG_CACHE_HOME",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+}
+
+// Windows names are stored uppercase because Windows environment variable names
+// are case-insensitive.
+var skillsCheckWindowsEnvAllowlist = []string{
+	"APPDATA",
+	"COMSPEC",
+	"HOMEDRIVE",
+	"HOMEPATH",
+	"LOCALAPPDATA",
+	"NUMBER_OF_PROCESSORS",
+	"OS",
+	"PATHEXT",
+	"PROCESSOR_ARCHITECTURE",
+	"PROGRAMDATA",
+	"PROGRAMFILES",
+	"PROGRAMFILES(X86)",
+	"PROGRAMW6432",
+	"SYSTEMDRIVE",
+	"SYSTEMROOT",
+	"USERPROFILE",
+	"WINDIR",
+}
+
+// skillsCheckWorkerEnvironment builds the detached worker environment: the
+// allowlisted runtime variables plus the private worker coordination values.
+func skillsCheckWorkerEnvironment(base []string, spec skillsCheckWorkerSpec) []string {
+	return append(
+		filterSkillsCheckEnvironment(base, runtime.GOOS),
+		skillsWorkerEnvVar+"=1",
+		skillsWorkerCacheEnvVar+"="+spec.cachePath,
+		skillsWorkerLockEnvVar+"="+spec.lockPath,
+		skillsWorkerTokenEnvVar+"="+spec.token,
+	)
+}
+
+// skillsCheckHelperEnvironment builds the environment for the PATH-resolved
+// `skills` or `npx` helper. Worker coordination values are not allowlisted, so
+// they stay inside the worker.
+func skillsCheckHelperEnvironment(base []string) []string {
+	return filterSkillsCheckEnvironment(base, runtime.GOOS)
+}
+
+func filterSkillsCheckEnvironment(base []string, goos string) []string {
+	allowed := skillsCheckEnvAllowlistFor(goos)
+	filtered := make([]string, 0, len(allowed))
+	for _, entry := range base {
+		key, _, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		if _, ok := allowed[normalizeSkillsCheckEnvKey(key, goos)]; ok {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+func skillsCheckEnvAllowlistFor(goos string) map[string]struct{} {
+	platform := skillsCheckUnixEnvAllowlist
+	if goos == "windows" {
+		platform = skillsCheckWindowsEnvAllowlist
+	}
+
+	allowed := make(map[string]struct{}, len(skillsCheckSharedEnvAllowlist)+len(platform))
+	for _, name := range skillsCheckSharedEnvAllowlist {
+		allowed[normalizeSkillsCheckEnvKey(name, goos)] = struct{}{}
+	}
+	for _, name := range platform {
+		allowed[normalizeSkillsCheckEnvKey(name, goos)] = struct{}{}
+	}
+	return allowed
+}
+
+func normalizeSkillsCheckEnvKey(key, goos string) string {
+	if goos == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
+}

--- a/internal/cli/install/skills_check_env.go
+++ b/internal/cli/install/skills_check_env.go
@@ -50,6 +50,15 @@ var skillsCheckProxyEnvAllowlist = []string{
 	"NO_PROXY",
 }
 
+// npm interprets npm_config_* environment configuration case-insensitively,
+// and the offline `npx` fallback needs the relocated cache to find the skills
+// package. Only the cache location is forwarded: it is a path, not a
+// credential, while other npm settings (registry URLs, auth tokens) can carry
+// secrets and stay excluded.
+var skillsCheckCaseInsensitiveEnvAllowlist = []string{
+	"NPM_CONFIG_CACHE",
+}
+
 // Windows names are stored uppercase because Windows environment variable names
 // are case-insensitive.
 var skillsCheckWindowsEnvAllowlist = []string{
@@ -105,11 +114,28 @@ func filterSkillsCheckEnvironment(base []string, goos string) []string {
 			}
 			continue
 		}
+		if skillsCheckEnvNameAllowedCaseInsensitively(key) {
+			filtered = append(filtered, entry)
+			continue
+		}
 		if _, ok := allowed[normalizeSkillsCheckEnvKey(key, goos)]; ok {
 			filtered = append(filtered, entry)
 		}
 	}
 	return filtered
+}
+
+// skillsCheckEnvNameAllowedCaseInsensitively reports whether key is a
+// credential-free setting whose consumer matches names case-insensitively on
+// every platform.
+func skillsCheckEnvNameAllowedCaseInsensitively(key string) bool {
+	upper := strings.ToUpper(key)
+	for _, name := range skillsCheckCaseInsensitiveEnvAllowlist {
+		if upper == name {
+			return true
+		}
+	}
+	return false
 }
 
 // skillsCheckProxyEnvName reports whether key names proxy configuration and

--- a/internal/cli/install/skills_check_env.go
+++ b/internal/cli/install/skills_check_env.go
@@ -36,14 +36,15 @@ var skillsCheckUnixEnvAllowlist = []string{
 
 // Proxy configuration is connectivity, not identity: the update check is a
 // network operation, so without these variables it silently fails behind a
-// corporate proxy. Proxy URLs may embed credentials in their userinfo, and a
-// credential must not cross the helper boundary, so HTTP_PROXY and HTTPS_PROXY
-// are forwarded with their userinfo stripped; a value that cannot be provably
-// sanitized is dropped. Authenticated proxies therefore still fail closed —
-// the check degrades to its cached result rather than forwarding a secret.
-// NO_PROXY is a host list with no credential form and is forwarded verbatim.
-// Names are matched case-insensitively on every platform because both the
-// upper- and lowercase spellings are conventional.
+// corporate proxy. Proxy URLs may embed credentials in their userinfo, query,
+// or fragment, and a credential must not cross the helper boundary, so
+// HTTP_PROXY and HTTPS_PROXY are reduced to scheme, host, and port before
+// forwarding; a value that cannot be provably sanitized is dropped.
+// Authenticated proxies therefore still fail closed — the check degrades to
+// its cached result rather than forwarding a secret. NO_PROXY is a host list
+// with no credential form and is forwarded verbatim. Names are matched
+// case-insensitively on every platform because both the upper- and lowercase
+// spellings are conventional.
 var skillsCheckProxyEnvAllowlist = []string{
 	"HTTP_PROXY",
 	"HTTPS_PROXY",
@@ -151,28 +152,28 @@ func skillsCheckProxyEnvName(key string) (string, bool) {
 }
 
 // sanitizeSkillsCheckProxyValue returns the proxy value safe to forward. A
-// proxy URL keeps its scheme, host, and port; userinfo, query, and fragment are
-// stripped because they can carry credentials. A value containing "@" that
-// cannot be parsed into a URL with explicit userinfo is dropped entirely: the
-// credential position cannot be proven, so the value is not forwarded.
+// hierarchical proxy URL is reduced to its scheme, host, and port: userinfo,
+// path, query, and fragment can all carry credentials. The common schemeless
+// host:port form is forwarded verbatim only when it contains none of "@", "?",
+// or "#", because without those separators the value has no structured place
+// for a credential. Anything else is dropped entirely: a credential position
+// that cannot be proven safe is not forwarded.
 func sanitizeSkillsCheckProxyValue(canonicalName, value string) (string, bool) {
 	if canonicalName == "NO_PROXY" {
 		return value, true
 	}
 	trimmed := strings.TrimSpace(value)
-	if trimmed == "" || !strings.Contains(trimmed, "@") {
+	if trimmed == "" {
 		return value, true
 	}
-	parsed, err := url.Parse(trimmed)
-	if err != nil || parsed.User == nil || parsed.Host == "" {
-		return "", false
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Host != "" && parsed.Opaque == "" {
+		safe := url.URL{Scheme: parsed.Scheme, Host: parsed.Host}
+		return safe.String(), true
 	}
-	parsed.User = nil
-	parsed.RawQuery = ""
-	parsed.ForceQuery = false
-	parsed.Fragment = ""
-	parsed.RawFragment = ""
-	return parsed.String(), true
+	if !strings.ContainsAny(trimmed, "@?#") {
+		return value, true
+	}
+	return "", false
 }
 
 func skillsCheckEnvAllowlistFor(goos string) map[string]struct{} {

--- a/internal/cli/install/skills_check_env.go
+++ b/internal/cli/install/skills_check_env.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"net/url"
 	"runtime"
 	"strings"
 )
@@ -31,6 +32,22 @@ var skillsCheckUnixEnvAllowlist = []string{
 	"XDG_CACHE_HOME",
 	"XDG_CONFIG_HOME",
 	"XDG_DATA_HOME",
+}
+
+// Proxy configuration is connectivity, not identity: the update check is a
+// network operation, so without these variables it silently fails behind a
+// corporate proxy. Proxy URLs may embed credentials in their userinfo, and a
+// credential must not cross the helper boundary, so HTTP_PROXY and HTTPS_PROXY
+// are forwarded with their userinfo stripped; a value that cannot be provably
+// sanitized is dropped. Authenticated proxies therefore still fail closed —
+// the check degrades to its cached result rather than forwarding a secret.
+// NO_PROXY is a host list with no credential form and is forwarded verbatim.
+// Names are matched case-insensitively on every platform because both the
+// upper- and lowercase spellings are conventional.
+var skillsCheckProxyEnvAllowlist = []string{
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
 }
 
 // Windows names are stored uppercase because Windows environment variable names
@@ -78,8 +95,14 @@ func filterSkillsCheckEnvironment(base []string, goos string) []string {
 	allowed := skillsCheckEnvAllowlistFor(goos)
 	filtered := make([]string, 0, len(allowed))
 	for _, entry := range base {
-		key, _, found := strings.Cut(entry, "=")
+		key, value, found := strings.Cut(entry, "=")
 		if !found {
+			continue
+		}
+		if proxyName, isProxy := skillsCheckProxyEnvName(key); isProxy {
+			if safe, ok := sanitizeSkillsCheckProxyValue(proxyName, value); ok {
+				filtered = append(filtered, key+"="+safe)
+			}
 			continue
 		}
 		if _, ok := allowed[normalizeSkillsCheckEnvKey(key, goos)]; ok {
@@ -87,6 +110,43 @@ func filterSkillsCheckEnvironment(base []string, goos string) []string {
 		}
 	}
 	return filtered
+}
+
+// skillsCheckProxyEnvName reports whether key names proxy configuration and
+// returns its canonical uppercase form.
+func skillsCheckProxyEnvName(key string) (string, bool) {
+	upper := strings.ToUpper(key)
+	for _, name := range skillsCheckProxyEnvAllowlist {
+		if upper == name {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// sanitizeSkillsCheckProxyValue returns the proxy value safe to forward. A
+// proxy URL keeps its scheme, host, and port; userinfo, query, and fragment are
+// stripped because they can carry credentials. A value containing "@" that
+// cannot be parsed into a URL with explicit userinfo is dropped entirely: the
+// credential position cannot be proven, so the value is not forwarded.
+func sanitizeSkillsCheckProxyValue(canonicalName, value string) (string, bool) {
+	if canonicalName == "NO_PROXY" {
+		return value, true
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || !strings.Contains(trimmed, "@") {
+		return value, true
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.User == nil || parsed.Host == "" {
+		return "", false
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	return parsed.String(), true
 }
 
 func skillsCheckEnvAllowlistFor(goos string) map[string]struct{} {

--- a/internal/cli/install/skills_check_env.go
+++ b/internal/cli/install/skills_check_env.go
@@ -18,7 +18,14 @@ var skillsCheckSharedEnvAllowlist = []string{
 	"LANG",
 	"LC_ALL",
 	"LC_CTYPE",
+	// CA trust-store paths are connectivity configuration: behind a corporate
+	// TLS proxy the helpers cannot establish TLS without them. They point at
+	// public trust anchors and carry no credential. NODE_OPTIONS stays
+	// excluded because it can inject arbitrary code into the helper.
+	"NODE_EXTRA_CA_CERTS",
 	"PATH",
+	"SSL_CERT_DIR",
+	"SSL_CERT_FILE",
 	"TEMP",
 	"TMP",
 	"TMPDIR",

--- a/internal/cli/install/skills_check_env_test.go
+++ b/internal/cli/install/skills_check_env_test.go
@@ -218,6 +218,34 @@ func TestSkillsCheckEnvironmentForwardsProxyConfigurationWithoutCredentials(t *t
 	assertNoCredentialSentinels(t, "proxy-aware filter", filtered)
 }
 
+func TestSkillsCheckEnvironmentStripsProxyQueryAndFragmentCredentials(t *testing.T) {
+	const proxyTokenSentinel = "asc-red-sentinel-proxy-token-9b21e4"
+	base := []string{
+		// No userinfo, but the query and fragment can still carry secrets.
+		"HTTP_PROXY=https://proxy.corp.example:3128/?token=" + proxyTokenSentinel,
+		"HTTPS_PROXY=https://proxy.corp.example:3128#" + proxyTokenSentinel,
+		// The schemeless host:port form is common and has no place to hide a
+		// structured credential.
+		"http_proxy=proxy.corp.example:3128",
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "darwin")
+
+	values := envMap(filtered)
+	if values["HTTP_PROXY"] != "https://proxy.corp.example:3128" {
+		t.Fatalf("HTTP_PROXY = %q, want scheme and host only", values["HTTP_PROXY"])
+	}
+	if values["HTTPS_PROXY"] != "https://proxy.corp.example:3128" {
+		t.Fatalf("HTTPS_PROXY = %q, want scheme and host only", values["HTTPS_PROXY"])
+	}
+	if values["http_proxy"] != "proxy.corp.example:3128" {
+		t.Fatalf("http_proxy = %q, want the schemeless host:port forwarded verbatim", values["http_proxy"])
+	}
+	if strings.Contains(strings.Join(filtered, "\n"), proxyTokenSentinel) {
+		t.Fatalf("proxy credential crossed the helper boundary: %v", filtered)
+	}
+}
+
 func TestSkillsCheckEnvironmentDropsProxyValuesItCannotSanitize(t *testing.T) {
 	const proxyPasswordSentinel = "asc-red-sentinel-proxy-pw-5d11c9"
 	base := []string{

--- a/internal/cli/install/skills_check_env_test.go
+++ b/internal/cli/install/skills_check_env_test.go
@@ -252,6 +252,8 @@ func TestSkillsCheckEnvironmentDropsProxyValuesItCannotSanitize(t *testing.T) {
 		// No scheme, so the credential position cannot be proven; the value
 		// must be dropped rather than forwarded.
 		"HTTP_PROXY=scanner:" + proxyPasswordSentinel + "@proxy.corp.example:3128",
+		// A schemeless value with a path segment can hide a secret there.
+		"HTTPS_PROXY=proxy.corp.example:3128/" + proxyPasswordSentinel,
 	}
 
 	filtered := filterSkillsCheckEnvironment(base, "darwin")

--- a/internal/cli/install/skills_check_env_test.go
+++ b/internal/cli/install/skills_check_env_test.go
@@ -1,0 +1,198 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Credentials a real user plausibly exports before running asc. None of them
+// belong to a PATH-resolved skills or npx helper.
+var skillsCheckCredentialSentinels = map[string]string{
+	"ASC_PRIVATE_KEY":                    "asc-red-sentinel-private-key-2ba917",
+	"ASC_KEY_ID":                         "asc-red-sentinel-key-id-8cd034",
+	"ASC_ISSUER_ID":                      "asc-red-sentinel-issuer-6f1e52",
+	"ASC_PRIVATE_KEY_PATH":               "/tmp/asc-red-sentinel-key-path-4a70bd.p8",
+	"ASC_SLACK_WEBHOOK":                  "https://hooks.slack.com/services/asc-red-sentinel-webhook-19e6cf",
+	"GITHUB_TOKEN":                       "asc-red-sentinel-github-token-d5b283",
+	"MATCH_PASSWORD":                     "asc-red-sentinel-signing-pw-7e40ca",
+	"NPM_TOKEN":                          "asc-red-sentinel-npm-token-b921fe",
+	"AWS_SECRET_ACCESS_KEY":              "asc-red-sentinel-aws-secret-3cd158",
+	"SOME_UNRECOGNIZED_INTERNAL_SETTING": "asc-red-sentinel-unknown-var-0f7a62",
+}
+
+func seedSkillsCheckCredentials(t *testing.T) {
+	t.Helper()
+	for key, value := range skillsCheckCredentialSentinels {
+		t.Setenv(key, value)
+	}
+}
+
+func assertNoCredentialSentinels(t *testing.T, label string, env []string) {
+	t.Helper()
+	joined := strings.Join(env, "\n")
+	for key, value := range skillsCheckCredentialSentinels {
+		if strings.Contains(joined, value) {
+			t.Fatalf("%s received credential %s: %s", label, key, joined)
+		}
+	}
+}
+
+func TestSkillsCheckWorkerEnvironmentExcludesCredentials(t *testing.T) {
+	seedSkillsCheckCredentials(t)
+
+	env := skillsCheckWorkerEnvironment(os.Environ(), skillsCheckWorkerSpec{
+		cachePath: filepath.Join(t.TempDir(), "cache.json"),
+		lockPath:  filepath.Join(t.TempDir(), "lock"),
+		token:     "worker-token",
+	})
+
+	assertNoCredentialSentinels(t, "detached worker", env)
+
+	values := envMap(env)
+	if values["PATH"] != os.Getenv("PATH") {
+		t.Fatalf("worker PATH = %q, want the parent PATH", values["PATH"])
+	}
+	if values[skillsWorkerEnvVar] != "1" {
+		t.Fatalf("worker coordination variable %s = %q, want 1", skillsWorkerEnvVar, values[skillsWorkerEnvVar])
+	}
+	if values[skillsWorkerTokenEnvVar] != "worker-token" {
+		t.Fatalf("worker token = %q, want worker-token", values[skillsWorkerTokenEnvVar])
+	}
+}
+
+func TestSkillsCheckHelperEnvironmentExcludesWorkerCoordinationVariables(t *testing.T) {
+	seedSkillsCheckCredentials(t)
+	t.Setenv(skillsWorkerEnvVar, "1")
+	t.Setenv(skillsWorkerTokenEnvVar, "worker-token")
+
+	env := skillsCheckHelperEnvironment(os.Environ())
+
+	assertNoCredentialSentinels(t, "skills helper", env)
+
+	values := envMap(env)
+	if _, ok := values[skillsWorkerEnvVar]; ok {
+		t.Fatalf("helper env exposed %s", skillsWorkerEnvVar)
+	}
+	if _, ok := values[skillsWorkerTokenEnvVar]; ok {
+		t.Fatalf("helper env exposed %s", skillsWorkerTokenEnvVar)
+	}
+	if values["PATH"] != os.Getenv("PATH") {
+		t.Fatal("helper env dropped PATH, breaking executable discovery")
+	}
+}
+
+func TestDefaultRunSkillsCheckCommandGivesDirectHelperOnlyAllowlistedEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	restoreSkillsCheckLookups(t)
+	seedSkillsCheckCredentials(t)
+
+	mockSkills := writeExecutable(t, "#!/bin/sh\nenv\n")
+	lookupSkillsCheckCLI = func(string) (string, error) {
+		return mockSkills, nil
+	}
+	lookupNpx = func(string) (string, error) {
+		t.Fatal("lookupNpx should not run when skills is available")
+		return "", nil
+	}
+
+	output, err := defaultRunSkillsCheckCommand(context.Background())
+	if err != nil {
+		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
+	}
+
+	assertNoCredentialSentinels(t, "direct skills helper", strings.Split(output, "\n"))
+	if !strings.Contains(output, "PATH=") {
+		t.Fatalf("direct skills helper lost PATH: %q", output)
+	}
+}
+
+func TestDefaultRunSkillsCheckCommandGivesNpxFallbackOnlyAllowlistedEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	restoreSkillsCheckLookups(t)
+	seedSkillsCheckCredentials(t)
+
+	mockNpx := writeExecutable(t, "#!/bin/sh\nenv\n")
+	lookupSkillsCheckCLI = func(string) (string, error) {
+		return "", os.ErrNotExist
+	}
+	lookupNpx = func(string) (string, error) {
+		return mockNpx, nil
+	}
+
+	output, err := defaultRunSkillsCheckCommand(context.Background())
+	if err != nil {
+		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
+	}
+
+	assertNoCredentialSentinels(t, "npx fallback", strings.Split(output, "\n"))
+	if !strings.Contains(output, "npm_config_offline=true") {
+		t.Fatalf("npx fallback lost the offline cache setting: %q", output)
+	}
+	if !strings.Contains(output, "PATH=") {
+		t.Fatalf("npx fallback lost PATH: %q", output)
+	}
+}
+
+func TestSkillsCheckEnvironmentAllowlistIsPlatformAware(t *testing.T) {
+	unix := skillsCheckEnvAllowlistFor("darwin")
+	windows := skillsCheckEnvAllowlistFor("windows")
+
+	for _, name := range []string{"PATH", "HOME", "TMPDIR"} {
+		if _, ok := unix[name]; !ok {
+			t.Fatalf("unix allowlist is missing %s", name)
+		}
+	}
+	for _, name := range []string{"PATH", "SYSTEMROOT", "PATHEXT", "USERPROFILE", "APPDATA"} {
+		if _, ok := windows[name]; !ok {
+			t.Fatalf("windows allowlist is missing %s", name)
+		}
+	}
+	if _, ok := windows["SHELL"]; ok {
+		t.Fatal("windows allowlist should not carry Unix-only variables")
+	}
+	if _, ok := unix["SYSTEMROOT"]; ok {
+		t.Fatal("unix allowlist should not carry Windows-only variables")
+	}
+}
+
+func TestFilterSkillsCheckEnvironmentMatchesWindowsCaseInsensitively(t *testing.T) {
+	base := []string{
+		"SystemRoot=C:\\Windows",
+		"Path=C:\\Windows\\System32",
+		"NPM_TOKEN=" + skillsCheckCredentialSentinels["NPM_TOKEN"],
+		"malformed-entry",
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "windows")
+
+	values := envMap(filtered)
+	if values["SystemRoot"] != "C:\\Windows" {
+		t.Fatalf("windows filter dropped SystemRoot: %v", filtered)
+	}
+	if values["Path"] != "C:\\Windows\\System32" {
+		t.Fatalf("windows filter dropped Path: %v", filtered)
+	}
+	assertNoCredentialSentinels(t, "windows filter", filtered)
+	if len(filtered) != 2 {
+		t.Fatalf("windows filter kept unexpected entries: %v", filtered)
+	}
+}
+
+func envMap(env []string) map[string]string {
+	values := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, found := strings.Cut(entry, "=")
+		if found {
+			values[key] = value
+		}
+	}
+	return values
+}

--- a/internal/cli/install/skills_check_env_test.go
+++ b/internal/cli/install/skills_check_env_test.go
@@ -278,6 +278,33 @@ func TestSkillsCheckEnvironmentForwardsProxyConfigurationOnWindows(t *testing.T)
 	}
 }
 
+func TestSkillsCheckEnvironmentForwardsCATrustPaths(t *testing.T) {
+	base := []string{
+		"SSL_CERT_FILE=/etc/corp/ca-bundle.pem",
+		"SSL_CERT_DIR=/etc/corp/certs",
+		"NODE_EXTRA_CA_CERTS=/etc/corp/extra-ca.pem",
+		// NODE_OPTIONS can inject arbitrary code into the helper and must not
+		// ride along with the trust-store paths.
+		"NODE_OPTIONS=--require=/tmp/evil.js",
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "darwin")
+
+	values := envMap(filtered)
+	if values["SSL_CERT_FILE"] != "/etc/corp/ca-bundle.pem" {
+		t.Fatalf("SSL_CERT_FILE = %q, want the trust-store path forwarded", values["SSL_CERT_FILE"])
+	}
+	if values["SSL_CERT_DIR"] != "/etc/corp/certs" {
+		t.Fatalf("SSL_CERT_DIR = %q, want the trust-store path forwarded", values["SSL_CERT_DIR"])
+	}
+	if values["NODE_EXTRA_CA_CERTS"] != "/etc/corp/extra-ca.pem" {
+		t.Fatalf("NODE_EXTRA_CA_CERTS = %q, want the trust-store path forwarded", values["NODE_EXTRA_CA_CERTS"])
+	}
+	if _, ok := values["NODE_OPTIONS"]; ok {
+		t.Fatalf("NODE_OPTIONS must stay outside the allowlist: %v", filtered)
+	}
+}
+
 func TestSkillsCheckEnvironmentForwardsNpmCacheLocation(t *testing.T) {
 	base := []string{
 		"npm_config_cache=/custom/npm-cache",

--- a/internal/cli/install/skills_check_env_test.go
+++ b/internal/cli/install/skills_check_env_test.go
@@ -250,6 +250,31 @@ func TestSkillsCheckEnvironmentForwardsProxyConfigurationOnWindows(t *testing.T)
 	}
 }
 
+func TestSkillsCheckEnvironmentForwardsNpmCacheLocation(t *testing.T) {
+	base := []string{
+		"npm_config_cache=/custom/npm-cache",
+		"NPM_CONFIG_CACHE=/custom/npm-cache-upper",
+		// A registry URL can embed an access token, so it must not ride along
+		// with the cache location.
+		"npm_config_registry=https://" + skillsCheckCredentialSentinels["NPM_TOKEN"] + "@registry.corp.example",
+		"npm_config__authToken=" + skillsCheckCredentialSentinels["NPM_TOKEN"],
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "darwin")
+
+	values := envMap(filtered)
+	if values["npm_config_cache"] != "/custom/npm-cache" {
+		t.Fatalf("npm_config_cache = %q, want the relocated cache forwarded for the offline npx fallback", values["npm_config_cache"])
+	}
+	if values["NPM_CONFIG_CACHE"] != "/custom/npm-cache-upper" {
+		t.Fatalf("NPM_CONFIG_CACHE = %q, want npm's case-insensitive spelling forwarded too", values["NPM_CONFIG_CACHE"])
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("only the cache location may be forwarded, got: %v", filtered)
+	}
+	assertNoCredentialSentinels(t, "npm cache filter", filtered)
+}
+
 func TestSkillsCheckWorkerEnvironmentForwardsProxyConfiguration(t *testing.T) {
 	const proxyPasswordSentinel = "asc-red-sentinel-proxy-pw-5d11c9"
 	t.Setenv("HTTP_PROXY", "http://scanner:"+proxyPasswordSentinel+"@proxy.corp.example:3128")

--- a/internal/cli/install/skills_check_env_test.go
+++ b/internal/cli/install/skills_check_env_test.go
@@ -186,6 +186,91 @@ func TestFilterSkillsCheckEnvironmentMatchesWindowsCaseInsensitively(t *testing.
 	}
 }
 
+func TestSkillsCheckEnvironmentForwardsProxyConfigurationWithoutCredentials(t *testing.T) {
+	const proxyPasswordSentinel = "asc-red-sentinel-proxy-pw-5d11c9"
+	base := []string{
+		"HTTP_PROXY=http://proxy.corp.example:3128",
+		"https_proxy=https://scanner:" + proxyPasswordSentinel + "@proxy.corp.example:3128",
+		"no_proxy=localhost,127.0.0.1,.corp.example",
+		"ALL_PROXY=socks5://scanner:" + proxyPasswordSentinel + "@proxy.corp.example:1080",
+		"NPM_TOKEN=" + skillsCheckCredentialSentinels["NPM_TOKEN"],
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "darwin")
+	values := envMap(filtered)
+
+	if values["HTTP_PROXY"] != "http://proxy.corp.example:3128" {
+		t.Fatalf("HTTP_PROXY = %q, want it forwarded verbatim", values["HTTP_PROXY"])
+	}
+	if values["https_proxy"] != "https://proxy.corp.example:3128" {
+		t.Fatalf("https_proxy = %q, want the proxy URL with its userinfo stripped", values["https_proxy"])
+	}
+	if values["no_proxy"] != "localhost,127.0.0.1,.corp.example" {
+		t.Fatalf("no_proxy = %q, want the host list forwarded verbatim", values["no_proxy"])
+	}
+	if _, ok := values["ALL_PROXY"]; ok {
+		t.Fatalf("ALL_PROXY should stay outside the allowlist: %v", filtered)
+	}
+	joined := strings.Join(filtered, "\n")
+	if strings.Contains(joined, proxyPasswordSentinel) {
+		t.Fatalf("proxy credential crossed the helper boundary: %v", filtered)
+	}
+	assertNoCredentialSentinels(t, "proxy-aware filter", filtered)
+}
+
+func TestSkillsCheckEnvironmentDropsProxyValuesItCannotSanitize(t *testing.T) {
+	const proxyPasswordSentinel = "asc-red-sentinel-proxy-pw-5d11c9"
+	base := []string{
+		// No scheme, so the credential position cannot be proven; the value
+		// must be dropped rather than forwarded.
+		"HTTP_PROXY=scanner:" + proxyPasswordSentinel + "@proxy.corp.example:3128",
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "darwin")
+
+	if len(filtered) != 0 {
+		t.Fatalf("unsanitizable proxy value was forwarded: %v", filtered)
+	}
+}
+
+func TestSkillsCheckEnvironmentForwardsProxyConfigurationOnWindows(t *testing.T) {
+	const proxyPasswordSentinel = "asc-red-sentinel-proxy-pw-5d11c9"
+	base := []string{
+		"Http_Proxy=http://scanner:" + proxyPasswordSentinel + "@proxy.corp.example:3128",
+	}
+
+	filtered := filterSkillsCheckEnvironment(base, "windows")
+
+	values := envMap(filtered)
+	if values["Http_Proxy"] != "http://proxy.corp.example:3128" {
+		t.Fatalf("Http_Proxy = %q, want the proxy URL with its userinfo stripped", values["Http_Proxy"])
+	}
+	if strings.Contains(strings.Join(filtered, "\n"), proxyPasswordSentinel) {
+		t.Fatalf("proxy credential crossed the helper boundary: %v", filtered)
+	}
+}
+
+func TestSkillsCheckWorkerEnvironmentForwardsProxyConfiguration(t *testing.T) {
+	const proxyPasswordSentinel = "asc-red-sentinel-proxy-pw-5d11c9"
+	t.Setenv("HTTP_PROXY", "http://scanner:"+proxyPasswordSentinel+"@proxy.corp.example:3128")
+	seedSkillsCheckCredentials(t)
+
+	env := skillsCheckWorkerEnvironment(os.Environ(), skillsCheckWorkerSpec{
+		cachePath: filepath.Join(t.TempDir(), "cache.json"),
+		lockPath:  filepath.Join(t.TempDir(), "lock"),
+		token:     "worker-token",
+	})
+
+	values := envMap(env)
+	if values["HTTP_PROXY"] != "http://proxy.corp.example:3128" {
+		t.Fatalf("worker HTTP_PROXY = %q, want the proxy URL with its userinfo stripped", values["HTTP_PROXY"])
+	}
+	if strings.Contains(strings.Join(env, "\n"), proxyPasswordSentinel) {
+		t.Fatalf("proxy credential reached the detached worker: %v", env)
+	}
+	assertNoCredentialSentinels(t, "proxy-aware worker", env)
+}
+
 func envMap(env []string) map[string]string {
 	values := make(map[string]string, len(env))
 	for _, entry := range env {

--- a/internal/cli/install/skills_check_process.go
+++ b/internal/cli/install/skills_check_process.go
@@ -3,7 +3,6 @@ package install
 import (
 	"os"
 	"os/exec"
-	"strings"
 )
 
 func defaultStartSkillsCheckWorker(spec skillsCheckWorkerSpec) error {
@@ -39,27 +38,4 @@ func startDetachedSkillsCheckProcess(executable string, args, env []string) erro
 	// process from retaining a wait obligation or zombie bookkeeping.
 	_ = cmd.Process.Release()
 	return nil
-}
-
-func skillsCheckWorkerEnvironment(base []string, spec skillsCheckWorkerSpec) []string {
-	workerKeys := map[string]struct{}{
-		skillsWorkerEnvVar:      {},
-		skillsWorkerCacheEnvVar: {},
-		skillsWorkerLockEnvVar:  {},
-		skillsWorkerTokenEnvVar: {},
-	}
-	env := make([]string, 0, len(base)+len(workerKeys))
-	for _, entry := range base {
-		key, _, _ := strings.Cut(entry, "=")
-		if _, isWorkerKey := workerKeys[key]; !isWorkerKey {
-			env = append(env, entry)
-		}
-	}
-	return append(
-		env,
-		skillsWorkerEnvVar+"=1",
-		skillsWorkerCacheEnvVar+"="+spec.cachePath,
-		skillsWorkerLockEnvVar+"="+spec.lockPath,
-		skillsWorkerTokenEnvVar+"="+spec.token,
-	)
 }

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -55,6 +55,7 @@ func MigrateImportCommand() *ffcli.Command {
 	fastlaneDir := fs.String("fastlane-dir", "", "Path to fastlane directory (optional)")
 	dryRun := fs.Bool("dry-run", false, "Preview changes without uploading")
 	skipScreenshots := fs.Bool("skip-screenshots", false, "Skip screenshot discovery and upload")
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -223,7 +224,8 @@ Examples:
 			}
 
 			if *dryRun {
-				return printMigrateOutput(result, *output.Output, *output.Pretty)
+				shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+				return printMigrateOutput(presentableImportResult(result, *includeSensitive), *output.Output, *output.Pretty)
 			}
 
 			if client == nil {
@@ -274,7 +276,8 @@ Examples:
 			result.ReviewInfoResult = reviewResult
 			result.ScreenshotResults = screenshotResults
 
-			if err := printMigrateOutput(result, *output.Output, *output.Pretty); err != nil {
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			if err := printMigrateOutput(presentableImportResult(result, *includeSensitive), *output.Output, *output.Pretty); err != nil {
 				return err
 			}
 			return shared.PrintSubmitReadinessCreateWarnings(os.Stderr, warnings)

--- a/internal/cli/migrate/review_information.go
+++ b/internal/cli/migrate/review_information.go
@@ -20,6 +20,31 @@ type ReviewInformation struct {
 	Notes               *string `json:"notes,omitempty"`
 }
 
+// presentableImportResult returns the result to render. Without an explicit
+// opt-in the imported demo account password is replaced so JSON, table, and
+// Markdown output cannot carry it, while the original result keeps the real
+// value for request construction and comparison.
+func presentableImportResult(result *MigrateImportResult, includeSensitive bool) *MigrateImportResult {
+	if includeSensitive || result == nil || result.ReviewInformation == nil {
+		return result
+	}
+	safe := *result
+	safe.ReviewInformation = result.ReviewInformation.redactedCopy()
+	return &safe
+}
+
+func (info *ReviewInformation) redactedCopy() *ReviewInformation {
+	if info == nil {
+		return nil
+	}
+	safe := *info
+	if info.DemoAccountPassword != nil {
+		redacted := asc.RedactSecret(*info.DemoAccountPassword)
+		safe.DemoAccountPassword = &redacted
+	}
+	return &safe
+}
+
 func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, error) {
 	reviewDir := filepath.Join(metadataDir, "review_information")
 	if exists, err := dirExists(reviewDir); err != nil {

--- a/internal/cli/migrate/review_information_redaction_test.go
+++ b/internal/cli/migrate/review_information_redaction_test.go
@@ -1,0 +1,70 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+const migrateRedactionSentinel = "asc-red-sentinel-migrate-unit-pw-6d0b12"
+
+func TestPresentableImportResultKeepsRealPasswordForRequests(t *testing.T) {
+	password := migrateRedactionSentinel
+	name := "reviewer@example.com"
+	info := &ReviewInformation{DemoAccountName: &name, DemoAccountPassword: &password}
+	result := &MigrateImportResult{VersionID: "version-1", ReviewInformation: info}
+
+	safe := presentableImportResult(result, false)
+
+	if safe.ReviewInformation.DemoAccountPassword == nil ||
+		*safe.ReviewInformation.DemoAccountPassword != asc.RedactedValuePlaceholder {
+		t.Fatalf("rendered password = %v, want placeholder", safe.ReviewInformation.DemoAccountPassword)
+	}
+	if safe.ReviewInformation.DemoAccountName == nil || *safe.ReviewInformation.DemoAccountName != name {
+		t.Fatalf("redaction dropped the demo account name: %+v", safe.ReviewInformation)
+	}
+	if *info.DemoAccountPassword != migrateRedactionSentinel {
+		t.Fatalf("redaction mutated the imported password to %q", *info.DemoAccountPassword)
+	}
+
+	attrs := buildReviewDetailUpdateAttributes(result.ReviewInformation)
+	if attrs.DemoAccountPassword == nil || *attrs.DemoAccountPassword != migrateRedactionSentinel {
+		t.Fatalf("update attributes password = %v, want the real value", attrs.DemoAccountPassword)
+	}
+	createAttrs := buildReviewDetailCreateAttributes(result.ReviewInformation)
+	if createAttrs.DemoAccountPassword == nil || *createAttrs.DemoAccountPassword != migrateRedactionSentinel {
+		t.Fatalf("create attributes password = %v, want the real value", createAttrs.DemoAccountPassword)
+	}
+}
+
+func TestPresentableImportResultComparesAgainstRealPassword(t *testing.T) {
+	password := migrateRedactionSentinel
+	info := &ReviewInformation{DemoAccountPassword: &password}
+	result := &MigrateImportResult{ReviewInformation: info}
+
+	_ = presentableImportResult(result, false)
+
+	existing := asc.AppStoreReviewDetailAttributes{DemoAccountPassword: migrateRedactionSentinel}
+	if !reviewInformationMatches(existing, result.ReviewInformation) {
+		t.Fatal("matching against the real password regressed after rendering a redacted copy")
+	}
+	redacted := asc.AppStoreReviewDetailAttributes{DemoAccountPassword: asc.RedactedValuePlaceholder}
+	if reviewInformationMatches(redacted, result.ReviewInformation) {
+		t.Fatal("a redacted remote value must not count as a match")
+	}
+}
+
+func TestPresentableImportResultPassesThroughWhenSensitiveRequested(t *testing.T) {
+	password := migrateRedactionSentinel
+	result := &MigrateImportResult{ReviewInformation: &ReviewInformation{DemoAccountPassword: &password}}
+
+	if got := presentableImportResult(result, true); got != result {
+		t.Fatal("--include-sensitive must render the original result")
+	}
+	if got := presentableImportResult(nil, false); got != nil {
+		t.Fatal("nil result must stay nil")
+	}
+	if got := presentableImportResult(&MigrateImportResult{}, false); got.ReviewInformation != nil {
+		t.Fatal("absent review information must stay absent")
+	}
+}

--- a/internal/cli/notify/notify.go
+++ b/internal/cli/notify/notify.go
@@ -198,7 +198,7 @@ Examples:
 				if readErr != nil {
 					return fmt.Errorf("notify slack: failed to read response: %w", readErr)
 				}
-				message := strings.TrimSpace(string(respBody))
+				message := redactWebhookSecretFromText(strings.TrimSpace(string(respBody)), webhookURL)
 				if message == "" {
 					return fmt.Errorf("notify slack: unexpected response %d", resp.StatusCode)
 				}
@@ -209,6 +209,40 @@ Examples:
 			return nil
 		},
 	}
+}
+
+// redactWebhookSecretFromText removes the webhook secret from response text
+// before it becomes part of an error message. Some servers and intercepting
+// proxies echo the requested URL or path in their error body, and for a Slack
+// incoming webhook the path is the secret. The full URL, the path, and each
+// path segment long enough to be an identifier are replaced; the rest of the
+// body keeps its diagnostic value.
+func redactWebhookSecretFromText(text, webhookURL string) string {
+	trimmed := strings.TrimSpace(webhookURL)
+	if text == "" || trimmed == "" {
+		return text
+	}
+	sanitized := strings.ReplaceAll(text, trimmed, urlsanitize.RedactedPlaceholder)
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return sanitized
+	}
+	secrets := make([]string, 0, 8)
+	if escaped := parsed.EscapedPath(); len(escaped) > 1 {
+		secrets = append(secrets, escaped)
+	}
+	if len(parsed.Path) > 1 {
+		secrets = append(secrets, parsed.Path)
+	}
+	for _, segment := range strings.Split(strings.Trim(parsed.Path, "/"), "/") {
+		if len(segment) >= 4 && segment != "services" {
+			secrets = append(secrets, segment)
+		}
+	}
+	for _, secret := range secrets {
+		sanitized = strings.ReplaceAll(sanitized, secret, urlsanitize.RedactedPlaceholder)
+	}
+	return sanitized
 }
 
 // newSanitizedWebhookError keeps the failing host and failure class while

--- a/internal/cli/notify/notify.go
+++ b/internal/cli/notify/notify.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/urlsanitize"
 )
 
 const (
@@ -180,14 +181,14 @@ Examples:
 
 			req, err := http.NewRequestWithContext(requestCtx, "POST", webhookURL, bytes.NewReader(body))
 			if err != nil {
-				return fmt.Errorf("notify slack: failed to create request: %w", err)
+				return fmt.Errorf("notify slack: failed to create request: %w", newSanitizedWebhookError("request creation", webhookURL, err))
 			}
 			req.Header.Set("Content-Type", "application/json")
 
 			client := slackHTTPClient()
 			resp, err := client.Do(req)
 			if err != nil {
-				return fmt.Errorf("notify slack: failed to send: %w", err)
+				return fmt.Errorf("notify slack: failed to send: %w", newSanitizedWebhookError("webhook POST", webhookURL, err))
 			}
 			defer resp.Body.Close()
 
@@ -208,6 +209,14 @@ Examples:
 			return nil
 		},
 	}
+}
+
+// newSanitizedWebhookError keeps the failing host and failure class while
+// dropping the webhook path, which is the incoming-webhook secret itself.
+// net/http renders the full request URL in its own error text, so the cause is
+// wrapped for inspection instead of being interpolated into the message.
+func newSanitizedWebhookError(operation, webhookURL string, err error) error {
+	return urlsanitize.NewTransportError(operation, urlsanitize.RedactURLHostForError(webhookURL), err)
 }
 
 func resolveWebhook(flagValue string) string {

--- a/internal/cli/notify/notify_transport_error_test.go
+++ b/internal/cli/notify/notify_transport_error_test.go
@@ -95,6 +95,83 @@ func TestNotifySlackTransportFailuresNeverExposeWebhookSecret(t *testing.T) {
 	}
 }
 
+type respondingSlackTransport struct {
+	status int
+	body   string
+}
+
+func (t *respondingSlackTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: t.status,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+	}, nil
+}
+
+func TestNotifySlackNon2xxResponseBodyNeverExposesWebhookSecret(t *testing.T) {
+	// Some servers and intercepting proxies echo the requested URL or path in
+	// their error body, and for an incoming webhook the path is the secret.
+	tests := []struct {
+		name string
+		body string
+		keep string
+	}{
+		{name: "echoed full URL", body: "cannot POST " + slackWebhookWithSecret(), keep: "cannot POST"},
+		{
+			name: "echoed path",
+			body: "no service at /services/T00000000/B00000000/" + slackWebhookSecretSentinel,
+			keep: "no service at",
+		},
+		{name: "echoed token", body: "unknown token " + slackWebhookSecretSentinel, keep: "unknown token"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(slackWebhookEnvVar, "")
+			t.Setenv(slackWebhookAllowLocalEnv, "1")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			original := slackHTTPClient
+			t.Cleanup(func() {
+				slackHTTPClient = original
+			})
+			slackHTTPClient = func() *http.Client {
+				return &http.Client{Transport: &respondingSlackTransport{status: http.StatusNotFound, body: test.body}}
+			}
+
+			root := SlackCommand()
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"--webhook", slackWebhookWithSecret(),
+					"--message", "Build uploaded",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected an unexpected-response error")
+			}
+			if strings.Contains(runErr.Error(), slackWebhookSecretSentinel) {
+				t.Fatalf("error leaked the webhook secret: %q", runErr.Error())
+			}
+			if strings.Contains(stderr, slackWebhookSecretSentinel) {
+				t.Fatalf("stderr leaked the webhook secret: %q", stderr)
+			}
+			if !strings.Contains(runErr.Error(), "unexpected response 404") {
+				t.Fatalf("error dropped the status context: %q", runErr.Error())
+			}
+			if !strings.Contains(runErr.Error(), test.keep) {
+				t.Fatalf("error dropped the harmless body context %q: %q", test.keep, runErr.Error())
+			}
+		})
+	}
+}
+
 func TestNotifySlackTransportErrorKeepsDNSErrorInspectable(t *testing.T) {
 	dnsErr := &net.DNSError{Err: "no such host", Name: "hooks.slack.com", IsNotFound: true}
 

--- a/internal/cli/notify/notify_transport_error_test.go
+++ b/internal/cli/notify/notify_transport_error_test.go
@@ -1,0 +1,127 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The webhook path is itself the credential, so the secret sentinel lives in the
+// path segments a Slack incoming webhook uses.
+const slackWebhookSecretSentinel = "asc-red-sentinel-slack-webhook-3fd914"
+
+func slackWebhookWithSecret() string {
+	return "http://127.0.0.1:1/services/T00000000/B00000000/" + slackWebhookSecretSentinel
+}
+
+type failingSlackTransport struct {
+	err error
+}
+
+func (t *failingSlackTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.err
+}
+
+func stubSlackTransport(t *testing.T, transportErr error) {
+	t.Helper()
+	original := slackHTTPClient
+	t.Cleanup(func() {
+		slackHTTPClient = original
+	})
+	slackHTTPClient = func() *http.Client {
+		return &http.Client{Transport: &failingSlackTransport{err: transportErr}}
+	}
+}
+
+func TestNotifySlackTransportFailuresNeverExposeWebhookSecret(t *testing.T) {
+	tests := []struct {
+		name         string
+		transportErr error
+		wantContext  string
+	}{
+		{name: "dns", transportErr: &net.DNSError{Err: "no such host", Name: "hooks.slack.com"}, wantContext: ""},
+		{name: "tls", transportErr: errors.New("tls: failed to verify certificate"), wantContext: ""},
+		{name: "connection refused", transportErr: errors.New("connect: connection refused"), wantContext: ""},
+		{name: "proxy", transportErr: errors.New("proxyconnect tcp: bad proxy"), wantContext: ""},
+		{name: "redirect", transportErr: errors.New("stopped after 10 redirects"), wantContext: ""},
+		{name: "timeout", transportErr: context.DeadlineExceeded, wantContext: "timeout"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(slackWebhookEnvVar, "")
+			t.Setenv(slackWebhookAllowLocalEnv, "1")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			stubSlackTransport(t, test.transportErr)
+
+			root := SlackCommand()
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"--webhook", slackWebhookWithSecret(),
+					"--message", "Build uploaded",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected a transport error")
+			}
+			if strings.Contains(runErr.Error(), slackWebhookSecretSentinel) {
+				t.Fatalf("error leaked the webhook secret: %q", runErr.Error())
+			}
+			if strings.Contains(stderr, slackWebhookSecretSentinel) {
+				t.Fatalf("stderr leaked the webhook secret: %q", stderr)
+			}
+			if !strings.Contains(runErr.Error(), "notify slack: failed to send") {
+				t.Fatalf("error dropped the operation context: %q", runErr.Error())
+			}
+			if !errors.Is(runErr, test.transportErr) {
+				t.Fatalf("errors.Is lost the wrapped transport error: %v", runErr)
+			}
+			if test.wantContext != "" && !strings.Contains(runErr.Error(), test.wantContext) {
+				t.Fatalf("error dropped %q context: %q", test.wantContext, runErr.Error())
+			}
+		})
+	}
+}
+
+func TestNotifySlackTransportErrorKeepsDNSErrorInspectable(t *testing.T) {
+	dnsErr := &net.DNSError{Err: "no such host", Name: "hooks.slack.com", IsNotFound: true}
+
+	t.Setenv(slackWebhookEnvVar, "")
+	t.Setenv(slackWebhookAllowLocalEnv, "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	stubSlackTransport(t, dnsErr)
+
+	root := SlackCommand()
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"--webhook", slackWebhookWithSecret(),
+			"--message", "Build uploaded",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	var target *net.DNSError
+	if !errors.As(runErr, &target) {
+		t.Fatalf("errors.As could not recover the DNS error from %v", runErr)
+	}
+	if !target.IsNotFound {
+		t.Fatal("errors.As recovered a DNS error without its classification")
+	}
+}

--- a/internal/cli/reviews/review_details.go
+++ b/internal/cli/reviews/review_details.go
@@ -29,6 +29,7 @@ func ReviewDetailsGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("details-get", flag.ExitOnError)
 
 	detailID := fs.String("id", "", "App Store review detail ID (required)")
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -61,7 +62,8 @@ Examples:
 				return fmt.Errorf("review details-get: failed to fetch: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			return shared.PrintOutput(presentableReviewDetail(resp, *includeSensitive), *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -71,6 +73,7 @@ func ReviewDetailsForVersionCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("details-for-version", flag.ExitOnError)
 
 	versionID := fs.String("version-id", "", "App Store version ID (required)")
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -128,7 +131,8 @@ Examples:
 				return fmt.Errorf("review details-for-version: failed to fetch: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			return shared.PrintOutput(presentableReviewDetail(resp, *includeSensitive), *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -146,6 +150,7 @@ func ReviewDetailsCreateCommand() *ffcli.Command {
 	demoAccountPassword := fs.String("demo-account-password", "", reviewDetailDemoAccountPasswordUsage)
 	demoAccountRequired := fs.Bool("demo-account-required", false, reviewDetailDemoAccountRequiredUsage)
 	notes := fs.String("notes", "", reviewDetailNotesUsage)
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -236,7 +241,8 @@ Examples:
 				return fmt.Errorf("review details-create: failed to create: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			return shared.PrintOutput(presentableReviewDetail(resp, *includeSensitive), *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -254,6 +260,7 @@ func ReviewDetailsUpdateCommand() *ffcli.Command {
 	demoAccountPassword := fs.String("demo-account-password", "", reviewDetailDemoAccountPasswordUsage)
 	demoAccountRequired := fs.Bool("demo-account-required", false, reviewDetailDemoAccountRequiredUsage)
 	notes := fs.String("notes", "", reviewDetailNotesUsage)
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -352,9 +359,20 @@ Examples:
 				return fmt.Errorf("review details-update: failed to update: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			return shared.PrintOutput(presentableReviewDetail(resp, *includeSensitive), *output.Output, *output.Pretty)
 		},
 	}
+}
+
+// presentableReviewDetail withholds the demo account password unless the caller
+// opted in for this invocation. The fetched response keeps its real value so
+// validation and request construction stay unaffected.
+func presentableReviewDetail(resp *asc.AppStoreReviewDetailResponse, includeSensitive bool) *asc.AppStoreReviewDetailResponse {
+	if includeSensitive {
+		return resp
+	}
+	return asc.RedactAppStoreReviewDetailResponse(resp)
 }
 
 func hasReviewDetailUpdates(visited map[string]bool) bool {

--- a/internal/cli/reviews/review_details_redaction_test.go
+++ b/internal/cli/reviews/review_details_redaction_test.go
@@ -1,0 +1,53 @@
+package reviews
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const reviewDetailRedactionSentinel = "asc-red-sentinel-reviews-unit-pw-b3f8e1"
+
+func TestPresentableReviewDetailRedactsUnlessRequested(t *testing.T) {
+	resp := &asc.AppStoreReviewDetailResponse{}
+	resp.Data.ID = "detail-1"
+	resp.Data.Attributes.DemoAccountPassword = reviewDetailRedactionSentinel
+
+	safe := presentableReviewDetail(resp, false)
+	if safe.Data.Attributes.DemoAccountPassword != asc.RedactedValuePlaceholder {
+		t.Fatalf("rendered password = %q, want placeholder", safe.Data.Attributes.DemoAccountPassword)
+	}
+	if resp.Data.Attributes.DemoAccountPassword != reviewDetailRedactionSentinel {
+		t.Fatalf("the fetched response was mutated to %q", resp.Data.Attributes.DemoAccountPassword)
+	}
+
+	if got := presentableReviewDetail(resp, true); got != resp {
+		t.Fatal("--include-sensitive must render the original response")
+	}
+}
+
+func TestReviewDetailCommandsExposeIncludeSensitiveFlag(t *testing.T) {
+	commands := map[string]*ffcli.Command{
+		"details-get":         ReviewDetailsGetCommand(),
+		"details-for-version": ReviewDetailsForVersionCommand(),
+		"details-create":      ReviewDetailsCreateCommand(),
+		"details-update":      ReviewDetailsUpdateCommand(),
+	}
+
+	for name, cmd := range commands {
+		flag := cmd.FlagSet.Lookup(shared.IncludeSensitiveFlagName)
+		if flag == nil {
+			t.Fatalf("%s is missing --%s", name, shared.IncludeSensitiveFlagName)
+		}
+		if flag.DefValue != "false" {
+			t.Fatalf("%s --%s defaults to %q, want false", name, shared.IncludeSensitiveFlagName, flag.DefValue)
+		}
+		if !strings.Contains(flag.Usage, "only to this invocation") {
+			t.Fatalf("%s --%s usage = %q, want per-invocation scope", name, shared.IncludeSensitiveFlagName, flag.Usage)
+		}
+	}
+}

--- a/internal/cli/shared/sensitive.go
+++ b/internal/cli/shared/sensitive.go
@@ -12,8 +12,9 @@ const (
 
 	// IncludeSensitiveFlagUsage documents the opt-in. It has no environment
 	// variable default: a secret must never become visible because of ambient
-	// configuration.
-	IncludeSensitiveFlagUsage = "Print secret values such as demo account passwords instead of \"" +
+	// configuration. The flag enters through the experimental tier like every
+	// new user-facing flag.
+	IncludeSensitiveFlagUsage = "[experimental] Print secret values such as demo account passwords instead of \"" +
 		"(redacted)\"; applies only to this invocation"
 
 	// IncludeSensitiveWarning is written to stderr whenever the opt-in is used.

--- a/internal/cli/shared/sensitive.go
+++ b/internal/cli/shared/sensitive.go
@@ -1,0 +1,36 @@
+package shared
+
+import (
+	"flag"
+	"fmt"
+	"io"
+)
+
+const (
+	// IncludeSensitiveFlagName is the per-invocation opt-in for printing secrets.
+	IncludeSensitiveFlagName = "include-sensitive"
+
+	// IncludeSensitiveFlagUsage documents the opt-in. It has no environment
+	// variable default: a secret must never become visible because of ambient
+	// configuration.
+	IncludeSensitiveFlagUsage = "Print secret values such as demo account passwords instead of \"" +
+		"(redacted)\"; applies only to this invocation"
+
+	// IncludeSensitiveWarning is written to stderr whenever the opt-in is used.
+	IncludeSensitiveWarning = "Warning: --include-sensitive prints secrets in plain text; " +
+		"they can persist in shell history, CI logs, and terminal scrollback."
+)
+
+// BindIncludeSensitiveFlag registers --include-sensitive on the flag set.
+func BindIncludeSensitiveFlag(fs *flag.FlagSet) *bool {
+	return fs.Bool(IncludeSensitiveFlagName, false, IncludeSensitiveFlagUsage)
+}
+
+// WarnIncludeSensitive writes the plaintext-secret warning when the opt-in is
+// enabled. It is a no-op otherwise so default output stays quiet.
+func WarnIncludeSensitive(w io.Writer, includeSensitive bool) {
+	if !includeSensitive || w == nil {
+		return
+	}
+	fmt.Fprintln(w, IncludeSensitiveWarning)
+}

--- a/internal/cli/shared/sensitive_test.go
+++ b/internal/cli/shared/sensitive_test.go
@@ -38,6 +38,15 @@ func TestBindIncludeSensitiveFlagDefaultsFalseWithoutEnvironmentOverride(t *test
 	}
 }
 
+func TestIncludeSensitiveFlagIsMarkedExperimental(t *testing.T) {
+	// New user-facing flags enter through the experimental tier; the marker
+	// keeps the freedom to adjust the opt-in's shape before it becomes a
+	// stable compatibility promise.
+	if !strings.HasPrefix(IncludeSensitiveFlagUsage, "[experimental] ") {
+		t.Fatalf("usage = %q, want the [experimental] prefix", IncludeSensitiveFlagUsage)
+	}
+}
+
 func TestWarnIncludeSensitiveOnlyWarnsWhenEnabled(t *testing.T) {
 	var quiet bytes.Buffer
 	WarnIncludeSensitive(&quiet, false)

--- a/internal/cli/shared/sensitive_test.go
+++ b/internal/cli/shared/sensitive_test.go
@@ -1,0 +1,57 @@
+package shared
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBindIncludeSensitiveFlagDefaultsFalseWithoutEnvironmentOverride(t *testing.T) {
+	// A secret must never become visible because of ambient configuration, so
+	// plausible environment spellings are set and must all be ignored.
+	for _, key := range []string{
+		"ASC_INCLUDE_SENSITIVE",
+		"ASC_SHOW_SENSITIVE",
+		"INCLUDE_SENSITIVE",
+	} {
+		t.Setenv(key, "1")
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	includeSensitive := BindIncludeSensitiveFlag(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if *includeSensitive {
+		t.Fatal("--include-sensitive defaulted to true")
+	}
+
+	if err := fs.Parse([]string{"--" + IncludeSensitiveFlagName}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if !*includeSensitive {
+		t.Fatal("--include-sensitive did not enable when passed explicitly")
+	}
+}
+
+func TestWarnIncludeSensitiveOnlyWarnsWhenEnabled(t *testing.T) {
+	var quiet bytes.Buffer
+	WarnIncludeSensitive(&quiet, false)
+	if quiet.Len() != 0 {
+		t.Fatalf("default invocation wrote %q, want nothing", quiet.String())
+	}
+
+	var loud bytes.Buffer
+	WarnIncludeSensitive(&loud, true)
+	warning := loud.String()
+	if !strings.Contains(warning, "--include-sensitive prints secrets in plain text") {
+		t.Fatalf("warning = %q, want plaintext-secret wording", warning)
+	}
+	if !strings.Contains(warning, "CI logs") {
+		t.Fatalf("warning = %q, want log-exposure guidance", warning)
+	}
+}

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -51,6 +51,7 @@ func TestFlightReviewGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("view", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -97,6 +98,10 @@ Examples:
 				return fmt.Errorf("testflight review view: failed to fetch: %w", err)
 			}
 
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			if !*includeSensitive {
+				details = asc.RedactBetaAppReviewDetailsResponse(details)
+			}
 			return shared.PrintOutput(details, *output.Output, *output.Pretty)
 		},
 	}
@@ -115,6 +120,7 @@ func TestFlightReviewUpdateCommand() *ffcli.Command {
 	demoAccountPassword := fs.String("demo-account-password", "", "Demo account password")
 	demoAccountRequired := fs.Bool("demo-account-required", false, "Demo account required")
 	notes := fs.String("notes", "", "Review notes")
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -200,6 +206,10 @@ Examples:
 				return fmt.Errorf("testflight review update: failed to update: %w", err)
 			}
 
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			if !*includeSensitive {
+				detail = asc.RedactBetaAppReviewDetailResponse(detail)
+			}
 			return shared.PrintOutput(detail, *output.Output, *output.Pretty)
 		},
 	}

--- a/internal/urlsanitize/error.go
+++ b/internal/urlsanitize/error.go
@@ -30,12 +30,9 @@ func RedactURLHostForError(rawURL string) string {
 	if !ok {
 		return RedactedPlaceholder
 	}
+	// parseForError guarantees a hierarchical URL with a host.
 	parsed.Path = ""
 	parsed.RawPath = ""
-	parsed.Opaque = ""
-	if parsed.Host == "" {
-		return RedactedPlaceholder
-	}
 	return parsed.String()
 }
 
@@ -47,10 +44,11 @@ func parseForError(rawURL string) (*url.URL, bool) {
 	if err != nil {
 		return nil, false
 	}
-	if parsed.Opaque != "" {
+	if parsed.Opaque != "" || parsed.Host == "" {
 		// A URL without an authority keeps everything after the scheme in
-		// Opaque, which URL.String renders verbatim; nothing in it can be
-		// proven safe.
+		// Opaque, which URL.String renders verbatim, and a hostless URL is
+		// not the absolute request URL these boundaries expect; nothing in
+		// either can be proven safe.
 		return nil, false
 	}
 	parsed.User = nil

--- a/internal/urlsanitize/error.go
+++ b/internal/urlsanitize/error.go
@@ -1,0 +1,99 @@
+package urlsanitize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// RedactedPlaceholder replaces a URL that cannot be reduced to a safe form.
+const RedactedPlaceholder = "[REDACTED]"
+
+// RedactURLForError reduces a URL to scheme, host, and path. Userinfo, query
+// values, and the fragment are dropped because presigned uploads carry their
+// capability there. The path is kept because it identifies the operation.
+func RedactURLForError(rawURL string) string {
+	parsed, ok := parseForError(rawURL)
+	if !ok {
+		return RedactedPlaceholder
+	}
+	return parsed.String()
+}
+
+// RedactURLHostForError reduces a URL to scheme and host only. Use it when the
+// path is itself a credential, as with Slack incoming webhooks.
+func RedactURLHostForError(rawURL string) string {
+	parsed, ok := parseForError(rawURL)
+	if !ok {
+		return RedactedPlaceholder
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	parsed.Opaque = ""
+	if parsed.Host == "" {
+		return RedactedPlaceholder
+	}
+	return parsed.String()
+}
+
+func parseForError(rawURL string) (*url.URL, bool) {
+	if strings.TrimSpace(rawURL) == "" {
+		return nil, false
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, false
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	return parsed, true
+}
+
+// ClassifyTransportFailure returns a short, credential-free description of a
+// transport failure so sanitized errors keep their diagnostic value.
+func ClassifyTransportFailure(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.DeadlineExceeded), os.IsTimeout(err):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	default:
+		return ""
+	}
+}
+
+// TransportError describes a failed request without repeating the request URL's
+// credentials. Unwrap keeps errors.Is and errors.As usable on the cause.
+type TransportError struct {
+	Message string
+	Err     error
+}
+
+// Error returns the sanitized message. The wrapped cause is deliberately not
+// interpolated: net/http renders the full request URL in its error text.
+func (e *TransportError) Error() string {
+	return e.Message
+}
+
+// Unwrap exposes the underlying transport error for inspection.
+func (e *TransportError) Unwrap() error {
+	return e.Err
+}
+
+// NewTransportError builds a sanitized transport error for an operation against
+// safeURL, which must already have been reduced by one of the redact helpers.
+func NewTransportError(operation, safeURL string, err error) *TransportError {
+	message := fmt.Sprintf("%s failed for %s", operation, safeURL)
+	if class := ClassifyTransportFailure(err); class != "" {
+		message += " (" + class + ")"
+	}
+	return &TransportError{Message: message, Err: err}
+}

--- a/internal/urlsanitize/error.go
+++ b/internal/urlsanitize/error.go
@@ -47,6 +47,12 @@ func parseForError(rawURL string) (*url.URL, bool) {
 	if err != nil {
 		return nil, false
 	}
+	if parsed.Opaque != "" {
+		// A URL without an authority keeps everything after the scheme in
+		// Opaque, which URL.String renders verbatim; nothing in it can be
+		// proven safe.
+		return nil, false
+	}
 	parsed.User = nil
 	parsed.RawQuery = ""
 	parsed.ForceQuery = false

--- a/internal/urlsanitize/error_test.go
+++ b/internal/urlsanitize/error_test.go
@@ -61,6 +61,25 @@ func TestRedactHelpersFallBackToPlaceholder(t *testing.T) {
 	}
 }
 
+func TestRedactHelpersRejectOpaqueURLs(t *testing.T) {
+	// url.Parse keeps everything after the scheme in Opaque when the URL has
+	// no authority, and URL.String renders Opaque verbatim, so an opaque
+	// payload must never reach the sanitized message.
+	tests := []string{
+		"https:" + pathSentinel,
+		"mailto:" + userinfoSentinel + "@example.com",
+	}
+
+	for _, raw := range tests {
+		if got := RedactURLForError(raw); got != RedactedPlaceholder {
+			t.Fatalf("RedactURLForError(%q) = %q, want %q", raw, got, RedactedPlaceholder)
+		}
+		if got := RedactURLHostForError(raw); got != RedactedPlaceholder {
+			t.Fatalf("RedactURLHostForError(%q) = %q, want %q", raw, got, RedactedPlaceholder)
+		}
+	}
+}
+
 func TestRedactURLHostForErrorRejectsHostlessURLs(t *testing.T) {
 	if got := RedactURLHostForError("/services/T00000000/" + pathSentinel); got != RedactedPlaceholder {
 		t.Fatalf("RedactURLHostForError() = %q, want %q", got, RedactedPlaceholder)

--- a/internal/urlsanitize/error_test.go
+++ b/internal/urlsanitize/error_test.go
@@ -1,0 +1,98 @@
+package urlsanitize
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const (
+	signatureSentinel = "asc-red-sentinel-urlsanitize-sig-1c7f04"
+	pathSentinel      = "asc-red-sentinel-urlsanitize-path-90ab6d"
+	userinfoSentinel  = "asc-red-sentinel-urlsanitize-user-42de81"
+)
+
+func TestRedactURLForErrorKeepsPathAndDropsCredentials(t *testing.T) {
+	raw := "https://" + userinfoSentinel + ":pw@upload.example.com/v1/assets/chunk-1" +
+		"?X-Amz-Signature=" + signatureSentinel + "#" + signatureSentinel
+
+	got := RedactURLForError(raw)
+
+	if got != "https://upload.example.com/v1/assets/chunk-1" {
+		t.Fatalf("RedactURLForError() = %q", got)
+	}
+	for _, sentinel := range []string{signatureSentinel, userinfoSentinel} {
+		if strings.Contains(got, sentinel) {
+			t.Fatalf("RedactURLForError() leaked %q: %q", sentinel, got)
+		}
+	}
+}
+
+func TestRedactURLHostForErrorDropsPath(t *testing.T) {
+	raw := "https://hooks.slack.com/services/T00000000/B00000000/" + pathSentinel
+
+	got := RedactURLHostForError(raw)
+
+	if got != "https://hooks.slack.com" {
+		t.Fatalf("RedactURLHostForError() = %q", got)
+	}
+}
+
+func TestRedactHelpersFallBackToPlaceholder(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "whitespace", raw: "   "},
+		{name: "unparseable", raw: "https://exa mple.com/\x7f"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RedactURLForError(test.raw); got != RedactedPlaceholder {
+				t.Fatalf("RedactURLForError(%q) = %q, want %q", test.raw, got, RedactedPlaceholder)
+			}
+			if got := RedactURLHostForError(test.raw); got != RedactedPlaceholder {
+				t.Fatalf("RedactURLHostForError(%q) = %q, want %q", test.raw, got, RedactedPlaceholder)
+			}
+		})
+	}
+}
+
+func TestRedactURLHostForErrorRejectsHostlessURLs(t *testing.T) {
+	if got := RedactURLHostForError("/services/T00000000/" + pathSentinel); got != RedactedPlaceholder {
+		t.Fatalf("RedactURLHostForError() = %q, want %q", got, RedactedPlaceholder)
+	}
+}
+
+func TestNewTransportErrorClassifiesAndStaysInspectable(t *testing.T) {
+	cause := errors.New("connect: connection refused")
+	err := NewTransportError("upload request", "https://upload.example.com/chunk-1", cause)
+
+	if err.Error() != "upload request failed for https://upload.example.com/chunk-1" {
+		t.Fatalf("Error() = %q", err.Error())
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("errors.Is lost the cause: %v", err)
+	}
+
+	timeout := NewTransportError("upload request", "https://upload.example.com/chunk-1", context.DeadlineExceeded)
+	if !strings.Contains(timeout.Error(), "(timeout)") {
+		t.Fatalf("timeout classification missing from %q", timeout.Error())
+	}
+	canceled := NewTransportError("upload request", "https://upload.example.com/chunk-1", context.Canceled)
+	if !strings.Contains(canceled.Error(), "(canceled)") {
+		t.Fatalf("cancellation classification missing from %q", canceled.Error())
+	}
+}
+
+func TestClassifyTransportFailureIgnoresUnknownCauses(t *testing.T) {
+	if got := ClassifyTransportFailure(nil); got != "" {
+		t.Fatalf("ClassifyTransportFailure(nil) = %q, want empty", got)
+	}
+	if got := ClassifyTransportFailure(errors.New("tls: handshake failure")); got != "" {
+		t.Fatalf("ClassifyTransportFailure(tls) = %q, want empty", got)
+	}
+}

--- a/internal/urlsanitize/error_test.go
+++ b/internal/urlsanitize/error_test.go
@@ -80,7 +80,12 @@ func TestRedactHelpersRejectOpaqueURLs(t *testing.T) {
 	}
 }
 
-func TestRedactURLHostForErrorRejectsHostlessURLs(t *testing.T) {
+func TestRedactHelpersRejectHostlessURLs(t *testing.T) {
+	// The boundaries only ever see absolute request URLs; anything without a
+	// host is malformed and nothing in it can be trusted, including the path.
+	if got := RedactURLForError("/services/T00000000/" + pathSentinel); got != RedactedPlaceholder {
+		t.Fatalf("RedactURLForError() = %q, want %q", got, RedactedPlaceholder)
+	}
 	if got := RedactURLHostForError("/services/T00000000/" + pathSentinel); got != RedactedPlaceholder {
 		t.Fatalf("RedactURLHostForError() = %q, want %q", got, RedactedPlaceholder)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the six credential-boundary failures: secrets must not cross stdout, stderr, or child-process boundaries unless the caller explicitly opts in.

## What changed

**Review credentials are withheld by default.** `internal/asc/review_redaction.go` builds a presentation-safe *copy* of App Store and TestFlight review data, replacing a non-empty `demoAccountPassword` with `(redacted)`. The fetched response keeps the real value, so request construction, `reviewInformationMatches`, and `validateReviewDetailUpdateDemoCredentials` are unaffected. `json:"-"` was deliberately not used. Covered surfaces: `review details-get`, `review details-for-version`, `review details-create`, `review details-update`, `testflight review view`, `testflight review edit`, and `migrate import` including `--dry-run` (JSON, pretty JSON, table, Markdown).

**`--include-sensitive` opt-in.** `shared.BindIncludeSensitiveFlag` defaults to `false`, has no environment-variable equivalent, applies only to the current invocation, and writes a plaintext-secret warning to stderr.

**Transport errors no longer carry capability-bearing URLs.** `internal/urlsanitize` gains `RedactURLForError` (drops userinfo, query, fragment; keeps path), `RedactURLHostForError` (scheme and host only — the Slack webhook path *is* the secret), `ClassifyTransportFailure`, and a `TransportError` type whose message never interpolates the cause because `net/http` renders the full request URL in its own error text. `assets_upload.go` now uses the same sanitizer as `upload.go`, and the obsolete local `sanitizedUploadError` type is gone.

**Helper environments are allowlisted, not denylisted.** The detached skills-check worker and its PATH-resolved `skills`/`npx` children get a platform-aware allowlist of executable-discovery and runtime variables (`PATH`, `HOME`, locale, temp, XDG on Unix; `SystemRoot`, `PATHEXT`, `USERPROFILE`, `APPDATA`, … on Windows, matched case-insensitively). Unknown variables are dropped rather than judged. Worker coordination values stay inside the worker and are not forwarded to helpers.

## RED-GREEN evidence

Every leak was proven first with unique sentinels. Selected RED output before the fix:

```
--- FAIL: TestMigrateImportDryRunRedactsDemoAccountPasswordInEveryFormat/table
    stdout leaked the demo account password sentinel:
    "│ Demo Account Password │ asc-red-sentinel-migrate-demo-pw-71ce40 │"
--- FAIL: TestReviewDetailsGetRedactsDemoAccountPasswordInEveryFormat/json
    stdout leaked the demo account password sentinel:
    "...\"demoAccountPassword\":\"asc-red-sentinel-appstore-demo-pw-9f31c7\"..."
--- FAIL: TestUploadAssetFromFileSanitizesTransportErrorURL
    upload error leaked presigned credentials: "upload operation 0 failed: Put
    \"https://asc-red-sentinel-presigned-userinfo-5a9b36:***@upload.example.com/v1/assets/chunk-1
    ?X-Amz-Signature=asc-red-sentinel-presigned-sig-8e15fa&token=asc-red-sentinel-presigned-token-c40d27
    #asc-red-sentinel-presigned-token-c40d27\": dial tcp: connection refused"
--- FAIL: TestNotifySlackTransportFailuresNeverExposeWebhookSecret/dns
    error leaked the webhook secret: "notify slack: failed to send: Post
    \"http://127.0.0.1:1/services/T00000000/B00000000/asc-red-sentinel-slack-webhook-3fd914\":
    lookup hooks.slack.com: no such host"
--- FAIL: TestSkillsCheckWorkerEnvironmentExcludesCredentials
    detached worker received credential NPM_TOKEN
--- FAIL: TestDefaultRunSkillsCheckCommandGivesNpxFallbackOnlyAllowlistedEnvironment
    npx fallback received credential SOME_UNRECOGNIZED_INTERNAL_SETTING
```

All six now pass, alongside positive assertions that the real password still reaches create/update request payloads, that `--include-sensitive` returns the real value, that `errors.Is`/`errors.As` still recover the transport cause (including `*net.DNSError` with its `IsNotFound` classification), and that timeouts remain visible as `(timeout)`.

## Leak-negative evidence from the built binary

`asc migrate import --dry-run` with `demo_password.txt` containing `SENTINEL-DEMO-PW-abc123`:

```
│ Demo Account Password │ (redacted)           │

{"dryRun":true,...,"demoAccountPassword":"(redacted)","demoAccountRequired":true},...}

# with --include-sensitive
Warning: --include-sensitive prints secrets in plain text; they can persist in shell history, CI logs, and terminal scrollback.
{"dryRun":true,...,"demoAccountPassword":"SENTINEL-DEMO-PW-abc123",...}
```

`asc notify slack` against an unreachable webhook whose path holds the secret:

```
Error: notify slack: failed to send: webhook POST failed for http://127.0.0.1:1
```

## Acceptance criteria

- [x] Default JSON, pretty JSON, table, and Markdown never emit an actual `demoAccountPassword`.
- [x] Migrate import and `--dry-run` never emit the real password without `--include-sensitive`.
- [x] `--include-sensitive` affects only the current invocation and returns the real value when requested.
- [x] Review create/update requests still send explicitly supplied passwords; comparison uses the real in-memory value.
- [x] Game Center/App Clip failures cannot expose presigned query credentials.
- [x] Slack DNS, TLS, redirect, proxy, timeout, and connection failures cannot expose the webhook secret.
- [x] `errors.Is` and `errors.As` remain available.
- [x] Worker, direct `skills`, and fallback `npx` processes receive only allowlisted variables.
- [x] Scheduling, cache/offline fallback, detachment, and Windows/Unix behavior remain green.
- [x] Secure-default migration documented; `docs/COMMANDS.md` regenerated (no diff — it lists commands, not flags).

## Validation

```
make format                      # clean
make check-docs                  # clean
make lint                        # 0 issues
ASC_BYPASS_KEYCHAIN=1 make test  # exit 0, 0 failures
```

No live Apple, Slack, GitHub, or signing credentials were used.

## Notes for review

`cmd/exit_codes_test.go` previously passed `SKILLS_MARKER`/`SKILLS_SLEEP_PID` through the environment to its fake `skills` helper. Those paths are now baked into the generated script, because the allowlist correctly refuses to forward arbitrary variables — the assertions themselves are unchanged.

`internal/validation`'s `ReviewDetails`/`BetaReviewDetails` snapshots also hold a `DemoAccountPassword`, but they carry no JSON tags and the validate report renders only check results, so they are not an output boundary and were left alone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b369a4ce-a2af-451e-b1ae-92b6d0ffb87c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b369a4ce-a2af-451e-b1ae-92b6d0ffb87c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787897072&installation_model_id=10418&pr_number=1827&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1827&signature=0876137dae25cc4d06bc509f5a26820140d128ef5d2dbcdad203a4daeed69c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an experimental `--include-sensitive` opt-in (disabled by default) for review and migration commands to show demo-account secrets for the current invocation, with a warning when enabled.
- **Bug Fixes**
  - Demo account passwords and review-related sensitive values are now consistently redacted by default across review and migration output formats.
  - Upload and Slack notification errors no longer reveal presigned URL parameters or webhook secrets, while keeping safe, inspectable context (e.g., timeout/cancellation labels).
  - Improved “skills check” environment handling to prevent credential leakage.
- **Documentation**
  - Added guidance on how sensitive values and credential-bearing URLs are redacted in CLI output and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->