### PR TITLE
Security: harden repository-controlled file I/O against path traversal and symlink escapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ User-facing commands and flags follow `experimental` -> `stable` -> `deprecated`
 - Put command implementations in `internal/cli/<domain>` and register new top-level commands in `internal/cli/registry/registry.go`.
 - Set `UsageFunc: shared.DefaultUsageFunc` on command groups and subcommands.
 - Use `shared.ContextWithTimeout` or `shared.ContextWithUploadTimeout` for outbound HTTP.
+- Read and write repository-controlled or API-supplied paths through `internal/rootfs`, anchored to the operator-selected root for that command, instead of plain `os` file operations.
 - Validate required flags before side effects and assert stderr messages in tests.
 - Use `internal/cli/cmdtest` for CLI-level coverage and `httptest` for HTTP payload coverage.
 - Remove shared wrappers or helpers made obsolete by a refactor.

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/99designs/keyring"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 // ErrKeychainAccessDenied is returned when a keychain backend is available but
@@ -535,20 +536,31 @@ func migrationPrivateKeyPath(cred Credential, privateKeyDir string, configName s
 		return "", false, fmt.Errorf("profile %q keychain private key PEM is invalid: %w", cred.Name, err)
 	}
 
-	exportPath := filepath.Join(privateKeyDir, migrationPrivateKeyFilename(configName, cred.KeyID))
-	if err := writePrivateKeyPEMFile(exportPath, privateKeyPEM); err != nil {
+	fileName := migrationPrivateKeyFilename(configName, cred.KeyID)
+	if err := writePrivateKeyPEMFile(privateKeyDir, fileName, privateKeyPEM); err != nil {
 		return "", false, fmt.Errorf("profile %q failed to export private key: %w", cred.Name, err)
 	}
-	return exportPath, true, nil
+	return filepath.Join(privateKeyDir, fileName), true, nil
 }
 
 func migrationPrivateKeyFilename(name, keyID string) string {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		name = "default"
+	safe := sanitizePrivateKeyFilenamePart(name)
+	if safeKeyID := sanitizePrivateKeyFilenamePart(strings.TrimSpace(keyID)); strings.TrimSpace(keyID) != "" {
+		return "AuthKey_" + safe + "_" + safeKeyID + ".p8"
+	}
+	return "AuthKey_" + safe + ".p8"
+}
+
+// sanitizePrivateKeyFilenamePart reduces an untrusted profile name or key ID to
+// a single safe filename component so it cannot carry path separators or
+// traversal segments into the key output directory.
+func sanitizePrivateKeyFilenamePart(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "default"
 	}
 	var b strings.Builder
