### PR TITLE
Security: harden workflow examples, interpreted output, and install-skills dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ Install them globally so they are available across projects:
 asc install-skills
 ```
 
-Direct install:
+`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit first and install from the local path:
 
 ```bash
-npx skills add rorkai/app-store-connect-cli-skills --global --agent codex
+git init asc-skills
+git -C asc-skills remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git
+git -C asc-skills fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115
+git -C asc-skills checkout --detach e30039abddbe388179324d0f9cdccb66c3843115
+npx --yes skills@1.5.20 add "$PWD/asc-skills" --global --agent codex --yes
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ Install them globally so they are available across projects:
 asc install-skills
 ```
 
-`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit first and install from the local path:
+`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit into a fresh temporary directory and install from the local path (each step stops the chain on failure):
 
 ```bash
-git init asc-skills
-git -C asc-skills remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git
-git -C asc-skills fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115
-git -C asc-skills checkout --detach e30039abddbe388179324d0f9cdccb66c3843115
-npx --yes skills@1.5.20 add "$PWD/asc-skills" --global --agent codex --yes
+asc_skills="$(mktemp -d)" &&
+  git init --quiet "$asc_skills" &&
+  git -C "$asc_skills" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
+  git -C "$asc_skills" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
+  git -C "$asc_skills" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
+  npx --yes skills@1.5.20 add "$asc_skills" --global --agent codex --yes &&
+  rm -rf "$asc_skills"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Install them globally so they are available across projects:
 asc install-skills
 ```
 
-`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and `npx` runs from the temporary directory so a local `node_modules/skills` in the current project cannot shadow the pinned installer:
+`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and the temporary directory lives under `/tmp` (outside any npm project, regardless of `TMPDIR`) with `npx` running from it, so a project `node_modules`, `package.json`, or `.npmrc` cannot shadow or redirect the pinned installer:
 
 ```bash
-asc_skills="$(mktemp -d)" &&
+asc_skills="$(mktemp -d /tmp/asc-skills.XXXXXX)" &&
   git init --quiet "$asc_skills/src" &&
   git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
   git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Install them globally so they are available across projects:
 asc install-skills
 ```
 
-`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit into a fresh temporary directory and install from the local path (each step stops the chain on failure):
+`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and `npx` runs from the temporary directory so a local `node_modules/skills` in the current project cannot shadow the pinned installer:
 
 ```bash
 asc_skills="$(mktemp -d)" &&
-  git init --quiet "$asc_skills" &&
-  git -C "$asc_skills" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
-  git -C "$asc_skills" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
-  git -C "$asc_skills" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
-  npx --yes skills@1.5.20 add "$asc_skills" --global --agent codex --yes &&
+  git init --quiet "$asc_skills/src" &&
+  git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
+  git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
+  git -C "$asc_skills/src" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
+  (cd "$asc_skills" && npx --yes skills@1.5.20 add "$asc_skills/src" --global --agent codex --yes) &&
   rm -rf "$asc_skills"
 ```
 

--- a/commands/validate.mdx
+++ b/commands/validate.mdx
@@ -81,15 +81,20 @@ fi
 ```yaml  theme={null}
 # GitHub Actions
 - name: Validate version
+  env:
+    APP_ID: ${{ secrets.APP_ID }}
+    TAG_NAME: ${{ github.ref_name }}
   run: |
-    asc validate --app ${{ secrets.APP_ID }} --version ${{ github.ref_name }}
-    if [ $? -ne 0 ]; then
+    if ! asc validate --app "$APP_ID" --version "$TAG_NAME"; then
       echo "Validation failed"
       exit 1
     fi
 
 - name: Publish to App Store
-  run: asc publish appstore --app ${{ secrets.APP_ID }} --ipa ./build/MyApp.ipa --version ${{ github.ref_name }} --submit --confirm
+  env:
+    APP_ID: ${{ secrets.APP_ID }}
+    TAG_NAME: ${{ github.ref_name }}
+  run: asc publish appstore --app "$APP_ID" --ipa ./build/MyApp.ipa --version "$TAG_NAME" --submit --confirm
 ```
 
 ## Exit codes

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -380,7 +380,9 @@ jobs:
         run: xcodebuild -scheme MyApp -archivePath build/MyApp.xcarchive archive
       
       - name: Run release workflow