-	for _, r := range name {
+	for _, r := range value {
 		switch {
 		case r >= 'a' && r <= 'z':
 			b.WriteRune(r)
@@ -563,54 +575,52 @@ func migrationPrivateKeyFilename(name, keyID string) string {
 		}
 	}
 	safe := strings.Trim(b.String(), "._-")
-	if safe == "" {
-		safe = "default"
+	if safe == "" || safe == ".." {
+		return "default"
 	}
-	keyID = strings.TrimSpace(keyID)
-	if keyID != "" {
-		return "AuthKey_" + safe + "_" + keyID + ".p8"
-	}
-	return "AuthKey_" + safe + ".p8"
+	return safe
 }
 
-func writePrivateKeyPEMFile(path, privateKeyPEM string) error {
-	if strings.TrimSpace(path) == "" {
+// writePrivateKeyPEMFile exports private key material to name beneath keyDir.
+// keyDir is the operator-selected key output root; name must stay beneath it and
+// must not resolve through a symlink.
+func writePrivateKeyPEMFile(keyDir, name, privateKeyPEM string) error {
+	if strings.TrimSpace(name) == "" {
 		return fmt.Errorf("empty private key path")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	root, err := rootfs.New(keyDir)
+	if err != nil {
 		return err
 	}
-	if info, err := os.Lstat(path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to overwrite symlink: %s", path)
-		}
-		existing, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
+	resolved, err := root.Resolve(name)
+	if err != nil {
+		return err
+	}
+	if err := root.MkdirAll(filepath.Dir(name), 0o700); err != nil {
+		return err
+	}
+
+	existing, found, err := root.ReadFileOptional(name)
+	if err != nil {
+		return err
+	}
+	if found {
 		if strings.TrimSpace(string(existing)) != strings.TrimSpace(privateKeyPEM) {
-			return fmt.Errorf("refusing to overwrite existing private key file: %s", path)
+			return fmt.Errorf("refusing to overwrite existing private key file: %s", resolved)
+		}
+		info, err := os.Lstat(resolved)
+		if err != nil {
+			return err
 		}
 		if filePermissionsTooPermissive(info.Mode()) {
-			if err := os.Chmod(path, 0o600); err != nil {
+			if err := os.Chmod(resolved, 0o600); err != nil {
 				return err
 			}
 		}
 		return nil
-	} else if !os.IsNotExist(err) {
-		return err
 	}
 
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return err
-	}
-	_, writeErr := file.WriteString(privateKeyPEM)
-	closeErr := file.Close()
-	if writeErr != nil {
-		return writeErr
-	}
-	return closeErr
+	return root.CreateNewFile(name, []byte(privateKeyPEM), 0o600)
 }
 
 func upsertConfigCredential(cfg *config.Config, cred config.Credential) {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -608,12 +608,19 @@ func writePrivateKeyPEMFile(keyDir, name, privateKeyPEM string) error {
 		if strings.TrimSpace(string(existing)) != strings.TrimSpace(privateKeyPEM) {
 			return fmt.Errorf("refusing to overwrite existing private key file: %s", resolved)
 		}
-		info, err := os.Lstat(resolved)
+		// Tighten permissions through a no-follow descriptor so an entry swapped
+		// for a symlink after the read can never chmod a file outside keyDir.
+		file, err := root.OpenFile(name)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		info, err := file.Stat()
 		if err != nil {
 			return err
 		}
 		if filePermissionsTooPermissive(info.Mode()) {
-			if err := os.Chmod(resolved, 0o600); err != nil {
+			if err := file.Chmod(0o600); err != nil {
 				return err
 			}
 		}

--- a/internal/auth/private_key_export_containment_test.go
+++ b/internal/auth/private_key_export_containment_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigrationPrivateKeyFilenameSanitizesPathBearingKeyID(t *testing.T) {
+	name := migrationPrivateKeyFilename("team", "../../escape")
+	if strings.ContainsAny(name, `/\`) {
+		t.Fatalf("migrationPrivateKeyFilename() = %q, want a single path component", name)
+	}
+	if strings.Contains(name, "..") {
+		t.Fatalf("migrationPrivateKeyFilename() = %q, want no parent traversal", name)
+	}
+}
+
+func TestWritePrivateKeyPEMFileRejectsPathBearingKeyID(t *testing.T) {
+	keyDir := filepath.Join(t.TempDir(), "keys")
+	if err := os.MkdirAll(keyDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	err := writePrivateKeyPEMFile(keyDir, "../escaped.p8", "PRIVATE KEY MATERIAL")
+	if err == nil {
+		t.Fatal("writePrivateKeyPEMFile() error = nil, want traversal rejection")
+	}
+	escaped := filepath.Join(filepath.Dir(keyDir), "escaped.p8")
+	if _, statErr := os.Stat(escaped); statErr == nil {
+		t.Fatalf("private key material was written outside the key directory: %s", escaped)
+	}
+}
+
+func TestWritePrivateKeyPEMFileRejectsSymlinkedParentDirectory(t *testing.T) {
+	keyDir := filepath.Join(t.TempDir(), "keys")
+	external := t.TempDir()
+	if err := os.MkdirAll(keyDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(keyDir, "nested")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := writePrivateKeyPEMFile(keyDir, filepath.Join("nested", "AuthKey.p8"), "PRIVATE KEY MATERIAL")
+	if err == nil {
+		t.Fatal("writePrivateKeyPEMFile() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writePrivateKeyPEMFile() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(external, "AuthKey.p8")); statErr == nil {
+		t.Fatal("private key material escaped through a symlinked parent")
+	}
+}
+
+func TestWritePrivateKeyPEMFileRejectsSymlinkedDestination(t *testing.T) {
+	keyDir := filepath.Join(t.TempDir(), "keys")
+	if err := os.MkdirAll(keyDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("original"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Symlink(sentinelPath, filepath.Join(keyDir, "AuthKey.p8")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := writePrivateKeyPEMFile(keyDir, "AuthKey.p8", "PRIVATE KEY MATERIAL")
+	if err == nil {
+		t.Fatal("writePrivateKeyPEMFile() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writePrivateKeyPEMFile() error = %v, want symlink rejection", err)
+	}
+	data, readErr := os.ReadFile(sentinelPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(data) != "original" {
+		t.Fatalf("sentinel content = %q, want %q", data, "original")
+	}
+}
+
+func TestWritePrivateKeyPEMFileWritesNewKeyWithSecureMode(t *testing.T) {
+	keyDir := filepath.Join(t.TempDir(), "keys")
+
+	if err := writePrivateKeyPEMFile(keyDir, "AuthKey_team_ABC123.p8", "PRIVATE KEY MATERIAL"); err != nil {
+		t.Fatalf("writePrivateKeyPEMFile() error = %v", err)
+	}
+
+	path := filepath.Join(keyDir, "AuthKey_team_ABC123.p8")
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("key mode = %v, want 0600", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != "PRIVATE KEY MATERIAL" {
+		t.Fatalf("key content = %q", data)
+	}
+
+	// Re-exporting identical material is idempotent.
+	if err := writePrivateKeyPEMFile(keyDir, "AuthKey_team_ABC123.p8", "PRIVATE KEY MATERIAL"); err != nil {
+		t.Fatalf("writePrivateKeyPEMFile() rerun error = %v", err)
+	}
+
+	// Different material must never silently replace an existing key.
+	if err := writePrivateKeyPEMFile(keyDir, "AuthKey_team_ABC123.p8", "OTHER MATERIAL"); err == nil {
+		t.Fatal("writePrivateKeyPEMFile() error = nil, want refusal to overwrite existing key")
+	}
+}

--- a/internal/auth/private_key_export_containment_test.go
+++ b/internal/auth/private_key_export_containment_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -81,6 +82,32 @@ func TestWritePrivateKeyPEMFileRejectsSymlinkedDestination(t *testing.T) {
 	}
 	if string(data) != "original" {
 		t.Fatalf("sentinel content = %q, want %q", data, "original")
+	}
+}
+
+func TestWritePrivateKeyPEMFileTightensLoosePermissionsWithoutFollowingSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not reported faithfully on Windows")
+	}
+	keyDir := filepath.Join(t.TempDir(), "keys")
+	if err := os.MkdirAll(keyDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	path := filepath.Join(keyDir, "AuthKey_team_ABC123.p8")
+	if err := os.WriteFile(path, []byte("PRIVATE KEY MATERIAL"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := writePrivateKeyPEMFile(keyDir, "AuthKey_team_ABC123.p8", "PRIVATE KEY MATERIAL"); err != nil {
+		t.Fatalf("writePrivateKeyPEMFile() error = %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("key mode = %v, want tightened to 0600", info.Mode().Perm())
 	}
 }
 

--- a/internal/cli/cmdtest/migrate_import_containment_test.go
+++ b/internal/cli/cmdtest/migrate_import_containment_test.go
@@ -1,0 +1,73 @@
+package cmdtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigrateImportRejectsSymlinkedMetadataBeforeAnyRequest(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := t.TempDir()
+	fastlaneDir := filepath.Join(root, "fastlane")
+	metadataDir := filepath.Join(fastlaneDir, "metadata", "en-US")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(fastlaneDir, "screenshots"), 0o755); err != nil {
+		t.Fatalf("mkdir screenshots root: %v", err)
+	}
+
+	secretPath := filepath.Join(t.TempDir(), "secret.txt")
+	writeFile(t, secretPath, "local secret that must not be published")
+	if err := os.Symlink(secretPath, filepath.Join(metadataDir, "description.txt")); err != nil {
+		t.Fatalf("symlink description.txt: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+	})
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", fastlaneDir,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = rootCmd.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected migrate import to fail for symlinked metadata")
+	}
+	if !strings.Contains(runErr.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", runErr)
+	}
+	if requests != 0 {
+		t.Fatalf("expected no App Store Connect requests, got %d", requests)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -63,6 +63,9 @@ func TestXcodeCommandExists(t *testing.T) {
 	if editCmd.FlagSet.Lookup("next-build-number") == nil {
 		t.Fatal("expected xcode version edit to expose --next-build-number")
 	}
+	if editCmd.FlagSet.Lookup("allow-external-xcconfig") == nil {
+		t.Fatal("expected xcode version edit to expose --allow-external-xcconfig")
+	}
 	bumpCmd := findSubcommand(root, "xcode", "version", "bump")
 	if bumpCmd == nil {
 		t.Fatal("expected xcode version bump command")
@@ -79,6 +82,9 @@ func TestXcodeCommandExists(t *testing.T) {
 	}
 	if bumpCmd.FlagSet.Lookup("next-build-number") == nil {
 		t.Fatal("expected xcode version bump to expose --next-build-number")
+	}
+	if bumpCmd.FlagSet.Lookup("allow-external-xcconfig") == nil {
+		t.Fatal("expected xcode version bump to expose --allow-external-xcconfig")
 	}
 	if findSubcommand(root, "xcode", "version", "get") != nil {
 		t.Fatal("expected xcode version get command to be absent")

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -63,8 +63,10 @@ func TestXcodeCommandExists(t *testing.T) {
 	if editCmd.FlagSet.Lookup("next-build-number") == nil {
 		t.Fatal("expected xcode version edit to expose --next-build-number")
 	}
-	if editCmd.FlagSet.Lookup("allow-external-xcconfig") == nil {
+	if flag := editCmd.FlagSet.Lookup("allow-external-xcconfig"); flag == nil {
 		t.Fatal("expected xcode version edit to expose --allow-external-xcconfig")
+	} else if !strings.HasPrefix(flag.Usage, "[experimental]") {
+		t.Fatalf("expected --allow-external-xcconfig to be introduced as experimental, usage = %q", flag.Usage)
 	}
 	bumpCmd := findSubcommand(root, "xcode", "version", "bump")
 	if bumpCmd == nil {
@@ -83,8 +85,10 @@ func TestXcodeCommandExists(t *testing.T) {
 	if bumpCmd.FlagSet.Lookup("next-build-number") == nil {
 		t.Fatal("expected xcode version bump to expose --next-build-number")
 	}
-	if bumpCmd.FlagSet.Lookup("allow-external-xcconfig") == nil {
+	if flag := bumpCmd.FlagSet.Lookup("allow-external-xcconfig"); flag == nil {
 		t.Fatal("expected xcode version bump to expose --allow-external-xcconfig")
+	} else if !strings.HasPrefix(flag.Usage, "[experimental]") {
+		t.Fatalf("expected --allow-external-xcconfig to be introduced as experimental, usage = %q", flag.Usage)
 	}
 	if findSubcommand(root, "xcode", "version", "get") != nil {
 		t.Fatal("expected xcode version get command to be absent")

--- a/internal/cli/docs/docs_init.go
+++ b/internal/cli/docs/docs_init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 const ascReferenceFile = "ASC.md"
@@ -218,8 +219,16 @@ func findRepoRoot(start string) (string, error) {
 }
 
 func writeASCReference(path string, force bool) (bool, bool, error) {
+	root, err := rootfs.New(filepath.Dir(path))
+	if err != nil {
+		return false, false, err
+	}
+	name := filepath.Base(path)
+
+	// Lstat, not Stat, so a dangling symlink still counts as an existing entry
+	// and is never followed.
 	exists := false
-	if _, err := os.Stat(path); err == nil {
+	if _, err := os.Lstat(path); err == nil {
 		exists = true
 	} else if !os.IsNotExist(err) {
 		return false, false, err
@@ -229,16 +238,12 @@ func writeASCReference(path string, force bool) (bool, bool, error) {
 		return false, false, fmt.Errorf("%w: %s (use --force to overwrite)", ErrASCReferenceExists, path)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return false, false, err
-	}
-
 	content := ascTemplate
 	if !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
 
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := root.WriteFile(name, []byte(content), 0o644); err != nil {
 		return false, false, err
 	}
 
@@ -248,50 +253,57 @@ func writeASCReference(path string, force bool) (bool, bool, error) {
 	return true, false, nil
 }
 
-func linkAgentFiles(root string, relRef string) ([]string, error) {
+func linkAgentFiles(rootDir string, relRef string) ([]string, error) {
+	root, err := rootfs.New(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
 	linked := []string{}
 
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	if !fileExists(agentsPath) {
-		agentsPath = filepath.Join(root, "Agents.md")
+	agentsName := "AGENTS.md"
+	if !entryExists(filepath.Join(rootDir, agentsName)) {
+		agentsName = "Agents.md"
 	}
-	agentsUpdated, err := updateAgentsLink(agentsPath, relRef)
+	agentsUpdated, err := updateAgentsLink(root, agentsName, relRef)
 	if err != nil {
 		return nil, err
 	}
 	if agentsUpdated {
-		linked = append(linked, agentsPath)
+		linked = append(linked, filepath.Join(rootDir, agentsName))
 	}
 
-	claudePath := filepath.Join(root, "CLAUDE.md")
-	claudeUpdated, err := updateClaudeLink(claudePath, relRef)
+	claudeName := "CLAUDE.md"
+	claudeUpdated, err := updateClaudeLink(root, claudeName, relRef)
 	if err != nil {
 		return nil, err
 	}
 	if claudeUpdated {
-		linked = append(linked, claudePath)
+		linked = append(linked, filepath.Join(rootDir, claudeName))
 	}
 
 	return linked, nil
 }
 
-func fileExists(path string) bool {
+// entryExists reports whether path exists without following a final symlink, so
+// a symlinked agent file is still selected and then rejected by the rooted read.
+func entryExists(path string) bool {
 	if path == "" {
 		return false
 	}
-	if _, err := os.Stat(path); err == nil {
+	if _, err := os.Lstat(path); err == nil {
 		return true
 	}
 	return false
 }
 
-func updateAgentsLink(path string, relRef string) (bool, error) {
-	data, err := os.ReadFile(path)
+func updateAgentsLink(root rootfs.Root, name string, relRef string) (bool, error) {
+	data, found, err := root.ReadFileOptional(name)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
 		return false, err
+	}
+	if !found {
+		return false, nil
 	}
 
 	desiredLine := fmt.Sprintf("See `%s` for the command catalog and workflows.", relRef)
@@ -319,21 +331,21 @@ func updateAgentsLink(path string, relRef string) (bool, error) {
 		if !changed {
 			return false, nil
 		}
-		return writeIfChanged(path, strings.Join(lines, "\n"))
+		return writeIfChanged(root, name, strings.Join(lines, "\n"))
 	}
 
 	section := fmt.Sprintf("## asc cli reference\n\n%s", desiredLine)
 	updated := appendSection(string(data), section)
-	return writeIfChanged(path, updated)
+	return writeIfChanged(root, name, updated)
 }
 
-func updateClaudeLink(path string, relRef string) (bool, error) {
-	data, err := os.ReadFile(path)
+func updateClaudeLink(root rootfs.Root, name string, relRef string) (bool, error) {
+	data, found, err := root.ReadFileOptional(name)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
 		return false, err
+	}
+	if !found {
+		return false, nil
 	}
 
 	desiredLine := "@" + relRef
@@ -362,7 +374,7 @@ func updateClaudeLink(path string, relRef string) (bool, error) {
 		if !changed {
 			return false, nil
 		}
-		return writeIfChanged(path, strings.Join(updatedLines, "\n"))
+		return writeIfChanged(root, name, strings.Join(updatedLines, "\n"))
 	}
 
 	updated := strings.TrimRight(string(data), "\n")
@@ -371,7 +383,7 @@ func updateClaudeLink(path string, relRef string) (bool, error) {
 	}
 	updated += desiredLine + "\n"
 
-	return writeIfChanged(path, updated)
+	return writeIfChanged(root, name, updated)
 }
 
 func isAgentsReferenceLine(line string) bool {
@@ -395,15 +407,15 @@ func appendSection(content, section string) string {
 	return trimmed + "\n\n" + section + "\n"
 }
 
-func writeIfChanged(path, content string) (bool, error) {
-	existing, err := os.ReadFile(path)
+func writeIfChanged(root rootfs.Root, name string, content string) (bool, error) {
+	existing, err := root.ReadFile(name)
 	if err != nil {
 		return false, err
 	}
 	if string(existing) == content {
 		return false, nil
 	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := root.WriteFile(name, []byte(content), 0o644); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/cli/docs/docs_init.go
+++ b/internal/cli/docs/docs_init.go
@@ -231,11 +231,14 @@ func findRepoRoot(start string) (string, error) {
 	}
 }
 
+const defaultDocsFileMode os.FileMode = 0o644
+
 // ascReferencePlan is a fully validated, not-yet-applied ASC.md write.
 type ascReferencePlan struct {
 	root   rootfs.Root
 	name   string
 	exists bool
+	perm   os.FileMode
 }
 
 // planASCReference validates the ASC.md destination without writing anything.
@@ -249,8 +252,13 @@ func planASCReference(path string, force bool) (ascReferencePlan, error) {
 	// Lstat, not Stat, so a dangling symlink still counts as an existing entry
 	// and is never followed.
 	exists := false
-	if _, err := os.Lstat(path); err == nil {
+	perm := defaultDocsFileMode
+	if info, err := os.Lstat(path); err == nil {
 		exists = true
+		if info.Mode().IsRegular() {
+			// Preserve the operator's chosen mode when replacing the file.
+			perm = info.Mode().Perm()
+		}
 	} else if !os.IsNotExist(err) {
 		return ascReferencePlan{}, err
 	}
@@ -265,7 +273,7 @@ func planASCReference(path string, force bool) (ascReferencePlan, error) {
 		return ascReferencePlan{}, err
 	}
 
-	return ascReferencePlan{root: root, name: name, exists: exists}, nil
+	return ascReferencePlan{root: root, name: name, exists: exists, perm: perm}, nil
 }
 
 func writeASCReference(plan ascReferencePlan) (bool, bool, error) {
@@ -274,7 +282,7 @@ func writeASCReference(plan ascReferencePlan) (bool, bool, error) {
 		content += "\n"
 	}
 
-	if err := plan.root.WriteFile(plan.name, []byte(content), 0o644); err != nil {
+	if err := plan.root.WriteFile(plan.name, []byte(content), plan.perm); err != nil {
 		return false, false, err
 	}
 
@@ -288,6 +296,7 @@ func writeASCReference(plan ascReferencePlan) (bool, bool, error) {
 type agentFileUpdate struct {
 	name    string
 	content string
+	perm    os.FileMode
 }
 
 // agentLinkPlan holds every agent-file update computed during planning.
@@ -315,7 +324,11 @@ func planAgentFileLinks(rootDir string, relRef string) (agentLinkPlan, error) {
 		return agentLinkPlan{}, err
 	}
 	if agentsChanged {
-		plan.updates = append(plan.updates, agentFileUpdate{name: agentsName, content: agentsContent})
+		update, err := plannedAgentFileUpdate(rootDir, agentsName, agentsContent)
+		if err != nil {
+			return agentLinkPlan{}, err
+		}
+		plan.updates = append(plan.updates, update)
 	}
 
 	claudeName := "CLAUDE.md"
@@ -324,16 +337,37 @@ func planAgentFileLinks(rootDir string, relRef string) (agentLinkPlan, error) {
 		return agentLinkPlan{}, err
 	}
 	if claudeChanged {
-		plan.updates = append(plan.updates, agentFileUpdate{name: claudeName, content: claudeContent})
+		update, err := plannedAgentFileUpdate(rootDir, claudeName, claudeContent)
+		if err != nil {
+			return agentLinkPlan{}, err
+		}
+		plan.updates = append(plan.updates, update)
 	}
 
 	return plan, nil
 }
 
+// plannedAgentFileUpdate records the rewrite along with the file's current
+// mode, so applying the plan preserves the operator's chosen permissions. The
+// rooted read that produced content already rejected symlinked entries.
+func plannedAgentFileUpdate(rootDir, name, content string) (agentFileUpdate, error) {
+	update := agentFileUpdate{name: name, content: content, perm: defaultDocsFileMode}
+	info, err := os.Lstat(filepath.Join(rootDir, name))
+	switch {
+	case err == nil:
+		if info.Mode().IsRegular() {
+			update.perm = info.Mode().Perm()
+		}
+	case !os.IsNotExist(err):
+		return agentFileUpdate{}, err
+	}
+	return update, nil
+}
+
 func applyAgentFileLinks(plan agentLinkPlan) ([]string, error) {
 	linked := []string{}
 	for _, update := range plan.updates {
-		if err := plan.root.WriteFile(update.name, []byte(update.content), 0o644); err != nil {
+		if err := plan.root.WriteFile(update.name, []byte(update.content), update.perm); err != nil {
 			return nil, err
 		}
 		linked = append(linked, filepath.Join(plan.rootDir, update.name))

--- a/internal/cli/docs/docs_init.go
+++ b/internal/cli/docs/docs_init.go
@@ -86,28 +86,41 @@ Examples:
 }
 
 // InitReference generates ASC.md in the target repo and links agent files.
+// Every validation, including the symlink containment checks on the ASC.md
+// destination and the agent files, runs before the first write, so a failed
+// init leaves the repository untouched.
 func InitReference(opts InitOptions) (InitResult, error) {
 	targetPath, linkRoot, err := resolveOutputPath(opts.Path)
 	if err != nil {
 		return InitResult{}, err
 	}
 
-	created, overwritten, err := writeASCReference(targetPath, opts.Force)
+	ascPlan, err := planASCReference(targetPath, opts.Force)
 	if err != nil {
 		return InitResult{}, err
 	}
 
-	linked := []string{}
+	linkPlan := agentLinkPlan{}
 	if opts.Link {
 		relRef, err := filepath.Rel(linkRoot, targetPath)
 		if err != nil {
 			relRef = ascReferenceFile
 		}
 		relRef = normalizeReferencePath(relRef)
-		linked, err = linkAgentFiles(linkRoot, relRef)
+		linkPlan, err = planAgentFileLinks(linkRoot, relRef)
 		if err != nil {
 			return InitResult{}, err
 		}
+	}
+
+	created, overwritten, err := writeASCReference(ascPlan)
+	if err != nil {
+		return InitResult{}, err
+	}
+
+	linked, err := applyAgentFileLinks(linkPlan)
+	if err != nil {
+		return InitResult{}, err
 	}
 
 	return InitResult{
@@ -218,10 +231,18 @@ func findRepoRoot(start string) (string, error) {
 	}
 }
 
-func writeASCReference(path string, force bool) (bool, bool, error) {
+// ascReferencePlan is a fully validated, not-yet-applied ASC.md write.
+type ascReferencePlan struct {
+	root   rootfs.Root
+	name   string
+	exists bool
+}
+
+// planASCReference validates the ASC.md destination without writing anything.
+func planASCReference(path string, force bool) (ascReferencePlan, error) {
 	root, err := rootfs.New(filepath.Dir(path))
 	if err != nil {
-		return false, false, err
+		return ascReferencePlan{}, err
 	}
 	name := filepath.Base(path)
 
@@ -231,57 +252,92 @@ func writeASCReference(path string, force bool) (bool, bool, error) {
 	if _, err := os.Lstat(path); err == nil {
 		exists = true
 	} else if !os.IsNotExist(err) {
-		return false, false, err
+		return ascReferencePlan{}, err
 	}
 
 	if exists && !force {
-		return false, false, fmt.Errorf("%w: %s (use --force to overwrite)", ErrASCReferenceExists, path)
+		return ascReferencePlan{}, fmt.Errorf("%w: %s (use --force to overwrite)", ErrASCReferenceExists, path)
 	}
 
+	// Reject a symlinked destination while planning so the failure happens
+	// before any file is written; the rooted write re-checks at write time.
+	if err := root.CheckContained(name); err != nil {
+		return ascReferencePlan{}, err
+	}
+
+	return ascReferencePlan{root: root, name: name, exists: exists}, nil
+}
+
+func writeASCReference(plan ascReferencePlan) (bool, bool, error) {
 	content := ascTemplate
 	if !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
 
-	if err := root.WriteFile(name, []byte(content), 0o644); err != nil {
+	if err := plan.root.WriteFile(plan.name, []byte(content), 0o644); err != nil {
 		return false, false, err
 	}
 
-	if exists {
+	if plan.exists {
 		return false, true, nil
 	}
 	return true, false, nil
 }
 
-func linkAgentFiles(rootDir string, relRef string) ([]string, error) {
+// agentFileUpdate is one planned agent-file rewrite.
+type agentFileUpdate struct {
+	name    string
+	content string
+}
+
+// agentLinkPlan holds every agent-file update computed during planning.
+type agentLinkPlan struct {
+	root    rootfs.Root
+	rootDir string
+	updates []agentFileUpdate
+}
+
+// planAgentFileLinks computes every agent-file update up front, so a symlinked
+// or unreadable agent file is rejected before anything is written.
+func planAgentFileLinks(rootDir string, relRef string) (agentLinkPlan, error) {
 	root, err := rootfs.New(rootDir)
 	if err != nil {
-		return nil, err
+		return agentLinkPlan{}, err
 	}
-
-	linked := []string{}
+	plan := agentLinkPlan{root: root, rootDir: rootDir}
 
 	agentsName := "AGENTS.md"
 	if !entryExists(filepath.Join(rootDir, agentsName)) {
 		agentsName = "Agents.md"
 	}
-	agentsUpdated, err := updateAgentsLink(root, agentsName, relRef)
+	agentsContent, agentsChanged, err := planAgentsLink(root, agentsName, relRef)
 	if err != nil {
-		return nil, err
+		return agentLinkPlan{}, err
 	}
-	if agentsUpdated {
-		linked = append(linked, filepath.Join(rootDir, agentsName))
+	if agentsChanged {
+		plan.updates = append(plan.updates, agentFileUpdate{name: agentsName, content: agentsContent})
 	}
 
 	claudeName := "CLAUDE.md"
-	claudeUpdated, err := updateClaudeLink(root, claudeName, relRef)
+	claudeContent, claudeChanged, err := planClaudeLink(root, claudeName, relRef)
 	if err != nil {
-		return nil, err
+		return agentLinkPlan{}, err
 	}
-	if claudeUpdated {
-		linked = append(linked, filepath.Join(rootDir, claudeName))
+	if claudeChanged {
+		plan.updates = append(plan.updates, agentFileUpdate{name: claudeName, content: claudeContent})
 	}
 
+	return plan, nil
+}
+
+func applyAgentFileLinks(plan agentLinkPlan) ([]string, error) {
+	linked := []string{}
+	for _, update := range plan.updates {
+		if err := plan.root.WriteFile(update.name, []byte(update.content), 0o644); err != nil {
+			return nil, err
+		}
+		linked = append(linked, filepath.Join(plan.rootDir, update.name))
+	}
 	return linked, nil
 }
 
@@ -297,13 +353,14 @@ func entryExists(path string) bool {
 	return false
 }
 
-func updateAgentsLink(root rootfs.Root, name string, relRef string) (bool, error) {
+// planAgentsLink computes the updated AGENTS.md content without writing it.
+func planAgentsLink(root rootfs.Root, name string, relRef string) (string, bool, error) {
 	data, found, err := root.ReadFileOptional(name)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	if !found {
-		return false, nil
+		return "", false, nil
 	}
 
 	desiredLine := fmt.Sprintf("See `%s` for the command catalog and workflows.", relRef)
@@ -329,23 +386,23 @@ func updateAgentsLink(root rootfs.Root, name string, relRef string) (bool, error
 	}
 	if foundReference {
 		if !changed {
-			return false, nil
+			return "", false, nil
 		}
-		return writeIfChanged(root, name, strings.Join(lines, "\n"))
+		return plannedContent(string(data), strings.Join(lines, "\n"))
 	}
 
 	section := fmt.Sprintf("## asc cli reference\n\n%s", desiredLine)
-	updated := appendSection(string(data), section)
-	return writeIfChanged(root, name, updated)
+	return plannedContent(string(data), appendSection(string(data), section))
 }
 
-func updateClaudeLink(root rootfs.Root, name string, relRef string) (bool, error) {
+// planClaudeLink computes the updated CLAUDE.md content without writing it.
+func planClaudeLink(root rootfs.Root, name string, relRef string) (string, bool, error) {
 	data, found, err := root.ReadFileOptional(name)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	if !found {
-		return false, nil
+		return "", false, nil
 	}
 
 	desiredLine := "@" + relRef
@@ -372,9 +429,9 @@ func updateClaudeLink(root rootfs.Root, name string, relRef string) (bool, error
 	}
 	if foundReference {
 		if !changed {
-			return false, nil
+			return "", false, nil
 		}
-		return writeIfChanged(root, name, strings.Join(updatedLines, "\n"))
+		return plannedContent(string(data), strings.Join(updatedLines, "\n"))
 	}
 
 	updated := strings.TrimRight(string(data), "\n")
@@ -383,7 +440,7 @@ func updateClaudeLink(root rootfs.Root, name string, relRef string) (bool, error
 	}
 	updated += desiredLine + "\n"
 
-	return writeIfChanged(root, name, updated)
+	return plannedContent(string(data), updated)
 }
 
 func isAgentsReferenceLine(line string) bool {
@@ -407,16 +464,11 @@ func appendSection(content, section string) string {
 	return trimmed + "\n\n" + section + "\n"
 }
 
-func writeIfChanged(root rootfs.Root, name string, content string) (bool, error) {
-	existing, err := root.ReadFile(name)
-	if err != nil {
-		return false, err
+// plannedContent reports updated as a pending write when it differs from the
+// existing content.
+func plannedContent(existing, updated string) (string, bool, error) {
+	if existing == updated {
+		return "", false, nil
 	}
-	if string(existing) == content {
-		return false, nil
-	}
-	if err := root.WriteFile(name, []byte(content), 0o644); err != nil {
-		return false, err
-	}
-	return true, nil
+	return updated, true, nil
 }

--- a/internal/cli/docs/docs_init_containment_test.go
+++ b/internal/cli/docs/docs_init_containment_test.go
@@ -3,6 +3,7 @@ package docs
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -179,6 +180,42 @@ func TestInitReference_WritesOrdinaryRepositoryFiles(t *testing.T) {
 	}
 	if !rerun.Overwritten {
 		t.Fatalf("InitReference() rerun result = %#v, want overwritten", rerun)
+	}
+}
+
+func TestInitReference_PreservesExistingFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not reported faithfully on Windows")
+	}
+	repo := newDocsContainmentRepo(t)
+	agentsPath := filepath.Join(repo, "AGENTS.md")
+	writeDocsContainmentFile(t, agentsPath, "# Agents\n")
+	if err := os.Chmod(agentsPath, 0o600); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	ascPath := filepath.Join(repo, ascReferenceFile)
+	writeDocsContainmentFile(t, ascPath, "# Existing\n")
+	if err := os.Chmod(ascPath, 0o600); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if _, err := InitReference(InitOptions{Path: repo, Force: true, Link: true}); err != nil {
+		t.Fatalf("InitReference() error = %v", err)
+	}
+
+	agentsInfo, err := os.Lstat(agentsPath)
+	if err != nil {
+		t.Fatalf("Lstat(AGENTS.md) error = %v", err)
+	}
+	if agentsInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("AGENTS.md mode = %v, want preserved 0600", agentsInfo.Mode().Perm())
+	}
+	ascInfo, err := os.Lstat(ascPath)
+	if err != nil {
+		t.Fatalf("Lstat(ASC.md) error = %v", err)
+	}
+	if ascInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("ASC.md mode = %v, want preserved 0600", ascInfo.Mode().Perm())
 	}
 }
 

--- a/internal/cli/docs/docs_init_containment_test.go
+++ b/internal/cli/docs/docs_init_containment_test.go
@@ -1,0 +1,152 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitReference_RefusesSymlinkedASCReference(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
+	writeDocsContainmentFile(t, sentinelPath, "# Sentinel\n")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(repo, ascReferenceFile)); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := InitReference(InitOptions{Path: repo, Force: true, Link: false})
+	if err == nil {
+		t.Fatal("InitReference() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("InitReference() error = %v, want symlink rejection", err)
+	}
+	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
+		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_RefusesSymlinkedAgentsFile(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
+	writeDocsContainmentFile(t, sentinelPath, "# Sentinel\n")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(repo, "AGENTS.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := InitReference(InitOptions{Path: repo, Force: true, Link: true})
+	if err == nil {
+		t.Fatal("InitReference() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("InitReference() error = %v, want symlink rejection", err)
+	}
+	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
+		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_RefusesSymlinkedClaudeFile(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
+	writeDocsContainmentFile(t, sentinelPath, "# Sentinel\n")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(repo, "CLAUDE.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := InitReference(InitOptions{Path: repo, Force: true, Link: true})
+	if err == nil {
+		t.Fatal("InitReference() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("InitReference() error = %v, want symlink rejection", err)
+	}
+	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
+		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_RefusesLowercaseSymlinkedAgentsFile(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
+	writeDocsContainmentFile(t, sentinelPath, "# Sentinel\n")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(repo, "Agents.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := InitReference(InitOptions{Path: repo, Force: true, Link: true})
+	if err == nil {
+		t.Fatal("InitReference() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("InitReference() error = %v, want symlink rejection", err)
+	}
+	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
+		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_WritesOrdinaryRepositoryFiles(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	writeDocsContainmentFile(t, filepath.Join(repo, "AGENTS.md"), "# Agents\n")
+	writeDocsContainmentFile(t, filepath.Join(repo, "CLAUDE.md"), "# Claude\n")
+
+	result, err := InitReference(InitOptions{Path: repo, Force: false, Link: true})
+	if err != nil {
+		t.Fatalf("InitReference() error = %v", err)
+	}
+	if !result.Created {
+		t.Fatalf("InitReference() result = %#v, want created", result)
+	}
+	if len(result.Linked) != 2 {
+		t.Fatalf("InitReference() linked = %v, want AGENTS.md and CLAUDE.md", result.Linked)
+	}
+	if got := readDocsContainmentFile(t, filepath.Join(repo, ascReferenceFile)); !strings.Contains(got, "asc") {
+		t.Fatalf("ASC.md content = %q", got)
+	}
+	if got := readDocsContainmentFile(t, filepath.Join(repo, "AGENTS.md")); !strings.Contains(got, "ASC.md") {
+		t.Fatalf("AGENTS.md content = %q, want ASC.md reference", got)
+	}
+	if got := readDocsContainmentFile(t, filepath.Join(repo, "CLAUDE.md")); !strings.Contains(got, "@ASC.md") {
+		t.Fatalf("CLAUDE.md content = %q, want @ASC.md directive", got)
+	}
+
+	// A rerun with --force must still overwrite the ordinary file in place.
+	rerun, err := InitReference(InitOptions{Path: repo, Force: true, Link: true})
+	if err != nil {
+		t.Fatalf("InitReference() rerun error = %v", err)
+	}
+	if !rerun.Overwritten {
+		t.Fatalf("InitReference() rerun result = %#v, want overwritten", rerun)
+	}
+}
+
+func newDocsContainmentRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) error = %v", err)
+	}
+	return repo
+}
+
+func writeDocsContainmentFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func readDocsContainmentFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/docs/docs_init_containment_test.go
+++ b/internal/cli/docs/docs_init_containment_test.go
@@ -91,6 +91,62 @@ func TestInitReference_RefusesLowercaseSymlinkedAgentsFile(t *testing.T) {
 	}
 }
 
+func TestInitReference_WritesNothingWhenAgentsFileIsSymlinked(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
+	writeDocsContainmentFile(t, sentinelPath, "# Sentinel\n")
+	writeDocsContainmentFile(t, filepath.Join(repo, "CLAUDE.md"), "# Claude\n")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(repo, "AGENTS.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := InitReference(InitOptions{Path: repo, Force: true, Link: true})
+	if err == nil {
+		t.Fatal("InitReference() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("InitReference() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(repo, ascReferenceFile)); !os.IsNotExist(statErr) {
+		t.Fatalf("Lstat(ASC.md) error = %v, want IsNotExist: a failed init must not leave ASC.md behind", statErr)
+	}
+	if got := readDocsContainmentFile(t, filepath.Join(repo, "CLAUDE.md")); got != "# Claude\n" {
+		t.Fatalf("CLAUDE.md content = %q, want unchanged", got)
+	}
+	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
+		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_WritesNothingWhenClaudeFileIsSymlinked(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
+	writeDocsContainmentFile(t, sentinelPath, "# Sentinel\n")
+	writeDocsContainmentFile(t, filepath.Join(repo, "AGENTS.md"), "# Agents\n")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(repo, "CLAUDE.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	_, err := InitReference(InitOptions{Path: repo, Force: true, Link: true})
+	if err == nil {
+		t.Fatal("InitReference() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("InitReference() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(repo, ascReferenceFile)); !os.IsNotExist(statErr) {
+		t.Fatalf("Lstat(ASC.md) error = %v, want IsNotExist: a failed init must not leave ASC.md behind", statErr)
+	}
+	if got := readDocsContainmentFile(t, filepath.Join(repo, "AGENTS.md")); got != "# Agents\n" {
+		t.Fatalf("AGENTS.md content = %q, want unchanged", got)
+	}
+	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
+		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
 func TestInitReference_WritesOrdinaryRepositoryFiles(t *testing.T) {
 	repo := newDocsContainmentRepo(t)
 	writeDocsContainmentFile(t, filepath.Join(repo, "AGENTS.md"), "# Agents\n")

--- a/internal/cli/docs/docs_init_test.go
+++ b/internal/cli/docs/docs_init_test.go
@@ -67,7 +67,7 @@ func TestInitReference_ReturnsTypedErrorWhenASCExists(t *testing.T) {
 	}
 }
 
-func TestUpdateAgentsLink_RewritesLegacyReference(t *testing.T) {
+func TestPlanAgentsLink_RewritesLegacyReference(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENTS.md")
 	legacy := "# AGENTS\n\n## ASC CLI Reference\n\nSee `ASC.md` for the command catalog and workflows.\n"
@@ -79,28 +79,31 @@ func TestUpdateAgentsLink_RewritesLegacyReference(t *testing.T) {
 		t.Fatalf("rootfs.New error: %v", err)
 	}
 
-	updated, err := updateAgentsLink(root, "AGENTS.md", "subdir/ASC.md")
+	content, changed, err := planAgentsLink(root, "AGENTS.md", "subdir/ASC.md")
 	if err != nil {
-		t.Fatalf("updateAgentsLink error: %v", err)
+		t.Fatalf("planAgentsLink error: %v", err)
 	}
-	if !updated {
-		t.Fatal("expected updateAgentsLink to update legacy reference")
+	if !changed {
+		t.Fatal("expected planAgentsLink to update legacy reference")
 	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
-	content := string(data)
 	if !strings.Contains(content, "See `subdir/ASC.md` for the command catalog and workflows.") {
 		t.Fatalf("expected rewritten reference, got %q", content)
 	}
 	if strings.Contains(content, "See `ASC.md` for the command catalog and workflows.") {
 		t.Fatalf("expected legacy reference removed, got %q", content)
 	}
+
+	// Planning must not touch the file; only the apply step writes.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if string(data) != legacy {
+		t.Fatalf("AGENTS.md content = %q, want untouched during planning", string(data))
+	}
 }
 
-func TestUpdateClaudeLink_RewritesLegacyReference(t *testing.T) {
+func TestPlanClaudeLink_RewritesLegacyReference(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CLAUDE.md")
 	legacy := "@Agents.md\n@ASC.md\n"
@@ -112,24 +115,27 @@ func TestUpdateClaudeLink_RewritesLegacyReference(t *testing.T) {
 		t.Fatalf("rootfs.New error: %v", err)
 	}
 
-	updated, err := updateClaudeLink(root, "CLAUDE.md", "subdir/ASC.md")
+	content, changed, err := planClaudeLink(root, "CLAUDE.md", "subdir/ASC.md")
 	if err != nil {
-		t.Fatalf("updateClaudeLink error: %v", err)
+		t.Fatalf("planClaudeLink error: %v", err)
 	}
-	if !updated {
-		t.Fatal("expected updateClaudeLink to update legacy reference")
+	if !changed {
+		t.Fatal("expected planClaudeLink to update legacy reference")
 	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
-	content := string(data)
 	if !strings.Contains(content, "@subdir/ASC.md") {
 		t.Fatalf("expected rewritten directive, got %q", content)
 	}
 	if strings.Contains(content, "@ASC.md") {
 		t.Fatalf("expected legacy directive removed, got %q", content)
+	}
+
+	// Planning must not touch the file; only the apply step writes.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if string(data) != legacy {
+		t.Fatalf("CLAUDE.md content = %q, want untouched during planning", string(data))
 	}
 }
 

--- a/internal/cli/docs/docs_init_test.go
+++ b/internal/cli/docs/docs_init_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 func TestResolveOutputPath_RejectsNonASCMarkdownFile(t *testing.T) {
@@ -66,13 +68,18 @@ func TestInitReference_ReturnsTypedErrorWhenASCExists(t *testing.T) {
 }
 
 func TestUpdateAgentsLink_RewritesLegacyReference(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "AGENTS.md")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
 	legacy := "# AGENTS\n\n## ASC CLI Reference\n\nSee `ASC.md` for the command catalog and workflows.\n"
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatalf("write AGENTS.md: %v", err)
 	}
+	root, err := rootfs.New(dir)
+	if err != nil {
+		t.Fatalf("rootfs.New error: %v", err)
+	}
 
-	updated, err := updateAgentsLink(path, "subdir/ASC.md")
+	updated, err := updateAgentsLink(root, "AGENTS.md", "subdir/ASC.md")
 	if err != nil {
 		t.Fatalf("updateAgentsLink error: %v", err)
 	}
@@ -94,13 +101,18 @@ func TestUpdateAgentsLink_RewritesLegacyReference(t *testing.T) {
 }
 
 func TestUpdateClaudeLink_RewritesLegacyReference(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CLAUDE.md")
 	legacy := "@Agents.md\n@ASC.md\n"
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatalf("write CLAUDE.md: %v", err)
 	}
+	root, err := rootfs.New(dir)
+	if err != nil {
+		t.Fatalf("rootfs.New error: %v", err)
+	}
 
-	updated, err := updateClaudeLink(path, "subdir/ASC.md")
+	updated, err := updateClaudeLink(root, "CLAUDE.md", "subdir/ASC.md")
 	if err != nil {
 		t.Fatalf("updateClaudeLink error: %v", err)
 	}

--- a/internal/cli/migrate/containment_test.go
+++ b/internal/cli/migrate/containment_test.go
@@ -236,6 +236,79 @@ func TestMigrateExportWritesOrdinaryFiles(t *testing.T) {
 	}
 }
 
+func TestResolveImportInputsRejectsAbsoluteDeliverfileMetadataPath(t *testing.T) {
+	workDir := t.TempDir()
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	deliverfile := "metadata_path \"" + external + "\"\nskip_screenshots true\n"
+	writeMigrateContainmentFile(t, filepath.Join(workDir, "Deliverfile"), deliverfile)
+
+	_, _, err := resolveImportInputs(importInputOptions{WorkDir: workDir})
+	if err == nil {
+		t.Fatal("resolveImportInputs() error = nil, want rejection of absolute Deliverfile metadata_path")
+	}
+	if !strings.Contains(err.Error(), "must be relative") && !strings.Contains(err.Error(), "escapes trusted root") {
+		t.Fatalf("resolveImportInputs() error = %v, want containment rejection", err)
+	}
+}
+
+func TestResolveImportInputsRejectsTraversingDeliverfileMetadataPath(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(base, "checkout")
+	external := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	deliverfile := "metadata_path \"../outside\"\nskip_screenshots true\n"
+	writeMigrateContainmentFile(t, filepath.Join(workDir, "Deliverfile"), deliverfile)
+
+	_, _, err := resolveImportInputs(importInputOptions{WorkDir: workDir})
+	if err == nil {
+		t.Fatal("resolveImportInputs() error = nil, want rejection of traversing Deliverfile metadata_path")
+	}
+	if !strings.Contains(err.Error(), "escapes trusted root") {
+		t.Fatalf("resolveImportInputs() error = %v, want containment rejection", err)
+	}
+}
+
+func TestScanFastlaneMetadataLocaleDirsRefusesSymlinkedInTreeMetadataDirectory(t *testing.T) {
+	t.Chdir(t.TempDir())
+	workDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeMigrateContainmentFile(t, filepath.Join(external, "en-US", "description.txt"), "local secret")
+
+	if err := os.MkdirAll(filepath.Join(workDir, "fastlane"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(workDir, "fastlane", "metadata")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	// The default fastlane/metadata layout ships with the checkout, so a
+	// symlinked metadata directory must be refused, not silently followed.
+	_, _, err = scanFastlaneMetadataLocaleDirs(filepath.Join(workDir, "fastlane", "metadata"))
+	if err == nil {
+		t.Fatal("scanFastlaneMetadataLocaleDirs() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("scanFastlaneMetadataLocaleDirs() error = %v, want symlink rejection", err)
+	}
+}
+
 func writeMigrateContainmentFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/migrate/containment_test.go
+++ b/internal/cli/migrate/containment_test.go
@@ -309,6 +309,58 @@ func TestScanFastlaneMetadataLocaleDirsRefusesSymlinkedInTreeMetadataDirectory(t
 	}
 }
 
+func TestResolveImportInputsResolvesDeliverfilePathsFromRelativeWorkDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	metadataDir := filepath.Join(cwd, "checkout", "fastlane", "metadata")
+	if err := os.MkdirAll(filepath.Join(metadataDir, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	deliverfile := "metadata_path \"./fastlane/metadata\"\nskip_screenshots true\n"
+	writeMigrateContainmentFile(t, filepath.Join(cwd, "checkout", "Deliverfile"), deliverfile)
+
+	inputs, _, err := resolveImportInputs(importInputOptions{WorkDir: "checkout"})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want relative work dir to resolve", err)
+	}
+	if inputs.MetadataDir != metadataDir {
+		t.Fatalf("MetadataDir = %q, want %q", inputs.MetadataDir, metadataDir)
+	}
+}
+
+func TestDiscoverScreenshotPlanRefusesSymlinkedInTreeScreenshotsDirectory(t *testing.T) {
+	t.Chdir(t.TempDir())
+	workDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, "fastlane"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(workDir, "fastlane", "screenshots")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	// The default fastlane/screenshots layout ships with the checkout, so a
+	// symlinked screenshots directory must be refused before any traversal.
+	_, _, err = discoverScreenshotPlan(filepath.Join(workDir, "fastlane", "screenshots"))
+	if err == nil {
+		t.Fatal("discoverScreenshotPlan() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("discoverScreenshotPlan() error = %v, want symlink rejection", err)
+	}
+}
+
 func writeMigrateContainmentFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/migrate/containment_test.go
+++ b/internal/cli/migrate/containment_test.go
@@ -1,0 +1,256 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadFastlaneMetadataRefusesSymlinkedVersionMetadataFile(t *testing.T) {
+	metadataDir := t.TempDir()
+	localeDir := filepath.Join(metadataDir, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	secretPath := filepath.Join(t.TempDir(), "id_rsa")
+	writeMigrateContainmentFile(t, secretPath, "PRIVATE KEY MATERIAL")
+
+	if err := os.Symlink(secretPath, filepath.Join(localeDir, "description.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	locs, err := readFastlaneMetadata(metadataDir)
+	if err == nil {
+		t.Fatalf("readFastlaneMetadata() error = nil, want symlink rejection (got %#v)", locs)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("readFastlaneMetadata() error = %v, want symlink rejection", err)
+	}
+	if strings.Contains(err.Error(), "PRIVATE KEY MATERIAL") {
+		t.Fatalf("error leaked file contents: %v", err)
+	}
+}
+
+func TestReadFastlaneAppInfoMetadataRefusesSymlinkedFile(t *testing.T) {
+	metadataDir := t.TempDir()
+	localeDir := filepath.Join(metadataDir, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	secretPath := filepath.Join(t.TempDir(), "secret.txt")
+	writeMigrateContainmentFile(t, secretPath, "local secret")
+
+	if err := os.Symlink(secretPath, filepath.Join(localeDir, "name.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	locs, err := readFastlaneAppInfoMetadata(metadataDir)
+	if err == nil {
+		t.Fatalf("readFastlaneAppInfoMetadata() error = nil, want symlink rejection (got %#v)", locs)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("readFastlaneAppInfoMetadata() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestReadFastlaneReviewInformationRefusesSymlinkedFile(t *testing.T) {
+	metadataDir := t.TempDir()
+	reviewDir := filepath.Join(metadataDir, "review_information")
+	if err := os.MkdirAll(reviewDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	secretPath := filepath.Join(t.TempDir(), "secret.txt")
+	writeMigrateContainmentFile(t, secretPath, "local secret")
+
+	if err := os.Symlink(secretPath, filepath.Join(reviewDir, "notes.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	info, err := readFastlaneReviewInformation(metadataDir)
+	if err == nil {
+		t.Fatalf("readFastlaneReviewInformation() error = nil, want symlink rejection (got %#v)", info)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("readFastlaneReviewInformation() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestScanFastlaneMetadataLocaleDirsReportsSymlinkedLocaleDirectory(t *testing.T) {
+	metadataDir := t.TempDir()
+	external := t.TempDir()
+	writeMigrateContainmentFile(t, filepath.Join(external, "description.txt"), "external")
+
+	if err := os.Symlink(external, filepath.Join(metadataDir, "en-US")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	dirs, skipped, err := scanFastlaneMetadataLocaleDirs(metadataDir)
+	if err != nil {
+		t.Fatalf("scanFastlaneMetadataLocaleDirs() error = %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Fatalf("scanFastlaneMetadataLocaleDirs() dirs = %#v, want none", dirs)
+	}
+	found := false
+	for _, item := range skipped {
+		if strings.Contains(item.Reason, "symlink") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("scanFastlaneMetadataLocaleDirs() skipped = %#v, want a symlink reason", skipped)
+	}
+}
+
+func TestReadFastlaneMetadataReadsOrdinaryFiles(t *testing.T) {
+	metadataDir := t.TempDir()
+	localeDir := filepath.Join(metadataDir, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeMigrateContainmentFile(t, filepath.Join(localeDir, "description.txt"), "English description\n")
+	writeMigrateContainmentFile(t, filepath.Join(localeDir, "name.txt"), "App Name\n")
+
+	locs, err := readFastlaneMetadata(metadataDir)
+	if err != nil {
+		t.Fatalf("readFastlaneMetadata() error = %v", err)
+	}
+	if len(locs) != 1 || locs[0].Description != "English description" {
+		t.Fatalf("readFastlaneMetadata() = %#v", locs)
+	}
+
+	appInfo, err := readFastlaneAppInfoMetadata(metadataDir)
+	if err != nil {
+		t.Fatalf("readFastlaneAppInfoMetadata() error = %v", err)
+	}
+	if len(appInfo) != 1 || appInfo[0].Name != "App Name" {
+		t.Fatalf("readFastlaneAppInfoMetadata() = %#v", appInfo)
+	}
+}
+
+func TestMigrateExportRefusesSymlinkedLocaleDirectory(t *testing.T) {
+	outputDir := t.TempDir()
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outputDir, "metadata"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(outputDir, "metadata", "en-US")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root, err := newMigrateExportRoot(outputDir)
+	if err != nil {
+		t.Fatalf("newMigrateExportRoot() error = %v", err)
+	}
+	err = root.MkdirAll(filepath.Join("metadata", "en-US"), 0o755)
+	if err == nil {
+		t.Fatal("MkdirAll() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("MkdirAll() error = %v, want symlink rejection", err)
+	}
+	entries, readErr := os.ReadDir(external)
+	if readErr != nil {
+		t.Fatalf("ReadDir() error = %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("export escaped into the symlink target: %v", entries)
+	}
+}
+
+func TestMigrateExportRefusesSymlinkedDestinationFile(t *testing.T) {
+	outputDir := t.TempDir()
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	writeMigrateContainmentFile(t, sentinelPath, "original")
+
+	localeDir := filepath.Join(outputDir, "metadata", "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(sentinelPath, filepath.Join(localeDir, "description.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root, err := newMigrateExportRoot(outputDir)
+	if err != nil {
+		t.Fatalf("newMigrateExportRoot() error = %v", err)
+	}
+	written, err := writeAndCount(root, filepath.Join("metadata", "en-US", "description.txt"), "attacker content")
+	if err == nil {
+		t.Fatal("writeAndCount() error = nil, want symlink rejection")
+	}
+	if written != 0 {
+		t.Fatalf("writeAndCount() = %d, want 0", written)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writeAndCount() error = %v, want symlink rejection", err)
+	}
+	if got := readMigrateContainmentFile(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+}
+
+func TestMigrateExportRejectsTraversingLocale(t *testing.T) {
+	outputDir := t.TempDir()
+	root, err := newMigrateExportRoot(outputDir)
+	if err != nil {
+		t.Fatalf("newMigrateExportRoot() error = %v", err)
+	}
+
+	if err := root.MkdirAll(filepath.Join("metadata", "../../escape"), 0o755); err == nil {
+		t.Fatal("MkdirAll() error = nil, want traversal rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(outputDir), "escape")); statErr == nil {
+		t.Fatal("MkdirAll() created a directory outside the output root")
+	}
+}
+
+func TestMigrateExportWritesOrdinaryFiles(t *testing.T) {
+	outputDir := t.TempDir()
+	root, err := newMigrateExportRoot(outputDir)
+	if err != nil {
+		t.Fatalf("newMigrateExportRoot() error = %v", err)
+	}
+	if err := root.MkdirAll(filepath.Join("metadata", "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	written, err := writeAndCount(root, filepath.Join("metadata", "en-US", "description.txt"), "English description")
+	if err != nil {
+		t.Fatalf("writeAndCount() error = %v", err)
+	}
+	if written != 1 {
+		t.Fatalf("writeAndCount() = %d, want 1", written)
+	}
+	if got := readMigrateContainmentFile(t, filepath.Join(outputDir, "metadata", "en-US", "description.txt")); got != "English description\n" {
+		t.Fatalf("content = %q", got)
+	}
+
+	skipped, err := writeAndCount(root, filepath.Join("metadata", "en-US", "keywords.txt"), "")
+	if err != nil {
+		t.Fatalf("writeAndCount() empty error = %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("writeAndCount() empty = %d, want 0", skipped)
+	}
+}
+
+func writeMigrateContainmentFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func readMigrateContainmentFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/migrate/containment_test.go
+++ b/internal/cli/migrate/containment_test.go
@@ -361,6 +361,31 @@ func TestDiscoverScreenshotPlanRefusesSymlinkedInTreeScreenshotsDirectory(t *tes
 	}
 }
 
+func TestResolveImportInputsRefusesSymlinkedExternalFastlaneMetadataChild(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	fastlane := t.TempDir()
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeMigrateContainmentFile(t, filepath.Join(external, "en-US", "description.txt"), "local secret")
+	if err := os.Symlink(external, filepath.Join(fastlane, "metadata")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	// The fastlane checkout's contents are repository-controlled even when the
+	// operator selected the fastlane root, so a symlinked metadata child must be
+	// refused.
+	_, _, err := resolveImportInputs(importInputOptions{FastlaneDir: fastlane, SkipScreenshots: true})
+	if err == nil {
+		t.Fatal("resolveImportInputs() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("resolveImportInputs() error = %v, want symlink rejection", err)
+	}
+}
+
 func writeMigrateContainmentFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/migrate/containment_test.go
+++ b/internal/cli/migrate/containment_test.go
@@ -386,6 +386,35 @@ func TestResolveImportInputsRefusesSymlinkedExternalFastlaneMetadataChild(t *tes
 	}
 }
 
+func TestDiscoverScreenshotPlanSkipsAndReportsSymlinkedLocaleDirectory(t *testing.T) {
+	screenshotsDir := t.TempDir()
+	external := t.TempDir()
+	// If a symlinked locale directory were followed, this file would surface as
+	// an invalid-screenshot error; the entry must instead be skipped and
+	// reported, matching the metadata scan.
+	writeMigrateContainmentFile(t, filepath.Join(external, "external.png"), "not a real png")
+	if err := os.Symlink(external, filepath.Join(screenshotsDir, "en-US")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	plans, skipped, err := discoverScreenshotPlan(screenshotsDir)
+	if err != nil {
+		t.Fatalf("discoverScreenshotPlan() error = %v, want symlinked locale skipped", err)
+	}
+	if len(plans) != 0 {
+		t.Fatalf("plans = %#v, want none from a symlinked locale", plans)
+	}
+	found := false
+	for _, item := range skipped {
+		if strings.Contains(item.Reason, "symlink") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("skipped = %#v, want a reported symlinked screenshots entry", skipped)
+	}
+}
+
 func writeMigrateContainmentFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -535,11 +535,43 @@ func readFastlaneAppInfoMetadata(metadataDir string) ([]AppInfoFastlaneLocalizat
 	return readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
 }
 
-// newMigrateMetadataRoot anchors metadata reads to the resolved metadata
-// directory so repository-controlled locale directories and files cannot
-// redirect reads to local secrets before they are published upstream.
-func newMigrateMetadataRoot(metadataDir string) (rootfs.Root, error) {
-	return rootfs.New(metadataDir)
+// newMigrateMetadataRoot anchors metadata reads for metadataDir so
+// repository-controlled locale directories and files cannot redirect reads to
+// local secrets before they are published upstream. A metadata directory inside
+// the working directory (including the default fastlane/metadata layout, whose
+// components ship with the checkout) is anchored at the working directory so
+// every component below it is validated; an operator-selected directory outside
+// the working directory is its own trusted root. The returned prefix is the
+// root-relative metadata directory.
+func newMigrateMetadataRoot(metadataDir string) (rootfs.Root, string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(metadataDir))
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		if root, rootErr := rootfs.New(cwd); rootErr == nil {
+			if relative, relErr := filepath.Rel(root.Path(), absolute); relErr == nil {
+				if relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+					return root, relative, nil
+				}
+			}
+		}
+	}
+	root, err := rootfs.New(absolute)
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	return root, ".", nil
+}
+
+// checkMetadataRootContained refuses a repository-controlled metadata directory
+// whose components below the trusted root traverse a symlink. The prefix "."
+// marks an operator-selected external directory, which is trusted as given.
+func checkMetadataRootContained(root rootfs.Root, prefix string) error {
+	if prefix == "." {
+		return nil
+	}
+	return root.CheckContained(prefix)
 }
 
 // newMigrateExportRoot anchors export writes to the operator-selected output
@@ -717,6 +749,13 @@ type fastlaneLocaleDir struct {
 }
 
 func scanFastlaneMetadataLocaleDirs(metadataDir string) ([]fastlaneLocaleDir, []SkippedItem, error) {
+	root, prefix, err := newMigrateMetadataRoot(metadataDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := checkMetadataRootContained(root, prefix); err != nil {
+		return nil, nil, err
+	}
 	entries, err := os.ReadDir(metadataDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read metadata directory: %w", err)
@@ -773,8 +812,11 @@ func scanFastlaneMetadataLocaleDirs(metadataDir string) ([]fastlaneLocaleDir, []
 }
 
 func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) ([]FastlaneLocalization, error) {
-	root, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateMetadataRoot(metadataDir)
 	if err != nil {
+		return nil, err
+	}
+	if err := checkMetadataRootContained(root, prefix); err != nil {
 		return nil, err
 	}
 
@@ -795,7 +837,7 @@ func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlan
 			{"marketing_url.txt", &loc.MarketingURL},
 		}
 		for _, field := range fields {
-			value, err := readMetadataFile(root, filepath.Join(ld.DirName, field.file))
+			value, err := readMetadataFile(root, filepath.Join(prefix, ld.DirName, field.file))
 			if err != nil {
 				return nil, err
 			}
@@ -808,22 +850,25 @@ func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlan
 }
 
 func readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) ([]AppInfoFastlaneLocalization, error) {
-	root, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateMetadataRoot(metadataDir)
 	if err != nil {
+		return nil, err
+	}
+	if err := checkMetadataRootContained(root, prefix); err != nil {
 		return nil, err
 	}
 
 	localizations := make([]AppInfoFastlaneLocalization, 0, len(localeDirs))
 	for _, ld := range localeDirs {
-		name, err := readMetadataFile(root, filepath.Join(ld.DirName, "name.txt"))
+		name, err := readMetadataFile(root, filepath.Join(prefix, ld.DirName, "name.txt"))
 		if err != nil {
 			return nil, err
 		}
-		subtitle, err := readMetadataFile(root, filepath.Join(ld.DirName, "subtitle.txt"))
+		subtitle, err := readMetadataFile(root, filepath.Join(prefix, ld.DirName, "subtitle.txt"))
 		if err != nil {
 			return nil, err
 		}
-		privacyURL, err := readMetadataFile(root, filepath.Join(ld.DirName, "privacy_url.txt"))
+		privacyURL, err := readMetadataFile(root, filepath.Join(prefix, ld.DirName, "privacy_url.txt"))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -918,7 +918,10 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			metadataDir := filepath.Join(*fastlaneDir, "metadata")
+			metadataDir, err := containFastlaneChild(*fastlaneDir, "metadata")
+			if err != nil {
+				return fmt.Errorf("migrate validate: %w", err)
+			}
 
 			// Read metadata from fastlane structure
 			localeDirs, skipped, err := scanFastlaneMetadataLocaleDirs(metadataDir)

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -535,16 +535,16 @@ func readFastlaneAppInfoMetadata(metadataDir string) ([]AppInfoFastlaneLocalizat
 	return readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
 }
 
-// newMigrateMetadataRoot anchors metadata reads for metadataDir so
-// repository-controlled locale directories and files cannot redirect reads to
-// local secrets before they are published upstream. A metadata directory inside
-// the working directory (including the default fastlane/metadata layout, whose
-// components ship with the checkout) is anchored at the working directory so
-// every component below it is validated; an operator-selected directory outside
-// the working directory is its own trusted root. The returned prefix is the
-// root-relative metadata directory.
-func newMigrateMetadataRoot(metadataDir string) (rootfs.Root, string, error) {
-	absolute, err := filepath.Abs(strings.TrimSpace(metadataDir))
+// newMigrateContentRoot anchors metadata and screenshot reads for dir so
+// repository-controlled directories and files cannot redirect reads to local
+// secrets before they are published upstream. A directory inside the working
+// directory (including the default fastlane/metadata and fastlane/screenshots
+// layouts, whose components ship with the checkout) is anchored at the working
+// directory so every component below it is validated; an operator-selected
+// directory outside the working directory is its own trusted root. The returned
+// prefix is the root-relative content directory.
+func newMigrateContentRoot(dir string) (rootfs.Root, string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(dir))
 	if err != nil {
 		return rootfs.Root{}, "", err
 	}
@@ -564,10 +564,10 @@ func newMigrateMetadataRoot(metadataDir string) (rootfs.Root, string, error) {
 	return root, ".", nil
 }
 
-// checkMetadataRootContained refuses a repository-controlled metadata directory
+// checkContentRootContained refuses a repository-controlled content directory
 // whose components below the trusted root traverse a symlink. The prefix "."
 // marks an operator-selected external directory, which is trusted as given.
-func checkMetadataRootContained(root rootfs.Root, prefix string) error {
+func checkContentRootContained(root rootfs.Root, prefix string) error {
 	if prefix == "." {
 		return nil
 	}
@@ -749,11 +749,11 @@ type fastlaneLocaleDir struct {
 }
 
 func scanFastlaneMetadataLocaleDirs(metadataDir string) ([]fastlaneLocaleDir, []SkippedItem, error) {
-	root, prefix, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateContentRoot(metadataDir)
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := checkMetadataRootContained(root, prefix); err != nil {
+	if err := checkContentRootContained(root, prefix); err != nil {
 		return nil, nil, err
 	}
 	entries, err := os.ReadDir(metadataDir)
@@ -812,11 +812,11 @@ func scanFastlaneMetadataLocaleDirs(metadataDir string) ([]fastlaneLocaleDir, []
 }
 
 func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) ([]FastlaneLocalization, error) {
-	root, prefix, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateContentRoot(metadataDir)
 	if err != nil {
 		return nil, err
 	}
-	if err := checkMetadataRootContained(root, prefix); err != nil {
+	if err := checkContentRootContained(root, prefix); err != nil {
 		return nil, err
 	}
 
@@ -850,11 +850,11 @@ func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlan
 }
 
 func readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) ([]AppInfoFastlaneLocalization, error) {
-	root, prefix, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateContentRoot(metadataDir)
 	if err != nil {
 		return nil, err
 	}
-	if err := checkMetadataRootContained(root, prefix); err != nil {
+	if err := checkContentRootContained(root, prefix); err != nil {
 		return nil, err
 	}
 

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
@@ -147,8 +148,14 @@ Examples:
 				}
 				skipped = append(skipped, metadataSkipped...)
 
-				localizations = readFastlaneMetadataFromLocaleDirs(metadataDir, localeDirs)
-				appInfoLocs = readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
+				localizations, err = readFastlaneMetadataFromLocaleDirs(metadataDir, localeDirs)
+				if err != nil {
+					return fmt.Errorf("migrate import: %w", err)
+				}
+				appInfoLocs, err = readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
+				if err != nil {
+					return fmt.Errorf("migrate import: %w", err)
+				}
 
 				reviewInfo, err = readFastlaneReviewInformation(metadataDir)
 				if err != nil {
@@ -345,9 +352,12 @@ Examples:
 				return fmt.Errorf("migrate export: %w", err)
 			}
 
-			// Create output directory structure
-			metadataDir := filepath.Join(*outputDir, "metadata")
-			if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+			// Create output directory structure beneath the operator-selected root
+			root, err := newMigrateExportRoot(*outputDir)
+			if err != nil {
+				return fmt.Errorf("migrate export: %w", err)
+			}
+			if err := root.MkdirAll("metadata", 0o755); err != nil {
 				return fmt.Errorf("migrate export: failed to create directory: %w", err)
 			}
 
@@ -356,18 +366,33 @@ Examples:
 			totalFiles := 0
 			for _, loc := range resp.Data {
 				locale := loc.Attributes.Locale
-				localeDir := filepath.Join(metadataDir, locale)
-				if err := os.MkdirAll(localeDir, 0o755); err != nil {
+				localeDir, err := migrateExportLocaleDir(locale)
+				if err != nil {
+					return fmt.Errorf("migrate export: %w", err)
+				}
+				if err := root.MkdirAll(localeDir, 0o755); err != nil {
 					return fmt.Errorf("migrate export: failed to create locale directory: %w", err)
 				}
 
 				// Write files (only non-empty content creates files)
-				totalFiles += writeAndCount(filepath.Join(localeDir, "description.txt"), loc.Attributes.Description)
-				totalFiles += writeAndCount(filepath.Join(localeDir, "keywords.txt"), loc.Attributes.Keywords)
-				totalFiles += writeAndCount(filepath.Join(localeDir, "release_notes.txt"), loc.Attributes.WhatsNew)
-				totalFiles += writeAndCount(filepath.Join(localeDir, "promotional_text.txt"), loc.Attributes.PromotionalText)
-				totalFiles += writeAndCount(filepath.Join(localeDir, "support_url.txt"), loc.Attributes.SupportURL)
-				totalFiles += writeAndCount(filepath.Join(localeDir, "marketing_url.txt"), loc.Attributes.MarketingURL)
+				files := []struct {
+					name    string
+					content string
+				}{
+					{"description.txt", loc.Attributes.Description},
+					{"keywords.txt", loc.Attributes.Keywords},
+					{"release_notes.txt", loc.Attributes.WhatsNew},
+					{"promotional_text.txt", loc.Attributes.PromotionalText},
+					{"support_url.txt", loc.Attributes.SupportURL},
+					{"marketing_url.txt", loc.Attributes.MarketingURL},
+				}
+				for _, file := range files {
+					written, err := writeAndCount(root, filepath.Join(localeDir, file.name), file.content)
+					if err != nil {
+						return fmt.Errorf("migrate export: %w", err)
+					}
+					totalFiles += written
+				}
 
 				exported = append(exported, locale)
 			}
@@ -382,12 +407,27 @@ Examples:
 				appInfoLocs, err := client.GetAppInfoLocalizations(requestCtx, appInfoID)
 				if err == nil {
 					for _, loc := range appInfoLocs.Data {
-						locale := loc.Attributes.Locale
-						localeDir := filepath.Join(metadataDir, locale)
+						localeDir, err := migrateExportLocaleDir(loc.Attributes.Locale)
+						if err != nil {
+							return fmt.Errorf("migrate export: %w", err)
+						}
 						// Create locale dir if it doesn't exist (may have App Info but no version localizations)
-						if err := os.MkdirAll(localeDir, 0o755); err == nil {
-							totalFiles += writeAndCount(filepath.Join(localeDir, "name.txt"), loc.Attributes.Name)
-							totalFiles += writeAndCount(filepath.Join(localeDir, "subtitle.txt"), loc.Attributes.Subtitle)
+						if err := root.MkdirAll(localeDir, 0o755); err != nil {
+							return fmt.Errorf("migrate export: failed to create locale directory: %w", err)
+						}
+						files := []struct {
+							name    string
+							content string
+						}{
+							{"name.txt", loc.Attributes.Name},
+							{"subtitle.txt", loc.Attributes.Subtitle},
+						}
+						for _, file := range files {
+							written, err := writeAndCount(root, filepath.Join(localeDir, file.name), file.content)
+							if err != nil {
+								return fmt.Errorf("migrate export: %w", err)
+							}
+							totalFiles += written
 						}
 					}
 				}
@@ -483,7 +523,7 @@ func readFastlaneMetadata(metadataDir string) ([]FastlaneLocalization, error) {
 	if err != nil {
 		return nil, err
 	}
-	return readFastlaneMetadataFromLocaleDirs(metadataDir, localeDirs), nil
+	return readFastlaneMetadataFromLocaleDirs(metadataDir, localeDirs)
 }
 
 // readFastlaneAppInfoMetadata reads app-level metadata (name, subtitle) from fastlane structure.
@@ -492,27 +532,58 @@ func readFastlaneAppInfoMetadata(metadataDir string) ([]AppInfoFastlaneLocalizat
 	if err != nil {
 		return nil, err
 	}
-	return readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs), nil
+	return readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
 }
 
-// readFileIfExists reads a file's contents if it exists, returning empty string otherwise.
-func readFileIfExists(path string) string {
-	data, err := os.ReadFile(path)
+// newMigrateMetadataRoot anchors metadata reads to the resolved metadata
+// directory so repository-controlled locale directories and files cannot
+// redirect reads to local secrets before they are published upstream.
+func newMigrateMetadataRoot(metadataDir string) (rootfs.Root, error) {
+	return rootfs.New(metadataDir)
+}
+
+// newMigrateExportRoot anchors export writes to the operator-selected output
+// directory, which may legitimately live outside the current repository.
+func newMigrateExportRoot(outputDir string) (rootfs.Root, error) {
+	return rootfs.New(outputDir)
+}
+
+// migrateExportLocaleDir builds the export-relative locale directory for a
+// locale returned by App Store Connect.
+func migrateExportLocaleDir(locale string) (string, error) {
+	trimmed := strings.TrimSpace(locale)
+	if trimmed == "" {
+		return "", fmt.Errorf("app store connect returned an empty locale")
+	}
+	if err := rootfs.ValidateRelative(trimmed); err != nil {
+		return "", err
+	}
+	return filepath.Join("metadata", trimmed), nil
+}
+
+// readMetadataFile reads an optional metadata file beneath the metadata root.
+// A missing file yields an empty value; a symlinked file is an error.
+func readMetadataFile(root rootfs.Root, name string) (string, error) {
+	data, found, err := root.ReadFileOptional(name)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return strings.TrimSpace(string(data))
+	if !found {
+		return "", nil
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
-// writeAndCount writes content to a file and returns 1 if written, 0 if skipped.
-func writeAndCount(path, content string) int {
+// writeAndCount writes content beneath root and returns 1 when a file was
+// written and 0 when the content was empty.
+func writeAndCount(root rootfs.Root, name, content string) (int, error) {
 	if content == "" {
-		return 0
+		return 0, nil
 	}
-	if err := os.WriteFile(path, []byte(content+"\n"), 0o644); err != nil {
-		return 0
+	if err := root.WriteFile(name, []byte(content+"\n"), 0o644); err != nil {
+		return 0, err
 	}
-	return 1
+	return 1, nil
 }
 
 // printMigrateOutput handles output for migrate-specific result types.
@@ -655,13 +726,26 @@ func scanFastlaneMetadataLocaleDirs(metadataDir string) ([]fastlaneLocaleDir, []
 	dirs := make([]fastlaneLocaleDir, 0, len(entries))
 	skipped := []SkippedItem{}
 	for _, entry := range entries {
+		dirName := entry.Name()
+		if entry.Type()&os.ModeSymlink != 0 {
+			// A symlinked locale directory would read metadata from outside the
+			// metadata root, so report it instead of silently following it.
+			skipped = append(skipped, SkippedItem{
+				Path:   filepath.Join(metadataDir, dirName),
+				Reason: fmt.Sprintf("skipped symlinked metadata entry %q", dirName),
+			})
+			continue
+		}
 		if !entry.IsDir() {
 			continue
 		}
 
-		dirName := entry.Name()
 		if dirName == "review_information" || dirName == "default" {
 			continue // Skip special directories
+		}
+
+		if err := rootfs.ValidateRelative(dirName); err != nil {
+			return nil, nil, err
 		}
 
 		normalized, err := normalizeLocale(dirName)
@@ -688,32 +772,61 @@ func scanFastlaneMetadataLocaleDirs(metadataDir string) ([]fastlaneLocaleDir, []
 	return dirs, skipped, nil
 }
 
-func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) []FastlaneLocalization {
+func readFastlaneMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) ([]FastlaneLocalization, error) {
+	root, err := newMigrateMetadataRoot(metadataDir)
+	if err != nil {
+		return nil, err
+	}
+
 	localizations := make([]FastlaneLocalization, 0, len(localeDirs))
 	for _, ld := range localeDirs {
-		localeDir := filepath.Join(metadataDir, ld.DirName)
 		loc := FastlaneLocalization{Locale: ld.Locale}
 
 		// Read each metadata file (version-level localization fields only)
-		loc.Description = readFileIfExists(filepath.Join(localeDir, "description.txt"))
-		loc.Keywords = readFileIfExists(filepath.Join(localeDir, "keywords.txt"))
-		loc.WhatsNew = readFileIfExists(filepath.Join(localeDir, "release_notes.txt"))
-		loc.PromotionalText = readFileIfExists(filepath.Join(localeDir, "promotional_text.txt"))
-		loc.SupportURL = readFileIfExists(filepath.Join(localeDir, "support_url.txt"))
-		loc.MarketingURL = readFileIfExists(filepath.Join(localeDir, "marketing_url.txt"))
+		fields := []struct {
+			file  string
+			field *string
+		}{
+			{"description.txt", &loc.Description},
+			{"keywords.txt", &loc.Keywords},
+			{"release_notes.txt", &loc.WhatsNew},
+			{"promotional_text.txt", &loc.PromotionalText},
+			{"support_url.txt", &loc.SupportURL},
+			{"marketing_url.txt", &loc.MarketingURL},
+		}
+		for _, field := range fields {
+			value, err := readMetadataFile(root, filepath.Join(ld.DirName, field.file))
+			if err != nil {
+				return nil, err
+			}
+			*field.field = value
+		}
 
 		localizations = append(localizations, loc)
 	}
-	return localizations
+	return localizations, nil
 }
 
-func readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) []AppInfoFastlaneLocalization {
+func readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir string, localeDirs []fastlaneLocaleDir) ([]AppInfoFastlaneLocalization, error) {
+	root, err := newMigrateMetadataRoot(metadataDir)
+	if err != nil {
+		return nil, err
+	}
+
 	localizations := make([]AppInfoFastlaneLocalization, 0, len(localeDirs))
 	for _, ld := range localeDirs {
-		localeDir := filepath.Join(metadataDir, ld.DirName)
-		name := readFileIfExists(filepath.Join(localeDir, "name.txt"))
-		subtitle := readFileIfExists(filepath.Join(localeDir, "subtitle.txt"))
-		privacyURL := readFileIfExists(filepath.Join(localeDir, "privacy_url.txt"))
+		name, err := readMetadataFile(root, filepath.Join(ld.DirName, "name.txt"))
+		if err != nil {
+			return nil, err
+		}
+		subtitle, err := readMetadataFile(root, filepath.Join(ld.DirName, "subtitle.txt"))
+		if err != nil {
+			return nil, err
+		}
+		privacyURL, err := readMetadataFile(root, filepath.Join(ld.DirName, "privacy_url.txt"))
+		if err != nil {
+			return nil, err
+		}
 
 		// Only include if at least one field has content
 		if name != "" || subtitle != "" || privacyURL != "" {
@@ -725,7 +838,7 @@ func readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir string, localeDirs []
 			})
 		}
 	}
-	return localizations
+	return localizations, nil
 }
 
 // MigrateValidateCommand returns the migrate validate subcommand.
@@ -770,10 +883,16 @@ Examples:
 				}
 				return fmt.Errorf("migrate validate: %w", err)
 			}
-			localizations := readFastlaneMetadataFromLocaleDirs(metadataDir, localeDirs)
+			localizations, err := readFastlaneMetadataFromLocaleDirs(metadataDir, localeDirs)
+			if err != nil {
+				return fmt.Errorf("migrate validate: %w", err)
+			}
 
 			// Read App Info metadata (name, subtitle)
-			appInfoLocs := readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
+			appInfoLocs, err := readFastlaneAppInfoMetadataFromLocaleDirs(metadataDir, localeDirs)
+			if err != nil {
+				return fmt.Errorf("migrate validate: %w", err)
+			}
 
 			// Validate and collect issues
 			var issues []ValidationIssue

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -610,12 +610,13 @@ func readMetadataFile(root rootfs.Root, name string) (string, error) {
 }
 
 // writeAndCount writes content beneath root and returns 1 when a file was
-// written and 0 when the content was empty.
+// written and 0 when the content was empty. An existing destination keeps its
+// permissions, matching the previous in-place write.
 func writeAndCount(root rootfs.Root, name, content string) (int, error) {
 	if content == "" {
 		return 0, nil
 	}
-	if err := root.WriteFile(name, []byte(content+"\n"), 0o644); err != nil {
+	if err := root.WriteFilePreservingMode(name, []byte(content+"\n"), 0o644); err != nil {
 		return 0, err
 	}
 	return 1, nil

--- a/internal/cli/migrate/migrate_test.go
+++ b/internal/cli/migrate/migrate_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc/types"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
-func TestReadFileIfExists_FileExists(t *testing.T) {
+func TestReadMetadataFile_FileExists(t *testing.T) {
 	// Create a temp file
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")
@@ -20,27 +21,36 @@ func TestReadFileIfExists_FileExists(t *testing.T) {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
 
-	got := readFileIfExists(path)
+	got, err := readMetadataFile(mustMigrateRoot(t, dir), "test.txt")
+	if err != nil {
+		t.Fatalf("readMetadataFile() error: %v", err)
+	}
 	if got != "hello world" {
 		t.Errorf("expected 'hello world', got %q", got)
 	}
 }
 
-func TestReadFileIfExists_FileDoesNotExist(t *testing.T) {
-	got := readFileIfExists("/nonexistent/path/file.txt")
+func TestReadMetadataFile_FileDoesNotExist(t *testing.T) {
+	got, err := readMetadataFile(mustMigrateRoot(t, t.TempDir()), "missing/file.txt")
+	if err != nil {
+		t.Fatalf("readMetadataFile() error: %v", err)
+	}
 	if got != "" {
 		t.Errorf("expected empty string, got %q", got)
 	}
 }
 
-func TestReadFileIfExists_TrimsWhitespace(t *testing.T) {
+func TestReadMetadataFile_TrimsWhitespace(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")
 	if err := os.WriteFile(path, []byte("  trimmed  \n\n"), 0o644); err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
 
-	got := readFileIfExists(path)
+	got, err := readMetadataFile(mustMigrateRoot(t, dir), "test.txt")
+	if err != nil {
+		t.Fatalf("readMetadataFile() error: %v", err)
+	}
 	if got != "trimmed" {
 		t.Errorf("expected 'trimmed', got %q", got)
 	}
@@ -50,7 +60,10 @@ func TestWriteAndCount_EmptyContent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")
 
-	count := writeAndCount(path, "")
+	count, err := writeAndCount(mustMigrateRoot(t, dir), "test.txt", "")
+	if err != nil {
+		t.Fatalf("writeAndCount() error: %v", err)
+	}
 	if count != 0 {
 		t.Errorf("expected 0, got %d", count)
 	}
@@ -65,7 +78,10 @@ func TestWriteAndCount_WritesContent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")
 
-	count := writeAndCount(path, "content")
+	count, err := writeAndCount(mustMigrateRoot(t, dir), "test.txt", "content")
+	if err != nil {
+		t.Fatalf("writeAndCount() error: %v", err)
+	}
 	if count != 1 {
 		t.Errorf("expected 1, got %d", count)
 	}
@@ -78,6 +94,15 @@ func TestWriteAndCount_WritesContent(t *testing.T) {
 	if string(data) != "content\n" {
 		t.Errorf("expected 'content\\n', got %q", string(data))
 	}
+}
+
+func mustMigrateRoot(t *testing.T, dir string) rootfs.Root {
+	t.Helper()
+	root, err := rootfs.New(dir)
+	if err != nil {
+		t.Fatalf("rootfs.New(%q) error: %v", dir, err)
+	}
+	return root
 }
 
 func TestCountNonEmptyFields_AllEmpty(t *testing.T) {

--- a/internal/cli/migrate/migrate_test.go
+++ b/internal/cli/migrate/migrate_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -93,6 +94,39 @@ func TestWriteAndCount_WritesContent(t *testing.T) {
 
 	if string(data) != "content\n" {
 		t.Errorf("expected 'content\\n', got %q", string(data))
+	}
+}
+
+func TestWriteAndCountPreservesExistingFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not reported faithfully on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "description.txt")
+	if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	count, err := writeAndCount(mustMigrateRoot(t, dir), "description.txt", "new")
+	if err != nil {
+		t.Fatalf("writeAndCount() error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1, got %d", count)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat() error: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %v, want preserved 0600", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "new\n" {
+		t.Fatalf("content = %q, want %q", data, "new\n")
 	}
 }
 

--- a/internal/cli/migrate/path_resolution.go
+++ b/internal/cli/migrate/path_resolution.go
@@ -136,7 +136,14 @@ func containDeliverfilePath(workDir, base, value string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resolved, err := root.Resolve(filepath.Clean(filepath.Join(base, trimmed)))
+	// The Deliverfile directory may itself be relative to the process working
+	// directory; make it absolute so joining below cannot re-resolve it against
+	// the trusted root and duplicate the leading components.
+	absoluteBase, err := filepath.Abs(base)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := root.Resolve(filepath.Clean(filepath.Join(absoluteBase, trimmed)))
 	if err != nil {
 		return "", fmt.Errorf("deliverfile path %q must stay inside %s: %w", value, root.Path(), err)
 	}

--- a/internal/cli/migrate/path_resolution.go
+++ b/internal/cli/migrate/path_resolution.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 type pathSource string
@@ -66,8 +68,14 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 		DeliverfileConfig: config,
 	}
 
-	metadataDir, metadataSource := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.MetadataDir, config.MetadataPath, "metadata")
-	screenshotsDir, screenshotsSource := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots")
+	metadataDir, metadataSource, err := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.MetadataDir, config.MetadataPath, "metadata")
+	if err != nil {
+		return importInputs{}, nil, err
+	}
+	screenshotsDir, screenshotsSource, err := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots")
+	if err != nil {
+		return importInputs{}, nil, err
+	}
 	skipScreenshots := opts.SkipScreenshots || config.SkipScreenshots
 
 	skipped := []SkippedItem{}
@@ -90,25 +98,49 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 	return inputs, skipped, nil
 }
 
-func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deliverfilePathValue, defaultDir string) (string, pathSource) {
+func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deliverfilePathValue, defaultDir string) (string, pathSource, error) {
 	if strings.TrimSpace(explicitPath) != "" {
-		return explicitPath, pathSourceFlag
+		return explicitPath, pathSourceFlag, nil
 	}
 	if strings.TrimSpace(fastlaneDir) != "" {
-		return filepath.Join(fastlaneDir, defaultDir), pathSourceFlag
+		return filepath.Join(fastlaneDir, defaultDir), pathSourceFlag, nil
 	}
 	if strings.TrimSpace(deliverfilePathValue) != "" {
 		base := workDir
 		if deliverfilePath != "" {
 			base = filepath.Dir(deliverfilePath)
 		}
-		return resolveRelativePath(base, deliverfilePathValue), pathSourceDeliverfile
+		resolved, err := containDeliverfilePath(workDir, base, deliverfilePathValue)
+		if err != nil {
+			return "", pathSourceDeliverfile, err
+		}
+		return resolved, pathSourceDeliverfile, nil
 	}
 	base := workDir
 	if deliverfilePath != "" {
 		base = filepath.Dir(deliverfilePath)
 	}
-	return filepath.Join(base, defaultDir), pathSourceDefault
+	return filepath.Join(base, defaultDir), pathSourceDefault, nil
+}
+
+// containDeliverfilePath resolves a repository-controlled Deliverfile path
+// value against the Deliverfile's own directory and requires the result to stay
+// inside the working directory, because the Deliverfile ships with the checkout
+// and must not select files outside it.
+func containDeliverfilePath(workDir, base, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if err := rootfs.ValidateRelativeAllowingTraversal(trimmed); err != nil {
+		return "", fmt.Errorf("deliverfile path %q: %w", value, err)
+	}
+	root, err := rootfs.New(workDir)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := root.Resolve(filepath.Clean(filepath.Join(base, trimmed)))
+	if err != nil {
+		return "", fmt.Errorf("deliverfile path %q must stay inside %s: %w", value, root.Path(), err)
+	}
+	return resolved, nil
 }
 
 func validateResolvedDir(path string, source pathSource, label string, skipped []SkippedItem) (string, []SkippedItem, error) {
@@ -151,13 +183,6 @@ func discoverDeliverfilePath(workDir, fastlaneDir string) (string, error) {
 		}
 	}
 	return "", nil
-}
-
-func resolveRelativePath(base, value string) string {
-	if filepath.IsAbs(value) {
-		return value
-	}
-	return filepath.Join(base, value)
 }
 
 func ensureDirExists(path string) error {

--- a/internal/cli/migrate/path_resolution.go
+++ b/internal/cli/migrate/path_resolution.go
@@ -103,7 +103,11 @@ func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deli
 		return explicitPath, pathSourceFlag, nil
 	}
 	if strings.TrimSpace(fastlaneDir) != "" {
-		return filepath.Join(fastlaneDir, defaultDir), pathSourceFlag, nil
+		resolved, err := containFastlaneChild(fastlaneDir, defaultDir)
+		if err != nil {
+			return "", pathSourceFlag, err
+		}
+		return resolved, pathSourceFlag, nil
 	}
 	if strings.TrimSpace(deliverfilePathValue) != "" {
 		base := workDir
@@ -121,6 +125,21 @@ func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deli
 		base = filepath.Dir(deliverfilePath)
 	}
 	return filepath.Join(base, defaultDir), pathSourceDefault, nil
+}
+
+// containFastlaneChild resolves a conventional child directory beneath the
+// operator-selected fastlane root and refuses a symlinked child, because the
+// fastlane checkout's contents are repository-controlled even when the root
+// itself was chosen by the operator.
+func containFastlaneChild(fastlaneDir, child string) (string, error) {
+	root, err := rootfs.New(fastlaneDir)
+	if err != nil {
+		return "", err
+	}
+	if err := root.CheckContained(child); err != nil {
+		return "", err
+	}
+	return filepath.Join(fastlaneDir, child), nil
 }
 
 // containDeliverfilePath resolves a repository-controlled Deliverfile path

--- a/internal/cli/migrate/review_information.go
+++ b/internal/cli/migrate/review_information.go
@@ -24,11 +24,11 @@ type ReviewInformation struct {
 const reviewInformationDir = "review_information"
 
 func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, error) {
-	root, prefix, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateContentRoot(metadataDir)
 	if err != nil {
 		return nil, err
 	}
-	if err := checkMetadataRootContained(root, prefix); err != nil {
+	if err := checkContentRootContained(root, prefix); err != nil {
 		return nil, err
 	}
 	if exists, err := dirExists(filepath.Join(metadataDir, reviewInformationDir)); err != nil {

--- a/internal/cli/migrate/review_information.go
+++ b/internal/cli/migrate/review_information.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 type ReviewInformation struct {
@@ -20,9 +21,14 @@ type ReviewInformation struct {
 	Notes               *string `json:"notes,omitempty"`
 }
 
+const reviewInformationDir = "review_information"
+
 func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, error) {
-	reviewDir := filepath.Join(metadataDir, "review_information")
-	if exists, err := dirExists(reviewDir); err != nil {
+	root, err := newMigrateMetadataRoot(metadataDir)
+	if err != nil {
+		return nil, err
+	}
+	if exists, err := dirExists(filepath.Join(metadataDir, reviewInformationDir)); err != nil {
 		return nil, err
 	} else if !exists {
 		return nil, nil
@@ -30,50 +36,32 @@ func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, erro
 
 	info := &ReviewInformation{}
 	assigned := 0
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "first_name.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.ContactFirstName = &value
-		assigned++
+	fields := []struct {
+		file  string
+		field **string
+	}{
+		{"first_name.txt", &info.ContactFirstName},
+		{"last_name.txt", &info.ContactLastName},
+		{"phone_number.txt", &info.ContactPhone},
+		{"email_address.txt", &info.ContactEmail},
+		{"demo_user.txt", &info.DemoAccountName},
+		{"demo_password.txt", &info.DemoAccountPassword},
+		{"notes.txt", &info.Notes},
 	}
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "last_name.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.ContactLastName = &value
-		assigned++
-	}
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "phone_number.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.ContactPhone = &value
-		assigned++
-	}
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "email_address.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.ContactEmail = &value
-		assigned++
-	}
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "demo_user.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.DemoAccountName = &value
-		assigned++
-	}
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "demo_password.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.DemoAccountPassword = &value
-		assigned++
-	}
-	if value, ok, err := readOptionalFile(filepath.Join(reviewDir, "notes.txt")); err != nil {
-		return nil, err
-	} else if ok {
-		info.Notes = &value
+	for _, field := range fields {
+		value, ok, err := readOptionalFile(root, reviewInformationRelativePath(field.file))
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		stored := value
+		*field.field = &stored
 		assigned++
 	}
 
-	required, err := readOptionalReviewRequired(reviewDir)
+	required, err := readOptionalReviewRequired(root)
 	if err != nil {
 		return nil, err
 	}
@@ -151,15 +139,15 @@ func reviewInformationMatches(existing asc.AppStoreReviewDetailAttributes, info 
 	return true
 }
 
-func readOptionalReviewRequired(reviewDir string) (*bool, error) {
-	primary := filepath.Join(reviewDir, "demo_account_required.txt")
-	secondary := filepath.Join(reviewDir, "demo_required.txt")
+func readOptionalReviewRequired(root rootfs.Root) (*bool, error) {
+	primary := reviewInformationRelativePath("demo_account_required.txt")
+	secondary := reviewInformationRelativePath("demo_required.txt")
 
-	primaryValue, primaryExists, err := readOptionalFile(primary)
+	primaryValue, primaryExists, err := readOptionalFile(root, primary)
 	if err != nil {
 		return nil, err
 	}
-	secondaryValue, secondaryExists, err := readOptionalFile(secondary)
+	secondaryValue, secondaryExists, err := readOptionalFile(root, secondary)
 	if err != nil {
 		return nil, err
 	}
@@ -168,11 +156,11 @@ func readOptionalReviewRequired(reviewDir string) (*bool, error) {
 		return nil, nil
 	}
 
-	primaryParsed, primaryErr := parseReviewRequiredValue(primary, primaryValue, primaryExists)
+	primaryParsed, primaryErr := parseReviewRequiredValue(filepath.Join(root.Path(), primary), primaryValue, primaryExists)
 	if primaryErr != nil {
 		return nil, primaryErr
 	}
-	secondaryParsed, secondaryErr := parseReviewRequiredValue(secondary, secondaryValue, secondaryExists)
+	secondaryParsed, secondaryErr := parseReviewRequiredValue(filepath.Join(root.Path(), secondary), secondaryValue, secondaryExists)
 	if secondaryErr != nil {
 		return nil, secondaryErr
 	}
@@ -205,13 +193,17 @@ func parseReviewRequiredValue(path, value string, exists bool) (*bool, error) {
 	}
 }
 
-func readOptionalFile(path string) (string, bool, error) {
-	data, err := os.ReadFile(path)
+func reviewInformationRelativePath(file string) string {
+	return filepath.Join(reviewInformationDir, file)
+}
+
+func readOptionalFile(root rootfs.Root, name string) (string, bool, error) {
+	data, found, err := root.ReadFileOptional(name)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", false, nil
-		}
 		return "", false, err
+	}
+	if !found {
+		return "", false, nil
 	}
 	return strings.TrimSpace(string(data)), true, nil
 }

--- a/internal/cli/migrate/review_information.go
+++ b/internal/cli/migrate/review_information.go
@@ -24,8 +24,11 @@ type ReviewInformation struct {
 const reviewInformationDir = "review_information"
 
 func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, error) {
-	root, err := newMigrateMetadataRoot(metadataDir)
+	root, prefix, err := newMigrateMetadataRoot(metadataDir)
 	if err != nil {
+		return nil, err
+	}
+	if err := checkMetadataRootContained(root, prefix); err != nil {
 		return nil, err
 	}
 	if exists, err := dirExists(filepath.Join(metadataDir, reviewInformationDir)); err != nil {
@@ -49,7 +52,7 @@ func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, erro
 		{"notes.txt", &info.Notes},
 	}
 	for _, field := range fields {
-		value, ok, err := readOptionalFile(root, reviewInformationRelativePath(field.file))
+		value, ok, err := readOptionalFile(root, filepath.Join(prefix, reviewInformationRelativePath(field.file)))
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +64,7 @@ func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, erro
 		assigned++
 	}
 
-	required, err := readOptionalReviewRequired(root)
+	required, err := readOptionalReviewRequired(root, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -139,9 +142,9 @@ func reviewInformationMatches(existing asc.AppStoreReviewDetailAttributes, info 
 	return true
 }
 
-func readOptionalReviewRequired(root rootfs.Root) (*bool, error) {
-	primary := reviewInformationRelativePath("demo_account_required.txt")
-	secondary := reviewInformationRelativePath("demo_required.txt")
+func readOptionalReviewRequired(root rootfs.Root, prefix string) (*bool, error) {
+	primary := filepath.Join(prefix, reviewInformationRelativePath("demo_account_required.txt"))
+	secondary := filepath.Join(prefix, reviewInformationRelativePath("demo_required.txt"))
 
 	primaryValue, primaryExists, err := readOptionalFile(root, primary)
 	if err != nil {

--- a/internal/cli/migrate/screenshots.go
+++ b/internal/cli/migrate/screenshots.go
@@ -47,6 +47,16 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 	var skipped []SkippedItem
 
 	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			// A symlinked locale directory would read screenshots from outside
+			// the screenshots root, so report it instead of silently ignoring
+			// it, matching the metadata scan.
+			skipped = append(skipped, SkippedItem{
+				Path:   filepath.Join(screenshotsDir, entry.Name()),
+				Reason: fmt.Sprintf("skipped symlinked screenshots entry %q", entry.Name()),
+			})
+			continue
+		}
 		if !entry.IsDir() {
 			continue
 		}

--- a/internal/cli/migrate/screenshots.go
+++ b/internal/cli/migrate/screenshots.go
@@ -24,6 +24,16 @@ type ScreenshotUploadResult struct {
 }
 
 func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedItem, error) {
+	// A screenshots directory inside the working directory ships with the
+	// checkout, so refuse symlinked components before traversing it; an
+	// operator-selected external directory remains its own trusted root.
+	root, prefix, err := newMigrateContentRoot(screenshotsDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := checkContentRootContained(root, prefix); err != nil {
+		return nil, nil, err
+	}
 	entries, err := os.ReadDir(screenshotsDir)
 	if err != nil {
 		return nil, nil, err

--- a/internal/cli/release/checkpoint_containment_test.go
+++ b/internal/cli/release/checkpoint_containment_test.go
@@ -1,0 +1,188 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveCheckpointDoesNotWriteThroughPredictableTemporarySymlink(t *testing.T) {
+	dir := t.TempDir()
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	writeContainmentFile(t, sentinelPath, "original")
+
+	checkpointPath := filepath.Join(dir, "release-checkpoint.json")
+	if err := os.Symlink(sentinelPath, checkpointPath+".tmp"); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	checkpoint := runCheckpoint{AppID: "123", Version: "1.0.0", Completed: map[string]bool{stepEnsureVersion: true}}
+	if err := saveCheckpoint(checkpointPath, checkpoint); err != nil {
+		t.Fatalf("saveCheckpoint() error = %v", err)
+	}
+
+	if got := readContainmentFile(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+	loaded, err := loadCheckpoint(checkpointPath)
+	if err != nil {
+		t.Fatalf("loadCheckpoint() error = %v", err)
+	}
+	if loaded == nil || loaded.AppID != "123" {
+		t.Fatalf("loadCheckpoint() = %#v, want persisted checkpoint", loaded)
+	}
+}
+
+func TestSaveCheckpointRefusesSymlinkedDestination(t *testing.T) {
+	dir := t.TempDir()
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	writeContainmentFile(t, sentinelPath, "original")
+
+	checkpointPath := filepath.Join(dir, "release-checkpoint.json")
+	if err := os.Symlink(sentinelPath, checkpointPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := saveCheckpoint(checkpointPath, runCheckpoint{AppID: "123", Completed: map[string]bool{}})
+	if err == nil {
+		t.Fatal("saveCheckpoint() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("saveCheckpoint() error = %v, want symlink rejection", err)
+	}
+	if got := readContainmentFile(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+}
+
+func TestSaveCheckpointRefusesSymlinkedRepositoryDirectoryComponent(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	externalDir := t.TempDir()
+	checkpointDir := defaultCheckpointPath("123", "1.0.0", "456", "IOS")
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(checkpointDir)), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(externalDir, filepath.Dir(checkpointDir)); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := saveCheckpoint(checkpointDir, runCheckpoint{AppID: "123", Completed: map[string]bool{}})
+	if err == nil {
+		t.Fatal("saveCheckpoint() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("saveCheckpoint() error = %v, want symlink rejection", err)
+	}
+	entries, readErr := os.ReadDir(externalDir)
+	if readErr != nil {
+		t.Fatalf("ReadDir() error = %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("checkpoint escaped into the symlink target: %v", entries)
+	}
+}
+
+func TestSaveCheckpointAllowsOperatorSelectedExternalCheckpointRoot(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	// An explicitly selected checkpoint directory outside the working directory
+	// is the operator's trusted root, even when reached through a symlink.
+	realDir := t.TempDir()
+	linkedDir := filepath.Join(t.TempDir(), "linked")
+	if err := os.Symlink(realDir, linkedDir); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	checkpointPath := filepath.Join(linkedDir, "release-checkpoint.json")
+	if err := saveCheckpoint(checkpointPath, runCheckpoint{AppID: "123", Completed: map[string]bool{}}); err != nil {
+		t.Fatalf("saveCheckpoint() error = %v", err)
+	}
+	if got := readContainmentFile(t, filepath.Join(realDir, "release-checkpoint.json")); !strings.Contains(got, `"appId": "123"`) {
+		t.Fatalf("checkpoint content = %q", got)
+	}
+}
+
+func TestLoadCheckpointRefusesSymlinkedCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	externalPath := filepath.Join(t.TempDir(), "external.json")
+	writeContainmentFile(t, externalPath, `{"appId":"external"}`)
+
+	checkpointPath := filepath.Join(dir, "release-checkpoint.json")
+	if err := os.Symlink(externalPath, checkpointPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	loaded, err := loadCheckpoint(checkpointPath)
+	if err == nil {
+		t.Fatalf("loadCheckpoint() error = nil, want symlink rejection (got %#v)", loaded)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("loadCheckpoint() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestSaveAndLoadCheckpointRoundTripsOrdinaryFile(t *testing.T) {
+	checkpointPath := filepath.Join(t.TempDir(), "nested", "release-checkpoint.json")
+	checkpoint := runCheckpoint{
+		AppID:     "123",
+		Version:   "1.2.3",
+		BuildID:   "456",
+		Platform:  "IOS",
+		Completed: map[string]bool{stepEnsureVersion: true},
+	}
+
+	if err := saveCheckpoint(checkpointPath, checkpoint); err != nil {
+		t.Fatalf("saveCheckpoint() error = %v", err)
+	}
+	if err := saveCheckpoint(checkpointPath, checkpoint); err != nil {
+		t.Fatalf("saveCheckpoint() overwrite error = %v", err)
+	}
+
+	loaded, err := loadCheckpoint(checkpointPath)
+	if err != nil {
+		t.Fatalf("loadCheckpoint() error = %v", err)
+	}
+	if loaded == nil || loaded.BuildID != "456" || !loaded.Completed[stepEnsureVersion] {
+		t.Fatalf("loadCheckpoint() = %#v, want round-tripped checkpoint", loaded)
+	}
+
+	info, err := os.Lstat(checkpointPath)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("checkpoint mode = %v, want 0600", info.Mode().Perm())
+	}
+	entries, err := os.ReadDir(filepath.Dir(checkpointPath))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "release-checkpoint.json" {
+			t.Fatalf("unexpected leftover file %q in checkpoint directory", entry.Name())
+		}
+	}
+}
+
+func writeContainmentFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func readContainmentFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	submitcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/submit"
 	validatecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/validate"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
@@ -705,8 +706,47 @@ func sanitizeCheckpointToken(value string) string {
 	return result
 }
 
+// checkpointRoot anchors checkpoint reads and writes to a trusted root so the
+// checkpoint file and its staging file cannot redirect through symlinks.
+//
+// Checkpoints under the working directory (including the default
+// .asc/release/checkpoints path) are anchored to the working directory so every
+// repository-controlled directory component is validated. A checkpoint the
+// operator placed outside the working directory is anchored to its own parent,
+// which keeps explicitly selected external locations working.
+func checkpointRoot(path string) (rootfs.Root, string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return rootfs.Root{}, "", fmt.Errorf("checkpoint path is empty")
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		if root, rootErr := rootfs.New(cwd); rootErr == nil {
+			if relative, relErr := filepath.Rel(root.Path(), absolute); relErr == nil {
+				if relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+					return root, relative, nil
+				}
+			}
+		}
+	}
+
+	root, err := rootfs.New(filepath.Dir(absolute))
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	return root, filepath.Base(absolute), nil
+}
+
 func loadCheckpoint(path string) (*runCheckpoint, error) {
-	data, err := os.ReadFile(path)
+	root, name, err := checkpointRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("read checkpoint: %w", err)
+	}
+	data, err := root.ReadFile(name)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
@@ -729,15 +769,12 @@ func saveCheckpoint(path string, checkpoint runCheckpoint) error {
 	if err != nil {
 		return fmt.Errorf("marshal checkpoint: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create checkpoint directory: %w", err)
-	}
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+	root, name, err := checkpointRoot(path)
+	if err != nil {
 		return fmt.Errorf("write checkpoint: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("persist checkpoint: %w", err)
+	if err := root.WriteFile(name, data, 0o600); err != nil {
+		return fmt.Errorf("write checkpoint: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/shared/atomic_write.go
+++ b/internal/cli/shared/atomic_write.go
@@ -1,44 +1,17 @@
 package shared
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 func createTempFileNoFollowWithPerm(dir string, pattern string, perm os.FileMode) (*os.File, error) {
-	// Mirror os.CreateTemp pattern semantics: replace the last "*" with random text,
-	// or append random text if no "*" is present.
-	prefix := pattern
-	suffix := ""
-	if idx := strings.LastIndex(pattern, "*"); idx != -1 {
-		prefix = pattern[:idx]
-		suffix = pattern[idx+1:]
-	}
-
-	const maxAttempts = 10_000
-	var randBytes [12]byte
-	for i := 0; i < maxAttempts; i++ {
-		if _, err := rand.Read(randBytes[:]); err != nil {
-			return nil, err
-		}
-		name := prefix + hex.EncodeToString(randBytes[:]) + suffix
-		f, err := OpenNewFileNoFollow(filepath.Join(dir, name), perm)
-		if err == nil {
-			return f, nil
-		}
-		if errors.Is(err, os.ErrExist) {
-			continue
-		}
-		return nil, err
-	}
-
-	return nil, fmt.Errorf("failed to create temporary file in %q", dir)
+	return secureopen.CreateTempNoFollow(dir, pattern, perm)
 }
 
 func writeFileNoSymlinkOverwrite(path string, perm os.FileMode, tempPattern string, backupPattern string, write func(*os.File) (int64, error)) (int64, error) {

--- a/internal/cli/snitch/snitch.go
+++ b/internal/cli/snitch/snitch.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 const (
@@ -547,8 +548,36 @@ func validateRequestedLabels(ctx context.Context, token string, requested []stri
 	return validated, nil
 }
 
+// localLogRoot anchors snitch log access to the working directory so the
+// repository-controlled .asc directory and log file cannot redirect the log, and
+// falls back to the log's own parent for a log the operator placed elsewhere.
+func localLogRoot(path string) (rootfs.Root, string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		if root, rootErr := rootfs.New(cwd); rootErr == nil {
+			if relative, relErr := filepath.Rel(root.Path(), absolute); relErr == nil {
+				if relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+					return root, relative, nil
+				}
+			}
+		}
+	}
+	root, err := rootfs.New(filepath.Dir(absolute))
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	return root, filepath.Base(absolute), nil
+}
+
 func readLocalLog(path string) ([]LogEntry, error) {
-	data, err := os.ReadFile(path)
+	root, name, err := localLogRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := root.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
@@ -740,29 +769,25 @@ func readGitHubAPIError(resp *http.Response) error {
 
 func writeLocalLog(entry LogEntry) error {
 	dir := ".asc"
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	path := filepath.Join(dir, "snitch.log")
+
+	root, name, err := localLogRoot(path)
+	if err != nil {
+		return fmt.Errorf("snitch: %w", err)
+	}
+	if err := root.MkdirAll(filepath.Dir(name), 0o755); err != nil {
 		return fmt.Errorf("snitch: failed to create %s: %w", dir, err)
 	}
-
-	path := filepath.Join(dir, "snitch.log")
 
 	data, err := json.Marshal(entry)
 	if err != nil {
 		return fmt.Errorf("snitch: failed to marshal entry: %w", err)
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("snitch: failed to open %s: %w", path, err)
-	}
-	defer f.Close()
-
-	if err := f.Chmod(0o600); err != nil {
-		return fmt.Errorf("snitch: failed to set secure permissions on %s: %w", path, err)
-	}
-
-	if _, err := f.Write(append(data, '\n')); err != nil {
-		return fmt.Errorf("snitch: failed to write entry: %w", err)
+	// AppendFile refuses a symlinked log and only tightens permissions on the
+	// descriptor it opened, so it can never chmod an external file.
+	if err := root.AppendFile(name, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("snitch: failed to append to %s: %w", path, err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Friction logged to %s\n", path)

--- a/internal/cli/snitch/snitch_containment_test.go
+++ b/internal/cli/snitch/snitch_containment_test.go
@@ -1,0 +1,120 @@
+package snitch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteLocalLogRefusesSymlinkedLogAndLeavesModeIntact(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("original"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, ".asc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(sentinelPath, filepath.Join(workDir, ".asc", "snitch.log")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := writeLocalLog(LogEntry{Description: "friction", Severity: "bug", Timestamp: time.Now().UTC()})
+	if err == nil {
+		t.Fatal("writeLocalLog() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writeLocalLog() error = %v, want symlink rejection", err)
+	}
+
+	data, readErr := os.ReadFile(sentinelPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(data) != "original" {
+		t.Fatalf("sentinel content = %q, want %q", data, "original")
+	}
+	info, statErr := os.Lstat(sentinelPath)
+	if statErr != nil {
+		t.Fatalf("Lstat() error = %v", statErr)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("sentinel mode = %v, want 0644 (writeLocalLog must not chmod its target)", info.Mode().Perm())
+	}
+}
+
+func TestWriteLocalLogRefusesSymlinkedASCDirectory(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	external := t.TempDir()
+	if err := os.Symlink(external, filepath.Join(workDir, ".asc")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := writeLocalLog(LogEntry{Description: "friction", Severity: "bug", Timestamp: time.Now().UTC()})
+	if err == nil {
+		t.Fatal("writeLocalLog() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writeLocalLog() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(external, "snitch.log")); statErr == nil {
+		t.Fatal("log escaped through a symlinked .asc directory")
+	}
+}
+
+func TestWriteLocalLogAppendsEntriesWithSecureMode(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	first := LogEntry{Description: "first", Severity: "bug", Timestamp: time.Now().UTC()}
+	second := LogEntry{Description: "second", Severity: "friction", Timestamp: time.Now().UTC()}
+	if err := writeLocalLog(first); err != nil {
+		t.Fatalf("writeLocalLog() error = %v", err)
+	}
+	if err := writeLocalLog(second); err != nil {
+		t.Fatalf("writeLocalLog() error = %v", err)
+	}
+
+	logPath := filepath.Join(workDir, ".asc", "snitch.log")
+	info, err := os.Lstat(logPath)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("log mode = %v, want 0600", info.Mode().Perm())
+	}
+
+	entries, err := readLocalLog(logPath)
+	if err != nil {
+		t.Fatalf("readLocalLog() error = %v", err)
+	}
+	if len(entries) != 2 || entries[0].Description != "first" || entries[1].Description != "second" {
+		t.Fatalf("readLocalLog() = %#v, want two appended entries", entries)
+	}
+}
+
+func TestReadLocalLogRefusesSymlinkedLog(t *testing.T) {
+	dir := t.TempDir()
+	externalPath := filepath.Join(t.TempDir(), "external.log")
+	if err := os.WriteFile(externalPath, []byte(`{"description":"external"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	logPath := filepath.Join(dir, "snitch.log")
+	if err := os.Symlink(externalPath, logPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	entries, err := readLocalLog(logPath)
+	if err == nil {
+		t.Fatalf("readLocalLog() error = nil, want symlink rejection (got %#v)", entries)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("readLocalLog() error = %v, want symlink rejection", err)
+	}
+}

--- a/internal/cli/web/web_containment_test.go
+++ b/internal/cli/web/web_containment_test.go
@@ -7,6 +7,37 @@ import (
 	"testing"
 )
 
+func TestDownloadRootRefusesSymlinkedRepositoryASCDirectory(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	externalDir := t.TempDir()
+	if err := os.Symlink(externalDir, filepath.Join(workDir, ".asc")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	// The default --out location is repository-controlled, so a symlinked .asc
+	// component must be refused before any directory or file is created.
+	outDir := resolveShowOutDir("app", "submission", "")
+	root, prefix, err := newDownloadRoot(outDir)
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error = %v", err)
+	}
+	if mkdirErr := root.MkdirAll(prefix, 0o755); mkdirErr == nil {
+		t.Fatal("MkdirAll() error = nil, want symlink rejection")
+	} else if !strings.Contains(mkdirErr.Error(), "symlink") {
+		t.Fatalf("MkdirAll() error = %v, want symlink rejection", mkdirErr)
+	}
+
+	entries, readErr := os.ReadDir(externalDir)
+	if readErr != nil {
+		t.Fatalf("ReadDir() error = %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("download directory escaped into the symlink target: %v", entries)
+	}
+}
+
 func TestWriteAttachmentRefusesSymlinkedDestination(t *testing.T) {
 	outDir := t.TempDir()
 	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
@@ -16,11 +47,11 @@ func TestWriteAttachmentRefusesSymlinkedDestination(t *testing.T) {
 		t.Fatalf("Symlink() error = %v", err)
 	}
 
-	root, err := newDownloadRoot(outDir)
+	root, prefix, err := newDownloadRoot(outDir)
 	if err != nil {
 		t.Fatalf("newDownloadRoot() error = %v", err)
 	}
-	_, err = resolveDownloadPath(root, "screenshot.png", true)
+	_, err = resolveDownloadPath(root, prefix, "screenshot.png", true)
 	if err == nil {
 		t.Fatal("resolveDownloadPath() error = nil, want symlink rejection")
 	}
@@ -41,7 +72,7 @@ func TestWriteAttachmentRefusesSymlinkedParentDirectory(t *testing.T) {
 
 	// The output directory itself is operator-selected, so a symlinked --out is
 	// still honoured; a symlinked directory *inside* it is not.
-	root, err := newDownloadRoot(outDir)
+	root, prefix, err := newDownloadRoot(outDir)
 	if err != nil {
 		t.Fatalf("newDownloadRoot() error = %v", err)
 	}
@@ -50,7 +81,7 @@ func TestWriteAttachmentRefusesSymlinkedParentDirectory(t *testing.T) {
 		t.Fatalf("Symlink() error = %v", err)
 	}
 
-	if err := writeDownloadedAttachment(root, filepath.Join("nested", "screenshot.png"), []byte("payload")); err == nil {
+	if err := writeDownloadedAttachment(root, filepath.Join(prefix, "nested", "screenshot.png"), []byte("payload")); err == nil {
 		t.Fatal("writeDownloadedAttachment() error = nil, want symlink rejection")
 	} else if !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("writeDownloadedAttachment() error = %v, want symlink rejection", err)
@@ -62,24 +93,24 @@ func TestWriteAttachmentRefusesSymlinkedParentDirectory(t *testing.T) {
 
 func TestResolveDownloadPathRejectsTraversingFileName(t *testing.T) {
 	outDir := t.TempDir()
-	root, err := newDownloadRoot(outDir)
+	root, prefix, err := newDownloadRoot(outDir)
 	if err != nil {
 		t.Fatalf("newDownloadRoot() error = %v", err)
 	}
 
-	if _, err := resolveDownloadPath(root, filepath.Join("..", "outside.txt"), true); err == nil {
+	if _, err := resolveDownloadPath(root, prefix, filepath.Join("..", "outside.txt"), true); err == nil {
 		t.Fatal("resolveDownloadPath() error = nil, want traversal rejection")
 	}
 }
 
 func TestWriteDownloadedAttachmentWritesOrdinaryFile(t *testing.T) {
 	outDir := filepath.Join(t.TempDir(), "downloads")
-	root, err := newDownloadRoot(outDir)
+	root, prefix, err := newDownloadRoot(outDir)
 	if err != nil {
 		t.Fatalf("newDownloadRoot() error = %v", err)
 	}
 
-	name, err := resolveDownloadPath(root, "screenshot.png", false)
+	name, err := resolveDownloadPath(root, prefix, "screenshot.png", false)
 	if err != nil {
 		t.Fatalf("resolveDownloadPath() error = %v", err)
 	}
@@ -91,7 +122,7 @@ func TestWriteDownloadedAttachmentWritesOrdinaryFile(t *testing.T) {
 	}
 
 	// Without --overwrite a second download must get a unique neighbouring name.
-	second, err := resolveDownloadPath(root, "screenshot.png", false)
+	second, err := resolveDownloadPath(root, prefix, "screenshot.png", false)
 	if err != nil {
 		t.Fatalf("resolveDownloadPath() error = %v", err)
 	}

--- a/internal/cli/web/web_containment_test.go
+++ b/internal/cli/web/web_containment_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -134,6 +135,28 @@ func TestWriteDownloadedAttachmentWritesOrdinaryFile(t *testing.T) {
 	}
 	if got := readWebContainmentFile(t, filepath.Join(outDir, second)); got != "payload-2" {
 		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestWritePrivacyDeclarationFilePreservesExistingMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not reported faithfully on Windows")
+	}
+	outPath := filepath.Join(t.TempDir(), "privacy.json")
+	if err := os.WriteFile(outPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := writePrivacyDeclarationFile(outPath, privacyDeclarationFile{}); err != nil {
+		t.Fatalf("writePrivacyDeclarationFile() error = %v", err)
+	}
+
+	info, err := os.Lstat(outPath)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("mode = %v, want preserved 0644", info.Mode().Perm())
 	}
 }
 

--- a/internal/cli/web/web_containment_test.go
+++ b/internal/cli/web/web_containment_test.go
@@ -194,6 +194,22 @@ func TestParsePrivacyDeclarationFileRefusesSymlinkedInput(t *testing.T) {
 	}
 }
 
+func TestDownloadDisplayPathPreservesOperatorPath(t *testing.T) {
+	// A relative default output directory keeps its relative display form.
+	relOut := filepath.Join(".asc", "web-review", "app", "sub")
+	got := downloadDisplayPath(relOut, relOut, filepath.Join(relOut, "shot.png"))
+	if want := filepath.Join(relOut, "shot.png"); got != want {
+		t.Fatalf("downloadDisplayPath() = %q, want %q", got, want)
+	}
+
+	// An operator-selected external directory keeps its absolute display form.
+	absOut := filepath.Join(string(filepath.Separator), "tmp", "downloads")
+	got = downloadDisplayPath(absOut, ".", "shot-1.png")
+	if want := filepath.Join(absOut, "shot-1.png"); got != want {
+		t.Fatalf("downloadDisplayPath() = %q, want %q", got, want)
+	}
+}
+
 func writeWebContainmentFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/web/web_containment_test.go
+++ b/internal/cli/web/web_containment_test.go
@@ -1,0 +1,183 @@
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteAttachmentRefusesSymlinkedDestination(t *testing.T) {
+	outDir := t.TempDir()
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	writeWebContainmentFile(t, sentinelPath, "original")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(outDir, "screenshot.png")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root, err := newDownloadRoot(outDir)
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error = %v", err)
+	}
+	_, err = resolveDownloadPath(root, "screenshot.png", true)
+	if err == nil {
+		t.Fatal("resolveDownloadPath() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("resolveDownloadPath() error = %v, want symlink rejection", err)
+	}
+	if got := readWebContainmentFile(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+}
+
+func TestWriteAttachmentRefusesSymlinkedParentDirectory(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "downloads")
+	external := t.TempDir()
+	if err := os.Symlink(external, outDir); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	// The output directory itself is operator-selected, so a symlinked --out is
+	// still honoured; a symlinked directory *inside* it is not.
+	root, err := newDownloadRoot(outDir)
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error = %v", err)
+	}
+	nestedExternal := t.TempDir()
+	if err := os.Symlink(nestedExternal, filepath.Join(external, "nested")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if err := writeDownloadedAttachment(root, filepath.Join("nested", "screenshot.png"), []byte("payload")); err == nil {
+		t.Fatal("writeDownloadedAttachment() error = nil, want symlink rejection")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writeDownloadedAttachment() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(nestedExternal, "screenshot.png")); statErr == nil {
+		t.Fatal("attachment escaped through a symlinked parent directory")
+	}
+}
+
+func TestResolveDownloadPathRejectsTraversingFileName(t *testing.T) {
+	outDir := t.TempDir()
+	root, err := newDownloadRoot(outDir)
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error = %v", err)
+	}
+
+	if _, err := resolveDownloadPath(root, filepath.Join("..", "outside.txt"), true); err == nil {
+		t.Fatal("resolveDownloadPath() error = nil, want traversal rejection")
+	}
+}
+
+func TestWriteDownloadedAttachmentWritesOrdinaryFile(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "downloads")
+	root, err := newDownloadRoot(outDir)
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error = %v", err)
+	}
+
+	name, err := resolveDownloadPath(root, "screenshot.png", false)
+	if err != nil {
+		t.Fatalf("resolveDownloadPath() error = %v", err)
+	}
+	if err := writeDownloadedAttachment(root, name, []byte("payload")); err != nil {
+		t.Fatalf("writeDownloadedAttachment() error = %v", err)
+	}
+	if got := readWebContainmentFile(t, filepath.Join(outDir, "screenshot.png")); got != "payload" {
+		t.Fatalf("content = %q", got)
+	}
+
+	// Without --overwrite a second download must get a unique neighbouring name.
+	second, err := resolveDownloadPath(root, "screenshot.png", false)
+	if err != nil {
+		t.Fatalf("resolveDownloadPath() error = %v", err)
+	}
+	if second == "screenshot.png" {
+		t.Fatal("resolveDownloadPath() reused the existing name without --overwrite")
+	}
+	if err := writeDownloadedAttachment(root, second, []byte("payload-2")); err != nil {
+		t.Fatalf("writeDownloadedAttachment() error = %v", err)
+	}
+	if got := readWebContainmentFile(t, filepath.Join(outDir, second)); got != "payload-2" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestWritePrivacyDeclarationFileRefusesSymlinkedOutput(t *testing.T) {
+	outDir := t.TempDir()
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.json")
+	writeWebContainmentFile(t, sentinelPath, "{}")
+
+	outPath := filepath.Join(outDir, "privacy.json")
+	if err := os.Symlink(sentinelPath, outPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := writePrivacyDeclarationFile(outPath, privacyDeclarationFile{})
+	if err == nil {
+		t.Fatal("writePrivacyDeclarationFile() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("writePrivacyDeclarationFile() error = %v, want symlink rejection", err)
+	}
+	if got := readWebContainmentFile(t, sentinelPath); got != "{}" {
+		t.Fatalf("sentinel content = %q, want %q", got, "{}")
+	}
+}
+
+func TestWritePrivacyDeclarationFileWritesOrdinaryOutput(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "nested", "privacy.json")
+
+	if err := writePrivacyDeclarationFile(outPath, privacyDeclarationFile{}); err != nil {
+		t.Fatalf("writePrivacyDeclarationFile() error = %v", err)
+	}
+	info, err := os.Lstat(outPath)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %v, want 0600", info.Mode().Perm())
+	}
+	if got := readWebContainmentFile(t, outPath); !strings.HasSuffix(got, "\n") {
+		t.Fatalf("content = %q, want trailing newline", got)
+	}
+}
+
+func TestParsePrivacyDeclarationFileRefusesSymlinkedInput(t *testing.T) {
+	dir := t.TempDir()
+	externalPath := filepath.Join(t.TempDir(), "external.json")
+	writeWebContainmentFile(t, externalPath, `{"usages":[]}`)
+
+	linkPath := filepath.Join(dir, "privacy.json")
+	if err := os.Symlink(externalPath, linkPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if _, err := parsePrivacyDeclarationFile(linkPath); err == nil {
+		t.Fatal("parsePrivacyDeclarationFile() error = nil, want symlink rejection")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("parsePrivacyDeclarationFile() error = %v, want symlink rejection", err)
+	}
+}
+
+func writeWebContainmentFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func readWebContainmentFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -789,7 +789,9 @@ func writePrivacyDeclarationFile(path string, declaration privacyDeclarationFile
 		return fmt.Errorf("failed to marshal privacy declaration: %w", err)
 	}
 	jsonData = append(jsonData, '\n')
-	if err := root.WriteFile(name, jsonData, 0o600); err != nil {
+	// An existing declaration keeps its permissions, matching the previous
+	// in-place write; new files default to 0600.
+	if err := root.WriteFilePreservingMode(name, jsonData, 0o600); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 	return nil

--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
@@ -728,7 +728,11 @@ func parsePrivacyDeclarationFile(path string) (privacyDeclarationFile, error) {
 	if path == "" {
 		return privacyDeclarationFile{}, fmt.Errorf("file path is required")
 	}
-	data, err := os.ReadFile(path)
+	root, name, err := privacyDeclarationRoot(path)
+	if err != nil {
+		return privacyDeclarationFile{}, err
+	}
+	data, err := root.ReadFile(name)
 	if err != nil {
 		return privacyDeclarationFile{}, fmt.Errorf("failed to read %s: %w", path, err)
 	}
@@ -753,20 +757,39 @@ func parsePrivacyDeclarationFile(path string) (privacyDeclarationFile, error) {
 	return declarationFromTupleSet(tuples), nil
 }
 
+// privacyDeclarationRoot anchors privacy declaration reads and writes to the
+// parent directory of the operator-selected path, so the final component and any
+// component created below it cannot resolve through a symlink.
+func privacyDeclarationRoot(path string) (rootfs.Root, string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return rootfs.Root{}, "", fmt.Errorf("file path is required")
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	root, err := rootfs.New(filepath.Dir(absolute))
+	if err != nil {
+		return rootfs.Root{}, "", err
+	}
+	return root, filepath.Base(absolute), nil
+}
+
 func writePrivacyDeclarationFile(path string, declaration privacyDeclarationFile) error {
-	path = strings.TrimSpace(path)
-	if path == "" {
+	if strings.TrimSpace(path) == "" {
 		return fmt.Errorf("output path is required")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("failed to create output directory: %w", err)
+	root, name, err := privacyDeclarationRoot(path)
+	if err != nil {
+		return err
 	}
 	jsonData, err := json.MarshalIndent(declaration, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal privacy declaration: %w", err)
 	}
 	jsonData = append(jsonData, '\n')
-	if err := os.WriteFile(path, jsonData, 0o600); err != nil {
+	if err := root.WriteFile(name, jsonData, 0o600); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 	return nil

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -564,6 +564,17 @@ func writeDownloadedAttachment(root rootfs.Root, name string, body []byte) error
 	return root.WriteFile(name, body, 0o600)
 }
 
+// downloadDisplayPath reports the download location the way the operator wrote
+// it: the selected (possibly relative) output directory joined with the file
+// name resolved beneath the root-relative prefix.
+func downloadDisplayPath(outDir, prefix, outputName string) string {
+	relative, err := filepath.Rel(prefix, outputName)
+	if err != nil {
+		return filepath.Join(outDir, filepath.Base(outputName))
+	}
+	return filepath.Join(outDir, relative)
+}
+
 func attachmentRefreshKey(attachment webcore.ReviewAttachment) string {
 	return strings.Join([]string{
 		strings.TrimSpace(attachment.SourceType),
@@ -708,7 +719,7 @@ func downloadAttachmentsForShow(
 			failures = append(failures, fmt.Sprintf("%s: %v", attachment.FileName, err))
 			continue
 		}
-		results = append(results, attachmentDownloadResult(attachment, filepath.Join(root.Path(), outputName), refreshed))
+		results = append(results, attachmentDownloadResult(attachment, downloadDisplayPath(outDir, prefix, outputName), refreshed))
 	}
 	return results, failures, nil
 }

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -487,26 +487,54 @@ func normalizeAttachmentFilename(attachment webcore.ReviewAttachment) string {
 	return id + ".bin"
 }
 
-// newDownloadRoot anchors attachment downloads to the operator-selected output
-// directory, which may legitimately live outside the current repository.
-func newDownloadRoot(outDir string) (rootfs.Root, error) {
-	root, err := rootfs.New(outDir)
-	if err != nil {
-		return rootfs.Root{}, fmt.Errorf("failed to resolve output directory %q: %w", outDir, err)
+// newDownloadRoot anchors attachment downloads for outDir. A directory inside
+// the working directory (including the default .asc/web-review location, whose
+// components are repository-controlled) is anchored at the working directory so
+// every component below it is validated; an operator-selected directory outside
+// the working directory is its own trusted root. The returned prefix is the
+// root-relative output directory.
+func newDownloadRoot(outDir string) (rootfs.Root, string, error) {
+	trimmed := strings.TrimSpace(outDir)
+	if trimmed == "" {
+		return rootfs.Root{}, "", fmt.Errorf("output directory is required")
 	}
-	return root, nil
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return rootfs.Root{}, "", fmt.Errorf("failed to resolve output directory %q: %w", outDir, err)
+	}
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		if root, rootErr := rootfs.New(cwd); rootErr == nil {
+			if relative, relErr := filepath.Rel(root.Path(), absolute); relErr == nil {
+				if relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+					return root, relative, nil
+				}
+			}
+		}
+	}
+	root, err := rootfs.New(absolute)
+	if err != nil {
+		return rootfs.Root{}, "", fmt.Errorf("failed to resolve output directory %q: %w", outDir, err)
+	}
+	return root, ".", nil
 }
 
-// resolveDownloadPath returns the root-relative destination name for fileName.
-// Names that traverse outside the root, or that resolve through a symlinked
-// parent or destination, are rejected before anything is written.
-func resolveDownloadPath(root rootfs.Root, fileName string, overwrite bool) (string, error) {
-	if err := root.CheckContained(fileName); err != nil {
+// resolveDownloadPath returns the root-relative destination name for fileName
+// beneath the prefix directory. File names that traverse outside the root, or
+// that resolve through a symlinked parent or destination, are rejected before
+// anything is written.
+func resolveDownloadPath(root rootfs.Root, prefix, fileName string, overwrite bool) (string, error) {
+	// Validate the attachment-supplied file name on its own so joining it onto
+	// the prefix cannot lexically collapse a ".." segment into a sibling path.
+	if err := rootfs.ValidateRelative(fileName); err != nil {
 		return "", err
 	}
-	base := filepath.Join(root.Path(), fileName)
+	name := filepath.Join(prefix, fileName)
+	if err := root.CheckContained(name); err != nil {
+		return "", err
+	}
+	base := filepath.Join(root.Path(), name)
 	if overwrite {
-		return fileName, nil
+		return name, nil
 	}
 	if _, err := os.Lstat(base); err == nil {
 		ext := filepath.Ext(fileName)
@@ -515,7 +543,7 @@ func resolveDownloadPath(root rootfs.Root, fileName string, overwrite bool) (str
 			stem = "attachment"
 		}
 		for i := 1; i <= 10_000; i++ {
-			candidate := fmt.Sprintf("%s-%d%s", stem, i, ext)
+			candidate := filepath.Join(prefix, fmt.Sprintf("%s-%d%s", stem, i, ext))
 			if err := root.CheckContained(candidate); err != nil {
 				return "", err
 			}
@@ -525,7 +553,7 @@ func resolveDownloadPath(root rootfs.Root, fileName string, overwrite bool) (str
 		}
 		return "", fmt.Errorf("failed to generate unique filename for %q", fileName)
 	} else if errors.Is(err, os.ErrNotExist) {
-		return fileName, nil
+		return name, nil
 	} else {
 		return "", fmt.Errorf("failed to check destination path %q: %w", base, err)
 	}
@@ -632,11 +660,11 @@ func downloadAttachmentsForShow(
 	if len(selected) == 0 {
 		return []reviewAttachmentDownloadResult{}, nil, nil
 	}
-	root, err := newDownloadRoot(outDir)
+	root, prefix, err := newDownloadRoot(outDir)
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := root.MkdirAll(".", 0o755); err != nil {
+	if err := root.MkdirAll(prefix, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("failed to create output directory %q: %w", outDir, err)
 	}
 
@@ -671,7 +699,7 @@ func downloadAttachmentsForShow(
 			continue
 		}
 
-		outputName, err := resolveDownloadPath(root, attachment.FileName, overwrite)
+		outputName, err := resolveDownloadPath(root, prefix, attachment.FileName, overwrite)
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", attachment.FileName, err))
 			continue

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
@@ -486,54 +487,53 @@ func normalizeAttachmentFilename(attachment webcore.ReviewAttachment) string {
 	return id + ".bin"
 }
 
-func ensurePathWithinDir(root, candidate string) error {
-	absRoot, err := filepath.Abs(root)
+// newDownloadRoot anchors attachment downloads to the operator-selected output
+// directory, which may legitimately live outside the current repository.
+func newDownloadRoot(outDir string) (rootfs.Root, error) {
+	root, err := rootfs.New(outDir)
 	if err != nil {
-		return fmt.Errorf("failed to resolve output directory %q: %w", root, err)
+		return rootfs.Root{}, fmt.Errorf("failed to resolve output directory %q: %w", outDir, err)
 	}
-	absCandidate, err := filepath.Abs(candidate)
-	if err != nil {
-		return fmt.Errorf("failed to resolve destination path %q: %w", candidate, err)
-	}
-	rel, err := filepath.Rel(absRoot, absCandidate)
-	if err != nil {
-		return fmt.Errorf("failed to compare destination path %q: %w", candidate, err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("destination path escapes output directory")
-	}
-	return nil
+	return root, nil
 }
 
-func resolveDownloadPath(outDir, fileName string, overwrite bool) (string, error) {
-	base := filepath.Join(outDir, fileName)
-	if err := ensurePathWithinDir(outDir, base); err != nil {
+// resolveDownloadPath returns the root-relative destination name for fileName.
+// Names that traverse outside the root, or that resolve through a symlinked
+// parent or destination, are rejected before anything is written.
+func resolveDownloadPath(root rootfs.Root, fileName string, overwrite bool) (string, error) {
+	if err := root.CheckContained(fileName); err != nil {
 		return "", err
 	}
+	base := filepath.Join(root.Path(), fileName)
 	if overwrite {
-		return base, nil
+		return fileName, nil
 	}
-	if _, err := os.Stat(base); err == nil {
+	if _, err := os.Lstat(base); err == nil {
 		ext := filepath.Ext(fileName)
 		stem := strings.TrimSuffix(fileName, ext)
 		if stem == "" {
 			stem = "attachment"
 		}
 		for i := 1; i <= 10_000; i++ {
-			candidate := filepath.Join(outDir, fmt.Sprintf("%s-%d%s", stem, i, ext))
-			if err := ensurePathWithinDir(outDir, candidate); err != nil {
+			candidate := fmt.Sprintf("%s-%d%s", stem, i, ext)
+			if err := root.CheckContained(candidate); err != nil {
 				return "", err
 			}
-			if _, err := os.Stat(candidate); errors.Is(err, os.ErrNotExist) {
+			if _, err := os.Lstat(filepath.Join(root.Path(), candidate)); errors.Is(err, os.ErrNotExist) {
 				return candidate, nil
 			}
 		}
 		return "", fmt.Errorf("failed to generate unique filename for %q", fileName)
 	} else if errors.Is(err, os.ErrNotExist) {
-		return base, nil
+		return fileName, nil
 	} else {
 		return "", fmt.Errorf("failed to check destination path %q: %w", base, err)
 	}
+}
+
+// writeDownloadedAttachment writes an attachment body beneath the download root.
+func writeDownloadedAttachment(root rootfs.Root, name string, body []byte) error {
+	return root.WriteFile(name, body, 0o600)
 }
 
 func attachmentRefreshKey(attachment webcore.ReviewAttachment) string {
@@ -632,7 +632,11 @@ func downloadAttachmentsForShow(
 	if len(selected) == 0 {
 		return []reviewAttachmentDownloadResult{}, nil, nil
 	}
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
+	root, err := newDownloadRoot(outDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := root.MkdirAll(".", 0o755); err != nil {
 		return nil, nil, fmt.Errorf("failed to create output directory %q: %w", outDir, err)
 	}
 
@@ -667,16 +671,16 @@ func downloadAttachmentsForShow(
 			continue
 		}
 
-		outputPath, err := resolveDownloadPath(outDir, attachment.FileName, overwrite)
+		outputName, err := resolveDownloadPath(root, attachment.FileName, overwrite)
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", attachment.FileName, err))
 			continue
 		}
-		if err := os.WriteFile(outputPath, body, 0o600); err != nil {
+		if err := writeDownloadedAttachment(root, outputName, body); err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", attachment.FileName, err))
 			continue
 		}
-		results = append(results, attachmentDownloadResult(attachment, outputPath, refreshed))
+		results = append(results, attachmentDownloadResult(attachment, filepath.Join(root.Path(), outputName), refreshed))
 	}
 	return results, failures, nil
 }

--- a/internal/cli/web/web_review_test.go
+++ b/internal/cli/web/web_review_test.go
@@ -48,12 +48,15 @@ func TestNormalizeAttachmentFilenameSanitizesFallbackAttachmentID(t *testing.T) 
 }
 
 func TestResolveDownloadPathRejectsEscapingOutDir(t *testing.T) {
-	outDir := t.TempDir()
-	_, err := resolveDownloadPath(outDir, "../outside.txt", true)
+	root, err := newDownloadRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error: %v", err)
+	}
+	_, err = resolveDownloadPath(root, "../outside.txt", true)
 	if err == nil {
 		t.Fatal("expected path escape error")
 	}
-	if !strings.Contains(err.Error(), "escapes output directory") {
+	if !strings.Contains(err.Error(), "escapes trusted root") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cli/web/web_review_test.go
+++ b/internal/cli/web/web_review_test.go
@@ -48,11 +48,11 @@ func TestNormalizeAttachmentFilenameSanitizesFallbackAttachmentID(t *testing.T) 
 }
 
 func TestResolveDownloadPathRejectsEscapingOutDir(t *testing.T) {
-	root, err := newDownloadRoot(t.TempDir())
+	root, prefix, err := newDownloadRoot(t.TempDir())
 	if err != nil {
 		t.Fatalf("newDownloadRoot() error: %v", err)
 	}
-	_, err = resolveDownloadPath(root, "../outside.txt", true)
+	_, err = resolveDownloadPath(root, prefix, "../outside.txt", true)
 	if err == nil {
 		t.Fatal("expected path escape error")
 	}

--- a/internal/cli/xcode/inject.go
+++ b/internal/cli/xcode/inject.go
@@ -623,19 +623,15 @@ func resolveXcodeInjectPath(root rootfs.Root, baseDir string, path string) (stri
 		return "", newXcodeInjectUsageError("path is required")
 	}
 	if err := rootfs.ValidateRelativeAllowingTraversal(trimmed); err != nil {
-		return "", newXcodeInjectUsageError(
-			"%v; manifest paths must be relative to the manifest directory and stay inside %q",
+		return "", fmt.Errorf(
+			"%w; manifest paths must be relative to the manifest directory and stay inside %s",
 			err,
 			root.Path(),
 		)
 	}
 	resolved, err := root.Resolve(filepath.Clean(filepath.Join(baseDir, trimmed)))
 	if err != nil {
-		return "", newXcodeInjectUsageError(
-			"%v; manifest paths must stay inside %q",
-			err,
-			root.Path(),
-		)
+		return "", fmt.Errorf("%w; manifest paths must stay inside %s", err, root.Path())
 	}
 	return resolved, nil
 }

--- a/internal/cli/xcode/inject.go
+++ b/internal/cli/xcode/inject.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 type xcodeInjectManifest struct {
@@ -81,6 +82,12 @@ The manifest is JSON with top-level "values" and "outputs" fields. Outputs can
 generate plist, json, or text files, and can copy declared assets such as app
 icons into asset catalog paths. Relative output paths and copy sources resolve
 from the manifest directory.
+
+Manifest paths must stay inside the manifest project root: the enclosing
+repository when one is found, the parent directory when the manifest lives in a
+dot-directory such as .asc, or the manifest directory itself. Absolute paths,
+volume or UNC-style paths, traversal that leaves the root, and symlinks that
+resolve outside the root are rejected before anything is written.
 
 String values support ${key} placeholders from manifest values and repeated
 --set key=value overrides.
@@ -186,8 +193,15 @@ func runXcodeInject(opts xcodeInjectOptions) (xcodeInjectResult, error) {
 		return xcodeInjectResult{}, err
 	}
 
-	baseDir := filepath.Dir(opts.ManifestPath)
-	if err := validateXcodeInjectOutputDestinations(baseDir, manifest.Outputs, opts.Overwrite); err != nil {
+	root, err := newXcodeInjectRoot(opts.ManifestPath)
+	if err != nil {
+		return xcodeInjectResult{}, err
+	}
+	baseDir, err := xcodeInjectBaseDir(opts.ManifestPath)
+	if err != nil {
+		return xcodeInjectResult{}, err
+	}
+	if err := validateXcodeInjectOutputDestinations(root, baseDir, manifest.Outputs, opts.Overwrite); err != nil {
 		return xcodeInjectResult{}, err
 	}
 
@@ -199,7 +213,7 @@ func runXcodeInject(opts xcodeInjectOptions) (xcodeInjectResult, error) {
 	plans := make([]xcodeInjectOutputPlan, 0, len(manifest.Outputs))
 
 	for i, output := range manifest.Outputs {
-		plan, err := planXcodeInjectOutput(baseDir, values, output)
+		plan, err := planXcodeInjectOutput(root, baseDir, values, output)
 		if err != nil {
 			return xcodeInjectResult{}, fmt.Errorf("output %d: %w", i+1, err)
 		}
@@ -207,7 +221,7 @@ func runXcodeInject(opts xcodeInjectOptions) (xcodeInjectResult, error) {
 	}
 
 	for i, plan := range plans {
-		fileResult, err := writeXcodeInjectBytes(plan.Path, plan.Type, plan.Source, plan.Payload, opts)
+		fileResult, err := writeXcodeInjectBytes(root, plan, opts)
 		if err != nil {
 			return xcodeInjectResult{}, fmt.Errorf("output %d: %w", i+1, err)
 		}
@@ -217,16 +231,77 @@ func runXcodeInject(opts xcodeInjectOptions) (xcodeInjectResult, error) {
 	return result, nil
 }
 
-func validateXcodeInjectOutputDestinations(baseDir string, outputs []xcodeInjectManifestOutput, overwrite bool) error {
+// newXcodeInjectRoot anchors manifest-declared outputs and copy sources to the
+// manifest's project root: the enclosing repository when one is found, the parent
+// of a dot-directory manifest location such as .asc, or the manifest directory
+// itself. Symlinked directories inside that tree remain supported because they
+// are a common asset-catalog layout, but a symlink that resolves outside the root
+// is refused.
+func newXcodeInjectRoot(manifestPath string) (rootfs.Root, error) {
+	rootDir, err := xcodeInjectRootDir(manifestPath)
+	if err != nil {
+		return rootfs.Root{}, err
+	}
+	root, err := rootfs.New(rootDir)
+	if err != nil {
+		return rootfs.Root{}, err
+	}
+	return root.AllowingInternalSymlinks(), nil
+}
+
+func xcodeInjectRootDir(manifestPath string) (string, error) {
+	absolute, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	manifestDir := filepath.Dir(absolute)
+	if repositoryRoot := xcodeInjectRepositoryRoot(manifestDir); repositoryRoot != "" {
+		return repositoryRoot, nil
+	}
+	if strings.HasPrefix(filepath.Base(manifestDir), ".") {
+		if parent := filepath.Dir(manifestDir); parent != manifestDir {
+			return parent, nil
+		}
+	}
+	return manifestDir, nil
+}
+
+func xcodeInjectRepositoryRoot(dir string) string {
+	current := dir
+	for {
+		if _, err := os.Lstat(filepath.Join(current, ".git")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+// xcodeInjectBaseDir is the directory manifest-relative paths resolve from.
+func xcodeInjectBaseDir(manifestPath string) (string, error) {
+	absolute, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(absolute), nil
+}
+
+func validateXcodeInjectOutputDestinations(root rootfs.Root, baseDir string, outputs []xcodeInjectManifestOutput, overwrite bool) error {
 	seen := map[string]int{}
 	paths := make([]string, 0, len(outputs))
 	pathKeys := make([]string, 0, len(outputs))
 	for i, output := range outputs {
-		targetPath := resolveXcodeInjectPath(baseDir, strings.TrimSpace(output.Path))
-		if targetPath == "" {
+		if strings.TrimSpace(output.Path) == "" {
 			continue
 		}
-		if err := validateXcodeInjectDestinationParents(targetPath); err != nil {
+		targetPath, err := resolveXcodeInjectPath(root, baseDir, output.Path)
+		if err != nil {
+			return fmt.Errorf("output %d: %w", i+1, err)
+		}
+		if err := validateXcodeInjectDestinationParents(root, targetPath); err != nil {
 			return fmt.Errorf("output %d: %w", i+1, err)
 		}
 		if err := validateXcodeInjectDestination(targetPath, overwrite); err != nil {
@@ -256,7 +331,10 @@ func validateXcodeInjectOutputDestinations(baseDir string, outputs []xcodeInject
 		if strings.ToLower(strings.TrimSpace(output.Type)) != "copy" || strings.TrimSpace(output.Source) == "" {
 			continue
 		}
-		sourcePath := resolveXcodeInjectPath(baseDir, strings.TrimSpace(output.Source))
+		sourcePath, err := resolveXcodeInjectPath(root, baseDir, output.Source)
+		if err != nil {
+			return fmt.Errorf("output %d: %w", i+1, err)
+		}
 		sourceKey, err := xcodeInjectPathConflictKey(sourcePath)
 		if err != nil {
 			return fmt.Errorf("output %d: %w", i+1, err)
@@ -268,7 +346,11 @@ func validateXcodeInjectOutputDestinations(baseDir string, outputs []xcodeInject
 	return nil
 }
 
-func validateXcodeInjectDestinationParents(path string) error {
+func validateXcodeInjectDestinationParents(root rootfs.Root, path string) error {
+	if err := root.CheckParents(path); err != nil {
+		return err
+	}
+
 	parent := filepath.Dir(path)
 	for {
 		if parent == "." || parent == "" {
@@ -358,11 +440,14 @@ func applyXcodeInjectSetValues(values map[string]any, setValues []string) error 
 	return nil
 }
 
-func planXcodeInjectOutput(baseDir string, values map[string]any, output xcodeInjectManifestOutput) (xcodeInjectOutputPlan, error) {
+func planXcodeInjectOutput(root rootfs.Root, baseDir string, values map[string]any, output xcodeInjectManifestOutput) (xcodeInjectOutputPlan, error) {
 	outputType := strings.ToLower(strings.TrimSpace(output.Type))
-	targetPath := resolveXcodeInjectPath(baseDir, strings.TrimSpace(output.Path))
-	if targetPath == "" {
+	if strings.TrimSpace(output.Path) == "" {
 		return xcodeInjectOutputPlan{}, newXcodeInjectUsageError("path is required")
+	}
+	targetPath, err := resolveXcodeInjectPath(root, baseDir, output.Path)
+	if err != nil {
+		return xcodeInjectOutputPlan{}, err
 	}
 
 	switch outputType {
@@ -394,11 +479,14 @@ func planXcodeInjectOutput(baseDir string, values map[string]any, output xcodeIn
 		}
 		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, Payload: []byte(renderedContents)}, nil
 	case "copy":
-		sourcePath := resolveXcodeInjectPath(baseDir, strings.TrimSpace(output.Source))
-		if sourcePath == "" {
+		if strings.TrimSpace(output.Source) == "" {
 			return xcodeInjectOutputPlan{}, newXcodeInjectUsageError("source is required for copy outputs")
 		}
-		payload, err := os.ReadFile(sourcePath)
+		sourcePath, err := resolveXcodeInjectPath(root, baseDir, output.Source)
+		if err != nil {
+			return xcodeInjectOutputPlan{}, err
+		}
+		payload, err := root.ReadFile(sourcePath)
 		if err != nil {
 			return xcodeInjectOutputPlan{}, err
 		}
@@ -476,28 +564,28 @@ func sortedXcodeInjectValueKeys(values map[string]any) []string {
 	return keys
 }
 
-func writeXcodeInjectBytes(path, outputType, source string, payload []byte, opts xcodeInjectOptions) (xcodeInjectFileResult, error) {
+func writeXcodeInjectBytes(root rootfs.Root, plan xcodeInjectOutputPlan, opts xcodeInjectOptions) (xcodeInjectFileResult, error) {
 	result := xcodeInjectFileResult{
-		Type:   outputType,
-		Path:   path,
-		Source: source,
-		Bytes:  int64(len(payload)),
+		Type:   plan.Type,
+		Path:   plan.Path,
+		Source: plan.Source,
+		Bytes:  int64(len(plan.Payload)),
 	}
-	if err := validateXcodeInjectDestination(path, opts.Overwrite); err != nil {
+	if err := validateXcodeInjectDestination(plan.Path, opts.Overwrite); err != nil {
 		return xcodeInjectFileResult{}, err
 	}
 	if opts.DryRun {
-		if outputType == "copy" {
+		if plan.Type == "copy" {
 			result.Action = "would_copy"
 		} else {
 			result.Action = "would_write"
 		}
 		return result, nil
 	}
-	if _, err := shared.WriteFileNoSymlinkOverwrite(path, bytes.NewReader(payload), 0o644, ".asc-inject-*", ".asc-inject-backup-*"); err != nil {
+	if _, err := root.WriteFrom(plan.Path, bytes.NewReader(plan.Payload), 0o644); err != nil {
 		return xcodeInjectFileResult{}, err
 	}
-	if outputType == "copy" {
+	if plan.Type == "copy" {
 		result.Action = "copied"
 	} else {
 		result.Action = "written"
@@ -525,15 +613,31 @@ func validateXcodeInjectDestination(path string, overwrite bool) error {
 	return nil
 }
 
-func resolveXcodeInjectPath(baseDir, path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return ""
+// resolveXcodeInjectPath resolves a manifest-declared path from the manifest
+// directory and confirms it stays inside the manifest project root. Absolute
+// paths, volume or UNC-style changes, and traversal that leaves the root are
+// refused because the manifest is repository-controlled.
+func resolveXcodeInjectPath(root rootfs.Root, baseDir string, path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", newXcodeInjectUsageError("path is required")
 	}
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
+	if err := rootfs.ValidateRelativeAllowingTraversal(trimmed); err != nil {
+		return "", newXcodeInjectUsageError(
+			"%v; manifest paths must be relative to the manifest directory and stay inside %q",
+			err,
+			root.Path(),
+		)
 	}
-	return filepath.Clean(filepath.Join(baseDir, path))
+	resolved, err := root.Resolve(filepath.Clean(filepath.Join(baseDir, trimmed)))
+	if err != nil {
+		return "", newXcodeInjectUsageError(
+			"%v; manifest paths must stay inside %q",
+			err,
+			root.Path(),
+		)
+	}
+	return resolved, nil
 }
 
 func xcodeInjectResultRows(result xcodeInjectResult) [][]string {

--- a/internal/cli/xcode/inject.go
+++ b/internal/cli/xcode/inject.go
@@ -60,6 +60,11 @@ type xcodeInjectOutputPlan struct {
 	Path    string
 	Source  string
 	Payload []byte
+	// DisplayPath and DisplaySource report the manifest-relative form the
+	// operator wrote, keeping the output contract stable while rooted I/O uses
+	// the absolute Path and Source.
+	DisplayPath   string
+	DisplaySource string
 }
 
 func XcodeInjectCommand() *ffcli.Command {
@@ -212,8 +217,11 @@ func runXcodeInject(opts xcodeInjectOptions) (xcodeInjectResult, error) {
 	}
 	plans := make([]xcodeInjectOutputPlan, 0, len(manifest.Outputs))
 
+	// Result paths keep the manifest-relative form the operator wrote, so a
+	// relative --manifest keeps producing relative output paths.
+	displayBase := filepath.Dir(opts.ManifestPath)
 	for i, output := range manifest.Outputs {
-		plan, err := planXcodeInjectOutput(root, baseDir, values, output)
+		plan, err := planXcodeInjectOutput(root, baseDir, displayBase, values, output)
 		if err != nil {
 			return xcodeInjectResult{}, fmt.Errorf("output %d: %w", i+1, err)
 		}
@@ -440,7 +448,7 @@ func applyXcodeInjectSetValues(values map[string]any, setValues []string) error 
 	return nil
 }
 
-func planXcodeInjectOutput(root rootfs.Root, baseDir string, values map[string]any, output xcodeInjectManifestOutput) (xcodeInjectOutputPlan, error) {
+func planXcodeInjectOutput(root rootfs.Root, baseDir, displayBase string, values map[string]any, output xcodeInjectManifestOutput) (xcodeInjectOutputPlan, error) {
 	outputType := strings.ToLower(strings.TrimSpace(output.Type))
 	if strings.TrimSpace(output.Path) == "" {
 		return xcodeInjectOutputPlan{}, newXcodeInjectUsageError("path is required")
@@ -449,6 +457,7 @@ func planXcodeInjectOutput(root rootfs.Root, baseDir string, values map[string]a
 	if err != nil {
 		return xcodeInjectOutputPlan{}, err
 	}
+	displayPath := xcodeInjectDisplayPath(displayBase, output.Path)
 
 	switch outputType {
 	case "plist":
@@ -460,7 +469,7 @@ func planXcodeInjectOutput(root rootfs.Root, baseDir string, values map[string]a
 		if err != nil {
 			return xcodeInjectOutputPlan{}, err
 		}
-		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, Payload: payload}, nil
+		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, DisplayPath: displayPath, Payload: payload}, nil
 	case "json":
 		renderedValues, err := renderXcodeInjectValue(output.Values, values)
 		if err != nil {
@@ -471,13 +480,13 @@ func planXcodeInjectOutput(root rootfs.Root, baseDir string, values map[string]a
 			return xcodeInjectOutputPlan{}, err
 		}
 		payload = append(payload, '\n')
-		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, Payload: payload}, nil
+		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, DisplayPath: displayPath, Payload: payload}, nil
 	case "text":
 		renderedContents, err := renderXcodeInjectString(output.Contents, values)
 		if err != nil {
 			return xcodeInjectOutputPlan{}, err
 		}
-		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, Payload: []byte(renderedContents)}, nil
+		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, DisplayPath: displayPath, Payload: []byte(renderedContents)}, nil
 	case "copy":
 		if strings.TrimSpace(output.Source) == "" {
 			return xcodeInjectOutputPlan{}, newXcodeInjectUsageError("source is required for copy outputs")
@@ -490,7 +499,14 @@ func planXcodeInjectOutput(root rootfs.Root, baseDir string, values map[string]a
 		if err != nil {
 			return xcodeInjectOutputPlan{}, err
 		}
-		return xcodeInjectOutputPlan{Type: outputType, Path: targetPath, Source: sourcePath, Payload: payload}, nil
+		return xcodeInjectOutputPlan{
+			Type:          outputType,
+			Path:          targetPath,
+			Source:        sourcePath,
+			Payload:       payload,
+			DisplayPath:   displayPath,
+			DisplaySource: xcodeInjectDisplayPath(displayBase, output.Source),
+		}, nil
 	default:
 		return xcodeInjectOutputPlan{}, newXcodeInjectUsageError("type must be one of plist, json, text, copy")
 	}
@@ -567,8 +583,8 @@ func sortedXcodeInjectValueKeys(values map[string]any) []string {
 func writeXcodeInjectBytes(root rootfs.Root, plan xcodeInjectOutputPlan, opts xcodeInjectOptions) (xcodeInjectFileResult, error) {
 	result := xcodeInjectFileResult{
 		Type:   plan.Type,
-		Path:   plan.Path,
-		Source: plan.Source,
+		Path:   plan.DisplayPath,
+		Source: plan.DisplaySource,
 		Bytes:  int64(len(plan.Payload)),
 	}
 	if err := validateXcodeInjectDestination(plan.Path, opts.Overwrite); err != nil {
@@ -611,6 +627,13 @@ func validateXcodeInjectDestination(path string, overwrite bool) error {
 		return fmt.Errorf("output path %q is a directory", path)
 	}
 	return nil
+}
+
+// xcodeInjectDisplayPath reports a manifest-declared path the way the operator
+// wrote it: resolved from the manifest directory as typed, so a relative
+// --manifest keeps relative result paths and an absolute one stays absolute.
+func xcodeInjectDisplayPath(displayBase, path string) string {
+	return filepath.Clean(filepath.Join(displayBase, strings.TrimSpace(path)))
 }
 
 // resolveXcodeInjectPath resolves a manifest-declared path from the manifest

--- a/internal/cli/xcode/inject_containment_test.go
+++ b/internal/cli/xcode/inject_containment_test.go
@@ -7,6 +7,41 @@ import (
 	"testing"
 )
 
+func TestXcodeInjectReportsManifestRelativePathsForRelativeManifest(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(".asc", 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(".asc", "icon.txt"), []byte("icon\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	writeXcodeInjectTestManifest(t, filepath.Join(".asc", "deployment.json"), `{
+		"outputs": [
+			{"type": "text", "path": "../Generated/version.txt", "contents": "1.2.3\n"},
+			{"type": "copy", "source": "icon.txt", "path": "../Generated/icon.txt"}
+		]
+	}`)
+
+	result, err := runXcodeInject(xcodeInjectOptions{ManifestPath: filepath.Join(".asc", "deployment.json"), Overwrite: true})
+	if err != nil {
+		t.Fatalf("runXcodeInject() error = %v", err)
+	}
+	if len(result.Outputs) != 2 {
+		t.Fatalf("outputs = %#v, want 2 entries", result.Outputs)
+	}
+	// A relative --manifest must keep manifest-relative result paths, matching
+	// the pre-rooting output contract.
+	if want := filepath.Join("Generated", "version.txt"); result.Outputs[0].Path != want {
+		t.Fatalf("outputs[0].path = %q, want %q", result.Outputs[0].Path, want)
+	}
+	if want := filepath.Join("Generated", "icon.txt"); result.Outputs[1].Path != want {
+		t.Fatalf("outputs[1].path = %q, want %q", result.Outputs[1].Path, want)
+	}
+	if want := filepath.Join(".asc", "icon.txt"); result.Outputs[1].Source != want {
+		t.Fatalf("outputs[1].source = %q, want %q", result.Outputs[1].Source, want)
+	}
+}
+
 func TestXcodeInjectRejectsParentTraversingOutputPath(t *testing.T) {
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "deployment.json")

--- a/internal/cli/xcode/inject_containment_test.go
+++ b/internal/cli/xcode/inject_containment_test.go
@@ -1,0 +1,184 @@
+package xcode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestXcodeInjectRejectsParentTraversingOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "text", "path": "../escaped.txt", "contents": "attacker\n"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want traversal rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(dir), "escaped.txt")); statErr == nil {
+		t.Fatal("output escaped the manifest root")
+	}
+}
+
+func TestXcodeInjectRejectsAbsoluteOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	externalPath := filepath.Join(t.TempDir(), "escaped.txt")
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "text", "path": "`+filepath.ToSlash(externalPath)+`", "contents": "attacker\n"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want absolute path rejection")
+	}
+	if _, statErr := os.Stat(externalPath); statErr == nil {
+		t.Fatal("output escaped the manifest root")
+	}
+}
+
+func TestXcodeInjectRejectsParentTraversingCopySource(t *testing.T) {
+	dir := t.TempDir()
+	secretDir := t.TempDir()
+	secretPath := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("local secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	// A sibling directory of the manifest root reached with "..".
+	nested := filepath.Join(dir, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "outside.txt"), []byte("root level"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	manifestPath := filepath.Join(nested, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "copy", "source": "../outside.txt", "path": "Generated/Copied.txt"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want copy source traversal rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(nested, "Generated", "Copied.txt")); statErr == nil {
+		t.Fatal("copy produced an artifact from a source outside the manifest root")
+	}
+}
+
+func TestXcodeInjectRejectsAbsoluteCopySource(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("local secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "copy", "source": "`+filepath.ToSlash(secretPath)+`", "path": "Generated/Copied.txt"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want copy source rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "Generated", "Copied.txt")); statErr == nil {
+		t.Fatal("copy produced an artifact from an absolute source")
+	}
+}
+
+func TestXcodeInjectRejectsEscapingSymlinkedOutputParent(t *testing.T) {
+	dir := t.TempDir()
+	external := t.TempDir()
+	if err := os.Symlink(external, filepath.Join(dir, "Generated")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "text", "path": "Generated/Info.plist", "contents": "attacker\n"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("runXcodeInject() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(external, "Info.plist")); statErr == nil {
+		t.Fatal("output escaped through a symlinked parent")
+	}
+}
+
+func TestXcodeInjectRejectsEscapingSymlinkedCopySource(t *testing.T) {
+	dir := t.TempDir()
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "secret.txt"), []byte("local secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(dir, "Assets")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "copy", "source": "Assets/secret.txt", "path": "Generated/Copied.txt"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("runXcodeInject() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "Generated", "Copied.txt")); statErr == nil {
+		t.Fatal("copy produced an artifact from a symlinked external source")
+	}
+}
+
+func TestXcodeInjectRejectsSymlinkedCopySourceFile(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("local secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Symlink(secretPath, filepath.Join(dir, "Contents.json")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "copy", "source": "Contents.json", "path": "Generated/Copied.json"}
+		]
+	}`)
+
+	_, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath, Overwrite: true})
+	if err == nil {
+		t.Fatal("runXcodeInject() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("runXcodeInject() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "Generated", "Copied.json")); statErr == nil {
+		t.Fatal("copy produced an artifact from a symlinked source file")
+	}
+}

--- a/internal/cli/xcode/xcode_version.go
+++ b/internal/cli/xcode/xcode_version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -194,6 +195,7 @@ func xcodeVersionEditCommand() *ffcli.Command {
 	configuration := fs.String("configuration", "", "Xcode build configuration name to edit")
 	version := fs.String("version", "", "Marketing version (CFBundleShortVersionString)")
 	buildNumber := fs.String("build-number", "", "Build number (CFBundleVersion)")
+	allowExternalXCConfig := fs.Bool("allow-external-xcconfig", false, "Allow rewriting xcconfig files referenced outside the project directory")
 	remote := bindXcodeRemoteBuildNumberFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
@@ -201,8 +203,21 @@ func xcodeVersionEditCommand() *ffcli.Command {
 		Name:       "edit",
 		ShortUsage: "asc xcode version edit [--version VER] [--build-number NUM | --next-build-number --app APP] [--target NAME] [--configuration NAME]",
 		ShortHelp:  "Edit version and/or build number.",
-		FlagSet:    fs,
-		UsageFunc:  shared.DefaultUsageFunc,
+		LongHelp: `Edit the marketing version and/or build number in an Xcode project.
+
+Modern project and xcconfig build settings are edited structurally.
+
+By default only xcconfig files inside the project directory are rewritten.
+Pass --allow-external-xcconfig to authorize rewriting an xcconfig the project
+references outside that directory.
+
+Examples:
+  asc xcode version edit --version "1.3.0"
+  asc xcode version edit --build-number "42"
+  asc xcode version edit --target Widget --configuration Release --build-number "42"
+  asc xcode version edit --next-build-number --app "com.example.app"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
 				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
@@ -221,16 +236,20 @@ func xcodeVersionEditCommand() *ffcli.Command {
 			}
 
 			projectInput := selectedProjectInput(*projectDir, *project)
+			if *allowExternalXCConfig {
+				warnExternalXCConfigAuthorized()
+			}
 			if *remote.next {
 				if err := validateXcodeRemoteBuildNumberOptions(remote.options(v)); err != nil {
 					return err
 				}
 				if err := runValidateSetVersion(localxcode.SetVersionOptions{
-					ProjectDir:    projectInput,
-					Target:        strings.TrimSpace(*target),
-					Configuration: strings.TrimSpace(*configuration),
-					Version:       v,
-					BuildNumber:   "1",
+					ProjectDir:            projectInput,
+					Target:                strings.TrimSpace(*target),
+					Configuration:         strings.TrimSpace(*configuration),
+					Version:               v,
+					BuildNumber:           "1",
+					AllowExternalXCConfig: *allowExternalXCConfig,
 				}); err != nil {
 					return fmt.Errorf("xcode version edit: validate local mutation: %w", err)
 				}
@@ -254,11 +273,12 @@ func xcodeVersionEditCommand() *ffcli.Command {
 			}
 
 			result, err := runSetVersion(ctx, localxcode.SetVersionOptions{
-				ProjectDir:    projectInput,
-				Target:        strings.TrimSpace(*target),
-				Configuration: strings.TrimSpace(*configuration),
-				Version:       v,
-				BuildNumber:   b,
+				ProjectDir:            projectInput,
+				Target:                strings.TrimSpace(*target),
+				Configuration:         strings.TrimSpace(*configuration),
+				Version:               v,
+				BuildNumber:           b,
+				AllowExternalXCConfig: *allowExternalXCConfig,
 			})
 			if err != nil {
 				return fmt.Errorf("xcode version edit: %w", err)
@@ -277,6 +297,7 @@ func xcodeVersionBumpCommand() *ffcli.Command {
 	target := fs.String("target", "", "Xcode target name to bump")
 	configuration := fs.String("configuration", "", "Xcode build configuration name to bump")
 	bumpType := fs.String("type", "", "Bump type: major, minor, patch, or build (required)")
+	allowExternalXCConfig := fs.Bool("allow-external-xcconfig", false, "Allow rewriting xcconfig files referenced outside the project directory")
 	remote := bindXcodeRemoteBuildNumberFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
@@ -297,6 +318,8 @@ Note:
   multiple sibling projects.
   --target and --configuration scope both the read and write.
   --next-build-number is accepted with --type build and uses App Store Connect.
+  Only xcconfig files inside the project directory are rewritten unless
+  --allow-external-xcconfig is passed.
 
 Examples:
   asc xcode version bump --type patch
@@ -323,17 +346,21 @@ Examples:
 				return shared.UsageError("remote build-number flags require --next-build-number")
 			}
 			projectInput := selectedProjectInput(*projectDir, *project)
+			if *allowExternalXCConfig {
+				warnExternalXCConfigAuthorized()
+			}
 			remoteBuildNumber := ""
 			if *remote.next {
 				if err := validateXcodeRemoteBuildNumberOptions(remote.options("")); err != nil {
 					return err
 				}
 				if err := runValidateBumpVersion(ctx, localxcode.BumpVersionOptions{
-					ProjectDir:    projectInput,
-					Target:        strings.TrimSpace(*target),
-					Configuration: strings.TrimSpace(*configuration),
-					BumpType:      localxcode.BumpBuild,
-					BuildNumber:   "1",
+					ProjectDir:            projectInput,
+					Target:                strings.TrimSpace(*target),
+					Configuration:         strings.TrimSpace(*configuration),
+					BumpType:              localxcode.BumpBuild,
+					BuildNumber:           "1",
+					AllowExternalXCConfig: *allowExternalXCConfig,
 				}); err != nil {
 					return fmt.Errorf("xcode version bump: validate local mutation: %w", err)
 				}
@@ -352,11 +379,12 @@ Examples:
 			}
 
 			result, err := runBumpVersion(ctx, localxcode.BumpVersionOptions{
-				ProjectDir:    projectInput,
-				Target:        strings.TrimSpace(*target),
-				Configuration: strings.TrimSpace(*configuration),
-				BumpType:      parsed,
-				BuildNumber:   remoteBuildNumber,
+				ProjectDir:            projectInput,
+				Target:                strings.TrimSpace(*target),
+				Configuration:         strings.TrimSpace(*configuration),
+				BumpType:              parsed,
+				BuildNumber:           remoteBuildNumber,
+				AllowExternalXCConfig: *allowExternalXCConfig,
 			})
 			if err != nil {
 				return fmt.Errorf("xcode version bump: %w", err)
@@ -365,6 +393,10 @@ Examples:
 			return shared.PrintOutput(result, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func warnExternalXCConfigAuthorized() {
+	fmt.Fprintln(os.Stderr, "Warning: --allow-external-xcconfig permits rewriting xcconfig files outside the project directory.")
 }
 
 func resolveXcodeNextBuildNumber(ctx context.Context, opts xcodeRemoteBuildNumberOptions) (string, error) {

--- a/internal/cli/xcode/xcode_version.go
+++ b/internal/cli/xcode/xcode_version.go
@@ -195,7 +195,7 @@ func xcodeVersionEditCommand() *ffcli.Command {
 	configuration := fs.String("configuration", "", "Xcode build configuration name to edit")
 	version := fs.String("version", "", "Marketing version (CFBundleShortVersionString)")
 	buildNumber := fs.String("build-number", "", "Build number (CFBundleVersion)")
-	allowExternalXCConfig := fs.Bool("allow-external-xcconfig", false, "Allow rewriting xcconfig files referenced outside the project directory")
+	allowExternalXCConfig := fs.Bool("allow-external-xcconfig", false, "[experimental] Allow rewriting xcconfig files referenced outside the project directory")
 	remote := bindXcodeRemoteBuildNumberFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
@@ -208,8 +208,8 @@ func xcodeVersionEditCommand() *ffcli.Command {
 Modern project and xcconfig build settings are edited structurally.
 
 By default only xcconfig files inside the project directory are rewritten.
-Pass --allow-external-xcconfig to authorize rewriting an xcconfig the project
-references outside that directory.
+Pass the experimental --allow-external-xcconfig flag to authorize rewriting an
+xcconfig the project references outside that directory.
 
 Examples:
   asc xcode version edit --version "1.3.0"
@@ -297,7 +297,7 @@ func xcodeVersionBumpCommand() *ffcli.Command {
 	target := fs.String("target", "", "Xcode target name to bump")
 	configuration := fs.String("configuration", "", "Xcode build configuration name to bump")
 	bumpType := fs.String("type", "", "Bump type: major, minor, patch, or build (required)")
-	allowExternalXCConfig := fs.Bool("allow-external-xcconfig", false, "Allow rewriting xcconfig files referenced outside the project directory")
+	allowExternalXCConfig := fs.Bool("allow-external-xcconfig", false, "[experimental] Allow rewriting xcconfig files referenced outside the project directory")
 	remote := bindXcodeRemoteBuildNumberFlags(fs)
 	output := shared.BindOutputFlags(fs)
 
@@ -318,8 +318,8 @@ Note:
   multiple sibling projects.
   --target and --configuration scope both the read and write.
   --next-build-number is accepted with --type build and uses App Store Connect.
-  Only xcconfig files inside the project directory are rewritten unless
-  --allow-external-xcconfig is passed.
+  Only xcconfig files inside the project directory are rewritten unless the
+  experimental --allow-external-xcconfig flag is passed.
 
 Examples:
   asc xcode version bump --type patch

--- a/internal/config/atomic_write.go
+++ b/internal/config/atomic_write.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -165,32 +163,7 @@ func isAllowedConfigDirSymlink(path string) bool {
 }
 
 func createTempConfigFile(dir, pattern string, perm os.FileMode) (*os.File, error) {
-	prefix := pattern
-	suffix := ""
-	if idx := strings.LastIndex(pattern, "*"); idx != -1 {
-		prefix = pattern[:idx]
-		suffix = pattern[idx+1:]
-	}
-
-	const maxAttempts = 10_000
-	var randBytes [12]byte
-	for i := 0; i < maxAttempts; i++ {
-		if _, err := rand.Read(randBytes[:]); err != nil {
-			return nil, err
-		}
-
-		name := prefix + hex.EncodeToString(randBytes[:]) + suffix
-		file, err := secureopen.OpenNewFileNoFollow(filepath.Join(dir, name), perm)
-		if err == nil {
-			return file, nil
-		}
-		if errors.Is(err, os.ErrExist) {
-			continue
-		}
-		return nil, err
-	}
-
-	return nil, fmt.Errorf("failed to create temporary config file in %q", dir)
+	return secureopen.CreateTempNoFollow(dir, pattern, perm)
 }
 
 func syncDir(path string) error {

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -39,6 +39,9 @@ const (
 // Root is a trusted directory anchor for rooted filesystem operations.
 type Root struct {
 	path string
+	// internalSymlinks tolerates symlinked components below the root when they
+	// resolve back inside the root.
+	internalSymlinks bool
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -60,6 +63,44 @@ func (r Root) Path() string {
 	return r.path
 }
 
+// AllowingInternalSymlinks returns a copy of the root that accepts a symlinked
+// directory component below the root when that component resolves back inside
+// the root, and still rejects one that escapes.
+//
+// Use it only where symlinked directories inside the root are an established,
+// supported layout. A symlinked final component is still refused.
+func (r Root) AllowingInternalSymlinks() Root {
+	r.internalSymlinks = true
+	return r
+}
+
+// containsResolvedComponent reports whether a symlinked component below the root
+// resolves back inside the root.
+func (r Root) containsResolvedComponent(path string) bool {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	root := r.path
+	if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolvedRoot
+	}
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+// checkSymlinkComponent decides whether a symlinked component below the root is
+// acceptable for this root's policy.
+func (r Root) checkSymlinkComponent(path string) error {
+	if r.internalSymlinks && r.containsResolvedComponent(path) {
+		return nil
+	}
+	return symlinkError(path)
+}
+
 // ValidateRelative reports whether name is safe to join onto a trusted root.
 // Both Unix and Windows separator conventions are considered so a repository
 // can not smuggle a drive-relative, UNC-style, or backslash-traversing path
@@ -79,6 +120,24 @@ func ValidateRelative(name string) error {
 		if component == ".." {
 			return fmt.Errorf("%w: %q traverses above the trusted root", ErrEscapesRoot, name)
 		}
+	}
+	return nil
+}
+
+// ValidateRelativeAllowingTraversal rejects absolute, drive-relative and
+// UNC-style paths but permits ".." segments, for callers that resolve a path
+// against a base directory below the root and then confirm containment of the
+// joined result with Resolve.
+func ValidateRelativeAllowingTraversal(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("%w: path is empty", ErrEscapesRoot)
+	}
+	if strings.ContainsRune(trimmed, 0) {
+		return fmt.Errorf("%w: %q contains a NUL byte", ErrEscapesRoot, name)
+	}
+	if isAbsoluteLike(trimmed) {
+		return fmt.Errorf("%w: %q must be relative to the trusted root", ErrEscapesRoot, name)
 	}
 	return nil
 }
@@ -136,6 +195,17 @@ func (r Root) CheckContained(name string) error {
 		return symlinkError(resolved)
 	}
 	return nil
+}
+
+// CheckParents verifies that name stays beneath the root and that every
+// component below the root leading to it is acceptable under the root's symlink
+// policy. The final component is not inspected.
+func (r Root) CheckParents(name string) error {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return err
+	}
+	return r.checkParentComponents(resolved)
 }
 
 // OpenFile opens an existing regular file beneath the root without following
@@ -201,7 +271,7 @@ func (r Root) MkdirAll(name string, perm os.FileMode) error {
 	current := r.path
 	for _, component := range components {
 		current = filepath.Join(current, component)
-		if err := mkdirNoFollow(current, perm); err != nil {
+		if err := r.mkdirNoFollow(current, perm); err != nil {
 			return err
 		}
 	}
@@ -424,7 +494,15 @@ func (r Root) checkParentComponents(absolute string) error {
 			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			return symlinkError(current)
+			if err := r.checkSymlinkComponent(current); err != nil {
+				return err
+			}
+			if resolved, err := os.Stat(current); err != nil {
+				return err
+			} else if !resolved.IsDir() {
+				return fmt.Errorf("%q is not a directory", current)
+			}
+			continue
 		}
 		if !info.IsDir() {
 			return fmt.Errorf("%q is not a directory", current)
@@ -433,8 +511,8 @@ func (r Root) checkParentComponents(absolute string) error {
 	return nil
 }
 
-func mkdirNoFollow(path string, perm os.FileMode) error {
-	if err := validateExistingDir(path); err == nil {
+func (r Root) mkdirNoFollow(path string, perm os.FileMode) error {
+	if err := r.validateExistingDir(path); err == nil {
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -442,16 +520,26 @@ func mkdirNoFollow(path string, perm os.FileMode) error {
 	if err := os.Mkdir(path, perm); err != nil && !errors.Is(err, os.ErrExist) {
 		return err
 	}
-	return validateExistingDir(path)
+	return r.validateExistingDir(path)
 }
 
-func validateExistingDir(path string) error {
+func (r Root) validateExistingDir(path string) error {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return symlinkError(path)
+		if err := r.checkSymlinkComponent(path); err != nil {
+			return err
+		}
+		resolved, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if !resolved.IsDir() {
+			return fmt.Errorf("%q is not a directory", path)
+		}
+		return nil
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("%q is not a directory", path)

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -1,0 +1,534 @@
+// Package rootfs provides rooted filesystem operations for paths that are not
+// fully trusted, such as filenames, directory components, or manifest entries
+// that come from a repository checkout or a remote API response.
+//
+// Every operation is anchored to a trusted root chosen by the operator (for
+// example a --out-dir flag, a manifest directory, or the resolved .asc
+// directory). Paths are validated lexically so absolute paths, volume or
+// UNC-style changes, and parent traversal are rejected, and filesystem access
+// refuses to follow symlinks for any component below the root. Writes stage
+// through unpredictable, exclusive, no-follow temporary files so a
+// pre-created symlink cannot redirect them.
+package rootfs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+)
+
+var (
+	// ErrEscapesRoot reports a path that does not stay beneath the trusted root.
+	ErrEscapesRoot = errors.New("path escapes trusted root")
+	// ErrSymlink reports a path component that is a symlink below the trusted root.
+	ErrSymlink = errors.New("refusing to follow symlink")
+)
+
+const (
+	temporaryFilePattern = ".asc-tmp-*"
+	backupFilePattern    = ".asc-tmp-backup-*"
+)
+
+// Root is a trusted directory anchor for rooted filesystem operations.
+type Root struct {
+	path string
+}
+
+// New returns a Root anchored at path. The root itself is operator-selected and
+// may live outside the current repository; only paths below it are constrained.
+func New(path string) (Root, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return Root{}, fmt.Errorf("%w: trusted root path is empty", ErrEscapesRoot)
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
+	}
+	return Root{path: filepath.Clean(absolute)}, nil
+}
+
+// Path returns the absolute trusted root path.
+func (r Root) Path() string {
+	return r.path
+}
+
+// ValidateRelative reports whether name is safe to join onto a trusted root.
+// Both Unix and Windows separator conventions are considered so a repository
+// can not smuggle a drive-relative, UNC-style, or backslash-traversing path
+// past validation on a different host platform.
+func ValidateRelative(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("%w: path is empty", ErrEscapesRoot)
+	}
+	if strings.ContainsRune(trimmed, 0) {
+		return fmt.Errorf("%w: %q contains a NUL byte", ErrEscapesRoot, name)
+	}
+	if isAbsoluteLike(trimmed) {
+		return fmt.Errorf("%w: %q must be relative to the trusted root", ErrEscapesRoot, name)
+	}
+	for _, component := range strings.FieldsFunc(trimmed, isPathSeparator) {
+		if component == ".." {
+			return fmt.Errorf("%w: %q traverses above the trusted root", ErrEscapesRoot, name)
+		}
+	}
+	return nil
+}
+
+// Resolve validates name and returns its absolute path beneath the root. name
+// may be relative to the root or an absolute path that is already inside it.
+func (r Root) Resolve(name string) (string, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: path is empty", ErrEscapesRoot)
+	}
+	if strings.ContainsRune(trimmed, 0) {
+		return "", fmt.Errorf("%w: %q contains a NUL byte", ErrEscapesRoot, name)
+	}
+
+	if isAbsoluteLike(trimmed) {
+		if !filepath.IsAbs(trimmed) {
+			return "", fmt.Errorf("%w: %q is not an absolute path below %q", ErrEscapesRoot, name, r.path)
+		}
+		cleaned := filepath.Clean(trimmed)
+		if err := r.checkWithin(cleaned, name); err != nil {
+			return "", err
+		}
+		return cleaned, nil
+	}
+
+	if err := ValidateRelative(trimmed); err != nil {
+		return "", err
+	}
+	joined := filepath.Join(r.path, trimmed)
+	if err := r.checkWithin(joined, name); err != nil {
+		return "", err
+	}
+	return joined, nil
+}
+
+// CheckContained verifies that name stays beneath the root and that neither its
+// parent components nor its final component is a symlink below the root.
+func (r Root) CheckContained(name string) error {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return err
+	}
+	if err := r.checkParentComponents(resolved); err != nil {
+		return err
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return symlinkError(resolved)
+	}
+	return nil
+}
+
+// OpenFile opens an existing regular file beneath the root without following
+// symlinks in the final component or in any component below the root.
+func (r Root) OpenFile(name string) (*os.File, error) {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.checkParentComponents(resolved); err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, symlinkError(resolved)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%q is not a regular file", resolved)
+	}
+	return secureopen.OpenExistingNoFollow(resolved)
+}
+
+// ReadFile reads a regular file beneath the root without following symlinks.
+func (r Root) ReadFile(name string) ([]byte, error) {
+	file, err := r.OpenFile(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}
+
+// ReadFileOptional reads a regular file beneath the root and reports whether it
+// exists. A missing file is not an error; a symlinked path still is.
+func (r Root) ReadFileOptional(name string) ([]byte, bool, error) {
+	data, err := r.ReadFile(name)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// MkdirAll creates name and any missing parents beneath the root, rejecting any
+// existing component that is a symlink or not a directory.
+func (r Root) MkdirAll(name string, perm os.FileMode) error {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return err
+	}
+	if err := r.ensureRootDir(perm); err != nil {
+		return err
+	}
+	components, err := r.componentsBelowRoot(resolved)
+	if err != nil {
+		return err
+	}
+	current := r.path
+	for _, component := range components {
+		current = filepath.Join(current, component)
+		if err := mkdirNoFollow(current, perm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteFile atomically creates or replaces a file beneath the root.
+func (r Root) WriteFile(name string, data []byte, perm os.FileMode) error {
+	_, err := r.WriteFrom(name, bytes.NewReader(data), perm)
+	return err
+}
+
+// WriteFrom atomically creates or replaces a file beneath the root with the
+// contents of reader and returns the number of bytes written.
+func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64, error) {
+	resolved, err := r.prepareWrite(name)
+	if err != nil {
+		return 0, err
+	}
+
+	hadExisting, err := checkReplaceableFile(resolved)
+	if err != nil {
+		return 0, err
+	}
+
+	directory := filepath.Dir(resolved)
+	temporary, err := secureopen.CreateTempNoFollow(directory, temporaryFilePattern, perm)
+	if err != nil {
+		return 0, err
+	}
+	temporaryPath := temporary.Name()
+	success := false
+	defer func() {
+		_ = temporary.Close()
+		if !success {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+
+	// Set the final mode explicitly so the process umask cannot widen it.
+	if err := temporary.Chmod(perm); err != nil {
+		return 0, err
+	}
+	written, err := io.Copy(temporary, reader)
+	if err != nil {
+		return 0, err
+	}
+	if err := temporary.Sync(); err != nil {
+		return 0, err
+	}
+	if err := temporary.Close(); err != nil {
+		return 0, err
+	}
+
+	if err := replaceFile(temporaryPath, resolved, hadExisting); err != nil {
+		return 0, err
+	}
+	success = true
+	return written, nil
+}
+
+// CreateNewFile writes data to a new file beneath the root and fails when the
+// destination already exists.
+func (r Root) CreateNewFile(name string, data []byte, perm os.FileMode) error {
+	resolved, err := r.prepareWrite(name)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(resolved)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return symlinkError(resolved)
+		}
+		return fmt.Errorf("%q already exists: %w", resolved, os.ErrExist)
+	case !errors.Is(err, os.ErrNotExist):
+		return err
+	}
+
+	file, err := secureopen.OpenNewFileNoFollow(resolved, perm)
+	if err != nil {
+		return err
+	}
+	if _, writeErr := file.Write(data); writeErr != nil {
+		_ = file.Close()
+		return writeErr
+	}
+	return file.Close()
+}
+
+// AppendFile appends data to a file beneath the root, creating it when missing,
+// without following a final or parent symlink.
+func (r Root) AppendFile(name string, data []byte, perm os.FileMode) error {
+	resolved, err := r.prepareWrite(name)
+	if err != nil {
+		return err
+	}
+
+	if info, err := os.Lstat(resolved); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return symlinkError(resolved)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%q is not a regular file", resolved)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	file, err := secureopen.OpenAppendNoFollow(resolved, perm)
+	if err != nil {
+		return err
+	}
+	// The descriptor is known not to be a symlink, so tightening permissions
+	// here cannot affect an external file.
+	if err := file.Chmod(perm); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func (r Root) prepareWrite(name string) (string, error) {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return "", err
+	}
+	if resolved == r.path {
+		return "", fmt.Errorf("%w: %q is the trusted root itself", ErrEscapesRoot, name)
+	}
+	parent, err := r.relativeToRoot(filepath.Dir(resolved))
+	if err != nil {
+		return "", err
+	}
+	if err := r.MkdirAll(parent, 0o755); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func (r Root) ensureRootDir(perm os.FileMode) error {
+	info, err := os.Stat(r.path)
+	switch {
+	case err == nil:
+		if !info.IsDir() {
+			return fmt.Errorf("trusted root %q is not a directory", r.path)
+		}
+		return nil
+	case !errors.Is(err, os.ErrNotExist):
+		return err
+	}
+	if err := os.MkdirAll(r.path, perm); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r Root) componentsBelowRoot(absolute string) ([]string, error) {
+	relative, err := r.relativeToRoot(absolute)
+	if err != nil {
+		return nil, err
+	}
+	if relative == "." {
+		return nil, nil
+	}
+	parts := strings.Split(relative, string(filepath.Separator))
+	components := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" || part == "." {
+			continue
+		}
+		components = append(components, part)
+	}
+	return components, nil
+}
+
+func (r Root) relativeToRoot(absolute string) (string, error) {
+	relative, err := filepath.Rel(r.path, absolute)
+	if err != nil {
+		return "", fmt.Errorf("%w: %q is not below %q", ErrEscapesRoot, absolute, r.path)
+	}
+	return relative, nil
+}
+
+func (r Root) checkWithin(absolute string, original string) error {
+	if !strings.EqualFold(filepath.VolumeName(absolute), filepath.VolumeName(r.path)) {
+		return fmt.Errorf("%w: %q changes volume from %q", ErrEscapesRoot, original, r.path)
+	}
+	relative, err := filepath.Rel(r.path, absolute)
+	if err != nil {
+		return fmt.Errorf("%w: %q is not below %q", ErrEscapesRoot, original, r.path)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %q is not below %q", ErrEscapesRoot, original, r.path)
+	}
+	return nil
+}
+
+func (r Root) checkParentComponents(absolute string) error {
+	components, err := r.componentsBelowRoot(absolute)
+	if err != nil {
+		return err
+	}
+	if len(components) == 0 {
+		return nil
+	}
+	current := r.path
+	for _, component := range components[:len(components)-1] {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return symlinkError(current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%q is not a directory", current)
+		}
+	}
+	return nil
+}
+
+func mkdirNoFollow(path string, perm os.FileMode) error {
+	if err := validateExistingDir(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Mkdir(path, perm); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	return validateExistingDir(path)
+}
+
+func validateExistingDir(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return symlinkError(path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%q is not a directory", path)
+	}
+	return nil
+}
+
+func checkReplaceableFile(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, symlinkError(path)
+	}
+	if info.IsDir() {
+		return false, fmt.Errorf("%q is a directory", path)
+	}
+	return true, nil
+}
+
+// replaceFile moves the staged temporary file onto path. Unix renames replace
+// the destination atomically; Windows renames fail when the destination exists,
+// so the original is moved aside first and restored if the final move fails.
+func replaceFile(temporaryPath, path string, hadExisting bool) error {
+	if err := os.Rename(temporaryPath, path); err == nil {
+		return nil
+	} else if !hadExisting || runtime.GOOS != "windows" {
+		return err
+	}
+
+	backup, err := secureopen.CreateTempNoFollow(filepath.Dir(path), backupFilePattern, 0o600)
+	if err != nil {
+		return err
+	}
+	backupPath := backup.Name()
+	if err := backup.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return err
+	}
+	if err := os.Rename(path, backupPath); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		_ = os.Rename(backupPath, path)
+		return err
+	}
+	_ = os.Remove(backupPath)
+	return nil
+}
+
+func symlinkError(path string) error {
+	return fmt.Errorf("%w: %q", ErrSymlink, path)
+}
+
+func isAbsoluteLike(path string) bool {
+	if path == "" {
+		return false
+	}
+	if isPathSeparator(rune(path[0])) {
+		return true
+	}
+	if filepath.IsAbs(path) {
+		return true
+	}
+	return len(path) >= 2 && path[1] == ':' && isASCIILetter(path[0])
+}
+
+func isPathSeparator(r rune) bool {
+	return r == '/' || r == '\\'
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -9,6 +9,10 @@
 // refuses to follow symlinks for any component below the root. Writes stage
 // through unpredictable, exclusive, no-follow temporary files so a
 // pre-created symlink cannot redirect them.
+//
+// Roots created with AllowingInternalSymlinks relax only the parent-component
+// rule, accepting a symlinked directory whose target stays inside the root; a
+// symlinked final component is always refused.
 package rootfs
 
 import (

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -337,6 +337,25 @@ func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64,
 	return written, nil
 }
 
+// WriteFilePreservingMode atomically creates or replaces a file beneath the
+// root, reusing an existing regular destination's permissions and falling back
+// to perm for a new file. Use it where the pre-rooted in-place write preserved
+// an operator's chosen mode across rewrites.
+func (r Root) WriteFilePreservingMode(name string, data []byte, perm os.FileMode) error {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return err
+	}
+	if info, err := os.Lstat(resolved); err == nil {
+		if info.Mode().IsRegular() {
+			perm = info.Mode().Perm()
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return r.WriteFile(name, data, perm)
+}
+
 // CreateNewFile writes data to a new file beneath the root and fails when the
 // destination already exists.
 func (r Root) CreateNewFile(name string, data []byte, perm os.FileMode) error {

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -344,7 +344,7 @@ func TestAppendFileRefusesSymlinkAndLeavesModeIntact(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Lstat() error = %v", err)
 	}
-	if info.Mode().Perm() != 0o644 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o644 {
 		t.Fatalf("sentinel mode = %v, want 0644", info.Mode().Perm())
 	}
 }

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -258,6 +258,41 @@ func TestWriteFromWritesReaderContents(t *testing.T) {
 	}
 }
 
+func TestWriteFilePreservingModeKeepsExistingModeAndDefaultsForNew(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+
+	existingPath := filepath.Join(dir, "existing.txt")
+	mustWrite(t, existingPath, "old")
+	if err := os.Chmod(existingPath, 0o600); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	if err := root.WriteFilePreservingMode("existing.txt", []byte("new"), 0o644); err != nil {
+		t.Fatalf("WriteFilePreservingMode() error = %v", err)
+	}
+	info, err := os.Lstat(existingPath)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("existing mode = %v, want preserved 0600", info.Mode().Perm())
+	}
+	if got := mustRead(t, existingPath); got != "new" {
+		t.Fatalf("content = %q, want %q", got, "new")
+	}
+
+	if err := root.WriteFilePreservingMode("fresh.txt", []byte("data"), 0o640); err != nil {
+		t.Fatalf("WriteFilePreservingMode() new file error = %v", err)
+	}
+	freshInfo, err := os.Lstat(filepath.Join(dir, "fresh.txt"))
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if runtime.GOOS != "windows" && freshInfo.Mode().Perm() != 0o640 {
+		t.Fatalf("new mode = %v, want default 0640", freshInfo.Mode().Perm())
+	}
+}
+
 func TestCreateNewFileRefusesExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "AuthKey.p8"), "existing")

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -364,6 +364,65 @@ func TestAppendFileAppendsInRoot(t *testing.T) {
 	}
 }
 
+func TestAllowingInternalSymlinksAcceptsContainedSymlinkedParent(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "SharedGenerated")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(dir, "Generated")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir).AllowingInternalSymlinks()
+	if err := root.WriteFile(filepath.Join("Generated", "Info.plist"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(realDir, "Info.plist")); got != "payload" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestAllowingInternalSymlinksRejectsEscapingSymlinkedParent(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	external := t.TempDir()
+	if err := os.Symlink(external, filepath.Join(dir, "Generated")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir).AllowingInternalSymlinks()
+	err := root.WriteFile(filepath.Join("Generated", "Info.plist"), []byte("payload"), 0o644)
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(external, "Info.plist")); statErr == nil {
+		t.Fatal("WriteFile() escaped through a symlinked parent")
+	}
+}
+
+func TestAllowingInternalSymlinksStillRejectsFinalSymlink(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	sentinelPath := filepath.Join(t.TempDir(), "sentinel.txt")
+	mustWrite(t, sentinelPath, "original")
+	if err := os.Symlink(sentinelPath, filepath.Join(dir, "Info.plist")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir).AllowingInternalSymlinks()
+	if err := root.WriteFile("Info.plist", []byte("payload"), 0o644); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", err)
+	}
+	if got := mustRead(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+}
+
 func TestCheckContainedRejectsSymlinkedParentForExternalCandidate(t *testing.T) {
 	requireSymlinks(t)
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -1,0 +1,449 @@
+package rootfs
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateRelativeRejectsEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+		{"unix absolute", "/etc/passwd"},
+		{"windows absolute backslash", `\Windows\System32`},
+		{"windows drive absolute", `C:\Windows\System32`},
+		{"windows drive relative", "C:evil.txt"},
+		{"unc share", `\\attacker\share\evil.txt`},
+		{"parent traversal", "../evil.txt"},
+		{"nested parent traversal", "a/../../evil.txt"},
+		{"bare parent", ".."},
+		{"backslash parent traversal", `..\evil.txt`},
+		{"mixed separator traversal", `a\..\..\evil.txt`},
+		{"nul byte", "a\x00b"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := ValidateRelative(testCase.path); err == nil {
+				t.Fatalf("ValidateRelative(%q) = nil, want error", testCase.path)
+			}
+		})
+	}
+}
+
+func TestValidateRelativeAcceptsOrdinaryPaths(t *testing.T) {
+	cases := []string{
+		"file.txt",
+		"metadata/en-US/description.txt",
+		"./file.txt",
+		"a..b/c.txt",
+		"...hidden",
+	}
+
+	for _, path := range cases {
+		if err := ValidateRelative(path); err != nil {
+			t.Fatalf("ValidateRelative(%q) error = %v, want nil", path, err)
+		}
+	}
+}
+
+func TestResolveRejectsEscapingAbsolutePath(t *testing.T) {
+	root := mustRoot(t, t.TempDir())
+	outside := filepath.Join(t.TempDir(), "sentinel.txt")
+
+	if _, err := root.Resolve(outside); !errors.Is(err, ErrEscapesRoot) {
+		t.Fatalf("Resolve(%q) error = %v, want ErrEscapesRoot", outside, err)
+	}
+}
+
+func TestResolveAcceptsAbsolutePathInsideRoot(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	inside := filepath.Join(dir, "nested", "file.txt")
+
+	resolved, err := root.Resolve(inside)
+	if err != nil {
+		t.Fatalf("Resolve(%q) error = %v", inside, err)
+	}
+	if resolved != filepath.Clean(inside) {
+		t.Fatalf("Resolve(%q) = %q, want %q", inside, resolved, filepath.Clean(inside))
+	}
+}
+
+func TestReadFileRefusesSymlinkedFinalComponent(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	secretDir := t.TempDir()
+	secretPath := filepath.Join(secretDir, "secret.txt")
+	mustWrite(t, secretPath, "top-secret")
+
+	linkPath := filepath.Join(dir, "description.txt")
+	if err := os.Symlink(secretPath, linkPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if _, err := root.ReadFile("description.txt"); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("ReadFile() error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestReadFileRefusesSymlinkedParentComponent(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	secretDir := t.TempDir()
+	mustWrite(t, filepath.Join(secretDir, "secret.txt"), "top-secret")
+
+	if err := os.Symlink(secretDir, filepath.Join(dir, "en-US")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if _, err := root.ReadFile(filepath.Join("en-US", "secret.txt")); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("ReadFile() error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestReadFileReadsOrdinaryFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "keywords.txt"), "one,two")
+
+	root := mustRoot(t, dir)
+	data, err := root.ReadFile("keywords.txt")
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != "one,two" {
+		t.Fatalf("ReadFile() = %q, want %q", data, "one,two")
+	}
+}
+
+func TestReadFileOptionalReportsMissingWithoutError(t *testing.T) {
+	root := mustRoot(t, t.TempDir())
+
+	data, found, err := root.ReadFileOptional("missing.txt")
+	if err != nil {
+		t.Fatalf("ReadFileOptional() error = %v", err)
+	}
+	if found {
+		t.Fatal("ReadFileOptional() found = true, want false")
+	}
+	if len(data) != 0 {
+		t.Fatalf("ReadFileOptional() data = %q, want empty", data)
+	}
+}
+
+func TestWriteFileRefusesFinalSymlink(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	sentinelDir := t.TempDir()
+	sentinelPath := filepath.Join(sentinelDir, "sentinel.txt")
+	mustWrite(t, sentinelPath, "original")
+
+	if err := os.Symlink(sentinelPath, filepath.Join(dir, "out.json")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if err := root.WriteFile("out.json", []byte("attacker"), 0o600); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", err)
+	}
+	if got := mustRead(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+}
+
+func TestWriteFileRefusesSymlinkedParent(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	sentinelDir := t.TempDir()
+	sentinelPath := filepath.Join(sentinelDir, "sentinel.txt")
+	mustWrite(t, sentinelPath, "original")
+
+	if err := os.Symlink(sentinelDir, filepath.Join(dir, "nested")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	err := root.WriteFile(filepath.Join("nested", "sentinel.txt"), []byte("attacker"), 0o600)
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", err)
+	}
+	if got := mustRead(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+}
+
+func TestWriteFileCreatesAndReplacesInRoot(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+
+	target := filepath.Join("nested", "deep", "out.json")
+	if err := root.WriteFile(target, []byte("first"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, target)); got != "first" {
+		t.Fatalf("content = %q, want %q", got, "first")
+	}
+	if err := root.WriteFile(target, []byte("second"), 0o600); err != nil {
+		t.Fatalf("WriteFile() replace error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, target)); got != "second" {
+		t.Fatalf("content = %q, want %q", got, "second")
+	}
+
+	info, err := os.Lstat(filepath.Join(dir, target))
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %v, want 0600", info.Mode().Perm())
+	}
+	if leftovers := temporaryLeftovers(t, filepath.Join(dir, "nested", "deep")); len(leftovers) > 0 {
+		t.Fatalf("temporary files left behind: %v", leftovers)
+	}
+}
+
+func TestWriteFileDoesNotUsePredictableTemporaryPath(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	sentinelDir := t.TempDir()
+	sentinelPath := filepath.Join(sentinelDir, "sentinel.txt")
+	mustWrite(t, sentinelPath, "original")
+
+	// A predictable "<target>.tmp" staging path lets a lower-trust checkout
+	// pre-create a symlink that redirects the staged write.
+	if err := os.Symlink(sentinelPath, filepath.Join(dir, "checkpoint.json.tmp")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if err := root.WriteFile("checkpoint.json", []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if got := mustRead(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+	if got := mustRead(t, filepath.Join(dir, "checkpoint.json")); got != `{"ok":true}` {
+		t.Fatalf("checkpoint content = %q", got)
+	}
+}
+
+func TestWriteFromWritesReaderContents(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+
+	written, err := root.WriteFrom("payload.bin", bytes.NewReader([]byte("payload")), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFrom() error = %v", err)
+	}
+	if written != int64(len("payload")) {
+		t.Fatalf("WriteFrom() = %d, want %d", written, len("payload"))
+	}
+	if got := mustRead(t, filepath.Join(dir, "payload.bin")); got != "payload" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestCreateNewFileRefusesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "AuthKey.p8"), "existing")
+
+	root := mustRoot(t, dir)
+	if err := root.CreateNewFile("AuthKey.p8", []byte("new"), 0o600); !errors.Is(err, os.ErrExist) {
+		t.Fatalf("CreateNewFile() error = %v, want os.ErrExist", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, "AuthKey.p8")); got != "existing" {
+		t.Fatalf("content = %q, want %q", got, "existing")
+	}
+}
+
+func TestMkdirAllRefusesSymlinkedComponent(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "metadata")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	err := root.MkdirAll(filepath.Join("metadata", "en-US"), 0o755)
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("MkdirAll() error = %v, want ErrSymlink", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "en-US")); statErr == nil {
+		t.Fatal("MkdirAll() created a directory outside the root")
+	}
+}
+
+func TestMkdirAllCreatesNestedDirectories(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+
+	if err := root.MkdirAll(filepath.Join("metadata", "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "metadata", "en-US"))
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("MkdirAll() did not create a directory")
+	}
+}
+
+func TestMkdirAllCreatesMissingRoot(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "created-root")
+	root := mustRoot(t, dir)
+
+	if err := root.MkdirAll(".", 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Fatalf("Stat(root) = %v, %v", info, err)
+	}
+}
+
+func TestAppendFileRefusesSymlinkAndLeavesModeIntact(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	sentinelDir := t.TempDir()
+	sentinelPath := filepath.Join(sentinelDir, "sentinel.txt")
+	mustWrite(t, sentinelPath, "original")
+	if err := os.Chmod(sentinelPath, 0o644); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if err := os.Symlink(sentinelPath, filepath.Join(dir, "snitch.log")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if err := root.AppendFile("snitch.log", []byte("entry\n"), 0o600); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("AppendFile() error = %v, want ErrSymlink", err)
+	}
+	if got := mustRead(t, sentinelPath); got != "original" {
+		t.Fatalf("sentinel content = %q, want %q", got, "original")
+	}
+	info, err := os.Lstat(sentinelPath)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("sentinel mode = %v, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestAppendFileAppendsInRoot(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+
+	if err := root.AppendFile("snitch.log", []byte("one\n"), 0o600); err != nil {
+		t.Fatalf("AppendFile() error = %v", err)
+	}
+	if err := root.AppendFile("snitch.log", []byte("two\n"), 0o600); err != nil {
+		t.Fatalf("AppendFile() error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, "snitch.log")); got != "one\ntwo\n" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestCheckContainedRejectsSymlinkedParentForExternalCandidate(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "Configs")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	mustWrite(t, filepath.Join(outside, "Shared.xcconfig"), "MARKETING_VERSION = 1.0.0\n")
+
+	root := mustRoot(t, dir)
+	err := root.CheckContained(filepath.Join(dir, "Configs", "Shared.xcconfig"))
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("CheckContained() error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestErrorMessagesIdentifyRejectedPath(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+
+	_, err := root.Resolve("../escape.txt")
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "../escape.txt") {
+		t.Fatalf("error %q does not identify the rejected path", err)
+	}
+}
+
+func mustRoot(t *testing.T, path string) Root {
+	t.Helper()
+	root, err := New(path)
+	if err != nil {
+		t.Fatalf("New(%q) error = %v", path, err)
+	}
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(data)
+}
+
+func temporaryLeftovers(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", dir, err)
+	}
+	var leftovers []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".asc-tmp-") {
+			leftovers = append(leftovers, entry.Name())
+		}
+	}
+	return leftovers
+}
+
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return
+	}
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skip("symlink creation is not permitted on this host")
+	}
+}

--- a/internal/secureopen/secure_open_other.go
+++ b/internal/secureopen/secure_open_other.go
@@ -14,6 +14,16 @@ func OpenNewFileNoFollow(path string, perm os.FileMode) (*os.File, error) {
 	})
 }
 
+// OpenAppendNoFollow opens a file for appending using best-effort symlink
+// checks because a portable O_NOFOLLOW equivalent is not available on this
+// platform.
+func OpenAppendNoFollow(path string, perm os.FileMode) (*os.File, error) {
+	return openNewFileNoFollowBestEffort(path, perm, func(path string, perm os.FileMode) (*os.File, error) {
+		flags := os.O_WRONLY | os.O_APPEND | os.O_CREATE
+		return os.OpenFile(path, flags, perm)
+	})
+}
+
 // OpenExistingNoFollow opens an existing file with best-effort symlink checks.
 // The validation/open sequence reduces, but does not eliminate, TOCTOU risk.
 func OpenExistingNoFollow(path string) (*os.File, error) {

--- a/internal/secureopen/secure_open_unix.go
+++ b/internal/secureopen/secure_open_unix.go
@@ -15,6 +15,13 @@ func OpenNewFileNoFollow(path string, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(path, flags, perm)
 }
 
+// OpenAppendNoFollow opens a file for appending without following symlinks,
+// creating it when it does not exist.
+func OpenAppendNoFollow(path string, perm os.FileMode) (*os.File, error) {
+	flags := os.O_WRONLY | os.O_APPEND | os.O_CREATE | unix.O_NOFOLLOW
+	return os.OpenFile(path, flags, perm)
+}
+
 // OpenExistingNoFollow opens an existing file without following symlinks.
 func OpenExistingNoFollow(path string) (*os.File, error) {
 	// O_NONBLOCK prevents hanging when opening FIFOs/devices in untrusted paths.

--- a/internal/secureopen/temp.go
+++ b/internal/secureopen/temp.go
@@ -1,0 +1,45 @@
+package secureopen
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CreateTempNoFollow creates a new temporary file in dir using an unpredictable
+// name derived from crypto/rand, an exclusive create, and no-follow semantics.
+//
+// The pattern follows os.CreateTemp semantics: the last "*" is replaced with
+// random text, or random text is appended when the pattern has no "*".
+func CreateTempNoFollow(dir string, pattern string, perm os.FileMode) (*os.File, error) {
+	prefix := pattern
+	suffix := ""
+	if idx := strings.LastIndex(pattern, "*"); idx != -1 {
+		prefix = pattern[:idx]
+		suffix = pattern[idx+1:]
+	}
+
+	const maxAttempts = 10_000
+	var randBytes [12]byte
+	for range maxAttempts {
+		if _, err := rand.Read(randBytes[:]); err != nil {
+			return nil, err
+		}
+
+		name := prefix + hex.EncodeToString(randBytes[:]) + suffix
+		file, err := OpenNewFileNoFollow(filepath.Join(dir, name), perm)
+		if err == nil {
+			return file, nil
+		}
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return nil, err
+	}
+
+	return nil, fmt.Errorf("failed to create temporary file in %q", dir)
+}

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -62,6 +62,9 @@ type SetVersionOptions struct {
 	Configuration string
 	Version       string
 	BuildNumber   string
+	// AllowExternalXCConfig authorizes rewriting xcconfig files that the project
+	// references outside its own directory. Without it, such a mutation fails.
+	AllowExternalXCConfig bool
 }
 
 // VersionChange describes one concrete build-setting mutation.
@@ -93,6 +96,9 @@ type BumpVersionOptions struct {
 	Configuration string
 	BumpType      BumpType
 	BuildNumber   string
+	// AllowExternalXCConfig authorizes rewriting xcconfig files that the project
+	// references outside its own directory. Without it, such a mutation fails.
+	AllowExternalXCConfig bool
 }
 
 // BumpVersionResult holds the result of a bump operation.
@@ -382,9 +388,10 @@ func (project *structuredVersionProject) prepareBump(opts BumpVersionOptions) (*
 		Configuration: strings.TrimSpace(opts.Configuration),
 	}
 	setOptions := SetVersionOptions{
-		ProjectDir:    opts.ProjectDir,
-		Target:        opts.Target,
-		Configuration: opts.Configuration,
+		ProjectDir:            opts.ProjectDir,
+		Target:                opts.Target,
+		Configuration:         opts.Configuration,
+		AllowExternalXCConfig: opts.AllowExternalXCConfig,
 	}
 	if opts.BumpType == BumpBuild {
 		currentBuild, err := project.bumpBaseline(opts, currentProjectSetting, true)

--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -848,13 +848,24 @@ func (project *structuredVersionProject) checkXCConfigWritable(path string, allo
 	}
 	if err := root.AllowingInternalSymlinks().CheckContained(path); err != nil {
 		if errors.Is(err, rootfs.ErrSymlink) {
-			// The write path refuses symlinked xcconfig files even when
-			// --allow-external-xcconfig is set, so do not present the flag as a
-			// remedy here.
+			if info, lstatErr := os.Lstat(path); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+				// The write path refuses a symlinked final component even when
+				// --allow-external-xcconfig is set, so do not present the flag
+				// as a remedy here.
+				return fmt.Errorf(
+					"refusing to modify xcconfig %s through a symlink: %w; "+
+						"replace the symlink with a regular file",
+					path,
+					err,
+				)
+			}
+			// A symlinked parent directory that resolves outside the project is
+			// supported once the operator authorizes external rewrites.
 			return fmt.Errorf(
-				"refusing to modify xcconfig %s through a symlink: %w; "+
-					"replace the symlink with a regular file",
+				"refusing to modify xcconfig %s reached through a symlinked directory that resolves outside project directory %s: %w; "+
+					"move the file inside the project or rerun with --allow-external-xcconfig",
 				path,
+				project.rootDir,
 				err,
 			)
 		}

--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 const (
@@ -777,6 +779,18 @@ func (project *structuredVersionProject) validateSetVersion(opts SetVersionOptio
 			if !mutable {
 				return nil, fmt.Errorf("%s not found for target %q configuration %q", requested.name, configuration.target, configuration.name)
 			}
+			if err := project.validateXCConfigMutationTargets(
+				configuration,
+				requested.name,
+				configFiles,
+				fileConsumers,
+				fileIdentities,
+				selectedIDs,
+				uncertainXCConfigConsumers,
+				opts.AllowExternalXCConfig,
+			); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return &setVersionValidation{
@@ -787,6 +801,61 @@ func (project *structuredVersionProject) validateSetVersion(opts SetVersionOptio
 		configFiles:                configFiles,
 		uncertainXCConfigConsumers: uncertainXCConfigConsumers,
 	}, nil
+}
+
+// validateXCConfigMutationTargets refuses to rewrite an xcconfig file the project
+// references outside its own directory unless the operator authorized it. The
+// check runs during validation so it fails before any local mutation or remote
+// build-number lookup.
+func (project *structuredVersionProject) validateXCConfigMutationTargets(
+	configuration *versionConfiguration,
+	setting string,
+	configFiles map[string][]string,
+	fileConsumers map[string]map[string]bool,
+	fileIdentities map[string]string,
+	selectedIDs map[string]bool,
+	uncertainXCConfigConsumers bool,
+	allowExternal bool,
+) error {
+	if len(matchingBuildSettingKeys(configuration.buildSettings, setting)) > 0 {
+		return nil
+	}
+	assignmentFiles, err := xcconfigFilesDefining(configFiles[configuration.id], setting)
+	if err != nil {
+		return err
+	}
+	if len(assignmentFiles) == 0 {
+		return nil
+	}
+	if uncertainXCConfigConsumers || !consumersSelected(assignmentFiles, fileConsumers, fileIdentities, selectedIDs) {
+		return nil
+	}
+	for _, path := range assignmentFiles {
+		if err := project.checkXCConfigWritable(path, allowExternal); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (project *structuredVersionProject) checkXCConfigWritable(path string, allowExternal bool) error {
+	if allowExternal {
+		return nil
+	}
+	root, err := rootfs.New(project.rootDir)
+	if err != nil {
+		return err
+	}
+	if err := root.AllowingInternalSymlinks().CheckContained(path); err != nil {
+		return fmt.Errorf(
+			"refusing to modify xcconfig %s outside project directory %s: %w; "+
+				"move the file inside the project or rerun with --allow-external-xcconfig",
+			path,
+			project.rootDir,
+			err,
+		)
+	}
+	return nil
 }
 
 func (project *structuredVersionProject) setVersion(opts SetVersionOptions) (*SetVersionResult, error) {
@@ -908,6 +977,9 @@ func (project *structuredVersionProject) setVersion(opts SetVersionOptions) (*Se
 	}
 	sort.Strings(xcconfigPaths)
 	for _, path := range xcconfigPaths {
+		if err := project.checkXCConfigWritable(path, opts.AllowExternalXCConfig); err != nil {
+			return nil, err
+		}
 		write, fileChanges, changed, err := prepareXCConfigWrite(path, xcconfigMutations[path])
 		if err != nil {
 			return nil, err

--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -847,6 +847,14 @@ func (project *structuredVersionProject) checkXCConfigWritable(path string, allo
 		return err
 	}
 	if err := root.AllowingInternalSymlinks().CheckContained(path); err != nil {
+		if errors.Is(err, rootfs.ErrSymlink) {
+			return fmt.Errorf(
+				"refusing to modify xcconfig %s through a symlink: %w; "+
+					"replace the symlink with a regular file or rerun with --allow-external-xcconfig",
+				path,
+				err,
+			)
+		}
 		return fmt.Errorf(
 			"refusing to modify xcconfig %s outside project directory %s: %w; "+
 				"move the file inside the project or rerun with --allow-external-xcconfig",

--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -848,9 +848,12 @@ func (project *structuredVersionProject) checkXCConfigWritable(path string, allo
 	}
 	if err := root.AllowingInternalSymlinks().CheckContained(path); err != nil {
 		if errors.Is(err, rootfs.ErrSymlink) {
+			// The write path refuses symlinked xcconfig files even when
+			// --allow-external-xcconfig is set, so do not present the flag as a
+			// remedy here.
 			return fmt.Errorf(
 				"refusing to modify xcconfig %s through a symlink: %w; "+
-					"replace the symlink with a regular file or rerun with --allow-external-xcconfig",
+					"replace the symlink with a regular file",
 				path,
 				err,
 			)

--- a/internal/xcode/version_xcconfig_containment_test.go
+++ b/internal/xcode/version_xcconfig_containment_test.go
@@ -158,6 +158,11 @@ func TestSetVersionReportsSymlinkedXCConfigAsSymlinkRejection(t *testing.T) {
 	if strings.Contains(err.Error(), "outside project directory") {
 		t.Fatalf("SetVersion() error = %v, want the symlink-specific message, not the containment one", err)
 	}
+	// The write path rejects symlinked xcconfig files even when authorized, so
+	// the error must not present --allow-external-xcconfig as a remedy.
+	if strings.Contains(err.Error(), "--allow-external-xcconfig") {
+		t.Fatalf("SetVersion() error = %v, want no --allow-external-xcconfig guidance for symlinks", err)
+	}
 	if after := mustReadVersionTestFile(t, externalPath); after != before {
 		t.Fatal("symlink target was rewritten despite the rejection")
 	}

--- a/internal/xcode/version_xcconfig_containment_test.go
+++ b/internal/xcode/version_xcconfig_containment_test.go
@@ -125,6 +125,44 @@ func TestSetVersionAllowsExternalXCConfigWhenAuthorized(t *testing.T) {
 	}
 }
 
+func TestSetVersionReportsSymlinkedXCConfigAsSymlinkRejection(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, true)
+	projectRoot := filepath.Dir(projectPath)
+	sharedPath := filepath.Join(projectRoot, "Configs", "Shared.xcconfig")
+
+	externalDir := t.TempDir()
+	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
+	data := mustReadVersionTestFile(t, sharedPath)
+	if err := os.WriteFile(externalPath, []byte(data), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Remove(sharedPath); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if err := os.Symlink(externalPath, sharedPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	before := mustReadVersionTestFile(t, externalPath)
+
+	_, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:  projectPath,
+		Version:     "2.0.0",
+		BuildNumber: "99",
+	})
+	if err == nil {
+		t.Fatal("SetVersion() error = nil, want symlinked xcconfig rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("SetVersion() error = %v, want symlink rejection", err)
+	}
+	if strings.Contains(err.Error(), "outside project directory") {
+		t.Fatalf("SetVersion() error = %v, want the symlink-specific message, not the containment one", err)
+	}
+	if after := mustReadVersionTestFile(t, externalPath); after != before {
+		t.Fatal("symlink target was rewritten despite the rejection")
+	}
+}
+
 func TestSetVersionStillEditsXCConfigInsideProjectRoot(t *testing.T) {
 	projectPath := writeStructuredVersionProject(t, true)
 	sharedPath := filepath.Join(filepath.Dir(projectPath), "Configs", "Shared.xcconfig")

--- a/internal/xcode/version_xcconfig_containment_test.go
+++ b/internal/xcode/version_xcconfig_containment_test.go
@@ -1,0 +1,146 @@
+package xcode
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// externalXCConfigProject builds an xcconfig-backed project whose base
+// configuration reference points at a directory outside the project root.
+func externalXCConfigProject(t *testing.T) (projectPath string, externalDir string) {
+	t.Helper()
+
+	projectPath = writeStructuredVersionProject(t, true)
+	projectRoot := filepath.Dir(projectPath)
+	externalDir = t.TempDir()
+
+	for _, name := range []string{"App.xcconfig", "Shared.xcconfig"} {
+		source := filepath.Join(projectRoot, "Configs", name)
+		data := mustReadVersionTestFile(t, source)
+		if err := os.WriteFile(filepath.Join(externalDir, name), []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+		if err := os.Remove(source); err != nil {
+			t.Fatalf("Remove(%s) error = %v", name, err)
+		}
+	}
+
+	pbxprojPath := filepath.Join(projectPath, "project.pbxproj")
+	contents := mustReadVersionTestFile(t, pbxprojPath)
+	old := "path = Configs/App.xcconfig; sourceTree = SOURCE_ROOT;"
+	if count := strings.Count(contents, old); count != 1 {
+		t.Fatalf("expected one App.xcconfig reference, found %d", count)
+	}
+	contents = strings.Replace(contents, old,
+		`path = "`+filepath.Join(externalDir, "App.xcconfig")+`"; sourceTree = "<absolute>";`, 1)
+	if err := os.WriteFile(pbxprojPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(project) error = %v", err)
+	}
+
+	return projectPath, externalDir
+}
+
+func TestSetVersionRefusesExternalXCConfigByDefault(t *testing.T) {
+	projectPath, externalDir := externalXCConfigProject(t)
+	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
+	before := mustReadVersionTestFile(t, externalPath)
+
+	_, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:  projectPath,
+		Version:     "2.0.0",
+		BuildNumber: "99",
+	})
+	if err == nil {
+		t.Fatal("SetVersion() error = nil, want external xcconfig rejection")
+	}
+	if !strings.Contains(err.Error(), "--allow-external-xcconfig") {
+		t.Fatalf("SetVersion() error = %v, want migration guidance naming --allow-external-xcconfig", err)
+	}
+	if after := mustReadVersionTestFile(t, externalPath); after != before {
+		t.Fatal("external xcconfig was rewritten despite the rejection")
+	}
+}
+
+func TestValidateSetVersionRefusesExternalXCConfigByDefault(t *testing.T) {
+	projectPath, externalDir := externalXCConfigProject(t)
+	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
+	before := mustReadVersionTestFile(t, externalPath)
+
+	err := ValidateSetVersion(SetVersionOptions{
+		ProjectDir:  projectPath,
+		BuildNumber: "1",
+	})
+	if err == nil {
+		t.Fatal("ValidateSetVersion() error = nil, want external xcconfig rejection")
+	}
+	if !strings.Contains(err.Error(), "--allow-external-xcconfig") {
+		t.Fatalf("ValidateSetVersion() error = %v, want migration guidance", err)
+	}
+	if after := mustReadVersionTestFile(t, externalPath); after != before {
+		t.Fatal("external xcconfig changed during validation")
+	}
+}
+
+func TestBumpVersionRefusesExternalXCConfigByDefault(t *testing.T) {
+	projectPath, externalDir := externalXCConfigProject(t)
+	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
+	before := mustReadVersionTestFile(t, externalPath)
+
+	_, err := BumpVersion(context.Background(), BumpVersionOptions{
+		ProjectDir: projectPath,
+		BumpType:   BumpPatch,
+	})
+	if err == nil {
+		t.Fatal("BumpVersion() error = nil, want external xcconfig rejection")
+	}
+	if !strings.Contains(err.Error(), "--allow-external-xcconfig") {
+		t.Fatalf("BumpVersion() error = %v, want migration guidance", err)
+	}
+	if after := mustReadVersionTestFile(t, externalPath); after != before {
+		t.Fatal("external xcconfig was rewritten despite the rejection")
+	}
+}
+
+func TestSetVersionAllowsExternalXCConfigWhenAuthorized(t *testing.T) {
+	projectPath, externalDir := externalXCConfigProject(t)
+	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
+
+	result, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:            projectPath,
+		Version:               "2.0.0",
+		BuildNumber:           "99",
+		AllowExternalXCConfig: true,
+	})
+	if err != nil {
+		t.Fatalf("SetVersion() error = %v", err)
+	}
+	if len(result.ChangedFiles) == 0 {
+		t.Fatalf("SetVersion() result = %#v, want changed files", result)
+	}
+	if after := mustReadVersionTestFile(t, externalPath); !strings.Contains(after, "MARKETING_VERSION = 2.0.0") {
+		t.Fatalf("external xcconfig content = %q, want authorized update", after)
+	}
+}
+
+func TestSetVersionStillEditsXCConfigInsideProjectRoot(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, true)
+	sharedPath := filepath.Join(filepath.Dir(projectPath), "Configs", "Shared.xcconfig")
+
+	result, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:  projectPath,
+		Version:     "2.0.0",
+		BuildNumber: "99",
+	})
+	if err != nil {
+		t.Fatalf("SetVersion() error = %v", err)
+	}
+	if len(result.ChangedFiles) == 0 {
+		t.Fatalf("SetVersion() result = %#v, want changed files", result)
+	}
+	if after := mustReadVersionTestFile(t, sharedPath); !strings.Contains(after, "MARKETING_VERSION = 2.0.0") {
+		t.Fatalf("in-root xcconfig content = %q, want update", after)
+	}
+}

--- a/internal/xcode/version_xcconfig_containment_test.go
+++ b/internal/xcode/version_xcconfig_containment_test.go
@@ -168,6 +168,52 @@ func TestSetVersionReportsSymlinkedXCConfigAsSymlinkRejection(t *testing.T) {
 	}
 }
 
+func TestSetVersionAdvisesOverrideForEscapingSymlinkedXCConfigParent(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, true)
+	projectRoot := filepath.Dir(projectPath)
+	configsDir := filepath.Join(projectRoot, "Configs")
+	externalDir := filepath.Join(t.TempDir(), "Configs")
+	if err := os.Rename(configsDir, externalDir); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+	if err := os.Symlink(externalDir, configsDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:  projectPath,
+		Version:     "2.0.0",
+		BuildNumber: "99",
+	})
+	if err == nil {
+		t.Fatal("SetVersion() error = nil, want escaping symlinked parent rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("SetVersion() error = %v, want symlink rejection", err)
+	}
+	// The write path only refuses a symlinked final component, so the override
+	// flag is a supported recovery for a symlinked parent and must be offered.
+	if !strings.Contains(err.Error(), "--allow-external-xcconfig") {
+		t.Fatalf("SetVersion() error = %v, want --allow-external-xcconfig guidance", err)
+	}
+
+	result, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:            projectPath,
+		Version:               "2.0.0",
+		BuildNumber:           "99",
+		AllowExternalXCConfig: true,
+	})
+	if err != nil {
+		t.Fatalf("SetVersion() authorized error = %v", err)
+	}
+	if len(result.ChangedFiles) == 0 {
+		t.Fatalf("SetVersion() result = %#v, want changed files", result)
+	}
+	if after := mustReadVersionTestFile(t, filepath.Join(externalDir, "Shared.xcconfig")); !strings.Contains(after, "MARKETING_VERSION = 2.0.0") {
+		t.Fatalf("xcconfig content = %q, want authorized update through the symlinked parent", after)
+	}
+}
+
 func TestSetVersionStillEditsXCConfigInsideProjectRoot(t *testing.T) {
 	projectPath := writeStructuredVersionProject(t, true)
 	sharedPath := filepath.Join(filepath.Dir(projectPath), "Configs", "Shared.xcconfig")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the 15 path-containment defects as one coherent rooted-filesystem change rather than 15 ad hoc patches.

New shared package `internal/rootfs` anchors every repository- or API-controlled path to a trusted root chosen per operation. It rejects absolute paths, drive-relative and UNC-style paths, volume changes, and `..` traversal lexically (using both Unix and Windows separator conventions, so a Windows-shaped payload is refused on Linux too), refuses to follow symlinks for components below the root, and stages writes through unpredictable, exclusive, no-follow temporary files. It builds on the existing `internal/secureopen` primitives, to which this adds `CreateTempNoFollow` (now also used by the existing `shared` and `config` atomic writers, removing two copies of the same loop) and `OpenAppendNoFollow`.

Operator-selected roots may live outside the repository; only paths *below* the root are constrained, so explicit external `--out-dir`, `--checkpoint-file`, `--private-key-dir`, and `--out` locations keep working.

## Trusted root per operation

| Flow | Trusted root |
| --- | --- |
| `release run` / `release stage` checkpoints | working directory for in-tree checkpoints (covers the default `.asc/release/checkpoints` path, whose components are repository-controlled); the checkpoint's own parent for an operator-selected external path |
| `docs init` / `metadata init` | output directory for `ASC.md`, resolved link root for `AGENTS.md`/`Agents.md`/`CLAUDE.md` |
| `migrate import` | resolved metadata directory |
| `migrate export` | `--output-dir` |
| `auth export-to-config` | resolved private-key directory |
| `web review show` attachments | resolved `--out` directory |
| `web privacy pull` / `plan` / `apply` | parent of the selected declaration path |
| `snitch --local` / `snitch flush` | working directory (validates the `.asc` component) |
| `xcode inject` | manifest project root: enclosing repository, else the parent of a dot-directory manifest location such as `.asc`, else the manifest directory |
| `xcode version edit` / `bump` | project directory (directory containing the `.xcodeproj`) |

## Fixes per reported defect

**Redirected writes/appends**

- `csf_d2d3382d0591dd7f12a51143` — checkpoints staged through a predictable `<path>.tmp`; a pre-created symlink there received the checkpoint JSON. Now written via a random exclusive no-follow temp file; loads no longer follow a symlinked checkpoint.
- `csf_09bb39b479e151d21e11bdda` — attachment downloads used `os.WriteFile` after a lexical-only check. Now rooted, refusing symlinked destinations and symlinked directories inside the output tree.
- `csf_6042db0e537c2ab073da4238` — the exported `.p8` filename embedded an unsanitized keychain key ID, and `os.MkdirAll` followed symlinked parents. The key ID is now sanitized like the profile name, and the write is rooted at the key directory.
- `csf_07b710d4b01c4a7d611924f5` — `migrate export` created locale directories and wrote metadata files through pre-existing symlinks. Now rooted at `--output-dir`, with API-supplied locales validated as single relative components.
- `csf_86363fd5c5b03c15b25d8e3d`, `csf_f4b6ac6c8ff71d86e9e1ea8e`, `csf_e99f3ea19b6a44914aa46ec3` — `docs init` wrote `ASC.md` and rewrote the agent files through symlinks. Existence is now detected with `Lstat` so a dangling symlink is never followed, and updates are rooted.
- `csf_c37e6ad0b94eaa61ed24bb86` — `web privacy pull --out` followed a symlinked output path. Now rooted at the path's parent.
- `csf_261a0d6e872c9e3dfaae9450` — `snitch --local` appended through a following open and then chmodded the opened path. It now refuses a symlinked `.asc` component or `snitch.log` and only tightens permissions on the descriptor it opened, so it can never chmod an external file.

**Redirected reads/publication**

- `csf_ad74ebae8e4998d87871221d`, `csf_a8b6b9a6605ba6dc47eed4ce`, `csf_0bfcf868e00aafab970ba25c` — `migrate import` read locale metadata, app-info metadata, and review information with symlink-following reads, so local secrets could be published as App Store metadata. Reads are now rooted and surface errors (the old helper swallowed every failure), symlinked metadata entries are reported as skipped, and rejection happens before any App Store Connect request.
- `csf_3811daf46707ba802b3adb69` — `xcode inject` copy sources could be absolute, parent-traversing, or symlinked outside the tree. Now resolved and read through the manifest root.

**Paths escaping intended roots**

- `csf_3772d2be946a212063845da8` — inject output paths are resolved from the manifest directory but must land inside the manifest project root.
- `csf_35eaf96ad623b6b368405579` — `xcode version edit`/`bump` rewrote any referenced `.xcconfig`, including files outside the project. This now fails closed during validation (before any local write or remote build-number lookup) unless the operator passes the new long-form `--allow-external-xcconfig`, which prints a warning to stderr.

## Compatibility

- New flag `--allow-external-xcconfig` on `asc xcode version edit` and `asc xcode version bump`; help text updated for both plus `asc xcode inject`. `docs/COMMANDS.md` regenerated (no content change — it lists top-level commands only).
- Intentional tightening: symlinked fastlane metadata files, manifest paths that leave the manifest project root, and unauthorized external `.xcconfig` mutation now fail with actionable guidance instead of silently succeeding.
- Preserved: symlinked directories *inside* the inject manifest root remain supported (a common asset-catalog layout) via `Root.AllowingInternalSymlinks`, which relaxes only the parent-component rule and still refuses a symlinked final component and any symlink resolving outside the root. `TestXcodeInjectAllowsDirectorySymlinkParent` still passes unchanged.
- `migrate` helpers `readFastlaneMetadataFromLocaleDirs`, `readFastlaneAppInfoMetadataFromLocaleDirs`, and `writeAndCount` now return errors; `readFileIfExists` was replaced by the rooted `readMetadataFile`. These are package-internal.

## Verification

RED-first for every case: each test was written and observed failing for the expected reason before the fix. Examples of the recorded RED output:

- Release checkpoint: `sentinel content = "{\n  \"appId\": \"123\"...}", want "original"` — the sentinel outside the checkpoint directory actually received the checkpoint JSON through the predictable `.tmp` symlink.
- `migrate`, `docs`, `snitch`, `web`, `auth`, `xcode inject`: `error = nil, want symlink rejection` / `want traversal rejection`.
- External `.xcconfig`: verified RED by temporarily short-circuiting `checkXCConfigWritable`, which reproduced `SetVersion() error = nil, want external xcconfig rejection` for set, validate, and bump.

Every rejection test asserts the external sentinel's content (and, for `snitch`, its mode) is unchanged, that no escaped output exists, and — for `migrate import` — that zero HTTP requests were made. Each area also has a positive test that ordinary in-root reads, writes, overwrites, and appends still work.

New tests: `internal/rootfs/rootfs_test.go` (validation incl. portable Windows drive/UNC/backslash cases, rooted reads, `MkdirAll`, atomic write/replace, append, internal-symlink policy), `internal/cli/release/checkpoint_containment_test.go`, `internal/cli/docs/docs_init_containment_test.go`, `internal/cli/migrate/containment_test.go`, `internal/cli/cmdtest/migrate_import_containment_test.go`, `internal/auth/private_key_export_containment_test.go`, `internal/cli/web/web_containment_test.go`, `internal/cli/snitch/snitch_containment_test.go`, `internal/cli/xcode/inject_containment_test.go`, `internal/xcode/version_xcconfig_containment_test.go`.

Repository gate, all passing:

```
make format          # gofumpt/go fmt clean
make check-docs      # command docs, repo docs, 80 website pages, 7 agent skills, OpenAPI index
make lint            # golangci-lint v2.12.1: 0 issues
ASC_BYPASS_KEYCHAIN=1 make test   # full suite green, no pre-existing failures
GOOS=windows go vet ./... && GOOS=darwin go vet ./...   # clean
```

Black-box verification against a `/tmp/asc` build (`ASC_BYPASS_KEYCHAIN=1`), abbreviated:

```
$ asc snitch --local "friction report"      # .asc/snitch.log -> external sentinel
exit=1  Error: snitch: failed to append to .asc/snitch.log: refusing to follow symlink: ".../.asc/snitch.log"
sentinel unchanged, mode unchanged
$ asc snitch --local "friction report"      # ordinary log
exit=0  Friction logged to .asc/snitch.log   (-rw-------), asc snitch flush reads it back

$ asc docs init                              # AGENTS.md -> external sentinel
exit=1  Error: docs init: refusing to follow symlink: ".../AGENTS.md"
$ asc docs init                              # ordinary repo
exit=0  {"path":".../ASC.md","created":true,"linked":[".../AGENTS.md",".../CLAUDE.md"]}

$ asc xcode inject --manifest .asc/deployment.json   # absolute output path
exit=1  Error: xcode inject: output 1: path escapes trusted root: "/tmp/.../escaped.txt" ...
$ asc xcode inject --manifest .asc/deployment.json   # escaping copy source, escaping symlinked parent
exit=1 for both; no file created outside the root
$ asc xcode inject --manifest .asc/deployment.json --output table  # valid ../Generated outputs
exit=0  text/written + copy/copied
```

No live Apple mutation was required or performed.

## Risks and limitations

- On platforms without `O_NOFOLLOW`, `secureopen` falls back to the pre-existing best-effort validate/open/verify sequence, which shrinks but cannot eliminate the TOCTOU window.
- `AllowingInternalSymlinks` resolves a symlinked parent and then writes to the logical path, so a contained symlink retargeted between the check and the write remains theoretically racy; the final component is still opened no-follow.
- The inject project-root rule is heuristic (repository root, dot-directory parent, or manifest directory). It keeps the documented `.asc/deployment.json` plus `../Generated/...` layout working, but a manifest in a non-dot subdirectory of a non-repository tree that writes to a sibling directory now needs the manifest moved.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92e17e87-295b-4b73-be32-11f2ecc57ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92e17e87-295b-4b73-be32-11f2ecc57ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787898477&installation_model_id=10418&pr_number=1830&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1830&signature=92cb978cd6e2050cc231bf054644ddfcc73a8f1f275ff06263066315d7caad7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--allow-external-xcconfig` to Xcode version edit and bump, with a warning that external `.xcconfig` files may be rewritten.
* **Bug Fixes**
  * Significantly hardened filesystem safety across migrations, docs initialization, checkpoint save/load, local log handling, web downloads, privacy declarations, Xcode injection/version updates, and private-key exports—blocking path traversal and symlink escape, tightening sensitive file permissions, and preventing partial writes when validation fails.
* **Tests**
  * Added extensive containment/security tests covering symlink/path refusal, idempotency, permission enforcement, and “no writes on validation failure,” including new rootfs-based coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->