-        run: asc workflow run release VERSION:${{ github.ref_name }}
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: asc workflow run release "VERSION:$TAG_NAME"
 ```
 
 ### GitLab CI

--- a/docs_github_actions_examples_test.go
+++ b/docs_github_actions_examples_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// githubActionsDocFiles lists documentation pages whose GitHub Actions examples
+// are copied into workflows that already have App Store Connect credentials
+// configured. A ref-controlled expression inside `run:` becomes shell source in
+// those workflows, so the examples must keep refs in `env:` instead.
+var githubActionsDocFiles = []string{
+	filepath.Join("configuration", "workflows.mdx"),
+	filepath.Join("commands", "validate.mdx"),
+}
+
+// refNameInjectionPayload is a valid Git ref name (no space, `~`, `^`, `:`, `?`,
+// `*`, `[`, or `\`) that appends a redirect if it ever reaches shell source.
+const refNameInjectionPayload = "v1.0;>injected"
+
+var actionsExpressionPattern = regexp.MustCompile(`\$\{\{\s*([^{}]+?)\s*\}\}`)
+
+type docActionStep struct {
+	File string
+	Name string
+	Env  map[string]string
+	Run  string
+}
+
+func TestGitHubActionsDocExamplesKeepRefNameOutOfShellSource(t *testing.T) {
+	for _, file := range githubActionsDocFiles {
+		steps := gitHubActionsDocSteps(t, file)
+		if len(steps) == 0 {
+			t.Fatalf("%s: expected at least one GitHub Actions run step", file)
+		}
+
+		refInEnv := false
+		for _, step := range steps {
+			if match := actionsExpressionPattern.FindString(step.Run); match != "" {
+				t.Errorf("%s: step %q interpolates %s inside run source; pass it through env instead", file, step.Name, match)
+			}
+			for name, value := range step.Env {
+				if strings.Contains(value, "github.ref_name") {
+					refInEnv = true
+					if !referencesQuotedShellVariable(step.Run, name) {
+						t.Errorf("%s: step %q sets env %s but does not reference it as a quoted shell variable", file, step.Name, name)
+					}
+				}
+			}
+		}
+		if !refInEnv {
+			t.Errorf("%s: expected a step-level env entry carrying github.ref_name", file)
+		}
+	}
+}
+
+func TestGitHubActionsDocExamplesTreatRefNameAsInertArgument(t *testing.T) {
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is not installed; shell-safety of the documented examples cannot be executed here: %v", err)
+	}
+
+	for _, file := range githubActionsDocFiles {
+		for _, step := range gitHubActionsDocSteps(t, file) {
+			script, env := renderDocStepScript(t, file, step)
+			if !strings.Contains(script, refNameInjectionPayload) && !stepEnvContains(env, refNameInjectionPayload) {
+				continue
+			}
+
+			t.Run(file+"/"+step.Name, func(t *testing.T) {
+				workDir := t.TempDir()
+				argsFile := filepath.Join(workDir, "asc-args.txt")
+				stubDir := writeASCStub(t, argsFile)
+
+				cmd := exec.Command(bashPath, "-c", script)
+				cmd.Dir = workDir
+				cmd.Env = append(os.Environ(), env...)
+				cmd.Env = append(cmd.Env, "PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("run documented step: %v\n%s", err, output)
+				}
+
+				if entries, err := os.ReadDir(workDir); err == nil {
+					for _, entry := range entries {
+						if entry.Name() == "injected" {
+							t.Fatalf("ref name executed shell syntax: %q was created", entry.Name())
+						}
+					}
+				}
+
+				args := recordedASCArgs(t, argsFile)
+				if len(args) == 0 {
+					t.Fatalf("expected the documented step to invoke asc")
+				}
+				sawFullRef := false
+				for _, arg := range args {
+					if !strings.Contains(arg, "v1.0") {
+						continue
+					}
+					if !strings.Contains(arg, refNameInjectionPayload) {
+						t.Fatalf("asc argument %q lost part of the ref; the ref must arrive as one inert argument containing %q", arg, refNameInjectionPayload)
+					}
+					sawFullRef = true
+				}
+				if !sawFullRef {
+					t.Fatalf("expected asc to receive the ref name; got args %q", args)
+				}
+			})
+		}
+	}
+}
+
+// referencesQuotedShellVariable reports whether script expands name at least
+// once and never expands it outside double quotes, so word splitting and glob
+// expansion cannot act on the value.
+func referencesQuotedShellVariable(script string, name string) bool {
+	found := false
+	inSingle := false
+	inDouble := false
+
+	for i := 0; i < len(script); i++ {
+		switch c := script[i]; {
+		case c == '\\' && !inSingle:
+			i++
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+		case c == '\n':
+			inSingle = false
+			inDouble = false
+		case c == '$' && !inSingle:
+			rest := script[i+1:]
+			braced := strings.HasPrefix(rest, "{"+name+"}")
+			bare := strings.HasPrefix(rest, name) && !isShellNameByte(byteAt(rest, len(name)))
+			if !braced && !bare {
+				continue
+			}
+			if !inDouble {
+				return false
+			}
+			found = true
+		}
+	}
+
+	return found
+}
+
+func isShellNameByte(c byte) bool {
+	return c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func byteAt(value string, index int) byte {
+	if index >= len(value) {
+		return 0
+	}
+	return value[index]
+}
+
+func gitHubActionsDocSteps(t *testing.T, file string) []docActionStep {
+	t.Helper()
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+
+	var steps []docActionStep
+	for _, block := range fencedBlocks(string(data), "yaml") {
+		if !strings.Contains(block, "run:") {
+			continue
+		}
+		var root yaml.Node
+		if err := yaml.Unmarshal([]byte(block), &root); err != nil {
+			t.Fatalf("%s: parse yaml example: %v\n%s", file, err, block)
+		}
+		collectDocActionSteps(file, &root, &steps)
+	}
+	return steps
+}
+
+func fencedBlocks(content string, language string) []string {
+	var blocks []string
+	var current []string
+	inBlock := false
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "```") {
+			if inBlock {
+				blocks = append(blocks, strings.Join(current, "\n"))
+				current = nil
+				inBlock = false
+				continue
+			}
+			inBlock = strings.HasPrefix(strings.TrimSpace(strings.TrimPrefix(line, "```")), language)
+			continue
+		}
+		if inBlock {
+			current = append(current, line)
+		}
+	}
+	return blocks
+}
+
+func collectDocActionSteps(file string, node *yaml.Node, steps *[]docActionStep) {
+	if node == nil {
+		return
+	}
+	if node.Kind == yaml.MappingNode {
+		step := docActionStep{File: file}
+		hasRun := false
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			value := node.Content[i+1]
+			switch key {
+			case "name":
+				step.Name = value.Value
+			case "run":
+				step.Run = value.Value
+				hasRun = true
+			case "env":
+				if value.Kind != yaml.MappingNode {
+					continue
+				}
+				step.Env = make(map[string]string, len(value.Content)/2)
+				for j := 0; j+1 < len(value.Content); j += 2 {
+					step.Env[value.Content[j].Value] = value.Content[j+1].Value
+				}
+			}
+		}
+		if hasRun {
+			*steps = append(*steps, step)
+		}
+	}
+	for _, child := range node.Content {
+		collectDocActionSteps(file, child, steps)
+	}
+}
+
+// renderDocStepScript expands GitHub Actions expressions the way the runner
+// does: expression results are substituted into the workflow text before the
+// shell ever sees it.
+func renderDocStepScript(t *testing.T, file string, step docActionStep) (string, []string) {
+	t.Helper()
+
+	env := make([]string, 0, len(step.Env))
+	for name, value := range step.Env {
+		env = append(env, name+"="+expandActionsExpressions(t, file, step, value))
+	}
+	return expandActionsExpressions(t, file, step, step.Run), env
+}
+
+func expandActionsExpressions(t *testing.T, file string, step docActionStep, value string) string {
+	t.Helper()
+
+	return actionsExpressionPattern.ReplaceAllStringFunc(value, func(match string) string {
+		expression := strings.TrimSpace(actionsExpressionPattern.FindStringSubmatch(match)[1])
+		switch {
+		case expression == "github.ref_name":
+			return refNameInjectionPayload
+		case strings.HasPrefix(expression, "secrets."):
+			return "123456789"
+		default:
+			t.Fatalf("%s: step %q uses unsupported expression %q", file, step.Name, expression)
+			return ""
+		}
+	})
+}
+
+func stepEnvContains(env []string, value string) bool {
+	for _, entry := range env {
+		if strings.Contains(entry, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeASCStub(t *testing.T, argsFile string) string {
+	t.Helper()
+
+	stubDir := t.TempDir()
+	stub := "#!/bin/sh\nfor arg in \"$@\"; do printf '%s\\n' \"$arg\" >> " + argsFile + "; done\n"
+	stubPath := filepath.Join(stubDir, "asc")
+	if err := os.WriteFile(stubPath, []byte(stub), 0o700); err != nil {
+		t.Fatalf("write asc stub: %v", err)
+	}
+	return stubDir
+}
+
+func recordedASCArgs(t *testing.T, argsFile string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read recorded asc args: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	return lines
+}

--- a/guides/testflight.mdx
+++ b/guides/testflight.mdx
@@ -97,6 +97,10 @@ TestFlight allows you to distribute pre-release builds to internal and external 
       --output "./testers.csv"
     ```
 
+    <Note>
+      Export prefixes a cell with a single quote when its first character would start a spreadsheet formula (`=`, `+`, `-`, `@`), so opening the file in Excel, Numbers, or Google Sheets cannot execute tester or group values. `asc testflight testers import` removes that prefix again.
+    </Note>
+
     Import testers from CSV (with dry-run first):
 
     ```bash  theme={null}

--- a/index.mdx
+++ b/index.mdx
@@ -76,10 +76,14 @@
         asc install-skills
         ```
 
-        Direct install:
+        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand:
 
         ```bash  theme={null}
-        npx skills add rorkai/app-store-connect-cli-skills --global --agent codex
+        git init asc-skills
+        git -C asc-skills remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git
+        git -C asc-skills fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115
+        git -C asc-skills checkout --detach e30039abddbe388179324d0f9cdccb66c3843115
+        npx --yes skills@1.5.20 add "$PWD/asc-skills" --global --agent codex --yes
         ```
       </Step>
 

--- a/index.mdx
+++ b/index.mdx
@@ -76,14 +76,16 @@
         asc install-skills
         ```
 
-        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand:
+        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand, using a fresh temporary directory and stopping on the first failed step:
 
         ```bash  theme={null}
-        git init asc-skills
-        git -C asc-skills remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git
-        git -C asc-skills fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115
-        git -C asc-skills checkout --detach e30039abddbe388179324d0f9cdccb66c3843115
-        npx --yes skills@1.5.20 add "$PWD/asc-skills" --global --agent codex --yes
+        asc_skills="$(mktemp -d)" &&
+          git init --quiet "$asc_skills" &&
+          git -C "$asc_skills" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
+          git -C "$asc_skills" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
+          git -C "$asc_skills" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
+          npx --yes skills@1.5.20 add "$asc_skills" --global --agent codex --yes &&
+          rm -rf "$asc_skills"
         ```
       </Step>
 

--- a/index.mdx
+++ b/index.mdx
@@ -76,15 +76,15 @@
         asc install-skills
         ```
 
-        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand, using a fresh temporary directory and stopping on the first failed step:
+        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand, using a fresh temporary directory (which `npx` also runs from, so a local `node_modules/skills` cannot shadow the pinned installer) and stopping on the first failed step:
 
         ```bash  theme={null}
         asc_skills="$(mktemp -d)" &&
-          git init --quiet "$asc_skills" &&
-          git -C "$asc_skills" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
-          git -C "$asc_skills" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
-          git -C "$asc_skills" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
-          npx --yes skills@1.5.20 add "$asc_skills" --global --agent codex --yes &&
+          git init --quiet "$asc_skills/src" &&
+          git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
+          git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
+          git -C "$asc_skills/src" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
+          (cd "$asc_skills" && npx --yes skills@1.5.20 add "$asc_skills/src" --global --agent codex --yes) &&
           rm -rf "$asc_skills"
         ```
       </Step>

--- a/index.mdx
+++ b/index.mdx
@@ -76,10 +76,10 @@
         asc install-skills
         ```
 
-        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand, using a fresh temporary directory (which `npx` also runs from, so a local `node_modules/skills` cannot shadow the pinned installer) and stopping on the first failed step:
+        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand, using a fresh directory under `/tmp` (outside any npm project regardless of `TMPDIR`, and the directory `npx` runs from, so project npm files cannot shadow or redirect the pinned installer) and stopping on the first failed step:
 
         ```bash  theme={null}
-        asc_skills="$(mktemp -d)" &&
+        asc_skills="$(mktemp -d /tmp/asc-skills.XXXXXX)" &&
           git init --quiet "$asc_skills/src" &&
           git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
           git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&

--- a/installation.mdx
+++ b/installation.mdx
@@ -190,14 +190,16 @@ asc install-skills
 
 `asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. It needs Node.js (`npx`) and `git`.
 
-To do the same by hand, check out that commit first and install from the local path:
+To do the same by hand, check out that commit into a fresh temporary directory and install from the local path (each step stops the chain on failure):
 
 ```bash  theme={null}
-git init asc-skills
-git -C asc-skills remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git
-git -C asc-skills fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115
-git -C asc-skills checkout --detach e30039abddbe388179324d0f9cdccb66c3843115
-npx --yes skills@1.5.20 add "$PWD/asc-skills" --global --agent codex --yes
+asc_skills="$(mktemp -d)" &&
+  git init --quiet "$asc_skills" &&
+  git -C "$asc_skills" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
+  git -C "$asc_skills" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
+  git -C "$asc_skills" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
+  npx --yes skills@1.5.20 add "$asc_skills" --global --agent codex --yes &&
+  rm -rf "$asc_skills"
 ```
 
 <Note>

--- a/installation.mdx
+++ b/installation.mdx
@@ -188,11 +188,21 @@ ASC_BYPASS_KEYCHAIN=1 make test
 asc install-skills
 ```
 
-Direct install:
+`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. It needs Node.js (`npx`) and `git`.
+
+To do the same by hand, check out that commit first and install from the local path:
 
 ```bash  theme={null}
-npx skills add rorkai/app-store-connect-cli-skills --global --agent codex
+git init asc-skills
+git -C asc-skills remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git
+git -C asc-skills fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115
+git -C asc-skills checkout --detach e30039abddbe388179324d0f9cdccb66c3843115
+npx --yes skills@1.5.20 add "$PWD/asc-skills" --global --agent codex --yes
 ```
+
+<Note>
+  The installer resolves a source ref with `git clone --branch`, which accepts only branch and tag names, so the pinned commit has to be checked out locally and passed as a path. Upgrading the skill pack is an explicit change to the pinned installer version and commit in `internal/cli/install/install.go`.
+</Note>
 
 ## Shell completion
 

--- a/installation.mdx
+++ b/installation.mdx
@@ -190,10 +190,10 @@ asc install-skills
 
 `asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. It needs Node.js (`npx`) and `git`.
 
-To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and `npx` runs from the temporary directory so a local `node_modules/skills` in the current project cannot shadow the pinned installer:
+To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and the temporary directory lives under `/tmp` (outside any npm project, regardless of `TMPDIR`) with `npx` running from it, so a project `node_modules`, `package.json`, or `.npmrc` cannot shadow or redirect the pinned installer:
 
 ```bash  theme={null}
-asc_skills="$(mktemp -d)" &&
+asc_skills="$(mktemp -d /tmp/asc-skills.XXXXXX)" &&
   git init --quiet "$asc_skills/src" &&
   git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
   git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&

--- a/installation.mdx
+++ b/installation.mdx
@@ -190,15 +190,15 @@ asc install-skills
 
 `asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. It needs Node.js (`npx`) and `git`.
 
-To do the same by hand, check out that commit into a fresh temporary directory and install from the local path (each step stops the chain on failure):
+To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and `npx` runs from the temporary directory so a local `node_modules/skills` in the current project cannot shadow the pinned installer:
 
 ```bash  theme={null}
 asc_skills="$(mktemp -d)" &&
-  git init --quiet "$asc_skills" &&
-  git -C "$asc_skills" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
-  git -C "$asc_skills" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
-  git -C "$asc_skills" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
-  npx --yes skills@1.5.20 add "$asc_skills" --global --agent codex --yes &&
+  git init --quiet "$asc_skills/src" &&
+  git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
+  git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
+  git -C "$asc_skills/src" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
+  (cd "$asc_skills" && npx --yes skills@1.5.20 add "$asc_skills/src" --global --agent codex --yes) &&
   rm -rf "$asc_skills"
 ```
 

--- a/internal/asc/assets_output.go
+++ b/internal/asc/assets_output.go
@@ -134,7 +134,10 @@ func appScreenshotSetsRows(resp *AppScreenshotSetsResponse) ([]string, [][]strin
 	headers := []string{"ID", "Display Type"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		rows = append(rows, []string{item.ID, item.Attributes.ScreenshotDisplayType})
+		rows = append(rows, []string{
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(item.Attributes.ScreenshotDisplayType),
+		})
 	}
 	return headers, rows
 }
@@ -143,15 +146,11 @@ func appScreenshotsRows(resp *AppScreenshotsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil {
-			state = item.Attributes.AssetDeliveryState.State
-		}
 		rows = append(rows, []string{
-			item.ID,
-			item.Attributes.FileName,
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(item.Attributes.FileName),
 			fmt.Sprintf("%d", item.Attributes.FileSize),
-			state,
+			SanitizeTerminalText(assetDeliveryStateValue(item.Attributes.AssetDeliveryState)),
 		})
 	}
 	return headers, rows
@@ -161,7 +160,10 @@ func appPreviewSetsRows(resp *AppPreviewSetsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Preview Type"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		rows = append(rows, []string{item.ID, item.Attributes.PreviewType})
+		rows = append(rows, []string{
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(item.Attributes.PreviewType),
+		})
 	}
 	return headers, rows
 }
@@ -170,16 +172,12 @@ func appPreviewsRows(resp *AppPreviewsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "File Name", "File Size", "Poster Frame", "State"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		state := ""
-		if item.Attributes.AssetDeliveryState != nil {
-			state = item.Attributes.AssetDeliveryState.State
-		}
 		rows = append(rows, []string{
-			item.ID,
-			item.Attributes.FileName,
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(item.Attributes.FileName),
 			fmt.Sprintf("%d", item.Attributes.FileSize),
-			item.Attributes.PreviewFrameTimeCode,
-			state,
+			SanitizeTerminalText(item.Attributes.PreviewFrameTimeCode),
+			SanitizeTerminalText(assetDeliveryStateValue(item.Attributes.AssetDeliveryState)),
 		})
 	}
 	return headers, rows
@@ -189,23 +187,20 @@ func appScreenshotListResultRows(result *AppScreenshotListResult) ([]string, [][
 	headers := []string{"Set ID", "Display Type", "Screenshot ID", "File Name", "File Size", "State"}
 	var rows [][]string
 	for _, set := range result.Sets {
-		displayType := set.Set.Attributes.ScreenshotDisplayType
+		setID := SanitizeTerminalText(set.Set.ID)
+		displayType := SanitizeTerminalText(set.Set.Attributes.ScreenshotDisplayType)
 		if len(set.Screenshots) == 0 {
-			rows = append(rows, []string{set.Set.ID, displayType, "", "", "", ""})
+			rows = append(rows, []string{setID, displayType, "", "", "", ""})
 			continue
 		}
 		for _, item := range set.Screenshots {
-			state := ""
-			if item.Attributes.AssetDeliveryState != nil {
-				state = item.Attributes.AssetDeliveryState.State
-			}
 			rows = append(rows, []string{
-				set.Set.ID,
+				setID,
 				displayType,
-				item.ID,
-				item.Attributes.FileName,
+				SanitizeTerminalText(item.ID),
+				SanitizeTerminalText(item.Attributes.FileName),
 				fmt.Sprintf("%d", item.Attributes.FileSize),
-				state,
+				SanitizeTerminalText(assetDeliveryStateValue(item.Attributes.AssetDeliveryState)),
 			})
 		}
 	}
@@ -216,24 +211,21 @@ func appPreviewListResultRows(result *AppPreviewListResult) ([]string, [][]strin
 	headers := []string{"Set ID", "Preview Type", "Preview ID", "File Name", "File Size", "Poster Frame", "State"}
 	var rows [][]string
 	for _, set := range result.Sets {
-		previewType := set.Set.Attributes.PreviewType
+		setID := SanitizeTerminalText(set.Set.ID)
+		previewType := SanitizeTerminalText(set.Set.Attributes.PreviewType)
 		if len(set.Previews) == 0 {
-			rows = append(rows, []string{set.Set.ID, previewType, "", "", "", "", ""})
+			rows = append(rows, []string{setID, previewType, "", "", "", "", ""})
 			continue
 		}
 		for _, item := range set.Previews {
-			state := ""
-			if item.Attributes.AssetDeliveryState != nil {
-				state = item.Attributes.AssetDeliveryState.State
-			}
 			rows = append(rows, []string{
-				set.Set.ID,
+				setID,
 				previewType,
-				item.ID,
-				item.Attributes.FileName,
+				SanitizeTerminalText(item.ID),
+				SanitizeTerminalText(item.Attributes.FileName),
 				fmt.Sprintf("%d", item.Attributes.FileSize),
-				item.Attributes.PreviewFrameTimeCode,
-				state,
+				SanitizeTerminalText(item.Attributes.PreviewFrameTimeCode),
+				SanitizeTerminalText(assetDeliveryStateValue(item.Attributes.AssetDeliveryState)),
 			})
 		}
 	}
@@ -243,9 +235,9 @@ func appPreviewListResultRows(result *AppPreviewListResult) ([]string, [][]strin
 func appScreenshotUploadResultMainRows(result *AppScreenshotUploadResult) ([]string, [][]string) {
 	headers := []string{"Localization ID", "Set ID", "Display Type", "Dry Run", "Resumed", "Total", "Uploaded", "Skipped", "Pending", "Failed", "Failure Artifact"}
 	rows := [][]string{{
-		result.VersionLocalizationID,
-		result.SetID,
-		result.DisplayType,
+		SanitizeTerminalText(result.VersionLocalizationID),
+		SanitizeTerminalText(result.SetID),
+		SanitizeTerminalText(result.DisplayType),
 		fmt.Sprintf("%t", result.DryRun),
 		fmt.Sprintf("%t", result.Resumed),
 		fmt.Sprintf("%d", result.Total),
@@ -253,7 +245,7 @@ func appScreenshotUploadResultMainRows(result *AppScreenshotUploadResult) ([]str
 		fmt.Sprintf("%d", result.Skipped),
 		fmt.Sprintf("%d", result.Pending),
 		fmt.Sprintf("%d", result.Failed),
-		result.FailureArtifactPath,
+		SanitizeTerminalText(result.FailureArtifactPath),
 	}}
 	return headers, rows
 }
@@ -261,11 +253,11 @@ func appScreenshotUploadResultMainRows(result *AppScreenshotUploadResult) ([]str
 func appScreenshotFanoutUploadResultMainRows(result *AppScreenshotFanoutUploadResult) ([]string, [][]string) {
 	headers := []string{"App ID", "Version", "Version ID", "Platform", "Display Type", "Dry Run", "Localizations"}
 	rows := [][]string{{
-		result.AppID,
-		result.Version,
-		result.VersionID,
-		result.Platform,
-		result.DisplayType,
+		SanitizeTerminalText(result.AppID),
+		SanitizeTerminalText(result.Version),
+		SanitizeTerminalText(result.VersionID),
+		SanitizeTerminalText(result.Platform),
+		SanitizeTerminalText(result.DisplayType),
 		fmt.Sprintf("%t", result.DryRun),
 		fmt.Sprintf("%d", len(result.Localizations)),
 	}}
@@ -281,15 +273,15 @@ func appScreenshotFanoutUploadLocalizationRows(result *AppScreenshotFanoutUpload
 			total = len(item.Results) + item.Pending
 		}
 		rows = append(rows, []string{
-			item.Locale,
-			item.VersionLocalizationID,
-			item.SetID,
+			SanitizeTerminalText(item.Locale),
+			SanitizeTerminalText(item.VersionLocalizationID),
+			SanitizeTerminalText(item.SetID),
 			fmt.Sprintf("%d", total),
 			fmt.Sprintf("%d", item.Uploaded),
 			fmt.Sprintf("%d", item.Skipped),
 			fmt.Sprintf("%d", item.Pending),
 			fmt.Sprintf("%d", item.Failed),
-			item.FailureArtifactPath,
+			SanitizeTerminalText(item.FailureArtifactPath),
 			summarizeAssetUploadStates(item.Results),
 		})
 	}
@@ -300,20 +292,17 @@ func appScreenshotFanoutUploadResultItemRows(result *AppScreenshotFanoutUploadRe
 	headers := []string{"Locale", "File Name", "Asset ID", "State"}
 	rows := make([][]string, 0)
 	for _, localization := range result.Localizations {
+		locale := SanitizeTerminalText(localization.Locale)
 		if len(localization.Results) == 0 {
-			rows = append(rows, []string{localization.Locale, "", "", ""})
+			rows = append(rows, []string{locale, "", "", ""})
 			continue
 		}
 		for _, item := range localization.Results {
-			state := item.State
-			if item.Skipped && state == "" {
-				state = "skipped"
-			}
 			rows = append(rows, []string{
-				localization.Locale,
-				item.FileName,
-				item.AssetID,
-				state,
+				locale,
+				SanitizeTerminalText(item.FileName),
+				SanitizeTerminalText(item.AssetID),
+				SanitizeTerminalText(assetUploadItemState(item)),
 			})
 		}
 	}
@@ -324,12 +313,13 @@ func appScreenshotFanoutUploadFailureRows(result *AppScreenshotFanoutUploadResul
 	headers := []string{"Locale", "File Name", "File Path", "Error"}
 	rows := make([][]string, 0)
 	for _, localization := range result.Localizations {
+		locale := SanitizeTerminalText(localization.Locale)
 		for _, item := range localization.Failures {
 			rows = append(rows, []string{
-				localization.Locale,
-				item.FileName,
-				item.FilePath,
-				item.Error,
+				locale,
+				SanitizeTerminalText(item.FileName),
+				SanitizeTerminalText(item.FilePath),
+				SanitizeTerminalText(item.Error),
 			})
 		}
 	}
@@ -338,25 +328,42 @@ func appScreenshotFanoutUploadFailureRows(result *AppScreenshotFanoutUploadResul
 
 func appPreviewUploadResultMainRows(result *AppPreviewUploadResult) ([]string, [][]string) {
 	headers := []string{"Localization ID", "Set ID", "Preview Type", "Dry Run"}
-	rows := [][]string{{result.VersionLocalizationID, result.SetID, result.PreviewType, fmt.Sprintf("%t", result.DryRun)}}
+	rows := [][]string{{
+		SanitizeTerminalText(result.VersionLocalizationID),
+		SanitizeTerminalText(result.SetID),
+		SanitizeTerminalText(result.PreviewType),
+		fmt.Sprintf("%t", result.DryRun),
+	}}
 	return headers, rows
 }
 
 func customProductPageScreenshotUploadResultMainRows(result *CustomProductPageScreenshotUploadResult) ([]string, [][]string) {
 	headers := []string{"Localization ID", "Set ID", "Display Type"}
-	rows := [][]string{{result.CustomProductPageLocalizationID, result.SetID, result.DisplayType}}
+	rows := [][]string{{
+		SanitizeTerminalText(result.CustomProductPageLocalizationID),
+		SanitizeTerminalText(result.SetID),
+		SanitizeTerminalText(result.DisplayType),
+	}}
 	return headers, rows
 }
 
 func experimentTreatmentLocalizationScreenshotUploadResultMainRows(result *ExperimentTreatmentLocalizationScreenshotUploadResult) ([]string, [][]string) {
 	headers := []string{"Localization ID", "Set ID", "Display Type"}
-	rows := [][]string{{result.ExperimentTreatmentLocalizationID, result.SetID, result.DisplayType}}
+	rows := [][]string{{
+		SanitizeTerminalText(result.ExperimentTreatmentLocalizationID),
+		SanitizeTerminalText(result.SetID),
+		SanitizeTerminalText(result.DisplayType),
+	}}
 	return headers, rows
 }
 
 func customProductPagePreviewUploadResultMainRows(result *CustomProductPagePreviewUploadResult) ([]string, [][]string) {
 	headers := []string{"Localization ID", "Set ID", "Preview Type"}
-	rows := [][]string{{result.CustomProductPageLocalizationID, result.SetID, result.PreviewType}}
+	rows := [][]string{{
+		SanitizeTerminalText(result.CustomProductPageLocalizationID),
+		SanitizeTerminalText(result.SetID),
+		SanitizeTerminalText(result.PreviewType),
+	}}
 	return headers, rows
 }
 
@@ -364,13 +371,27 @@ func assetUploadResultItemRows(results []AssetUploadResultItem) ([]string, [][]s
 	headers := []string{"File Name", "Asset ID", "State"}
 	rows := make([][]string, 0, len(results))
 	for _, item := range results {
-		state := item.State
-		if item.Skipped && state == "" {
-			state = "skipped"
-		}
-		rows = append(rows, []string{item.FileName, item.AssetID, state})
+		rows = append(rows, []string{
+			SanitizeTerminalText(item.FileName),
+			SanitizeTerminalText(item.AssetID),
+			SanitizeTerminalText(assetUploadItemState(item)),
+		})
 	}
 	return headers, rows
+}
+
+func assetDeliveryStateValue(state *AssetDeliveryState) string {
+	if state == nil {
+		return ""
+	}
+	return state.State
+}
+
+func assetUploadItemState(item AssetUploadResultItem) string {
+	if item.State == "" && item.Skipped {
+		return "skipped"
+	}
+	return item.State
 }
 
 func summarizeAssetUploadStates(results []AssetUploadResultItem) string {
@@ -381,10 +402,7 @@ func summarizeAssetUploadStates(results []AssetUploadResultItem) string {
 	counts := make(map[string]int)
 	states := make([]string, 0, len(results))
 	for _, item := range results {
-		state := item.State
-		if item.Skipped && state == "" {
-			state = "skipped"
-		}
+		state := SanitizeTerminalText(assetUploadItemState(item))
 		if state == "" {
 			state = "uploaded"
 		}
@@ -407,7 +425,11 @@ func assetUploadFailureItemRows(results []AssetUploadFailureItem) ([]string, [][
 	headers := []string{"File Name", "File Path", "Error"}
 	rows := make([][]string, 0, len(results))
 	for _, item := range results {
-		rows = append(rows, []string{item.FileName, item.FilePath, item.Error})
+		rows = append(rows, []string{
+			SanitizeTerminalText(item.FileName),
+			SanitizeTerminalText(item.FilePath),
+			SanitizeTerminalText(item.Error),
+		})
 	}
 	return headers, rows
 }
@@ -417,8 +439,8 @@ func screenshotSizesRows(result *ScreenshotSizesResult) ([]string, [][]string) {
 	rows := make([][]string, 0, len(result.Sizes))
 	for _, item := range result.Sizes {
 		rows = append(rows, []string{
-			item.DisplayType,
-			item.Family,
+			SanitizeTerminalText(item.DisplayType),
+			SanitizeTerminalText(item.Family),
 			formatScreenshotDimensions(item.Dimensions),
 		})
 	}
@@ -427,6 +449,6 @@ func screenshotSizesRows(result *ScreenshotSizesResult) ([]string, [][]string) {
 
 func assetDeleteResultRows(result *AssetDeleteResult) ([]string, [][]string) {
 	headers := []string{"ID", "Deleted"}
-	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
+	rows := [][]string{{SanitizeTerminalText(result.ID), fmt.Sprintf("%t", result.Deleted)}}
 	return headers, rows
 }

--- a/internal/asc/assets_output_test.go
+++ b/internal/asc/assets_output_test.go
@@ -1,0 +1,269 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// hostileText carries an OSC window-title sequence, a C1 CSI, a DEL, and a bidi
+// override, all of which a terminal or CI log viewer would interpret.
+const hostileText = "shot\x1b]0;pwned\x07\u009b2K\u007f\u202egpj.png"
+
+func assertRowsAreInert(t *testing.T, headers []string, rows [][]string) {
+	t.Helper()
+
+	for _, header := range headers {
+		if HasInterpretedTerminalSequence(header) {
+			t.Fatalf("header %q contains interpreted terminal sequences", header)
+		}
+	}
+	for i, row := range rows {
+		for j, cell := range row {
+			if HasInterpretedTerminalSequence(cell) {
+				t.Fatalf("row %d column %d = %q contains interpreted terminal sequences", i, j, cell)
+			}
+			if strings.Contains(cell, "\x1b") || strings.Contains(cell, "\u202e") {
+				t.Fatalf("row %d column %d = %q retained a control character", i, j, cell)
+			}
+		}
+	}
+}
+
+func TestAppScreenshotRowsRemoveTerminalControls(t *testing.T) {
+	resp := &AppScreenshotsResponse{
+		Data: []Resource[AppScreenshotAttributes]{{
+			ID: "SHOT\x1b[31mID",
+			Attributes: AppScreenshotAttributes{
+				FileName:           hostileText,
+				FileSize:           1024,
+				AssetDeliveryState: &AssetDeliveryState{State: "COMPLETE\u202e"},
+			},
+		}},
+	}
+
+	headers, rows := appScreenshotsRows(resp)
+	assertRowsAreInert(t, headers, rows)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0][1] != SanitizeTerminalText(hostileText) {
+		t.Fatalf("file name = %q, want %q", rows[0][1], SanitizeTerminalText(hostileText))
+	}
+
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	var decoded AppScreenshotsResponse
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if decoded.Data[0].Attributes.FileName != hostileText {
+		t.Fatalf("JSON file name = %q, want the original %q", decoded.Data[0].Attributes.FileName, hostileText)
+	}
+}
+
+func TestAppPreviewRowsRemoveTerminalControls(t *testing.T) {
+	resp := &AppPreviewsResponse{
+		Data: []Resource[AppPreviewAttributes]{{
+			ID: "PREVIEW\x1bID",
+			Attributes: AppPreviewAttributes{
+				FileName:             hostileText,
+				PreviewFrameTimeCode: "00:00:03\u009b2K",
+				AssetDeliveryState:   &AssetDeliveryState{State: "FAILED\x1b[0m"},
+			},
+		}},
+	}
+
+	headers, rows := appPreviewsRows(resp)
+	assertRowsAreInert(t, headers, rows)
+}
+
+func TestAppScreenshotSetRowsRemoveTerminalControls(t *testing.T) {
+	headers, rows := appScreenshotSetsRows(&AppScreenshotSetsResponse{
+		Data: []Resource[AppScreenshotSetAttributes]{{
+			ID:         "SET\x1bID",
+			Attributes: AppScreenshotSetAttributes{ScreenshotDisplayType: "APP_IPHONE_67\u202e"},
+		}},
+	})
+	assertRowsAreInert(t, headers, rows)
+
+	headers, rows = appPreviewSetsRows(&AppPreviewSetsResponse{
+		Data: []Resource[AppPreviewSetAttributes]{{
+			ID:         "SET\x1bID",
+			Attributes: AppPreviewSetAttributes{PreviewType: "IPHONE_67\u009b2K"},
+		}},
+	})
+	assertRowsAreInert(t, headers, rows)
+}
+
+func TestAssetListResultRowsRemoveTerminalControls(t *testing.T) {
+	screenshotHeaders, screenshotRows := appScreenshotListResultRows(&AppScreenshotListResult{
+		VersionLocalizationID: "LOC\x1bID",
+		Sets: []AppScreenshotSetWithScreenshots{{
+			Set: Resource[AppScreenshotSetAttributes]{
+				ID:         "SET\x1bID",
+				Attributes: AppScreenshotSetAttributes{ScreenshotDisplayType: "APP_IPHONE_67\u202e"},
+			},
+			Screenshots: []Resource[AppScreenshotAttributes]{{
+				ID: "SHOT\x1bID",
+				Attributes: AppScreenshotAttributes{
+					FileName:           hostileText,
+					AssetDeliveryState: &AssetDeliveryState{State: "COMPLETE\x07"},
+				},
+			}},
+		}},
+	})
+	assertRowsAreInert(t, screenshotHeaders, screenshotRows)
+
+	previewHeaders, previewRows := appPreviewListResultRows(&AppPreviewListResult{
+		VersionLocalizationID: "LOC\x1bID",
+		Sets: []AppPreviewSetWithPreviews{{
+			Set: Resource[AppPreviewSetAttributes]{
+				ID:         "SET\x1bID",
+				Attributes: AppPreviewSetAttributes{PreviewType: "IPHONE_67\u202e"},
+			},
+			Previews: []Resource[AppPreviewAttributes]{{
+				ID: "PREVIEW\x1bID",
+				Attributes: AppPreviewAttributes{
+					FileName:             hostileText,
+					PreviewFrameTimeCode: "00:00:03\x1b[0m",
+					AssetDeliveryState:   &AssetDeliveryState{State: "COMPLETE\x07"},
+				},
+			}},
+		}},
+	})
+	assertRowsAreInert(t, previewHeaders, previewRows)
+}
+
+func TestAssetUploadRowsRemoveTerminalControlsAndPreserveJSON(t *testing.T) {
+	result := &AppScreenshotUploadResult{
+		VersionLocalizationID: "LOC\x1bID",
+		SetID:                 "SET\x1bID",
+		DisplayType:           "APP_IPHONE_67\u202e",
+		Total:                 1,
+		FailureArtifactPath:   "./artifacts/failures\x1b[0m.json",
+		Results: []AssetUploadResultItem{{
+			FileName: hostileText,
+			FilePath: "./shots/" + hostileText,
+			AssetID:  "ASSET\x1bID",
+			State:    "UPLOAD_COMPLETE\u009b2K",
+		}},
+		Failures: []AssetUploadFailureItem{{
+			FileName: hostileText,
+			FilePath: "./shots/" + hostileText,
+			Error:    "upload failed\x1b]0;pwned\x07",
+		}},
+	}
+
+	mainHeaders, mainRows := appScreenshotUploadResultMainRows(result)
+	assertRowsAreInert(t, mainHeaders, mainRows)
+
+	itemHeaders, itemRows := assetUploadResultItemRows(result.Results)
+	assertRowsAreInert(t, itemHeaders, itemRows)
+
+	failureHeaders, failureRows := assetUploadFailureItemRows(result.Failures)
+	assertRowsAreInert(t, failureHeaders, failureRows)
+
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var decoded AppScreenshotUploadResult
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if decoded.Results[0].FileName != hostileText {
+		t.Fatalf("JSON result file name = %q, want the original", decoded.Results[0].FileName)
+	}
+	if decoded.Failures[0].Error != "upload failed\x1b]0;pwned\x07" {
+		t.Fatalf("JSON failure error = %q, want the original", decoded.Failures[0].Error)
+	}
+}
+
+func TestAssetFanoutUploadRowsRemoveTerminalControls(t *testing.T) {
+	result := &AppScreenshotFanoutUploadResult{
+		AppID:       "123\x1b456",
+		Version:     "1.0\u202e",
+		VersionID:   "VER\x1bID",
+		Platform:    "IOS\x07",
+		DisplayType: "APP_IPHONE_67\u009b2K",
+		Localizations: []AppScreenshotLocalizationUploadResult{{
+			Locale:                "en-US\u202e",
+			VersionLocalizationID: "LOC\x1bID",
+			SetID:                 "SET\x1bID",
+			FailureArtifactPath:   "./failures\x1b[0m.json",
+			Results: []AssetUploadResultItem{{
+				FileName: hostileText,
+				AssetID:  "ASSET\x1bID",
+				State:    "UPLOAD_COMPLETE\x1b[0m",
+			}},
+			Failures: []AssetUploadFailureItem{{
+				FileName: hostileText,
+				FilePath: "./shots/" + hostileText,
+				Error:    "upload failed\u009b2K",
+			}},
+		}},
+	}
+
+	mainHeaders, mainRows := appScreenshotFanoutUploadResultMainRows(result)
+	assertRowsAreInert(t, mainHeaders, mainRows)
+
+	localizationHeaders, localizationRows := appScreenshotFanoutUploadLocalizationRows(result)
+	assertRowsAreInert(t, localizationHeaders, localizationRows)
+
+	itemHeaders, itemRows := appScreenshotFanoutUploadResultItemRows(result)
+	assertRowsAreInert(t, itemHeaders, itemRows)
+
+	failureHeaders, failureRows := appScreenshotFanoutUploadFailureRows(result)
+	assertRowsAreInert(t, failureHeaders, failureRows)
+}
+
+func TestAssetUploadStateSummaryRemovesTerminalControls(t *testing.T) {
+	summary := summarizeAssetUploadStates([]AssetUploadResultItem{
+		{FileName: "a.png", State: "UPLOAD_COMPLETE\x1b[0m"},
+		{FileName: "b.png", State: "UPLOAD_COMPLETE\x1b[0m"},
+		{FileName: "c.png", Skipped: true},
+	})
+	if HasInterpretedTerminalSequence(summary) {
+		t.Fatalf("state summary %q contains interpreted terminal sequences", summary)
+	}
+	if !strings.Contains(summary, "UPLOAD_COMPLETE[0m=2") {
+		t.Fatalf("state summary = %q, want the sanitized state count", summary)
+	}
+}
+
+func TestAssetPreviewAndDeleteRowsRemoveTerminalControls(t *testing.T) {
+	headers, rows := appPreviewUploadResultMainRows(&AppPreviewUploadResult{
+		VersionLocalizationID: "LOC\x1bID",
+		SetID:                 "SET\x1bID",
+		PreviewType:           "IPHONE_67\u202e",
+	})
+	assertRowsAreInert(t, headers, rows)
+
+	headers, rows = customProductPageScreenshotUploadResultMainRows(&CustomProductPageScreenshotUploadResult{
+		CustomProductPageLocalizationID: "LOC\x1bID",
+		SetID:                           "SET\x1bID",
+		DisplayType:                     "APP_IPHONE_67\u202e",
+	})
+	assertRowsAreInert(t, headers, rows)
+
+	headers, rows = experimentTreatmentLocalizationScreenshotUploadResultMainRows(&ExperimentTreatmentLocalizationScreenshotUploadResult{
+		ExperimentTreatmentLocalizationID: "LOC\x1bID",
+		SetID:                             "SET\x1bID",
+		DisplayType:                       "APP_IPHONE_67\u202e",
+	})
+	assertRowsAreInert(t, headers, rows)
+
+	headers, rows = customProductPagePreviewUploadResultMainRows(&CustomProductPagePreviewUploadResult{
+		CustomProductPageLocalizationID: "LOC\x1bID",
+		SetID:                           "SET\x1bID",
+		PreviewType:                     "IPHONE_67\u202e",
+	})
+	assertRowsAreInert(t, headers, rows)
+
+	headers, rows = assetDeleteResultRows(&AssetDeleteResult{ID: "ASSET\x1bID", Deleted: true})
+	assertRowsAreInert(t, headers, rows)
+}

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -727,23 +727,6 @@ func sanitizeErrorBody(body []byte) string {
 	return string(result)
 }
 
-// sanitizeTerminal strips control characters to prevent terminal escape injection.
-// It removes ASCII control characters (0x00-0x1F) and DEL (0x7F).
-func sanitizeTerminal(input string) string {
-	if input == "" {
-		return ""
-	}
-	var b strings.Builder
-	b.Grow(len(input))
-	for _, r := range input {
-		if r < 0x20 || r == 0x7f {
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
-}
-
 // validateAPIPath checks a relative API path for dangerous characters that
 // could indicate a hallucinated or malicious resource ID. Full URLs (pagination
 // cursors) are skipped — they are validated separately by validateNextURL.

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -33,9 +33,9 @@ type APIAssociatedError struct {
 }
 
 func (e *APIError) Error() string {
-	title := strings.TrimSpace(sanitizeTerminal(e.Title))
-	detail := strings.TrimSpace(sanitizeTerminal(e.Detail))
-	code := strings.TrimSpace(sanitizeTerminal(e.Code))
+	title := strings.TrimSpace(SanitizeTerminalText(e.Title))
+	detail := strings.TrimSpace(SanitizeTerminalText(e.Detail))
+	code := strings.TrimSpace(SanitizeTerminalText(e.Code))
 	baseMessage := ""
 	switch {
 	case title != "" && detail != "":
@@ -77,7 +77,7 @@ func formatAssociatedErrors(values map[string][]APIAssociatedError) string {
 
 	sections := make([]string, 0, len(keys))
 	for _, key := range keys {
-		resource := strings.TrimSpace(sanitizeTerminal(key))
+		resource := strings.TrimSpace(SanitizeTerminalText(key))
 		if resource == "" {
 			resource = "(unknown resource)"
 		}
@@ -87,8 +87,8 @@ func formatAssociatedErrors(values map[string][]APIAssociatedError) string {
 		lines = append(lines, fmt.Sprintf("Associated errors for %s:", resource))
 
 		for _, entry := range entries {
-			entryDetail := strings.TrimSpace(sanitizeTerminal(entry.Detail))
-			entryCode := strings.TrimSpace(sanitizeTerminal(entry.Code))
+			entryDetail := strings.TrimSpace(SanitizeTerminalText(entry.Detail))
+			entryCode := strings.TrimSpace(SanitizeTerminalText(entry.Code))
 			switch {
 			case entryDetail != "":
 				lines = append(lines, fmt.Sprintf("  - %s", entryDetail))

--- a/internal/asc/iap_output.go
+++ b/internal/asc/iap_output.go
@@ -140,9 +140,9 @@ func inAppPurchaseOfferCodePricesRows(resp *InAppPurchaseOfferPricesResponse) ([
 			return nil, nil, err
 		}
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(territoryID),
-			sanitizeTerminal(pricePointID),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(territoryID),
+			SanitizeTerminalText(pricePointID),
 		})
 	}
 	return headers, rows, nil
@@ -169,11 +169,11 @@ func inAppPurchaseOfferCodeCustomCodesRows(resp *InAppPurchaseOfferCodeCustomCod
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(attrs.CustomCode),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(attrs.CustomCode),
 			fmt.Sprintf("%d", attrs.NumberOfCodes),
-			sanitizeTerminal(attrs.ExpirationDate),
-			sanitizeTerminal(attrs.CreatedDate),
+			SanitizeTerminalText(attrs.ExpirationDate),
+			SanitizeTerminalText(attrs.CreatedDate),
 			fmt.Sprintf("%t", attrs.Active),
 		})
 	}
@@ -186,12 +186,12 @@ func inAppPurchaseOfferCodeOneTimeUseCodesRows(resp *InAppPurchaseOfferCodeOneTi
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
+			SanitizeTerminalText(item.ID),
 			fmt.Sprintf("%d", attrs.NumberOfCodes),
-			sanitizeTerminal(attrs.ExpirationDate),
-			sanitizeTerminal(attrs.CreatedDate),
+			SanitizeTerminalText(attrs.ExpirationDate),
+			SanitizeTerminalText(attrs.CreatedDate),
 			fmt.Sprintf("%t", attrs.Active),
-			sanitizeTerminal(attrs.Environment),
+			SanitizeTerminalText(attrs.Environment),
 		})
 	}
 	return headers, rows

--- a/internal/asc/nominations_output.go
+++ b/internal/asc/nominations_output.go
@@ -8,12 +8,12 @@ func nominationsRows(resp *NominationsResponse) ([]string, [][]string) {
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
+			SanitizeTerminalText(item.ID),
 			compactWhitespace(fallbackValue(attrs.Name)),
-			sanitizeTerminal(fallbackValue(string(attrs.Type))),
-			sanitizeTerminal(fallbackValue(string(attrs.State))),
-			sanitizeTerminal(fallbackValue(attrs.PublishStartDate)),
-			sanitizeTerminal(fallbackValue(attrs.PublishEndDate)),
+			SanitizeTerminalText(fallbackValue(string(attrs.Type))),
+			SanitizeTerminalText(fallbackValue(string(attrs.State))),
+			SanitizeTerminalText(fallbackValue(attrs.PublishStartDate)),
+			SanitizeTerminalText(fallbackValue(attrs.PublishEndDate)),
 		})
 	}
 	return headers, rows

--- a/internal/asc/offer_codes_custom_output.go
+++ b/internal/asc/offer_codes_custom_output.go
@@ -11,11 +11,11 @@ func offerCodeCustomCodesRows(resp *SubscriptionOfferCodeCustomCodesResponse) ([
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(attrs.CustomCode),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(attrs.CustomCode),
 			fmt.Sprintf("%d", attrs.NumberOfCodes),
-			sanitizeTerminal(attrs.ExpirationDate),
-			sanitizeTerminal(attrs.CreatedDate),
+			SanitizeTerminalText(attrs.ExpirationDate),
+			SanitizeTerminalText(attrs.CreatedDate),
 			fmt.Sprintf("%t", attrs.Active),
 		})
 	}
@@ -30,7 +30,7 @@ func offerCodePricesRows(resp *SubscriptionOfferCodePricesResponse) ([]string, [
 		if err != nil {
 			return nil, nil, err
 		}
-		rows = append(rows, []string{sanitizeTerminal(item.ID), sanitizeTerminal(territoryID), sanitizeTerminal(pricePointID)})
+		rows = append(rows, []string{SanitizeTerminalText(item.ID), SanitizeTerminalText(territoryID), SanitizeTerminalText(pricePointID)})
 	}
 	return headers, rows, nil
 }
@@ -54,7 +54,7 @@ func offerCodeValuesRows(result *OfferCodeValuesResult) ([]string, [][]string) {
 	headers := []string{"Code"}
 	rows := make([][]string, 0, len(result.Codes))
 	for _, code := range result.Codes {
-		rows = append(rows, []string{sanitizeTerminal(code)})
+		rows = append(rows, []string{SanitizeTerminalText(code)})
 	}
 	return headers, rows
 }

--- a/internal/asc/offer_codes_output.go
+++ b/internal/asc/offer_codes_output.go
@@ -11,10 +11,10 @@ func offerCodesRows(resp *SubscriptionOfferCodeOneTimeUseCodesResponse) ([]strin
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
+			SanitizeTerminalText(item.ID),
 			fmt.Sprintf("%d", attrs.NumberOfCodes),
-			sanitizeTerminal(attrs.ExpirationDate),
-			sanitizeTerminal(attrs.CreatedDate),
+			SanitizeTerminalText(attrs.ExpirationDate),
+			SanitizeTerminalText(attrs.CreatedDate),
 			fmt.Sprintf("%t", attrs.Active),
 		})
 	}
@@ -27,12 +27,12 @@ func subscriptionOfferCodesRows(resp *SubscriptionOfferCodesResponse) ([]string,
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(compactWhitespace(attrs.Name)),
-			sanitizeTerminal(formatOfferCodeCustomerEligibilities(attrs.CustomerEligibilities)),
-			sanitizeTerminal(string(attrs.OfferEligibility)),
-			sanitizeTerminal(string(attrs.Duration)),
-			sanitizeTerminal(string(attrs.OfferMode)),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(compactWhitespace(attrs.Name)),
+			SanitizeTerminalText(formatOfferCodeCustomerEligibilities(attrs.CustomerEligibilities)),
+			SanitizeTerminalText(string(attrs.OfferEligibility)),
+			SanitizeTerminalText(string(attrs.Duration)),
+			SanitizeTerminalText(string(attrs.OfferMode)),
 			fmt.Sprintf("%d", attrs.NumberOfPeriods),
 			fmt.Sprintf("%d", attrs.TotalNumberOfCodes),
 			fmt.Sprintf("%d", attrs.ProductionCodeCount),

--- a/internal/asc/output_accessibility.go
+++ b/internal/asc/output_accessibility.go
@@ -13,9 +13,9 @@ func accessibilityDeclarationsRows(resp *AccessibilityDeclarationsResponse) ([]s
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(fallbackValue(string(attrs.DeviceFamily))),
-			sanitizeTerminal(fallbackValue(string(attrs.State))),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(fallbackValue(string(attrs.DeviceFamily))),
+			SanitizeTerminalText(fallbackValue(string(attrs.State))),
 			formatOptionalBool(attrs.SupportsAudioDescriptions),
 			formatOptionalBool(attrs.SupportsCaptions),
 			formatOptionalBool(attrs.SupportsDarkInterface),

--- a/internal/asc/output_app_events.go
+++ b/internal/asc/output_app_events.go
@@ -30,12 +30,12 @@ func appEventsRows(resp *AppEventsResponse) ([]string, [][]string) {
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
+			SanitizeTerminalText(item.ID),
 			compactWhitespace(attrs.ReferenceName),
-			sanitizeTerminal(attrs.Badge),
-			sanitizeTerminal(attrs.EventState),
-			sanitizeTerminal(attrs.PrimaryLocale),
-			sanitizeTerminal(attrs.Priority),
+			SanitizeTerminalText(attrs.Badge),
+			SanitizeTerminalText(attrs.EventState),
+			SanitizeTerminalText(attrs.PrimaryLocale),
+			SanitizeTerminalText(attrs.Priority),
 		})
 	}
 	return headers, rows
@@ -47,8 +47,8 @@ func appEventLocalizationsRows(resp *AppEventLocalizationsResponse) ([]string, [
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(attrs.Locale),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(attrs.Locale),
 			compactWhitespace(attrs.Name),
 			compactWhitespace(attrs.ShortDescription),
 			compactWhitespace(attrs.LongDescription),
@@ -63,11 +63,11 @@ func appEventScreenshotsRows(resp *AppEventScreenshotsResponse) ([]string, [][]s
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(attrs.FileName),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(attrs.FileName),
 			fmt.Sprintf("%d", attrs.FileSize),
-			sanitizeTerminal(attrs.AppEventAssetType),
-			sanitizeTerminal(formatAppMediaAssetState(attrs.AssetDeliveryState)),
+			SanitizeTerminalText(attrs.AppEventAssetType),
+			SanitizeTerminalText(formatAppMediaAssetState(attrs.AssetDeliveryState)),
 		})
 	}
 	return headers, rows
@@ -79,11 +79,11 @@ func appEventVideoClipsRows(resp *AppEventVideoClipsResponse) ([]string, [][]str
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(attrs.FileName),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(attrs.FileName),
 			fmt.Sprintf("%d", attrs.FileSize),
-			sanitizeTerminal(attrs.AppEventAssetType),
-			sanitizeTerminal(formatAppMediaVideoState(attrs.VideoDeliveryState, attrs.AssetDeliveryState)),
+			SanitizeTerminalText(attrs.AppEventAssetType),
+			SanitizeTerminalText(formatAppMediaVideoState(attrs.VideoDeliveryState, attrs.AssetDeliveryState)),
 		})
 	}
 	return headers, rows
@@ -108,12 +108,12 @@ func appEventSubmissionResultRows(result *AppEventSubmissionResult) ([]string, [
 		submittedDate = *result.SubmittedDate
 	}
 	rows := [][]string{{
-		sanitizeTerminal(result.SubmissionID),
-		sanitizeTerminal(result.ItemID),
-		sanitizeTerminal(result.EventID),
-		sanitizeTerminal(result.AppID),
-		sanitizeTerminal(result.Platform),
-		sanitizeTerminal(submittedDate),
+		SanitizeTerminalText(result.SubmissionID),
+		SanitizeTerminalText(result.ItemID),
+		SanitizeTerminalText(result.EventID),
+		SanitizeTerminalText(result.AppID),
+		SanitizeTerminalText(result.Platform),
+		SanitizeTerminalText(submittedDate),
 	}}
 	return headers, rows
 }

--- a/internal/asc/output_builds.go
+++ b/internal/asc/output_builds.go
@@ -205,7 +205,7 @@ func buildIconsRows(resp *BuildIconsResponse) ([]string, [][]string) {
 			compactWhitespace(item.Attributes.Name),
 			string(item.Attributes.IconType),
 			fmt.Sprintf("%t", item.Attributes.Masked),
-			sanitizeTerminal(buildIconAssetURL(item.Attributes)),
+			SanitizeTerminalText(buildIconAssetURL(item.Attributes)),
 		})
 	}
 	return headers, rows

--- a/internal/asc/output_builds.go
+++ b/internal/asc/output_builds.go
@@ -201,9 +201,9 @@ func buildIconsRows(resp *BuildIconsResponse) ([]string, [][]string) {
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{
-			item.ID,
+			SanitizeTerminalText(item.ID),
 			compactWhitespace(item.Attributes.Name),
-			string(item.Attributes.IconType),
+			SanitizeTerminalText(string(item.Attributes.IconType)),
 			fmt.Sprintf("%t", item.Attributes.Masked),
 			SanitizeTerminalText(buildIconAssetURL(item.Attributes)),
 		})

--- a/internal/asc/output_encryption.go
+++ b/internal/asc/output_encryption.go
@@ -18,14 +18,14 @@ func appEncryptionDeclarationsRows(resp *AppEncryptionDeclarationsResponse) ([]s
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(fallbackValue(string(attrs.AppEncryptionDeclarationState))),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(fallbackValue(string(attrs.AppEncryptionDeclarationState))),
 			formatOptionalBool(attrs.Exempt),
 			formatOptionalBool(attrs.ContainsProprietaryCryptography),
 			formatOptionalBool(attrs.ContainsThirdPartyCryptography),
 			formatOptionalBool(attrs.AvailableOnFrenchStore),
-			sanitizeTerminal(fallbackValue(attrs.CreatedDate)),
-			sanitizeTerminal(fallbackValue(attrs.CodeValue)),
+			SanitizeTerminalText(fallbackValue(attrs.CreatedDate)),
+			SanitizeTerminalText(fallbackValue(attrs.CodeValue)),
 		})
 	}
 	return headers, rows
@@ -96,9 +96,9 @@ func appEncryptionDeclarationDocumentFields(resp *AppEncryptionDeclarationDocume
 func appEncryptionDeclarationBuildsUpdateResultRows(result *AppEncryptionDeclarationBuildsUpdateResult) ([]string, [][]string) {
 	headers := []string{"Declaration ID", "Build IDs", "Action"}
 	rows := [][]string{{
-		sanitizeTerminal(result.DeclarationID),
-		sanitizeTerminal(strings.Join(result.BuildIDs, ",")),
-		sanitizeTerminal(result.Action),
+		SanitizeTerminalText(result.DeclarationID),
+		SanitizeTerminalText(strings.Join(result.BuildIDs, ",")),
+		SanitizeTerminalText(result.Action),
 	}}
 	return headers, rows
 }

--- a/internal/asc/output_feedback.go
+++ b/internal/asc/output_feedback.go
@@ -40,16 +40,16 @@ func feedbackRows(resp *FeedbackResponse) ([]string, [][]string) {
 	for _, item := range resp.Data {
 		if hasScreenshots {
 			rows = append(rows, []string{
-				sanitizeTerminal(item.Attributes.CreatedDate),
-				sanitizeTerminal(item.Attributes.Email),
+				SanitizeTerminalText(item.Attributes.CreatedDate),
+				SanitizeTerminalText(item.Attributes.Email),
 				compactWhitespace(item.Attributes.Comment),
-				sanitizeTerminal(formatScreenshotURLs(item.Attributes.Screenshots)),
+				SanitizeTerminalText(formatScreenshotURLs(item.Attributes.Screenshots)),
 			})
 			continue
 		}
 		rows = append(rows, []string{
-			sanitizeTerminal(item.Attributes.CreatedDate),
-			sanitizeTerminal(item.Attributes.Email),
+			SanitizeTerminalText(item.Attributes.CreatedDate),
+			SanitizeTerminalText(item.Attributes.Email),
 			compactWhitespace(item.Attributes.Comment),
 		})
 	}
@@ -61,10 +61,10 @@ func crashesRows(resp *CrashesResponse) ([]string, [][]string) {
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{
-			sanitizeTerminal(item.Attributes.CreatedDate),
-			sanitizeTerminal(item.Attributes.Email),
-			sanitizeTerminal(item.Attributes.DeviceModel),
-			sanitizeTerminal(item.Attributes.OSVersion),
+			SanitizeTerminalText(item.Attributes.CreatedDate),
+			SanitizeTerminalText(item.Attributes.Email),
+			SanitizeTerminalText(item.Attributes.DeviceModel),
+			SanitizeTerminalText(item.Attributes.OSVersion),
 			compactWhitespace(item.Attributes.Comment),
 		})
 	}
@@ -76,9 +76,9 @@ func reviewsRows(resp *ReviewsResponse) ([]string, [][]string) {
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		rows = append(rows, []string{
-			sanitizeTerminal(item.Attributes.CreatedDate),
+			SanitizeTerminalText(item.Attributes.CreatedDate),
 			fmt.Sprintf("%d", item.Attributes.Rating),
-			sanitizeTerminal(item.Attributes.Territory),
+			SanitizeTerminalText(item.Attributes.Territory),
 			compactWhitespace(item.Attributes.Title),
 		})
 	}

--- a/internal/asc/output_helpers.go
+++ b/internal/asc/output_helpers.go
@@ -3,7 +3,7 @@ package asc
 import "strings"
 
 func compactWhitespace(input string) string {
-	clean := sanitizeTerminal(input)
+	clean := SanitizeTerminalText(input)
 	return strings.Join(strings.Fields(clean), " ")
 }
 

--- a/internal/asc/output_review_attachments.go
+++ b/internal/asc/output_review_attachments.go
@@ -13,11 +13,11 @@ func appStoreReviewAttachmentsRows(resp *AppStoreReviewAttachmentsResponse) ([]s
 	for _, item := range resp.Data {
 		attrs := item.Attributes
 		rows = append(rows, []string{
-			sanitizeTerminal(item.ID),
-			sanitizeTerminal(fallbackValue(attrs.FileName)),
+			SanitizeTerminalText(item.ID),
+			SanitizeTerminalText(fallbackValue(attrs.FileName)),
 			formatAttachmentFileSize(attrs.FileSize),
-			sanitizeTerminal(fallbackValue(attrs.SourceFileChecksum)),
-			sanitizeTerminal(formatAssetDeliveryState(attrs.AssetDeliveryState)),
+			SanitizeTerminalText(fallbackValue(attrs.SourceFileChecksum)),
+			SanitizeTerminalText(formatAssetDeliveryState(attrs.AssetDeliveryState)),
 		})
 	}
 	return headers, rows

--- a/internal/asc/output_rows_sanitize_test.go
+++ b/internal/asc/output_rows_sanitize_test.go
@@ -1,0 +1,62 @@
+package asc
+
+import "testing"
+
+func TestReviewSubmissionRowsRemoveTerminalControls(t *testing.T) {
+	resp := &ReviewSubmissionsResponse{
+		Data: []ReviewSubmissionResource{{
+			ID: "SUBMISSION\x1b[31mID\u202e",
+			Attributes: ReviewSubmissionAttributes{
+				SubmissionState: "READY_FOR_REVIEW\u009b2K",
+			},
+		}},
+	}
+
+	headers, rows := reviewSubmissionsRows(resp)
+	assertRowsAreInert(t, headers, rows)
+}
+
+func TestReviewSubmissionItemRowsRemoveTerminalControls(t *testing.T) {
+	resp := &ReviewSubmissionItemsResponse{
+		Data: []ReviewSubmissionItemResource{{
+			ID: "ITEM\x1b]0;pwned\x07ID",
+			Attributes: ReviewSubmissionItemAttributes{
+				State: "ACCEPTED\u202e",
+			},
+		}},
+	}
+
+	headers, rows := reviewSubmissionItemsRows(resp)
+	assertRowsAreInert(t, headers, rows)
+}
+
+func TestBuildIconsRowsRemoveTerminalControls(t *testing.T) {
+	resp := &BuildIconsResponse{
+		Data: []Resource[BuildIconAttributes]{{
+			ID: "ICON\x1b[31mID",
+			Attributes: BuildIconAttributes{
+				Name:     hostileText,
+				IconType: IconAssetType("APP_STORE\u202e\x1b[0m"),
+			},
+		}},
+	}
+
+	headers, rows := buildIconsRows(resp)
+	assertRowsAreInert(t, headers, rows)
+}
+
+func TestCustomerReviewResponseRowsRemoveTerminalControls(t *testing.T) {
+	resp := &CustomerReviewResponseResponse{
+		Data: CustomerReviewResponseResource{
+			ID: "RESPONSE\x1b[31mID",
+			Attributes: CustomerReviewResponseAttributes{
+				ResponseBody: hostileText,
+				State:        "PUBLISHED\u202e",
+				LastModified: "2026-01-01T00:00:00Z",
+			},
+		},
+	}
+
+	headers, rows := customerReviewResponseRows(resp)
+	assertRowsAreInert(t, headers, rows)
+}

--- a/internal/asc/review_responses_output.go
+++ b/internal/asc/review_responses_output.go
@@ -6,8 +6,8 @@ func customerReviewResponseRows(resp *CustomerReviewResponseResponse) ([]string,
 	headers := []string{"ID", "State", "Last Modified", "Response Body"}
 	rows := [][]string{{
 		resp.Data.ID,
-		sanitizeTerminal(resp.Data.Attributes.State),
-		sanitizeTerminal(resp.Data.Attributes.LastModified),
+		SanitizeTerminalText(resp.Data.Attributes.State),
+		SanitizeTerminalText(resp.Data.Attributes.LastModified),
 		compactWhitespace(resp.Data.Attributes.ResponseBody),
 	}}
 	return headers, rows

--- a/internal/asc/review_responses_output.go
+++ b/internal/asc/review_responses_output.go
@@ -5,7 +5,7 @@ import "fmt"
 func customerReviewResponseRows(resp *CustomerReviewResponseResponse) ([]string, [][]string) {
 	headers := []string{"ID", "State", "Last Modified", "Response Body"}
 	rows := [][]string{{
-		resp.Data.ID,
+		SanitizeTerminalText(resp.Data.ID),
 		SanitizeTerminalText(resp.Data.Attributes.State),
 		SanitizeTerminalText(resp.Data.Attributes.LastModified),
 		compactWhitespace(resp.Data.Attributes.ResponseBody),

--- a/internal/asc/review_submissions_output.go
+++ b/internal/asc/review_submissions_output.go
@@ -13,10 +13,10 @@ func reviewSubmissionsRows(resp *ReviewSubmissionsResponse) ([]string, [][]strin
 		itemCount := reviewSubmissionItemCount(item.Relationships)
 		rows = append(rows, []string{
 			item.ID,
-			sanitizeTerminal(string(item.Attributes.SubmissionState)),
-			sanitizeTerminal(string(item.Attributes.Platform)),
-			sanitizeTerminal(item.Attributes.SubmittedDate),
-			sanitizeTerminal(appID),
+			SanitizeTerminalText(string(item.Attributes.SubmissionState)),
+			SanitizeTerminalText(string(item.Attributes.Platform)),
+			SanitizeTerminalText(item.Attributes.SubmittedDate),
+			SanitizeTerminalText(appID),
 			itemCount,
 		})
 	}
@@ -31,10 +31,10 @@ func reviewSubmissionItemsRows(resp *ReviewSubmissionItemsResponse) ([]string, [
 		submissionID := reviewSubmissionItemSubmissionID(item.Relationships)
 		rows = append(rows, []string{
 			item.ID,
-			sanitizeTerminal(item.Attributes.State),
-			sanitizeTerminal(itemType),
-			sanitizeTerminal(itemID),
-			sanitizeTerminal(submissionID),
+			SanitizeTerminalText(item.Attributes.State),
+			SanitizeTerminalText(itemType),
+			SanitizeTerminalText(itemID),
+			SanitizeTerminalText(submissionID),
 		})
 	}
 	return headers, rows

--- a/internal/asc/review_submissions_output.go
+++ b/internal/asc/review_submissions_output.go
@@ -12,7 +12,7 @@ func reviewSubmissionsRows(resp *ReviewSubmissionsResponse) ([]string, [][]strin
 		appID := reviewSubmissionAppID(item.Relationships)
 		itemCount := reviewSubmissionItemCount(item.Relationships)
 		rows = append(rows, []string{
-			item.ID,
+			SanitizeTerminalText(item.ID),
 			SanitizeTerminalText(string(item.Attributes.SubmissionState)),
 			SanitizeTerminalText(string(item.Attributes.Platform)),
 			SanitizeTerminalText(item.Attributes.SubmittedDate),
@@ -30,7 +30,7 @@ func reviewSubmissionItemsRows(resp *ReviewSubmissionItemsResponse) ([]string, [
 		itemType, itemID := reviewSubmissionItemTarget(item.Relationships)
 		submissionID := reviewSubmissionItemSubmissionID(item.Relationships)
 		rows = append(rows, []string{
-			item.ID,
+			SanitizeTerminalText(item.ID),
 			SanitizeTerminalText(item.Attributes.State),
 			SanitizeTerminalText(itemType),
 			SanitizeTerminalText(itemID),

--- a/internal/asc/signing_output.go
+++ b/internal/asc/signing_output.go
@@ -159,7 +159,7 @@ func formatCapabilitySettings(settings []CapabilitySetting) string {
 	if err != nil {
 		return ""
 	}
-	return sanitizeTerminal(string(payload))
+	return SanitizeTerminalText(string(payload))
 }
 
 func certificateDisplayName(attrs CertificateAttributes) string {

--- a/internal/asc/terminal_sanitize.go
+++ b/internal/asc/terminal_sanitize.go
@@ -1,6 +1,9 @@
 package asc
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // SanitizeTerminalText removes characters that a terminal, pager, or CI log
 // viewer interprets instead of displaying. Structured output (JSON) keeps the
@@ -20,6 +23,10 @@ import "strings"
 //
 // Line breaks and tabs are removed rather than preserved so a single value
 // cannot forge extra rows or columns in table, Markdown, or log output.
+//
+// Invalid UTF-8 bytes are removed as well: a raw 0x9B or 0x9D byte is the
+// single-byte CSI or OSC form on terminals that accept 8-bit C1 controls, and
+// ranging over the string would otherwise decode it to U+FFFD and keep it.
 func SanitizeTerminalText(input string) string {
 	if input == "" || !HasInterpretedTerminalSequence(input) {
 		return input
@@ -27,11 +34,14 @@ func SanitizeTerminalText(input string) string {
 
 	var b strings.Builder
 	b.Grow(len(input))
-	for _, r := range input {
-		if isInterpretedTerminalRune(r) {
+	for i := 0; i < len(input); {
+		r, size := utf8.DecodeRuneInString(input[i:])
+		if (r == utf8.RuneError && size == 1) || isInterpretedTerminalRune(r) {
+			i += size
 			continue
 		}
-		b.WriteRune(r)
+		b.WriteString(input[i : i+size])
+		i += size
 	}
 	return b.String()
 }
@@ -39,10 +49,12 @@ func SanitizeTerminalText(input string) string {
 // HasInterpretedTerminalSequence reports whether input contains any character
 // that SanitizeTerminalText removes.
 func HasInterpretedTerminalSequence(input string) bool {
-	for _, r := range input {
-		if isInterpretedTerminalRune(r) {
+	for i := 0; i < len(input); {
+		r, size := utf8.DecodeRuneInString(input[i:])
+		if (r == utf8.RuneError && size == 1) || isInterpretedTerminalRune(r) {
 			return true
 		}
+		i += size
 	}
 	return false
 }

--- a/internal/asc/terminal_sanitize.go
+++ b/internal/asc/terminal_sanitize.go
@@ -15,6 +15,8 @@ import "strings"
 //   - Bidirectional marks, embeddings, overrides, and isolates (U+061C, U+200E,
 //     U+200F, U+202A-U+202E, U+2066-U+2069), which can visually reorder a
 //     rendered cell
+//   - Unicode line and paragraph separators (U+2028, U+2029), which
+//     browser-backed log and Markdown viewers render as mandatory breaks
 //
 // Line breaks and tabs are removed rather than preserved so a single value
 // cannot forge extra rows or columns in table, Markdown, or log output.
@@ -56,6 +58,8 @@ func isInterpretedTerminalRune(r rune) bool {
 	case r == 0x200e, r == 0x200f:
 		return true
 	case r >= 0x202a && r <= 0x202e:
+		return true
+	case r == 0x2028, r == 0x2029:
 		return true
 	case r >= 0x2066 && r <= 0x2069:
 		return true

--- a/internal/asc/terminal_sanitize.go
+++ b/internal/asc/terminal_sanitize.go
@@ -12,8 +12,9 @@ import "strings"
 //     introducer used by CSI/OSC sequences as well as BEL, CR, LF, and TAB
 //   - C1 controls (U+0080-U+009F), which include the single-byte CSI (U+009B)
 //     and OSC (U+009D) forms
-//   - Bidirectional marks, embeddings, overrides, and isolates (U+200E, U+200F,
-//     U+202A-U+202E, U+2066-U+2069), which can visually reorder a rendered cell
+//   - Bidirectional marks, embeddings, overrides, and isolates (U+061C, U+200E,
+//     U+200F, U+202A-U+202E, U+2066-U+2069), which can visually reorder a
+//     rendered cell
 //
 // Line breaks and tabs are removed rather than preserved so a single value
 // cannot forge extra rows or columns in table, Markdown, or log output.
@@ -49,6 +50,8 @@ func isInterpretedTerminalRune(r rune) bool {
 	case r < 0x20, r == 0x7f:
 		return true
 	case r >= 0x80 && r <= 0x9f:
+		return true
+	case r == 0x061c:
 		return true
 	case r == 0x200e, r == 0x200f:
 		return true

--- a/internal/asc/terminal_sanitize.go
+++ b/internal/asc/terminal_sanitize.go
@@ -1,0 +1,62 @@
+package asc
+
+import "strings"
+
+// SanitizeTerminalText removes characters that a terminal, pager, or CI log
+// viewer interprets instead of displaying. Structured output (JSON) keeps the
+// original values; only human-facing table, Markdown, stdout, and stderr text
+// is sanitized.
+//
+// Removed characters:
+//   - C0 controls (U+0000-U+001F) and DEL (U+007F), which include the ESC
+//     introducer used by CSI/OSC sequences as well as BEL, CR, LF, and TAB
+//   - C1 controls (U+0080-U+009F), which include the single-byte CSI (U+009B)
+//     and OSC (U+009D) forms
+//   - Bidirectional marks, embeddings, overrides, and isolates (U+200E, U+200F,
+//     U+202A-U+202E, U+2066-U+2069), which can visually reorder a rendered cell
+//
+// Line breaks and tabs are removed rather than preserved so a single value
+// cannot forge extra rows or columns in table, Markdown, or log output.
+func SanitizeTerminalText(input string) string {
+	if input == "" || !HasInterpretedTerminalSequence(input) {
+		return input
+	}
+
+	var b strings.Builder
+	b.Grow(len(input))
+	for _, r := range input {
+		if isInterpretedTerminalRune(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// HasInterpretedTerminalSequence reports whether input contains any character
+// that SanitizeTerminalText removes.
+func HasInterpretedTerminalSequence(input string) bool {
+	for _, r := range input {
+		if isInterpretedTerminalRune(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isInterpretedTerminalRune(r rune) bool {
+	switch {
+	case r < 0x20, r == 0x7f:
+		return true
+	case r >= 0x80 && r <= 0x9f:
+		return true
+	case r == 0x200e, r == 0x200f:
+		return true
+	case r >= 0x202a && r <= 0x202e:
+		return true
+	case r >= 0x2066 && r <= 0x2069:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/asc/terminal_sanitize_test.go
+++ b/internal/asc/terminal_sanitize_test.go
@@ -54,6 +54,11 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 			want:  "abc",
 		},
 		{
+			name:  "arabic letter mark",
+			input: "total\u061c123",
+			want:  "total123",
+		},
+		{
 			name:  "newline and tab",
 			input: "line one\nline\ttwo",
 			want:  "line onelinetwo",
@@ -79,7 +84,7 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 }
 
 func TestHasInterpretedTerminalSequenceDetectsControls(t *testing.T) {
-	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\x7f", "\r", "\n"}
+	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\u061c", "\x7f", "\r", "\n"}
 	for _, value := range unsafe {
 		if !HasInterpretedTerminalSequence(value) {
 			t.Fatalf("HasInterpretedTerminalSequence(%q) = false, want true", value)

--- a/internal/asc/terminal_sanitize_test.go
+++ b/internal/asc/terminal_sanitize_test.go
@@ -59,6 +59,11 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 			want:  "total123",
 		},
 		{
+			name:  "unicode line and paragraph separators",
+			input: "row one\u2028row two\u2029row three",
+			want:  "row onerow tworow three",
+		},
+		{
 			name:  "newline and tab",
 			input: "line one\nline\ttwo",
 			want:  "line onelinetwo",
@@ -84,7 +89,7 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 }
 
 func TestHasInterpretedTerminalSequenceDetectsControls(t *testing.T) {
-	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\u061c", "\x7f", "\r", "\n"}
+	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\u061c", "\u2028", "\u2029", "\x7f", "\r", "\n"}
 	for _, value := range unsafe {
 		if !HasInterpretedTerminalSequence(value) {
 			t.Fatalf("HasInterpretedTerminalSequence(%q) = false, want true", value)

--- a/internal/asc/terminal_sanitize_test.go
+++ b/internal/asc/terminal_sanitize_test.go
@@ -1,0 +1,95 @@
+package asc
+
+import "testing"
+
+func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text is unchanged",
+			input: "screenshot-6.5-inch.png",
+			want:  "screenshot-6.5-inch.png",
+		},
+		{
+			name:  "escape introducer",
+			input: "before\x1b[31mafter",
+			want:  "before[31mafter",
+		},
+		{
+			name:  "osc window title with bell terminator",
+			input: "shot\x1b]0;pwned\x07.png",
+			want:  "shot]0;pwned.png",
+		},
+		{
+			name:  "c1 control sequence introducer",
+			input: "state\u009b2Kdone",
+			want:  "state2Kdone",
+		},
+		{
+			name:  "c1 operating system command",
+			input: "state\u009d0;pwned\u009cdone",
+			want:  "state0;pwneddone",
+		},
+		{
+			name:  "carriage return and del",
+			input: "visible\rhidden\u007f",
+			want:  "visiblehidden",
+		},
+		{
+			name:  "bidi override",
+			input: "gpj.\u202egnp.exe",
+			want:  "gpj.gnp.exe",
+		},
+		{
+			name:  "bidi isolates",
+			input: "a\u2066b\u2067c\u2068d\u2069e",
+			want:  "abcde",
+		},
+		{
+			name:  "bidi marks",
+			input: "a\u200eb\u200fc",
+			want:  "abc",
+		},
+		{
+			name:  "newline and tab",
+			input: "line one\nline\ttwo",
+			want:  "line onelinetwo",
+		},
+		{
+			name:  "non-latin text is preserved",
+			input: "スクリーンショット.png",
+			want:  "スクリーンショット.png",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeTerminalText(tc.input)
+			if got != tc.want {
+				t.Fatalf("SanitizeTerminalText(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			if HasInterpretedTerminalSequence(got) {
+				t.Fatalf("SanitizeTerminalText(%q) left interpreted sequences in %q", tc.input, got)
+			}
+		})
+	}
+}
+
+func TestHasInterpretedTerminalSequenceDetectsControls(t *testing.T) {
+	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\x7f", "\r", "\n"}
+	for _, value := range unsafe {
+		if !HasInterpretedTerminalSequence(value) {
+			t.Fatalf("HasInterpretedTerminalSequence(%q) = false, want true", value)
+		}
+	}
+
+	safe := []string{"", "plain", "6.5-inch", "スクリーンショット"}
+	for _, value := range safe {
+		if HasInterpretedTerminalSequence(value) {
+			t.Fatalf("HasInterpretedTerminalSequence(%q) = true, want false", value)
+		}
+	}
+}

--- a/internal/asc/terminal_sanitize_test.go
+++ b/internal/asc/terminal_sanitize_test.go
@@ -64,6 +64,16 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 			want:  "row onerow tworow three",
 		},
 		{
+			name:  "raw single-byte c1 controls in invalid utf-8",
+			input: "state\x9b2K\x9d0;pwned",
+			want:  "state2K0;pwned",
+		},
+		{
+			name:  "invalid utf-8 continuation byte",
+			input: "name\xc2suffix",
+			want:  "namesuffix",
+		},
+		{
 			name:  "newline and tab",
 			input: "line one\nline\ttwo",
 			want:  "line onelinetwo",
@@ -89,7 +99,7 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 }
 
 func TestHasInterpretedTerminalSequenceDetectsControls(t *testing.T) {
-	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\u061c", "\u2028", "\u2029", "\x7f", "\r", "\n"}
+	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\u061c", "\u2028", "\u2029", "\x7f", "\r", "\n", "\x9b", "\x9d"}
 	for _, value := range unsafe {
 		if !HasInterpretedTerminalSequence(value) {
 			t.Fatalf("HasInterpretedTerminalSequence(%q) = false, want true", value)

--- a/internal/cli/diffcmd/localizations.go
+++ b/internal/cli/diffcmd/localizations.go
@@ -473,8 +473,12 @@ func buildLocalizationDiffRows(plan localizationDiffPlan) [][]string {
 	return rows
 }
 
+// sanitizeDiffCell prepares a localization value for human table or Markdown
+// output. Newlines become a visible escape, terminal control and bidi sequences
+// are removed before truncation so a clipped cell cannot leave a partial escape
+// behind, and long values are shortened on a rune boundary.
 func sanitizeDiffCell(value string) string {
-	normalized := strings.ReplaceAll(value, "\n", "\\n")
+	normalized := asc.SanitizeTerminalText(strings.ReplaceAll(value, "\n", "\\n"))
 	const maxLen = 80
 	const suffix = "..."
 	runes := []rune(normalized)

--- a/internal/cli/diffcmd/localizations.go
+++ b/internal/cli/diffcmd/localizations.go
@@ -433,11 +433,14 @@ func renderLocalizationDiffMarkdown(plan localizationDiffPlan) {
 func buildLocalizationDiffRows(plan localizationDiffPlan) [][]string {
 	rows := make([][]string, 0, len(plan.Adds)+len(plan.Updates)+len(plan.Deletes))
 
+	// Key and Locale can come from repository-controlled local files or remote
+	// data, so they get the same cell sanitization as the values. Field and
+	// Reason are internal constants.
 	for _, item := range plan.Adds {
 		rows = append(rows, []string{
 			"add",
-			item.Key,
-			item.Locale,
+			sanitizeDiffCell(item.Key),
+			sanitizeDiffCell(item.Locale),
 			item.Field,
 			item.Reason,
 			"",
@@ -447,8 +450,8 @@ func buildLocalizationDiffRows(plan localizationDiffPlan) [][]string {
 	for _, item := range plan.Updates {
 		rows = append(rows, []string{
 			"update",
-			item.Key,
-			item.Locale,
+			sanitizeDiffCell(item.Key),
+			sanitizeDiffCell(item.Locale),
 			item.Field,
 			item.Reason,
 			sanitizeDiffCell(item.From),
@@ -458,8 +461,8 @@ func buildLocalizationDiffRows(plan localizationDiffPlan) [][]string {
 	for _, item := range plan.Deletes {
 		rows = append(rows, []string{
 			"delete",
-			item.Key,
-			item.Locale,
+			sanitizeDiffCell(item.Key),
+			sanitizeDiffCell(item.Locale),
 			item.Field,
 			item.Reason,
 			sanitizeDiffCell(item.From),

--- a/internal/cli/diffcmd/localizations_test.go
+++ b/internal/cli/diffcmd/localizations_test.go
@@ -1,9 +1,12 @@
 package diffcmd
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestSanitizeDiffCellPreservesUTF8WhenUnderRuneLimit(t *testing.T) {
@@ -64,5 +67,70 @@ func TestSanitizeDiffCellEscapesNewlinesBeforeTruncation(t *testing.T) {
 	}
 	if !utf8.ValidString(got) {
 		t.Fatalf("expected sanitized value to remain valid UTF-8")
+	}
+}
+
+func TestSanitizeDiffCellRemovesTerminalControls(t *testing.T) {
+	for _, input := range []string{
+		"promo\x1b[31mtext",
+		"promo\x1b]0;pwned\x07text",
+		"promo\u009b2Ktext",
+		"promo\u202etxet",
+		"promo\u2066text\u2069",
+		"promo\rtext\u007f",
+	} {
+		got := sanitizeDiffCell(input)
+		if asc.HasInterpretedTerminalSequence(got) {
+			t.Fatalf("sanitizeDiffCell(%q) = %q, want no interpreted terminal sequences", input, got)
+		}
+	}
+}
+
+func TestSanitizeDiffCellRemovesControlsBeforeTruncation(t *testing.T) {
+	// A control sequence at the truncation boundary must not survive as a
+	// half-written escape.
+	input := strings.Repeat("a", 78) + "\x1b[31m" + strings.Repeat("b", 20)
+
+	got := sanitizeDiffCell(input)
+
+	if asc.HasInterpretedTerminalSequence(got) {
+		t.Fatalf("sanitizeDiffCell(...) = %q, want no interpreted terminal sequences", got)
+	}
+	if len([]rune(got)) != 80 {
+		t.Fatalf("expected 80 runes after truncation, got %d (%q)", len([]rune(got)), got)
+	}
+}
+
+func TestLocalizationDiffRowsRemoveTerminalControlsAndJSONKeepsOriginals(t *testing.T) {
+	hostile := "New\x1b]0;pwned\x07 features\u202e"
+	plan := buildLocalizationDiffPlan(
+		"123456789",
+		localizationDiffEndpoint{Kind: "local", Path: "./metadata"},
+		localizationDiffEndpoint{Kind: "remote", VersionID: "VERSION_ID"},
+		map[string]map[string]string{"en-US": {"whatsNew": "Bug fixes"}},
+		map[string]map[string]string{"en-US": {"whatsNew": hostile}},
+	)
+
+	for _, row := range buildLocalizationDiffRows(plan) {
+		for i, cell := range row {
+			if asc.HasInterpretedTerminalSequence(cell) {
+				t.Fatalf("diff row column %d = %q contains interpreted terminal sequences", i, cell)
+			}
+		}
+	}
+
+	payload, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	var decoded localizationDiffPlan
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal plan: %v", err)
+	}
+	if len(decoded.Updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(decoded.Updates))
+	}
+	if decoded.Updates[0].To != hostile {
+		t.Fatalf("JSON update value = %q, want the original %q", decoded.Updates[0].To, hostile)
 	}
 }

--- a/internal/cli/diffcmd/localizations_test.go
+++ b/internal/cli/diffcmd/localizations_test.go
@@ -134,3 +134,26 @@ func TestLocalizationDiffRowsRemoveTerminalControlsAndJSONKeepsOriginals(t *test
 		t.Fatalf("JSON update value = %q, want the original %q", decoded.Updates[0].To, hostile)
 	}
 }
+
+func TestLocalizationDiffRowsSanitizeLocaleAndKey(t *testing.T) {
+	hostileLocale := "en-US\x1b[31m\u202e"
+	plan := buildLocalizationDiffPlan(
+		"123456789",
+		localizationDiffEndpoint{Kind: "local", Path: "./metadata"},
+		localizationDiffEndpoint{Kind: "remote", VersionID: "VERSION_ID"},
+		map[string]map[string]string{hostileLocale: {"whatsNew": "Bug fixes"}},
+		map[string]map[string]string{hostileLocale: {"whatsNew": "New features"}},
+	)
+
+	rows := buildLocalizationDiffRows(plan)
+	if len(rows) == 0 {
+		t.Fatalf("expected at least one diff row")
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if asc.HasInterpretedTerminalSequence(cell) {
+				t.Fatalf("diff row column %d = %q contains interpreted terminal sequences", i, cell)
+			}
+		}
+	}
+}

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -32,6 +32,7 @@ const (
 var (
 	lookupExecutable = exec.LookPath
 	runCommand       = defaultRunCommand
+	runCommandInDir  = defaultRunCommandInDir
 	errNpxNotFound   = errors.New("npx not found")
 	errGitNotFound   = errors.New("git not found")
 )
@@ -93,7 +94,21 @@ func installSkills(ctx context.Context) error {
 		return err
 	}
 
-	return runCommand(ctx, npxPath, "--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes")
+	// npx prefers a local dependency whose name and version match the requested
+	// package, so running it inside a caller project that carries
+	// node_modules/skills at the pinned version would execute
+	// repository-controlled code instead of the reviewed registry package. The
+	// installer therefore runs in a fresh empty directory with no node_modules
+	// in reach.
+	runDir, err := os.MkdirTemp("", "asc-skills-npx-")
+	if err != nil {
+		return fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(runDir)
+	}()
+
+	return runCommandInDir(ctx, runDir, npxPath, "--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes")
 }
 
 // checkoutPinnedSkills fetches exactly skillsSourceCommit into sourceDir. Git
@@ -115,6 +130,15 @@ func checkoutPinnedSkills(ctx context.Context, gitPath string, sourceDir string)
 	}
 
 	return nil
+}
+
+func defaultRunCommandInDir(ctx context.Context, dir string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
 }
 
 func defaultRunCommand(ctx context.Context, name string, args ...string) error {

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -13,12 +13,27 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-const defaultSkillsPackage = "rorkai/app-store-connect-cli-skills"
+// Pinned installer and skills source. Both are reviewed inputs: bump
+// skillsInstallerPackage only after reviewing the `skills` release, and
+// skillsSourceCommit only after reviewing the ASC skills diff at that commit.
+//
+// The upstream installer cannot consume an immutable ref itself: `skills add
+// owner/repo#<ref>` resolves the ref with `git clone --depth 1 --branch <ref>`,
+// which accepts only branch and tag names and rejects commit SHAs, and the
+// ASC skills repository publishes no tags. The pinned commit is therefore
+// materialized locally with git, which verifies object hashes, and handed to
+// the installer as a local path. Nothing here falls back to a mutable ref.
+const (
+	skillsInstallerPackage    = "skills@1.5.20"
+	skillsSourceRepositoryURL = "https://github.com/rorkai/app-store-connect-cli-skills.git"
+	skillsSourceCommit        = "e30039abddbe388179324d0f9cdccb66c3843115"
+)
 
 var (
-	lookupNpx      = exec.LookPath
-	runCommand     = defaultRunCommand
-	errNpxNotFound = errors.New("npx not found")
+	lookupExecutable = exec.LookPath
+	runCommand       = defaultRunCommand
+	errNpxNotFound   = errors.New("npx not found")
+	errGitNotFound   = errors.New("git not found")
 )
 
 // InstallSkillsCommand returns the top-level `install-skills` command.
@@ -29,10 +44,18 @@ func InstallSkillsCommand() *ffcli.Command {
 		Name:       "install-skills",
 		ShortUsage: "asc install-skills",
 		ShortHelp:  "Install the asc skill pack globally for App Store Connect workflows.",
-		LongHelp: `Install the asc skill pack globally for App Store Connect workflows.
+		LongHelp: fmt.Sprintf(`Install the asc skill pack globally for App Store Connect workflows.
+
+Runs the pinned installer %s against the reviewed skills commit
+%s.
+
+Both pins live in the asc source, so upgrading the skill pack is an explicit
+reviewed change rather than an automatic update.
+
+Requires Node.js (npx) and git.
 
 Examples:
-  asc install-skills`,
+  asc install-skills`, skillsInstallerPackage, skillsSourceCommit),
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -48,13 +71,50 @@ func installSkills(ctx context.Context) error {
 	ctx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
-	path, err := lookupNpx("npx")
+	npxPath, err := lookupExecutable("npx")
 	if err != nil {
 		return fmt.Errorf("%w; install Node.js to continue", errNpxNotFound)
 	}
 
-	// `npx add-skill` is deprecated upstream; use the new subcommand style.
-	return runCommand(ctx, path, "--yes", "skills", "add", defaultSkillsPackage, "--global", "--agent", "codex", "--yes")
+	gitPath, err := lookupExecutable("git")
+	if err != nil {
+		return fmt.Errorf("%w; git is required to check out the pinned skills commit %s", errGitNotFound, skillsSourceCommit)
+	}
+
+	sourceDir, err := os.MkdirTemp("", "asc-skills-")
+	if err != nil {
+		return fmt.Errorf("failed to create a checkout directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(sourceDir)
+	}()
+
+	if err := checkoutPinnedSkills(ctx, gitPath, sourceDir); err != nil {
+		return err
+	}
+
+	return runCommand(ctx, npxPath, "--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes")
+}
+
+// checkoutPinnedSkills fetches exactly skillsSourceCommit into sourceDir. Git
+// validates that the received objects hash to the requested commit, so the
+// checkout is verified as well as immutable.
+func checkoutPinnedSkills(ctx context.Context, gitPath string, sourceDir string) error {
+	steps := [][]string{
+		{"init", "--quiet"},
+		{"remote", "add", "origin", skillsSourceRepositoryURL},
+		{"fetch", "--quiet", "--depth", "1", "origin", skillsSourceCommit},
+		{"checkout", "--quiet", "--detach", skillsSourceCommit},
+	}
+
+	for _, step := range steps {
+		args := append([]string{"-C", sourceDir}, step...)
+		if err := runCommand(ctx, gitPath, args...); err != nil {
+			return fmt.Errorf("failed to check out pinned skills commit %s from %s: %w", skillsSourceCommit, skillsSourceRepositoryURL, err)
+		}
+	}
+
+	return nil
 }
 
 func defaultRunCommand(ctx context.Context, name string, args ...string) error {

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -100,15 +101,47 @@ func installSkills(ctx context.Context) error {
 	// repository-controlled code instead of the reviewed registry package. The
 	// installer therefore runs in a fresh empty directory with no node_modules
 	// in reach.
-	runDir, err := os.MkdirTemp("", "asc-skills-npx-")
+	runDir, err := isolatedInstallerDir()
 	if err != nil {
-		return fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
+		return err
 	}
 	defer func() {
 		_ = os.RemoveAll(runDir)
 	}()
 
 	return runCommandInDir(ctx, runDir, npxPath, "--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes")
+}
+
+// isolatedInstallerDir creates the working directory for the pinned installer
+// and verifies that no ancestor carries a node_modules directory. npm resolves
+// package specifiers against local dependencies found by walking up from the
+// working directory, so TMPDIR pointing inside a Node.js project would let a
+// repository-controlled skills package shadow the pinned registry package.
+func isolatedInstallerDir() (string, error) {
+	runDir, err := os.MkdirTemp("", "asc-skills-npx-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
+	}
+	if ancestor := nearestNodeModulesAncestor(runDir); ancestor != "" {
+		_ = os.RemoveAll(runDir)
+		return "", fmt.Errorf("temporary directory %s sits inside a Node.js project (%s contains node_modules), which could shadow the pinned installer; point TMPDIR outside any Node.js project and retry", runDir, ancestor)
+	}
+	return runDir, nil
+}
+
+// nearestNodeModulesAncestor returns the closest directory at or above dir that
+// contains a node_modules entry, or an empty string when there is none.
+func nearestNodeModulesAncestor(dir string) string {
+	for current := dir; ; {
+		if _, err := os.Stat(filepath.Join(current, "node_modules")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
 }
 
 // checkoutPinnedSkills fetches exactly skillsSourceCommit into sourceDir. Git

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -112,33 +112,43 @@ func installSkills(ctx context.Context) error {
 	return runCommandInDir(ctx, runDir, npxPath, "--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes")
 }
 
+// npmProjectMarkers are the entries that make npm treat a directory as a
+// project root: node_modules can satisfy a package specifier with a local
+// dependency, and package.json or .npmrc supply project configuration such as
+// a replacement registry.
+var npmProjectMarkers = []string{"node_modules", "package.json", ".npmrc"}
+
 // isolatedInstallerDir creates the working directory for the pinned installer
-// and verifies that no ancestor carries a node_modules directory. npm resolves
-// package specifiers against local dependencies found by walking up from the
-// working directory, so TMPDIR pointing inside a Node.js project would let a
-// repository-controlled skills package shadow the pinned registry package.
+// and verifies that no ancestor carries an npm project marker. npm resolves
+// package specifiers against local dependencies and reads project
+// configuration by walking up from the working directory, so TMPDIR pointing
+// inside an npm project would let repository-controlled files shadow or
+// redirect the pinned registry package.
 func isolatedInstallerDir() (string, error) {
 	runDir, err := os.MkdirTemp("", "asc-skills-npx-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
 	}
-	if ancestor := nearestNodeModulesAncestor(runDir); ancestor != "" {
+	if ancestor, marker := nearestNpmProjectAncestor(runDir); ancestor != "" {
 		_ = os.RemoveAll(runDir)
-		return "", fmt.Errorf("temporary directory %s sits inside a Node.js project (%s contains node_modules), which could shadow the pinned installer; point TMPDIR outside any Node.js project and retry", runDir, ancestor)
+		return "", fmt.Errorf("temporary directory %s sits inside an npm project (%s contains %s), which could shadow or redirect the pinned installer; point TMPDIR outside any npm project and retry", runDir, ancestor, marker)
 	}
 	return runDir, nil
 }
 
-// nearestNodeModulesAncestor returns the closest directory at or above dir that
-// contains a node_modules entry, or an empty string when there is none.
-func nearestNodeModulesAncestor(dir string) string {
+// nearestNpmProjectAncestor returns the closest directory at or above dir that
+// contains an npm project marker together with the marker it found, or empty
+// strings when there is none.
+func nearestNpmProjectAncestor(dir string) (string, string) {
 	for current := dir; ; {
-		if _, err := os.Stat(filepath.Join(current, "node_modules")); err == nil {
-			return current
+		for _, marker := range npmProjectMarkers {
+			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
+				return current, marker
+			}
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
-			return ""
+			return "", ""
 		}
 		current = parent
 	}

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -3,33 +3,64 @@ package install
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
 
-func TestInstallSkillsRunsNpxSkillsAdd(t *testing.T) {
-	originalLookup := lookupNpx
-	originalRun := runCommand
-	t.Cleanup(func() {
-		lookupNpx = originalLookup
-		runCommand = originalRun
-	})
+type recordedCommand struct {
+	name string
+	args []string
+}
 
-	lookupNpx = func(name string) (string, error) {
-		if name != "npx" {
-			t.Fatalf("expected lookup for npx, got %q", name)
+func stubLookups(t *testing.T, paths map[string]string) {
+	t.Helper()
+
+	originalLookup := lookupExecutable
+	t.Cleanup(func() { lookupExecutable = originalLookup })
+
+	lookupExecutable = func(name string) (string, error) {
+		path, ok := paths[name]
+		if !ok {
+			return "", errors.New("executable not found: " + name)
 		}
-		return "/bin/npx", nil
+		return path, nil
 	}
+}
 
-	var gotName string
-	var gotArgs []string
+func recordCommands(t *testing.T) *[]recordedCommand {
+	t.Helper()
+
+	originalRun := runCommand
+	t.Cleanup(func() { runCommand = originalRun })
+
+	recorded := &[]recordedCommand{}
 	runCommand = func(ctx context.Context, name string, args ...string) error {
-		gotName = name
-		gotArgs = append([]string{}, args...)
+		*recorded = append(*recorded, recordedCommand{name: name, args: append([]string(nil), args...)})
 		return nil
 	}
+	return recorded
+}
+
+func TestSkillsSourceIsPinnedToImmutableInput(t *testing.T) {
+	if !regexp.MustCompile(`^skills@\d+\.\d+\.\d+$`).MatchString(skillsInstallerPackage) {
+		t.Fatalf("skillsInstallerPackage = %q, want an exact skills@MAJOR.MINOR.PATCH pin", skillsInstallerPackage)
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(skillsSourceCommit) {
+		t.Fatalf("skillsSourceCommit = %q, want a full 40-character commit SHA", skillsSourceCommit)
+	}
+	if !strings.HasPrefix(skillsSourceRepositoryURL, "https://github.com/rorkai/app-store-connect-cli-skills") {
+		t.Fatalf("skillsSourceRepositoryURL = %q, want the reviewed ASC skills repository", skillsSourceRepositoryURL)
+	}
+}
+
+func TestInstallSkillsRunsPinnedInstallerAgainstPinnedCommit(t *testing.T) {
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	recorded := recordCommands(t)
 
 	cmd := InstallSkillsCommand()
 	if err := cmd.Parse([]string{}); err != nil {
@@ -39,30 +70,74 @@ func TestInstallSkillsRunsNpxSkillsAdd(t *testing.T) {
 		t.Fatalf("run error: %v", err)
 	}
 
-	if gotName != "/bin/npx" {
-		t.Fatalf("expected npx path /bin/npx, got %q", gotName)
+	if len(*recorded) != 5 {
+		t.Fatalf("expected 5 subprocess calls, got %d: %#v", len(*recorded), *recorded)
 	}
-	expected := []string{"--yes", "skills", "add", defaultSkillsPackage, "--global", "--agent", "codex", "--yes"}
-	if !reflect.DeepEqual(gotArgs, expected) {
-		t.Fatalf("expected args %v, got %v", expected, gotArgs)
+
+	sourceDir := (*recorded)[0].args[1]
+	if !filepath.IsAbs(sourceDir) {
+		t.Fatalf("expected an absolute checkout directory, got %q", sourceDir)
+	}
+
+	want := []recordedCommand{
+		{name: "/bin/git", args: []string{"-C", sourceDir, "init", "--quiet"}},
+		{name: "/bin/git", args: []string{"-C", sourceDir, "remote", "add", "origin", skillsSourceRepositoryURL}},
+		{name: "/bin/git", args: []string{"-C", sourceDir, "fetch", "--quiet", "--depth", "1", "origin", skillsSourceCommit}},
+		{name: "/bin/git", args: []string{"-C", sourceDir, "checkout", "--quiet", "--detach", skillsSourceCommit}},
+		{name: "/bin/npx", args: []string{"--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes"}},
+	}
+	if !reflect.DeepEqual(*recorded, want) {
+		t.Fatalf("subprocess calls =\n%#v\nwant\n%#v", *recorded, want)
+	}
+
+	if _, err := os.Stat(sourceDir); !os.IsNotExist(err) {
+		t.Fatalf("expected the pinned checkout %q to be removed, stat error: %v", sourceDir, err)
+	}
+}
+
+func TestInstallSkillsNeverPassesAMutableRefToTheInstaller(t *testing.T) {
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	recorded := recordCommands(t)
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	for _, call := range *recorded {
+		for _, arg := range call.args {
+			for _, mutableRef := range []string{"HEAD", "FETCH_HEAD", "main", "master", "@latest", "skills"} {
+				if arg == mutableRef {
+					t.Fatalf("argument %q is a mutable ref or unpinned package", arg)
+				}
+			}
+		}
+	}
+
+	installerCall := (*recorded)[len(*recorded)-1]
+	if installerCall.name != "/bin/npx" {
+		t.Fatalf("last subprocess = %q, want the installer", installerCall.name)
+	}
+	for _, arg := range installerCall.args {
+		if strings.Contains(arg, "github.com") || strings.Contains(arg, "app-store-connect-cli-skills") {
+			t.Fatalf("installer argument %q resolves the skills source itself instead of using the pinned checkout", arg)
+		}
 	}
 }
 
 func TestInstallSkillsAppliesASCTimeout(t *testing.T) {
 	t.Setenv("ASC_TIMEOUT", "1m")
 
-	originalLookup := lookupNpx
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+
 	originalRun := runCommand
-	t.Cleanup(func() {
-		lookupNpx = originalLookup
-		runCommand = originalRun
-	})
-
-	lookupNpx = func(name string) (string, error) {
-		return "/bin/npx", nil
-	}
-
+	t.Cleanup(func() { runCommand = originalRun })
+	calls := 0
 	runCommand = func(ctx context.Context, name string, args ...string) error {
+		calls++
 		deadline, ok := ctx.Deadline()
 		if !ok {
 			t.Fatal("expected install command context to have a deadline")
@@ -81,23 +156,14 @@ func TestInstallSkillsAppliesASCTimeout(t *testing.T) {
 	if err := cmd.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
+	if calls == 0 {
+		t.Fatal("expected at least one subprocess call")
+	}
 }
 
 func TestInstallSkillsFailsWhenNpxMissing(t *testing.T) {
-	originalLookup := lookupNpx
-	originalRun := runCommand
-	t.Cleanup(func() {
-		lookupNpx = originalLookup
-		runCommand = originalRun
-	})
-
-	lookupNpx = func(name string) (string, error) {
-		return "", errors.New("missing")
-	}
-	runCommand = func(ctx context.Context, name string, args ...string) error {
-		t.Fatal("runCommand should not be called when npx is missing")
-		return nil
-	}
+	stubLookups(t, map[string]string{"git": "/bin/git"})
+	recorded := recordCommands(t)
 
 	cmd := InstallSkillsCommand()
 	if err := cmd.Parse([]string{}); err != nil {
@@ -109,5 +175,88 @@ func TestInstallSkillsFailsWhenNpxMissing(t *testing.T) {
 	}
 	if !errors.Is(err, errNpxNotFound) {
 		t.Fatalf("expected npx error, got %q", err.Error())
+	}
+	if len(*recorded) != 0 {
+		t.Fatalf("expected no subprocess calls, got %#v", *recorded)
+	}
+}
+
+func TestInstallSkillsFailsWhenGitMissing(t *testing.T) {
+	stubLookups(t, map[string]string{"npx": "/bin/npx"})
+	recorded := recordCommands(t)
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errGitNotFound) {
+		t.Fatalf("expected git error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), skillsSourceCommit) {
+		t.Fatalf("expected the error to name the pinned commit, got %q", err.Error())
+	}
+	if len(*recorded) != 0 {
+		t.Fatalf("expected no subprocess calls, got %#v", *recorded)
+	}
+}
+
+func TestInstallSkillsStopsWhenPinnedCommitCannotBeFetched(t *testing.T) {
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+
+	originalRun := runCommand
+	t.Cleanup(func() { runCommand = originalRun })
+
+	var recorded []recordedCommand
+	runCommand = func(ctx context.Context, name string, args ...string) error {
+		recorded = append(recorded, recordedCommand{name: name, args: append([]string(nil), args...)})
+		if len(args) > 2 && args[2] == "fetch" {
+			return errors.New("could not read from remote repository")
+		}
+		return nil
+	}
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), skillsSourceCommit) {
+		t.Fatalf("expected the error to name the pinned commit, got %q", err.Error())
+	}
+	for _, call := range recorded {
+		if call.name == "/bin/npx" {
+			t.Fatalf("installer ran without the pinned source: %#v", call)
+		}
+	}
+}
+
+func TestPinnedSkillsDocumentationMatchesConstants(t *testing.T) {
+	for _, path := range []string{
+		filepath.Join("..", "..", "..", "README.md"),
+		filepath.Join("..", "..", "..", "installation.mdx"),
+		filepath.Join("..", "..", "..", "index.mdx"),
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		content := string(data)
+
+		if strings.Contains(content, "npx skills add rorkai/app-store-connect-cli-skills") {
+			t.Errorf("%s documents an unpinned installer and skills source", path)
+		}
+		if !strings.Contains(content, skillsInstallerPackage) {
+			t.Errorf("%s does not mention the pinned installer %q", path, skillsInstallerPackage)
+		}
+		if !strings.Contains(content, skillsSourceCommit) {
+			t.Errorf("%s does not mention the pinned skills commit %q", path, skillsSourceCommit)
+		}
 	}
 }

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -14,6 +14,7 @@ import (
 
 type recordedCommand struct {
 	name string
+	dir  string
 	args []string
 }
 
@@ -38,9 +39,16 @@ func recordCommands(t *testing.T) *[]recordedCommand {
 	originalRun := runCommand
 	t.Cleanup(func() { runCommand = originalRun })
 
+	originalRunInDir := runCommandInDir
+	t.Cleanup(func() { runCommandInDir = originalRunInDir })
+
 	recorded := &[]recordedCommand{}
 	runCommand = func(ctx context.Context, name string, args ...string) error {
 		*recorded = append(*recorded, recordedCommand{name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+	runCommandInDir = func(ctx context.Context, dir string, name string, args ...string) error {
+		*recorded = append(*recorded, recordedCommand{name: name, dir: dir, args: append([]string(nil), args...)})
 		return nil
 	}
 	return recorded
@@ -79,12 +87,13 @@ func TestInstallSkillsRunsPinnedInstallerAgainstPinnedCommit(t *testing.T) {
 		t.Fatalf("expected an absolute checkout directory, got %q", sourceDir)
 	}
 
+	installerDir := (*recorded)[4].dir
 	want := []recordedCommand{
 		{name: "/bin/git", args: []string{"-C", sourceDir, "init", "--quiet"}},
 		{name: "/bin/git", args: []string{"-C", sourceDir, "remote", "add", "origin", skillsSourceRepositoryURL}},
 		{name: "/bin/git", args: []string{"-C", sourceDir, "fetch", "--quiet", "--depth", "1", "origin", skillsSourceCommit}},
 		{name: "/bin/git", args: []string{"-C", sourceDir, "checkout", "--quiet", "--detach", skillsSourceCommit}},
-		{name: "/bin/npx", args: []string{"--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes"}},
+		{name: "/bin/npx", dir: installerDir, args: []string{"--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes"}},
 	}
 	if !reflect.DeepEqual(*recorded, want) {
 		t.Fatalf("subprocess calls =\n%#v\nwant\n%#v", *recorded, want)
@@ -92,6 +101,51 @@ func TestInstallSkillsRunsPinnedInstallerAgainstPinnedCommit(t *testing.T) {
 
 	if _, err := os.Stat(sourceDir); !os.IsNotExist(err) {
 		t.Fatalf("expected the pinned checkout %q to be removed, stat error: %v", sourceDir, err)
+	}
+	if _, err := os.Stat(installerDir); !os.IsNotExist(err) {
+		t.Fatalf("expected the isolated installer directory %q to be removed, stat error: %v", installerDir, err)
+	}
+}
+
+// TestInstallSkillsRunsInstallerOutsideCallerDirectory pins the npx working
+// directory to a fresh isolated directory. npx prefers a local dependency whose
+// name and version match the requested package, so running it inside a caller
+// project containing node_modules/skills at the pinned version would execute
+// repository-controlled code instead of the reviewed registry package.
+func TestInstallSkillsRunsInstallerOutsideCallerDirectory(t *testing.T) {
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	recorded := recordCommands(t)
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	installer := (*recorded)[len(*recorded)-1]
+	if installer.name != "/bin/npx" {
+		t.Fatalf("last subprocess = %q, want the installer", installer.name)
+	}
+	if installer.dir == "" || !filepath.IsAbs(installer.dir) {
+		t.Fatalf("installer working directory = %q, want an absolute isolated directory", installer.dir)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if installer.dir == cwd {
+		t.Fatalf("installer ran in the caller directory %q", cwd)
+	}
+	if rel, err := filepath.Rel(cwd, installer.dir); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		t.Fatalf("installer working directory %q is inside the caller directory %q", installer.dir, cwd)
+	}
+
+	sourceDir := installer.args[3]
+	if installer.dir == sourceDir {
+		t.Fatalf("installer must not run inside the skills checkout %q", sourceDir)
 	}
 }
 
@@ -134,9 +188,13 @@ func TestInstallSkillsAppliesASCTimeout(t *testing.T) {
 	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
 
 	originalRun := runCommand
-	t.Cleanup(func() { runCommand = originalRun })
+	originalRunInDir := runCommandInDir
+	t.Cleanup(func() {
+		runCommand = originalRun
+		runCommandInDir = originalRunInDir
+	})
 	calls := 0
-	runCommand = func(ctx context.Context, name string, args ...string) error {
+	assertDeadline := func(ctx context.Context) {
 		calls++
 		deadline, ok := ctx.Deadline()
 		if !ok {
@@ -146,6 +204,13 @@ func TestInstallSkillsAppliesASCTimeout(t *testing.T) {
 		if remaining <= 0 || remaining > time.Minute {
 			t.Fatalf("expected ASC_TIMEOUT deadline within 1m, got %s", remaining)
 		}
+	}
+	runCommand = func(ctx context.Context, name string, args ...string) error {
+		assertDeadline(ctx)
+		return nil
+	}
+	runCommandInDir = func(ctx context.Context, dir string, name string, args ...string) error {
+		assertDeadline(ctx)
 		return nil
 	}
 
@@ -208,7 +273,11 @@ func TestInstallSkillsStopsWhenPinnedCommitCannotBeFetched(t *testing.T) {
 	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
 
 	originalRun := runCommand
-	t.Cleanup(func() { runCommand = originalRun })
+	originalRunInDir := runCommandInDir
+	t.Cleanup(func() {
+		runCommand = originalRun
+		runCommandInDir = originalRunInDir
+	})
 
 	var recorded []recordedCommand
 	runCommand = func(ctx context.Context, name string, args ...string) error {
@@ -216,6 +285,10 @@ func TestInstallSkillsStopsWhenPinnedCommitCannotBeFetched(t *testing.T) {
 		if len(args) > 2 && args[2] == "fetch" {
 			return errors.New("could not read from remote repository")
 		}
+		return nil
+	}
+	runCommandInDir = func(ctx context.Context, dir string, name string, args ...string) error {
+		recorded = append(recorded, recordedCommand{name: name, dir: dir, args: append([]string(nil), args...)})
 		return nil
 	}
 

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -311,38 +311,58 @@ func TestInstallSkillsStopsWhenPinnedCommitCannotBeFetched(t *testing.T) {
 }
 
 // TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject guards the
-// isolated npx directory against TMPDIR pointing into a Node.js project: npm
-// walks up from the working directory, so an ancestor node_modules could still
-// shadow the pinned registry package with a local skills dependency.
+// isolated npx directory against TMPDIR pointing into an npm project: npm walks
+// up from the working directory, so an ancestor node_modules could shadow the
+// pinned registry package with a local skills dependency, and an ancestor
+// package.json or .npmrc could redirect the install to a project-controlled
+// registry.
 func TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject(t *testing.T) {
-	project := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(project, "node_modules"), 0o755); err != nil {
-		t.Fatalf("create node_modules fixture: %v", err)
+	markers := []struct {
+		name string
+		dir  bool
+	}{
+		{name: "node_modules", dir: true},
+		{name: "package.json", dir: false},
+		{name: ".npmrc", dir: false},
 	}
-	tmpInsideProject := filepath.Join(project, "tmp")
-	if err := os.MkdirAll(tmpInsideProject, 0o755); err != nil {
-		t.Fatalf("create nested tmp dir: %v", err)
-	}
-	t.Setenv("TMPDIR", tmpInsideProject)
 
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-	recorded := recordCommands(t)
+	for _, marker := range markers {
+		t.Run(marker.name, func(t *testing.T) {
+			project := t.TempDir()
+			markerPath := filepath.Join(project, marker.name)
+			if marker.dir {
+				if err := os.MkdirAll(markerPath, 0o755); err != nil {
+					t.Fatalf("create %s fixture: %v", marker.name, err)
+				}
+			} else if err := os.WriteFile(markerPath, []byte("{}"), 0o644); err != nil {
+				t.Fatalf("create %s fixture: %v", marker.name, err)
+			}
+			tmpInsideProject := filepath.Join(project, "tmp")
+			if err := os.MkdirAll(tmpInsideProject, 0o755); err != nil {
+				t.Fatalf("create nested tmp dir: %v", err)
+			}
+			t.Setenv("TMPDIR", tmpInsideProject)
 
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	err := cmd.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected an error when TMPDIR sits inside a Node.js project")
-	}
-	if !strings.Contains(err.Error(), "node_modules") {
-		t.Fatalf("expected the error to explain the node_modules conflict, got %q", err.Error())
-	}
-	for _, call := range *recorded {
-		if call.name == "/bin/npx" {
-			t.Fatalf("installer ran despite the unsafe working directory: %#v", call)
-		}
+			stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+			recorded := recordCommands(t)
+
+			cmd := InstallSkillsCommand()
+			if err := cmd.Parse([]string{}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			err := cmd.Run(context.Background())
+			if err == nil {
+				t.Fatal("expected an error when TMPDIR sits inside an npm project")
+			}
+			if !strings.Contains(err.Error(), marker.name) {
+				t.Fatalf("expected the error to name the %s marker, got %q", marker.name, err.Error())
+			}
+			for _, call := range *recorded {
+				if call.name == "/bin/npx" {
+					t.Fatalf("installer ran despite the unsafe working directory: %#v", call)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -310,6 +310,42 @@ func TestInstallSkillsStopsWhenPinnedCommitCannotBeFetched(t *testing.T) {
 	}
 }
 
+// TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject guards the
+// isolated npx directory against TMPDIR pointing into a Node.js project: npm
+// walks up from the working directory, so an ancestor node_modules could still
+// shadow the pinned registry package with a local skills dependency.
+func TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, "node_modules"), 0o755); err != nil {
+		t.Fatalf("create node_modules fixture: %v", err)
+	}
+	tmpInsideProject := filepath.Join(project, "tmp")
+	if err := os.MkdirAll(tmpInsideProject, 0o755); err != nil {
+		t.Fatalf("create nested tmp dir: %v", err)
+	}
+	t.Setenv("TMPDIR", tmpInsideProject)
+
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	recorded := recordCommands(t)
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when TMPDIR sits inside a Node.js project")
+	}
+	if !strings.Contains(err.Error(), "node_modules") {
+		t.Fatalf("expected the error to explain the node_modules conflict, got %q", err.Error())
+	}
+	for _, call := range *recorded {
+		if call.name == "/bin/npx" {
+			t.Fatalf("installer ran despite the unsafe working directory: %#v", call)
+		}
+	}
+}
+
 func TestPinnedSkillsDocumentationMatchesConstants(t *testing.T) {
 	for _, path := range []string{
 		filepath.Join("..", "..", "..", "README.md"),

--- a/internal/cli/install/skills_check.go
+++ b/internal/cli/install/skills_check.go
@@ -587,7 +587,7 @@ func defaultRunSkillsCheckCommand(ctx context.Context) (string, error) {
 		return runSkillsCheckProcess(ctx, skillsPath, []string{"check"}, nil)
 	}
 
-	npxPath, err := lookupNpx("npx")
+	npxPath, err := lookupExecutable("npx")
 	if err != nil {
 		return "", errSkillsCheckUnavailable
 	}
@@ -595,7 +595,7 @@ func defaultRunSkillsCheckCommand(ctx context.Context) (string, error) {
 	output, runErr := runSkillsCheckProcess(
 		ctx,
 		npxPath,
-		[]string{"--offline", "--yes", "skills", "check"},
+		[]string{"--offline", "--yes", skillsInstallerPackage, "check"},
 		append(os.Environ(), "npm_config_offline=true"),
 	)
 	if runErr != nil && isUnavailableSkillsCheckOutput(output) {

--- a/internal/cli/install/skills_check_test.go
+++ b/internal/cli/install/skills_check_test.go
@@ -702,8 +702,8 @@ func TestDefaultRunSkillsCheckCommandUsesSkillsBinaryCheckCommand(t *testing.T) 
 		}
 		return mockSkills, nil
 	}
-	lookupNpx = func(string) (string, error) {
-		t.Fatal("lookupNpx should not run when skills is available")
+	lookupExecutable = func(string) (string, error) {
+		t.Fatal("lookupExecutable should not run when skills is available")
 		return "", errors.New("unexpected")
 	}
 
@@ -721,7 +721,7 @@ func TestDefaultRunSkillsCheckCommandMissingCLIsIsUnavailable(t *testing.T) {
 	lookupSkillsCheckCLI = func(string) (string, error) {
 		return "", exec.ErrNotFound
 	}
-	lookupNpx = func(string) (string, error) {
+	lookupExecutable = func(string) (string, error) {
 		return "", exec.ErrNotFound
 	}
 
@@ -743,9 +743,9 @@ func TestDefaultRunSkillsCheckCommandFallsBackToNpxOffline(t *testing.T) {
 	lookupSkillsCheckCLI = func(string) (string, error) {
 		return "", exec.ErrNotFound
 	}
-	lookupNpx = func(file string) (string, error) {
+	lookupExecutable = func(file string) (string, error) {
 		if file != "npx" {
-			t.Fatalf("lookupNpx called with %q, want npx", file)
+			t.Fatalf("lookupExecutable called with %q, want npx", file)
 		}
 		return mockNpx, nil
 	}
@@ -754,8 +754,9 @@ func TestDefaultRunSkillsCheckCommandFallsBackToNpxOffline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
 	}
-	if !strings.Contains(output, "--offline --yes skills check|true") {
-		t.Fatalf("offline npx invocation = %q", output)
+	want := "--offline --yes " + skillsInstallerPackage + " check|true"
+	if !strings.Contains(output, want) {
+		t.Fatalf("offline npx invocation = %q, want %q", output, want)
 	}
 }
 
@@ -768,7 +769,7 @@ func TestDefaultRunSkillsCheckCommandOfflineCacheMissIsUnavailable(t *testing.T)
 	lookupSkillsCheckCLI = func(string) (string, error) {
 		return "", exec.ErrNotFound
 	}
-	lookupNpx = func(string) (string, error) {
+	lookupExecutable = func(string) (string, error) {
 		return mockNpx, nil
 	}
 
@@ -790,8 +791,8 @@ func TestDefaultRunSkillsCheckCommandDoesNotWaitForDescendantPipes(t *testing.T)
 	lookupSkillsCheckCLI = func(string) (string, error) {
 		return mockSkills, nil
 	}
-	lookupNpx = func(string) (string, error) {
-		t.Fatal("lookupNpx should not run")
+	lookupExecutable = func(string) (string, error) {
+		t.Fatal("lookupExecutable should not run")
 		return "", errors.New("unexpected")
 	}
 
@@ -921,10 +922,10 @@ func TestValidateSkillsCheckWorkerSpec(t *testing.T) {
 func restoreSkillsCheckLookups(t *testing.T) {
 	t.Helper()
 	origSkills := lookupSkillsCheckCLI
-	origNpx := lookupNpx
+	origNpx := lookupExecutable
 	t.Cleanup(func() {
 		lookupSkillsCheckCLI = origSkills
-		lookupNpx = origNpx
+		lookupExecutable = origNpx
 	})
 }
 

--- a/internal/cli/snitch/snitch.go
+++ b/internal/cli/snitch/snitch.go
@@ -142,7 +142,7 @@ Examples:
 					if errors.Is(err, flag.ErrHelp) {
 						return err
 					}
-					fmt.Fprintf(os.Stderr, "Warning: %v; continuing without preflight label validation.\n", err)
+					fmt.Fprintf(os.Stderr, "Warning: %s; continuing without preflight label validation.\n", asc.SanitizeTerminalText(err.Error()))
 					entry.Labels = dedupeLabels(entry.Labels)
 				} else {
 					entry.Labels = validatedLabels
@@ -161,7 +161,7 @@ Examples:
 				var err error
 				duplicates, err = searchIssues(requestCtx, token, issueTitle(entry))
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: duplicate search failed: %v\n", err)
+					fmt.Fprintf(os.Stderr, "Warning: duplicate search failed: %s\n", asc.SanitizeTerminalText(err.Error()))
 				}
 			} else {
 				fmt.Fprintln(os.Stderr, "Note: skipping duplicate search because GITHUB_TOKEN or GH_TOKEN is not set.")
@@ -184,11 +184,11 @@ Examples:
 			}
 			if labels := issueLabels(entry); len(labels) > 0 {
 				if err := addIssueLabels(requestCtx, token, issue.Number, labels); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: issue created, but labels could not be applied: %v\n", err)
+					fmt.Fprintf(os.Stderr, "Warning: issue created, but labels could not be applied: %s\n", asc.SanitizeTerminalText(err.Error()))
 				}
 			}
 
-			fmt.Fprintf(os.Stderr, "Issue created: #%d %s\n", issue.Number, issue.HTMLURL)
+			fmt.Fprintf(os.Stderr, "Issue created: #%d %s\n", issue.Number, asc.SanitizeTerminalText(issue.HTMLURL))
 			result := map[string]any{
 				"number":   issue.Number,
 				"html_url": issue.HTMLURL,
@@ -408,7 +408,13 @@ func printPotentialDuplicates(duplicates []GitHubIssue) {
 
 	fmt.Fprintf(os.Stderr, "Potentially related issues (%d):\n", len(duplicates))
 	for _, dup := range duplicates {
-		fmt.Fprintf(os.Stderr, "  #%d %s\n       %s\n", dup.Number, dup.Title, dup.HTMLURL)
+		fmt.Fprintf(
+			os.Stderr,
+			"  #%d %s\n       %s\n",
+			dup.Number,
+			asc.SanitizeTerminalText(dup.Title),
+			asc.SanitizeTerminalText(dup.HTMLURL),
+		)
 	}
 	fmt.Fprintln(os.Stderr)
 }
@@ -419,11 +425,27 @@ func printPreview(entry LogEntry, dryRun bool) {
 	} else {
 		fmt.Fprintln(os.Stderr, "--- Preview only: rerun with --confirm to create issue ---")
 	}
-	fmt.Fprintf(os.Stderr, "Title: %s\n", issueTitle(entry))
+	fmt.Fprintf(os.Stderr, "Title: %s\n", asc.SanitizeTerminalText(issueTitle(entry)))
 	if labels := issueLabels(entry); len(labels) > 0 {
-		fmt.Fprintf(os.Stderr, "Labels: %s\n", strings.Join(labels, ", "))
+		fmt.Fprintf(os.Stderr, "Labels: %s\n", asc.SanitizeTerminalText(strings.Join(labels, ", ")))
 	}
-	fmt.Fprintf(os.Stderr, "Body:\n%s\n", issueBody(entry))
+	fmt.Fprintf(os.Stderr, "Body:\n%s\n", sanitizeTerminalBlock(issueBody(entry)))
+}
+
+// sanitizeTerminalBlock removes terminal control and bidi sequences from a
+// multi-line value while keeping the line structure that makes the block
+// readable. Line breaks the CLI itself writes stay intact; every other control
+// character is dropped.
+func sanitizeTerminalBlock(value string) string {
+	if !asc.HasInterpretedTerminalSequence(value) {
+		return value
+	}
+
+	lines := strings.Split(value, "\n")
+	for i, line := range lines {
+		lines[i] = asc.SanitizeTerminalText(line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func dedupeLabels(labels []string) []string {
@@ -576,31 +598,34 @@ func readLocalLog(path string) ([]LogEntry, error) {
 	return entries, nil
 }
 
+// formatLocalEntries renders log entries for human review. The log file is
+// repository-controlled text, so every field is stripped of terminal control and
+// bidi sequences before printing; the file on disk keeps its original values.
 func formatLocalEntries(entries []LogEntry) string {
 	var b strings.Builder
 
 	for i, entry := range entries {
-		fmt.Fprintf(&b, "[%d] %s: %s\n", i+1, entry.Severity, entry.Description)
+		fmt.Fprintf(&b, "[%d] %s: %s\n", i+1, asc.SanitizeTerminalText(entry.Severity), asc.SanitizeTerminalText(entry.Description))
 		if !entry.Timestamp.IsZero() {
 			fmt.Fprintf(&b, "Timestamp: %s\n", entry.Timestamp.Format(time.RFC3339))
 		}
 		if entry.ASCVersion != "" {
-			fmt.Fprintf(&b, "ASC version: %s\n", entry.ASCVersion)
+			fmt.Fprintf(&b, "ASC version: %s\n", asc.SanitizeTerminalText(entry.ASCVersion))
 		}
 		if entry.OS != "" {
-			fmt.Fprintf(&b, "OS: %s\n", entry.OS)
+			fmt.Fprintf(&b, "OS: %s\n", asc.SanitizeTerminalText(entry.OS))
 		}
 		if entry.Repro != "" {
-			fmt.Fprintf(&b, "Reproduction:\n%s\n", entry.Repro)
+			fmt.Fprintf(&b, "Reproduction:\n%s\n", sanitizeTerminalBlock(entry.Repro))
 		}
 		if entry.Expected != "" {
-			fmt.Fprintf(&b, "Expected:\n%s\n", entry.Expected)
+			fmt.Fprintf(&b, "Expected:\n%s\n", sanitizeTerminalBlock(entry.Expected))
 		}
 		if entry.Actual != "" {
-			fmt.Fprintf(&b, "Actual:\n%s\n", entry.Actual)
+			fmt.Fprintf(&b, "Actual:\n%s\n", sanitizeTerminalBlock(entry.Actual))
 		}
 		if len(entry.Labels) > 0 {
-			fmt.Fprintf(&b, "Labels: %s\n", strings.Join(entry.Labels, ", "))
+			fmt.Fprintf(&b, "Labels: %s\n", asc.SanitizeTerminalText(strings.Join(entry.Labels, ", ")))
 		}
 		if i < len(entries)-1 {
 			b.WriteString("\n")

--- a/internal/cli/snitch/snitch.go
+++ b/internal/cli/snitch/snitch.go
@@ -757,10 +757,13 @@ func addIssueLabels(ctx context.Context, token string, issueNumber int, labels [
 	return nil
 }
 
+// readGitHubAPIError embeds the GitHub response body in the returned error.
+// The body is attacker-influenced text that reaches stderr, so terminal control
+// and bidi sequences are removed here at the source.
 func readGitHubAPIError(resp *http.Response) error {
 	limited := io.LimitReader(resp.Body, maxResponseBodyBytes)
 	respBody, _ := io.ReadAll(limited)
-	return fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	return fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, asc.SanitizeTerminalText(strings.TrimSpace(string(respBody))))
 }
 
 func writeLocalLog(entry LogEntry) error {

--- a/internal/cli/snitch/snitch_sanitize_test.go
+++ b/internal/cli/snitch/snitch_sanitize_test.go
@@ -77,7 +77,8 @@ func TestSnitchPreviewRemovesTerminalControls(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
 
-	_, stderr, err := runSnitchCommand(t, "1.2.3",
+	_, stderr, err := runSnitchCommand(
+		t, "9.9.9",
 		"--dry-run",
 		"--actual", "Error: failed\x1b]0;pwned\x07",
 		hostileTitle,
@@ -87,6 +88,9 @@ func TestSnitchPreviewRemovesTerminalControls(t *testing.T) {
 	}
 
 	assertNoInterpretedSequences(t, "stderr", stderr)
+	if !strings.Contains(stderr, "**asc version:** 9.9.9") {
+		t.Fatalf("stderr = %q, want the reported asc version in the preview body", stderr)
+	}
 }
 
 func TestSnitchFlushRemovesTerminalControls(t *testing.T) {

--- a/internal/cli/snitch/snitch_sanitize_test.go
+++ b/internal/cli/snitch/snitch_sanitize_test.go
@@ -2,6 +2,7 @@ package snitch
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -156,5 +157,24 @@ func TestSnitchFlushKeepsLogEntriesIntactOnDisk(t *testing.T) {
 	}
 	if entries[0].Description != hostileTitle {
 		t.Fatalf("stored description = %q, want the original %q", entries[0].Description, hostileTitle)
+	}
+}
+
+func TestReadGitHubAPIErrorRemovesTerminalControls(t *testing.T) {
+	body := "{\"message\":\"boom\x1b]0;pwned\x07\u009b2K\u202e\",\"line\":\"two\u2028three\"}"
+	resp := &http.Response{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	err := readGitHubAPIError(resp)
+	if err == nil {
+		t.Fatalf("expected an error for a non-2xx response")
+	}
+	if !strings.Contains(err.Error(), "422") {
+		t.Fatalf("error %q should include the status code", err.Error())
+	}
+	if asc.HasInterpretedTerminalSequence(err.Error()) {
+		t.Fatalf("readGitHubAPIError() = %q contains interpreted terminal sequences", err.Error())
 	}
 }

--- a/internal/cli/snitch/snitch_sanitize_test.go
+++ b/internal/cli/snitch/snitch_sanitize_test.go
@@ -1,0 +1,156 @@
+package snitch
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// hostileTitle carries an OSC window-title sequence, a C1 CSI, and a bidi
+// override, all of which a maintainer terminal or CI log viewer interprets.
+const hostileTitle = "crash on launch\x1b]0;pwned\x07\u009b2K\u202egpj.exe"
+
+func assertNoInterpretedSequences(t *testing.T, label string, output string) {
+	t.Helper()
+
+	for i, line := range strings.Split(output, "\n") {
+		if asc.HasInterpretedTerminalSequence(line) {
+			t.Fatalf("%s line %d = %q contains interpreted terminal sequences", label, i+1, line)
+		}
+	}
+}
+
+func TestPrintPotentialDuplicatesRemovesTerminalControls(t *testing.T) {
+	_, stderr := captureOutput(t, func() {
+		printPotentialDuplicates([]GitHubIssue{{
+			Number:  42,
+			Title:   hostileTitle,
+			HTMLURL: "https://github.com/rorkai/App-Store-Connect-CLI/issues/42\x1b[2K",
+			State:   "open",
+		}})
+	})
+
+	assertNoInterpretedSequences(t, "stderr", stderr)
+	if !strings.Contains(stderr, "#42") {
+		t.Fatalf("stderr = %q, want the issue number", stderr)
+	}
+	if !strings.Contains(stderr, "crash on launch") {
+		t.Fatalf("stderr = %q, want the readable part of the title", stderr)
+	}
+}
+
+func TestDuplicateSearchWarningRemovesTerminalControls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte("boom\x1b]0;pwned\x07\u202e")); err != nil {
+			t.Fatalf("w.Write() error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	origBase := githubAPIBase
+	defer func() { setGitHubAPIBase(origBase) }()
+	setGitHubAPIBase(server.URL)
+
+	t.Setenv("GITHUB_TOKEN", "token")
+	t.Setenv("GH_TOKEN", "")
+
+	_, stderr, err := runSnitchCommand(t, "1.2.3", "--dry-run", "friction report")
+	if err != nil {
+		t.Fatalf("run snitch: %v", err)
+	}
+
+	assertNoInterpretedSequences(t, "stderr", stderr)
+	if !strings.Contains(stderr, "duplicate search failed") {
+		t.Fatalf("stderr = %q, want the duplicate search warning", stderr)
+	}
+}
+
+func TestSnitchPreviewRemovesTerminalControls(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	_, stderr, err := runSnitchCommand(t, "1.2.3",
+		"--dry-run",
+		"--actual", "Error: failed\x1b]0;pwned\x07",
+		hostileTitle,
+	)
+	if err != nil {
+		t.Fatalf("run snitch: %v", err)
+	}
+
+	assertNoInterpretedSequences(t, "stderr", stderr)
+}
+
+func TestSnitchFlushRemovesTerminalControls(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "snitch.log")
+
+	entry := LogEntry{
+		Description: hostileTitle,
+		Severity:    "bug",
+		Repro:       "asc status --app \"com.example\"\nasc builds list\x1b[2K",
+		Expected:    "resolution works\u2066",
+		Actual:      "Error: not found\u009b2K",
+		Labels:      []string{"p3\x1b[31m", "bug"},
+		Timestamp:   time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+		ASCVersion:  "1.2.3\x1b[0m",
+		OS:          "darwin/arm64\u202e",
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if err := os.WriteFile(logPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error: %v", err)
+	}
+
+	stdout, _, err := runSnitchCommand(t, "1.2.3", "flush", "--file", logPath)
+	if err != nil {
+		t.Fatalf("run snitch flush: %v", err)
+	}
+
+	assertNoInterpretedSequences(t, "stdout", stdout)
+	if !strings.Contains(stdout, "asc status --app \"com.example\"\nasc builds list") {
+		t.Fatalf("stdout = %q, want the multi-line reproduction preserved", stdout)
+	}
+	if !strings.Contains(stdout, "Timestamp: 2026-03-07T12:00:00Z") {
+		t.Fatalf("stdout = %q, want the timestamp", stdout)
+	}
+}
+
+func TestSnitchFlushKeepsLogEntriesIntactOnDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "snitch.log")
+
+	entry := LogEntry{Description: hostileTitle, Severity: "bug"}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if err := os.WriteFile(logPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error: %v", err)
+	}
+
+	if _, _, err := runSnitchCommand(t, "1.2.3", "flush", "--file", logPath); err != nil {
+		t.Fatalf("run snitch flush: %v", err)
+	}
+
+	entries, err := readLocalLog(logPath)
+	if err != nil {
+		t.Fatalf("readLocalLog() error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Description != hostileTitle {
+		t.Fatalf("stored description = %q, want the original %q", entries[0].Description, hostileTitle)
+	}
+}

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -1018,9 +1018,12 @@ func neutralizeSpreadsheetFormulaRow(row []string) []string {
 // neutralizeSpreadsheetFormula prefixes externally derived cells whose first
 // effective character would start a spreadsheet formula. Leading whitespace and
 // control characters are skipped when looking for that character, because
-// spreadsheet software ignores them too. Safe cells are returned unchanged.
+// spreadsheet software ignores them too. A cell that already begins with
+// literal apostrophes in front of a formula character gains one more, so import
+// can always remove exactly one and recover the original value. Safe cells are
+// returned unchanged.
 func neutralizeSpreadsheetFormula(value string) string {
-	if !isSpreadsheetFormulaCell(value) {
+	if !isSpreadsheetFormulaCell(strings.TrimLeft(value, spreadsheetTextPrefix)) {
 		return value
 	}
 	return spreadsheetTextPrefix + value
@@ -1028,16 +1031,16 @@ func neutralizeSpreadsheetFormula(value string) string {
 
 // denormalizeSpreadsheetFormula reverses neutralizeSpreadsheetFormula so an
 // exported file can be imported again without the neutralization prefix leaking
-// into tester or group values.
+// into tester or group values. Exactly one prefix apostrophe is removed, which
+// also restores values whose originals begin with literal apostrophes.
 func denormalizeSpreadsheetFormula(value string) string {
 	if !strings.HasPrefix(value, spreadsheetTextPrefix) {
 		return value
 	}
-	rest := strings.TrimPrefix(value, spreadsheetTextPrefix)
-	if !isSpreadsheetFormulaCell(rest) {
+	if !isSpreadsheetFormulaCell(strings.TrimLeft(value, spreadsheetTextPrefix)) {
 		return value
 	}
-	return rest
+	return strings.TrimPrefix(value, spreadsheetTextPrefix)
 }
 
 func isSpreadsheetFormulaCell(value string) bool {

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -77,6 +78,9 @@ func BetaTestersExportCommand() *ffcli.Command {
 CSV format:
   email,first_name,last_name,groups
   - groups are semicolon-delimited when present (for fastlane compatibility)
+  - a cell whose first character would start a spreadsheet formula (=, +, -, @)
+    is prefixed with a single quote so spreadsheet software treats it as text;
+    "beta-testers import" removes that prefix again
 
 Examples:
   asc testflight beta-testers export --app "APP_ID" --output "./testflight-testers.csv"
@@ -277,6 +281,8 @@ CSV formats accepted:
 
 Groups are semicolon-delimited in canonical import/export files.
 For compatibility, comma-delimited groups are also accepted when no semicolon is present.
+A leading single quote before =, +, -, or @ is removed, reversing the formula
+neutralization that "beta-testers export" applies.
 
 Examples:
   asc testflight beta-testers import --app "APP_ID" --input "./testflight-testers.csv" --dry-run
@@ -928,7 +934,7 @@ func parseHeaderMappedBetaTesterCSVRow(record []string, headerIdx map[string]int
 		if !ok || i < 0 || i >= len(record) {
 			return ""
 		}
-		return strings.TrimSpace(record[i])
+		return strings.TrimSpace(denormalizeSpreadsheetFormula(record[i]))
 	}
 	groups := make([]string, 0)
 	if idx, ok := headerIdx["groups"]; ok && idx >= 0 && idx < len(record) {
@@ -947,9 +953,9 @@ func parseLegacyBetaTesterCSVRow(record []string) (betaTestersCSVRow, error) {
 		return betaTestersCSVRow{}, shared.UsageError("legacy CSV rows must have 3 or 4 columns: first_name,last_name,email[,groups]")
 	}
 	row := betaTestersCSVRow{
-		firstName: strings.TrimSpace(record[0]),
-		lastName:  strings.TrimSpace(record[1]),
-		email:     strings.TrimSpace(record[2]),
+		firstName: strings.TrimSpace(denormalizeSpreadsheetFormula(record[0])),
+		lastName:  strings.TrimSpace(denormalizeSpreadsheetFormula(record[1])),
+		email:     strings.TrimSpace(denormalizeSpreadsheetFormula(record[2])),
 	}
 	if len(record) >= 4 {
 		row.groups = splitBetaTesterCSVGroups(record[3])
@@ -958,7 +964,7 @@ func parseLegacyBetaTesterCSVRow(record []string) (betaTestersCSVRow, error) {
 }
 
 func splitBetaTesterCSVGroups(value string) []string {
-	trimmed := strings.TrimSpace(value)
+	trimmed := strings.TrimSpace(denormalizeSpreadsheetFormula(value))
 	if trimmed == "" {
 		return nil
 	}
@@ -989,6 +995,59 @@ func isValidTesterEmail(value string) bool {
 		return false
 	}
 	return strings.EqualFold(addr.Address, trimmed)
+}
+
+// spreadsheetFormulaMarkers are the characters that Excel, LibreOffice Calc, and
+// Google Sheets treat as the start of a formula when they open a CSV file.
+const spreadsheetFormulaMarkers = "=+-@"
+
+// spreadsheetTextPrefix neutralizes a formula-leading cell. Spreadsheet software
+// reads a leading apostrophe as "the rest of this cell is text" and does not
+// display it; `asc testflight beta-testers import` strips it again, so exported
+// files still round-trip.
+const spreadsheetTextPrefix = "'"
+
+func neutralizeSpreadsheetFormulaRow(row []string) []string {
+	safe := make([]string, len(row))
+	for i, cell := range row {
+		safe[i] = neutralizeSpreadsheetFormula(cell)
+	}
+	return safe
+}
+
+// neutralizeSpreadsheetFormula prefixes externally derived cells whose first
+// effective character would start a spreadsheet formula. Leading whitespace and
+// control characters are skipped when looking for that character, because
+// spreadsheet software ignores them too. Safe cells are returned unchanged.
+func neutralizeSpreadsheetFormula(value string) string {
+	if !isSpreadsheetFormulaCell(value) {
+		return value
+	}
+	return spreadsheetTextPrefix + value
+}
+
+// denormalizeSpreadsheetFormula reverses neutralizeSpreadsheetFormula so an
+// exported file can be imported again without the neutralization prefix leaking
+// into tester or group values.
+func denormalizeSpreadsheetFormula(value string) string {
+	if !strings.HasPrefix(value, spreadsheetTextPrefix) {
+		return value
+	}
+	rest := strings.TrimPrefix(value, spreadsheetTextPrefix)
+	if !isSpreadsheetFormulaCell(rest) {
+		return value
+	}
+	return rest
+}
+
+func isSpreadsheetFormulaCell(value string) bool {
+	for _, r := range value {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			continue
+		}
+		return strings.ContainsRune(spreadsheetFormulaMarkers, r)
+	}
+	return false
 }
 
 func writeCSVFileAtomicNoSymlink(outputPath string, header []string, rows [][]string) error {
@@ -1036,7 +1095,7 @@ func writeCSVFileAtomicNoSymlink(outputPath string, header []string, rows [][]st
 		return err
 	}
 	for _, row := range rows {
-		if err := w.Write(row); err != nil {
+		if err := w.Write(neutralizeSpreadsheetFormulaRow(row)); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/testflight/beta_testers_csv_formula_test.go
+++ b/internal/cli/testflight/beta_testers_csv_formula_test.go
@@ -31,7 +31,9 @@ func TestNeutralizeSpreadsheetFormulaCoversEveryMarkerAndLeadingVariant(t *testi
 		{name: "plain name", input: `Ada Lovelace`, want: `Ada Lovelace`},
 		{name: "group list", input: `Beta;Internal`, want: `Beta;Internal`},
 		{name: "internal marker", input: `Team=Beta`, want: `Team=Beta`},
-		{name: "already neutralized", input: `'=1+1`, want: `'=1+1`},
+		{name: "literal apostrophe before formula is escaped", input: `'=1+1`, want: `''=1+1`},
+		{name: "double apostrophe before formula is escaped", input: `''=1+1`, want: `'''=1+1`},
+		{name: "apostrophe before plain text", input: `'quoted`, want: `'quoted`},
 	}
 
 	for _, tc := range cases {
@@ -96,6 +98,7 @@ func TestBetaTesterCSVRoundTripsNeutralizedCells(t *testing.T) {
 	header := []string{"email", "first_name", "last_name", "groups"}
 	rows := [][]string{
 		{"-tester@example.com", "Ada", "Lovelace", "+Internal;-Beta"},
+		{"quoted@example.com", "'=Ada", "''@Lovelace", "'=Internal"},
 	}
 
 	if err := writeCSVFileAtomicNoSymlink(outputPath, header, rows); err != nil {
@@ -106,8 +109,8 @@ func TestBetaTesterCSVRoundTripsNeutralizedCells(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readBetaTestersCSV() error: %v", err)
 	}
-	if len(parsed) != 1 {
-		t.Fatalf("expected 1 row, got %d", len(parsed))
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(parsed))
 	}
 	if parsed[0].email != "-tester@example.com" {
 		t.Fatalf("email = %q, want the original %q", parsed[0].email, "-tester@example.com")
@@ -115,5 +118,17 @@ func TestBetaTesterCSVRoundTripsNeutralizedCells(t *testing.T) {
 	wantGroups := []string{"+Internal", "-Beta"}
 	if strings.Join(parsed[0].groups, ";") != strings.Join(wantGroups, ";") {
 		t.Fatalf("groups = %q, want %q", parsed[0].groups, wantGroups)
+	}
+
+	// Values that already begin with literal apostrophes before formula
+	// characters must survive the export -> import round trip unchanged.
+	if parsed[1].firstName != "'=Ada" {
+		t.Fatalf("first name = %q, want the original %q", parsed[1].firstName, "'=Ada")
+	}
+	if parsed[1].lastName != "''@Lovelace" {
+		t.Fatalf("last name = %q, want the original %q", parsed[1].lastName, "''@Lovelace")
+	}
+	if strings.Join(parsed[1].groups, ";") != "'=Internal" {
+		t.Fatalf("groups = %q, want %q", parsed[1].groups, []string{"'=Internal"})
 	}
 }

--- a/internal/cli/testflight/beta_testers_csv_formula_test.go
+++ b/internal/cli/testflight/beta_testers_csv_formula_test.go
@@ -1,0 +1,119 @@
+package testflight
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNeutralizeSpreadsheetFormulaCoversEveryMarkerAndLeadingVariant(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "equals", input: `=1+1`, want: `'=1+1`},
+		{name: "plus", input: `+1`, want: `'+1`},
+		{name: "minus", input: `-1+1`, want: `'-1+1`},
+		{name: "at", input: `@SUM(A1)`, want: `'@SUM(A1)`},
+		{name: "dde", input: `=cmd|' /C calc'!A0`, want: `'=cmd|' /C calc'!A0`},
+		{name: "leading space", input: ` =1+1`, want: `' =1+1`},
+		{name: "leading tab", input: "\t=1+1", want: "'\t=1+1"},
+		{name: "leading carriage return", input: "\r=1+1", want: "'\r=1+1"},
+		{name: "leading newline", input: "\n@SUM(A1)", want: "'\n@SUM(A1)"},
+		{name: "leading non-breaking space", input: "\u00a0-1", want: "'\u00a0-1"},
+		{name: "leading control character", input: "\x01+1", want: "'\x01+1"},
+		{name: "empty", input: ``, want: ``},
+		{name: "whitespace only", input: `  `, want: `  `},
+		{name: "plain email", input: `tester@example.com`, want: `tester@example.com`},
+		{name: "plain name", input: `Ada Lovelace`, want: `Ada Lovelace`},
+		{name: "group list", input: `Beta;Internal`, want: `Beta;Internal`},
+		{name: "internal marker", input: `Team=Beta`, want: `Team=Beta`},
+		{name: "already neutralized", input: `'=1+1`, want: `'=1+1`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := neutralizeSpreadsheetFormula(tc.input); got != tc.want {
+				t.Fatalf("neutralizeSpreadsheetFormula(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteCSVFileNeutralizesFormulaLeadingCells(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "testers.csv")
+	header := []string{"email", "first_name", "last_name", "groups"}
+	rows := [][]string{
+		{"tester@example.com", "Ada", "Lovelace", "Beta;Internal"},
+		{"-tester@example.com", "=1+1", " @SUM(A1)", "+Internal;-Beta"},
+		{"formula@example.com", "\t-2+3", "Byron", `=cmd|' /C calc'!A0`},
+	}
+
+	if err := writeCSVFileAtomicNoSymlink(outputPath, header, rows); err != nil {
+		t.Fatalf("writeCSVFileAtomicNoSymlink() error: %v", err)
+	}
+
+	file, err := os.Open(outputPath)
+	if err != nil {
+		t.Fatalf("open csv: %v", err)
+	}
+	defer file.Close()
+
+	records, err := csv.NewReader(file).ReadAll()
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if len(records) != len(rows)+1 {
+		t.Fatalf("expected %d records, got %d", len(rows)+1, len(records))
+	}
+
+	if strings.Join(records[0], ",") != strings.Join(header, ",") {
+		t.Fatalf("header = %q, want %q", records[0], header)
+	}
+	if strings.Join(records[1], ",") != strings.Join(rows[0], ",") {
+		t.Fatalf("safe row = %q, want it unchanged %q", records[1], rows[0])
+	}
+
+	for _, record := range records[1:] {
+		for _, cell := range record {
+			if isSpreadsheetFormulaCell(cell) {
+				t.Fatalf("cell %q would be interpreted as a spreadsheet formula", cell)
+			}
+		}
+	}
+
+	want := []string{"'-tester@example.com", "'=1+1", "' @SUM(A1)", "'+Internal;-Beta"}
+	if strings.Join(records[2], ",") != strings.Join(want, ",") {
+		t.Fatalf("neutralized row = %q, want %q", records[2], want)
+	}
+}
+
+func TestBetaTesterCSVRoundTripsNeutralizedCells(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "testers.csv")
+	header := []string{"email", "first_name", "last_name", "groups"}
+	rows := [][]string{
+		{"-tester@example.com", "Ada", "Lovelace", "+Internal;-Beta"},
+	}
+
+	if err := writeCSVFileAtomicNoSymlink(outputPath, header, rows); err != nil {
+		t.Fatalf("writeCSVFileAtomicNoSymlink() error: %v", err)
+	}
+
+	parsed, err := readBetaTestersCSV(outputPath)
+	if err != nil {
+		t.Fatalf("readBetaTestersCSV() error: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(parsed))
+	}
+	if parsed[0].email != "-tester@example.com" {
+		t.Fatalf("email = %q, want the original %q", parsed[0].email, "-tester@example.com")
+	}
+	wantGroups := []string{"+Internal", "-Beta"}
+	if strings.Join(parsed[0].groups, ";") != strings.Join(wantGroups, ";") {
+		t.Fatalf("groups = %q, want %q", parsed[0].groups, wantGroups)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the eight boundaries where repository, GitHub, App Store Connect, or TestFlight data crossed into an interpreting consumer (privileged shell, terminal, spreadsheet, package runner). Structured JSON output is unchanged.

Three logical tracks, one commit each, plus one small follow-up commit noted below.

### 1. Shell-safe GitHub Actions examples (`docs(ci)`)

- `configuration/workflows.mdx` and `commands/validate.mdx` no longer place `${{ github.ref_name }}` (or `${{ secrets.APP_ID }}`) inside `run:` source. Both route values through step-level `env:` and reference only quoted shell variables.
- `commands/validate.mdx` also replaces the `$?` check with `if ! asc validate ...`, which is what the runner's `bash -e` shell actually honors.
- New regression test `docs_github_actions_examples_test.go` parses the documented steps, rejects any `${{ ... }}` expression inside `run:`, requires the ref env var to be expanded only inside double quotes, and executes each step through `bash` with the valid ref name `v1.0;>injected` against a stub `asc`. It asserts the ref arrives as one inert argument and that no `injected` file is created. On the pre-fix docs this test failed by actually creating that file.

### 2. Terminal and CSV output sanitization (`fix(output)`)

- Promoted the existing in-package helper to `asc.SanitizeTerminalText` and extended it beyond C0/DEL to C1 controls (single-byte CSI/OSC) and bidi marks, embeddings, overrides, and isolates. Added `asc.HasInterpretedTerminalSequence` so tests in other packages can assert inertness.
- Applied it to every asset table/Markdown row builder (file names, states, display/preview types, asset IDs, failure paths and error text, and the fan-out state summary).
- Localization diff: controls are removed *before* truncation, so a clipped cell can no longer leave a partial escape. The existing `\n` escaping behavior is preserved.
- `snitch`: duplicate results, the duplicate-search and label warnings, the "Issue created" line, the preview, and `snitch flush` are sanitized. Multi-line fields keep their line structure via a line-wise pass; the log file on disk and the GitHub payload keep original values.
- Beta tester CSV export prefixes a single quote to any cell whose first effective character is `=`, `+`, `-`, or `@`, including leading whitespace and control variants. `beta-testers import` strips that prefix again, so exported files still round-trip (a group named `+Internal` survives export → import). Documented in both command help texts and in `guides/testflight.mdx`.

### 3. Pinned install-skills execution (`fix(install-skills)`)

- Installer pinned to `skills@1.5.20`; the skill pack pinned to reviewed commit `e30039abddbe388179324d0f9cdccb66c3843115`. The offline `skills check` probe uses the same pinned version.
- **Upstream installer limitation (verified, not worked around with mutable code):** `skills add owner/repo#<ref>` resolves the ref with `git clone --depth 1 --branch <ref>`, which accepts only branch and tag names. Passing the commit SHA fails with `Remote branch <sha> not found in upstream origin`, and the ASC skills repository publishes no tags. Blob/API installs are allowlisted to other owners only.
- Therefore `asc install-skills` fetches exactly the pinned commit with `git` (which verifies object hashes) into a temporary checkout and hands the installer that local path. A missing `git` fails with guidance naming the pinned commit rather than falling back to a mutable ref.
- README, `installation.mdx`, and `index.mdx` document the same pinned manual path; the previous unpinned `npx skills add rorkai/...` snippets are gone. A test asserts the docs stay in sync with the pinned constants.

### Follow-up commit

`test(snitch)` adds the missing assertion that the preview body reports the running `asc` version. This also clears a pre-existing `unparam` lint finding on the shared snitch test helper (its `version` parameter had only ever received one value), which `make lint` reports on `main` as well.

## Verification

RED was established first for every track (documented example execution creating `injected`, control sequences surviving in asset/diff/snitch output, formula-leading CSV cells, and undefined pinned constants).

```
ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc ./internal/cli/install ./internal/cli/snitch ./internal/cli/diffcmd ./internal/cli/testflight   # pass
make format          # clean
make check-docs      # pass
make lint            # 0 issues
ASC_BYPASS_KEYCHAIN=1 make test   # pass (93 packages, no failures)
```

Live checks with an isolated `HOME` (no App Store Connect calls, no repository mutation):

- `asc install-skills` installs 23 skills from the pinned commit and removes the temporary checkout.
- The pre-fix `skills add rorkai/app-store-connect-cli-skills#<sha>` invocation fails as described above.
- Missing `git` and missing `npx` both fail with actionable messages.
- The manual snippet documented in the README was executed verbatim and succeeds.

## Compatibility

- JSON output is unchanged.
- Human table, Markdown, stdout, and stderr text drops control characters instead of forwarding them.
- Exported CSV shows a leading apostrophe on formula-leading cells; safe rows are byte-identical, and `asc` import reverses the prefix.
- Upgrading the skill pack is now an explicit source change to the two pinned constants in `internal/cli/install/install.go`. `asc install-skills` now requires `git` in addition to Node.js.
- No interactive prompt was introduced.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da8acda5-6fbd-4d33-9925-613e6005f5c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da8acda5-6fbd-4d33-9925-613e6005f5c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787897409&installation_model_id=10418&pr_number=1829&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1829&signature=6a47dad1470635c77fdb192beb63f9602b2c7a603c2bd5503a6e514378fa2437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `install-skills` now performs a reproducible, pinned install from a reviewed skills revision.
  - TestFlight beta tester CSV export/import neutralizes spreadsheet-formula-looking cells and restores original values on import.
- **Bug Fixes**
  - Improved safety of terminal output by removing terminal/bidi control sequences across CLI tables, previews, and error text (including truncation-safe rendering).
- **Documentation**
  - Updated installation and CI/CD workflow examples to use pinned, reproducible steps and safer environment variable usage.
- **Tests**
  - Expanded coverage for pinned installs, terminal/control sanitization, documentation snippet safety, and CSV/security round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->