### PR TITLE
fix(security): close post-merge release blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,19 @@ Install them globally so they are available across projects:
 asc install-skills
 ```
 
-`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and the temporary directory lives under `/tmp` (outside any npm project, regardless of `TMPDIR`) with `npx` running from it, so a project `node_modules`, `package.json`, or `.npmrc` cannot shadow or redirect the pinned installer:
+`asc install-skills` checks out reviewed commit
+`e30039abddbe388179324d0f9cdccb66c3843115` and copies its 23 skills directly
+into the standard global agent-skills directory. It verifies the complete pack
+and every installed file before succeeding, preserves unrelated skills and
+unrelated lock entries, and pins the 23 ASC lock entries to the same reviewed
+commit so external checks cannot update them from a mutable branch. It rolls
+back the pack if any replacement fails. Only
+`git` is required; the command does not execute Node.js, `npx`, an npm package,
+or repository scripts.
 
 ```bash
-asc_skills="$(mktemp -d /tmp/asc-skills.XXXXXX)" &&
-  git init --quiet "$asc_skills/src" &&
-  git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
-  git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
-  git -C "$asc_skills/src" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
-  (cd "$asc_skills" && npx --yes skills@1.5.20 add "$asc_skills/src" --global --agent codex --yes) &&
-  rm -rf "$asc_skills"
+git --version
+asc install-skills
 ```
 
 ## Quick Start

--- a/cicd/github-actions.mdx
+++ b/cicd/github-actions.mdx
@@ -46,9 +46,10 @@ jobs:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+          ASC_APP_ID: ${{ secrets.APP_ID }}
         run: |
           asc builds upload \
-            --app "${{ secrets.APP_ID }}" \
+            --app "$ASC_APP_ID" \
             --ipa "MyApp.ipa"
 ```
 
@@ -176,10 +177,11 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
           ASC_APP_ID: ${{ secrets.APP_ID }}
+          VERSION: ${{ inputs.version }}
         run: |
           asc validate \
             --app "$ASC_APP_ID" \
-            --version "${{ inputs.version }}"
+            --version "$VERSION"
       
       - name: Publish to the App Store
         env:
@@ -187,18 +189,21 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
           ASC_APP_ID: ${{ secrets.APP_ID }}
+          VERSION: ${{ inputs.version }}
         run: |
           asc publish appstore \
             --app "$ASC_APP_ID" \
             --ipa "./build/MyApp.ipa" \
-            --version "${{ inputs.version }}" \
+            --version "$VERSION" \
             --submit \
             --confirm
       
       - name: Notify on success
         if: success()
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "::notice::Version ${{ inputs.version }} submitted successfully"
+          echo "::notice::Version $VERSION submitted successfully"
 ```
 
 ### Metadata Sync
@@ -331,13 +336,16 @@ jobs:
         uses: rudrankriyam/setup-asc@v1
       
       - name: Build ${{ matrix.app.name }}
+        env:
+          APP_NAME: ${{ matrix.app.name }}
+          APP_SCHEME: ${{ matrix.app.scheme }}
         run: |
-          xcodebuild -scheme ${{ matrix.app.scheme }} \
-            -archivePath build/${{ matrix.app.name }}.xcarchive \
+          xcodebuild -scheme "$APP_SCHEME" \
+            -archivePath "build/$APP_NAME.xcarchive" \
             archive
           
           xcodebuild -exportArchive \
-            -archivePath build/${{ matrix.app.name }}.xcarchive \
+            -archivePath "build/$APP_NAME.xcarchive" \
             -exportPath build \
             -exportOptionsPlist ExportOptions.plist
       
@@ -346,10 +354,12 @@ jobs:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+          APP_ID: ${{ matrix.app.id }}
+          APP_NAME: ${{ matrix.app.name }}
         run: |
           asc builds upload \
-            --app "${{ matrix.app.id }}" \
-            --ipa build/${{ matrix.app.name }}.ipa
+            --app "$APP_ID" \
+            --ipa "build/$APP_NAME.ipa"
 ```
 
 ## Authentication Setup
@@ -384,8 +394,10 @@ If you prefer not to use base64 encoding:
 ```yaml  theme={null}
 steps:
   - name: Write private key
+    env:
+      ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
     run: |
-      echo "${{ secrets.ASC_PRIVATE_KEY }}" > /tmp/AuthKey.p8
+      printf '%s' "$ASC_PRIVATE_KEY" > /tmp/AuthKey.p8
       chmod 600 /tmp/AuthKey.p8
   
   - name: Run asc command

--- a/cmd/age_rating_run_test.go
+++ b/cmd/age_rating_run_test.go
@@ -40,7 +40,7 @@ func TestRun_AgeRatingSetAllNoneFalseReturnsUsage(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "unexpected argument(s): false") {
-		t.Fatalf("expected unexpected argument error, got %q", stderr)
+	if !strings.Contains(stderr, "at least one update flag is required") {
+		t.Fatalf("expected no-update usage error, got %q", stderr)
 	}
 }

--- a/cmd/boolean_args_test.go
+++ b/cmd/boolean_args_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"flag"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+func TestNormalizeSpacedBooleanFlags(t *testing.T) {
+	root := &ffcli.Command{
+		Name:    "asc",
+		FlagSet: flag.NewFlagSet("asc", flag.ContinueOnError),
+	}
+	commandFlags := flag.NewFlagSet("import", flag.ContinueOnError)
+	commandFlags.Bool("confirm", false, "")
+	commandFlags.Bool("dry-run", false, "")
+	commandFlags.Bool("continue-on-error", true, "")
+	commandFlags.String("input", "", "")
+	importCommand := &ffcli.Command{
+		Name:    "import",
+		FlagSet: commandFlags,
+	}
+	stringSiblingFlags := flag.NewFlagSet("push", flag.ContinueOnError)
+	stringSiblingFlags.String("continue-on-error", "", "")
+	root.Subcommands = []*ffcli.Command{
+		importCommand,
+		{Name: "push", FlagSet: stringSiblingFlags},
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "explicit false before another flag",
+			args: []string{"import", "--confirm", "false", "--dry-run"},
+			want: []string{"import", "--confirm=false", "--dry-run"},
+		},
+		{
+			name: "all boolean flags are normalized",
+			args: []string{"import", "--confirm", "--continue-on-error", "false", "--dry-run", "true"},
+			want: []string{"import", "--confirm", "--continue-on-error=false", "--dry-run=true"},
+		},
+		{
+			name: "non-boolean values are untouched",
+			args: []string{"import", "--input", "false", "--confirm"},
+			want: []string{"import", "--input", "false", "--confirm"},
+		},
+		{
+			name: "equals syntax is untouched",
+			args: []string{"import", "--confirm=false", "--dry-run=true"},
+			want: []string{"import", "--confirm=false", "--dry-run=true"},
+		},
+		{
+			name: "positional boolean is untouched",
+			args: []string{"import", "false"},
+			want: []string{"import", "false"},
+		},
+		{
+			name: "mixed sibling flag kinds use active command",
+			args: []string{"import", "--continue-on-error", "false"},
+			want: []string{"import", "--continue-on-error=false"},
+		},
+		{
+			name: "flag terminator stops normalization",
+			args: []string{"import", "--", "--confirm", "false"},
+			want: []string{"import", "--", "--confirm", "false"},
+		},
+		{
+			name: "flag-looking string value is untouched",
+			args: []string{"import", "--input", "--confirm", "false"},
+			want: []string{"import", "--input", "--confirm", "false"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeSpacedBooleanFlags(root, test.args)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("normalizeSpacedBooleanFlags() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRunNormalizesSpacedBooleansOnActiveCommandPath(t *testing.T) {
+	resetReportFlags(t)
+	tests := [][]string{
+		{
+			"subscriptions", "offers", "introductory", "import",
+			"--confirm", "--continue-on-error", "false", "--help",
+		},
+		{
+			"migrate", "import",
+			"--confirm", "false", "--dry-run", "true", "--help",
+		},
+	}
+
+	for _, args := range tests {
+		_, stderr := captureCommandOutput(t, func() {
+			if code := Run(args, "1.0.0"); code != ExitSuccess {
+				t.Fatalf("Run(%v) exit code = %d, want success", args, code)
+			}
+		})
+		if !strings.Contains(stderr, "USAGE") {
+			t.Fatalf("Run(%v) stderr = %q, want command help", args, stderr)
+		}
+	}
+}
+
+func TestRunNormalizesSpacedRootBooleanBeforeLazyCommandDiscovery(t *testing.T) {
+	resetReportFlags(t)
+	_, stderr := captureCommandOutput(t, func() {
+		args := []string{"--version", "false", "builds", "list", "--help"}
+		if code := Run(args, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("Run(%v) exit code = %d, want success", args, code)
+		}
+	})
+	if !strings.Contains(stderr, "asc builds list") {
+		t.Fatalf("stderr = %q, want builds list help", stderr)
+	}
+}
+
+func TestRunVersionRootFlagNeverDispatchesTrailingCommand(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		args := []string{"--version", "true", "builds", "list"}
+		if code := Run(args, "9.8.7-test"); code != ExitSuccess {
+			t.Fatalf("Run(%v) exit code = %d, want success", args, code)
+		}
+	})
+	if stdout != "9.8.7-test\n" {
+		t.Fatalf("stdout = %q, want version only", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want no nested-command output", stderr)
+	}
+}

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -1000,7 +1000,7 @@ func TestWebAuthLoginPromptInterruptSkipsSkillsAutoCheck(t *testing.T) {
 	}
 }
 
-func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
+func TestSkillsAutoCheckIsDisabledEvenWhenEnvironmentOptsIn(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY timing regression requires a Unix shell")
 	}
@@ -1085,63 +1085,12 @@ func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
 		t.Fatalf("PTY stayed open after foreground exit\noutput:\n%s", output.String())
 	}
 
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if _, statErr := os.Stat(markerPath); statErr == nil {
-			break
-		} else if !os.IsNotExist(statErr) {
-			t.Fatalf("failed to stat skills marker: %v", statErr)
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("detached skills checker did not start")
-		}
-		time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
+	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("automatic skills checker ran despite being disabled: %v", statErr)
 	}
-
-	cachePath := filepath.Join(tmpDir, "skills-check.json")
-	lockPath := filepath.Join(tmpDir, "skills-check.lock")
-	deadline = time.Now().Add(3 * time.Second)
-	for {
-		_, cacheErr := os.Stat(cachePath)
-		_, lockErr := os.Stat(lockPath)
-		if cacheErr == nil && os.IsNotExist(lockErr) {
-			break
-		}
-		if cacheErr != nil && !os.IsNotExist(cacheErr) {
-			t.Fatalf("stat skills cache: %v", cacheErr)
-		}
-		if lockErr != nil && !os.IsNotExist(lockErr) {
-			t.Fatalf("stat skills worker lock: %v", lockErr)
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("detached worker did not finish cache publication (cache: %v, lock: %v)", cacheErr, lockErr)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	deadline = time.Now().Add(2 * time.Second)
-	for {
-		pidBytes, readErr := os.ReadFile(sleepPIDPath)
-		if readErr == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-			if parseErr != nil {
-				t.Fatalf("parse checker sleep PID: %v", parseErr)
-			}
-			process, findErr := os.FindProcess(pid)
-			if findErr != nil {
-				t.Fatalf("find checker sleep process: %v", findErr)
-			}
-			_ = process.Kill()
-			_ = os.Remove(sleepPIDPath)
-			break
-		}
-		if !os.IsNotExist(readErr) {
-			t.Fatalf("read checker sleep PID: %v", readErr)
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("checker did not record descendant PID")
-		}
-		time.Sleep(10 * time.Millisecond)
+	if _, statErr := os.Stat(sleepPIDPath); !os.IsNotExist(statErr) {
+		t.Fatalf("automatic skills checker spawned a descendant despite being disabled: %v", statErr)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,10 @@ func RootCommand(version string) *ffcli.Command {
 func rootCommandForArgs(version string, args []string) *ffcli.Command {
 	catalog := registry.NewCatalog(version)
 	root := newRootCommand(version, catalog.MetadataCommands())
-	commandName := getCommandName(root, args)
+	// Command discovery must understand the same liberal `--bool false` form
+	// as final parsing. Otherwise the separated value looks positional and the
+	// lazy catalog can materialize the wrong command tree.
+	commandName := getCommandName(root, normalizeSpacedBooleanFlags(root, args))
 	parts := strings.Fields(commandName)
 	if len(parts) < 2 {
 		return root

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,9 +31,6 @@ var (
 // Run executes the CLI using the provided args (not including argv[0]) and version string.
 // It returns the intended process exit code.
 func Run(args []string, versionInfo string) int {
-	if install.RunSkillsCheckWorkerIfRequested() {
-		return ExitSuccess
-	}
 	defer shared.CleanupTempPrivateKeys()
 
 	// Fast path for the most common version check invocation. This avoids
@@ -43,6 +41,7 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	root := rootCommandForArgs(versionInfo, args)
+	args = normalizeSpacedBooleanFlags(root, args)
 	analysis := analyzeInvocation(root, args)
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
@@ -73,13 +72,10 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	if versionRequested {
-		if err := root.Run(runCtx); err != nil {
-			if errors.Is(err, flag.ErrHelp) {
-				return ExitUsage
-			}
-			fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
-			return ExitCodeFromError(err)
-		}
+		// A root informational flag must never dispatch a trailing subcommand.
+		// Printing directly also keeps `asc --version true ...` as harmless as
+		// the conventional `asc --version` form.
+		fmt.Fprintln(os.Stdout, versionInfo)
 		return ExitSuccess
 	}
 
@@ -167,6 +163,70 @@ func Run(args []string, versionInfo string) int {
 		InvocationShape: analysis.shape,
 	})
 	return ExitSuccess
+}
+
+// normalizeSpacedBooleanFlags preserves the CLI's liberal support for both
+// `--flag=false` and `--flag false`. The standard flag package stops parsing at
+// the value after a bare bool flag, which can otherwise leave later safety
+// flags unparsed and make an explicit false behave as true.
+func normalizeSpacedBooleanFlags(root *ffcli.Command, args []string) []string {
+	command := root
+	normalized := make([]string, 0, len(args))
+	for index := 0; index < len(args); index++ {
+		token := args[index]
+		if token == "--" {
+			normalized = append(normalized, args[index:]...)
+			break
+		}
+		if !strings.HasPrefix(token, "-") || token == "-" {
+			if subcommand := findDirectSubcommand(command, token); subcommand != nil {
+				command = subcommand
+				normalized = append(normalized, token)
+				continue
+			}
+			normalized = append(normalized, args[index:]...)
+			break
+		}
+
+		name := strings.TrimLeft(strings.SplitN(token, "=", 2)[0], "-")
+		if command == nil || command.FlagSet == nil || name == "" {
+			normalized = append(normalized, token)
+			continue
+		}
+		item := command.FlagSet.Lookup(name)
+		if item == nil {
+			// Parsing will report the unknown flag. Do not reinterpret anything
+			// after the token that stops standard flag parsing.
+			normalized = append(normalized, args[index:]...)
+			break
+		}
+		if strings.ContainsRune(token, '=') {
+			normalized = append(normalized, token)
+			continue
+		}
+
+		boolFlag, isBool := item.Value.(interface{ IsBoolFlag() bool })
+		if isBool && boolFlag.IsBoolFlag() {
+			if index+1 < len(args) {
+				if value, err := strconv.ParseBool(strings.TrimSpace(args[index+1])); err == nil {
+					normalized = append(normalized, token+"="+strconv.FormatBool(value))
+					index++
+					continue
+				}
+			}
+			normalized = append(normalized, token)
+			continue
+		}
+
+		// A non-bool flag consumes its following value even when that value
+		// looks like another flag. Never normalize inside the value.
+		normalized = append(normalized, token)
+		if index+1 < len(args) {
+			index++
+			normalized = append(normalized, args[index])
+		}
+	}
+	return normalized
 }
 
 func printParseFailure(parseErr error, parseOutput string, analysis invocationAnalysis) {
@@ -267,16 +327,11 @@ func shouldCancelRunContextAfterError(err error) bool {
 }
 
 func shouldRunSkillsUpdateCheck(commandName string, runCtx context.Context, runErr error) bool {
-	if commandName == "asc" || commandName == "asc install-skills" || commandName == "asc version" {
-		return false
-	}
-	if runCtx != nil && runCtx.Err() != nil {
-		return false
-	}
-	if shouldCancelRunContextAfterError(runErr) {
-		return false
-	}
-	return true
+	// The external `skills check` command is not read-only: current releases
+	// route it through the updater and can rewrite globally installed skills.
+	// Keep automatic execution disabled until a reviewed, read-only protocol
+	// exists. Explicit `asc install-skills` remains available.
+	return false
 }
 
 func isVersionOnlyInvocation(args []string) bool {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -759,7 +759,7 @@ func TestRun_NoArgsShowsHelpReturnsSuccess(t *testing.T) {
 	}
 }
 
-func TestRun_InvokesSkillsUpdateCheckForSubcommand(t *testing.T) {
+func TestRun_DisablesAutomaticSkillsUpdateCheckForSubcommand(t *testing.T) {
 	resetReportFlags(t)
 
 	origCheck := maybeScheduleSkillsUpdateCheck
@@ -782,8 +782,8 @@ func TestRun_InvokesSkillsUpdateCheckForSubcommand(t *testing.T) {
 
 	select {
 	case <-called:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("expected skills update check to be invoked")
+		t.Fatal("automatic skills update check unexpectedly ran")
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -887,44 +887,22 @@ func TestShouldCancelRunContextAfterError(t *testing.T) {
 }
 
 func TestShouldRunSkillsUpdateCheck(t *testing.T) {
-	t.Run("runs for successful subcommand context", func(t *testing.T) {
-		if !shouldRunSkillsUpdateCheck("asc completion", context.Background(), nil) {
-			t.Fatal("expected skills update check to run for successful subcommand")
-		}
-	})
+	for _, commandName := range []string{"asc", "asc completion", "asc install-skills", "asc version"} {
+		t.Run(commandName, func(t *testing.T) {
+			if shouldRunSkillsUpdateCheck(commandName, context.Background(), nil) {
+				t.Fatal("automatic external skills check must remain disabled")
+			}
+		})
+	}
 
-	t.Run("skips for root command", func(t *testing.T) {
-		if shouldRunSkillsUpdateCheck("asc", context.Background(), nil) {
-			t.Fatal("expected skills update check to be skipped for root command")
-		}
-	})
-
-	t.Run("skips for install-skills command", func(t *testing.T) {
-		if shouldRunSkillsUpdateCheck("asc install-skills", context.Background(), nil) {
-			t.Fatal("expected skills update check to be skipped for install-skills command")
-		}
-	})
-
-	t.Run("skips for version command", func(t *testing.T) {
-		if shouldRunSkillsUpdateCheck("asc version", context.Background(), nil) {
-			t.Fatal("expected skills update check to be skipped for version command")
-		}
-	})
-
-	t.Run("skips when run context is already canceled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		if shouldRunSkillsUpdateCheck("asc web auth login", ctx, nil) {
-			t.Fatal("expected skills update check to be skipped for canceled run context")
-		}
-	})
-
-	t.Run("skips when run error indicates cancellation before context observes it", func(t *testing.T) {
-		if shouldRunSkillsUpdateCheck("asc web auth login", context.Background(), fmt.Errorf("prompt interrupted: %w", context.Canceled)) {
-			t.Fatal("expected skills update check to be skipped for canceled run error")
-		}
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if shouldRunSkillsUpdateCheck("asc web auth login", ctx, context.Canceled) {
+		t.Fatal("automatic external skills check must remain disabled")
+	}
+	if shouldRunSkillsUpdateCheck("asc web auth login", context.Background(), fmt.Errorf("boom")) {
+		t.Fatal("automatic external skills check must remain disabled")
+	}
 }
 
 func TestRun_HelpSkipsAuthResolution(t *testing.T) {

--- a/commands/metadata.mdx
+++ b/commands/metadata.mdx
@@ -332,9 +332,10 @@ jobs:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+          ASC_APP_ID: ${{ secrets.APP_ID }}
         run: |
           asc metadata push \
-            --app "${{ secrets.APP_ID }}" \
+            --app "$ASC_APP_ID" \
             --version "1.2.3" \
             --dir "./metadata"
 ```

--- a/commands/publish.mdx
+++ b/commands/publish.mdx
@@ -118,9 +118,11 @@ asc publish appstore \
 ```yaml  theme={null}
 # GitHub Actions
 - name: Publish to TestFlight
+  env:
+    ASC_APP_ID: ${{ secrets.APP_ID }}
   run: |
     asc publish testflight \
-      --app ${{ secrets.APP_ID }} \
+      --app "$ASC_APP_ID" \
       --ipa MyApp.ipa \
       --group "External Testers"
 ```

--- a/concepts/workflows.mdx
+++ b/concepts/workflows.mdx
@@ -441,11 +441,12 @@ Or on error:
 ```yaml  theme={null}
 # GitHub Actions example
 - name: Run workflow
-  run: asc workflow run beta BUILD_ID:${{ secrets.BUILD_ID }}
   env:
     ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
     ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
     ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+    BUILD_ID: ${{ secrets.BUILD_ID }}
+  run: asc workflow run beta "BUILD_ID:$BUILD_ID"
 ```
 
 <Note>

--- a/configuration/profiles.mdx
+++ b/configuration/profiles.mdx
@@ -193,10 +193,11 @@ env:
   ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
   ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
   ASC_BYPASS_KEYCHAIN: true
+  ASC_APP_ID: ${{ secrets.APP_ID }}
 
 steps:
   - name: Upload to TestFlight
-    run: asc builds upload --app ${{ secrets.APP_ID }} --ipa MyApp.ipa
+    run: asc builds upload --app "$ASC_APP_ID" --ipa MyApp.ipa
 ```
 
 ### Testing with staging vs production keys

--- a/docs_github_actions_examples_test.go
+++ b/docs_github_actions_examples_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,15 +11,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
-
-// githubActionsDocFiles lists documentation pages whose GitHub Actions examples
-// are copied into workflows that already have App Store Connect credentials
-// configured. A ref-controlled expression inside `run:` becomes shell source in
-// those workflows, so the examples must keep refs in `env:` instead.
-var githubActionsDocFiles = []string{
-	filepath.Join("configuration", "workflows.mdx"),
-	filepath.Join("commands", "validate.mdx"),
-}
 
 // refNameInjectionPayload is a valid Git ref name (no space, `~`, `^`, `:`, `?`,
 // `*`, `[`, or `\`) that appends a redirect if it ever reaches shell source.
@@ -34,29 +26,25 @@ type docActionStep struct {
 }
 
 func TestGitHubActionsDocExamplesKeepRefNameOutOfShellSource(t *testing.T) {
-	for _, file := range githubActionsDocFiles {
+	sawUntrustedEnv := false
+	for _, file := range githubActionsDocFiles(t) {
 		steps := gitHubActionsDocSteps(t, file)
-		if len(steps) == 0 {
-			t.Fatalf("%s: expected at least one GitHub Actions run step", file)
-		}
-
-		refInEnv := false
 		for _, step := range steps {
 			if match := actionsExpressionPattern.FindString(step.Run); match != "" {
 				t.Errorf("%s: step %q interpolates %s inside run source; pass it through env instead", file, step.Name, match)
 			}
 			for name, value := range step.Env {
-				if strings.Contains(value, "github.ref_name") {
-					refInEnv = true
-					if !referencesQuotedShellVariable(step.Run, name) {
+				if hasUntrustedActionsExpression(value) {
+					sawUntrustedEnv = true
+					if referencesShellVariable(step.Run, name) && !referencesQuotedShellVariable(step.Run, name) {
 						t.Errorf("%s: step %q sets env %s but does not reference it as a quoted shell variable", file, step.Name, name)
 					}
 				}
 			}
 		}
-		if !refInEnv {
-			t.Errorf("%s: expected a step-level env entry carrying github.ref_name", file)
-		}
+	}
+	if !sawUntrustedEnv {
+		t.Fatal("expected at least one documented step to route an untrusted GitHub value through env")
 	}
 }
 
@@ -66,12 +54,12 @@ func TestGitHubActionsDocExamplesTreatRefNameAsInertArgument(t *testing.T) {
 		t.Skipf("bash is not installed; shell-safety of the documented examples cannot be executed here: %v", err)
 	}
 
-	for _, file := range githubActionsDocFiles {
+	for _, file := range githubActionsDocFiles(t) {
 		for _, step := range gitHubActionsDocSteps(t, file) {
-			script, env := renderDocStepScript(t, file, step)
-			if !strings.Contains(script, refNameInjectionPayload) && !stepEnvContains(env, refNameInjectionPayload) {
+			if !strings.Contains(step.Run, "asc ") || !stepReferencesUntrustedEnv(step) {
 				continue
 			}
+			script, env := renderDocStepScript(t, file, step)
 
 			t.Run(file+"/"+step.Name, func(t *testing.T) {
 				workDir := t.TempDir()
@@ -116,6 +104,74 @@ func TestGitHubActionsDocExamplesTreatRefNameAsInertArgument(t *testing.T) {
 	}
 }
 
+func githubActionsDocFiles(t *testing.T) []string {
+	t.Helper()
+
+	files := make([]string, 0)
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != "." && (entry.Name() == ".git" || entry.Name() == "node_modules") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".md" && ext != ".mdx" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		content := string(data)
+		if strings.Contains(content, "${{") && strings.Contains(content, "run:") {
+			files = append(files, filepath.Clean(path))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("discover GitHub Actions documentation: %v", err)
+	}
+	return files
+}
+
+func hasUntrustedActionsExpression(value string) bool {
+	for _, match := range actionsExpressionPattern.FindAllStringSubmatch(value, -1) {
+		expression := strings.TrimSpace(match[1])
+		if strings.HasPrefix(expression, "github.ref") ||
+			strings.HasPrefix(expression, "github.event.inputs.") ||
+			strings.HasPrefix(expression, "inputs.") ||
+			strings.HasPrefix(expression, "secrets.") {
+			return true
+		}
+	}
+	return false
+}
+
+func stepReferencesUntrustedEnv(step docActionStep) bool {
+	for name, value := range step.Env {
+		if hasRefOrInputActionsExpression(value) && referencesQuotedShellVariable(step.Run, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRefOrInputActionsExpression(value string) bool {
+	for _, match := range actionsExpressionPattern.FindAllStringSubmatch(value, -1) {
+		expression := strings.TrimSpace(match[1])
+		if strings.HasPrefix(expression, "github.ref") ||
+			strings.HasPrefix(expression, "github.event.inputs.") ||
+			strings.HasPrefix(expression, "inputs.") {
+			return true
+		}
+	}
+	return false
+}
+
 // referencesQuotedShellVariable reports whether script expands name at least
 // once and never expands it outside double quotes, so word splitting and glob
 // expansion cannot act on the value.
@@ -132,9 +188,6 @@ func referencesQuotedShellVariable(script string, name string) bool {
 			inSingle = !inSingle
 		case c == '"' && !inSingle:
 			inDouble = !inDouble
-		case c == '\n':
-			inSingle = false
-			inDouble = false
 		case c == '$' && !inSingle:
 			rest := script[i+1:]
 			braced := strings.HasPrefix(rest, "{"+name+"}")
@@ -150,6 +203,10 @@ func referencesQuotedShellVariable(script string, name string) bool {
 	}
 
 	return found
+}
+
+func referencesShellVariable(script string, name string) bool {
+	return strings.Contains(script, "$"+name) || strings.Contains(script, "${"+name+"}")
 }
 
 func isShellNameByte(c byte) bool {
@@ -172,15 +229,17 @@ func gitHubActionsDocSteps(t *testing.T, file string) []docActionStep {
 	}
 
 	var steps []docActionStep
-	for _, block := range fencedBlocks(string(data), "yaml") {
-		if !strings.Contains(block, "run:") {
-			continue
+	for _, language := range []string{"yaml", "yml"} {
+		for _, block := range fencedBlocks(string(data), language) {
+			if !strings.Contains(block, "run:") {
+				continue
+			}
+			var root yaml.Node
+			if err := yaml.Unmarshal([]byte(block), &root); err != nil {
+				t.Fatalf("%s: parse yaml example: %v\n%s", file, err, block)
+			}
+			collectDocActionSteps(file, &root, &steps)
 		}
-		var root yaml.Node
-		if err := yaml.Unmarshal([]byte(block), &root); err != nil {
-			t.Fatalf("%s: parse yaml example: %v\n%s", file, err, block)
-		}
-		collectDocActionSteps(file, &root, &steps)
 	}
 	return steps
 }
@@ -260,25 +319,11 @@ func expandActionsExpressions(t *testing.T, file string, step docActionStep, val
 
 	return actionsExpressionPattern.ReplaceAllStringFunc(value, func(match string) string {
 		expression := strings.TrimSpace(actionsExpressionPattern.FindStringSubmatch(match)[1])
-		switch {
-		case expression == "github.ref_name":
-			return refNameInjectionPayload
-		case strings.HasPrefix(expression, "secrets."):
-			return "123456789"
-		default:
-			t.Fatalf("%s: step %q uses unsupported expression %q", file, step.Name, expression)
-			return ""
+		if expression == "" {
+			t.Fatalf("%s: step %q contains an empty GitHub Actions expression", file, step.Name)
 		}
+		return refNameInjectionPayload
 	})
-}
-
-func stepEnvContains(env []string, value string) bool {
-	for _, entry := range env {
-		if strings.Contains(entry, value) {
-			return true
-		}
-	}
-	return false
 }
 
 func writeASCStub(t *testing.T, argsFile string) string {

--- a/guides/automation.mdx
+++ b/guides/automation.mdx
@@ -413,8 +413,10 @@ jobs:
           echo "Credentials configured"
       
       - name: Run release workflow
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          asc workflow run release VERSION:${{ github.event.inputs.version }}
+          asc workflow run release "VERSION:$VERSION"
       
       - name: Upload workflow output
         uses: actions/upload-artifact@v3

--- a/guides/testflight.mdx
+++ b/guides/testflight.mdx
@@ -98,7 +98,7 @@ TestFlight allows you to distribute pre-release builds to internal and external 
     ```
 
     <Note>
-      Export prefixes a cell with a single quote when its first character would start a spreadsheet formula (`=`, `+`, `-`, `@`), so opening the file in Excel, Numbers, or Google Sheets cannot execute tester or group values. `asc testflight testers import` removes that prefix again.
+      Export prefixes a cell with a single quote when its first character would start a spreadsheet formula (`=`, `+`, `-`, `@`), so opening the file in Excel, Numbers, or Google Sheets cannot execute tester or group values. When a prefix is needed, export adds an `_asc_formula_escaping` provenance column. `asc testflight testers import` only removes prefixes from rows carrying that marker, so leading apostrophes in third-party or user-authored CSV files remain unchanged.
     </Note>
 
     Import testers from CSV (with dry-run first):

--- a/index.mdx
+++ b/index.mdx
@@ -76,16 +76,11 @@
         asc install-skills
         ```
 
-        This runs the pinned installer `skills@1.5.20` against a reviewed skills commit and needs Node.js (`npx`) and `git`. To do the same by hand, using a fresh directory under `/tmp` (outside any npm project regardless of `TMPDIR`, and the directory `npx` runs from, so project npm files cannot shadow or redirect the pinned installer) and stopping on the first failed step:
+        This checks out reviewed commit `e30039abddbe388179324d0f9cdccb66c3843115` and installs its 23 skills directly. The command verifies the complete pack and every installed file, preserves unrelated skills and lock entries, and pins the 23 ASC lock entries to that commit so external checks cannot update them from a mutable branch. It rolls back on a partial failure. It requires `git` but does not execute Node.js, `npx`, npm packages, or repository scripts.
 
         ```bash  theme={null}
-        asc_skills="$(mktemp -d /tmp/asc-skills.XXXXXX)" &&
-          git init --quiet "$asc_skills/src" &&
-          git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
-          git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
-          git -C "$asc_skills/src" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
-          (cd "$asc_skills" && npx --yes skills@1.5.20 add "$asc_skills/src" --global --agent codex --yes) &&
-          rm -rf "$asc_skills"
+        git --version
+        asc install-skills
         ```
       </Step>
 

--- a/installation.mdx
+++ b/installation.mdx
@@ -188,22 +188,24 @@ ASC_BYPASS_KEYCHAIN=1 make test
 asc install-skills
 ```
 
-`asc install-skills` runs the pinned installer `skills@1.5.20` against a reviewed skills commit, so an upstream change cannot alter what gets installed. It needs Node.js (`npx`) and `git`.
-
-To do the same by hand, check out that commit into a fresh temporary directory and install from the local path. Each step stops the chain on failure, and the temporary directory lives under `/tmp` (outside any npm project, regardless of `TMPDIR`) with `npx` running from it, so a project `node_modules`, `package.json`, or `.npmrc` cannot shadow or redirect the pinned installer:
+`asc install-skills` checks out reviewed commit
+`e30039abddbe388179324d0f9cdccb66c3843115` and copies its 23 skills directly
+into the standard global agent-skills directory. It verifies the complete pack
+and every installed file before succeeding, preserves unrelated skills and
+unrelated lock entries, and pins the 23 ASC lock entries to the same reviewed
+commit so external checks cannot update them from a mutable branch. It rolls
+back the pack if any replacement fails. Only
+`git` is required; the command does not execute Node.js, `npx`, npm packages,
+or repository scripts.
 
 ```bash  theme={null}
-asc_skills="$(mktemp -d /tmp/asc-skills.XXXXXX)" &&
-  git init --quiet "$asc_skills/src" &&
-  git -C "$asc_skills/src" remote add origin https://github.com/rorkai/app-store-connect-cli-skills.git &&
-  git -C "$asc_skills/src" fetch --depth 1 origin e30039abddbe388179324d0f9cdccb66c3843115 &&
-  git -C "$asc_skills/src" checkout --detach e30039abddbe388179324d0f9cdccb66c3843115 &&
-  (cd "$asc_skills" && npx --yes skills@1.5.20 add "$asc_skills/src" --global --agent codex --yes) &&
-  rm -rf "$asc_skills"
+git --version
+asc install-skills
 ```
 
 <Note>
-  The installer resolves a source ref with `git clone --branch`, which accepts only branch and tag names, so the pinned commit has to be checked out locally and passed as a path. Upgrading the skill pack is an explicit change to the pinned installer version and commit in `internal/cli/install/install.go`.
+  Upgrading the skill pack is an explicit change to the pinned commit and the
+  reviewed 23-skill manifest in `internal/cli/install/install.go`.
 </Note>
 
 ## Shell completion

--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -646,7 +646,7 @@ func (c *Client) DownloadAnalyticsReport(ctx context.Context, downloadURL string
 		return nil, fmt.Errorf("analytics download: %w", err)
 	}
 
-	resp, err := c.doStreamNoAuth(ctx, "GET", downloadURL, "application/a-gzip")
+	resp, err := c.doStreamNoAuth(ctx, downloadURL, "application/a-gzip")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asc/assets_upload.go
+++ b/internal/asc/assets_upload.go
@@ -41,7 +41,7 @@ func UploadAssetFromFile(ctx context.Context, file *os.File, fileSize int64, ope
 		return fmt.Errorf("no upload operations provided")
 	}
 
-	client := &http.Client{Timeout: ResolveUploadTimeout()}
+	client := clientWithoutRedirects(&http.Client{Timeout: ResolveUploadTimeout()})
 
 	for i, op := range operations {
 		method := strings.ToUpper(strings.TrimSpace(op.Method))

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -565,28 +565,35 @@ func (c *Client) doStream(ctx context.Context, path string, accept string) (*htt
 	return resp, nil
 }
 
-func (c *Client) doStreamNoAuth(ctx context.Context, method, rawURL, accept string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+func (c *Client) doStreamNoAuth(ctx context.Context, rawURL, accept string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, newSanitizedNoAuthStreamError("create download request", rawURL, err)
 	}
 	if strings.TrimSpace(accept) != "" {
 		req.Header.Set("Accept", accept)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	client := clientWithoutRedirects(c.httpClient)
+	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, newSanitizedNoAuthStreamError("download request", rawURL, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		if err := ParseErrorWithStatus(respBody, resp.StatusCode); err != nil {
-			return nil, err
+		// Presigned-CDN error bodies are untrusted and can echo the requested
+		// capability. The status code is sufficient diagnostic context here.
+		return nil, &APIError{
+			Code:       apiErrorCodeFromStatus(resp.StatusCode),
+			Title:      fmt.Sprintf("download request failed with status %d", resp.StatusCode),
+			StatusCode: resp.StatusCode,
 		}
-		return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
 	}
 	return resp, nil
+}
+
+func newSanitizedNoAuthStreamError(operation, rawURL string, err error) error {
+	return urlsanitize.NewTransportError(operation, urlsanitize.RedactURLForError(rawURL), err)
 }
 
 // BuildRequestBody builds a JSON request body

--- a/internal/asc/client_stream_noauth_security_test.go
+++ b/internal/asc/client_stream_noauth_security_test.go
@@ -1,0 +1,97 @@
+package asc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDoStreamNoAuthRefusesRedirectWithoutForwardingReferer(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		t.Errorf("redirect target received request with referer %q", r.Referer())
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/capture", http.StatusFound)
+	}))
+	defer source.Close()
+
+	client := &Client{httpClient: source.Client()}
+	rawURL := source.URL + "/download?Signature=signed-secret"
+	_, err := client.doStreamNoAuth(context.Background(), rawURL, "application/octet-stream")
+	if err == nil {
+		t.Fatal("expected redirect response to fail")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", got)
+	}
+	if strings.Contains(err.Error(), "signed-secret") {
+		t.Fatalf("redirect error leaked signed query: %v", err)
+	}
+}
+
+func TestDoStreamNoAuthSanitizesTransportErrorAndPreservesCause(t *testing.T) {
+	sentinel := errors.New("dial failed for https://download.example/file?Signature=signed-secret")
+	client := &Client{httpClient: &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, sentinel
+		}),
+	}}
+
+	_, err := client.doStreamNoAuth(
+		context.Background(),
+		"https://download.example/file?Signature=signed-secret",
+		"application/octet-stream",
+	)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if strings.Contains(err.Error(), "signed-secret") || strings.Contains(err.Error(), "Signature") {
+		t.Fatalf("transport error leaked signed query: %v", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("transport cause was not preserved: %v", err)
+	}
+}
+
+func TestDoStreamNoAuthDoesNotEchoCapabilityFromErrorBody(t *testing.T) {
+	client := &Client{httpClient: &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "403 Forbidden",
+				StatusCode: http.StatusForbidden,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"errors":[{"title":"Denied","detail":"https://download.example/file?Signature=signed-secret"}]}`,
+				)),
+			}, nil
+		}),
+	}}
+
+	_, err := client.doStreamNoAuth(
+		context.Background(),
+		"https://download.example/file?Signature=signed-secret",
+		"application/octet-stream",
+	)
+	if err == nil {
+		t.Fatal("expected HTTP error")
+	}
+	if strings.Contains(err.Error(), "signed-secret") || strings.Contains(err.Error(), "Signature") {
+		t.Fatalf("HTTP error leaked capability-bearing response text: %v", err)
+	}
+	if !strings.Contains(err.Error(), "status 403") {
+		t.Fatalf("HTTP error lost safe status context: %v", err)
+	}
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("HTTP error lost forbidden classification: %v", err)
+	}
+}

--- a/internal/asc/client_testflight_review.go
+++ b/internal/asc/client_testflight_review.go
@@ -112,6 +112,9 @@ func (c *Client) UpdateBetaAppReviewDetail(ctx context.Context, detailID string,
 	if detailID == "" {
 		return nil, fmt.Errorf("detailID is required")
 	}
+	if err := validateSecretMutationValue(attrs.DemoAccountPassword); err != nil {
+		return nil, err
+	}
 
 	payload := BetaAppReviewDetailUpdateRequest{
 		Data: BetaAppReviewDetailUpdateData{
@@ -128,7 +131,7 @@ func (c *Client) UpdateBetaAppReviewDetail(ctx context.Context, detailID string,
 
 	data, err := c.do(ctx, "PATCH", fmt.Sprintf("/v1/betaAppReviewDetails/%s", detailID), body)
 	if err != nil {
-		return nil, err
+		return nil, redactSubmittedSecretFromError(err, attrs.DemoAccountPassword)
 	}
 
 	var response BetaAppReviewDetailResponse

--- a/internal/asc/http_redirect.go
+++ b/internal/asc/http_redirect.go
@@ -1,0 +1,16 @@
+package asc
+
+import "net/http"
+
+func clientWithoutRedirects(client *http.Client) *http.Client {
+	if client == nil {
+		client = newDefaultHTTPClient(ResolveTimeout())
+	}
+	safeClient := *client
+	safeClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		// A redirect can disclose a signed URL through Referer and 307/308 can
+		// replay an upload body to an attacker-controlled destination.
+		return http.ErrUseLastResponse
+	}
+	return &safeClient
+}

--- a/internal/asc/review_details.go
+++ b/internal/asc/review_details.go
@@ -158,6 +158,11 @@ func (c *Client) CreateAppStoreReviewDetail(ctx context.Context, versionID strin
 	if versionID == "" {
 		return nil, fmt.Errorf("versionID is required")
 	}
+	if attrs != nil {
+		if err := validateSecretMutationValue(attrs.DemoAccountPassword); err != nil {
+			return nil, err
+		}
+	}
 
 	payload := AppStoreReviewDetailCreateRequest{
 		Data: AppStoreReviewDetailCreateData{
@@ -181,7 +186,11 @@ func (c *Client) CreateAppStoreReviewDetail(ctx context.Context, versionID strin
 
 	data, err := c.do(ctx, "POST", "/v1/appStoreReviewDetails", body)
 	if err != nil {
-		return nil, err
+		var password *string
+		if attrs != nil {
+			password = attrs.DemoAccountPassword
+		}
+		return nil, redactSubmittedSecretFromError(err, password)
 	}
 
 	var response AppStoreReviewDetailResponse
@@ -197,6 +206,9 @@ func (c *Client) UpdateAppStoreReviewDetail(ctx context.Context, detailID string
 	detailID = strings.TrimSpace(detailID)
 	if detailID == "" {
 		return nil, fmt.Errorf("detailID is required")
+	}
+	if err := validateSecretMutationValue(attrs.DemoAccountPassword); err != nil {
+		return nil, err
 	}
 
 	payload := AppStoreReviewDetailUpdateRequest{
@@ -214,7 +226,7 @@ func (c *Client) UpdateAppStoreReviewDetail(ctx context.Context, detailID string
 
 	data, err := c.do(ctx, "PATCH", fmt.Sprintf("/v1/appStoreReviewDetails/%s", detailID), body)
 	if err != nil {
-		return nil, err
+		return nil, redactSubmittedSecretFromError(err, attrs.DemoAccountPassword)
 	}
 
 	var response AppStoreReviewDetailResponse

--- a/internal/asc/review_error_redaction.go
+++ b/internal/asc/review_error_redaction.go
@@ -1,0 +1,94 @@
+package asc
+
+import (
+	"errors"
+	"strings"
+)
+
+type submittedSecretRedactedError struct {
+	message      string
+	cause        error
+	safeAPIError *APIError
+}
+
+func (e *submittedSecretRedactedError) Error() string {
+	return e.message
+}
+
+func (e *submittedSecretRedactedError) Unwrap() error {
+	return e.cause
+}
+
+func (e *submittedSecretRedactedError) As(target any) bool {
+	apiErrorTarget, ok := target.(**APIError)
+	if !ok || e.safeAPIError == nil {
+		return false
+	}
+	*apiErrorTarget = e.safeAPIError
+	return true
+}
+
+// redactSubmittedSecretFromError is the credential-mutation error boundary.
+// App Store Connect may echo an invalid submitted password in its structured
+// error title, detail, or associated errors. Preserve error classification
+// through safe cloned causes while exposing only a redacted message.
+func redactSubmittedSecretFromError(err error, secret *string) error {
+	if err == nil || secret == nil || *secret == "" {
+		return err
+	}
+
+	values := []string{*secret, SanitizeTerminalText(*secret)}
+	redact := func(value string) string {
+		for _, secretValue := range values {
+			if secretValue != "" {
+				value = strings.ReplaceAll(value, secretValue, RedactedValuePlaceholder)
+			}
+		}
+		return value
+	}
+
+	message := redact(err.Error())
+
+	var safeAPIError *APIError
+	var apiError *APIError
+	if errors.As(err, &apiError) {
+		safe := *apiError
+		// Code is a protocol enum used by APIError.Is. Preserve it verbatim so a
+		// short submitted password cannot accidentally erase classification.
+		safe.Title = redact(safe.Title)
+		safe.Detail = redact(safe.Detail)
+		if apiError.AssociatedErrors != nil {
+			safe.AssociatedErrors = make(map[string][]APIAssociatedError, len(apiError.AssociatedErrors))
+			for resource, entries := range apiError.AssociatedErrors {
+				safeEntries := make([]APIAssociatedError, len(entries))
+				for index, entry := range entries {
+					entry.Code = redact(entry.Code)
+					entry.Detail = redact(entry.Detail)
+					safeEntries[index] = entry
+				}
+				safe.AssociatedErrors[redact(resource)] = safeEntries
+			}
+		}
+		safeAPIError = &safe
+	}
+
+	safeCause := err
+	if safeAPIError != nil {
+		safeCause = safeAPIError
+		var retryable *RetryableError
+		if errors.As(err, &retryable) {
+			safeRetryable := *retryable
+			safeRetryable.Err = &submittedSecretRedactedError{
+				message:      redact(retryable.Err.Error()),
+				cause:        safeAPIError,
+				safeAPIError: safeAPIError,
+			}
+			safeCause = &safeRetryable
+		}
+	}
+	return &submittedSecretRedactedError{
+		message:      message,
+		cause:        safeCause,
+		safeAPIError: safeAPIError,
+	}
+}

--- a/internal/asc/review_error_redaction_test.go
+++ b/internal/asc/review_error_redaction_test.go
@@ -1,0 +1,142 @@
+package asc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const submittedPasswordErrorSentinel = "asc-submitted-password-sentinel-91a47f"
+
+func echoedPasswordErrorResponse() *http.Response {
+	return jsonResponse(
+		http.StatusBadRequest,
+		`{"errors":[{"code":"BAD_REQUEST","title":"Invalid password `+
+			submittedPasswordErrorSentinel+
+			`","detail":"demoAccountPassword `+
+			submittedPasswordErrorSentinel+
+			` is rejected","meta":{"associatedErrors":{"reviewDetail":[{"detail":"bad `+
+			submittedPasswordErrorSentinel+
+			`"}]}}}]}`,
+	)
+}
+
+func assertSubmittedPasswordRedacted(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if strings.Contains(err.Error(), submittedPasswordErrorSentinel) {
+		t.Fatalf("API error exposed submitted password: %v", err)
+	}
+	if !strings.Contains(err.Error(), RedactedValuePlaceholder) {
+		t.Fatalf("API error did not mark redacted password: %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("API error classification was not preserved: %T: %v", err, err)
+	}
+	if strings.Contains(apiErr.Error(), submittedPasswordErrorSentinel) {
+		t.Fatalf("errors.As exposed submitted password: %v", apiErr)
+	}
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("bad-request classification was not preserved: %v", err)
+	}
+}
+
+func TestCreateAppStoreReviewDetailRedactsSubmittedPasswordFromAPIError(t *testing.T) {
+	client := newTestClient(t, nil, echoedPasswordErrorResponse())
+	password := submittedPasswordErrorSentinel
+	_, err := client.CreateAppStoreReviewDetail(
+		context.Background(),
+		"version-1",
+		&AppStoreReviewDetailCreateAttributes{DemoAccountPassword: &password},
+	)
+	assertSubmittedPasswordRedacted(t, err)
+}
+
+func TestUpdateAppStoreReviewDetailRedactsSubmittedPasswordFromAPIError(t *testing.T) {
+	client := newTestClient(t, nil, echoedPasswordErrorResponse())
+	password := submittedPasswordErrorSentinel
+	_, err := client.UpdateAppStoreReviewDetail(
+		context.Background(),
+		"detail-1",
+		AppStoreReviewDetailUpdateAttributes{DemoAccountPassword: &password},
+	)
+	assertSubmittedPasswordRedacted(t, err)
+}
+
+func TestUpdateBetaAppReviewDetailRedactsSubmittedPasswordFromAPIError(t *testing.T) {
+	client := newTestClient(t, nil, echoedPasswordErrorResponse())
+	password := submittedPasswordErrorSentinel
+	_, err := client.UpdateBetaAppReviewDetail(
+		context.Background(),
+		"detail-1",
+		BetaAppReviewDetailUpdateAttributes{DemoAccountPassword: &password},
+	)
+	assertSubmittedPasswordRedacted(t, err)
+}
+
+func TestSubmittedPasswordRedactionPreservesProtocolCodeClassification(t *testing.T) {
+	password := "BAD"
+	response := jsonResponse(
+		http.StatusBadRequest,
+		`{"errors":[{"code":"BAD_REQUEST","title":"Invalid submitted credential","detail":"credential rejected"}]}`,
+	)
+	client := newTestClient(t, nil, response)
+	_, err := client.UpdateAppStoreReviewDetail(
+		context.Background(),
+		"detail-1",
+		AppStoreReviewDetailUpdateAttributes{DemoAccountPassword: &password},
+	)
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("errors.Is(err, ErrBadRequest) = false: %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("errors.As(err, *APIError) = false: %T", err)
+	}
+	if apiErr.Code != "BAD_REQUEST" {
+		t.Fatalf("safe API error code = %q, want BAD_REQUEST", apiErr.Code)
+	}
+}
+
+func TestReviewPasswordRedactionKeepsRetryableChainSafe(t *testing.T) {
+	response := jsonResponse(
+		http.StatusInternalServerError,
+		`{"errors":[{"code":"INTERNAL_ERROR","title":"temporary failure `+
+			submittedPasswordErrorSentinel+
+			`","detail":"retry `+
+			submittedPasswordErrorSentinel+
+			`"}]}`,
+	)
+	client := newTestClient(t, nil, response)
+	password := submittedPasswordErrorSentinel
+	_, err := client.UpdateAppStoreReviewDetail(
+		context.Background(),
+		"detail-1",
+		AppStoreReviewDetailUpdateAttributes{DemoAccountPassword: &password},
+	)
+	if err == nil {
+		t.Fatal("expected retryable API error")
+	}
+	if !IsRetryable(err) {
+		t.Fatalf("retryable classification was not preserved: %v", err)
+	}
+	var retryable *RetryableError
+	if !errors.As(err, &retryable) {
+		t.Fatalf("retryable error was not inspectable: %v", err)
+	}
+	if strings.Contains(retryable.Error(), submittedPasswordErrorSentinel) {
+		t.Fatalf("errors.As exposed submitted password through RetryableError: %v", retryable)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("API error was not inspectable: %v", err)
+	}
+	if strings.Contains(apiErr.Error(), submittedPasswordErrorSentinel) {
+		t.Fatalf("errors.As exposed submitted password through APIError: %v", apiErr)
+	}
+}

--- a/internal/asc/review_redaction.go
+++ b/internal/asc/review_redaction.go
@@ -1,8 +1,14 @@
 package asc
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
 // RedactedValuePlaceholder marks a secret that was withheld from output. It is
-// deliberately not a valid App Store Connect value so a redacted payload can
-// never be mistaken for a usable credential.
+// a presentation marker and must be rejected at credential mutation boundaries
+// so exported redacted output cannot overwrite a real credential.
 const RedactedValuePlaceholder = "(redacted)"
 
 // RedactSecret returns the placeholder for any non-empty secret and leaves the
@@ -14,6 +20,19 @@ func RedactSecret(value string) string {
 		return value
 	}
 	return RedactedValuePlaceholder
+}
+
+func validateSecretMutationValue(value *string) error {
+	if value != nil && *value == RedactedValuePlaceholder {
+		return fmt.Errorf("demo account password is the redaction placeholder; provide the actual password or omit the field")
+	}
+	return nil
+}
+
+// ValidateSecretMutationValue rejects presentation placeholders before they
+// can cross a credential mutation boundary.
+func ValidateSecretMutationValue(value *string) error {
+	return validateSecretMutationValue(value)
 }
 
 // RedactAppStoreReviewDetailAttributes returns a presentation-safe copy of App
@@ -47,6 +66,90 @@ func RedactBetaAppReviewDetailResponse(resp *BetaAppReviewDetailResponse) *BetaA
 // TestFlight beta app review details list response.
 func RedactBetaAppReviewDetailsResponse(resp *BetaAppReviewDetailsResponse) *BetaAppReviewDetailsResponse {
 	return redactListResponse(resp, RedactBetaAppReviewDetailAttributes)
+}
+
+// RedactAppStoreReviewDetailIncludesInSingleResponse returns a presentation-safe
+// copy whose included appStoreReviewDetails resources cannot expose a password.
+func RedactAppStoreReviewDetailIncludesInSingleResponse[T any](resp *SingleResponse[T]) (*SingleResponse[T], error) {
+	if resp == nil {
+		return nil, nil
+	}
+	safe := *resp
+	included, err := redactAppStoreReviewDetailIncluded(resp.Included)
+	if err != nil {
+		return nil, err
+	}
+	safe.Included = included
+	return &safe, nil
+}
+
+// RedactAppStoreReviewDetailIncludesInListResponse returns a presentation-safe
+// copy whose included appStoreReviewDetails resources cannot expose a password.
+func RedactAppStoreReviewDetailIncludesInListResponse[T any](resp *Response[T]) (*Response[T], error) {
+	if resp == nil {
+		return nil, nil
+	}
+	safe := *resp
+	included, err := redactAppStoreReviewDetailIncluded(resp.Included)
+	if err != nil {
+		return nil, err
+	}
+	safe.Included = included
+	return &safe, nil
+}
+
+func redactAppStoreReviewDetailIncluded(included json.RawMessage) (json.RawMessage, error) {
+	if len(bytes.TrimSpace(included)) == 0 {
+		return included, nil
+	}
+
+	var resources []json.RawMessage
+	if err := json.Unmarshal(included, &resources); err != nil {
+		return nil, fmt.Errorf("redact included review details: %w", err)
+	}
+	for index, rawResource := range resources {
+		// Always rebuild the resource object, even when its final attributes
+		// member has no password. This collapses duplicate object members so an
+		// earlier attributes object cannot smuggle a secret past last-key-wins
+		// decoding.
+		var resource map[string]json.RawMessage
+		if err := json.Unmarshal(rawResource, &resource); err != nil {
+			return nil, fmt.Errorf("redact included resource %d: %w", index, err)
+		}
+		if rawAttributes, present := resource["attributes"]; present {
+			var attributes map[string]json.RawMessage
+			if err := json.Unmarshal(rawAttributes, &attributes); err != nil {
+				return nil, fmt.Errorf("redact included review detail %d attributes: %w", index, err)
+			}
+			if password, present := attributes["demoAccountPassword"]; present &&
+				!bytes.Equal(bytes.TrimSpace(password), []byte("null")) {
+				var value string
+				if err := json.Unmarshal(password, &value); err != nil || value != "" {
+					placeholder, err := json.Marshal(RedactedValuePlaceholder)
+					if err != nil {
+						return nil, err
+					}
+					attributes["demoAccountPassword"] = placeholder
+				}
+			}
+			redactedAttributes, err := json.Marshal(attributes)
+			if err != nil {
+				return nil, fmt.Errorf("redact included review detail %d attributes: %w", index, err)
+			}
+			resource["attributes"] = redactedAttributes
+		}
+
+		redactedResource, err := json.Marshal(resource)
+		if err != nil {
+			return nil, fmt.Errorf("redact included resource %d: %w", index, err)
+		}
+		resources[index] = redactedResource
+	}
+	redacted, err := json.Marshal(resources)
+	if err != nil {
+		return nil, fmt.Errorf("redact included review details: %w", err)
+	}
+	return redacted, nil
 }
 
 func redactSingleResponse[T any](resp *SingleResponse[T], redact func(T) T) *SingleResponse[T] {

--- a/internal/asc/review_redaction_test.go
+++ b/internal/asc/review_redaction_test.go
@@ -95,3 +95,92 @@ func TestRedactResponseHelpersHandleNil(t *testing.T) {
 		t.Fatalf("RedactBetaAppReviewDetailsResponse(nil) = %v, want nil", got)
 	}
 }
+
+func TestRedactAppStoreReviewDetailIncludedResources(t *testing.T) {
+	originalIncluded := json.RawMessage(`[
+		{"type":"appStoreReviewDetails","id":"detail-1","attributes":{"demoAccountPassword":"` + reviewRedactionSentinel + `","notes":"keep"},"relationships":{"version":{"data":{"type":"appStoreVersions","id":"version-1"}}}},
+		{"type":"builds","id":"build-1","attributes":{"version":"42"}}
+	]`)
+	original := &SingleResponse[AppStoreVersionAttributes]{Included: originalIncluded}
+
+	safe, err := RedactAppStoreReviewDetailIncludesInSingleResponse(original)
+	if err != nil {
+		t.Fatalf("RedactAppStoreReviewDetailIncludesInSingleResponse() error = %v", err)
+	}
+	encoded, err := json.Marshal(safe)
+	if err != nil {
+		t.Fatalf("marshal redacted response: %v", err)
+	}
+	if strings.Contains(string(encoded), reviewRedactionSentinel) {
+		t.Fatalf("included resource leaked password: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"demoAccountPassword":"`+RedactedValuePlaceholder+`"`) {
+		t.Fatalf("included resource missing placeholder: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"notes":"keep"`) ||
+		!strings.Contains(string(encoded), `"relationships"`) ||
+		!strings.Contains(string(encoded), `"type":"builds"`) {
+		t.Fatalf("redaction dropped unrelated included data: %s", encoded)
+	}
+	if !strings.Contains(string(original.Included), reviewRedactionSentinel) {
+		t.Fatal("redaction mutated original Included bytes")
+	}
+}
+
+func TestRedactIncludedPasswordDoesNotTrustResourceType(t *testing.T) {
+	original := &SingleResponse[AppStoreVersionAttributes]{
+		Included: json.RawMessage(`[
+			{"type":"appStoreReviewDetails","type":"misleadingType","attributes":{"demoAccountPassword":"` + reviewRedactionSentinel + `"}}
+		]`),
+	}
+
+	safe, err := RedactAppStoreReviewDetailIncludesInSingleResponse(original)
+	if err != nil {
+		t.Fatalf("RedactAppStoreReviewDetailIncludesInSingleResponse() error = %v", err)
+	}
+	encoded, err := json.Marshal(safe)
+	if err != nil {
+		t.Fatalf("marshal redacted response: %v", err)
+	}
+	if strings.Contains(string(encoded), reviewRedactionSentinel) {
+		t.Fatalf("misleading resource type bypassed password redaction: %s", encoded)
+	}
+}
+
+func TestRedactIncludedPasswordCollapsesDuplicateAttributes(t *testing.T) {
+	original := &SingleResponse[AppStoreVersionAttributes]{
+		Included: json.RawMessage(`[
+			{"attributes":{"demoAccountPassword":"` + reviewRedactionSentinel + `"},"attributes":{"notes":"last"}}
+		]`),
+	}
+
+	safe, err := RedactAppStoreReviewDetailIncludesInSingleResponse(original)
+	if err != nil {
+		t.Fatalf("RedactAppStoreReviewDetailIncludesInSingleResponse() error = %v", err)
+	}
+	encoded, err := json.Marshal(safe)
+	if err != nil {
+		t.Fatalf("marshal redacted response: %v", err)
+	}
+	if strings.Contains(string(encoded), reviewRedactionSentinel) {
+		t.Fatalf("duplicate attributes bypassed password redaction: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"notes":"last"`) {
+		t.Fatalf("last attributes object was not preserved: %s", encoded)
+	}
+}
+
+func TestValidateSecretMutationValueRejectsRedactionPlaceholder(t *testing.T) {
+	placeholder := RedactedValuePlaceholder
+	if err := validateSecretMutationValue(&placeholder); err == nil {
+		t.Fatal("validateSecretMutationValue() error = nil, want placeholder rejection")
+	}
+
+	actual := "actual-password"
+	if err := validateSecretMutationValue(&actual); err != nil {
+		t.Fatalf("validateSecretMutationValue(actual) error = %v", err)
+	}
+	if err := validateSecretMutationValue(nil); err != nil {
+		t.Fatalf("validateSecretMutationValue(nil) error = %v", err)
+	}
+}

--- a/internal/asc/table_render.go
+++ b/internal/asc/table_render.go
@@ -12,6 +12,7 @@ import (
 // Headers preserve their original casing and are center-aligned.
 // Data rows are left-aligned for readability.
 func RenderTable(headers []string, rows [][]string) {
+	safeHeaders, safeRows := sanitizeHumanTableData(headers, rows)
 	table := tablewriter.NewTable(
 		os.Stdout,
 		tablewriter.WithConfig(tablewriter.Config{
@@ -26,8 +27,8 @@ func RenderTable(headers []string, rows [][]string) {
 			},
 		}),
 	)
-	table.Header(headers)
-	_ = table.Bulk(rows)
+	table.Header(safeHeaders)
+	_ = table.Bulk(safeRows)
 	_ = table.Render()
 }
 
@@ -35,6 +36,7 @@ func RenderTable(headers []string, rows [][]string) {
 // Headers preserve their original casing. Data rows are left-aligned.
 // Pipe characters in cell values are escaped automatically by the renderer.
 func RenderMarkdown(headers []string, rows [][]string) {
+	safeHeaders, safeRows := sanitizeHumanTableData(headers, rows)
 	table := tablewriter.NewTable(
 		os.Stdout,
 		tablewriter.WithRenderer(renderer.NewMarkdown()),
@@ -50,7 +52,23 @@ func RenderMarkdown(headers []string, rows [][]string) {
 			},
 		}),
 	)
-	table.Header(headers)
-	_ = table.Bulk(rows)
+	table.Header(safeHeaders)
+	_ = table.Bulk(safeRows)
 	_ = table.Render()
+}
+
+func sanitizeHumanTableData(headers []string, rows [][]string) ([]string, [][]string) {
+	safeHeaders := make([]string, len(headers))
+	for i, header := range headers {
+		safeHeaders[i] = SanitizeTerminalText(header)
+	}
+
+	safeRows := make([][]string, len(rows))
+	for i, row := range rows {
+		safeRows[i] = make([]string, len(row))
+		for j, cell := range row {
+			safeRows[i][j] = SanitizeTerminalText(cell)
+		}
+	}
+	return safeHeaders, safeRows
 }

--- a/internal/asc/table_render_test.go
+++ b/internal/asc/table_render_test.go
@@ -1,0 +1,60 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestHumanRenderersSanitizeEveryHeaderAndCell(t *testing.T) {
+	renderers := []struct {
+		name   string
+		render func([]string, [][]string)
+	}{
+		{name: "table", render: RenderTable},
+		{name: "markdown", render: RenderMarkdown},
+	}
+
+	for _, renderer := range renderers {
+		t.Run(renderer.name, func(t *testing.T) {
+			output := captureStdout(t, func() error {
+				renderer.render(
+					[]string{"unsafe\x1b]0;title\x07header"},
+					[][]string{{"one\u2028two", "bad\xc2byte", "bidi\u202etext"}},
+				)
+				return nil
+			})
+
+			for _, unsafe := range []string{"\x1b", "\u2028", "\u202e", "\xc2"} {
+				if strings.Contains(output, unsafe) {
+					t.Fatalf("%s output still contains unsafe source bytes %q: %q", renderer.name, unsafe, output)
+				}
+			}
+			for _, want := range []string{"unsafe]0;titleheader", "one two", "bad�byte", "biditext"} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("%s output = %q, want sanitized value %q", renderer.name, output, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCentralHumanSanitizationDoesNotChangeJSON(t *testing.T) {
+	value := struct {
+		Text string `json:"text"`
+	}{Text: "raw\x1b\u202e\u2028value"}
+
+	output := captureStdout(t, func() error {
+		return PrintJSON(value)
+	})
+
+	var decoded struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("decode JSON output: %v", err)
+	}
+	if decoded.Text != value.Text {
+		t.Fatalf("JSON text = %q, want exact original %q", decoded.Text, value.Text)
+	}
+}

--- a/internal/asc/terminal_sanitize.go
+++ b/internal/asc/terminal_sanitize.go
@@ -10,7 +10,7 @@ import (
 // original values; only human-facing table, Markdown, stdout, and stderr text
 // is sanitized.
 //
-// Removed characters:
+// Removed or replaced characters:
 //   - C0 controls (U+0000-U+001F) and DEL (U+007F), which include the ESC
 //     introducer used by CSI/OSC sequences as well as BEL, CR, LF, and TAB
 //   - C1 controls (U+0080-U+009F), which include the single-byte CSI (U+009B)
@@ -21,12 +21,13 @@ import (
 //   - Unicode line and paragraph separators (U+2028, U+2029), which
 //     browser-backed log and Markdown viewers render as mandatory breaks
 //
-// Line breaks and tabs are removed rather than preserved so a single value
-// cannot forge extra rows or columns in table, Markdown, or log output.
+// Line breaks, tabs, and Unicode separators are replaced with ordinary spaces
+// so a single value cannot forge extra rows or columns without concatenating
+// the text on either side.
 //
-// Invalid UTF-8 bytes are removed as well: a raw 0x9B or 0x9D byte is the
-// single-byte CSI or OSC form on terminals that accept 8-bit C1 controls, and
-// ranging over the string would otherwise decode it to U+FFFD and keep it.
+// Invalid UTF-8 bytes are replaced with U+FFFD. This preserves the fact that
+// text was separated at that byte boundary while ensuring a raw 0x9B or 0x9D
+// cannot act as a single-byte CSI or OSC introducer.
 func SanitizeTerminalText(input string) string {
 	if input == "" || !HasInterpretedTerminalSequence(input) {
 		return input
@@ -36,7 +37,17 @@ func SanitizeTerminalText(input string) string {
 	b.Grow(len(input))
 	for i := 0; i < len(input); {
 		r, size := utf8.DecodeRuneInString(input[i:])
-		if (r == utf8.RuneError && size == 1) || isInterpretedTerminalRune(r) {
+		if r == utf8.RuneError && size == 1 {
+			b.WriteRune(utf8.RuneError)
+			i += size
+			continue
+		}
+		if isTerminalTextSeparator(r) {
+			b.WriteByte(' ')
+			i += size
+			continue
+		}
+		if isInterpretedTerminalRune(r) {
 			i += size
 			continue
 		}
@@ -57,6 +68,15 @@ func HasInterpretedTerminalSequence(input string) bool {
 		i += size
 	}
 	return false
+}
+
+func isTerminalTextSeparator(r rune) bool {
+	switch r {
+	case '\t', '\n', '\v', '\f', '\r', '\u0085', '\u2028', '\u2029':
+		return true
+	default:
+		return false
+	}
 }
 
 func isInterpretedTerminalRune(r rune) bool {

--- a/internal/asc/terminal_sanitize_test.go
+++ b/internal/asc/terminal_sanitize_test.go
@@ -36,7 +36,7 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 		{
 			name:  "carriage return and del",
 			input: "visible\rhidden\u007f",
-			want:  "visiblehidden",
+			want:  "visible hidden",
 		},
 		{
 			name:  "bidi override",
@@ -60,23 +60,23 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 		},
 		{
 			name:  "unicode line and paragraph separators",
-			input: "row one\u2028row two\u2029row three",
-			want:  "row onerow tworow three",
+			input: "row one\u0085row two\u2028row three\u2029row four",
+			want:  "row one row two row three row four",
 		},
 		{
 			name:  "raw single-byte c1 controls in invalid utf-8",
 			input: "state\x9b2K\x9d0;pwned",
-			want:  "state2K0;pwned",
+			want:  "state�2K�0;pwned",
 		},
 		{
 			name:  "invalid utf-8 continuation byte",
 			input: "name\xc2suffix",
-			want:  "namesuffix",
+			want:  "name�suffix",
 		},
 		{
 			name:  "newline and tab",
 			input: "line one\nline\ttwo",
-			want:  "line onelinetwo",
+			want:  "line one line two",
 		},
 		{
 			name:  "non-latin text is preserved",
@@ -99,7 +99,7 @@ func TestSanitizeTerminalTextRemovesInterpretedSequences(t *testing.T) {
 }
 
 func TestHasInterpretedTerminalSequenceDetectsControls(t *testing.T) {
-	unsafe := []string{"\x1b[0m", "\u009b0m", "\u202e", "\u2069", "\u061c", "\u2028", "\u2029", "\x7f", "\r", "\n", "\x9b", "\x9d"}
+	unsafe := []string{"\x1b[0m", "\u0085", "\u009b0m", "\u202e", "\u2069", "\u061c", "\u2028", "\u2029", "\x7f", "\r", "\n", "\x9b", "\x9d"}
 	for _, value := range unsafe {
 		if !HasInterpretedTerminalSequence(value) {
 			t.Fatalf("HasInterpretedTerminalSequence(%q) = false, want true", value)

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -100,6 +100,7 @@ func ExecuteUploadOperations(ctx context.Context, filePath string, operations []
 	if uploadOpts.Client == nil {
 		uploadOpts.Client = newUploadClient()
 	}
+	uploadOpts.Client = clientWithoutRedirects(uploadOpts.Client)
 	if uploadOpts.Concurrency > len(operations) {
 		uploadOpts.Concurrency = len(operations)
 	}

--- a/internal/asc/upload_output_redaction.go
+++ b/internal/asc/upload_output_redaction.go
@@ -1,0 +1,24 @@
+package asc
+
+// RedactUploadOperations returns a presentation-safe copy of presigned upload
+// operations. URLs and request-header values are capabilities; method, size,
+// offset, expiration, and header names remain useful for dry-run diagnostics.
+func RedactUploadOperations(operations []UploadOperation) []UploadOperation {
+	if operations == nil {
+		return nil
+	}
+
+	safe := make([]UploadOperation, len(operations))
+	for index, operation := range operations {
+		safe[index] = operation
+		safe[index].URL = RedactedValuePlaceholder
+		if operation.RequestHeaders != nil {
+			safe[index].RequestHeaders = make([]HTTPHeader, len(operation.RequestHeaders))
+			for headerIndex, header := range operation.RequestHeaders {
+				safe[index].RequestHeaders[headerIndex] = header
+				safe[index].RequestHeaders[headerIndex].Value = RedactedValuePlaceholder
+			}
+		}
+	}
+	return safe
+}

--- a/internal/asc/upload_output_redaction_test.go
+++ b/internal/asc/upload_output_redaction_test.go
@@ -1,0 +1,36 @@
+package asc
+
+import "testing"
+
+func TestRedactUploadOperationsWithholdsCapabilitiesWithoutMutatingInput(t *testing.T) {
+	original := []UploadOperation{{
+		Method: "PUT",
+		URL:    "https://upload.example/object?Signature=signed-secret",
+		Length: 42,
+		Offset: 7,
+		RequestHeaders: []HTTPHeader{{
+			Name:  "Authorization",
+			Value: "header-secret",
+		}},
+	}}
+
+	safe := RedactUploadOperations(original)
+	if len(safe) != 1 {
+		t.Fatalf("redacted operations length = %d, want 1", len(safe))
+	}
+	if safe[0].Method != "PUT" || safe[0].Length != 42 || safe[0].Offset != 7 {
+		t.Fatalf("redaction dropped non-sensitive operation metadata: %+v", safe[0])
+	}
+	if safe[0].URL != RedactedValuePlaceholder {
+		t.Fatalf("redacted URL = %q, want placeholder", safe[0].URL)
+	}
+	if len(safe[0].RequestHeaders) != 1 || safe[0].RequestHeaders[0].Name != "Authorization" {
+		t.Fatalf("redaction dropped header shape: %+v", safe[0].RequestHeaders)
+	}
+	if safe[0].RequestHeaders[0].Value != RedactedValuePlaceholder {
+		t.Fatalf("redacted header value = %q, want placeholder", safe[0].RequestHeaders[0].Value)
+	}
+	if original[0].URL == safe[0].URL || original[0].RequestHeaders[0].Value == safe[0].RequestHeaders[0].Value {
+		t.Fatal("redaction mutated the input operations")
+	}
+}

--- a/internal/asc/upload_redirect_test.go
+++ b/internal/asc/upload_redirect_test.go
@@ -1,0 +1,101 @@
+package asc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestExecuteUploadOperationsRefusesRedirectWithoutForwardingBodyOrReferer(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		t.Errorf("redirect target received request: method=%s referer=%q body=%q", r.Method, r.Referer(), body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/capture", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	filePath := filepath.Join(t.TempDir(), "asset.bin")
+	if err := os.WriteFile(filePath, []byte("secret upload body"), 0o600); err != nil {
+		t.Fatalf("write upload fixture: %v", err)
+	}
+
+	err := ExecuteUploadOperations(
+		context.Background(),
+		filePath,
+		[]UploadOperation{{
+			Method: http.MethodPut,
+			URL:    source.URL + "/upload?X-Amz-Signature=signed-secret",
+			Length: int64(len("secret upload body")),
+		}},
+		WithUploadHTTPClient(source.Client()),
+		WithUploadConcurrency(1),
+		withUploadRetryOptions(0),
+	)
+	if err == nil {
+		t.Fatal("expected redirect response to fail")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", got)
+	}
+	if strings.Contains(err.Error(), "signed-secret") {
+		t.Fatalf("redirect error leaked signed query: %v", err)
+	}
+}
+
+func TestUploadAssetFromFileRefusesRedirectWithoutForwardingBodyOrReferer(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		t.Errorf("redirect target received request: method=%s referer=%q body=%q", r.Method, r.Referer(), body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/capture", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	filePath := filepath.Join(t.TempDir(), "asset.bin")
+	if err := os.WriteFile(filePath, []byte("secret upload body"), 0o600); err != nil {
+		t.Fatalf("write upload fixture: %v", err)
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("open upload fixture: %v", err)
+	}
+	defer file.Close()
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = source.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	err = UploadAssetFromFile(context.Background(), file, int64(len("secret upload body")), []UploadOperation{{
+		Method: http.MethodPut,
+		URL:    source.URL + "/upload?X-Amz-Signature=signed-secret",
+		Length: int64(len("secret upload body")),
+	}})
+	if err == nil {
+		t.Fatal("expected redirect response to fail")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", got)
+	}
+	if strings.Contains(err.Error(), "signed-secret") {
+		t.Fatalf("redirect error leaked signed query: %v", err)
+	}
+}

--- a/internal/asc/xcode_cloud_results.go
+++ b/internal/asc/xcode_cloud_results.go
@@ -516,7 +516,7 @@ func (c *Client) DownloadCiArtifact(ctx context.Context, downloadURL string) (*R
 		return nil, fmt.Errorf("ci artifact download: %w", err)
 	}
 
-	resp, err := c.doStreamNoAuth(ctx, "GET", downloadURL, "application/octet-stream")
+	resp, err := c.doStreamNoAuth(ctx, downloadURL, "application/octet-stream")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -336,7 +336,6 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 }
 
 func loadPrivateKeyPEMForStorage(path string) (string, error) {
-	path = strings.TrimSpace(path)
 	if path == "" {
 		return "", nil
 	}
@@ -490,7 +489,6 @@ func MigrateKeychainToConfig(opts MigrateKeychainToConfigOptions) (MigrateKeycha
 }
 
 func resolveMigrationConfigPath(raw string) (string, error) {
-	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return config.Path()
 	}
@@ -502,7 +500,6 @@ func resolveMigrationConfigPath(raw string) (string, error) {
 }
 
 func resolveMigrationPrivateKeyDir(raw, configPath string) (string, error) {
-	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		raw = filepath.Join(filepath.Dir(configPath), "keys")
 	}
@@ -514,7 +511,7 @@ func resolveMigrationPrivateKeyDir(raw, configPath string) (string, error) {
 }
 
 func migrationPrivateKeyPath(cred Credential, privateKeyDir string, configName string) (string, bool, error) {
-	currentPath := strings.TrimSpace(cred.PrivateKeyPath)
+	currentPath := cred.PrivateKeyPath
 	if currentPath != "" {
 		info, err := os.Stat(currentPath)
 		if err == nil {
@@ -1629,7 +1626,7 @@ func hasAnyCredentials(cfg *config.Config) bool {
 	}
 	if strings.TrimSpace(cfg.KeyID) != "" ||
 		strings.TrimSpace(cfg.IssuerID) != "" ||
-		strings.TrimSpace(cfg.PrivateKeyPath) != "" ||
+		cfg.PrivateKeyPath != "" ||
 		strings.TrimSpace(cfg.KeyType) != "" {
 		return true
 	}
@@ -1637,7 +1634,7 @@ func hasAnyCredentials(cfg *config.Config) bool {
 		if strings.TrimSpace(cred.Name) != "" ||
 			strings.TrimSpace(cred.KeyID) != "" ||
 			strings.TrimSpace(cred.IssuerID) != "" ||
-			strings.TrimSpace(cred.PrivateKeyPath) != "" ||
+			cred.PrivateKeyPath != "" ||
 			strings.TrimSpace(cred.KeyType) != "" {
 			return true
 		}
@@ -1650,14 +1647,14 @@ func isCompleteConfigCredential(cred config.Credential) bool {
 		config.IsIndividualCredentialKeyType(cred.KeyType)
 	return strings.TrimSpace(cred.KeyID) != "" &&
 		hasIssuer &&
-		strings.TrimSpace(cred.PrivateKeyPath) != ""
+		cred.PrivateKeyPath != ""
 }
 
 func hasLegacyCredentials(cfg *config.Config) bool {
 	return cfg != nil &&
 		strings.TrimSpace(cfg.KeyID) != "" &&
 		(strings.TrimSpace(cfg.IssuerID) != "" || config.IsIndividualCredentialKeyType(cfg.KeyType)) &&
-		strings.TrimSpace(cfg.PrivateKeyPath) != ""
+		cfg.PrivateKeyPath != ""
 }
 
 func configCredentialList(cfg *config.Config) []config.Credential {
@@ -1719,7 +1716,7 @@ func findConfigCredential(cfg *config.Config, name string) (config.Credential, b
 	}
 	if name == legacyName && (strings.TrimSpace(cfg.KeyID) != "" ||
 		strings.TrimSpace(cfg.IssuerID) != "" ||
-		strings.TrimSpace(cfg.PrivateKeyPath) != "" ||
+		cfg.PrivateKeyPath != "" ||
 		strings.TrimSpace(cfg.KeyType) != "") {
 		cred := config.Credential{
 			Name:           legacyName,

--- a/internal/auth/keychain_path_whitespace_test.go
+++ b/internal/auth/keychain_path_whitespace_test.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveMigrationPathsPreserveExactWhitespace(t *testing.T) {
+	t.Run("config path", func(t *testing.T) {
+		base := t.TempDir()
+		spaced := filepath.Join(base, " config.json ")
+		unspaced := filepath.Join(base, "config.json")
+
+		got, err := resolveMigrationConfigPath(spaced)
+		if err != nil {
+			t.Fatalf("resolveMigrationConfigPath() error = %v", err)
+		}
+		if got != spaced {
+			t.Fatalf("resolveMigrationConfigPath() = %q, want exact path %q (not sibling %q)", got, spaced, unspaced)
+		}
+	})
+
+	t.Run("private key directory", func(t *testing.T) {
+		base := t.TempDir()
+		spaced := filepath.Join(base, " keys ")
+		unspaced := filepath.Join(base, "keys")
+
+		got, err := resolveMigrationPrivateKeyDir(spaced, filepath.Join(base, "config.json"))
+		if err != nil {
+			t.Fatalf("resolveMigrationPrivateKeyDir() error = %v", err)
+		}
+		if got != spaced {
+			t.Fatalf("resolveMigrationPrivateKeyDir() = %q, want exact path %q (not sibling %q)", got, spaced, unspaced)
+		}
+	})
+}
+
+func TestResolveMigrationPathsTreatAllSpaceNamesAsPaths(t *testing.T) {
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	work := t.TempDir()
+	if err := os.Chdir(work); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Errorf("restore Chdir() error = %v", err)
+		}
+	})
+
+	const allSpaceName = "   "
+	want, err := filepath.Abs(allSpaceName)
+	if err != nil {
+		t.Fatalf("Abs() error = %v", err)
+	}
+
+	configPath, err := resolveMigrationConfigPath(allSpaceName)
+	if err != nil {
+		t.Fatalf("resolveMigrationConfigPath() error = %v", err)
+	}
+	if configPath != want {
+		t.Fatalf("resolveMigrationConfigPath() = %q, want %q", configPath, want)
+	}
+
+	keyDir, err := resolveMigrationPrivateKeyDir(allSpaceName, filepath.Join(work, "config.json"))
+	if err != nil {
+		t.Fatalf("resolveMigrationPrivateKeyDir() error = %v", err)
+	}
+	if keyDir != want {
+		t.Fatalf("resolveMigrationPrivateKeyDir() = %q, want %q", keyDir, want)
+	}
+}
+
+func TestStoredPrivateKeyPathPreservesExactWhitespace(t *testing.T) {
+	base := t.TempDir()
+	spaced := filepath.Join(base, " AuthKey.p8 ")
+	unspaced := filepath.Join(base, "AuthKey.p8")
+	if err := os.WriteFile(spaced, []byte("spaced-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(spaced) error = %v", err)
+	}
+	if err := os.WriteFile(unspaced, []byte("wrong-sibling"), 0o600); err != nil {
+		t.Fatalf("WriteFile(unspaced) error = %v", err)
+	}
+
+	pem, err := loadPrivateKeyPEMForStorage(spaced)
+	if err != nil {
+		t.Fatalf("loadPrivateKeyPEMForStorage() error = %v", err)
+	}
+	if pem != "spaced-key" {
+		t.Fatalf("loadPrivateKeyPEMForStorage() = %q, want content from %q", pem, spaced)
+	}
+
+	got, exported, err := migrationPrivateKeyPath(Credential{
+		Name:           "team",
+		PrivateKeyPath: spaced,
+	}, filepath.Join(base, "exports"), "team")
+	if err != nil {
+		t.Fatalf("migrationPrivateKeyPath() error = %v", err)
+	}
+	if got != spaced || exported {
+		t.Fatalf("migrationPrivateKeyPath() = (%q, %t), want (%q, false)", got, exported, spaced)
+	}
+}
+
+func TestStoredPrivateKeyPathAcceptsAllSpaceFilename(t *testing.T) {
+	base := t.TempDir()
+	allSpacePath := filepath.Join(base, "   ")
+	if err := os.WriteFile(allSpacePath, []byte("space-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	pem, err := loadPrivateKeyPEMForStorage(allSpacePath)
+	if err != nil {
+		t.Fatalf("loadPrivateKeyPEMForStorage() error = %v", err)
+	}
+	if pem != "space-key" {
+		t.Fatalf("loadPrivateKeyPEMForStorage() = %q, want %q", pem, "space-key")
+	}
+
+	got, exported, err := migrationPrivateKeyPath(Credential{
+		Name:           "team",
+		PrivateKeyPath: allSpacePath,
+	}, filepath.Join(base, "exports"), "team")
+	if err != nil {
+		t.Fatalf("migrationPrivateKeyPath() error = %v", err)
+	}
+	if got != allSpacePath || exported {
+		t.Fatalf("migrationPrivateKeyPath() = (%q, %t), want (%q, false)", got, exported, allSpacePath)
+	}
+}
+
+func TestPrivateKeyExportRootPreservesExactWhitespace(t *testing.T) {
+	base := t.TempDir()
+	spacedKeyDir := filepath.Join(base, " keys ")
+	unspacedKeyDir := filepath.Join(base, "keys")
+	if err := os.MkdirAll(unspacedKeyDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(unspaced) error = %v", err)
+	}
+	const name = "AuthKey_team.p8"
+
+	if err := writePrivateKeyPEMFile(spacedKeyDir, name, "spaced-root-key"); err != nil {
+		t.Fatalf("writePrivateKeyPEMFile() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(spacedKeyDir, name))
+	if err != nil {
+		t.Fatalf("ReadFile(spaced) error = %v", err)
+	}
+	if string(got) != "spaced-root-key" {
+		t.Fatalf("spaced root key = %q, want %q", got, "spaced-root-key")
+	}
+	if _, err := os.Stat(filepath.Join(unspacedKeyDir, name)); !os.IsNotExist(err) {
+		t.Fatalf("unspaced sibling Stat() error = %v, want not-exist", err)
+	}
+
+	allSpaceKeyDir := filepath.Join(base, "   ")
+	if err := writePrivateKeyPEMFile(allSpaceKeyDir, name, "all-space-root-key"); err != nil {
+		t.Fatalf("writePrivateKeyPEMFile(all-space root) error = %v", err)
+	}
+	got, err = os.ReadFile(filepath.Join(allSpaceKeyDir, name))
+	if err != nil {
+		t.Fatalf("ReadFile(all-space root) error = %v", err)
+	}
+	if string(got) != "all-space-root-key" {
+		t.Fatalf("all-space root key = %q, want %q", got, "all-space-root-key")
+	}
+}

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -296,7 +296,7 @@ Examples:
 			}
 
 			if !hasAgeRatingUpdates(attributes) {
-				return fmt.Errorf("age-rating edit: at least one update flag is required")
+				return shared.UsageError("age-rating edit: at least one update flag is required")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/assets/assets_screenshots_upload.go
+++ b/internal/cli/assets/assets_screenshots_upload.go
@@ -3,6 +3,8 @@ package assets
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -350,9 +352,28 @@ func uploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, fileP
 		return asc.AssetUploadResultItem{}, err
 	}
 	defer file.Close()
+	return uploadScreenshotAssetFromFile(ctx, client, setID, filePath, file)
+}
 
+func uploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setID, filePath string, file *os.File) (asc.AssetUploadResultItem, error) {
+	if file == nil {
+		return asc.AssetUploadResultItem{}, fmt.Errorf("screenshot file is required")
+	}
 	info, err := file.Stat()
 	if err != nil {
+		return asc.AssetUploadResultItem{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return asc.AssetUploadResultItem{}, fmt.Errorf("expected regular file: %q", filePath)
+	}
+	if info.Size() <= 0 {
+		return asc.AssetUploadResultItem{}, fmt.Errorf("file is empty: %q", filePath)
+	}
+	const maxScreenshotUploadFileSize = int64(1024 * 1024 * 1024)
+	if info.Size() > maxScreenshotUploadFileSize {
+		return asc.AssetUploadResultItem{}, fmt.Errorf("file size exceeds %d bytes: %q", maxScreenshotUploadFileSize, filePath)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return asc.AssetUploadResultItem{}, err
 	}
 
@@ -393,6 +414,13 @@ func uploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, fileP
 // UploadScreenshotAsset uploads a screenshot file to a set.
 func UploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, error) {
 	return uploadScreenshotAsset(ctx, client, setID, filePath)
+}
+
+// UploadScreenshotAssetFromFile uploads from an already-open, validated source
+// handle. Callers that discover files under a rooted filesystem can retain the
+// handle so a later pathname replacement cannot redirect the upload.
+func UploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setID, filePath string, file *os.File) (asc.AssetUploadResultItem, error) {
+	return uploadScreenshotAssetFromFile(ctx, client, setID, filePath, file)
 }
 
 func waitForScreenshotDelivery(ctx context.Context, client *asc.Client, screenshotID string) (string, error) {

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -593,17 +593,11 @@ Examples:
 			if !*confirm {
 				return shared.UsageError("--confirm is required")
 			}
-			if strings.TrimSpace(*privateKeyDir) == "" && *privateKeyDir != "" {
-				return shared.UsageError("--private-key-dir cannot be blank")
-			}
-			if strings.TrimSpace(*configPath) == "" && *configPath != "" {
-				return shared.UsageError("--config cannot be blank")
-			}
-			if *local && strings.TrimSpace(*configPath) != "" {
+			if *local && *configPath != "" {
 				return shared.UsageError("--local and --config are mutually exclusive")
 			}
 
-			targetConfigPath := strings.TrimSpace(*configPath)
+			targetConfigPath := *configPath
 			if targetConfigPath == "" {
 				if *local {
 					targetConfigPath, err = config.LocalPath()
@@ -622,7 +616,7 @@ Examples:
 
 			result, err := migrateKeychainToConfig(authsvc.MigrateKeychainToConfigOptions{
 				ConfigPath:     targetConfigPath,
-				PrivateKeyDir:  strings.TrimSpace(*privateKeyDir),
+				PrivateKeyDir:  *privateKeyDir,
 				RemoveKeychain: *removeKeychain,
 			})
 			if err != nil {
@@ -640,7 +634,7 @@ Examples:
 
 func printMigrateToConfigResult(result authsvc.MigrateKeychainToConfigResult) {
 	fmt.Printf("Migrated %d credential(s) to %s\n", len(result.Migrated), result.ConfigPath)
-	if strings.TrimSpace(result.PrivateKeyDir) != "" {
+	if result.PrivateKeyDir != "" {
 		fmt.Printf("Private key directory: %s\n", result.PrivateKeyDir)
 	}
 	if len(result.Migrated) > 0 {

--- a/internal/cli/auth/auth_path_whitespace_test.go
+++ b/internal/cli/auth/auth_path_whitespace_test.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	authsvc "github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
+)
+
+func TestAuthExportToConfigPreservesExactPathBytes(t *testing.T) {
+	base := t.TempDir()
+	spacedConfig := filepath.Join(base, " config.json ")
+	spacedKeyDir := filepath.Join(base, " keys ")
+	var captured authsvc.MigrateKeychainToConfigOptions
+	restore := SetMigrateKeychainToConfig(func(opts authsvc.MigrateKeychainToConfigOptions) (authsvc.MigrateKeychainToConfigResult, error) {
+		captured = opts
+		return authsvc.MigrateKeychainToConfigResult{ConfigPath: opts.ConfigPath}, nil
+	})
+	t.Cleanup(restore)
+
+	cmd := AuthExportToConfigCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--confirm",
+		"--output", "json",
+		"--config", spacedConfig,
+		"--private-key-dir", spacedKeyDir,
+	}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if err := cmd.Exec(context.Background(), nil); err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+
+	if captured.ConfigPath != spacedConfig {
+		t.Fatalf("ConfigPath = %q, want exact path %q", captured.ConfigPath, spacedConfig)
+	}
+	if captured.PrivateKeyDir != spacedKeyDir {
+		t.Fatalf("PrivateKeyDir = %q, want exact path %q", captured.PrivateKeyDir, spacedKeyDir)
+	}
+}
+
+func TestAuthExportToConfigTreatsAllSpaceNamesAsPaths(t *testing.T) {
+	var captured authsvc.MigrateKeychainToConfigOptions
+	restore := SetMigrateKeychainToConfig(func(opts authsvc.MigrateKeychainToConfigOptions) (authsvc.MigrateKeychainToConfigResult, error) {
+		captured = opts
+		return authsvc.MigrateKeychainToConfigResult{ConfigPath: opts.ConfigPath}, nil
+	})
+	t.Cleanup(restore)
+
+	cmd := AuthExportToConfigCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--confirm",
+		"--output", "json",
+		"--config", "   ",
+		"--private-key-dir", "   ",
+	}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if err := cmd.Exec(context.Background(), nil); err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+
+	want, err := filepath.Abs("   ")
+	if err != nil {
+		t.Fatalf("Abs() error = %v", err)
+	}
+	if captured.ConfigPath != want {
+		t.Fatalf("ConfigPath = %q, want all-space path %q", captured.ConfigPath, want)
+	}
+	if captured.PrivateKeyDir != "   " {
+		t.Fatalf("PrivateKeyDir = %q, want exact all-space value", captured.PrivateKeyDir)
+	}
+}

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -710,38 +710,6 @@ func TestAuthExportToConfigCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("blank private key dir", func(t *testing.T) {
-		cmd := AuthExportToConfigCommand()
-		if err := cmd.FlagSet.Parse([]string{"--confirm", "--private-key-dir", "   "}); err != nil {
-			t.Fatalf("Parse() error: %v", err)
-		}
-		_, stderr := captureAuthOutput(t, func() {
-			err := cmd.Exec(context.Background(), []string{})
-			if !errors.Is(err, flag.ErrHelp) {
-				t.Fatalf("expected flag.ErrHelp, got %v", err)
-			}
-		})
-		if !strings.Contains(stderr, "--private-key-dir cannot be blank") {
-			t.Fatalf("expected blank private-key-dir error, got %q", stderr)
-		}
-	})
-
-	t.Run("blank config path", func(t *testing.T) {
-		cmd := AuthExportToConfigCommand()
-		if err := cmd.FlagSet.Parse([]string{"--confirm", "--config", "   "}); err != nil {
-			t.Fatalf("Parse() error: %v", err)
-		}
-		_, stderr := captureAuthOutput(t, func() {
-			err := cmd.Exec(context.Background(), []string{})
-			if !errors.Is(err, flag.ErrHelp) {
-				t.Fatalf("expected flag.ErrHelp, got %v", err)
-			}
-		})
-		if !strings.Contains(stderr, "--config cannot be blank") {
-			t.Fatalf("expected blank config error, got %q", stderr)
-		}
-	})
-
 	t.Run("local and config are mutually exclusive", func(t *testing.T) {
 		cmd := AuthExportToConfigCommand()
 		if err := cmd.FlagSet.Parse([]string{"--confirm", "--local", "--config", filepath.Join(t.TempDir(), "config.json")}); err != nil {

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -38,6 +38,7 @@ func BuildsUploadCommand() *ffcli.Command {
 	pollInterval := fs.Duration("poll-interval", shared.PublishDefaultPollInterval, "Polling interval for --wait and --test-notes")
 	verifyTimeout := fs.Duration("verify-timeout", 0, "How long to watch for immediate post-commit upload failures (0 to disable)")
 	output := shared.BindOutputFlags(fs)
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 
 	return &ffcli.Command{
 		Name:       "upload",
@@ -50,6 +51,8 @@ the file immediately. Use --verify-timeout to briefly watch for immediate
 post-commit processing failures, or --wait for full build discovery and
 processing.
 Use --dry-run to only reserve the upload operations.
+Presigned URLs and request-header values are redacted from output by default.
+Pass --include-sensitive only when another tool must consume those capabilities.
 
 Use --ipa for iOS, tvOS, and visionOS apps. Use --pkg for macOS apps.
 When using --pkg, the platform is automatically set to MAC_OS.
@@ -58,6 +61,7 @@ Examples:
   asc builds upload --app "123456789" --ipa "path/to/app.ipa"
   asc builds upload --ipa "app.ipa" --version "1.0.0" --build-number "123"
   asc builds upload --app "123456789" --ipa "app.ipa" --dry-run
+  asc builds upload --app "123456789" --ipa "app.ipa" --dry-run --include-sensitive
   asc builds upload --app "123456789" --ipa "app.ipa" --test-notes "Test flow" --locale "en-US" --wait
   asc builds upload --app "123456789" --pkg "path/to/app.pkg" --version "1.0.0" --build-number "123"`,
 		FlagSet:   fs,
@@ -236,13 +240,21 @@ Examples:
 				return fmt.Errorf("builds upload: %w", err)
 			}
 
-			// Return upload info including presigned URL operations
+			outputOperations := fileResp.Data.Attributes.UploadOperations
+			if *includeSensitive {
+				shared.WarnIncludeSensitive(os.Stderr, true)
+			} else {
+				outputOperations = asc.RedactUploadOperations(outputOperations)
+			}
+
+			// Return upload metadata. Capability-bearing URL and header values
+			// require an explicit per-invocation opt-in.
 			result := &asc.BuildUploadResult{
 				UploadID:   uploadResp.Data.ID,
 				FileID:     fileResp.Data.ID,
 				FileName:   fileResp.Data.Attributes.FileName,
 				FileSize:   fileResp.Data.Attributes.FileSize,
-				Operations: fileResp.Data.Attributes.UploadOperations,
+				Operations: outputOperations,
 			}
 
 			if !*dryRun {

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -65,6 +65,17 @@ func TestBuildsUploadCommand_HelpShowsConcurrencyDefaultOnce(t *testing.T) {
 	}
 }
 
+func TestBuildsUploadCommandHasExplicitSensitiveOutputOptIn(t *testing.T) {
+	cmd := BuildsUploadCommand()
+	flag := cmd.FlagSet.Lookup("include-sensitive")
+	if flag == nil {
+		t.Fatal("expected --include-sensitive to be registered")
+	}
+	if !strings.Contains(flag.Usage, "secret") {
+		t.Fatalf("expected sensitive-output warning in flag usage, got %q", flag.Usage)
+	}
+}
+
 func TestBuildsListCommand_ProcessingStateFlagDescription(t *testing.T) {
 	cmd := BuildsListCommand()
 

--- a/internal/cli/builds/builds_dsyms.go
+++ b/internal/cli/builds/builds_dsyms.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/urlsanitize"
 )
 
 // dsymHTTPClient is the HTTP client used for dSYM downloads.
@@ -249,12 +250,28 @@ func displayBundleID(bundleID string, index int) string {
 func downloadDSYM(ctx context.Context, rawURL, destPath string) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return 0, fmt.Errorf("download failed: %w", err)
+		return 0, urlsanitize.NewTransportError(
+			"create dSYM download request",
+			urlsanitize.RedactURLHostForError(rawURL),
+			err,
+		)
 	}
 
-	resp, err := dsymHTTPClient.Do(req)
+	client := dsymHTTPClient
+	if client == nil {
+		client = &http.Client{}
+	}
+	safeClient := *client
+	safeClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := safeClient.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("download failed: %w", err)
+		return 0, urlsanitize.NewTransportError(
+			"dSYM download request",
+			urlsanitize.RedactURLHostForError(rawURL),
+			err,
+		)
 	}
 	defer resp.Body.Close()
 

--- a/internal/cli/builds/builds_dsyms_security_test.go
+++ b/internal/cli/builds/builds_dsyms_security_test.go
@@ -1,0 +1,95 @@
+package builds
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDownloadDSYMRefusesRedirectWithoutForwardingReferer(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		t.Errorf("redirect target received request with referer %q", r.Referer())
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/capture", http.StatusFound)
+	}))
+	defer source.Close()
+
+	restore := SetDSYMHTTPClient(source.Client())
+	t.Cleanup(restore)
+	_, err := downloadDSYM(
+		context.Background(),
+		source.URL+"/symbols?Signature=signed-secret",
+		filepath.Join(t.TempDir(), "symbols.zip"),
+	)
+	if err == nil {
+		t.Fatal("expected redirect response to fail")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", got)
+	}
+	if strings.Contains(err.Error(), "signed-secret") {
+		t.Fatalf("redirect error leaked signed query: %v", err)
+	}
+}
+
+func TestDownloadDSYMSanitizesTransportErrorAndPreservesCause(t *testing.T) {
+	sentinel := errors.New("dial failed for https://download.example/file?Signature=signed-secret")
+	restore := SetDSYMHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, sentinel
+		}),
+	})
+	t.Cleanup(restore)
+
+	_, err := downloadDSYM(
+		context.Background(),
+		"https://download.example/file?Signature=signed-secret",
+		filepath.Join(t.TempDir(), "symbols.zip"),
+	)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if strings.Contains(err.Error(), "signed-secret") || strings.Contains(err.Error(), "Signature") {
+		t.Fatalf("transport error leaked signed query: %v", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("transport cause was not preserved: %v", err)
+	}
+}
+
+func TestDownloadDSYMDoesNotWriteRedirectOrErrorBody(t *testing.T) {
+	restore := SetDSYMHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Status:     "403 Forbidden",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("signed-secret")),
+			}, nil
+		}),
+	})
+	t.Cleanup(restore)
+
+	dest := filepath.Join(t.TempDir(), "symbols.zip")
+	if _, err := downloadDSYM(context.Background(), "https://download.example/file", dest); err == nil {
+		t.Fatal("expected HTTP error")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}

--- a/internal/cli/cmdtest/builds_upload_concurrency_test.go
+++ b/internal/cli/cmdtest/builds_upload_concurrency_test.go
@@ -111,7 +111,69 @@ func TestBuildsUploadDryRunSucceedsWithDefaultConcurrency(t *testing.T) {
 	if !strings.Contains(stdout, "upload-1") {
 		t.Fatalf("expected reserved upload in output, got %q", stdout)
 	}
+	if strings.Contains(stdout, "https://upload.example.com/part-1") ||
+		strings.Contains(stdout, "application/octet-stream") {
+		t.Fatalf("default dry-run output exposed upload capabilities: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"(redacted)"`) {
+		t.Fatalf("default dry-run output did not mark withheld upload capabilities: %q", stdout)
+	}
 	if got := atomic.LoadInt32(&uploadRequests); got != 0 {
 		t.Fatalf("expected no chunk uploads in dry-run, got %d", got)
+	}
+}
+
+func TestBuildsUploadDryRunRequiresExplicitOptInForUploadCapabilities(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
+	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write ipa fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":4,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1?Signature=signed-secret","length":4,"offset":0,"requestHeaders":[{"name":"Authorization","value":"header-secret"}]}]}}}`)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, http.ErrUseLastResponse
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "upload",
+			"--app", "123456789",
+			"--ipa", ipaPath,
+			"--version", "1.0.0",
+			"--build-number", "42",
+			"--dry-run",
+			"--include-sensitive",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	for _, secret := range []string{"signed-secret", "header-secret"} {
+		if !strings.Contains(stdout, secret) {
+			t.Fatalf("--include-sensitive output omitted %q: %q", secret, stdout)
+		}
+	}
+	if !strings.Contains(stderr, "Warning: --include-sensitive prints secrets") {
+		t.Fatalf("expected sensitive-output warning, got %q", stderr)
 	}
 }

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -2301,7 +2301,7 @@ func TestAgeRatingValidationErrors(t *testing.T) {
 			name:     "age-rating edit missing updates",
 			args:     []string{"age-rating", "edit", "--id", "AGE_ID"},
 			wantErr:  "at least one update flag is required",
-			wantHelp: false,
+			wantHelp: true,
 		},
 		{
 			name:     "age-rating edit invalid enum",

--- a/internal/cli/cmdtest/publish_appstore_submit_test.go
+++ b/internal/cli/cmdtest/publish_appstore_submit_test.go
@@ -31,6 +31,23 @@ func respondToPublishAppLookup(t *testing.T, req *http.Request) (*http.Response,
 	return resp, err, true
 }
 
+func respondToFinalReviewSubmissionValidation(req *http.Request) (*http.Response, error, bool) {
+	if req.Method != http.MethodGet {
+		return nil, nil, false
+	}
+
+	switch req.URL.Path {
+	case "/v1/reviewSubmissions/review-sub-1":
+		resp, err := jsonResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"review-sub-1","attributes":{"state":"READY_FOR_REVIEW","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`)
+		return resp, err, true
+	case "/v1/reviewSubmissions/review-sub-1/items":
+		resp, err := jsonResponse(http.StatusOK, `{"data":[{"type":"reviewSubmissionItems","id":"item-1","relationships":{"appStoreVersion":{"data":{"type":"appStoreVersions","id":"version-1"}}}}]}`)
+		return resp, err, true
+	default:
+		return nil, nil, false
+	}
+}
+
 func TestPublishAppStoreSubmitUsesModernReviewSubmissionFlow(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -45,6 +62,9 @@ func TestPublishAppStoreSubmitUsesModernReviewSubmissionFlow(t *testing.T) {
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests.Add(req.Method + " " + req.URL.Path)
 		if resp, err, ok := respondToPublishAppLookup(t, req); ok {
+			return resp, err
+		}
+		if resp, err, ok := respondToFinalReviewSubmissionValidation(req); ok {
 			return resp, err
 		}
 
@@ -634,6 +654,9 @@ func TestPublishAppStoreSubmitUsesFreshTimeoutBudgetsForPreflightAndSubmission(t
 		if resp, err, ok := respondToPublishAppLookup(t, req); ok {
 			return resp, err
 		}
+		if resp, err, ok := respondToFinalReviewSubmissionValidation(req); ok {
+			return resp, err
+		}
 
 		switch {
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
@@ -765,6 +788,9 @@ func TestPublishAppStoreSubmitPreflightUsesPublishTimeoutOverride(t *testing.T) 
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if resp, err, ok := respondToPublishAppLookup(t, req); ok {
+			return resp, err
+		}
+		if resp, err, ok := respondToFinalReviewSubmissionValidation(req); ok {
 			return resp, err
 		}
 
@@ -1012,6 +1038,9 @@ func TestPublishAppStoreSubmitDefaultTimeoutUsesSharedPipelineBudget(t *testing.
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if resp, err, ok := respondToPublishAppLookup(t, req); ok {
+			return resp, err
+		}
+		if resp, err, ok := respondToFinalReviewSubmissionValidation(req); ok {
 			return resp, err
 		}
 

--- a/internal/cli/cmdtest/review_credentials_redaction_test.go
+++ b/internal/cli/cmdtest/review_credentials_redaction_test.go
@@ -41,6 +41,11 @@ func betaAppReviewDetailJSON() string {
 		`"demoAccountPassword":"` + testFlightDemoPasswordSentinel + `"}}}`
 }
 
+func includedAppStoreReviewDetailJSON() string {
+	return `{"type":"appStoreReviewDetails","id":"detail-1","attributes":{` +
+		`"demoAccountPassword":"` + appStoreDemoPasswordSentinel + `","notes":"keep"}}`
+}
+
 func assertNoSentinel(t *testing.T, label, sentinel, content string) {
 	t.Helper()
 	if strings.Contains(content, sentinel) {
@@ -165,6 +170,75 @@ func TestReviewDetailsForVersionRedactsDemoAccountPassword(t *testing.T) {
 	assertNoSentinel(t, "stderr", appStoreDemoPasswordSentinel, stderr)
 	if !strings.Contains(stdout, redactedDemoPasswordText) {
 		t.Fatalf("expected redaction placeholder, got %q", stdout)
+	}
+}
+
+func TestIncludedReviewDetailsRedactDemoAccountPasswordByDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		args []string
+		body string
+	}{
+		{
+			name: "versions view",
+			path: "/v1/appStoreVersions/version-1",
+			args: []string{
+				"versions", "view", "--version-id", "version-1",
+				"--include", "appStoreReviewDetail", "--output", "json",
+			},
+			body: `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.0","platform":"IOS"}},"included":[` +
+				includedAppStoreReviewDetailJSON() + `]}`,
+		},
+		{
+			name: "review attachment list",
+			path: "/v1/appStoreReviewDetails/detail-1/appStoreReviewAttachments",
+			args: []string{
+				"review", "attachments-list", "--review-detail", "detail-1",
+				"--include", "appStoreReviewDetail", "--detail-fields", "demoAccountPassword", "--output", "json",
+			},
+			body: `{"data":[],"included":[` + includedAppStoreReviewDetailJSON() + `]}`,
+		},
+		{
+			name: "review attachment get",
+			path: "/v1/appStoreReviewAttachments/attachment-1",
+			args: []string{
+				"review", "attachments-get", "--id", "attachment-1",
+				"--include", "appStoreReviewDetail", "--detail-fields", "demoAccountPassword", "--output", "json",
+			},
+			body: `{"data":{"type":"appStoreReviewAttachments","id":"attachment-1","attributes":{"fileName":"review.pdf"}},"included":[` +
+				includedAppStoreReviewDetailJSON() + `]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			stubTransport(t, func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path != test.path {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+				}
+				return jsonResponse(http.StatusOK, test.body)
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			assertNoSentinel(t, "stdout", appStoreDemoPasswordSentinel, stdout)
+			assertNoSentinel(t, "stderr", appStoreDemoPasswordSentinel, stderr)
+			if !strings.Contains(stdout, redactedDemoPasswordText) {
+				t.Fatalf("expected redaction placeholder, got %q", stdout)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/review_submit_test.go
+++ b/internal/cli/cmdtest/review_submit_test.go
@@ -347,6 +347,9 @@ func TestReviewSubmitUsesModernReviewSubmissionFlow(t *testing.T) {
 	requests := newRequestLog(20)
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests.Add(req.Method + " " + req.URL.Path)
+		if resp, err, ok := respondToFinalReviewSubmissionValidation(req); ok {
+			return resp, err
+		}
 
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":

--- a/internal/cli/docs/docs_init.go
+++ b/internal/cli/docs/docs_init.go
@@ -112,6 +112,9 @@ func InitReference(opts InitOptions) (InitResult, error) {
 			return InitResult{}, err
 		}
 	}
+	if err := validateInitReferencePlan(ascPlan, linkPlan); err != nil {
+		return InitResult{}, err
+	}
 
 	created, overwritten, err := writeASCReference(ascPlan)
 	if err != nil {
@@ -132,9 +135,8 @@ func InitReference(opts InitOptions) (InitResult, error) {
 }
 
 func resolveOutputPath(path string) (string, string, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed != "" {
-		abs, err := filepath.Abs(trimmed)
+	if path != "" {
+		abs, err := filepath.Abs(path)
 		if err != nil {
 			return "", "", err
 		}
@@ -204,11 +206,11 @@ func isASCReferencePath(path string) bool {
 }
 
 func normalizeReferencePath(path string) string {
-	trimmed := strings.TrimSpace(filepath.ToSlash(path))
-	if trimmed == "" || trimmed == "." {
+	normalized := filepath.ToSlash(path)
+	if normalized == "" || normalized == "." {
 		return ascReferenceFile
 	}
-	return trimmed
+	return normalized
 }
 
 func findRepoRoot(start string) (string, error) {
@@ -249,8 +251,9 @@ func planASCReference(path string, force bool) (ascReferencePlan, error) {
 	}
 	name := filepath.Base(path)
 
-	// Lstat, not Stat, so a dangling symlink still counts as an existing entry
-	// and is never followed.
+	// Lstat, not Stat, so a dangling symlink still counts as an existing entry.
+	// A final symlink may be followed only after proving that its physical target
+	// is still a regular file beneath the repository root.
 	exists := false
 	perm := defaultDocsFileMode
 	if info, err := os.Lstat(path); err == nil {
@@ -258,6 +261,22 @@ func planASCReference(path string, force bool) (ascReferencePlan, error) {
 		if info.Mode().IsRegular() {
 			// Preserve the operator's chosen mode when replacing the file.
 			perm = info.Mode().Perm()
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			name, err = root.ResolveContainedFinalSymlink(name)
+			if err != nil {
+				return ascReferencePlan{}, fmt.Errorf("%w: ASC.md target is not contained: %w", rootfs.ErrSymlink, err)
+			}
+			if err := validateContainedMarkdownTarget(name); err != nil {
+				return ascReferencePlan{}, err
+			}
+			targetInfo, err := os.Lstat(filepath.Join(root.Path(), name))
+			if err != nil {
+				return ascReferencePlan{}, err
+			}
+			if !targetInfo.Mode().IsRegular() {
+				return ascReferencePlan{}, fmt.Errorf("%q is not a regular file", path)
+			}
+			perm = targetInfo.Mode().Perm()
 		}
 	} else if !os.IsNotExist(err) {
 		return ascReferencePlan{}, err
@@ -267,8 +286,9 @@ func planASCReference(path string, force bool) (ascReferencePlan, error) {
 		return ascReferencePlan{}, fmt.Errorf("%w: %s (use --force to overwrite)", ErrASCReferenceExists, path)
 	}
 
-	// Reject a symlinked destination while planning so the failure happens
-	// before any file is written; the rooted write re-checks at write time.
+	// The name now denotes either the ordinary destination or the already
+	// resolved target of a safe final symlink. The rooted write re-checks every
+	// component at write time.
 	if err := root.CheckContained(name); err != nil {
 		return ascReferencePlan{}, err
 	}
@@ -282,7 +302,7 @@ func writeASCReference(plan ascReferencePlan) (bool, bool, error) {
 		content += "\n"
 	}
 
-	if err := plan.root.WriteFile(plan.name, []byte(content), plan.perm); err != nil {
+	if err := plan.root.WriteFilePreservingMode(plan.name, []byte(content), plan.perm); err != nil {
 		return false, false, err
 	}
 
@@ -294,9 +314,10 @@ func writeASCReference(plan ascReferencePlan) (bool, bool, error) {
 
 // agentFileUpdate is one planned agent-file rewrite.
 type agentFileUpdate struct {
-	name    string
-	content string
-	perm    os.FileMode
+	name        string
+	content     string
+	perm        os.FileMode
+	reportPaths []string
 }
 
 // agentLinkPlan holds every agent-file update computed during planning.
@@ -314,37 +335,164 @@ func planAgentFileLinks(rootDir string, relRef string) (agentLinkPlan, error) {
 		return agentLinkPlan{}, err
 	}
 	plan := agentLinkPlan{root: root, rootDir: rootDir}
+	pending := make(map[string]agentFileUpdate)
 
 	agentsName := "AGENTS.md"
 	if !entryExists(filepath.Join(rootDir, agentsName)) {
 		agentsName = "Agents.md"
 	}
-	agentsContent, agentsChanged, err := planAgentsLink(root, agentsName, relRef)
+	agentsTarget, err := resolveContainedDocsEntry(root, agentsName)
 	if err != nil {
 		return agentLinkPlan{}, err
 	}
-	if agentsChanged {
-		update, err := plannedAgentFileUpdate(rootDir, agentsName, agentsContent)
+	agentsContent, agentsFound, err := readPendingAgentFile(root, pending, agentsTarget)
+	if err != nil {
+		return agentLinkPlan{}, err
+	}
+	if agentsFound {
+		agentsContent, agentsChanged, err := planAgentsLinkContent(agentsContent, relRef)
 		if err != nil {
 			return agentLinkPlan{}, err
 		}
-		plan.updates = append(plan.updates, update)
+		if agentsChanged {
+			update, err := plannedAgentFileUpdate(rootDir, agentsTarget, agentsContent)
+			if err != nil {
+				return agentLinkPlan{}, err
+			}
+			update.reportPaths = append(update.reportPaths, agentsName)
+			pending[agentsTarget] = update
+		}
 	}
 
 	claudeName := "CLAUDE.md"
-	claudeContent, claudeChanged, err := planClaudeLink(root, claudeName, relRef)
+	claudeTarget, err := resolveContainedDocsEntry(root, claudeName)
 	if err != nil {
 		return agentLinkPlan{}, err
 	}
-	if claudeChanged {
-		update, err := plannedAgentFileUpdate(rootDir, claudeName, claudeContent)
+	claudeContent, claudeFound, err := readPendingAgentFile(root, pending, claudeTarget)
+	if err != nil {
+		return agentLinkPlan{}, err
+	}
+	if claudeFound {
+		claudeContent, claudeChanged, err := planClaudeLinkContent(claudeContent, relRef)
 		if err != nil {
 			return agentLinkPlan{}, err
 		}
+		if claudeChanged {
+			update, ok := pending[claudeTarget]
+			if !ok {
+				update, err = plannedAgentFileUpdate(rootDir, claudeTarget, claudeContent)
+				if err != nil {
+					return agentLinkPlan{}, err
+				}
+			} else {
+				update.content = claudeContent
+			}
+			update.reportPaths = append(update.reportPaths, claudeName)
+			pending[claudeTarget] = update
+		}
+	}
+
+	for _, name := range []string{agentsTarget, claudeTarget} {
+		update, ok := pending[name]
+		if !ok {
+			continue
+		}
 		plan.updates = append(plan.updates, update)
+		delete(pending, name)
 	}
 
 	return plan, nil
+}
+
+// resolveContainedDocsEntry keeps ordinary files unchanged while permitting a
+// final symlink whose resolved target remains inside the repository. External
+// and dangling links are rejected.
+func resolveContainedDocsEntry(root rootfs.Root, name string) (string, error) {
+	if !entryExists(filepath.Join(root.Path(), name)) {
+		return name, nil
+	}
+	if err := root.CheckContained(name); err == nil {
+		return name, nil
+	} else if !errors.Is(err, rootfs.ErrSymlink) {
+		return "", err
+	}
+	target, err := root.ResolveContainedFinalSymlink(name)
+	if err != nil {
+		return "", fmt.Errorf("%w: agent-file target is not contained: %w", rootfs.ErrSymlink, err)
+	}
+	if err := validateContainedAgentTarget(target); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func validateContainedMarkdownTarget(name string) error {
+	if !strings.EqualFold(filepath.Ext(name), ".md") {
+		return fmt.Errorf("%w: contained target %q is not a Markdown file", rootfs.ErrSymlink, name)
+	}
+	for _, component := range strings.FieldsFunc(filepath.Clean(name), func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		switch strings.ToLower(component) {
+		case ".git", ".hg", ".svn":
+			return fmt.Errorf("%w: contained target %q is repository metadata", rootfs.ErrSymlink, name)
+		}
+	}
+	return nil
+}
+
+func validateContainedAgentTarget(name string) error {
+	if err := validateContainedMarkdownTarget(name); err != nil {
+		return err
+	}
+	switch strings.ToLower(filepath.Base(name)) {
+	case "agents.md", "claude.md":
+		return nil
+	default:
+		return fmt.Errorf("%w: agent-file link target %q is not AGENTS.md or CLAUDE.md", rootfs.ErrSymlink, name)
+	}
+}
+
+func validateInitReferencePlan(ascPlan ascReferencePlan, linkPlan agentLinkPlan) error {
+	paths := make(map[string]string, len(linkPlan.updates)+1)
+	check := func(root rootfs.Root, name, label string) error {
+		if err := root.CheckWriteFilePreservingMode(name); err != nil {
+			return fmt.Errorf("preflight %s: %w", label, err)
+		}
+		physicalRoot := filepath.Clean(root.Path())
+		if resolvedRoot, err := filepath.EvalSymlinks(root.Path()); err == nil {
+			physicalRoot = resolvedRoot
+		}
+		physicalPath := filepath.Join(physicalRoot, name)
+		if previous, exists := paths[physicalPath]; exists {
+			return fmt.Errorf("%s and %s resolve to the same destination %q", previous, label, physicalPath)
+		}
+		paths[physicalPath] = label
+		return nil
+	}
+
+	if err := check(ascPlan.root, ascPlan.name, ascReferenceFile); err != nil {
+		return err
+	}
+	for _, update := range linkPlan.updates {
+		label := update.name
+		if len(update.reportPaths) > 0 {
+			label = strings.Join(update.reportPaths, "/")
+		}
+		if err := check(linkPlan.root, update.name, label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readPendingAgentFile(root rootfs.Root, pending map[string]agentFileUpdate, name string) (string, bool, error) {
+	if update, ok := pending[name]; ok {
+		return update.content, true, nil
+	}
+	data, found, err := root.ReadFileOptional(name)
+	return string(data), found, err
 }
 
 // plannedAgentFileUpdate records the rewrite along with the file's current
@@ -367,10 +515,12 @@ func plannedAgentFileUpdate(rootDir, name, content string) (agentFileUpdate, err
 func applyAgentFileLinks(plan agentLinkPlan) ([]string, error) {
 	linked := []string{}
 	for _, update := range plan.updates {
-		if err := plan.root.WriteFile(update.name, []byte(update.content), update.perm); err != nil {
+		if err := plan.root.WriteFilePreservingMode(update.name, []byte(update.content), update.perm); err != nil {
 			return nil, err
 		}
-		linked = append(linked, filepath.Join(plan.rootDir, update.name))
+		for _, reportPath := range update.reportPaths {
+			linked = append(linked, filepath.Join(plan.rootDir, reportPath))
+		}
 	}
 	return linked, nil
 }
@@ -396,10 +546,13 @@ func planAgentsLink(root rootfs.Root, name string, relRef string) (string, bool,
 	if !found {
 		return "", false, nil
 	}
+	return planAgentsLinkContent(string(data), relRef)
+}
 
+func planAgentsLinkContent(content string, relRef string) (string, bool, error) {
 	desiredLine := fmt.Sprintf("See `%s` for the command catalog and workflows.", relRef)
 
-	lines := strings.Split(string(data), "\n")
+	lines := strings.Split(content, "\n")
 	foundReference := false
 	changed := false
 	for i, line := range lines {
@@ -422,11 +575,11 @@ func planAgentsLink(root rootfs.Root, name string, relRef string) (string, bool,
 		if !changed {
 			return "", false, nil
 		}
-		return plannedContent(string(data), strings.Join(lines, "\n"))
+		return plannedContent(content, strings.Join(lines, "\n"))
 	}
 
 	section := fmt.Sprintf("## asc cli reference\n\n%s", desiredLine)
-	return plannedContent(string(data), appendSection(string(data), section))
+	return plannedContent(content, appendSection(content, section))
 }
 
 // planClaudeLink computes the updated CLAUDE.md content without writing it.
@@ -438,10 +591,13 @@ func planClaudeLink(root rootfs.Root, name string, relRef string) (string, bool,
 	if !found {
 		return "", false, nil
 	}
+	return planClaudeLinkContent(string(data), relRef)
+}
 
+func planClaudeLinkContent(content string, relRef string) (string, bool, error) {
 	desiredLine := "@" + relRef
 
-	lines := strings.Split(string(data), "\n")
+	lines := strings.Split(content, "\n")
 	updatedLines := make([]string, 0, len(lines))
 	foundReference := false
 	changed := false
@@ -465,16 +621,16 @@ func planClaudeLink(root rootfs.Root, name string, relRef string) (string, bool,
 		if !changed {
 			return "", false, nil
 		}
-		return plannedContent(string(data), strings.Join(updatedLines, "\n"))
+		return plannedContent(content, strings.Join(updatedLines, "\n"))
 	}
 
-	updated := strings.TrimRight(string(data), "\n")
+	updated := strings.TrimRight(content, "\n")
 	if updated != "" {
 		updated += "\n"
 	}
 	updated += desiredLine + "\n"
 
-	return plannedContent(string(data), updated)
+	return plannedContent(content, updated)
 }
 
 func isAgentsReferenceLine(line string) bool {

--- a/internal/cli/docs/docs_init_containment_test.go
+++ b/internal/cli/docs/docs_init_containment_test.go
@@ -29,6 +29,65 @@ func TestInitReference_RefusesSymlinkedASCReference(t *testing.T) {
 	}
 }
 
+func TestInitReference_AllowsASCReferenceSymlinkToContainedRegularFile(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	targetName := "ASC.actual.md"
+	targetPath := filepath.Join(repo, targetName)
+	writeDocsContainmentFile(t, targetPath, "# Existing\n")
+	linkPath := filepath.Join(repo, ascReferenceFile)
+	if err := os.Symlink(targetName, linkPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	result, err := InitReference(InitOptions{Path: repo, Force: true, Link: false})
+	if err != nil {
+		t.Fatalf("InitReference() error = %v", err)
+	}
+	if !result.Overwritten {
+		t.Fatalf("InitReference() result = %#v, want overwritten", result)
+	}
+	if got := readDocsContainmentFile(t, targetPath); !strings.Contains(got, "asc") {
+		t.Fatalf("contained target content = %q, want generated reference", got)
+	}
+	if info, err := os.Lstat(linkPath); err != nil {
+		t.Fatalf("Lstat(ASC.md) error = %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("ASC.md mode = %v, want symlink preserved", info.Mode())
+	}
+}
+
+func TestInitReference_RejectsASCReferenceSymlinkToRepositoryMetadata(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	configPath := filepath.Join(repo, ".git", "config")
+	writeDocsContainmentFile(t, configPath, "[core]\n")
+	if err := os.Symlink(filepath.Join(".git", "config"), filepath.Join(repo, ascReferenceFile)); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if _, err := InitReference(InitOptions{Path: repo, Force: true}); err == nil {
+		t.Fatal("InitReference() error = nil, want repository-metadata rejection")
+	}
+	if got := readDocsContainmentFile(t, configPath); got != "[core]\n" {
+		t.Fatalf(".git/config content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_RejectsDestinationAliasCollisionBeforeWriting(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	agentsPath := filepath.Join(repo, "AGENTS.md")
+	writeDocsContainmentFile(t, agentsPath, "# Agents\n")
+	if err := os.Symlink("AGENTS.md", filepath.Join(repo, ascReferenceFile)); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if _, err := InitReference(InitOptions{Path: repo, Force: true, Link: true}); err == nil {
+		t.Fatal("InitReference() error = nil, want alias collision rejection")
+	}
+	if got := readDocsContainmentFile(t, agentsPath); got != "# Agents\n" {
+		t.Fatalf("AGENTS.md content = %q, want unchanged", got)
+	}
+}
+
 func TestInitReference_RefusesSymlinkedAgentsFile(t *testing.T) {
 	repo := newDocsContainmentRepo(t)
 	sentinelPath := filepath.Join(t.TempDir(), "sentinel.md")
@@ -68,6 +127,33 @@ func TestInitReference_RefusesSymlinkedClaudeFile(t *testing.T) {
 	}
 	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
 		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_AllowsClaudeSymlinkToContainedAgentsFile(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	agentsPath := filepath.Join(repo, "AGENTS.md")
+	writeDocsContainmentFile(t, agentsPath, "# Shared agent instructions\n")
+	claudePath := filepath.Join(repo, "CLAUDE.md")
+	if err := os.Symlink("AGENTS.md", claudePath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	result, err := InitReference(InitOptions{Path: repo, Link: true})
+	if err != nil {
+		t.Fatalf("InitReference() error = %v", err)
+	}
+	if len(result.Linked) != 2 {
+		t.Fatalf("InitReference() linked = %v, want both logical agent files", result.Linked)
+	}
+	shared := readDocsContainmentFile(t, agentsPath)
+	if !strings.Contains(shared, "See `ASC.md`") || !strings.Contains(shared, "@ASC.md") {
+		t.Fatalf("shared agent content = %q, want both reference forms", shared)
+	}
+	if info, err := os.Lstat(claudePath); err != nil {
+		t.Fatalf("Lstat(CLAUDE.md) error = %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("CLAUDE.md mode = %v, want symlink preserved", info.Mode())
 	}
 }
 
@@ -145,6 +231,25 @@ func TestInitReference_WritesNothingWhenClaudeFileIsSymlinked(t *testing.T) {
 	}
 	if got := readDocsContainmentFile(t, sentinelPath); got != "# Sentinel\n" {
 		t.Fatalf("sentinel content = %q, want unchanged", got)
+	}
+}
+
+func TestInitReference_PreflightsHardlinkedAgentFileBeforeWritingASC(t *testing.T) {
+	repo := newDocsContainmentRepo(t)
+	agentsPath := filepath.Join(repo, "AGENTS.md")
+	writeDocsContainmentFile(t, agentsPath, "# Agents\n")
+	if err := os.Link(agentsPath, filepath.Join(t.TempDir(), "external-agent.md")); err != nil {
+		t.Skipf("hard links unavailable: %v", err)
+	}
+
+	if _, err := InitReference(InitOptions{Path: repo, Link: true}); err == nil {
+		t.Fatal("InitReference() error = nil, want hard-link preflight rejection")
+	}
+	if _, err := os.Lstat(filepath.Join(repo, ascReferenceFile)); !os.IsNotExist(err) {
+		t.Fatalf("ASC.md exists after failed preflight: %v", err)
+	}
+	if got := readDocsContainmentFile(t, agentsPath); got != "# Agents\n" {
+		t.Fatalf("AGENTS.md content = %q, want unchanged", got)
 	}
 }
 

--- a/internal/cli/docs/docs_init_test.go
+++ b/internal/cli/docs/docs_init_test.go
@@ -67,6 +67,25 @@ func TestInitReference_ReturnsTypedErrorWhenASCExists(t *testing.T) {
 	}
 }
 
+func TestResolveOutputPathPreservesWhitespaceInDirectoryName(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, " repo ")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("create whitespace-named repo: %v", err)
+	}
+
+	target, linkRoot, err := resolveOutputPath(repo)
+	if err != nil {
+		t.Fatalf("resolveOutputPath() error = %v", err)
+	}
+	if target != filepath.Join(repo, ascReferenceFile) {
+		t.Fatalf("target = %q, want %q", target, filepath.Join(repo, ascReferenceFile))
+	}
+	if linkRoot != repo {
+		t.Fatalf("link root = %q, want %q", linkRoot, repo)
+	}
+}
+
 func TestPlanAgentsLink_RewritesLegacyReference(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENTS.md")

--- a/internal/cli/docs/template_sync_test.go
+++ b/internal/cli/docs/template_sync_test.go
@@ -50,6 +50,25 @@ func TestASCTemplateIncludesAllRootFlags(t *testing.T) {
 	}
 }
 
+func TestASCTemplateMigrateExamplesBindVersionID(t *testing.T) {
+	section := sectionBetween(t, embeddedTemplate, "### Migrate Metadata (Fastlane)", "## Command Groups")
+	for _, command := range []string{"asc migrate import", "asc migrate export"} {
+		line := ""
+		for _, candidate := range strings.Split(section, "\n") {
+			if strings.Contains(candidate, command) {
+				line = candidate
+				break
+			}
+		}
+		if line == "" {
+			t.Fatalf("template migrate section is missing %q", command)
+		}
+		if !strings.Contains(line, `--version-id "VERSION_ID"`) {
+			t.Fatalf("template example %q must bind the App Store version with --version-id", line)
+		}
+	}
+}
+
 func sectionBetween(t *testing.T, content, startHeading, endHeading string) string {
 	t.Helper()
 

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -114,8 +114,8 @@ asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confir
 
 ```bash
 asc migrate validate --fastlane-dir ./metadata
-asc migrate import --app "APP_ID" --fastlane-dir ./metadata --confirm
-asc migrate export --app "APP_ID" --output ./exported-metadata
+asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./metadata --confirm
+asc migrate export --app "APP_ID" --version-id "VERSION_ID" --output-dir ./exported-metadata
 ```
 
 ## Command Groups

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -2,41 +2,106 @@ package install
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
-// Pinned installer and skills source. Both are reviewed inputs: bump
-// skillsInstallerPackage only after reviewing the `skills` release, and
-// skillsSourceCommit only after reviewing the ASC skills diff at that commit.
-//
-// The upstream installer cannot consume an immutable ref itself: `skills add
-// owner/repo#<ref>` resolves the ref with `git clone --depth 1 --branch <ref>`,
-// which accepts only branch and tag names and rejects commit SHAs, and the
-// ASC skills repository publishes no tags. The pinned commit is therefore
-// materialized locally with git, which verifies object hashes, and handed to
-// the installer as a local path. Nothing here falls back to a mutable ref.
+// The skills check still uses the exact package version in offline mode. The
+// install command deliberately does not execute this package (or any npm
+// dependency); it checks out and installs the reviewed source directly.
 const (
 	skillsInstallerPackage    = "skills@1.5.20"
 	skillsSourceRepositoryURL = "https://github.com/rorkai/app-store-connect-cli-skills.git"
 	skillsSourceCommit        = "e30039abddbe388179324d0f9cdccb66c3843115"
+	expectedSkillsCount       = 23
 )
 
+var expectedSkillNames = []string{
+	"asc-app-create-ui",
+	"asc-apple-ads",
+	"asc-aso-audit",
+	"asc-build-lifecycle",
+	"asc-cli-usage",
+	"asc-crash-triage",
+	"asc-id-resolver",
+	"asc-localize-metadata",
+	"asc-metadata-sync",
+	"asc-notarization",
+	"asc-ppp-pricing",
+	"asc-release-flow",
+	"asc-revenuecat-catalog-sync",
+	"asc-screenshot-resize",
+	"asc-shots-pipeline",
+	"asc-signing-setup",
+	"asc-submission-health",
+	"asc-subscription-localization",
+	"asc-testflight-orchestration",
+	"asc-wall-submit",
+	"asc-whats-new-writer",
+	"asc-workflow",
+	"asc-xcode-build",
+}
+
+// expectedSkillTreeHashes are the Git tree object IDs at skillsSourceCommit.
+// The external skills CLI uses these hashes for its version 3 lock schema.
+var expectedSkillTreeHashes = map[string]string{
+	"asc-app-create-ui":             "8a254ebc29c92a2db288046b44eb44f98badfaf8",
+	"asc-apple-ads":                 "1b36ce3bc8e377cbbb6f687888e998cceede8394",
+	"asc-aso-audit":                 "cd716013f166a536af1a4b96eda258d7427ec593",
+	"asc-build-lifecycle":           "ace286d720b4ad94978b39d1ee06d3cef436a268",
+	"asc-cli-usage":                 "a71332449b340d465b36fb18f8692938db72d6cf",
+	"asc-crash-triage":              "ddd74903f7d5ca6a3ab2adca3a5fe5d16bf91a2c",
+	"asc-id-resolver":               "3b3af77091eaf5458a5c96c68da7cca6d1ad6d95",
+	"asc-localize-metadata":         "0e4b61406cab8b4f4f3e56c0c061300e70d078e5",
+	"asc-metadata-sync":             "96acf6364c8f4a6842f1d5a94614d57ee2824c72",
+	"asc-notarization":              "36d8850790528df621beafcd6e511a6d24d685c0",
+	"asc-ppp-pricing":               "6362caecb7b9c6db19d4ce6709cdbea0d0ede7a5",
+	"asc-release-flow":              "263b644f73ae241a9fba09167454f7dcd1e3b593",
+	"asc-revenuecat-catalog-sync":   "a358fe99cf76a475ce6b5f1e1bd3cb9f0d1078a3",
+	"asc-screenshot-resize":         "5ac1818b9083168aa7156d22f422bef8f4a8255f",
+	"asc-shots-pipeline":            "abe751dc2dcbf63518be4337e482485498eb723d",
+	"asc-signing-setup":             "cee2136e2f85f2a15e5c3a75792d59c181946d38",
+	"asc-submission-health":         "c69838e7df462aa99e76d60ef53b1c6ae402bec9",
+	"asc-subscription-localization": "02b30fc38f23e8d5ce0107f8548096d9ed4902ce",
+	"asc-testflight-orchestration":  "335fe9c5a2826320f9663b4e9c9fbb0722f6d34e",
+	"asc-wall-submit":               "80e3a2f914a7f07aa7641d523eadab226f869f41",
+	"asc-whats-new-writer":          "95607774f0b4f620cc4a02a33bc4a3281845a76b",
+	"asc-workflow":                  "6f27477fab98a4196e7d5b8ed3821e32416739cc",
+	"asc-xcode-build":               "343717164fa420e104b9f20ee8182d85fa4d0b75",
+}
+
 var (
-	lookupExecutable = exec.LookPath
-	runCommand       = defaultRunCommand
-	runCommandInDir  = defaultRunCommandInDir
-	evalInstallerDir = filepath.EvalSymlinks
-	errNpxNotFound   = errors.New("npx not found")
-	errGitNotFound   = errors.New("git not found")
+	lookupExecutable      = exec.LookPath
+	runGitCommand         = defaultRunGitCommand
+	checkoutSkillsSource  = checkoutPinnedSkills
+	userHomeDirectory     = os.UserHomeDir
+	renameWithinRoot      = func(root *os.Root, oldName, newName string) error { return root.Rename(oldName, newName) }
+	currentTime           = time.Now
+	errGitNotFound        = errors.New("git not found")
+	errIncompleteSkillSet = errors.New("pinned checkout does not contain the complete asc skill pack")
+)
+
+const (
+	installLockName = ".asc-install-skills.lock"
+	skillLockName   = ".skill-lock.json"
 )
 
 // InstallSkillsCommand returns the top-level `install-skills` command.
@@ -49,19 +114,24 @@ func InstallSkillsCommand() *ffcli.Command {
 		ShortHelp:  "Install the asc skill pack globally for App Store Connect workflows.",
 		LongHelp: fmt.Sprintf(`Install the asc skill pack globally for App Store Connect workflows.
 
-Runs the pinned installer %s against the reviewed skills commit
-%s.
+Checks out the reviewed skills commit
+%s
+and installs its %d skills directly into the standard global agent-skills
+directory. No Node.js package or installer is executed.
 
-Both pins live in the asc source, so upgrading the skill pack is an explicit
-reviewed change rather than an automatic update.
+The source pin lives in the asc source, so upgrading the skill pack is an
+explicit reviewed change rather than an automatic update.
 
-Requires Node.js (npx) and git.
+Requires git.
 
 Examples:
-  asc install-skills`, skillsInstallerPackage, skillsSourceCommit),
+  asc install-skills`, skillsSourceCommit, expectedSkillsCount),
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("install skills: unexpected arguments: %s", strings.Join(args, " "))
+			}
 			if err := installSkills(ctx); err != nil {
 				return fmt.Errorf("install skills: %w", err)
 			}
@@ -70,154 +140,841 @@ Examples:
 	}
 }
 
-func installSkills(ctx context.Context) error {
+func installSkills(ctx context.Context) (resultErr error) {
 	ctx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
-
-	npxPath, err := lookupExecutable("npx")
-	if err != nil {
-		return fmt.Errorf("%w; install Node.js to continue", errNpxNotFound)
-	}
 
 	gitPath, err := lookupExecutable("git")
 	if err != nil {
 		return fmt.Errorf("%w; git is required to check out the pinned skills commit %s", errGitNotFound, skillsSourceCommit)
 	}
-
-	sourceDir, err := os.MkdirTemp("", "asc-skills-")
+	gitPath, err = filepath.Abs(gitPath)
 	if err != nil {
-		return fmt.Errorf("failed to create a checkout directory: %w", err)
+		return fmt.Errorf("resolve the git executable path: %w", err)
 	}
-	defer func() {
-		_ = os.RemoveAll(sourceDir)
-	}()
 
-	if err := checkoutPinnedSkills(ctx, gitPath, sourceDir); err != nil {
+	homeDir, err := userHomeDirectory()
+	if err != nil {
+		return fmt.Errorf("resolve the user home directory: %w", err)
+	}
+	if strings.TrimSpace(homeDir) == "" {
+		return errors.New("resolve the user home directory: path is empty")
+	}
+	homeDir, err = filepath.Abs(homeDir)
+	if err != nil {
+		return fmt.Errorf("resolve the absolute user home directory: %w", err)
+	}
+
+	agentsDir := filepath.Join(homeDir, ".agents")
+	if err := os.MkdirAll(agentsDir, 0o700); err != nil {
+		return fmt.Errorf("create the global agent directory: %w", err)
+	}
+	agentsRoot, err := os.OpenRoot(agentsDir)
+	if err != nil {
+		return fmt.Errorf("open the global agent directory: %w", err)
+	}
+	defer agentsRoot.Close()
+
+	installLock, err := acquireInstallLock(agentsRoot, filepath.Join(agentsDir, installLockName))
+	if err != nil {
 		return err
 	}
-
-	// npx prefers a local dependency whose name and version match the requested
-	// package, so running it inside a caller project that carries
-	// node_modules/skills at the pinned version would execute
-	// repository-controlled code instead of the reviewed registry package. The
-	// installer therefore runs in a fresh empty directory with no node_modules
-	// in reach.
-	runDir, err := isolatedInstallerDir()
-	if err != nil {
-		return err
-	}
 	defer func() {
-		_ = os.RemoveAll(runDir)
-	}()
-
-	return runCommandInDir(ctx, runDir, npxPath, "--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes")
-}
-
-// npmProjectMarkers are the entries that make npm treat a directory as a
-// project root: node_modules can satisfy a package specifier with a local
-// dependency, and package.json or .npmrc supply project configuration such as
-// a replacement registry.
-var npmProjectMarkers = []string{"node_modules", "package.json", ".npmrc"}
-
-// isolatedInstallerDir creates the working directory for the pinned installer
-// and verifies that no ancestor carries an npm project marker. npm resolves
-// package specifiers against local dependencies and reads project
-// configuration by walking up from the working directory, so TMPDIR pointing
-// inside an npm project would let repository-controlled files shadow or
-// redirect the pinned registry package.
-func isolatedInstallerDir() (string, error) {
-	runDir, err := os.MkdirTemp("", "asc-skills-npx-")
-	if err != nil {
-		return "", fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
-	}
-	physicalRunDir, err := evalInstallerDir(runDir)
-	if err != nil {
-		_ = os.RemoveAll(runDir)
-		return "", fmt.Errorf("failed to resolve the isolated working directory for the installer: %w", err)
-	}
-
-	userHome := ""
-	if home, homeErr := os.UserHomeDir(); homeErr == nil {
-		if physicalHome, resolveErr := filepath.EvalSymlinks(home); resolveErr == nil {
-			userHome = physicalHome
+		if releaseErr := installLock.release(); releaseErr != nil {
+			resultErr = errors.Join(resultErr, releaseErr)
 		}
-	}
-	if ancestor, marker := nearestNpmProjectAncestor(physicalRunDir, userHome); ancestor != "" {
-		// Clean up only the entry MkdirTemp created. The entry could have been
-		// swapped for a symlink while it was being resolved; removing the
-		// physical target would then delete unrelated data.
-		_ = os.RemoveAll(runDir)
-		return "", fmt.Errorf("temporary directory %s sits inside an npm project (%s contains %s), which could shadow or redirect the pinned installer; point TMPDIR outside any npm project and retry", physicalRunDir, ancestor, marker)
-	}
-	return physicalRunDir, nil
-}
+	}()
 
-// nearestNpmProjectAncestor returns the closest directory at or above dir that
-// contains an npm project marker together with the marker it found, or empty
-// strings when there is none. A .npmrc in the user's home directory is npm's
-// ordinary user configuration, not project configuration, so it does not make
-// a temporary directory below the home directory unsafe by itself.
-func nearestNpmProjectAncestor(dir string, userHome string) (string, string) {
-	for current := dir; ; {
-		for _, marker := range npmProjectMarkers {
-			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
-				if marker == ".npmrc" && sameDirectory(current, userHome) {
-					continue
-				}
-				return current, marker
+	workspaceName, workspaceRoot, err := createPrivateDirectory(agentsRoot, ".asc-install-skills-")
+	if err != nil {
+		return fmt.Errorf("create a private install workspace: %w", err)
+	}
+	defer func() {
+		_ = workspaceRoot.Close()
+		// Removal is relative to the retained .agents handle. If the workspace
+		// path is swapped for a symlink, Root.RemoveAll removes the link rather
+		// than traversing to and deleting its target.
+		_ = agentsRoot.RemoveAll(workspaceName)
+	}()
+
+	if err := workspaceRoot.Mkdir("source", 0o700); err != nil {
+		return fmt.Errorf("create the pinned checkout directory: %w", err)
+	}
+	if err := workspaceRoot.Mkdir("git-home", 0o700); err != nil {
+		return fmt.Errorf("create the isolated git home directory: %w", err)
+	}
+	if err := workspaceRoot.Mkdir(filepath.Join("git-home", "config"), 0o700); err != nil {
+		return fmt.Errorf("create the isolated git config directory: %w", err)
+	}
+	if err := workspaceRoot.Mkdir("git-hooks", 0o700); err != nil {
+		return fmt.Errorf("create the empty git hooks directory: %w", err)
+	}
+	if err := workspaceRoot.Mkdir("git-template", 0o700); err != nil {
+		return fmt.Errorf("create the empty git template directory: %w", err)
+	}
+	if err := workspaceRoot.WriteFile(filepath.Join("git-home", "gitconfig"), nil, 0o600); err != nil {
+		return fmt.Errorf("create the isolated git configuration: %w", err)
+	}
+
+	workspaceDir := filepath.Join(agentsDir, workspaceName)
+	sourceDir := filepath.Join(workspaceDir, "source")
+	gitIsolation := gitIsolationPaths{
+		home:       filepath.Join(workspaceDir, "git-home"),
+		globalCfg:  filepath.Join(workspaceDir, "git-home", "gitconfig"),
+		hooks:      filepath.Join(workspaceDir, "git-hooks"),
+		template:   filepath.Join(workspaceDir, "git-template"),
+		xdgConfig:  filepath.Join(workspaceDir, "git-home", "config"),
+		sourceDir:  sourceDir,
+		workingDir: workspaceDir,
+	}
+	if err := checkoutSkillsSource(ctx, gitPath, gitIsolation); err != nil {
+		return err
+	}
+
+	sourceSkills, err := os.OpenRoot(filepath.Join(sourceDir, "skills"))
+	if err != nil {
+		return fmt.Errorf("open skills in pinned checkout: %w", err)
+	}
+	defer sourceSkills.Close()
+
+	names, err := validatePinnedSkills(sourceSkills)
+	if err != nil {
+		return err
+	}
+
+	skillsDir := filepath.Join(agentsDir, "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		return fmt.Errorf("create the global skills directory: %w", err)
+	}
+	skillsRoot, err := os.OpenRoot(skillsDir)
+	if err != nil {
+		return fmt.Errorf("open the global skills directory: %w", err)
+	}
+	defer skillsRoot.Close()
+
+	lockState, err := preparePinnedSkillLock(homeDir)
+	if err != nil {
+		return err
+	}
+	defer lockState.close()
+	if err := lockState.bind(names); err != nil {
+		return err
+	}
+
+	if err := installSkillPack(sourceSkills, skillsRoot, names); err != nil {
+		var retainedBackup *retainedSkillBackupError
+		if errors.As(err, &retainedBackup) {
+			if untrackErr := lockState.untrack(names); untrackErr != nil {
+				return errors.Join(err, fmt.Errorf("remove inconsistent asc entries from the skill lock: %w", untrackErr))
+			}
+		} else if !mustKeepPinnedSkillLock(err) {
+			if restoreErr := lockState.restore(); restoreErr != nil {
+				return errors.Join(err, fmt.Errorf("restore previous skill lock: %w", restoreErr))
 			}
 		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return "", ""
-		}
-		current = parent
+		return err
 	}
-}
-
-func sameDirectory(left string, right string) bool {
-	if left == "" || right == "" {
-		return false
-	}
-	leftInfo, leftErr := os.Stat(left)
-	rightInfo, rightErr := os.Stat(right)
-	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
-}
-
-// checkoutPinnedSkills fetches exactly skillsSourceCommit into sourceDir. Git
-// validates that the received objects hash to the requested commit, so the
-// checkout is verified as well as immutable.
-func checkoutPinnedSkills(ctx context.Context, gitPath string, sourceDir string) error {
-	steps := [][]string{
-		{"init", "--quiet"},
-		{"remote", "add", "origin", skillsSourceRepositoryURL},
-		{"fetch", "--quiet", "--depth", "1", "origin", skillsSourceCommit},
-		{"checkout", "--quiet", "--detach", skillsSourceCommit},
-	}
-
-	for _, step := range steps {
-		args := append([]string{"-C", sourceDir}, step...)
-		if err := runCommand(ctx, gitPath, args...); err != nil {
-			return fmt.Errorf("failed to check out pinned skills commit %s from %s: %w", skillsSourceCommit, skillsSourceRepositoryURL, err)
-		}
-	}
-
+	fmt.Fprintf(os.Stdout, "Installed %d asc skills from reviewed commit %s.\n", len(names), skillsSourceCommit)
 	return nil
 }
 
-func defaultRunCommandInDir(ctx context.Context, dir string, name string, args ...string) error {
+type activeInstallLock struct {
+	file *os.File
+	path string
+}
+
+func acquireInstallLock(root *os.Root, path string) (*activeInstallLock, error) {
+	file, err := secureopen.OpenAppendNoFollowInRoot(root, installLockName, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create cross-process install lock %s: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("cross-process install lock %s must be a regular file: %w", path, err)
+	}
+	if err := lockInstallFile(file); err != nil {
+		_ = file.Close()
+		if errors.Is(err, errInstallLockHeld) {
+			return nil, fmt.Errorf("another asc skill installation is already running (lock %s): %w", path, err)
+		}
+		return nil, fmt.Errorf("acquire cross-process install lock %s: %w", path, err)
+	}
+	return &activeInstallLock{file: file, path: path}, nil
+}
+
+func (lock *activeInstallLock) release() error {
+	unlockErr := unlockInstallFile(lock.file)
+	closeErr := lock.file.Close()
+	if unlockErr != nil || closeErr != nil {
+		return fmt.Errorf("release install lock %s: %w", lock.path, errors.Join(unlockErr, closeErr))
+	}
+	return nil
+}
+
+type pinnedSkillLock struct {
+	root         *os.Root
+	path         string
+	original     []byte
+	originalMode os.FileMode
+	existed      bool
+	bound        bool
+}
+
+func preparePinnedSkillLock(homeDir string) (*pinnedSkillLock, error) {
+	lockDir := filepath.Join(homeDir, ".agents")
+	if stateHome := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); stateHome != "" {
+		absoluteStateHome, err := filepath.Abs(stateHome)
+		if err != nil {
+			return nil, fmt.Errorf("resolve XDG_STATE_HOME: %w", err)
+		}
+		lockDir = filepath.Join(absoluteStateHome, "skills")
+	}
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create skills lock directory: %w", err)
+	}
+	root, err := os.OpenRoot(lockDir)
+	if err != nil {
+		return nil, fmt.Errorf("open skills lock directory: %w", err)
+	}
+	state := &pinnedSkillLock{
+		root:         root,
+		path:         filepath.Join(lockDir, skillLockName),
+		originalMode: 0o600,
+	}
+	info, err := root.Lstat(skillLockName)
+	if errors.Is(err, fs.ErrNotExist) {
+		return state, nil
+	}
+	if err != nil {
+		root.Close()
+		return nil, fmt.Errorf("inspect skills lock %s: %w", state.path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		root.Close()
+		return nil, fmt.Errorf("skills lock %s must be a regular file, not a symlink or special file", state.path)
+	}
+	state.original, err = root.ReadFile(skillLockName)
+	if err != nil {
+		root.Close()
+		return nil, fmt.Errorf("read skills lock %s: %w", state.path, err)
+	}
+	state.originalMode = info.Mode().Perm()
+	state.existed = true
+	return state, nil
+}
+
+func (state *pinnedSkillLock) close() {
+	if state != nil && state.root != nil {
+		_ = state.root.Close()
+	}
+}
+
+func (state *pinnedSkillLock) bind(names []string) error {
+	data, err := buildPinnedSkillLock(state.original, names, currentTime().UTC())
+	if err != nil {
+		return fmt.Errorf("prepare pinned skills lock %s: %w", state.path, err)
+	}
+	if err := atomicWriteRootFile(state.root, skillLockName, data, state.originalMode); err != nil {
+		return fmt.Errorf("write pinned skills lock %s: %w", state.path, err)
+	}
+	state.bound = true
+	return nil
+}
+
+func (state *pinnedSkillLock) restore() error {
+	if !state.bound {
+		return nil
+	}
+	if !state.existed {
+		if err := state.root.Remove(skillLockName); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		state.bound = false
+		return nil
+	}
+	if err := atomicWriteRootFile(state.root, skillLockName, state.original, state.originalMode); err != nil {
+		return err
+	}
+	state.bound = false
+	return nil
+}
+
+func (state *pinnedSkillLock) untrack(names []string) error {
+	if !state.existed {
+		if err := state.root.Remove(skillLockName); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		state.bound = false
+		return nil
+	}
+	data, err := buildUntrackedSkillLock(state.original, names)
+	if err != nil {
+		return err
+	}
+	if err := atomicWriteRootFile(state.root, skillLockName, data, state.originalMode); err != nil {
+		return err
+	}
+	state.bound = false
+	return nil
+}
+
+func buildPinnedSkillLock(original []byte, names []string, now time.Time) ([]byte, error) {
+	document := make(map[string]json.RawMessage)
+	if len(strings.TrimSpace(string(original))) != 0 {
+		if err := json.Unmarshal(original, &document); err != nil {
+			return nil, fmt.Errorf("invalid version 3 lock JSON: %w", err)
+		}
+	}
+
+	if rawVersion, ok := document["version"]; ok {
+		var version int
+		if err := json.Unmarshal(rawVersion, &version); err != nil || version != 3 {
+			return nil, fmt.Errorf("unsupported skills lock version %s; expected version 3", strings.TrimSpace(string(rawVersion)))
+		}
+	}
+	document["version"] = json.RawMessage("3")
+
+	entries := make(map[string]json.RawMessage)
+	if rawSkills, ok := document["skills"]; ok {
+		if err := json.Unmarshal(rawSkills, &entries); err != nil {
+			return nil, fmt.Errorf("invalid skills object: %w", err)
+		}
+	}
+	timestamp := now.Format(time.RFC3339Nano)
+	for _, name := range names {
+		entry := make(map[string]json.RawMessage)
+		if rawEntry, ok := entries[name]; ok {
+			if err := json.Unmarshal(rawEntry, &entry); err != nil {
+				return nil, fmt.Errorf("invalid lock entry for %s: %w", name, err)
+			}
+		}
+		installedAt := timestamp
+		if rawInstalledAt, ok := entry["installedAt"]; ok {
+			var existing string
+			if json.Unmarshal(rawInstalledAt, &existing) == nil && strings.TrimSpace(existing) != "" {
+				installedAt = existing
+			}
+		}
+		fields := map[string]string{
+			"source":          "rorkai/app-store-connect-cli-skills",
+			"sourceType":      "github",
+			"sourceUrl":       skillsSourceRepositoryURL,
+			"ref":             skillsSourceCommit,
+			"skillPath":       filepath.ToSlash(filepath.Join("skills", name, "SKILL.md")),
+			"skillFolderHash": expectedSkillTreeHashes[name],
+			"installedAt":     installedAt,
+			"updatedAt":       timestamp,
+		}
+		for key, value := range fields {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return nil, err
+			}
+			entry[key] = encoded
+		}
+		encodedEntry, err := json.Marshal(entry)
+		if err != nil {
+			return nil, err
+		}
+		entries[name] = encodedEntry
+	}
+	encodedSkills, err := json.Marshal(entries)
+	if err != nil {
+		return nil, err
+	}
+	document["skills"] = encodedSkills
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func buildUntrackedSkillLock(original []byte, names []string) ([]byte, error) {
+	document := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(original, &document); err != nil {
+		return nil, fmt.Errorf("invalid version 3 lock JSON: %w", err)
+	}
+	rawSkills, ok := document["skills"]
+	if !ok {
+		return append(append([]byte(nil), original...), '\n'), nil
+	}
+	entries := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(rawSkills, &entries); err != nil {
+		return nil, fmt.Errorf("invalid skills object: %w", err)
+	}
+	for _, name := range names {
+		delete(entries, name)
+	}
+	encodedSkills, err := json.Marshal(entries)
+	if err != nil {
+		return nil, err
+	}
+	document["skills"] = encodedSkills
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func atomicWriteRootFile(root *os.Root, name string, data []byte, mode os.FileMode) error {
+	file, temporaryName, err := secureopen.CreateTempNoFollowInRoot(root, ".", ".asc-skill-lock-*.tmp", mode)
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		_ = file.Close()
+		if cleanup {
+			_ = root.Remove(temporaryName)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Chmod(mode); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := root.Rename(temporaryName, name); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+type gitIsolationPaths struct {
+	home       string
+	globalCfg  string
+	hooks      string
+	template   string
+	xdgConfig  string
+	sourceDir  string
+	workingDir string
+}
+
+// checkoutPinnedSkills fetches exactly skillsSourceCommit into an empty
+// directory. Git configuration, hooks, credential helpers, filters, alternate
+// object stores, and askpass helpers are isolated so caller- or
+// repository-controlled configuration cannot execute code during checkout.
+func checkoutPinnedSkills(ctx context.Context, gitPath string, paths gitIsolationPaths) error {
+	common := []string{
+		"-c", "credential.helper=",
+		"-c", "core.hooksPath=" + paths.hooks,
+		"-c", "init.templateDir=" + paths.template,
+		"-c", "core.fsmonitor=false",
+		"-c", "protocol.file.allow=never",
+		"-c", "protocol.ext.allow=never",
+		"-c", "protocol.ssh.allow=never",
+		"-c", "protocol.git.allow=never",
+		"-c", "protocol.http.allow=never",
+		"-c", "protocol.https.allow=always",
+	}
+	steps := [][]string{
+		append(append([]string{}, common...), "-C", paths.sourceDir, "init", "--quiet"),
+		append(append([]string{}, common...), "-C", paths.sourceDir, "fetch", "--quiet", "--depth=1", "--no-tags", skillsSourceRepositoryURL, skillsSourceCommit),
+		append(append([]string{}, common...), "-C", paths.sourceDir, "checkout", "--quiet", "--detach", skillsSourceCommit),
+	}
+	env := isolatedGitEnvironment(os.Environ(), paths)
+
+	for _, args := range steps {
+		if err := runGitCommand(ctx, paths.workingDir, env, gitPath, args...); err != nil {
+			return fmt.Errorf("failed to check out pinned skills commit %s from %s: %w", skillsSourceCommit, skillsSourceRepositoryURL, err)
+		}
+	}
+	return nil
+}
+
+func isolatedGitEnvironment(base []string, paths gitIsolationPaths) []string {
+	env := make([]string, 0, len(base)+8)
+	safeGitEnvironment := make(map[string]string)
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		upper := strings.ToUpper(key)
+		switch {
+		case strings.HasPrefix(upper, "GIT_"):
+			// Corporate Git installations commonly require a private CA. These
+			// two values configure certificate lookup but cannot select a Git
+			// directory, helper, hook, filter, or executable.
+			if upper == "GIT_SSL_CAINFO" || upper == "GIT_SSL_CAPATH" {
+				safeGitEnvironment[upper] = value
+			}
+			continue
+		case upper == "HOME", upper == "USERPROFILE", upper == "HOMEDRIVE", upper == "HOMEPATH":
+			continue
+		case upper == "XDG_CONFIG_HOME", upper == "SSH_ASKPASS", upper == "GCM_INTERACTIVE":
+			continue
+		}
+		env = append(env, entry)
+	}
+	for _, key := range []string{"GIT_SSL_CAINFO", "GIT_SSL_CAPATH"} {
+		if value, ok := safeGitEnvironment[key]; ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	env = append(
+		env,
+		"HOME="+paths.home,
+		"USERPROFILE="+paths.home,
+		"XDG_CONFIG_HOME="+paths.xdgConfig,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_ATTR_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL="+paths.globalCfg,
+		"GIT_TERMINAL_PROMPT=0",
+		"GCM_INTERACTIVE=never",
+	)
+	return env
+}
+
+func defaultRunGitCommand(ctx context.Context, dir string, env []string, name string, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
+	cmd.Stdin = nil
 	return cmd.Run()
 }
 
-func defaultRunCommand(ctx context.Context, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-	return cmd.Run()
+func validatePinnedSkills(root *os.Root) ([]string, error) {
+	entries, err := readRootDir(root, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read skills in pinned checkout: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("%w: unexpected entry %q", errIncompleteSkillSet, entry.Name())
+		}
+		if _, err := root.Stat(filepath.Join(entry.Name(), "SKILL.md")); err != nil {
+			return nil, fmt.Errorf("%w: %s has no readable SKILL.md", errIncompleteSkillSet, entry.Name())
+		}
+		if _, err := snapshotTree(root, entry.Name()); err != nil {
+			return nil, fmt.Errorf("%w: %s: %w", errIncompleteSkillSet, entry.Name(), err)
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	want := append([]string(nil), expectedSkillNames...)
+	sort.Strings(want)
+	if len(names) != expectedSkillsCount || !reflect.DeepEqual(names, want) {
+		return nil, fmt.Errorf("%w: found %d skills (%s), want exactly %d (%s)",
+			errIncompleteSkillSet, len(names), strings.Join(names, ", "), expectedSkillsCount, strings.Join(want, ", "))
+	}
+	return names, nil
+}
+
+func installSkillPack(source, destination *os.Root, names []string) error {
+	stageName, stageRoot, err := createPrivateDirectory(destination, ".asc-stage-")
+	if err != nil {
+		return fmt.Errorf("create skill staging directory: %w", err)
+	}
+	defer func() {
+		_ = stageRoot.Close()
+		_ = destination.RemoveAll(stageName)
+	}()
+
+	backupName, backupRoot, err := createPrivateDirectory(destination, ".asc-backup-")
+	if err != nil {
+		return fmt.Errorf("create skill backup directory: %w", err)
+	}
+	preserveBackup := false
+	defer func() {
+		_ = backupRoot.Close()
+		if !preserveBackup {
+			_ = destination.RemoveAll(backupName)
+		}
+	}()
+
+	for _, name := range names {
+		if err := copyTree(source, name, stageRoot, name); err != nil {
+			return fmt.Errorf("stage skill %s: %w", name, err)
+		}
+		sourceSnapshot, err := snapshotTree(source, name)
+		if err != nil {
+			return fmt.Errorf("verify source skill %s: %w", name, err)
+		}
+		stagedSnapshot, err := snapshotTree(stageRoot, name)
+		if err != nil {
+			return fmt.Errorf("verify staged skill %s: %w", name, err)
+		}
+		if !reflect.DeepEqual(sourceSnapshot, stagedSnapshot) {
+			return fmt.Errorf("verify staged skill %s: copied files do not match the pinned checkout", name)
+		}
+	}
+
+	type replacement struct {
+		name        string
+		hadExisting bool
+		installed   bool
+	}
+	replaced := make([]replacement, 0, len(names))
+
+	rollback := func(cause error) error {
+		var rollbackErrs []error
+		for i := len(replaced) - 1; i >= 0; i-- {
+			item := replaced[i]
+			if item.installed {
+				if err := destination.RemoveAll(item.name); err != nil {
+					rollbackErrs = append(rollbackErrs, fmt.Errorf("remove replacement %s: %w", item.name, err))
+				}
+			}
+			if item.hadExisting {
+				if err := renameWithinRoot(destination, filepath.Join(backupName, item.name), item.name); err != nil {
+					rollbackErrs = append(rollbackErrs, fmt.Errorf("restore previous %s: %w", item.name, err))
+				}
+			}
+		}
+		if len(rollbackErrs) == 0 {
+			return cause
+		}
+		preserveBackup = true
+		backupPath := filepath.Join(destination.Name(), backupName)
+		return &retainedSkillBackupError{
+			cause: errors.Join(cause, fmt.Errorf("rollback failed: %w", errors.Join(rollbackErrs...))),
+			path:  backupPath,
+		}
+	}
+
+	for _, name := range names {
+		item := replacement{name: name}
+		if _, err := destination.Lstat(name); err == nil {
+			if err := renameWithinRoot(destination, name, filepath.Join(backupName, name)); err != nil {
+				return rollback(fmt.Errorf("back up existing skill %s: %w", name, err))
+			}
+			item.hadExisting = true
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return rollback(fmt.Errorf("inspect existing skill %s: %w", name, err))
+		}
+		replaced = append(replaced, item)
+
+		if err := renameWithinRoot(destination, filepath.Join(stageName, name), name); err != nil {
+			return rollback(fmt.Errorf("install skill %s: %w", name, err))
+		}
+		replaced[len(replaced)-1].installed = true
+	}
+
+	for _, name := range names {
+		sourceSnapshot, err := snapshotTree(source, name)
+		if err != nil {
+			return rollback(fmt.Errorf("verify source skill %s after install: %w", name, err))
+		}
+		installedSnapshot, err := snapshotTree(destination, name)
+		if err != nil {
+			return rollback(fmt.Errorf("verify installed skill %s: %w", name, err))
+		}
+		if !reflect.DeepEqual(sourceSnapshot, installedSnapshot) {
+			return rollback(fmt.Errorf("verify installed skill %s: installed files do not match the pinned checkout", name))
+		}
+	}
+
+	if err := backupRoot.Close(); err != nil {
+		return &committedSkillInstallError{cause: fmt.Errorf("close previous asc skill backup directory: %w", err)}
+	}
+	if err := destination.RemoveAll(backupName); err != nil {
+		preserveBackup = true
+		return &committedSkillInstallError{cause: fmt.Errorf("remove previous asc skill backups at %s: %w", filepath.Join(destination.Name(), backupName), err)}
+	}
+	if err := stageRoot.Close(); err != nil {
+		return &committedSkillInstallError{cause: fmt.Errorf("close skill staging directory: %w", err)}
+	}
+	if err := destination.RemoveAll(stageName); err != nil {
+		return &committedSkillInstallError{cause: fmt.Errorf("remove skill staging directory: %w", err)}
+	}
+	return nil
+}
+
+type retainedSkillBackupError struct {
+	cause error
+	path  string
+}
+
+func (err *retainedSkillBackupError) Error() string {
+	return fmt.Sprintf("%v; previous skill data was preserved at %s; after resolving target conflicts, restore needed entries from that directory and then remove it", err.cause, err.path)
+}
+
+func (err *retainedSkillBackupError) Unwrap() error {
+	return err.cause
+}
+
+type committedSkillInstallError struct {
+	cause error
+}
+
+func (err *committedSkillInstallError) Error() string {
+	return err.cause.Error()
+}
+
+func (err *committedSkillInstallError) Unwrap() error {
+	return err.cause
+}
+
+func mustKeepPinnedSkillLock(err error) bool {
+	var committed *committedSkillInstallError
+	return errors.As(err, &committed)
+}
+
+type treeEntry struct {
+	mode   fs.FileMode
+	digest [sha256.Size]byte
+}
+
+func snapshotTree(root *os.Root, path string) (map[string]treeEntry, error) {
+	snapshot := make(map[string]treeEntry)
+	if err := snapshotTreeAt(root, path, ".", snapshot); err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+func snapshotTreeAt(root *os.Root, path, relative string, snapshot map[string]treeEntry) error {
+	info, err := root.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symbolic link %q is not permitted in the reviewed skill pack", path)
+	}
+	if info.IsDir() {
+		snapshot[relative] = treeEntry{mode: info.Mode().Perm()}
+		entries, err := readRootDir(root, path)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			childRelative := entry.Name()
+			if relative != "." {
+				childRelative = filepath.Join(relative, entry.Name())
+			}
+			if err := snapshotTreeAt(root, filepath.Join(path, entry.Name()), childRelative, snapshot); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("non-regular file %q is not permitted in the reviewed skill pack", path)
+	}
+	file, err := root.Open(path)
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], hash.Sum(nil))
+	snapshot[relative] = treeEntry{mode: info.Mode().Perm(), digest: digest}
+	return nil
+}
+
+func copyTree(source *os.Root, sourcePath string, destination *os.Root, destinationPath string) error {
+	info, err := source.Lstat(sourcePath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symbolic link %q is not permitted", sourcePath)
+	}
+	if info.IsDir() {
+		if err := destination.Mkdir(destinationPath, info.Mode().Perm()); err != nil {
+			return err
+		}
+		if err := destination.Chmod(destinationPath, info.Mode().Perm()); err != nil {
+			return err
+		}
+		entries, err := readRootDir(source, sourcePath)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := copyTree(
+				source,
+				filepath.Join(sourcePath, entry.Name()),
+				destination,
+				filepath.Join(destinationPath, entry.Name()),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("non-regular file %q is not permitted", sourcePath)
+	}
+	input, err := source.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := destination.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(output, input)
+	closeErr := output.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return destination.Chmod(destinationPath, info.Mode().Perm())
+}
+
+func readRootDir(root *os.Root, path string) ([]os.DirEntry, error) {
+	dir, err := root.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	entries, readErr := dir.ReadDir(-1)
+	closeErr := dir.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return entries, nil
+}
+
+func createPrivateDirectory(root *os.Root, prefix string) (string, *os.Root, error) {
+	for range 100 {
+		var random [16]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", nil, err
+		}
+		name := fmt.Sprintf("%s%x", prefix, random[:])
+		if err := root.Mkdir(name, 0o700); err != nil {
+			if errors.Is(err, fs.ErrExist) {
+				continue
+			}
+			return "", nil, err
+		}
+		child, err := root.OpenRoot(name)
+		if err != nil {
+			_ = root.RemoveAll(name)
+			return "", nil, err
+		}
+		return name, child, nil
+	}
+	return "", nil, errors.New("could not allocate a unique private directory")
 }

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -129,20 +129,37 @@ func isolatedInstallerDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
 	}
-	if ancestor, marker := nearestNpmProjectAncestor(runDir); ancestor != "" {
+	physicalRunDir, err := filepath.EvalSymlinks(runDir)
+	if err != nil {
 		_ = os.RemoveAll(runDir)
-		return "", fmt.Errorf("temporary directory %s sits inside an npm project (%s contains %s), which could shadow or redirect the pinned installer; point TMPDIR outside any npm project and retry", runDir, ancestor, marker)
+		return "", fmt.Errorf("failed to resolve the isolated working directory for the installer: %w", err)
 	}
-	return runDir, nil
+
+	userHome := ""
+	if home, homeErr := os.UserHomeDir(); homeErr == nil {
+		if physicalHome, resolveErr := filepath.EvalSymlinks(home); resolveErr == nil {
+			userHome = physicalHome
+		}
+	}
+	if ancestor, marker := nearestNpmProjectAncestor(physicalRunDir, userHome); ancestor != "" {
+		_ = os.RemoveAll(physicalRunDir)
+		return "", fmt.Errorf("temporary directory %s sits inside an npm project (%s contains %s), which could shadow or redirect the pinned installer; point TMPDIR outside any npm project and retry", physicalRunDir, ancestor, marker)
+	}
+	return physicalRunDir, nil
 }
 
 // nearestNpmProjectAncestor returns the closest directory at or above dir that
 // contains an npm project marker together with the marker it found, or empty
-// strings when there is none.
-func nearestNpmProjectAncestor(dir string) (string, string) {
+// strings when there is none. A .npmrc in the user's home directory is npm's
+// ordinary user configuration, not project configuration, so it does not make
+// a temporary directory below the home directory unsafe by itself.
+func nearestNpmProjectAncestor(dir string, userHome string) (string, string) {
 	for current := dir; ; {
 		for _, marker := range npmProjectMarkers {
 			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
+				if marker == ".npmrc" && sameDirectory(current, userHome) {
+					continue
+				}
 				return current, marker
 			}
 		}
@@ -152,6 +169,15 @@ func nearestNpmProjectAncestor(dir string) (string, string) {
 		}
 		current = parent
 	}
+}
+
+func sameDirectory(left string, right string) bool {
+	if left == "" || right == "" {
+		return false
+	}
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
 }
 
 // checkoutPinnedSkills fetches exactly skillsSourceCommit into sourceDir. Git

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -34,6 +34,7 @@ var (
 	lookupExecutable = exec.LookPath
 	runCommand       = defaultRunCommand
 	runCommandInDir  = defaultRunCommandInDir
+	evalInstallerDir = filepath.EvalSymlinks
 	errNpxNotFound   = errors.New("npx not found")
 	errGitNotFound   = errors.New("git not found")
 )
@@ -129,7 +130,7 @@ func isolatedInstallerDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create an isolated working directory for the installer: %w", err)
 	}
-	physicalRunDir, err := filepath.EvalSymlinks(runDir)
+	physicalRunDir, err := evalInstallerDir(runDir)
 	if err != nil {
 		_ = os.RemoveAll(runDir)
 		return "", fmt.Errorf("failed to resolve the isolated working directory for the installer: %w", err)
@@ -142,7 +143,10 @@ func isolatedInstallerDir() (string, error) {
 		}
 	}
 	if ancestor, marker := nearestNpmProjectAncestor(physicalRunDir, userHome); ancestor != "" {
-		_ = os.RemoveAll(physicalRunDir)
+		// Clean up only the entry MkdirTemp created. The entry could have been
+		// swapped for a symlink while it was being resolved; removing the
+		// physical target would then delete unrelated data.
+		_ = os.RemoveAll(runDir)
 		return "", fmt.Errorf("temporary directory %s sits inside an npm project (%s contains %s), which could shadow or redirect the pinned installer; point TMPDIR outside any npm project and retry", physicalRunDir, ancestor, marker)
 	}
 	return physicalRunDir, nil

--- a/internal/cli/install/install_lock_other.go
+++ b/internal/cli/install/install_lock_other.go
@@ -1,0 +1,32 @@
+//go:build !darwin && !linux && !freebsd && !netbsd && !openbsd && !dragonfly && !windows
+
+package install
+
+import (
+	"errors"
+	"os"
+	"sync"
+)
+
+var (
+	errInstallLockHeld  = errors.New("install lock is held")
+	fallbackInstallLock sync.Mutex
+	fallbackLockHeld    bool
+)
+
+func lockInstallFile(_ *os.File) error {
+	fallbackInstallLock.Lock()
+	defer fallbackInstallLock.Unlock()
+	if fallbackLockHeld {
+		return errInstallLockHeld
+	}
+	fallbackLockHeld = true
+	return nil
+}
+
+func unlockInstallFile(_ *os.File) error {
+	fallbackInstallLock.Lock()
+	fallbackLockHeld = false
+	fallbackInstallLock.Unlock()
+	return nil
+}

--- a/internal/cli/install/install_lock_unix.go
+++ b/internal/cli/install/install_lock_unix.go
@@ -1,0 +1,24 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package install
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+var errInstallLockHeld = errors.New("install lock is held")
+
+func lockInstallFile(file *os.File) error {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return errInstallLockHeld
+	}
+	return err
+}
+
+func unlockInstallFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}

--- a/internal/cli/install/install_lock_windows.go
+++ b/internal/cli/install/install_lock_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package install
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+var errInstallLockHeld = errors.New("install lock is held")
+
+func lockInstallFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return errInstallLockHeld
+	}
+	return err
+}
+
+func unlockInstallFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -2,470 +2,724 @@ package install
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 )
 
-type recordedCommand struct {
-	name string
-	dir  string
-	args []string
-}
-
-func stubLookups(t *testing.T, paths map[string]string) {
+func preserveInstallerGlobals(t *testing.T) {
 	t.Helper()
-
 	originalLookup := lookupExecutable
-	t.Cleanup(func() { lookupExecutable = originalLookup })
+	originalRunGit := runGitCommand
+	originalCheckout := checkoutSkillsSource
+	originalHome := userHomeDirectory
+	originalRename := renameWithinRoot
+	originalTime := currentTime
+	t.Cleanup(func() {
+		lookupExecutable = originalLookup
+		runGitCommand = originalRunGit
+		checkoutSkillsSource = originalCheckout
+		userHomeDirectory = originalHome
+		renameWithinRoot = originalRename
+		currentTime = originalTime
+	})
+}
 
+func installFixture(t *testing.T, checkout func(gitIsolationPaths) error) string {
+	t.Helper()
+	preserveInstallerGlobals(t)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	home := t.TempDir()
+	currentTime = func() time.Time {
+		return time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	}
+	userHomeDirectory = func() (string, error) { return home, nil }
 	lookupExecutable = func(name string) (string, error) {
-		path, ok := paths[name]
-		if !ok {
-			return "", errors.New("executable not found: " + name)
+		if name != "git" {
+			t.Fatalf("looked up unexpected executable %q", name)
 		}
-		return path, nil
+		return "/test/bin/git", nil
+	}
+	checkoutSkillsSource = func(_ context.Context, gitPath string, paths gitIsolationPaths) error {
+		if gitPath != "/test/bin/git" {
+			t.Fatalf("git path = %q", gitPath)
+		}
+		return checkout(paths)
+	}
+	return home
+}
+
+func populatePinnedSkillsFixture(t *testing.T, sourceDir string, names []string) {
+	t.Helper()
+	for _, name := range names {
+		skillDir := filepath.Join(sourceDir, "skills", name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("create %s fixture: %v", name, err)
+		}
+		content := []byte("---\nname: " + name + "\n---\n")
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0o644); err != nil {
+			t.Fatalf("write %s fixture: %v", name, err)
+		}
+	}
+	referenceDir := filepath.Join(sourceDir, "skills", "asc-release-flow", "references")
+	if err := os.MkdirAll(referenceDir, 0o755); err != nil {
+		t.Fatalf("create nested reference fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(referenceDir, "release.md"), []byte("reviewed reference\n"), 0o644); err != nil {
+		t.Fatalf("write nested reference fixture: %v", err)
 	}
 }
 
-func recordCommands(t *testing.T) *[]recordedCommand {
+func runInstallCommand(t *testing.T, args ...string) error {
 	t.Helper()
-
-	originalRun := runCommand
-	t.Cleanup(func() { runCommand = originalRun })
-
-	originalRunInDir := runCommandInDir
-	t.Cleanup(func() { runCommandInDir = originalRunInDir })
-
-	recorded := &[]recordedCommand{}
-	runCommand = func(ctx context.Context, name string, args ...string) error {
-		*recorded = append(*recorded, recordedCommand{name: name, args: append([]string(nil), args...)})
-		return nil
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse(args); err != nil {
+		t.Fatalf("parse error: %v", err)
 	}
-	runCommandInDir = func(ctx context.Context, dir string, name string, args ...string) error {
-		*recorded = append(*recorded, recordedCommand{name: name, dir: dir, args: append([]string(nil), args...)})
-		return nil
-	}
-	return recorded
+	return cmd.Run(context.Background())
 }
 
 func TestSkillsSourceIsPinnedToImmutableInput(t *testing.T) {
-	if !regexp.MustCompile(`^skills@\d+\.\d+\.\d+$`).MatchString(skillsInstallerPackage) {
-		t.Fatalf("skillsInstallerPackage = %q, want an exact skills@MAJOR.MINOR.PATCH pin", skillsInstallerPackage)
-	}
 	if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(skillsSourceCommit) {
 		t.Fatalf("skillsSourceCommit = %q, want a full 40-character commit SHA", skillsSourceCommit)
 	}
-	if !strings.HasPrefix(skillsSourceRepositoryURL, "https://github.com/rorkai/app-store-connect-cli-skills") {
+	if skillsSourceRepositoryURL != "https://github.com/rorkai/app-store-connect-cli-skills.git" {
 		t.Fatalf("skillsSourceRepositoryURL = %q, want the reviewed ASC skills repository", skillsSourceRepositoryURL)
 	}
-}
-
-func TestInstallSkillsRunsPinnedInstallerAgainstPinnedCommit(t *testing.T) {
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
+	if len(expectedSkillNames) != expectedSkillsCount {
+		t.Fatalf("expectedSkillNames has %d entries, want %d", len(expectedSkillNames), expectedSkillsCount)
 	}
-	if err := cmd.Run(context.Background()); err != nil {
-		t.Fatalf("run error: %v", err)
+	if len(expectedSkillTreeHashes) != expectedSkillsCount {
+		t.Fatalf("expectedSkillTreeHashes has %d entries, want %d", len(expectedSkillTreeHashes), expectedSkillsCount)
 	}
-
-	if len(*recorded) != 5 {
-		t.Fatalf("expected 5 subprocess calls, got %d: %#v", len(*recorded), *recorded)
-	}
-
-	sourceDir := (*recorded)[0].args[1]
-	if !filepath.IsAbs(sourceDir) {
-		t.Fatalf("expected an absolute checkout directory, got %q", sourceDir)
-	}
-
-	installerDir := (*recorded)[4].dir
-	want := []recordedCommand{
-		{name: "/bin/git", args: []string{"-C", sourceDir, "init", "--quiet"}},
-		{name: "/bin/git", args: []string{"-C", sourceDir, "remote", "add", "origin", skillsSourceRepositoryURL}},
-		{name: "/bin/git", args: []string{"-C", sourceDir, "fetch", "--quiet", "--depth", "1", "origin", skillsSourceCommit}},
-		{name: "/bin/git", args: []string{"-C", sourceDir, "checkout", "--quiet", "--detach", skillsSourceCommit}},
-		{name: "/bin/npx", dir: installerDir, args: []string{"--yes", skillsInstallerPackage, "add", sourceDir, "--global", "--agent", "codex", "--yes"}},
-	}
-	if !reflect.DeepEqual(*recorded, want) {
-		t.Fatalf("subprocess calls =\n%#v\nwant\n%#v", *recorded, want)
-	}
-
-	if _, err := os.Stat(sourceDir); !os.IsNotExist(err) {
-		t.Fatalf("expected the pinned checkout %q to be removed, stat error: %v", sourceDir, err)
-	}
-	if _, err := os.Stat(installerDir); !os.IsNotExist(err) {
-		t.Fatalf("expected the isolated installer directory %q to be removed, stat error: %v", installerDir, err)
+	seen := make(map[string]struct{}, len(expectedSkillNames))
+	for _, name := range expectedSkillNames {
+		if _, duplicate := seen[name]; duplicate {
+			t.Fatalf("duplicate expected skill %q", name)
+		}
+		seen[name] = struct{}{}
+		if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(expectedSkillTreeHashes[name]) {
+			t.Fatalf("tree hash for %s = %q, want a Git object ID", name, expectedSkillTreeHashes[name])
+		}
 	}
 }
 
-// TestInstallSkillsRunsInstallerOutsideCallerDirectory pins the npx working
-// directory to a fresh isolated directory. npx prefers a local dependency whose
-// name and version match the requested package, so running it inside a caller
-// project containing node_modules/skills at the pinned version would execute
-// repository-controlled code instead of the reviewed registry package.
-func TestInstallSkillsRunsInstallerOutsideCallerDirectory(t *testing.T) {
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	if err := cmd.Run(context.Background()); err != nil {
-		t.Fatalf("run error: %v", err)
+func TestInstallSkillsRejectsPositionalArgumentsBeforeSideEffects(t *testing.T) {
+	preserveInstallerGlobals(t)
+	lookupExecutable = func(name string) (string, error) {
+		t.Fatalf("positional argument caused executable lookup for %q", name)
+		return "", nil
 	}
 
-	installer := (*recorded)[len(*recorded)-1]
-	if installer.name != "/bin/npx" {
-		t.Fatalf("last subprocess = %q, want the installer", installer.name)
+	err := runInstallCommand(t, "unexpected")
+	if err == nil {
+		t.Fatal("expected positional argument error")
 	}
-	if installer.dir == "" || !filepath.IsAbs(installer.dir) {
-		t.Fatalf("installer working directory = %q, want an absolute isolated directory", installer.dir)
+	if !strings.Contains(err.Error(), "unexpected arguments: unexpected") {
+		t.Fatalf("error = %q, want unexpected argument diagnostic", err)
+	}
+}
+
+func TestInstallSkillsCopiesExactPackWithoutNodeAndPreservesUnrelatedData(t *testing.T) {
+	home := installFixture(t, func(paths gitIsolationPaths) error {
+		populatePinnedSkillsFixture(t, paths.sourceDir, expectedSkillNames)
+		return nil
+	})
+
+	unrelatedDir := filepath.Join(home, ".agents", "skills", "user-owned-skill")
+	if err := os.MkdirAll(unrelatedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unrelatedDir, "SKILL.md"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(home, ".agents", ".skill-lock.json")
+	lockData := []byte(`{
+  "version": 3,
+  "skills": {
+    "user-owned-skill": {
+      "source": "local",
+      "custom": {"preserve": true}
+    },
+    "asc-app-create-ui": {
+      "source": "rorkai/app-store-connect-cli-skills",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/rorkai/app-store-connect-cli-skills.git",
+      "skillPath": "skills/asc-app-create-ui/SKILL.md",
+      "skillFolderHash": "stale",
+      "installedAt": "2026-01-02T03:04:05Z",
+      "updatedAt": "2026-01-02T03:04:05Z"
+    }
+  },
+  "dismissed": {"findSkillsPrompt": true},
+  "lastSelectedAgents": ["codex"],
+  "futureTopLevel": {"keep": 1}
+}`)
+	if err := os.WriteFile(lockPath, lockData, 0o600); err != nil {
+		t.Fatal(err)
 	}
 
-	cwd, err := os.Getwd()
+	if err := runInstallCommand(t); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	for _, name := range expectedSkillNames {
+		data, err := os.ReadFile(filepath.Join(home, ".agents", "skills", name, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("%s was not installed: %v", name, err)
+		}
+		if !strings.Contains(string(data), "name: "+name) {
+			t.Fatalf("%s content = %q", name, data)
+		}
+	}
+	if data, err := os.ReadFile(filepath.Join(home, ".agents", "skills", "asc-release-flow", "references", "release.md")); err != nil {
+		t.Fatalf("nested skill file was not installed: %v", err)
+	} else if string(data) != "reviewed reference\n" {
+		t.Fatalf("nested skill content = %q", data)
+	}
+	if data, err := os.ReadFile(filepath.Join(unrelatedDir, "SKILL.md")); err != nil || string(data) != "keep me\n" {
+		t.Fatalf("unrelated skill changed: data=%q err=%v", data, err)
+	}
+	assertPinnedLock(t, lockPath, "2026-01-02T03:04:05Z")
+	assertNoInstallWorkspace(t, filepath.Join(home, ".agents"))
+}
+
+func TestInstallSkillsReplacesOnlyPinnedSkills(t *testing.T) {
+	home := installFixture(t, func(paths gitIsolationPaths) error {
+		populatePinnedSkillsFixture(t, paths.sourceDir, expectedSkillNames)
+		return nil
+	})
+	oldPath := filepath.Join(home, ".agents", "skills", expectedSkillNames[0], "old-only.txt")
+	if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInstallCommand(t); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old pinned-skill content was not replaced: %v", err)
+	}
+}
+
+func TestInstallSkillsRejectsIncompletePackBeforeReplacingAnything(t *testing.T) {
+	missing := append([]string(nil), expectedSkillNames[:len(expectedSkillNames)-1]...)
+	home := installFixture(t, func(paths gitIsolationPaths) error {
+		populatePinnedSkillsFixture(t, paths.sourceDir, missing)
+		return nil
+	})
+	existing := filepath.Join(home, ".agents", "skills", expectedSkillNames[0], "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(existing), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(existing, []byte("existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInstallCommand(t)
+	if err == nil {
+		t.Fatal("expected incomplete pack error")
+	}
+	if !errors.Is(err, errIncompleteSkillSet) {
+		t.Fatalf("error = %v, want errIncompleteSkillSet", err)
+	}
+	if data, readErr := os.ReadFile(existing); readErr != nil || string(data) != "existing\n" {
+		t.Fatalf("existing skill changed before pack validation: data=%q err=%v", data, readErr)
+	}
+}
+
+func TestInstallSkillPackRollsBackEveryReplacementOnPartialFailure(t *testing.T) {
+	sourceDir := t.TempDir()
+	populatePinnedSkillsFixture(t, sourceDir, expectedSkillNames)
+	source, err := os.OpenRoot(filepath.Join(sourceDir, "skills"))
 	if err != nil {
-		t.Fatalf("getwd: %v", err)
+		t.Fatal(err)
 	}
-	if installer.dir == cwd {
-		t.Fatalf("installer ran in the caller directory %q", cwd)
+	defer source.Close()
+
+	destinationDir := t.TempDir()
+	for _, name := range expectedSkillNames {
+		path := filepath.Join(destinationDir, name)
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte("old "+name+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if rel, err := filepath.Rel(cwd, installer.dir); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		t.Fatalf("installer working directory %q is inside the caller directory %q", installer.dir, cwd)
+	unrelated := filepath.Join(destinationDir, "user-owned", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(unrelated), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unrelated, []byte("unrelated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	destination, err := os.OpenRoot(destinationDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+
+	preserveInstallerGlobals(t)
+	failed := false
+	renameWithinRoot = func(root *os.Root, oldName, newName string) error {
+		if !failed && strings.Contains(oldName, ".asc-stage-") && filepath.Base(oldName) == expectedSkillNames[2] {
+			failed = true
+			return errors.New("injected install failure")
+		}
+		return root.Rename(oldName, newName)
 	}
 
-	sourceDir := installer.args[3]
-	if installer.dir == sourceDir {
-		t.Fatalf("installer must not run inside the skills checkout %q", sourceDir)
+	names := append([]string(nil), expectedSkillNames...)
+	sort.Strings(names)
+	err = installSkillPack(source, destination, names)
+	if err == nil || !strings.Contains(err.Error(), "injected install failure") {
+		t.Fatalf("error = %v, want injected partial failure", err)
+	}
+	for _, name := range expectedSkillNames {
+		data, readErr := os.ReadFile(filepath.Join(destinationDir, name, "SKILL.md"))
+		if readErr != nil {
+			t.Fatalf("%s was not restored: %v", name, readErr)
+		}
+		if string(data) != "old "+name+"\n" {
+			t.Fatalf("%s was not rolled back: %q", name, data)
+		}
+	}
+	if data, readErr := os.ReadFile(unrelated); readErr != nil || string(data) != "unrelated\n" {
+		t.Fatalf("unrelated skill changed: data=%q err=%v", data, readErr)
 	}
 }
 
-func TestInstallSkillsNeverPassesAMutableRefToTheInstaller(t *testing.T) {
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
+func TestInstallSkillPackPreservesBackupWhenRollbackRestoreFails(t *testing.T) {
+	sourceDir := t.TempDir()
+	populatePinnedSkillsFixture(t, sourceDir, expectedSkillNames)
+	source, err := os.OpenRoot(filepath.Join(sourceDir, "skills"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := cmd.Run(context.Background()); err != nil {
-		t.Fatalf("run error: %v", err)
-	}
+	defer source.Close()
 
-	for _, call := range *recorded {
-		for _, arg := range call.args {
-			for _, mutableRef := range []string{"HEAD", "FETCH_HEAD", "main", "master", "@latest", "skills"} {
-				if arg == mutableRef {
-					t.Fatalf("argument %q is a mutable ref or unpinned package", arg)
-				}
-			}
+	destinationDir := t.TempDir()
+	for _, name := range expectedSkillNames {
+		path := filepath.Join(destinationDir, name)
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte("old "+name+"\n"), 0o644); err != nil {
+			t.Fatal(err)
 		}
 	}
-
-	installerCall := (*recorded)[len(*recorded)-1]
-	if installerCall.name != "/bin/npx" {
-		t.Fatalf("last subprocess = %q, want the installer", installerCall.name)
+	destination, err := os.OpenRoot(destinationDir)
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, arg := range installerCall.args {
-		if strings.Contains(arg, "github.com") || strings.Contains(arg, "app-store-connect-cli-skills") {
-			t.Fatalf("installer argument %q resolves the skills source itself instead of using the pinned checkout", arg)
+	defer destination.Close()
+
+	preserveInstallerGlobals(t)
+	stageFailed := false
+	restoreFailed := false
+	renameWithinRoot = func(root *os.Root, oldName, newName string) error {
+		if !stageFailed && strings.Contains(oldName, ".asc-stage-") && filepath.Base(oldName) == expectedSkillNames[2] {
+			stageFailed = true
+			return errors.New("injected install failure")
 		}
+		if !restoreFailed && strings.Contains(oldName, ".asc-backup-") && filepath.Base(oldName) == expectedSkillNames[0] {
+			restoreFailed = true
+			return errors.New("injected restore failure")
+		}
+		return root.Rename(oldName, newName)
+	}
+
+	names := append([]string(nil), expectedSkillNames...)
+	sort.Strings(names)
+	err = installSkillPack(source, destination, names)
+	if err == nil {
+		t.Fatal("expected rollback failure")
+	}
+	var retained *retainedSkillBackupError
+	if !errors.As(err, &retained) {
+		t.Fatalf("error = %v, want retainedSkillBackupError", err)
+	}
+	if !strings.Contains(err.Error(), "previous skill data was preserved at") ||
+		!strings.Contains(err.Error(), "restore needed entries") {
+		t.Fatalf("error lacks recovery instructions: %v", err)
+	}
+	data, readErr := os.ReadFile(filepath.Join(retained.path, expectedSkillNames[0], "SKILL.md"))
+	if readErr != nil || string(data) != "old "+expectedSkillNames[0]+"\n" {
+		t.Fatalf("only recovery backup was lost: data=%q err=%v path=%s", data, readErr, retained.path)
 	}
 }
 
-func TestInstallSkillsAppliesASCTimeout(t *testing.T) {
-	t.Setenv("ASC_TIMEOUT", "1m")
+func TestInstallSkillsSerializesAcrossProcessesWithAdvisoryLock(t *testing.T) {
+	agentsDir := t.TempDir()
+	root, err := os.OpenRoot(agentsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	path := filepath.Join(agentsDir, installLockName)
+	lockContents := []byte("persistent operator metadata must not be rewritten\n")
+	if err := os.WriteFile(path, lockContents, 0o600); err != nil {
+		t.Fatal(err)
+	}
 
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	first, err := acquireInstallLock(root, path)
+	if err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+	if _, err := acquireInstallLock(root, path); err == nil || !errors.Is(err, errInstallLockHeld) {
+		t.Fatalf("second lock error = %v, want held advisory lock", err)
+	}
+	if err := first.release(); err != nil {
+		t.Fatalf("release first lock: %v", err)
+	}
+	if data, err := os.ReadFile(path); err != nil || !reflect.DeepEqual(data, lockContents) {
+		t.Fatalf("advisory locking mutated persistent lock inode: data=%q err=%v", data, err)
+	}
 
-	originalRun := runCommand
-	originalRunInDir := runCommandInDir
-	t.Cleanup(func() {
-		runCommand = originalRun
-		runCommandInDir = originalRunInDir
+	// The lock file is intentionally persistent. Advisory ownership is released
+	// by the OS on close or process death, so a stale metadata file cannot
+	// strand future installs.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("persistent lock metadata missing: %v", err)
+	}
+	second, err := acquireInstallLock(root, path)
+	if err != nil {
+		t.Fatalf("reacquire persistent lock after release: %v", err)
+	}
+	if err := second.release(); err != nil {
+		t.Fatalf("release second lock: %v", err)
+	}
+}
+
+func TestInstallLockNeverMutatesPreexistingHardlink(t *testing.T) {
+	agentsDir := t.TempDir()
+	backing := filepath.Join(t.TempDir(), "operator-data")
+	original := []byte("must survive advisory locking\n")
+	if err := os.WriteFile(backing, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(agentsDir, installLockName)
+	if err := os.Link(backing, lockPath); err != nil {
+		t.Skipf("hardlinks are not available: %v", err)
+	}
+	root, err := os.OpenRoot(agentsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	lock, err := acquireInstallLock(root, lockPath)
+	if err != nil {
+		t.Fatalf("acquire hard-linked advisory lock: %v", err)
+	}
+	if err := lock.release(); err != nil {
+		t.Fatalf("release hard-linked advisory lock: %v", err)
+	}
+	data, err := os.ReadFile(backing)
+	if err != nil || !reflect.DeepEqual(data, original) {
+		t.Fatalf("hardlink target was mutated: data=%q err=%v", data, err)
+	}
+}
+
+func TestUntrackedRecoveryLockRemovesOnlyASCEntries(t *testing.T) {
+	original := []byte(`{
+  "version": 3,
+  "skills": {
+    "unrelated": {"source": "local", "future": {"keep": true}},
+    "asc-app-create-ui": {"source": "rorkai/app-store-connect-cli-skills", "ref": "main"},
+    "asc-xcode-build": {"source": "rorkai/app-store-connect-cli-skills"}
+  },
+  "dismissed": {"findSkillsPrompt": true},
+  "futureTopLevel": [1, 2, 3]
+}`)
+	data, err := buildUntrackedSkillLock(original, expectedSkillNames)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(document["skills"], &entries); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := entries["asc-app-create-ui"]; ok {
+		t.Fatal("ASC entry remained tracked after incomplete rollback")
+	}
+	if _, ok := entries["asc-xcode-build"]; ok {
+		t.Fatal("ASC entry remained tracked after incomplete rollback")
+	}
+	if _, ok := entries["unrelated"]; !ok {
+		t.Fatal("unrelated entry was removed")
+	}
+	if _, ok := document["dismissed"]; !ok {
+		t.Fatal("dismissed metadata was removed")
+	}
+	if _, ok := document["futureTopLevel"]; !ok {
+		t.Fatal("future top-level metadata was removed")
+	}
+}
+
+func TestInstallSkillsRestoresExactLockBytesAfterSuccessfulRollback(t *testing.T) {
+	home := installFixture(t, func(paths gitIsolationPaths) error {
+		populatePinnedSkillsFixture(t, paths.sourceDir, expectedSkillNames)
+		return nil
 	})
-	calls := 0
-	assertDeadline := func(ctx context.Context) {
-		calls++
-		deadline, ok := ctx.Deadline()
-		if !ok {
-			t.Fatal("expected install command context to have a deadline")
+	lockPath := filepath.Join(home, ".agents", skillLockName)
+	original := []byte("{\n  \"version\": 3,\n  \"skills\": {\"unrelated\": {\"opaque\": [3,2,1]}}\n}\n")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	failed := false
+	renameWithinRoot = func(root *os.Root, oldName, newName string) error {
+		if !failed && strings.Contains(oldName, ".asc-stage-") && filepath.Base(oldName) == expectedSkillNames[2] {
+			failed = true
+			return errors.New("injected install failure")
 		}
-		remaining := time.Until(deadline)
-		if remaining <= 0 || remaining > time.Minute {
-			t.Fatalf("expected ASC_TIMEOUT deadline within 1m, got %s", remaining)
+		return root.Rename(oldName, newName)
+	}
+	if err := runInstallCommand(t); err == nil {
+		t.Fatal("expected injected installation failure")
+	}
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(data, original) {
+		t.Fatalf("lock rollback changed original bytes:\n%s\nwant:\n%s", data, original)
+	}
+}
+
+func TestInstallSkillsUsesXDGStateSkillsLock(t *testing.T) {
+	xdgState := t.TempDir()
+	home := installFixture(t, func(paths gitIsolationPaths) error {
+		populatePinnedSkillsFixture(t, paths.sourceDir, expectedSkillNames)
+		return nil
+	})
+	t.Setenv("XDG_STATE_HOME", xdgState)
+	if err := runInstallCommand(t); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	assertPinnedLock(t, filepath.Join(xdgState, "skills", skillLockName), "2026-07-30T12:00:00Z")
+	if _, err := os.Stat(filepath.Join(home, ".agents", skillLockName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("HOME lock should not be written when XDG_STATE_HOME is set: %v", err)
+	}
+}
+
+func TestInstallSkillsCleanupNeverFollowsSwappedWorkspaceSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing an open directory; the retained handle is already protective")
+	}
+	victim := t.TempDir()
+	sentinel := filepath.Join(victim, "keep-me")
+	if err := os.WriteFile(sentinel, []byte("unrelated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	home := installFixture(t, func(paths gitIsolationPaths) error {
+		if err := os.RemoveAll(paths.workingDir); err != nil {
+			return err
 		}
-	}
-	runCommand = func(ctx context.Context, name string, args ...string) error {
-		assertDeadline(ctx)
-		return nil
-	}
-	runCommandInDir = func(ctx context.Context, dir string, name string, args ...string) error {
-		assertDeadline(ctx)
-		return nil
-	}
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	if err := cmd.Run(context.Background()); err != nil {
-		t.Fatalf("run error: %v", err)
-	}
-	if calls == 0 {
-		t.Fatal("expected at least one subprocess call")
-	}
-}
-
-func TestInstallSkillsFailsWhenNpxMissing(t *testing.T) {
-	stubLookups(t, map[string]string{"git": "/bin/git"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	err := cmd.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, errNpxNotFound) {
-		t.Fatalf("expected npx error, got %q", err.Error())
-	}
-	if len(*recorded) != 0 {
-		t.Fatalf("expected no subprocess calls, got %#v", *recorded)
-	}
-}
-
-func TestInstallSkillsFailsWhenGitMissing(t *testing.T) {
-	stubLookups(t, map[string]string{"npx": "/bin/npx"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	err := cmd.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, errGitNotFound) {
-		t.Fatalf("expected git error, got %q", err.Error())
-	}
-	if !strings.Contains(err.Error(), skillsSourceCommit) {
-		t.Fatalf("expected the error to name the pinned commit, got %q", err.Error())
-	}
-	if len(*recorded) != 0 {
-		t.Fatalf("expected no subprocess calls, got %#v", *recorded)
-	}
-}
-
-func TestInstallSkillsStopsWhenPinnedCommitCannotBeFetched(t *testing.T) {
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-
-	originalRun := runCommand
-	originalRunInDir := runCommandInDir
-	t.Cleanup(func() {
-		runCommand = originalRun
-		runCommandInDir = originalRunInDir
+		if err := os.Symlink(victim, paths.workingDir); err != nil {
+			return err
+		}
+		return errors.New("injected checkout failure after workspace swap")
 	})
 
-	var recorded []recordedCommand
-	runCommand = func(ctx context.Context, name string, args ...string) error {
-		recorded = append(recorded, recordedCommand{name: name, args: append([]string(nil), args...)})
-		if len(args) > 2 && args[2] == "fetch" {
-			return errors.New("could not read from remote repository")
-		}
-		return nil
-	}
-	runCommandInDir = func(ctx context.Context, dir string, name string, args ...string) error {
-		recorded = append(recorded, recordedCommand{name: name, dir: dir, args: append([]string(nil), args...)})
-		return nil
-	}
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	err := cmd.Run(context.Background())
+	err := runInstallCommand(t)
 	if err == nil {
-		t.Fatal("expected error, got nil")
+		t.Fatal("expected injected checkout failure")
 	}
-	if !strings.Contains(err.Error(), skillsSourceCommit) {
-		t.Fatalf("expected the error to name the pinned commit, got %q", err.Error())
+	if data, readErr := os.ReadFile(sentinel); readErr != nil || string(data) != "unrelated" {
+		t.Fatalf("cleanup followed swapped workspace symlink: data=%q err=%v", data, readErr)
 	}
-	for _, call := range recorded {
-		if call.name == "/bin/npx" {
-			t.Fatalf("installer ran without the pinned source: %#v", call)
-		}
-	}
+	assertNoInstallWorkspace(t, filepath.Join(home, ".agents"))
 }
 
-// TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject guards the
-// isolated npx directory against TMPDIR pointing into an npm project: npm walks
-// up from the working directory, so an ancestor node_modules could shadow the
-// pinned registry package with a local skills dependency, and an ancestor
-// package.json or .npmrc could redirect the install to a project-controlled
-// registry.
-func TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject(t *testing.T) {
-	markers := []struct {
-		name string
-		dir  bool
+func TestInstallSkillsIgnoresRelativeAndSymlinkedTMPDIR(t *testing.T) {
+	cases := []struct {
+		name  string
+		value func(*testing.T) string
 	}{
-		{name: "node_modules", dir: true},
-		{name: "package.json", dir: false},
-		{name: ".npmrc", dir: false},
+		{name: "relative", value: func(*testing.T) string { return "relative-temp" }},
+		{name: "symlink", value: func(t *testing.T) string {
+			target := t.TempDir()
+			link := filepath.Join(t.TempDir(), "tmp-link")
+			if err := os.Symlink(target, link); err != nil {
+				t.Skipf("symlink creation is not permitted: %v", err)
+			}
+			return link
+		}},
 	}
 
-	for _, marker := range markers {
-		t.Run(marker.name, func(t *testing.T) {
-			project := t.TempDir()
-			markerPath := filepath.Join(project, marker.name)
-			if marker.dir {
-				if err := os.MkdirAll(markerPath, 0o755); err != nil {
-					t.Fatalf("create %s fixture: %v", marker.name, err)
-				}
-			} else if err := os.WriteFile(markerPath, []byte("{}"), 0o644); err != nil {
-				t.Fatalf("create %s fixture: %v", marker.name, err)
-			}
-			tmpInsideProject := filepath.Join(project, "tmp")
-			if err := os.MkdirAll(tmpInsideProject, 0o755); err != nil {
-				t.Fatalf("create nested tmp dir: %v", err)
-			}
-			t.Setenv("TMPDIR", tmpInsideProject)
-
-			stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-			recorded := recordCommands(t)
-
-			cmd := InstallSkillsCommand()
-			if err := cmd.Parse([]string{}); err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
-			err := cmd.Run(context.Background())
-			if err == nil {
-				t.Fatal("expected an error when TMPDIR sits inside an npm project")
-			}
-			if !strings.Contains(err.Error(), marker.name) {
-				t.Fatalf("expected the error to name the %s marker, got %q", marker.name, err.Error())
-			}
-			for _, call := range *recorded {
-				if call.name == "/bin/npx" {
-					t.Fatalf("installer ran despite the unsafe working directory: %#v", call)
-				}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := tc.value(t)
+			installFixture(t, func(paths gitIsolationPaths) error {
+				populatePinnedSkillsFixture(t, paths.sourceDir, expectedSkillNames)
+				return nil
+			})
+			t.Setenv("TMPDIR", tmpDir)
+			if err := runInstallCommand(t); err != nil {
+				t.Fatalf("install with %s TMPDIR: %v", tc.name, err)
 			}
 		})
 	}
 }
 
-func TestInstallSkillsRejectsSymlinkedTempDirectoryInsideNodeProject(t *testing.T) {
-	project := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(project, "node_modules", "skills"), 0o755); err != nil {
-		t.Fatalf("create project node_modules fixture: %v", err)
-	}
-	tmpInsideProject := filepath.Join(project, "tmp")
-	if err := os.MkdirAll(tmpInsideProject, 0o755); err != nil {
-		t.Fatalf("create project temp directory: %v", err)
-	}
-
-	linkParent := t.TempDir()
-	symlinkedTmp := filepath.Join(linkParent, "tmp-link")
-	if err := os.Symlink(tmpInsideProject, symlinkedTmp); err != nil {
-		t.Skipf("symlink creation is not permitted on this host: %v", err)
-	}
-	t.Setenv("TMPDIR", symlinkedTmp)
-
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	err := cmd.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected an error when symlinked TMPDIR resolves inside an npm project")
-	}
-	if !strings.Contains(err.Error(), "node_modules") {
-		t.Fatalf("expected the error to name node_modules, got %q", err.Error())
-	}
-	for _, call := range *recorded {
-		if call.name == "/bin/npx" {
-			t.Fatalf("installer ran despite the physical npm project ancestor: %#v", call)
-		}
-	}
-}
-
-func TestIsolatedInstallerDirCleanupNeverFollowsSwappedTempSymlink(t *testing.T) {
-	victim := t.TempDir()
-	sentinel := filepath.Join(victim, "keep-me")
-	if err := os.WriteFile(sentinel, []byte("unrelated"), 0o600); err != nil {
-		t.Fatalf("create unrelated sentinel: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(victim, "package.json"), []byte("{}"), 0o600); err != nil {
-		t.Fatalf("create npm project marker: %v", err)
-	}
-
-	originalEval := evalInstallerDir
-	t.Cleanup(func() { evalInstallerDir = originalEval })
-	evalInstallerDir = func(runDir string) (string, error) {
-		if err := os.RemoveAll(runDir); err != nil {
-			return "", err
-		}
-		if err := os.Symlink(victim, runDir); err != nil {
-			return "", err
-		}
-		return filepath.EvalSymlinks(runDir)
-	}
-
-	if _, err := isolatedInstallerDir(); err == nil {
-		t.Fatal("expected the swapped directory to fail npm project validation")
-	}
-	if data, err := os.ReadFile(sentinel); err != nil {
-		t.Fatalf("cleanup followed the swapped symlink and removed unrelated data: %v", err)
-	} else if string(data) != "unrelated" {
-		t.Fatalf("unrelated sentinel changed to %q", data)
-	}
-}
-
-func TestInstallSkillsAllowsUserNpmrcAboveTempDirectory(t *testing.T) {
+func TestInstallSkillsAppliesASCTimeoutToGit(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "1m")
+	preserveInstallerGlobals(t)
 	home := t.TempDir()
-	if err := os.WriteFile(filepath.Join(home, ".npmrc"), []byte("fund=false\n"), 0o600); err != nil {
-		t.Fatalf("create user npmrc fixture: %v", err)
-	}
-	tmpBelowHome := filepath.Join(home, "tmp")
-	if err := os.MkdirAll(tmpBelowHome, 0o755); err != nil {
-		t.Fatalf("create home temp directory: %v", err)
-	}
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	t.Setenv("TMPDIR", tmpBelowHome)
-
-	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
-	recorded := recordCommands(t)
-
-	cmd := InstallSkillsCommand()
-	if err := cmd.Parse([]string{}); err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	if err := cmd.Run(context.Background()); err != nil {
-		t.Fatalf("user-level .npmrc must not reject an otherwise isolated installer: %v", err)
+	userHomeDirectory = func() (string, error) { return home, nil }
+	lookupExecutable = func(string) (string, error) { return "/test/bin/git", nil }
+	checkoutSkillsSource = func(ctx context.Context, _ string, paths gitIsolationPaths) error {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected install context to have a deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > time.Minute {
+			t.Fatalf("expected ASC_TIMEOUT deadline within 1m, got %s", remaining)
+		}
+		populatePinnedSkillsFixture(t, paths.sourceDir, expectedSkillNames)
+		return nil
 	}
 
-	if len(*recorded) == 0 || (*recorded)[len(*recorded)-1].name != "/bin/npx" {
-		t.Fatalf("installer did not reach pinned npx execution: %#v", *recorded)
+	if err := runInstallCommand(t); err != nil {
+		t.Fatalf("install: %v", err)
 	}
 }
 
-func TestPinnedSkillsDocumentationMatchesConstants(t *testing.T) {
+func TestInstallSkillsFailsWhenGitMissing(t *testing.T) {
+	preserveInstallerGlobals(t)
+	lookupExecutable = func(string) (string, error) { return "", errors.New("not found") }
+
+	err := runInstallCommand(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errGitNotFound) {
+		t.Fatalf("error = %v, want errGitNotFound", err)
+	}
+	if !strings.Contains(err.Error(), skillsSourceCommit) {
+		t.Fatalf("error does not name pinned commit: %v", err)
+	}
+}
+
+func TestCheckoutPinnedSkillsUsesOnlyExactSourceAndIsolatedGitState(t *testing.T) {
+	preserveInstallerGlobals(t)
+	base := t.TempDir()
+	paths := gitIsolationPaths{
+		home:       filepath.Join(base, "home"),
+		globalCfg:  filepath.Join(base, "home", "gitconfig"),
+		hooks:      filepath.Join(base, "hooks"),
+		template:   filepath.Join(base, "template"),
+		xdgConfig:  filepath.Join(base, "home", "config"),
+		sourceDir:  filepath.Join(base, "source"),
+		workingDir: base,
+	}
+	for _, dir := range []string{paths.home, paths.hooks, paths.template, paths.xdgConfig, paths.sourceDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("GIT_CONFIG_PARAMETERS", "'alias.checkout=!touch /tmp/pwned'")
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.hooksPath")
+	t.Setenv("GIT_CONFIG_VALUE_0", "/tmp/hooks")
+	t.Setenv("GIT_DIR", "/tmp/attacker")
+	t.Setenv("GIT_ASKPASS", "/tmp/askpass")
+	t.Setenv("GIT_SSL_CAINFO", "/corporate/ca.pem")
+	t.Setenv("GIT_SSL_CAPATH", "/corporate/certs")
+	t.Setenv("HOME", "/tmp/caller-home")
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/caller-xdg")
+
+	type call struct {
+		dir  string
+		env  []string
+		name string
+		args []string
+	}
+	var calls []call
+	runGitCommand = func(_ context.Context, dir string, env []string, name string, args ...string) error {
+		calls = append(calls, call{dir: dir, env: append([]string(nil), env...), name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+
+	if err := checkoutPinnedSkills(context.Background(), "/test/bin/git", paths); err != nil {
+		t.Fatalf("checkout: %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("git calls = %d, want 3", len(calls))
+	}
+	for _, call := range calls {
+		if call.dir != paths.workingDir || call.name != "/test/bin/git" {
+			t.Fatalf("call = %#v", call)
+		}
+		assertSafeGitEnvironment(t, call.env, paths)
+		joined := strings.Join(call.args, "\x00")
+		for _, required := range []string{
+			"credential.helper=",
+			"core.hooksPath=" + paths.hooks,
+			"init.templateDir=" + paths.template,
+			"protocol.file.allow=never",
+			"protocol.ext.allow=never",
+			"protocol.http.allow=never",
+		} {
+			if !strings.Contains(joined, required) {
+				t.Fatalf("git args %q do not include %q", call.args, required)
+			}
+		}
+	}
+	fetch := strings.Join(calls[1].args, "\x00")
+	if !strings.Contains(fetch, skillsSourceRepositoryURL) || !strings.Contains(fetch, skillsSourceCommit) {
+		t.Fatalf("fetch args do not bind repository and commit: %q", calls[1].args)
+	}
+	for _, mutable := range []string{"HEAD", "main", "master", "@latest"} {
+		if strings.Contains(fetch, "\x00"+mutable+"\x00") {
+			t.Fatalf("fetch uses mutable ref %q: %q", mutable, calls[1].args)
+		}
+	}
+}
+
+func TestValidatePinnedSkillsRejectsSymlinks(t *testing.T) {
+	sourceDir := t.TempDir()
+	populatePinnedSkillsFixture(t, sourceDir, expectedSkillNames)
+	link := filepath.Join(sourceDir, "skills", expectedSkillNames[0], "unsafe")
+	if err := os.Symlink(filepath.Join(sourceDir, "outside"), link); err != nil {
+		t.Skipf("symlink creation is not permitted: %v", err)
+	}
+	root, err := os.OpenRoot(filepath.Join(sourceDir, "skills"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if _, err := validatePinnedSkills(root); err == nil || !errors.Is(err, errIncompleteSkillSet) {
+		t.Fatalf("error = %v, want rejected symlink", err)
+	}
+}
+
+func TestPinnedSkillsDocumentationMatchesDirectInstaller(t *testing.T) {
 	for _, path := range []string{
 		filepath.Join("..", "..", "..", "README.md"),
 		filepath.Join("..", "..", "..", "installation.mdx"),
@@ -476,15 +730,130 @@ func TestPinnedSkillsDocumentationMatchesConstants(t *testing.T) {
 			t.Fatalf("read %s: %v", path, err)
 		}
 		content := string(data)
-
-		if strings.Contains(content, "npx skills add rorkai/app-store-connect-cli-skills") {
-			t.Errorf("%s documents an unpinned installer and skills source", path)
-		}
-		if !strings.Contains(content, skillsInstallerPackage) {
-			t.Errorf("%s does not mention the pinned installer %q", path, skillsInstallerPackage)
+		if strings.Contains(content, "npx --yes skills") || strings.Contains(content, "needs Node.js") {
+			t.Errorf("%s still documents executable npm installer code", path)
 		}
 		if !strings.Contains(content, skillsSourceCommit) {
 			t.Errorf("%s does not mention the pinned skills commit %q", path, skillsSourceCommit)
 		}
+		if !strings.Contains(content, "23") {
+			t.Errorf("%s does not mention verification of all 23 skills", path)
+		}
+	}
+}
+
+func assertSafeGitEnvironment(t *testing.T, env []string, paths gitIsolationPaths) {
+	t.Helper()
+	values := make(map[string]string)
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[strings.ToUpper(key)] = value
+		}
+	}
+	for _, key := range []string{
+		"GIT_CONFIG_PARAMETERS",
+		"GIT_CONFIG_COUNT",
+		"GIT_CONFIG_KEY_0",
+		"GIT_CONFIG_VALUE_0",
+		"GIT_DIR",
+		"GIT_ASKPASS",
+	} {
+		if _, exists := values[key]; exists {
+			t.Fatalf("unsafe %s survived git environment isolation", key)
+		}
+	}
+	want := map[string]string{
+		"HOME":                paths.home,
+		"USERPROFILE":         paths.home,
+		"XDG_CONFIG_HOME":     paths.xdgConfig,
+		"GIT_CONFIG_NOSYSTEM": "1",
+		"GIT_CONFIG_GLOBAL":   paths.globalCfg,
+		"GIT_TERMINAL_PROMPT": "0",
+		"GCM_INTERACTIVE":     "never",
+		"GIT_SSL_CAINFO":      "/corporate/ca.pem",
+		"GIT_SSL_CAPATH":      "/corporate/certs",
+	}
+	for key, value := range want {
+		if values[key] != value {
+			t.Fatalf("%s = %q, want %q", key, values[key], value)
+		}
+	}
+}
+
+func assertNoInstallWorkspace(t *testing.T, agentsDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".asc-install-skills-") {
+			t.Fatalf("install workspace was not cleaned up: %s", entry.Name())
+		}
+	}
+}
+
+func assertPinnedLock(t *testing.T, path string, preservedInstalledAt string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pinned lock %s: %v", path, err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("parse pinned lock: %v", err)
+	}
+	var version int
+	if err := json.Unmarshal(document["version"], &version); err != nil || version != 3 {
+		t.Fatalf("lock version = %d err=%v", version, err)
+	}
+	var entries map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(document["skills"], &entries); err != nil {
+		t.Fatalf("parse lock entries: %v", err)
+	}
+	for _, name := range expectedSkillNames {
+		entry, ok := entries[name]
+		if !ok {
+			t.Fatalf("lock is missing %s", name)
+		}
+		want := map[string]string{
+			"source":          "rorkai/app-store-connect-cli-skills",
+			"sourceType":      "github",
+			"sourceUrl":       skillsSourceRepositoryURL,
+			"ref":             skillsSourceCommit,
+			"skillPath":       filepath.ToSlash(filepath.Join("skills", name, "SKILL.md")),
+			"skillFolderHash": expectedSkillTreeHashes[name],
+			"updatedAt":       "2026-07-30T12:00:00Z",
+		}
+		for key, wantValue := range want {
+			var got string
+			if err := json.Unmarshal(entry[key], &got); err != nil || got != wantValue {
+				t.Fatalf("%s.%s = %q err=%v, want %q", name, key, got, err, wantValue)
+			}
+		}
+		var installedAt string
+		if err := json.Unmarshal(entry["installedAt"], &installedAt); err != nil {
+			t.Fatalf("%s.installedAt: %v", name, err)
+		}
+		if name == "asc-app-create-ui" && preservedInstalledAt != "" {
+			if installedAt != preservedInstalledAt {
+				t.Fatalf("%s installedAt = %q, want preserved %q", name, installedAt, preservedInstalledAt)
+			}
+		} else if installedAt == "" {
+			t.Fatalf("%s installedAt is empty", name)
+		}
+	}
+	if unrelated, ok := entries["user-owned-skill"]; ok {
+		var source string
+		if err := json.Unmarshal(unrelated["source"], &source); err != nil || source != "local" {
+			t.Fatalf("unrelated skill metadata changed: source=%q err=%v", source, err)
+		}
+	}
+	if raw, ok := document["dismissed"]; ok && !strings.Contains(string(raw), "findSkillsPrompt") {
+		t.Fatalf("dismissed metadata changed: %s", raw)
+	}
+	if raw, ok := document["futureTopLevel"]; ok && !strings.Contains(string(raw), `"keep": 1`) && !strings.Contains(string(raw), `"keep":1`) {
+		t.Fatalf("future top-level metadata changed: %s", raw)
 	}
 }

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -366,6 +366,73 @@ func TestInstallSkillsRejectsInstallerDirectoryInsideNodeProject(t *testing.T) {
 	}
 }
 
+func TestInstallSkillsRejectsSymlinkedTempDirectoryInsideNodeProject(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, "node_modules", "skills"), 0o755); err != nil {
+		t.Fatalf("create project node_modules fixture: %v", err)
+	}
+	tmpInsideProject := filepath.Join(project, "tmp")
+	if err := os.MkdirAll(tmpInsideProject, 0o755); err != nil {
+		t.Fatalf("create project temp directory: %v", err)
+	}
+
+	linkParent := t.TempDir()
+	symlinkedTmp := filepath.Join(linkParent, "tmp-link")
+	if err := os.Symlink(tmpInsideProject, symlinkedTmp); err != nil {
+		t.Skipf("symlink creation is not permitted on this host: %v", err)
+	}
+	t.Setenv("TMPDIR", symlinkedTmp)
+
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	recorded := recordCommands(t)
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := cmd.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when symlinked TMPDIR resolves inside an npm project")
+	}
+	if !strings.Contains(err.Error(), "node_modules") {
+		t.Fatalf("expected the error to name node_modules, got %q", err.Error())
+	}
+	for _, call := range *recorded {
+		if call.name == "/bin/npx" {
+			t.Fatalf("installer ran despite the physical npm project ancestor: %#v", call)
+		}
+	}
+}
+
+func TestInstallSkillsAllowsUserNpmrcAboveTempDirectory(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".npmrc"), []byte("fund=false\n"), 0o600); err != nil {
+		t.Fatalf("create user npmrc fixture: %v", err)
+	}
+	tmpBelowHome := filepath.Join(home, "tmp")
+	if err := os.MkdirAll(tmpBelowHome, 0o755); err != nil {
+		t.Fatalf("create home temp directory: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("TMPDIR", tmpBelowHome)
+
+	stubLookups(t, map[string]string{"npx": "/bin/npx", "git": "/bin/git"})
+	recorded := recordCommands(t)
+
+	cmd := InstallSkillsCommand()
+	if err := cmd.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatalf("user-level .npmrc must not reject an otherwise isolated installer: %v", err)
+	}
+
+	if len(*recorded) == 0 || (*recorded)[len(*recorded)-1].name != "/bin/npx" {
+		t.Fatalf("installer did not reach pinned npx execution: %#v", *recorded)
+	}
+}
+
 func TestPinnedSkillsDocumentationMatchesConstants(t *testing.T) {
 	for _, path := range []string{
 		filepath.Join("..", "..", "..", "README.md"),

--- a/internal/cli/install/install_test.go
+++ b/internal/cli/install/install_test.go
@@ -404,6 +404,38 @@ func TestInstallSkillsRejectsSymlinkedTempDirectoryInsideNodeProject(t *testing.
 	}
 }
 
+func TestIsolatedInstallerDirCleanupNeverFollowsSwappedTempSymlink(t *testing.T) {
+	victim := t.TempDir()
+	sentinel := filepath.Join(victim, "keep-me")
+	if err := os.WriteFile(sentinel, []byte("unrelated"), 0o600); err != nil {
+		t.Fatalf("create unrelated sentinel: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(victim, "package.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("create npm project marker: %v", err)
+	}
+
+	originalEval := evalInstallerDir
+	t.Cleanup(func() { evalInstallerDir = originalEval })
+	evalInstallerDir = func(runDir string) (string, error) {
+		if err := os.RemoveAll(runDir); err != nil {
+			return "", err
+		}
+		if err := os.Symlink(victim, runDir); err != nil {
+			return "", err
+		}
+		return filepath.EvalSymlinks(runDir)
+	}
+
+	if _, err := isolatedInstallerDir(); err == nil {
+		t.Fatal("expected the swapped directory to fail npm project validation")
+	}
+	if data, err := os.ReadFile(sentinel); err != nil {
+		t.Fatalf("cleanup followed the swapped symlink and removed unrelated data: %v", err)
+	} else if string(data) != "unrelated" {
+		t.Fatalf("unrelated sentinel changed to %q", data)
+	}
+}
+
 func TestInstallSkillsAllowsUserNpmrcAboveTempDirectory(t *testing.T) {
 	home := t.TempDir()
 	if err := os.WriteFile(filepath.Join(home, ".npmrc"), []byte("fund=false\n"), 0o600); err != nil {

--- a/internal/cli/migrate/containment_test.go
+++ b/internal/cli/migrate/containment_test.go
@@ -278,6 +278,119 @@ func TestResolveImportInputsRejectsTraversingDeliverfileMetadataPath(t *testing.
 	}
 }
 
+func TestResolveImportInputsAllowsExternalDeliverfileMetadataPathWithExplicitTrust(t *testing.T) {
+	workDir := t.TempDir()
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	deliverfile := "metadata_path \"" + external + "\"\nskip_screenshots true\n"
+	writeMigrateContainmentFile(t, filepath.Join(workDir, "Deliverfile"), deliverfile)
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		WorkDir:               workDir,
+		AllowExternalMetadata: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want explicitly trusted path accepted", err)
+	}
+	expected, err := filepath.EvalSymlinks(external)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	if inputs.MetadataDir != expected {
+		t.Fatalf("MetadataDir = %q, want %q", inputs.MetadataDir, expected)
+	}
+}
+
+func TestResolveImportInputsRequiresTrustForSymlinkedFastlaneMetadata(t *testing.T) {
+	fastlane := t.TempDir()
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(fastlane, "metadata")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if _, _, err := resolveImportInputs(importInputOptions{
+		FastlaneDir:     fastlane,
+		SkipScreenshots: true,
+	}); err == nil {
+		t.Fatal("resolveImportInputs() error = nil, want default symlink rejection")
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		FastlaneDir:           fastlane,
+		SkipScreenshots:       true,
+		AllowExternalMetadata: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want explicitly trusted symlink accepted", err)
+	}
+	expected, err := filepath.EvalSymlinks(external)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	if inputs.MetadataDir != expected {
+		t.Fatalf("MetadataDir = %q, want resolved trusted target %q", inputs.MetadataDir, expected)
+	}
+}
+
+func TestResolveImportInputsAllowsSymlinkedFastlaneScreenshotsWithExplicitTrust(t *testing.T) {
+	fastlane := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(fastlane, "metadata"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(metadata) error = %v", err)
+	}
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "en-US"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(screenshots) error = %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(fastlane, "screenshots")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		FastlaneDir:              fastlane,
+		AllowExternalScreenshots: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want explicitly trusted screenshot symlink accepted", err)
+	}
+	expected, err := filepath.EvalSymlinks(external)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	if inputs.ScreenshotsDir != expected {
+		t.Fatalf("ScreenshotsDir = %q, want resolved trusted target %q", inputs.ScreenshotsDir, expected)
+	}
+}
+
+func TestResolveImportInputsRejectsSymlinkedDeliverfileByDefault(t *testing.T) {
+	workDir := t.TempDir()
+	external := filepath.Join(t.TempDir(), "Deliverfile")
+	writeMigrateContainmentFile(t, external, "skip_metadata true\nskip_screenshots true\n")
+	if err := os.Symlink(external, filepath.Join(workDir, "Deliverfile")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if _, _, err := resolveImportInputs(importInputOptions{WorkDir: workDir}); err == nil {
+		t.Fatal("resolveImportInputs() error = nil, want symlinked Deliverfile rejected")
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		WorkDir:                   workDir,
+		AllowSymlinkedDeliverfile: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want explicitly trusted Deliverfile accepted", err)
+	}
+	if !inputs.DeliverfileConfig.SkipMetadata || !inputs.DeliverfileConfig.SkipScreenshots {
+		t.Fatalf("DeliverfileConfig = %+v, want parsed trusted file", inputs.DeliverfileConfig)
+	}
+}
+
 func TestScanFastlaneMetadataLocaleDirsRefusesSymlinkedInTreeMetadataDirectory(t *testing.T) {
 	t.Chdir(t.TempDir())
 	workDir, err := os.Getwd()

--- a/internal/cli/migrate/deliverfile_parser.go
+++ b/internal/cli/migrate/deliverfile_parser.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,9 +25,12 @@ func parseDeliverfile(path string) (DeliverfileConfig, error) {
 		return DeliverfileConfig{}, err
 	}
 	defer file.Close()
+	return parseDeliverfileReader(path, file)
+}
 
+func parseDeliverfileReader(path string, reader io.Reader) (DeliverfileConfig, error) {
 	var config DeliverfileConfig
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(reader)
 	lineNumber := 0
 	for scanner.Scan() {
 		lineNumber++

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -388,7 +388,21 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 					})
 					continue
 				}
-				item, err := assets.UploadScreenshotAsset(uploadCtx, client, setID, filePath)
+				var item asc.AssetUploadResultItem
+				var err error
+				if opened, ok, openErr := plan.openedFile(filePath); openErr != nil {
+					err = openErr
+				} else if ok {
+					item, err = assets.UploadScreenshotAssetFromFile(uploadCtx, client, setID, filePath, opened)
+					if closeErr := opened.Close(); err == nil {
+						err = closeErr
+					}
+				} else {
+					// Keep compatibility for callers that construct plans
+					// directly; migrate import discovery always supplies a
+					// pinned rooted handle.
+					item, err = assets.UploadScreenshotAsset(uploadCtx, client, setID, filePath)
+				}
 				if err != nil {
 					return nil, fmt.Errorf("migrate import: failed to upload screenshot %s: %w", filePath, err)
 				}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -30,8 +30,8 @@ func MigrateCommand() *ffcli.Command {
 This enables transitioning from fastlane's deliver tool to asc.
 
 Examples:
-  asc migrate import --app "APP_ID" --version "VERSION_ID" --fastlane-dir ./fastlane --confirm
-  asc migrate export --app "APP_ID" --version "VERSION_ID" --output-dir ./fastlane
+  asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir ./fastlane --confirm
+  asc migrate export --app "APP_ID" --version-id "VERSION_ID" --output-dir ./fastlane
   asc migrate metadata pull --app "APP_ID" --version "1.2.3" --dir "./metadata"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -57,6 +57,9 @@ func MigrateImportCommand() *ffcli.Command {
 	dryRun := fs.Bool("dry-run", false, "Preview changes without uploading")
 	confirm := fs.Bool("confirm", false, "Confirm uploading the imported metadata and screenshots (required unless --dry-run)")
 	skipScreenshots := fs.Bool("skip-screenshots", false, "Skip screenshot discovery and upload")
+	allowExternalMetadata := fs.Bool("allow-external-metadata", false, "Trust Deliverfile metadata paths and symlinks outside the selected Fastlane directory")
+	allowExternalScreenshots := fs.Bool("allow-external-screenshots", false, "Trust Deliverfile screenshot paths and symlinks outside the selected Fastlane directory")
+	allowSymlinkedDeliverfile := fs.Bool("allow-symlinked-deliverfile", false, "Trust and follow a symlinked Deliverfile")
 	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
@@ -116,9 +119,12 @@ Examples:
 			}
 
 			inputs, skipped, err := resolveImportInputs(importInputOptions{
-				WorkDir:         workDir,
-				FastlaneDir:     strings.TrimSpace(*fastlaneDir),
-				SkipScreenshots: *skipScreenshots,
+				WorkDir:                   workDir,
+				FastlaneDir:               *fastlaneDir,
+				SkipScreenshots:           *skipScreenshots,
+				AllowExternalMetadata:     *allowExternalMetadata,
+				AllowExternalScreenshots:  *allowExternalScreenshots,
+				AllowSymlinkedDeliverfile: *allowSymlinkedDeliverfile,
 			})
 			if err != nil {
 				return fmt.Errorf("migrate import: %w", err)
@@ -176,10 +182,11 @@ Examples:
 			var screenshotPlan []ScreenshotPlan
 			var skippedScreenshots []SkippedItem
 			if screenshotsDir != "" {
-				screenshotPlan, skippedScreenshots, err = discoverScreenshotPlan(screenshotsDir)
+				screenshotPlan, skippedScreenshots, err = discoverScreenshotPlanForUpload(screenshotsDir)
 				if err != nil {
 					return fmt.Errorf("migrate import: %w", err)
 				}
+				defer closeScreenshotPlans(screenshotPlan)
 				skipped = append(skipped, skippedScreenshots...)
 			}
 
@@ -560,7 +567,7 @@ func readFastlaneAppInfoMetadata(metadataDir string) ([]AppInfoFastlaneLocalizat
 // directory outside the working directory is its own trusted root. The returned
 // prefix is the root-relative content directory.
 func newMigrateContentRoot(dir string) (rootfs.Root, string, error) {
-	absolute, err := filepath.Abs(strings.TrimSpace(dir))
+	absolute, err := filepath.Abs(dir)
 	if err != nil {
 		return rootfs.Root{}, "", err
 	}
@@ -908,6 +915,7 @@ func MigrateValidateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("migrate validate", flag.ExitOnError)
 
 	fastlaneDir := fs.String("fastlane-dir", "", "Path to fastlane directory (required)")
+	allowExternalMetadata := fs.Bool("allow-external-metadata", false, "Trust a metadata symlink outside the selected Fastlane directory")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -935,7 +943,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			metadataDir, err := containFastlaneChild(*fastlaneDir, "metadata")
+			metadataDir, err := resolveFastlaneChild(*fastlaneDir, "metadata", *allowExternalMetadata)
 			if err != nil {
 				return fmt.Errorf("migrate validate: %w", err)
 			}

--- a/internal/cli/migrate/migrate_test.go
+++ b/internal/cli/migrate/migrate_test.go
@@ -14,6 +14,40 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
+func TestMigrateCommandExamplesUseVersionIDFlag(t *testing.T) {
+	help := MigrateCommand().LongHelp
+	if strings.Contains(help, `migrate import --app "APP_ID" --version "VERSION_ID"`) {
+		t.Fatalf("migrate help still documents unsupported --version for import:\n%s", help)
+	}
+	if strings.Contains(help, `migrate export --app "APP_ID" --version "VERSION_ID"`) {
+		t.Fatalf("migrate help still documents unsupported --version for export:\n%s", help)
+	}
+	for _, want := range []string{
+		`migrate import --app "APP_ID" --version-id "VERSION_ID"`,
+		`migrate export --app "APP_ID" --version-id "VERSION_ID"`,
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("migrate help = %q, want example containing %q", help, want)
+		}
+	}
+}
+
+func TestMigrateImportExposesExplicitPathTrustFlags(t *testing.T) {
+	flags := MigrateImportCommand().FlagSet
+	for _, name := range []string{
+		"allow-external-metadata",
+		"allow-external-screenshots",
+		"allow-symlinked-deliverfile",
+	} {
+		if flags.Lookup(name) == nil {
+			t.Fatalf("migrate import flag --%s is missing", name)
+		}
+	}
+	if MigrateValidateCommand().FlagSet.Lookup("allow-external-metadata") == nil {
+		t.Fatal("migrate validate flag --allow-external-metadata is missing")
+	}
+}
+
 func TestReadMetadataFile_FileExists(t *testing.T) {
 	// Create a temp file
 	dir := t.TempDir()

--- a/internal/cli/migrate/path_resolution.go
+++ b/internal/cli/migrate/path_resolution.go
@@ -23,6 +23,12 @@ type importInputOptions struct {
 	MetadataDir     string
 	ScreenshotsDir  string
 	SkipScreenshots bool
+	// The allow options preserve legacy Fastlane layouts only when the operator
+	// explicitly trusts paths that repository-controlled configuration can
+	// redirect outside the selected checkout.
+	AllowExternalMetadata     bool
+	AllowExternalScreenshots  bool
+	AllowSymlinkedDeliverfile bool
 }
 
 type importInputs struct {
@@ -35,8 +41,8 @@ type importInputs struct {
 }
 
 func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, error) {
-	workDir := strings.TrimSpace(opts.WorkDir)
-	if workDir == "" {
+	workDir := opts.WorkDir
+	if strings.TrimSpace(workDir) == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return importInputs{}, nil, fmt.Errorf("resolve import paths: %w", err)
@@ -57,7 +63,7 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 
 	var config DeliverfileConfig
 	if deliverfilePath != "" {
-		config, err = parseDeliverfile(deliverfilePath)
+		config, err = readDeliverfileConfig(workDir, opts.FastlaneDir, deliverfilePath, opts.AllowSymlinkedDeliverfile)
 		if err != nil {
 			return importInputs{}, nil, err
 		}
@@ -68,11 +74,11 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 		DeliverfileConfig: config,
 	}
 
-	metadataDir, metadataSource, err := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.MetadataDir, config.MetadataPath, "metadata")
+	metadataDir, metadataSource, err := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.MetadataDir, config.MetadataPath, "metadata", opts.AllowExternalMetadata)
 	if err != nil {
 		return importInputs{}, nil, err
 	}
-	screenshotsDir, screenshotsSource, err := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots")
+	screenshotsDir, screenshotsSource, err := resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots", opts.AllowExternalScreenshots)
 	if err != nil {
 		return importInputs{}, nil, err
 	}
@@ -98,12 +104,12 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 	return inputs, skipped, nil
 }
 
-func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deliverfilePathValue, defaultDir string) (string, pathSource, error) {
+func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deliverfilePathValue, defaultDir string, allowExternal bool) (string, pathSource, error) {
 	if strings.TrimSpace(explicitPath) != "" {
 		return explicitPath, pathSourceFlag, nil
 	}
 	if strings.TrimSpace(fastlaneDir) != "" {
-		resolved, err := containFastlaneChild(fastlaneDir, defaultDir)
+		resolved, err := resolveFastlaneChild(fastlaneDir, defaultDir, allowExternal)
 		if err != nil {
 			return "", pathSourceFlag, err
 		}
@@ -116,7 +122,13 @@ func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deli
 		}
 		resolved, err := containDeliverfilePath(workDir, base, deliverfilePathValue)
 		if err != nil {
-			return "", pathSourceDeliverfile, err
+			if !allowExternal {
+				return "", pathSourceDeliverfile, err
+			}
+			resolved, err = resolveTrustedDeliverfilePath(base, deliverfilePathValue)
+			if err != nil {
+				return "", pathSourceDeliverfile, err
+			}
 		}
 		return resolved, pathSourceDeliverfile, nil
 	}
@@ -125,6 +137,29 @@ func resolveImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deli
 		base = filepath.Dir(deliverfilePath)
 	}
 	return filepath.Join(base, defaultDir), pathSourceDefault, nil
+}
+
+func resolveFastlaneChild(fastlaneDir, child string, allowExternal bool) (string, error) {
+	resolved, err := containFastlaneChild(fastlaneDir, child)
+	if err == nil {
+		return resolved, nil
+	}
+	if !allowExternal {
+		return "", err
+	}
+	return filepath.EvalSymlinks(filepath.Join(fastlaneDir, child))
+}
+
+func resolveTrustedDeliverfilePath(base, value string) (string, error) {
+	path := value
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(base, path)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
 }
 
 // containFastlaneChild resolves a conventional child directory beneath the
@@ -147,8 +182,7 @@ func containFastlaneChild(fastlaneDir, child string) (string, error) {
 // inside the working directory, because the Deliverfile ships with the checkout
 // and must not select files outside it.
 func containDeliverfilePath(workDir, base, value string) (string, error) {
-	trimmed := strings.TrimSpace(value)
-	if err := rootfs.ValidateRelativeAllowingTraversal(trimmed); err != nil {
+	if err := rootfs.ValidateRelativeAllowingTraversal(value); err != nil {
 		return "", fmt.Errorf("deliverfile path %q: %w", value, err)
 	}
 	root, err := rootfs.New(workDir)
@@ -162,7 +196,7 @@ func containDeliverfilePath(workDir, base, value string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resolved, err := root.Resolve(filepath.Clean(filepath.Join(absoluteBase, trimmed)))
+	resolved, err := root.Resolve(filepath.Clean(filepath.Join(absoluteBase, value)))
 	if err != nil {
 		return "", fmt.Errorf("deliverfile path %q must stay inside %s: %w", value, root.Path(), err)
 	}
@@ -209,6 +243,37 @@ func discoverDeliverfilePath(workDir, fastlaneDir string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+// readDeliverfileConfig reads repository-controlled Deliverfiles through a
+// rooted no-follow handle. The legacy symlink-following behavior remains
+// available only behind an explicit trust decision.
+func readDeliverfileConfig(workDir, fastlaneDir, path string, allowSymlink bool) (DeliverfileConfig, error) {
+	if allowSymlink {
+		return parseDeliverfile(path)
+	}
+	rootPath := workDir
+	if strings.TrimSpace(fastlaneDir) != "" {
+		rootPath = fastlaneDir
+	}
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return DeliverfileConfig{}, err
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return DeliverfileConfig{}, err
+	}
+	relative, err := filepath.Rel(root.Path(), absolutePath)
+	if err != nil {
+		return DeliverfileConfig{}, err
+	}
+	file, err := root.OpenFile(relative)
+	if err != nil {
+		return DeliverfileConfig{}, fmt.Errorf("read Deliverfile: %w", err)
+	}
+	defer file.Close()
+	return parseDeliverfileReader(path, file)
 }
 
 func ensureDirExists(path string) error {

--- a/internal/cli/migrate/path_resolution_test.go
+++ b/internal/cli/migrate/path_resolution_test.go
@@ -195,3 +195,46 @@ func TestResolveImportInputs_AllowsMissingFastlaneScreenshotsWhenDeliverfileSkip
 		t.Fatalf("expected screenshots dir %q, got %q", filepath.Join(fastlaneDir, "screenshots"), inputs.ScreenshotsDir)
 	}
 }
+
+func TestResolveImportInputsPreservesWhitespaceInFastlanePath(t *testing.T) {
+	base := t.TempDir()
+	fastlaneDir := filepath.Join(base, " fastlane ")
+	if err := os.MkdirAll(filepath.Join(fastlaneDir, "metadata"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		WorkDir:         base,
+		FastlaneDir:     fastlaneDir,
+		SkipScreenshots: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error: %v", err)
+	}
+	if inputs.MetadataDir != filepath.Join(fastlaneDir, "metadata") {
+		t.Fatalf("MetadataDir = %q, want exact whitespace path %q", inputs.MetadataDir, filepath.Join(fastlaneDir, "metadata"))
+	}
+}
+
+func TestResolveImportInputsPreservesWhitespaceInDeliverfilePathValue(t *testing.T) {
+	workDir := t.TempDir()
+	metadataName := " metadata "
+	if err := os.MkdirAll(filepath.Join(workDir, metadataName), 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workDir, "Deliverfile"),
+		[]byte("metadata_path \""+metadataName+"\"\nskip_screenshots true\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write Deliverfile: %v", err)
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{WorkDir: workDir})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error: %v", err)
+	}
+	if inputs.MetadataDir != filepath.Join(workDir, metadataName) {
+		t.Fatalf("MetadataDir = %q, want exact whitespace path %q", inputs.MetadataDir, filepath.Join(workDir, metadataName))
+	}
+}

--- a/internal/cli/migrate/review_information.go
+++ b/internal/cli/migrate/review_information.go
@@ -101,6 +101,9 @@ func readFastlaneReviewInformation(metadataDir string) (*ReviewInformation, erro
 	if assigned == 0 {
 		return nil, nil
 	}
+	if err := asc.ValidateSecretMutationValue(info.DemoAccountPassword); err != nil {
+		return nil, fmt.Errorf("review information: %w", err)
+	}
 	return info, nil
 }
 

--- a/internal/cli/migrate/review_information_test.go
+++ b/internal/cli/migrate/review_information_test.go
@@ -1,10 +1,15 @@
 package migrate
 
 import (
+	"context"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestReadFastlaneReviewInformation_ParsesFiles(t *testing.T) {
@@ -60,6 +65,53 @@ func TestReadFastlaneReviewInformation_ParsesFiles(t *testing.T) {
 	}
 	if info.DemoAccountRequired == nil || !*info.DemoAccountRequired {
 		t.Fatalf("expected demo account required true, got %#v", info.DemoAccountRequired)
+	}
+}
+
+func TestMigrateImportRejectsRedactionPlaceholderBeforeMutation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "dry run",
+			args: []string{"--app", "app-1", "--version-id", "version-1", "--dry-run", "--skip-screenshots"},
+		},
+		{
+			name: "real import",
+			args: []string{"--app", "app-1", "--version-id", "version-1", "--confirm", "--skip-screenshots"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fastlaneDir := t.TempDir()
+			reviewDir := filepath.Join(fastlaneDir, "metadata", "review_information")
+			if err := os.MkdirAll(reviewDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(reviewDir, "demo_password.txt"), []byte(asc.RedactedValuePlaceholder), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			originalTransport := http.DefaultTransport
+			requests := 0
+			http.DefaultTransport = migrateUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				t.Fatalf("unexpected HTTP mutation or lookup: %s %s", req.Method, req.URL)
+				return nil, nil
+			})
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+			command := MigrateImportCommand()
+			command.FlagSet.SetOutput(io.Discard)
+			args := append(append([]string{}, test.args...), "--fastlane-dir", fastlaneDir)
+			err := command.ParseAndRun(context.Background(), args)
+			if err == nil {
+				t.Fatal("ParseAndRun() error = nil, want redaction placeholder rejection")
+			}
+			if requests != 0 {
+				t.Fatalf("HTTP requests = %d, want zero", requests)
+			}
+		})
 	}
 }
 

--- a/internal/cli/migrate/screenshots.go
+++ b/internal/cli/migrate/screenshots.go
@@ -2,18 +2,24 @@ package migrate
 
 import (
 	"fmt"
+	"image"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 type ScreenshotPlan struct {
 	Locale      string   `json:"locale"`
 	DisplayType string   `json:"displayType"`
 	Files       []string `json:"files"`
+	sourceRoot  *screenshotSourceRoot
+	sources     map[string]screenshotSource
 }
 
 type ScreenshotUploadResult struct {
@@ -23,7 +29,21 @@ type ScreenshotUploadResult struct {
 	Skipped     []SkippedItem               `json:"skipped,omitempty"`
 }
 
+const maxMigrateScreenshotFileSize = int64(1024 * 1024 * 1024)
+
 func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedItem, error) {
+	return discoverScreenshotPlanWithOpenFiles(screenshotsDir, false)
+}
+
+// discoverScreenshotPlanForUpload pins discovery to one rooted directory
+// handle and records each file's identity. Upload reopens one file at a time
+// through that root, preventing path redirection without retaining an
+// unbounded number of descriptors.
+func discoverScreenshotPlanForUpload(screenshotsDir string) ([]ScreenshotPlan, []SkippedItem, error) {
+	return discoverScreenshotPlanWithOpenFiles(screenshotsDir, true)
+}
+
+func discoverScreenshotPlanWithOpenFiles(screenshotsDir string, retainOpenFiles bool) ([]ScreenshotPlan, []SkippedItem, error) {
 	// A screenshots directory inside the working directory ships with the
 	// checkout, so refuse symlinked components before traversing it; an
 	// operator-selected external directory remains its own trusted root.
@@ -34,7 +54,23 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 	if err := checkContentRootContained(root, prefix); err != nil {
 		return nil, nil, err
 	}
-	entries, err := os.ReadDir(screenshotsDir)
+	rooted, err := os.OpenRoot(root.Path())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rooted.Close()
+	contentRoot, err := rooted.OpenRoot(filepath.ToSlash(prefix))
+	if err != nil {
+		return nil, nil, err
+	}
+	sourceRoot := &screenshotSourceRoot{root: contentRoot}
+	keepSourceRoot := false
+	defer func() {
+		if !keepSourceRoot {
+			_ = sourceRoot.root.Close()
+		}
+	}()
+	entries, err := fs.ReadDir(contentRoot.FS(), ".")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -43,7 +79,11 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 		locale      string
 		displayType string
 	}
-	plans := make(map[planKey][]string)
+	type planFiles struct {
+		paths   []string
+		sources map[string]screenshotSource
+	}
+	plans := make(map[planKey]*planFiles)
 	var skipped []SkippedItem
 
 	for _, entry := range entries {
@@ -69,34 +109,57 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 			return nil, nil, fmt.Errorf("invalid locale directory %q: %w", localeName, err)
 		}
 		localeDir := filepath.Join(screenshotsDir, entry.Name())
-		files, localeSkipped, err := collectScreenshotFiles(localeDir)
+		files, localeSkipped, err := collectScreenshotFiles(contentRoot, entry.Name(), localeDir)
 		if err != nil {
 			return nil, nil, err
 		}
 		skipped = append(skipped, localeSkipped...)
-		for _, filePath := range files {
-			dimensions, err := asc.ReadImageDimensions(filePath)
+		for candidateIndex, candidate := range files {
+			dimensions, err := readOpenedImageDimensions(candidate.path, candidate.file)
 			if err != nil {
-				return nil, nil, fmt.Errorf("invalid screenshot file %q: %w", filePath, err)
+				closeOpenedScreenshotCandidates(files[candidateIndex:])
+				return nil, nil, fmt.Errorf("invalid screenshot file %q: %w", candidate.path, err)
 			}
-			displayType, err := inferScreenshotDisplayTypeFromDimensions(filePath, dimensions.Width, dimensions.Height)
+			displayType, err := inferScreenshotDisplayTypeFromDimensions(candidate.path, dimensions.Width, dimensions.Height)
 			if err != nil {
+				closeOpenedScreenshotCandidates(files[candidateIndex:])
 				return nil, nil, err
 			}
 			key := planKey{locale: locale, displayType: displayType}
-			plans[key] = append(plans[key], filePath)
+			if plans[key] == nil {
+				plans[key] = &planFiles{sources: make(map[string]screenshotSource)}
+			}
+			plans[key].paths = append(plans[key].paths, candidate.path)
+			if retainOpenFiles {
+				info, err := candidate.file.Stat()
+				if err != nil {
+					closeOpenedScreenshotCandidates(files[candidateIndex:])
+					return nil, nil, err
+				}
+				plans[key].sources[candidate.path] = screenshotSource{
+					relative: candidate.relative,
+					info:     info,
+				}
+			}
+			_ = candidate.file.Close()
 		}
 	}
 
 	result := make([]ScreenshotPlan, 0, len(plans))
 	for key, files := range plans {
-		sort.Strings(files)
-		result = append(result, ScreenshotPlan{
+		sort.Strings(files.paths)
+		plan := ScreenshotPlan{
 			Locale:      key.locale,
 			DisplayType: key.displayType,
-			Files:       files,
-		})
+			Files:       files.paths,
+		}
+		if retainOpenFiles {
+			plan.sourceRoot = sourceRoot
+			plan.sources = files.sources
+		}
+		result = append(result, plan)
 	}
+	keepSourceRoot = retainOpenFiles && len(result) > 0
 
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].Locale == result[j].Locale {
@@ -108,12 +171,118 @@ func discoverScreenshotPlan(screenshotsDir string) ([]ScreenshotPlan, []SkippedI
 	return result, skipped, nil
 }
 
-func collectScreenshotFiles(localeDir string) ([]string, []SkippedItem, error) {
-	var files []string
+func readOpenedImageDimensions(path string, file *os.File) (asc.ImageDimensions, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return asc.ImageDimensions{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return asc.ImageDimensions{}, fmt.Errorf("expected regular file: %q", path)
+	}
+	if info.Size() <= 0 {
+		return asc.ImageDimensions{}, fmt.Errorf("file is empty: %q", path)
+	}
+	if info.Size() > maxMigrateScreenshotFileSize {
+		return asc.ImageDimensions{}, fmt.Errorf("file size exceeds %d bytes: %q", maxMigrateScreenshotFileSize, path)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return asc.ImageDimensions{}, err
+	}
+	cfg, _, err := image.DecodeConfig(file)
+	if err != nil {
+		return asc.ImageDimensions{}, fmt.Errorf("decode image dimensions for %q: %w", path, err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 {
+		return asc.ImageDimensions{}, fmt.Errorf("invalid image dimensions %dx%d for %q", cfg.Width, cfg.Height, path)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return asc.ImageDimensions{}, err
+	}
+	return asc.ImageDimensions{Width: cfg.Width, Height: cfg.Height}, nil
+}
+
+type screenshotSourceRoot struct {
+	root *os.Root
+}
+
+type screenshotSource struct {
+	relative string
+	info     os.FileInfo
+}
+
+func (p ScreenshotPlan) openedFile(path string) (*os.File, bool, error) {
+	source, ok := p.sources[path]
+	if !ok || p.sourceRoot == nil || p.sourceRoot.root == nil {
+		return nil, false, nil
+	}
+	file, err := secureopen.OpenExistingNoFollowInRoot(p.sourceRoot.root, source.relative)
+	if err != nil {
+		return nil, true, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, true, err
+	}
+	if !os.SameFile(source.info, info) ||
+		source.info.Size() != info.Size() ||
+		!source.info.ModTime().Equal(info.ModTime()) {
+		_ = file.Close()
+		return nil, true, fmt.Errorf("screenshot file %q changed after discovery", path)
+	}
+	return file, true, nil
+}
+
+func closeScreenshotPlans(plans []ScreenshotPlan) {
+	closed := make(map[*screenshotSourceRoot]struct{})
+	for _, plan := range plans {
+		if plan.sourceRoot == nil || plan.sourceRoot.root == nil {
+			continue
+		}
+		if _, ok := closed[plan.sourceRoot]; ok {
+			continue
+		}
+		closed[plan.sourceRoot] = struct{}{}
+		_ = plan.sourceRoot.root.Close()
+	}
+}
+
+type openedScreenshotCandidate struct {
+	path     string
+	relative string
+	file     *os.File
+}
+
+func closeOpenedScreenshotCandidates(files []openedScreenshotCandidate) {
+	for _, candidate := range files {
+		_ = candidate.file.Close()
+	}
+}
+
+func collectScreenshotFiles(rooted *os.Root, localeRelative, localeDir string) (_ []openedScreenshotCandidate, _ []SkippedItem, resultErr error) {
+	localeRoot, err := rooted.OpenRoot(filepath.ToSlash(localeRelative))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer localeRoot.Close()
+
+	var files []openedScreenshotCandidate
 	var skipped []SkippedItem
-	err := filepath.WalkDir(localeDir, func(path string, entry os.DirEntry, err error) error {
+	defer func() {
+		if resultErr == nil {
+			return
+		}
+		for _, candidate := range files {
+			_ = candidate.file.Close()
+		}
+	}()
+	err = fs.WalkDir(localeRoot.FS(), ".", func(relative string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		displayPath := localeDir
+		if relative != "." {
+			displayPath = filepath.Join(localeDir, filepath.FromSlash(strings.TrimPrefix(relative, "./")))
 		}
 		if entry.IsDir() {
 			return nil
@@ -123,19 +292,27 @@ func collectScreenshotFiles(localeDir string) ([]string, []SkippedItem, error) {
 			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to read symlink %q", path)
+			return fmt.Errorf("refusing to read symlink %q", displayPath)
 		}
 		if !info.Mode().IsRegular() {
 			return nil
 		}
-		if shouldSkipScreenshotFile(path) {
+		if shouldSkipScreenshotFile(displayPath) {
 			skipped = append(skipped, SkippedItem{
-				Path:   path,
+				Path:   displayPath,
 				Reason: "unsupported screenshot file",
 			})
 			return nil
 		}
-		files = append(files, path)
+		file, err := secureopen.OpenExistingNoFollowInRoot(localeRoot, relative)
+		if err != nil {
+			return fmt.Errorf("open screenshot file %q: %w", displayPath, err)
+		}
+		files = append(files, openedScreenshotCandidate{
+			path:     displayPath,
+			relative: filepath.ToSlash(filepath.Join(localeRelative, relative)),
+			file:     file,
+		})
 		return nil
 	})
 	if err != nil {
@@ -148,7 +325,9 @@ func collectScreenshotFiles(localeDir string) ([]string, []SkippedItem, error) {
 		})
 		return nil, skipped, nil
 	}
-	sort.Strings(files)
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].path < files[j].path
+	})
 	return files, skipped, nil
 }
 

--- a/internal/cli/migrate/screenshots_test.go
+++ b/internal/cli/migrate/screenshots_test.go
@@ -1,13 +1,62 @@
 package migrate
 
 import (
+	"bytes"
 	"image"
 	"image/color"
 	"image/png"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestDiscoverScreenshotPlanForUploadRejectsReplacedFile(t *testing.T) {
+	screenshotsDir := t.TempDir()
+	localeDir := filepath.Join(screenshotsDir, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	path := filepath.Join(localeDir, "iphone_65_1.png")
+	writePNG(t, path, 1242, 2688)
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(original) error = %v", err)
+	}
+
+	plans, _, err := discoverScreenshotPlanForUpload(screenshotsDir)
+	if err != nil {
+		t.Fatalf("discoverScreenshotPlanForUpload() error = %v", err)
+	}
+	defer closeScreenshotPlans(plans)
+	if len(plans) != 1 || len(plans[0].Files) != 1 {
+		t.Fatalf("plans = %#v, want one screenshot", plans)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	writePNG(t, path, 1290, 2796)
+
+	opened, ok, err := plans[0].openedFile(path)
+	if !ok {
+		t.Fatal("openedFile() did not retain a rooted source")
+	}
+	if opened != nil {
+		_ = opened.Close()
+		t.Fatal("openedFile() returned a replaced screenshot")
+	}
+	if err == nil || !strings.Contains(err.Error(), "changed after discovery") {
+		t.Fatalf("openedFile() error = %v, want changed-after-discovery rejection", err)
+	}
+	replacement, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(replacement) error = %v", err)
+	}
+	if bytes.Equal(replacement, original) {
+		t.Fatal("test setup did not replace the pathname")
+	}
+}
 
 func TestInferScreenshotDisplayType_FromFilenameAndDimensions(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/notify/notify.go
+++ b/internal/cli/notify/notify.go
@@ -37,6 +37,20 @@ var slackHTTPClient = func() *http.Client {
 	return &http.Client{Timeout: asc.ResolveTimeout()}
 }
 
+func slackClientWithoutRedirects(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{Timeout: asc.ResolveTimeout()}
+	}
+	safeClient := *client
+	safeClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		// Return the redirect response to the caller without making the next
+		// request. Following it can disclose the webhook path through Referer,
+		// and 307/308 responses can also replay the JSON message body.
+		return http.ErrUseLastResponse
+	}
+	return &safeClient
+}
+
 func slackFlags(fs *flag.FlagSet) (
 	webhook *string,
 	channel *string,
@@ -185,7 +199,7 @@ Examples:
 			}
 			req.Header.Set("Content-Type", "application/json")
 
-			client := slackHTTPClient()
+			client := slackClientWithoutRedirects(slackHTTPClient())
 			resp, err := client.Do(req)
 			if err != nil {
 				return fmt.Errorf("notify slack: failed to send: %w", newSanitizedWebhookError("webhook POST", webhookURL, err))
@@ -390,6 +404,9 @@ func validateSlackWebhookURL(rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil {
 		return fmt.Errorf("--webhook must be a valid Slack webhook URL (https://hooks.slack.com/... or https://hooks.slack-gov.com/...)")
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return fmt.Errorf("--webhook must not contain a query string or fragment")
 	}
 	host := strings.ToLower(parsed.Hostname())
 	if allowLocalSlackWebhook() && isLocalhost(host) {

--- a/internal/cli/notify/notify_redirect_test.go
+++ b/internal/cli/notify/notify_redirect_test.go
@@ -1,0 +1,56 @@
+package notify
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestNotifySlackRefusesRedirectWithoutForwardingPayloadOrReferer(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		t.Errorf("redirect target received request: method=%s referer=%q body=%q", r.Method, r.Referer(), body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/capture", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	t.Setenv(slackWebhookEnvVar, "")
+	t.Setenv(slackWebhookAllowLocalEnv, "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalClient := slackHTTPClient
+	t.Cleanup(func() { slackHTTPClient = originalClient })
+	slackHTTPClient = source.Client
+
+	root := SlackCommand()
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"--webhook", source.URL + "/services/T/B/redirect-secret",
+		"--message", "secret message body",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := root.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected redirect response to fail")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", got)
+	}
+	if !strings.Contains(err.Error(), "unexpected response 307") {
+		t.Fatalf("unexpected redirect error: %v", err)
+	}
+}

--- a/internal/cli/notify/notify_test.go
+++ b/internal/cli/notify/notify_test.go
@@ -612,6 +612,17 @@ func TestValidateSlackWebhookURLAllowsGovHost(t *testing.T) {
 	}
 }
 
+func TestValidateSlackWebhookURLRejectsQueryAndFragment(t *testing.T) {
+	for _, webhook := range []string{
+		"https://hooks.slack.com/services/T/B/secret?token=query-secret",
+		"https://hooks.slack.com/services/T/B/secret#fragment-secret",
+	} {
+		if err := validateSlackWebhookURL(webhook); err == nil {
+			t.Fatalf("validateSlackWebhookURL(%q) error = nil, want rejection", webhook)
+		}
+	}
+}
+
 func TestNotifySlackRejectsInsecureScheme(t *testing.T) {
 	t.Setenv(slackWebhookEnvVar, "")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/release/checkpoint_binding.go
+++ b/internal/cli/release/checkpoint_binding.go
@@ -63,6 +63,19 @@ func verifyResumedCheckpointBinding(
 		return fmt.Errorf("checkpoint version %s is version %q, not %q", versionID, resolved, strings.TrimSpace(opts.Version))
 	}
 
+	// These completions cannot be authenticated from current remote state.
+	// Metadata input may have changed since the checkpoint was written, and
+	// readiness is a point-in-time observation rather than a durable server
+	// state. An unsigned checkpoint must never be able to suppress either.
+	if checkpoint.Completed[stepApplyMetadata] {
+		delete(checkpoint.Completed, stepApplyMetadata)
+		emitMessage("Rechecking %s: an unsigned checkpoint cannot prove the current metadata input was applied.", stepApplyMetadata)
+	}
+	if checkpoint.Completed[stepValidateReadiness] {
+		delete(checkpoint.Completed, stepValidateReadiness)
+		emitMessage("Rechecking %s: readiness must be evaluated again against current App Store Connect state.", stepValidateReadiness)
+	}
+
 	if checkpoint.Completed[stepAttachBuild] {
 		attachedBuildID, buildErr := attachedAppStoreVersionBuildID(ctx, client, versionID)
 		attachDiscarded := false

--- a/internal/cli/release/checkpoint_binding_test.go
+++ b/internal/cli/release/checkpoint_binding_test.go
@@ -526,8 +526,11 @@ func TestVerifyResumedCheckpointBindingKeepsProvenCheckpoint(t *testing.T) {
 	if err := verifyResumedCheckpointBinding(context.Background(), client, checkpointBindingOptions(), &checkpoint, nil); err != nil {
 		t.Fatalf("verifyResumedCheckpointBinding error: %v", err)
 	}
-	if len(checkpoint.Completed) != 5 {
-		t.Fatalf("expected all verified completions to survive, got %#v", checkpoint.Completed)
+	if len(checkpoint.Completed) != 3 {
+		t.Fatalf("expected only remotely verifiable completions to survive, got %#v", checkpoint.Completed)
+	}
+	if checkpoint.Completed[stepApplyMetadata] || checkpoint.Completed[stepValidateReadiness] {
+		t.Fatalf("expected local unprovable completions to be discarded, got %#v", checkpoint.Completed)
 	}
 	if checkpoint.SubmissionID != "SUBMISSION_123" {
 		t.Fatalf("expected verified submission ID to survive, got %q", checkpoint.SubmissionID)
@@ -641,8 +644,55 @@ func TestVerifyResumedCheckpointBindingDropsReadinessWithIncompletePrerequisite(
 		t.Fatal("expected validate_readiness to be discarded while attach_build is incomplete")
 	}
 	joined := strings.Join(messages, "\n")
-	if !strings.Contains(joined, stepValidateReadiness) || !strings.Contains(joined, stepAttachBuild) {
-		t.Fatalf("expected a diagnostic naming validate_readiness and attach_build, got %v", messages)
+	if !strings.Contains(joined, stepValidateReadiness) || !strings.Contains(joined, stepApplyMetadata) {
+		t.Fatalf("expected diagnostics naming the unprovable local steps, got %v", messages)
+	}
+}
+
+// TestVerifyResumedCheckpointBindingRerunsUnprovableLocalSteps proves an
+// unsigned checkpoint cannot suppress operations whose effects cannot be
+// authenticated from current App Store Connect state. Metadata may have
+// changed locally after the checkpoint was written, and readiness is a
+// point-in-time validation, so both steps must run on every resume.
+func TestVerifyResumedCheckpointBindingRerunsUnprovableLocalSteps(t *testing.T) {
+	client := newCheckpointBindingClient(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_123"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"BUILD_123","attributes":{"version":"42"}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+
+	checkpoint := runCheckpoint{
+		VersionID: "VERSION_123",
+		Completed: map[string]bool{
+			stepEnsureVersion:     true,
+			stepApplyMetadata:     true,
+			stepAttachBuild:       true,
+			stepValidateReadiness: true,
+		},
+	}
+	var messages []string
+	if err := verifyResumedCheckpointBinding(context.Background(), client, checkpointBindingOptions(), &checkpoint, func(message string) {
+		messages = append(messages, message)
+	}); err != nil {
+		t.Fatalf("verifyResumedCheckpointBinding error: %v", err)
+	}
+	if checkpoint.Completed[stepApplyMetadata] {
+		t.Fatal("expected unprovable apply_metadata completion to be discarded")
+	}
+	if checkpoint.Completed[stepValidateReadiness] {
+		t.Fatal("expected point-in-time validate_readiness completion to be discarded")
+	}
+	if !checkpoint.Completed[stepEnsureVersion] || !checkpoint.Completed[stepAttachBuild] {
+		t.Fatalf("expected authenticated remote-state completions to survive, got %#v", checkpoint.Completed)
+	}
+	joined := strings.Join(messages, "\n")
+	if !strings.Contains(joined, stepApplyMetadata) || !strings.Contains(joined, stepValidateReadiness) {
+		t.Fatalf("expected diagnostics naming both rerun steps, got %v", messages)
 	}
 }
 

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -173,13 +173,15 @@ func TestExecuteRun_ResumesCompletedCheckpoint(t *testing.T) {
 		}
 	})
 	releaseClientFactory = func() (*asc.Client, error) { return client, nil }
+	metadataRuns := 0
+	readinessRuns := 0
 	metadataPushExecutor = func(context.Context, metadata.PushExecutionOptions) (metadata.PushPlanResult, error) {
-		t.Fatal("metadata executor should not be called for completed checkpoint")
-		return metadata.PushPlanResult{}, nil
+		metadataRuns++
+		return metadata.PushPlanResult{VersionID: "VERSION_123"}, nil
 	}
 	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
-		t.Fatal("readiness builder should not be called for completed checkpoint")
-		return validation.Report{}, nil
+		readinessRuns++
+		return validation.Report{Summary: validation.Summary{}}, nil
 	}
 
 	dir := t.TempDir()
@@ -234,9 +236,17 @@ func TestExecuteRun_ResumesCompletedCheckpoint(t *testing.T) {
 	if len(result.Steps) != 5 {
 		t.Fatalf("expected 5 skipped steps, got %d", len(result.Steps))
 	}
-	for i, step := range result.Steps {
-		if step.Status != "skipped" {
-			t.Fatalf("expected step %d skipped, got %q", i, step.Status)
+	if metadataRuns != 1 || readinessRuns != 1 {
+		t.Fatalf("expected unprovable local steps to rerun once, got metadata=%d readiness=%d", metadataRuns, readinessRuns)
+	}
+	for _, index := range []int{0, 2, 4} {
+		if result.Steps[index].Status != "skipped" {
+			t.Fatalf("expected remotely verified step %d skipped, got %q", index, result.Steps[index].Status)
+		}
+	}
+	for _, index := range []int{1, 3} {
+		if result.Steps[index].Status == "skipped" {
+			t.Fatalf("expected unprovable local step %d to rerun", index)
 		}
 	}
 }
@@ -299,6 +309,10 @@ func TestExecuteRun_SuccessPath(t *testing.T) {
 			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"REV_SUB_123","attributes":{"state":"READY_FOR_REVIEW","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/reviewSubmissionItems":
 			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissionItems","id":"ITEM_123"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/REV_SUB_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"REV_SUB_123","attributes":{"state":"READY_FOR_REVIEW","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_123"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/REV_SUB_123/items":
+			return releaseJSONResponse(http.StatusOK, `{"data":[{"type":"reviewSubmissionItems","id":"ITEM_123","relationships":{"appStoreVersion":{"data":{"type":"appStoreVersions","id":"VERSION_123"}}}}]}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/REV_SUB_123":
 			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"REV_SUB_123","attributes":{"state":"SUBMITTED","platform":"IOS","submittedDate":"2026-03-02T00:00:00Z"}}}`)
 		default:
@@ -605,6 +619,7 @@ func TestExecuteRun_EmitsSubmitProgressMessagesToStderr(t *testing.T) {
 		}, nil
 	}
 
+	itemReads := 0
 	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/appStoreVersions":
@@ -616,15 +631,17 @@ func TestExecuteRun_EmitsSubmitProgressMessagesToStderr(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/reviewSubmissions":
 			return releaseJSONResponse(http.StatusOK, `{"data":[{"type":"reviewSubmissions","id":"STALE_123","attributes":{"state":"READY_FOR_REVIEW","platform":"IOS"}}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/STALE_123/items":
-			return releaseJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/STALE_123":
-			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"STALE_123","attributes":{"state":"CANCELED","platform":"IOS"}}}`)
-		case req.Method == http.MethodPost && req.URL.Path == "/v1/reviewSubmissions":
-			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"REV_SUB_123","attributes":{"state":"READY_FOR_REVIEW","platform":"IOS"}}}`)
+			itemReads++
+			if itemReads == 1 {
+				return releaseJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+			}
+			return releaseJSONResponse(http.StatusOK, `{"data":[{"type":"reviewSubmissionItems","id":"ITEM_123","relationships":{"appStoreVersion":{"data":{"type":"appStoreVersions","id":"VERSION_123"}}}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/STALE_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"STALE_123","attributes":{"state":"READY_FOR_REVIEW","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_123"}}}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/reviewSubmissionItems":
 			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissionItems","id":"ITEM_123"}}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/REV_SUB_123":
-			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"REV_SUB_123","attributes":{"state":"SUBMITTED","platform":"IOS","submittedDate":"2026-03-16T00:00:00Z"}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/STALE_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"STALE_123","attributes":{"state":"SUBMITTED","platform":"IOS","submittedDate":"2026-03-16T00:00:00Z"}}}`)
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
@@ -649,13 +666,13 @@ func TestExecuteRun_EmitsSubmitProgressMessagesToStderr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("executeRun error: %v", err)
 		}
-		if result.SubmissionID != "REV_SUB_123" {
-			t.Fatalf("expected submissionID REV_SUB_123, got %q", result.SubmissionID)
+		if result.SubmissionID != "STALE_123" {
+			t.Fatalf("expected submissionID STALE_123, got %q", result.SubmissionID)
 		}
 	})
 
-	if !strings.Contains(stderr, "Canceled stale review submission STALE_123") {
-		t.Fatalf("expected stale submission progress on stderr, got %q", stderr)
+	if !strings.Contains(stderr, "Reusing existing review submission STALE_123") {
+		t.Fatalf("expected safe reuse progress on stderr, got %q", stderr)
 	}
 }
 

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -744,11 +744,10 @@ func sanitizeCheckpointToken(value string) string {
 // operator placed outside the working directory is anchored to its own parent,
 // which keeps explicitly selected external locations working.
 func checkpointRoot(path string) (rootfs.Root, string, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	if path == "" {
 		return rootfs.Root{}, "", fmt.Errorf("checkpoint path is empty")
 	}
-	absolute, err := filepath.Abs(trimmed)
+	absolute, err := filepath.Abs(path)
 	if err != nil {
 		return rootfs.Root{}, "", err
 	}

--- a/internal/cli/release/run_path_whitespace_test.go
+++ b/internal/cli/release/run_path_whitespace_test.go
@@ -1,0 +1,64 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckpointRootPreservesOperatorPathWhitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantName string
+	}{
+		{
+			name:     "leading whitespace in relative path",
+			path:     " release-checkpoint.json",
+			wantName: " release-checkpoint.json",
+		},
+		{
+			name:     "trailing whitespace in absolute path",
+			path:     filepath.Join(t.TempDir(), "release-checkpoint.json "),
+			wantName: "release-checkpoint.json ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, gotName, err := checkpointRoot(tt.path)
+			if err != nil {
+				t.Fatalf("checkpointRoot(%q) error = %v", tt.path, err)
+			}
+			if gotName != tt.wantName {
+				t.Fatalf("checkpointRoot(%q) name = %q, want %q", tt.path, gotName, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadCheckpointPreserveOperatorPathWhitespace(t *testing.T) {
+	checkpointPath := filepath.Join(t.TempDir(), " release-checkpoint.json ")
+	checkpoint := runCheckpoint{
+		AppID:     "123",
+		Version:   "1.2.3",
+		BuildID:   "456",
+		Platform:  "IOS",
+		Completed: map[string]bool{stepEnsureVersion: true},
+	}
+
+	if err := saveCheckpoint(checkpointPath, checkpoint); err != nil {
+		t.Fatalf("saveCheckpoint(%q) error = %v", checkpointPath, err)
+	}
+	if _, err := os.Lstat(checkpointPath); err != nil {
+		t.Fatalf("Lstat(%q) error = %v", checkpointPath, err)
+	}
+
+	loaded, err := loadCheckpoint(checkpointPath)
+	if err != nil {
+		t.Fatalf("loadCheckpoint(%q) error = %v", checkpointPath, err)
+	}
+	if loaded == nil || loaded.AppID != checkpoint.AppID {
+		t.Fatalf("loadCheckpoint(%q) = %#v, want app %q", checkpointPath, loaded, checkpoint.AppID)
+	}
+}

--- a/internal/cli/reviews/review_attachments.go
+++ b/internal/cli/reviews/review_attachments.go
@@ -25,6 +25,7 @@ func ReviewDetailsAttachmentsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -87,16 +88,25 @@ Examples:
 				pages, err := shared.PaginateWithSpinner(
 					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
-						return client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, reviewDetailValue, paginateOpts...)
+						resp, err := client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, reviewDetailValue, paginateOpts...)
+						if err != nil || *includeSensitive {
+							return resp, err
+						}
+						return asc.RedactAppStoreReviewDetailIncludesInListResponse(resp)
 					},
 					func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-						return client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, reviewDetailValue, asc.WithAppStoreReviewAttachmentsNextURL(nextURL))
+						resp, err := client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, reviewDetailValue, asc.WithAppStoreReviewAttachmentsNextURL(nextURL))
+						if err != nil || *includeSensitive {
+							return resp, err
+						}
+						return asc.RedactAppStoreReviewDetailIncludesInListResponse(resp)
 					},
 				)
 				if err != nil {
 					return fmt.Errorf("review attachments-list: %w", err)
 				}
 
+				shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
 				return shared.PrintOutput(pages, *output.Output, *output.Pretty)
 			}
 
@@ -105,7 +115,15 @@ Examples:
 				return fmt.Errorf("review attachments-list: failed to fetch: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			if *includeSensitive {
+				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			}
+			safe, err := asc.RedactAppStoreReviewDetailIncludesInListResponse(resp)
+			if err != nil {
+				return fmt.Errorf("review attachments-list: %w", err)
+			}
+			return shared.PrintOutput(safe, *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -118,6 +136,7 @@ func ReviewDetailsAttachmentsGetCommand() *ffcli.Command {
 	fields := fs.String("fields", "", "Fields to include: "+strings.Join(reviewAttachmentFieldList(), ", "))
 	detailFields := fs.String("detail-fields", "", "Review detail fields to include: "+strings.Join(reviewDetailFieldList(), ", "))
 	include := fs.String("include", "", "Include relationships: "+strings.Join(reviewAttachmentIncludeList(), ", "))
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -169,7 +188,15 @@ Examples:
 				return fmt.Errorf("review attachments-get: failed to fetch: %w", err)
 			}
 
-			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			shared.WarnIncludeSensitive(os.Stderr, *includeSensitive)
+			if *includeSensitive {
+				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
+			}
+			safe, err := asc.RedactAppStoreReviewDetailIncludesInSingleResponse(resp)
+			if err != nil {
+				return fmt.Errorf("review attachments-get: %w", err)
+			}
+			return shared.PrintOutput(safe, *output.Output, *output.Pretty)
 		},
 	}
 }

--- a/internal/cli/reviews/reviews_respond_batch.go
+++ b/internal/cli/reviews/reviews_respond_batch.go
@@ -1,14 +1,17 @@
 package reviews
 
 import (
-	"bytes"
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -69,6 +72,12 @@ const reviewBatchMaxFileBytes = 64 << 20
 // leaves fourfold headroom while stopping a flood of tiny elements before the
 // document is materialized.
 const reviewBatchMaxFileTokens = 16 << 10
+
+// reviewBatchMaxPages is a final backstop for a malicious or broken
+// pagination chain. With the command's first-page limit of 200 this still
+// permits scanning ten million reviews, far beyond a normal batch lookup,
+// while guaranteeing that unique-but-never-ending next links terminate.
+const reviewBatchMaxPages = 50_000
 
 type reviewBatchInput struct {
 	Replies []reviewBatchReplyInput `json:"replies"`
@@ -163,7 +172,7 @@ Examples:
 			if strings.TrimSpace(resolvedAppID) == "" {
 				return shared.UsageError("--app is required (or set ASC_APP_ID)")
 			}
-			if strings.TrimSpace(*filePath) == "" {
+			if *filePath == "" {
 				return shared.UsageError("--file is required")
 			}
 
@@ -214,110 +223,455 @@ Examples:
 }
 
 func loadReviewBatchTargets(path string) ([]reviewBatchTarget, error) {
-	data, err := readReviewBatchFile(strings.TrimSpace(path))
-	if err != nil {
-		return nil, err
-	}
-	if len(bytes.TrimSpace(data)) == 0 {
-		return nil, fmt.Errorf("--file must not be empty")
-	}
-	if err := checkReviewBatchTokenBudget(data); err != nil {
-		return nil, err
-	}
-
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-
-	var input reviewBatchInput
-	if err := decoder.Decode(&input); err != nil {
-		return nil, fmt.Errorf("failed to parse --file: %w", err)
-	}
-	var extra json.RawMessage
-	if err := decoder.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return nil, fmt.Errorf("failed to parse --file: multiple JSON values are not allowed")
-		}
-		return nil, fmt.Errorf("failed to parse --file: %w", err)
-	}
-	if len(input.Replies) == 0 {
-		return nil, fmt.Errorf("replies must contain at least one item")
-	}
-
-	seen := map[string]struct{}{}
-	targets := make([]reviewBatchTarget, 0)
-	for replyIndex, reply := range input.Replies {
-		response := strings.TrimSpace(reply.Response)
-		if response == "" {
-			return nil, fmt.Errorf("replies[%d].response is required", replyIndex)
-		}
-		if len(response) > reviewBatchMaxResponseBytes {
-			return nil, fmt.Errorf("replies[%d].response must not exceed %d bytes", replyIndex, reviewBatchMaxResponseBytes)
-		}
-		if len(reply.ReviewIDs) == 0 {
-			return nil, fmt.Errorf("replies[%d].reviewIds must contain at least one review id", replyIndex)
-		}
-		for reviewIndex, reviewID := range reply.ReviewIDs {
-			trimmedReviewID := strings.TrimSpace(reviewID)
-			if trimmedReviewID == "" {
-				return nil, fmt.Errorf("replies[%d].reviewIds[%d] is required", replyIndex, reviewIndex)
-			}
-			if _, ok := seen[trimmedReviewID]; ok {
-				return nil, fmt.Errorf("duplicate review id %q", trimmedReviewID)
-			}
-			if len(targets) >= reviewBatchMaxTargets {
-				return nil, fmt.Errorf("--file must not contain more than %d review ids", reviewBatchMaxTargets)
-			}
-			seen[trimmedReviewID] = struct{}{}
-			targets = append(targets, reviewBatchTarget{
-				ReviewID: trimmedReviewID,
-				Response: response,
-			})
-		}
-	}
-
-	return targets, nil
-}
-
-// checkReviewBatchTokenBudget streams the raw document once, without
-// materializing it, and fails as soon as it yields more JSON tokens than any
-// permitted batch can produce. This stops a file that stays under the byte
-// ceiling but packs millions of tiny elements from being decoded whole before
-// the target-count check can reject it.
-func checkReviewBatchTokenBudget(data []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	tokens := 0
-	for {
-		if _, err := decoder.Token(); err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return fmt.Errorf("failed to parse --file: %w", err)
-		}
-		tokens++
-		if tokens > reviewBatchMaxFileTokens {
-			return fmt.Errorf("--file must not contain more than %d JSON tokens", reviewBatchMaxFileTokens)
-		}
-	}
-}
-
-// readReviewBatchFile expands at most reviewBatchMaxFileBytes so an oversized
-// batch file is rejected before it is parsed, before an App Store Connect
-// client exists, and before any request is issued.
-func readReviewBatchFile(path string) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read --file: %w", err)
 	}
 	defer file.Close()
-
-	data, err := io.ReadAll(io.LimitReader(file, reviewBatchMaxFileBytes+1))
-	if err != nil {
+	if info, err := file.Stat(); err != nil {
 		return nil, fmt.Errorf("failed to read --file: %w", err)
-	}
-	if len(data) > reviewBatchMaxFileBytes {
+	} else if info.Size() > reviewBatchMaxFileBytes {
 		return nil, fmt.Errorf("--file must not exceed %d bytes", reviewBatchMaxFileBytes)
 	}
-	return data, nil
+	if err := checkReviewBatchFileBudget(file); err != nil {
+		return nil, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("failed to read --file: %w", err)
+	}
+
+	stream := &reviewBatchTokenStream{
+		decoder: json.NewDecoder(newStrictReviewBatchReader(file)),
+	}
+	return stream.parse()
+}
+
+// checkReviewBatchFileBudget is a constant-memory lexical pass. Unlike a
+// json.Decoder token pre-pass it never materializes string values, so a single
+// near-limit string cannot create another file-sized allocation. The real
+// schema parser below repeats both strict encoding and token checks in case a
+// concurrently modified file changes after this pass.
+func checkReviewBatchFileBudget(file io.Reader) error {
+	counter := &reviewBatchLexicalCounter{}
+	if _, err := io.Copy(counter, newStrictReviewBatchReader(file)); err != nil {
+		if strings.Contains(err.Error(), "--file must not exceed") {
+			return err
+		}
+		return fmt.Errorf("failed to parse --file: %w", err)
+	}
+	return nil
+}
+
+type reviewBatchLexicalCounter struct {
+	tokens      int
+	inString    bool
+	escaped     bool
+	inPrimitive bool
+}
+
+func (c *reviewBatchLexicalCounter) Write(data []byte) (int, error) {
+	for index, current := range data {
+		if c.inString {
+			if c.escaped {
+				c.escaped = false
+			} else if current == '\\' {
+				c.escaped = true
+			} else if current == '"' {
+				c.inString = false
+			}
+			continue
+		}
+		if c.inPrimitive && isReviewBatchJSONSeparator(current) {
+			c.inPrimitive = false
+		}
+		switch {
+		case current == '"':
+			c.inString = true
+			if err := c.addToken(); err != nil {
+				return index, err
+			}
+		case current == '{' || current == '}' || current == '[' || current == ']':
+			if err := c.addToken(); err != nil {
+				return index, err
+			}
+		case isReviewBatchJSONSeparator(current):
+			continue
+		case !c.inPrimitive:
+			c.inPrimitive = true
+			if err := c.addToken(); err != nil {
+				return index, err
+			}
+		}
+	}
+	return len(data), nil
+}
+
+func (c *reviewBatchLexicalCounter) addToken() error {
+	c.tokens++
+	if c.tokens > reviewBatchMaxFileTokens {
+		return fmt.Errorf("--file must not contain more than %d JSON tokens", reviewBatchMaxFileTokens)
+	}
+	return nil
+}
+
+func isReviewBatchJSONSeparator(value byte) bool {
+	switch value {
+	case ' ', '\t', '\r', '\n', ',', ':', '{', '}', '[', ']':
+		return true
+	default:
+		return false
+	}
+}
+
+type reviewBatchTokenStream struct {
+	decoder *json.Decoder
+	tokens  int
+	seenIDs map[string]struct{}
+	targets []reviewBatchTarget
+}
+
+func (s *reviewBatchTokenStream) token() (json.Token, error) {
+	token, err := s.decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.tokens++
+	if s.tokens > reviewBatchMaxFileTokens {
+		return nil, fmt.Errorf("--file must not contain more than %d JSON tokens", reviewBatchMaxFileTokens)
+	}
+	return token, nil
+}
+
+func (s *reviewBatchTokenStream) parse() ([]reviewBatchTarget, error) {
+	first, err := s.token()
+	if errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("--file must not be empty")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse --file: %w", err)
+	}
+	if first != json.Delim('{') {
+		return nil, fmt.Errorf("failed to parse --file: top-level value must be an object")
+	}
+
+	s.seenIDs = make(map[string]struct{})
+	seenFields := make(map[string]struct{}, 1)
+	replies := 0
+	for {
+		token, err := s.token()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse --file: %w", err)
+		}
+		if token == json.Delim('}') {
+			break
+		}
+		field, ok := token.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse --file: expected a top-level field name")
+		}
+		if _, exists := seenFields[field]; exists {
+			return nil, fmt.Errorf("failed to parse --file: duplicate JSON field %q", field)
+		}
+		seenFields[field] = struct{}{}
+		if field != "replies" {
+			return nil, fmt.Errorf("failed to parse --file: unknown field %q", field)
+		}
+
+		start, err := s.token()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse --file: %w", err)
+		}
+		if start != json.Delim('[') {
+			return nil, fmt.Errorf("failed to parse --file: replies must be an array")
+		}
+		for {
+			next, err := s.token()
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse --file: %w", err)
+			}
+			if next == json.Delim(']') {
+				break
+			}
+			if next != json.Delim('{') {
+				return nil, fmt.Errorf("failed to parse --file: replies[%d] must be an object", replies)
+			}
+			if err := s.parseReply(replies); err != nil {
+				return nil, err
+			}
+			replies++
+		}
+	}
+	if _, ok := seenFields["replies"]; !ok || replies == 0 {
+		return nil, fmt.Errorf("replies must contain at least one item")
+	}
+
+	extra, err := s.token()
+	if err == nil {
+		_ = extra
+		return nil, fmt.Errorf("failed to parse --file: multiple JSON values are not allowed")
+	}
+	if !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("failed to parse --file: %w", err)
+	}
+	return s.targets, nil
+}
+
+func (s *reviewBatchTokenStream) parseReply(replyIndex int) error {
+	seenFields := make(map[string]struct{}, 2)
+	response := ""
+	hasResponse := false
+	reviewIDs := make([]string, 0, 1)
+
+	for {
+		token, err := s.token()
+		if err != nil {
+			return fmt.Errorf("failed to parse --file: %w", err)
+		}
+		if token == json.Delim('}') {
+			break
+		}
+		field, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("failed to parse --file: expected a field name in replies[%d]", replyIndex)
+		}
+		if _, exists := seenFields[field]; exists {
+			return fmt.Errorf("failed to parse --file: duplicate JSON field %q in replies[%d]", field, replyIndex)
+		}
+		seenFields[field] = struct{}{}
+
+		switch field {
+		case "response":
+			value, err := s.token()
+			if err != nil {
+				return fmt.Errorf("failed to parse --file: %w", err)
+			}
+			raw, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("failed to parse --file: replies[%d].response must be a string", replyIndex)
+			}
+			trimmed := strings.TrimSpace(raw)
+			if len(trimmed) > reviewBatchMaxResponseBytes {
+				return fmt.Errorf("replies[%d].response must not exceed %d bytes", replyIndex, reviewBatchMaxResponseBytes)
+			}
+			response = cloneTrimmedReviewBatchString(raw, trimmed)
+			hasResponse = true
+		case "reviewIds":
+			start, err := s.token()
+			if err != nil {
+				return fmt.Errorf("failed to parse --file: %w", err)
+			}
+			if start != json.Delim('[') {
+				return fmt.Errorf("failed to parse --file: replies[%d].reviewIds must be an array", replyIndex)
+			}
+			for {
+				value, err := s.token()
+				if err != nil {
+					return fmt.Errorf("failed to parse --file: %w", err)
+				}
+				if value == json.Delim(']') {
+					break
+				}
+				raw, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("failed to parse --file: replies[%d].reviewIds[%d] must be a string", replyIndex, len(reviewIDs))
+				}
+				trimmed := strings.TrimSpace(raw)
+				reviewID := cloneTrimmedReviewBatchString(raw, trimmed)
+				if reviewID == "" {
+					return fmt.Errorf("replies[%d].reviewIds[%d] is required", replyIndex, len(reviewIDs))
+				}
+				if _, exists := s.seenIDs[reviewID]; exists {
+					return fmt.Errorf("duplicate review id %q", reviewID)
+				}
+				if len(s.targets)+len(reviewIDs) >= reviewBatchMaxTargets {
+					return fmt.Errorf("--file must not contain more than %d review ids", reviewBatchMaxTargets)
+				}
+				s.seenIDs[reviewID] = struct{}{}
+				reviewIDs = append(reviewIDs, reviewID)
+			}
+		default:
+			return fmt.Errorf("failed to parse --file: unknown field %q in replies[%d]", field, replyIndex)
+		}
+	}
+
+	if !hasResponse || response == "" {
+		return fmt.Errorf("replies[%d].response is required", replyIndex)
+	}
+	if len(reviewIDs) == 0 {
+		return fmt.Errorf("replies[%d].reviewIds must contain at least one review id", replyIndex)
+	}
+	for _, reviewID := range reviewIDs {
+		s.targets = append(s.targets, reviewBatchTarget{
+			ReviewID: reviewID,
+			Response: response,
+		})
+	}
+	return nil
+}
+
+func cloneTrimmedReviewBatchString(raw, trimmed string) string {
+	if len(raw) == len(trimmed) {
+		return raw
+	}
+	return strings.Clone(trimmed)
+}
+
+// strictReviewBatchReader validates bytes while json.Decoder consumes them.
+// encoding/json deliberately replaces malformed UTF-8 and invalid UTF-16
+// surrogate escapes with U+FFFD; mutation input must reject both instead.
+// The reader also enforces the raw byte ceiling without retaining the file.
+type strictReviewBatchReader struct {
+	source      *bufio.Reader
+	pending     [12]byte
+	pendingFrom int
+	pendingTo   int
+	bytesRead   int
+	inString    bool
+	deferredErr error
+}
+
+func newStrictReviewBatchReader(source io.Reader) io.Reader {
+	return &strictReviewBatchReader{source: bufio.NewReader(source)}
+}
+
+func (r *strictReviewBatchReader) Read(p []byte) (int, error) {
+	written := 0
+	for written < len(p) {
+		if r.pendingFrom < r.pendingTo {
+			n := copy(p[written:], r.pending[r.pendingFrom:r.pendingTo])
+			r.pendingFrom += n
+			written += n
+			continue
+		}
+		if r.deferredErr != nil {
+			err := r.deferredErr
+			r.deferredErr = nil
+			if written > 0 {
+				r.deferredErr = err
+				return written, nil
+			}
+			return 0, err
+		}
+		if err := r.fillPending(); err != nil {
+			if written > 0 {
+				r.deferredErr = err
+				return written, nil
+			}
+			return 0, err
+		}
+	}
+	return written, nil
+}
+
+func (r *strictReviewBatchReader) fillPending() error {
+	r.pendingFrom = 0
+	r.pendingTo = 0
+
+	value, err := r.readRune()
+	if err != nil {
+		if errors.Is(err, io.EOF) && r.inString {
+			return io.ErrUnexpectedEOF
+		}
+		return err
+	}
+	r.pendingTo += utf8.EncodeRune(r.pending[r.pendingTo:], value)
+
+	if !r.inString {
+		if value == '"' {
+			r.inString = true
+		}
+		return nil
+	}
+	switch {
+	case value == '"':
+		r.inString = false
+		return nil
+	case value < 0x20:
+		return fmt.Errorf("unescaped control character in JSON string")
+	case value != '\\':
+		return nil
+	}
+
+	escaped, err := r.readRune()
+	if err != nil {
+		return fmt.Errorf("incomplete JSON escape: %w", err)
+	}
+	r.pendingTo += utf8.EncodeRune(r.pending[r.pendingTo:], escaped)
+	switch escaped {
+	case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+		return nil
+	case 'u':
+		unit, err := r.readHexCodeUnit()
+		if err != nil {
+			return err
+		}
+		if utf16.IsSurrogate(rune(unit)) {
+			if unit >= 0xDC00 {
+				return fmt.Errorf("invalid JSON Unicode surrogate: unexpected low surrogate")
+			}
+			slash, err := r.readRune()
+			if err != nil {
+				return fmt.Errorf("invalid JSON Unicode surrogate pair: %w", err)
+			}
+			r.pendingTo += utf8.EncodeRune(r.pending[r.pendingTo:], slash)
+			u, err := r.readRune()
+			if err != nil {
+				return fmt.Errorf("invalid JSON Unicode surrogate pair: %w", err)
+			}
+			r.pendingTo += utf8.EncodeRune(r.pending[r.pendingTo:], u)
+			if slash != '\\' || u != 'u' {
+				return fmt.Errorf("invalid JSON Unicode surrogate pair")
+			}
+			low, err := r.readHexCodeUnit()
+			if err != nil {
+				return err
+			}
+			if low < 0xDC00 || low > 0xDFFF {
+				return fmt.Errorf("invalid JSON Unicode surrogate pair")
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid JSON escape %q", escaped)
+	}
+}
+
+func (r *strictReviewBatchReader) readHexCodeUnit() (uint16, error) {
+	var value uint16
+	for range 4 {
+		digit, err := r.readRune()
+		if err != nil {
+			return 0, fmt.Errorf("incomplete JSON Unicode escape: %w", err)
+		}
+		r.pendingTo += utf8.EncodeRune(r.pending[r.pendingTo:], digit)
+		value <<= 4
+		switch {
+		case digit >= '0' && digit <= '9':
+			value += uint16(digit - '0')
+		case digit >= 'a' && digit <= 'f':
+			value += uint16(digit-'a') + 10
+		case digit >= 'A' && digit <= 'F':
+			value += uint16(digit-'A') + 10
+		default:
+			return 0, fmt.Errorf("invalid JSON Unicode escape")
+		}
+	}
+	return value, nil
+}
+
+func (r *strictReviewBatchReader) readRune() (rune, error) {
+	value, size, err := r.source.ReadRune()
+	if err != nil {
+		return 0, err
+	}
+	r.bytesRead += size
+	if r.bytesRead > reviewBatchMaxFileBytes {
+		return 0, fmt.Errorf("--file must not exceed %d bytes", reviewBatchMaxFileBytes)
+	}
+	if value == utf8.RuneError && size == 1 {
+		return 0, fmt.Errorf("invalid UTF-8 in --file")
+	}
+	return value, nil
 }
 
 func executeReviewsRespondBatch(ctx context.Context, client *asc.Client, appID string, targets []reviewBatchTarget, dryRun bool, skipExisting bool, responseState string) (reviewBatchResult, error) {
@@ -398,6 +752,10 @@ func executeReviewsRespondBatch(ctx context.Context, client *asc.Client, appID s
 }
 
 func fetchReviewBatchReviewInfo(ctx context.Context, client *asc.Client, appID string, targets []reviewBatchTarget) (map[string]reviewBatchReviewInfo, error) {
+	return fetchReviewBatchReviewInfoWithPageLimit(ctx, client, appID, targets, reviewBatchMaxPages)
+}
+
+func fetchReviewBatchReviewInfoWithPageLimit(ctx context.Context, client *asc.Client, appID string, targets []reviewBatchTarget, maxPages int) (map[string]reviewBatchReviewInfo, error) {
 	wanted := make(map[string]struct{}, len(targets))
 	for _, target := range targets {
 		wanted[target.ReviewID] = struct{}{}
@@ -405,7 +763,13 @@ func fetchReviewBatchReviewInfo(ctx context.Context, client *asc.Client, appID s
 
 	found := make(map[string]reviewBatchReviewInfo, len(targets))
 	nextURL := ""
+	seenNextURLs := make(map[string]struct{})
+	page := 0
 	for {
+		if page >= maxPages {
+			return found, fmt.Errorf("review pagination must not exceed %d pages", maxPages)
+		}
+		page++
 		var (
 			response *asc.ReviewsResponse
 			err      error
@@ -430,10 +794,15 @@ func fetchReviewBatchReviewInfo(ctx context.Context, client *asc.Client, appID s
 			}
 		}
 
-		if len(found) == len(wanted) || strings.TrimSpace(response.Links.Next) == "" {
+		next := strings.TrimSpace(response.Links.Next)
+		if len(found) == len(wanted) || next == "" {
 			break
 		}
-		nextURL = response.Links.Next
+		if _, exists := seenNextURLs[next]; exists {
+			return found, fmt.Errorf("page %d: %w", page+1, asc.ErrRepeatedPaginationURL)
+		}
+		seenNextURLs[next] = struct{}{}
+		nextURL = next
 	}
 
 	return found, nil

--- a/internal/cli/reviews/reviews_respond_batch_limits_test.go
+++ b/internal/cli/reviews/reviews_respond_batch_limits_test.go
@@ -1,12 +1,17 @@
 package reviews
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 // TestLoadReviewBatchTargetsReadsFileAtSizeLimit proves an at-limit file
@@ -228,6 +233,155 @@ func TestLoadReviewBatchTargetsTokenBudgetAdmitsFileAtTokenLimit(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "JSON tokens") {
 		t.Fatalf("file at the token limit must pass the token budget, got %v", err)
+	}
+}
+
+func TestLoadReviewBatchTargetsRejectsInvalidUTF8(t *testing.T) {
+	path := writeReviewBatchTestFile(t, []byte("{\"replies\":[{\"response\":\"\xff\",\"reviewIds\":[\"review-1\"]}]}"))
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected invalid UTF-8 rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid UTF-8") {
+		t.Fatalf("expected invalid UTF-8 error, got %v", err)
+	}
+}
+
+func TestLoadReviewBatchTargetsRejectsUnpairedSurrogateEscape(t *testing.T) {
+	path := writeReviewBatchTestFile(t, []byte(`{"replies":[{"response":"\ud835x","reviewIds":["review-1"]}]}`))
+
+	_, err := loadReviewBatchTargets(path)
+	if err == nil {
+		t.Fatal("expected unpaired surrogate rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "surrogate") {
+		t.Fatalf("expected surrogate error, got %v", err)
+	}
+}
+
+func TestLoadReviewBatchTargetsRejectsDuplicateObjectKeys(t *testing.T) {
+	for _, body := range []string{
+		`{"replies":[],"replies":[]}`,
+		`{"replies":[{"response":"first","response":"second","reviewIds":["review-1"]}]}`,
+		`{"replies":[{"response":"first","reviewIds":["review-1"],"reviewIds":["review-2"]}]}`,
+	} {
+		path := writeReviewBatchTestFile(t, []byte(body))
+		_, err := loadReviewBatchTargets(path)
+		if err == nil {
+			t.Fatalf("expected duplicate-key rejection for %s", body)
+		}
+		if !strings.Contains(err.Error(), "duplicate JSON field") {
+			t.Fatalf("expected duplicate-field error for %s, got %v", body, err)
+		}
+	}
+}
+
+func TestLoadReviewBatchTargetsClonesTrimmedStrings(t *testing.T) {
+	body := `{"replies":[{"response":"  Thanks  ","reviewIds":["  review-1  "]}]}`
+	path := writeReviewBatchTestFile(t, []byte(body))
+
+	targets, err := loadReviewBatchTargets(path)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != 1 || targets[0].Response != "Thanks" || targets[0].ReviewID != "review-1" {
+		t.Fatalf("unexpected trimmed target: %+v", targets)
+	}
+}
+
+func TestLoadReviewBatchTargetsPreservesTrailingSpaceInPath(t *testing.T) {
+	directory := t.TempDir()
+	plainPath := filepath.Join(directory, "replies.json")
+	spacedPath := plainPath + " "
+	plainBody := []byte(`{"replies":[{"response":"plain","reviewIds":["plain-review"]}]}`)
+	spacedBody := []byte(`{"replies":[{"response":"spaced","reviewIds":["spaced-review"]}]}`)
+	if err := os.WriteFile(plainPath, plainBody, 0o600); err != nil {
+		t.Fatalf("write plain batch file: %v", err)
+	}
+	if err := os.WriteFile(spacedPath, spacedBody, 0o600); err != nil {
+		t.Fatalf("write trailing-space batch file: %v", err)
+	}
+
+	targets, err := loadReviewBatchTargets(spacedPath)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != 1 || targets[0].ReviewID != "spaced-review" || targets[0].Response != "spaced" {
+		t.Fatalf("expected exact trailing-space path, got %+v", targets)
+	}
+}
+
+func TestLoadReviewBatchTargetsAcceptsAllSpaceFilename(t *testing.T) {
+	path := filepath.Join(t.TempDir(), " ")
+	body := []byte(`{"replies":[{"response":"spaces are a legal filename","reviewIds":["review-1"]}]}`)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write all-space batch file: %v", err)
+	}
+
+	targets, err := loadReviewBatchTargets(path)
+	if err != nil {
+		t.Fatalf("loadReviewBatchTargets() error: %v", err)
+	}
+	if len(targets) != 1 || targets[0].ReviewID != "review-1" {
+		t.Fatalf("unexpected targets: %+v", targets)
+	}
+}
+
+func TestFetchReviewBatchReviewInfoRejectsRepeatedPaginationURL(t *testing.T) {
+	requests := 0
+	transport := testRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return testJSONResponse(http.StatusOK, `{
+			"data": [],
+			"links": {"next": "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviews?cursor=same"}
+		}`), nil
+	})
+	client := newTestHistoryClient(t, transport)
+
+	_, err := fetchReviewBatchReviewInfo(
+		context.Background(),
+		client,
+		"app-1",
+		[]reviewBatchTarget{{ReviewID: "review-1", Response: "Thanks"}},
+	)
+	if err == nil {
+		t.Fatal("expected repeated pagination URL rejection, got nil")
+	}
+	if !errors.Is(err, asc.ErrRepeatedPaginationURL) {
+		t.Fatalf("expected ErrRepeatedPaginationURL, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected two requests before repeated-link rejection, got %d", requests)
+	}
+}
+
+func TestFetchReviewBatchReviewInfoAppliesPageBound(t *testing.T) {
+	requests := 0
+	transport := testRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return testJSONResponse(http.StatusOK, fmt.Sprintf(`{
+			"data": [],
+			"links": {"next": "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviews?cursor=%d"}
+		}`, requests)), nil
+	})
+	client := newTestHistoryClient(t, transport)
+
+	_, err := fetchReviewBatchReviewInfoWithPageLimit(
+		context.Background(),
+		client,
+		"app-1",
+		[]reviewBatchTarget{{ReviewID: "review-1", Response: "Thanks"}},
+		2,
+	)
+	if err == nil {
+		t.Fatal("expected pagination page-limit rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "must not exceed 2 pages") {
+		t.Fatalf("expected page-limit error, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected two requests before the page bound, got %d", requests)
 	}
 }
 

--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -83,6 +83,9 @@ func readBundleInfoFromInfoPlist(file *zip.File) (IPABundleInfo, error) {
 	if err != nil {
 		return IPABundleInfo{}, fmt.Errorf("read Info.plist: %w", err)
 	}
+	if err := infoplist.ValidateStructure(data); err != nil {
+		return IPABundleInfo{}, fmt.Errorf("decode Info.plist: %w", err)
+	}
 
 	var info map[string]any
 	decoder := plist.NewDecoder(bytes.NewReader(data))

--- a/internal/cli/snitch/snitch.go
+++ b/internal/cli/snitch/snitch.go
@@ -281,7 +281,7 @@ Examples:
 				return shared.UsageError("snitch flush does not accept positional arguments; use --file PATH to specify a log file")
 			}
 
-			path := strings.TrimSpace(*logFile)
+			path := *logFile
 			if path == "" {
 				path = filepath.Join(".asc", "snitch.log")
 			}
@@ -574,7 +574,11 @@ func validateRequestedLabels(ctx context.Context, token string, requested []stri
 // repository-controlled .asc directory and log file cannot redirect the log, and
 // falls back to the log's own parent for a log the operator placed elsewhere.
 func localLogRoot(path string) (rootfs.Root, string, error) {
-	absolute, err := filepath.Abs(strings.TrimSpace(path))
+	if path == "" {
+		return rootfs.Root{}, "", fmt.Errorf("log path must not be empty")
+	}
+
+	absolute, err := filepath.Abs(path)
 	if err != nil {
 		return rootfs.Root{}, "", err
 	}

--- a/internal/cli/snitch/snitch_containment_test.go
+++ b/internal/cli/snitch/snitch_containment_test.go
@@ -118,3 +118,48 @@ func TestReadLocalLogRefusesSymlinkedLog(t *testing.T) {
 		t.Fatalf("readLocalLog() error = %v, want symlink rejection", err)
 	}
 }
+
+func TestReadLocalLogPreservesWhitespaceInPath(t *testing.T) {
+	dir := t.TempDir()
+	exactPath := filepath.Join(dir, " snitch.log ")
+	trimmedPath := filepath.Join(dir, "snitch.log")
+
+	writeLogEntry := func(path, description string) {
+		t.Helper()
+		data := []byte(`{"description":"` + description + `","severity":"bug"}` + "\n")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", path, err)
+		}
+	}
+	writeLogEntry(exactPath, "exact whitespace path")
+	writeLogEntry(trimmedPath, "trimmed sibling")
+
+	entries, err := readLocalLog(exactPath)
+	if err != nil {
+		t.Fatalf("readLocalLog(%q) error = %v", exactPath, err)
+	}
+	if len(entries) != 1 || entries[0].Description != "exact whitespace path" {
+		t.Fatalf("readLocalLog(%q) = %#v, want exact whitespace-bearing file", exactPath, entries)
+	}
+}
+
+func TestSnitchFlushPreservesWhitespaceInFileFlag(t *testing.T) {
+	dir := t.TempDir()
+	exactPath := filepath.Join(dir, " snitch.log ")
+	trimmedPath := filepath.Join(dir, "snitch.log")
+
+	if err := os.WriteFile(exactPath, []byte(`{"description":"exact whitespace path","severity":"bug"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", exactPath, err)
+	}
+	if err := os.WriteFile(trimmedPath, []byte(`{"description":"trimmed sibling","severity":"bug"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", trimmedPath, err)
+	}
+
+	stdout, _, err := runSnitchCommand(t, "1.2.3", "flush", "--file", exactPath)
+	if err != nil {
+		t.Fatalf("snitch flush --file %q error = %v", exactPath, err)
+	}
+	if !strings.Contains(stdout, "exact whitespace path") || strings.Contains(stdout, "trimmed sibling") {
+		t.Fatalf("snitch flush output = %q, want exact whitespace-bearing file only", stdout)
+	}
+}

--- a/internal/cli/submit/submit_create.go
+++ b/internal/cli/submit/submit_create.go
@@ -5,85 +5,114 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
-var submitCreateRecentlyCanceledRetryDelays = []time.Duration{
-	250 * time.Millisecond,
-	500 * time.Millisecond,
-	time.Second,
-	2 * time.Second,
-}
-
 func addVersionToSubmissionOrRecover(
 	ctx context.Context,
 	client *asc.Client,
-	submissionID, versionID string,
-	recentlyCanceledSubmissionIDs map[string]struct{},
+	submissionID, versionID, appID, platform string,
 	emit func(string),
 ) (string, error) {
-	for attempt := 0; ; attempt++ {
-		_, err := client.AddReviewSubmissionItem(ctx, submissionID, versionID)
-		if err == nil {
-			return submissionID, nil
-		}
-
-		conflict := extractSubmissionConflict(err)
-		conflictSubmissionID := strings.TrimSpace(conflict.SubmissionID)
-		if conflictSubmissionID == "" {
-			return "", err
-		}
-
-		switch conflict.Kind {
-		case submissionConflictAlreadyAttached:
-			if _, ok := recentlyCanceledSubmissionIDs[conflictSubmissionID]; !ok {
-				message := fmt.Sprintf("Version already in review submission %s, reusing it.", conflictSubmissionID)
-				if emit != nil {
-					emit(message)
-				} else {
-					fmt.Fprintln(os.Stderr, message)
-				}
-				return conflictSubmissionID, nil
-			}
-		case submissionConflictStillInProgress:
-			if _, ok := recentlyCanceledSubmissionIDs[conflictSubmissionID]; !ok {
-				return "", err
-			}
-		default:
-			return "", err
-		}
-		if attempt >= len(submitCreateRecentlyCanceledRetryDelays) {
-			return "", fmt.Errorf(
-				"version is still attached to recently canceled review submission %s after %d retries: %w",
-				conflictSubmissionID,
-				len(submitCreateRecentlyCanceledRetryDelays),
-				err,
-			)
-		}
-
-		delay := submitCreateRecentlyCanceledRetryDelays[attempt]
-		message := fmt.Sprintf(
-			"Version is still detaching from recently canceled review submission %s, retrying add in %s.",
-			conflictSubmissionID,
-			delay,
-		)
-		if emit != nil {
-			emit(message)
-		} else {
-			fmt.Fprintln(os.Stderr, message)
-		}
-		if err := sleepWithContext(ctx, delay); err != nil {
-			return "", fmt.Errorf("waiting for recently canceled review submission %s to clear: %w", conflictSubmissionID, err)
-		}
+	_, err := client.AddReviewSubmissionItem(ctx, submissionID, versionID)
+	if err == nil {
+		return submissionID, nil
 	}
+
+	conflict := extractSubmissionConflict(err)
+	conflictSubmissionID := strings.TrimSpace(conflict.SubmissionID)
+	if conflict.Kind != submissionConflictAlreadyAttached || conflictSubmissionID == "" {
+		return "", err
+	}
+	if verifyErr := verifyReviewSubmissionForSubmit(ctx, client, conflictSubmissionID, appID, platform, versionID); verifyErr != nil {
+		return "", fmt.Errorf(
+			"conflict review submission %s could not be safely reused: %w",
+			conflictSubmissionID,
+			verifyErr,
+		)
+	}
+
+	message := fmt.Sprintf("Version already in review submission %s, reusing it.", conflictSubmissionID)
+	if emit != nil {
+		emit(message)
+	} else {
+		fmt.Fprintln(os.Stderr, message)
+	}
+	return conflictSubmissionID, nil
+}
+
+func verifyReviewSubmissionForSubmit(
+	ctx context.Context,
+	client *asc.Client,
+	submissionID, appID, platform, versionID string,
+) error {
+	submissionID = strings.TrimSpace(submissionID)
+	appID = strings.TrimSpace(appID)
+	platform = strings.ToUpper(strings.TrimSpace(platform))
+	versionID = strings.TrimSpace(versionID)
+	if submissionID == "" || appID == "" || platform == "" || versionID == "" {
+		return fmt.Errorf("submission, app, platform, and version IDs are required")
+	}
+
+	refreshed, err := client.GetReviewSubmission(
+		ctx,
+		submissionID,
+		asc.WithReviewSubmissionInclude([]string{"app"}),
+	)
+	if err != nil {
+		return fmt.Errorf("refresh review submission: %w", err)
+	}
+	if refreshed == nil || strings.TrimSpace(refreshed.Data.ID) != submissionID {
+		return fmt.Errorf("app store connect did not return review submission %s", submissionID)
+	}
+	submission := &refreshed.Data
+	if submission.Attributes.SubmissionState != asc.ReviewSubmissionStateReadyForReview {
+		return fmt.Errorf(
+			"review submission %s is in state %q, not %q",
+			submissionID,
+			submission.Attributes.SubmissionState,
+			asc.ReviewSubmissionStateReadyForReview,
+		)
+	}
+	if !strings.EqualFold(string(submission.Attributes.Platform), platform) {
+		return fmt.Errorf(
+			"review submission %s is for platform %q, not %q",
+			submissionID,
+			submission.Attributes.Platform,
+			platform,
+		)
+	}
+	if actualAppID := reviewSubmissionAppID(submission); actualAppID != appID {
+		if actualAppID == "" {
+			return fmt.Errorf("review submission %s did not prove its app relationship", submissionID)
+		}
+		return fmt.Errorf("review submission %s belongs to app %q, not %q", submissionID, actualAppID, appID)
+	}
+
+	summary, err := summarizeReviewSubmissionItems(ctx, client, submissionID, versionID)
+	if err != nil {
+		return fmt.Errorf("inspect review submission items: %w", err)
+	}
+	if !summary.hasTargetVersion {
+		return fmt.Errorf("review submission %s does not contain target version %s", submissionID, versionID)
+	}
+	if summary.hasOtherItems {
+		return fmt.Errorf("review submission %s contains unrelated review items", submissionID)
+	}
+	return nil
+}
+
+func reviewSubmissionAppID(submission *asc.ReviewSubmissionResource) string {
+	if submission == nil || submission.Relationships == nil || submission.Relationships.App == nil {
+		return ""
+	}
+	return strings.TrimSpace(submission.Relationships.App.Data.ID)
 }
 
 type submitCreateReviewSubmissionPreparation struct {
 	reuseSubmissionID         string
 	reuseSubmissionHasVersion bool
-	canceledSubmissionIDs     map[string]struct{}
 }
 
 func prepareReviewSubmissionForCreate(
@@ -132,9 +161,7 @@ func prepareReviewSubmissionForCreate(
 		return submitCreateReviewSubmissionPreparation{}
 	}
 
-	result := submitCreateReviewSubmissionPreparation{
-		canceledSubmissionIDs: make(map[string]struct{}, len(submissions)),
-	}
+	result := submitCreateReviewSubmissionPreparation{}
 	normalizedPlatform := strings.ToUpper(strings.TrimSpace(platform))
 	targetVersionID := strings.TrimSpace(versionID)
 	inspector := newReviewSubmissionInspector(client, targetVersionID)
@@ -147,82 +174,32 @@ func prepareReviewSubmissionForCreate(
 		if normalizedPlatform != "" && !strings.EqualFold(string(sub.Attributes.Platform), normalizedPlatform) {
 			continue
 		}
-		if currentVersionID := reviewSubmissionAppStoreVersionID(&sub); targetVersionID != "" && currentVersionID == targetVersionID {
-			reusable, hasVersion, reuseErr := inspector.canReuse(ctx, &sub)
-			if reuseErr != nil {
-				emitMessage("Warning: failed to inspect review submission %s before reuse: %v", sub.ID, reuseErr)
-				continue
-			}
-			if reusable {
-				emitMessage("Reusing existing review submission %s because the target version is already attached.", sub.ID)
-				result.reuseSubmissionID = strings.TrimSpace(sub.ID)
-				result.reuseSubmissionHasVersion = hasVersion
-				result.canceledSubmissionIDs = nil
-				return result
-			}
-		}
-	}
-
-	for i := range submissions {
-		sub := submissions[i]
-		if sub.Attributes.SubmissionState != asc.ReviewSubmissionStateReadyForReview {
-			continue
-		}
-		if normalizedPlatform != "" && !strings.EqualFold(string(sub.Attributes.Platform), normalizedPlatform) {
-			continue
-		}
-
-		cancellable, blockedReason, inspectErr := inspector.canCancel(ctx, &sub)
-		if inspectErr != nil {
+		reusable, hasVersion, reuseErr := inspector.canReuse(ctx, &sub)
+		if reuseErr != nil {
 			emitMessage(
 				"Skipped stale review submission %s: could not confirm which versions it holds (%v). Cancel it explicitly with `asc submit cancel --id %s --confirm` if you intend to replace it.",
 				sub.ID,
-				inspectErr,
+				reuseErr,
 				sub.ID,
 			)
 			continue
 		}
-		if !cancellable {
-			emitMessage(
-				"Skipped stale review submission %s: %s. Cancel it explicitly with `asc submit cancel --id %s --confirm` if you intend to replace it.",
-				sub.ID,
-				blockedReason,
-				sub.ID,
-			)
-			continue
-		}
-
-		if _, cancelErr := client.CancelReviewSubmission(ctx, sub.ID); cancelErr != nil {
-			if isExpectedNonCancellableReviewSubmissionError(cancelErr) {
-				reuseSubmission, reuseHasVersion, reuseErr := inspector.reusableAfterCancelConflict(ctx, &sub)
-				if reuseErr == nil && reuseSubmission != "" {
-					if reuseHasVersion {
-						emitMessage("Reusing existing review submission %s because the target version is already attached and App Store Connect would not cancel it.", reuseSubmission)
-					} else {
-						emitMessage("Reusing existing empty review submission %s because App Store Connect would not cancel it.", reuseSubmission)
-					}
-					result.reuseSubmissionID = reuseSubmission
-					result.reuseSubmissionHasVersion = reuseHasVersion
-					if len(result.canceledSubmissionIDs) == 0 {
-						result.canceledSubmissionIDs = nil
-					}
-					return result
-				}
-				if reuseErr != nil {
-					emitMessage("Warning: failed to inspect stale submission %s after cancel conflict: %v", sub.ID, reuseErr)
-				}
-				emitMessage("Skipped stale submission %s: already transitioned to a non-cancellable state", sub.ID)
+		if reusable {
+			if hasVersion {
+				emitMessage("Reusing existing review submission %s because the target version is already attached.", sub.ID)
 			} else {
-				emitMessage("Warning: failed to cancel stale submission %s: %v", sub.ID, cancelErr)
+				emitMessage("Reusing existing review submission %s because it has no review items.", sub.ID)
 			}
-			continue
+			result.reuseSubmissionID = strings.TrimSpace(sub.ID)
+			result.reuseSubmissionHasVersion = hasVersion
+			return result
 		}
-		result.canceledSubmissionIDs[sub.ID] = struct{}{}
-		emitMessage("Canceled stale review submission %s", sub.ID)
-	}
-
-	if len(result.canceledSubmissionIDs) == 0 {
-		result.canceledSubmissionIDs = nil
+		emitMessage(
+			"Skipped stale review submission %s because it is not exclusively usable for version %s. Cancel it explicitly with `asc submit cancel --id %s --confirm` if you intend to replace it.",
+			sub.ID,
+			targetVersionID,
+			sub.ID,
+		)
 	}
 	return result
 }
@@ -247,6 +224,7 @@ type reviewSubmissionInspector struct {
 	client          *asc.Client
 	targetVersionID string
 	summaries       map[string]reviewSubmissionItemSummary
+	summaryErrors   map[string]error
 }
 
 func newReviewSubmissionInspector(client *asc.Client, targetVersionID string) *reviewSubmissionInspector {
@@ -254,25 +232,25 @@ func newReviewSubmissionInspector(client *asc.Client, targetVersionID string) *r
 		client:          client,
 		targetVersionID: strings.TrimSpace(targetVersionID),
 		summaries:       make(map[string]reviewSubmissionItemSummary),
+		summaryErrors:   make(map[string]error),
 	}
 }
 
 func (i *reviewSubmissionInspector) summarize(ctx context.Context, submissionID string) (reviewSubmissionItemSummary, error) {
+	submissionID = strings.TrimSpace(submissionID)
 	if cached, ok := i.summaries[submissionID]; ok {
 		return cached, nil
 	}
+	if cachedErr, ok := i.summaryErrors[submissionID]; ok {
+		return reviewSubmissionItemSummary{}, cachedErr
+	}
 	summary, err := summarizeReviewSubmissionItems(ctx, i.client, submissionID, i.targetVersionID)
 	if err != nil {
+		i.summaryErrors[submissionID] = err
 		return reviewSubmissionItemSummary{}, err
 	}
 	i.summaries[submissionID] = summary
 	return summary, nil
-}
-
-// forget drops the cached item summary for a submission whose membership may
-// have changed since it was read, forcing the next inspection to re-fetch.
-func (i *reviewSubmissionInspector) forget(submissionID string) {
-	delete(i.summaries, strings.TrimSpace(submissionID))
 }
 
 func (i *reviewSubmissionInspector) canReuse(ctx context.Context, submission *asc.ReviewSubmissionResource) (reusable bool, hasVersion bool, err error) {
@@ -282,6 +260,9 @@ func (i *reviewSubmissionInspector) canReuse(ctx context.Context, submission *as
 
 	submissionID := strings.TrimSpace(submission.ID)
 	if submissionID == "" {
+		return false, false, nil
+	}
+	if linkedVersionID := reviewSubmissionAppStoreVersionID(submission); linkedVersionID != "" && linkedVersionID != i.targetVersionID {
 		return false, false, nil
 	}
 
@@ -297,70 +278,6 @@ func (i *reviewSubmissionInspector) canReuse(ctx context.Context, submission *as
 	}
 
 	return true, false, nil
-}
-
-// canCancel reports whether a stale submission is proven empty or proven to
-// hold the selected version. Anything else may carry review work the operator
-// did not select, so preparation must leave it alone and say so; the returned
-// reason explains what blocked the implicit cancellation.
-func (i *reviewSubmissionInspector) canCancel(ctx context.Context, submission *asc.ReviewSubmissionResource) (bool, string, error) {
-	if submission == nil {
-		return false, "the submission could not be identified", nil
-	}
-
-	submissionID := strings.TrimSpace(submission.ID)
-	if submissionID == "" {
-		return false, "the submission could not be identified", nil
-	}
-
-	itemSummary, err := i.summarize(ctx, submissionID)
-	if err != nil {
-		return false, "", err
-	}
-	if itemSummary.hasTargetVersion {
-		if itemSummary.hasOtherItems {
-			return false, "it holds the selected version alongside other review items", nil
-		}
-		return true, "", nil
-	}
-	if itemSummary.hasItems {
-		return false, "it holds review items that are not the selected version", nil
-	}
-	if versionForReview := reviewSubmissionAppStoreVersionID(submission); versionForReview != "" && versionForReview != i.targetVersionID {
-		return false, fmt.Sprintf("it is bound to version %s", versionForReview), nil
-	}
-	return true, "", nil
-}
-
-func (i *reviewSubmissionInspector) reusableAfterCancelConflict(ctx context.Context, submission *asc.ReviewSubmissionResource) (submissionID string, hasVersion bool, err error) {
-	if submission == nil {
-		return "", false, nil
-	}
-
-	submissionID = strings.TrimSpace(submission.ID)
-	if submissionID == "" {
-		return "", false, nil
-	}
-	refreshed, err := refreshReviewSubmission(ctx, i.client, submissionID)
-	if err != nil {
-		return "", false, err
-	}
-
-	// The cancel conflict proves the submission changed after the initial
-	// inspection, so the cached item summary can no longer decide reuse.
-	i.forget(submissionID)
-	if refreshed == nil || refreshed.Attributes.SubmissionState != asc.ReviewSubmissionStateReadyForReview {
-		return "", false, nil
-	}
-
-	reusable, hasVersion, err := i.canReuse(ctx, refreshed)
-	if err != nil {
-		return "", false, err
-	}
-	if reusable {
-		return submissionID, hasVersion, nil
-	}
-	return "", false, nil
 }
 
 func summarizeReviewSubmissionItems(
@@ -456,21 +373,5 @@ func cleanupEmptyReviewSubmission(ctx context.Context, client *asc.Client, submi
 		} else {
 			fmt.Fprintln(os.Stderr, message)
 		}
-	}
-}
-
-func sleepWithContext(ctx context.Context, delay time.Duration) error {
-	if delay <= 0 {
-		return nil
-	}
-
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
 	}
 }

--- a/internal/cli/submit/submit_create_cancel_scope_test.go
+++ b/internal/cli/submit/submit_create_cancel_scope_test.go
@@ -13,7 +13,7 @@ import (
 // proves that preparation never withdraws a review submission holding another
 // version's review items.
 func TestPrepareReviewSubmissionForCreateDoesNotCancelSubmissionForAnotherVersion(t *testing.T) {
-	requests := make([]string, 0, 3)
+	requests := make([]string, 0, 2)
 	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests = append(requests, req.Method+" "+req.URL.RequestURI())
 
@@ -53,14 +53,10 @@ func TestPrepareReviewSubmissionForCreateDoesNotCancelSubmissionForAnotherVersio
 		if got.reuseSubmissionID != "" {
 			t.Fatalf("expected no reusable submission, got %#v", got)
 		}
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("expected no canceled submissions, got %#v", got.canceledSubmissionIDs)
-		}
 	})
 
 	wantRequests := []string{
 		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/other-version-submission/items?limit=200",
 	}
 	if !reflect.DeepEqual(requests, wantRequests) {
 		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
@@ -74,9 +70,9 @@ func TestPrepareReviewSubmissionForCreateDoesNotCancelSubmissionForAnotherVersio
 }
 
 // TestPrepareReviewSubmissionForCreateDoesNotCancelUnprovenSubmission proves
-// that a failed item lookup blocks cancellation instead of falling back to it.
+// that a failed item lookup blocks reuse without falling back to cancellation.
 func TestPrepareReviewSubmissionForCreateDoesNotCancelUnprovenSubmission(t *testing.T) {
-	requests := make([]string, 0, 3)
+	requests := make([]string, 0, 2)
 	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests = append(requests, req.Method+" "+req.URL.RequestURI())
 
@@ -90,7 +86,7 @@ func TestPrepareReviewSubmissionForCreateDoesNotCancelUnprovenSubmission(t *test
 				}]
 			}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/unproven-submission/items":
-			return submitJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","title":"Server error"}]}`)
+			return submitJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","title":"Invalid request"}]}`)
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
 		}
@@ -98,8 +94,8 @@ func TestPrepareReviewSubmissionForCreateDoesNotCancelUnprovenSubmission(t *test
 
 	stderr := captureSubmitStderr(t, func() {
 		got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", nil)
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("expected no canceled submissions, got %#v", got.canceledSubmissionIDs)
+		if got.reuseSubmissionID != "" {
+			t.Fatalf("expected unproven submission not to be reused, got %#v", got)
 		}
 	})
 
@@ -110,113 +106,5 @@ func TestPrepareReviewSubmissionForCreateDoesNotCancelUnprovenSubmission(t *test
 	}
 	if !strings.Contains(stderr, "Skipped stale review submission unproven-submission") {
 		t.Fatalf("expected skip diagnostic naming the submission, got %q", stderr)
-	}
-}
-
-// TestPrepareReviewSubmissionForCreateDoesNotReuseSubmissionThatGainedItemsAfterCancelConflict
-// proves the post-cancel-conflict reuse path re-reads item membership: the
-// conflict is evidence the submission changed after the initial inspection, so
-// the cached summary must not decide reuse.
-func TestPrepareReviewSubmissionForCreateDoesNotReuseSubmissionThatGainedItemsAfterCancelConflict(t *testing.T) {
-	itemCalls := 0
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissions",
-					"id": "raced-submission",
-					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"}
-				}]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/raced-submission/items":
-			itemCalls++
-			if itemCalls == 1 {
-				return submitJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
-			}
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissionItems",
-					"id": "other-version-item",
-					"relationships": {
-						"appStoreVersion": {
-							"data": {"type": "appStoreVersions", "id": "version-2"}
-						}
-					}
-				}]
-			}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/raced-submission":
-			return submitJSONResponse(http.StatusConflict, `{
-				"errors": [{
-					"status": "409",
-					"code": "CONFLICT",
-					"title": "Resource state is invalid.",
-					"detail": "Resource is not in cancellable state"
-				}]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/raced-submission":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": {
-					"type": "reviewSubmissions",
-					"id": "raced-submission",
-					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"}
-				}
-			}`)
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
-		}
-	}))
-
-	captureSubmitStderr(t, func() {
-		got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", nil)
-		if got.reuseSubmissionID != "" {
-			t.Fatalf("expected no reuse of a submission that gained other items, got %#v", got)
-		}
-	})
-
-	if itemCalls < 2 {
-		t.Fatalf("expected item membership to be re-read after the cancel conflict, got %d fetch(es)", itemCalls)
-	}
-}
-
-// TestPrepareReviewSubmissionForCreateCancelsSubmissionProvenEmpty keeps the
-// working path: a submission with no review items is safe to withdraw.
-func TestPrepareReviewSubmissionForCreateCancelsSubmissionProvenEmpty(t *testing.T) {
-	requests := make([]string, 0, 3)
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.RequestURI())
-
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissions",
-					"id": "empty-submission",
-					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"}
-				}]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/empty-submission/items":
-			return submitJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/empty-submission":
-			return submitJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"empty-submission"}}`)
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
-		}
-	}))
-
-	captureSubmitStderr(t, func() {
-		got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", nil)
-		if _, ok := got.canceledSubmissionIDs["empty-submission"]; !ok {
-			t.Fatalf("expected empty submission to be canceled, got %#v", got.canceledSubmissionIDs)
-		}
-	})
-
-	wantRequests := []string{
-		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/empty-submission/items?limit=200",
-		"PATCH /v1/reviewSubmissions/empty-submission",
-	}
-	if !reflect.DeepEqual(requests, wantRequests) {
-		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
 	}
 }

--- a/internal/cli/submit/submit_flow.go
+++ b/internal/cli/submit/submit_flow.go
@@ -248,7 +248,8 @@ func SubmitResolvedVersion(ctx context.Context, client *asc.Client, opts SubmitR
 			client,
 			submissionIDToSubmit,
 			versionID,
-			preparedSubmission.canceledSubmissionIDs,
+			appID,
+			platform,
 			emit,
 		)
 		if err != nil {
@@ -260,6 +261,17 @@ func SubmitResolvedVersion(ctx context.Context, client *asc.Client, opts SubmitR
 		if createdSubmissionID != "" && submissionIDToSubmit != createdSubmissionID {
 			cleanupEmptyReviewSubmission(submitCtx, client, createdSubmissionID, emit)
 		}
+	}
+
+	if err := verifyReviewSubmissionForSubmit(
+		submitCtx,
+		client,
+		submissionIDToSubmit,
+		appID,
+		platform,
+		versionID,
+	); err != nil {
+		return result, fmt.Errorf("submit review: final submission validation: %w", err)
 	}
 
 	submitResp, err := client.SubmitReviewSubmission(submitCtx, submissionIDToSubmit)

--- a/internal/cli/submit/submit_flow_test.go
+++ b/internal/cli/submit/submit_flow_test.go
@@ -54,6 +54,22 @@ func TestSubmitResolvedVersionReusesReadySubmissionWithTargetVersion(t *testing.
 					}
 				}]
 			}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/existing-submission":
+			return submitJSONResponse(http.StatusOK, `{
+				"data": {
+					"type": "reviewSubmissions",
+					"id": "existing-submission",
+					"attributes": {
+						"state": "READY_FOR_REVIEW",
+						"platform": "IOS"
+					},
+					"relationships": {
+						"app": {
+							"data": {"type": "apps", "id": "app-1"}
+						}
+					}
+				}
+			}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/reviewSubmissions":
 			createdSubmission = true
 			return submitJSONResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"new-submission"}}`)

--- a/internal/cli/submit/submit_revalidation_test.go
+++ b/internal/cli/submit/submit_revalidation_test.go
@@ -1,0 +1,289 @@
+package submit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSubmitResolvedVersionRejectsUnverifiedConflictSubmission(t *testing.T) {
+	var submitted bool
+	itemPage := 0
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
+			return submitJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/reviewSubmissions":
+			return submitJSONResponse(http.StatusCreated, `{"data":{"type":"reviewSubmissions","id":"new-submission"}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/reviewSubmissionItems":
+			return submitJSONResponse(http.StatusConflict, submitAlreadyAddedConflictBody("conflict-submission"))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/conflict-submission":
+			if got := req.URL.Query().Get("include"); got != "app" {
+				return nil, fmt.Errorf("expected include=app, got %q", got)
+			}
+			return submitJSONResponse(http.StatusOK, `{
+				"data": {
+					"type": "reviewSubmissions",
+					"id": "conflict-submission",
+					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"},
+					"relationships": {
+						"app": {"data": {"type": "apps", "id": "app-1"}}
+					}
+				}
+			}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/conflict-submission/items":
+			itemPage++
+			if req.URL.Query().Get("cursor") == "" {
+				return submitJSONResponse(http.StatusOK, `{
+					"data": [{
+						"type": "reviewSubmissionItems",
+						"id": "target-item",
+						"relationships": {
+							"appStoreVersion": {
+								"data": {"type": "appStoreVersions", "id": "version-1"}
+							}
+						}
+					}],
+					"links": {"next": "https://api.appstoreconnect.apple.com/v1/reviewSubmissions/conflict-submission/items?cursor=page-2"}
+				}`)
+			}
+			return submitJSONResponse(http.StatusOK, `{
+				"data": [{"type": "reviewSubmissionItems", "id": "unrelated-item"}],
+				"links": {}
+			}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/new-submission":
+			return submitJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"new-submission"}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/conflict-submission":
+			submitted = true
+			return submitJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"conflict-submission"}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	_, err := SubmitResolvedVersion(context.Background(), client, SubmitResolvedVersionOptions{
+		AppID:     "app-1",
+		VersionID: "version-1",
+		Platform:  "IOS",
+	})
+	if err == nil {
+		t.Fatal("expected mixed conflict submission to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unrelated review items") {
+		t.Fatalf("expected exclusive-target verification error, got %v", err)
+	}
+	if itemPage != 2 {
+		t.Fatalf("expected every conflict-submission item page to be inspected, got %d", itemPage)
+	}
+	if submitted {
+		t.Fatal("must not submit a conflict-derived submission that has unrelated review items")
+	}
+}
+
+func TestVerifyReviewSubmissionForSubmitRejectsWrongBinding(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes string
+		appID      string
+		want       string
+	}{
+		{
+			name:       "state",
+			attributes: `"state": "CANCELING", "platform": "IOS"`,
+			appID:      "app-1",
+			want:       "not \"READY_FOR_REVIEW\"",
+		},
+		{
+			name:       "platform",
+			attributes: `"state": "READY_FOR_REVIEW", "platform": "MAC_OS"`,
+			appID:      "app-1",
+			want:       "not \"IOS\"",
+		},
+		{
+			name:       "app",
+			attributes: `"state": "READY_FOR_REVIEW", "platform": "IOS"`,
+			appID:      "app-2",
+			want:       "belongs to app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			itemReads := 0
+			client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/submission-1":
+					return submitJSONResponse(http.StatusOK, fmt.Sprintf(`{
+						"data": {
+							"type": "reviewSubmissions",
+							"id": "submission-1",
+							"attributes": {%s},
+							"relationships": {
+								"app": {"data": {"type": "apps", "id": %q}}
+							}
+						}
+					}`, tt.attributes, tt.appID))
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/submission-1/items":
+					itemReads++
+					return submitJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+				default:
+					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+				}
+			}))
+
+			err := verifyReviewSubmissionForSubmit(
+				context.Background(),
+				client,
+				"submission-1",
+				"app-1",
+				"IOS",
+				"version-1",
+			)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q binding error, got %v", tt.want, err)
+			}
+			if itemReads != 0 {
+				t.Fatalf("expected binding mismatch to fail before item inspection, got %d item reads", itemReads)
+			}
+		})
+	}
+}
+
+func TestSubmitResolvedVersionReusesTargetOnlySubmissionWithoutVersionRelationship(t *testing.T) {
+	itemReads := 0
+	detailReads := 0
+	var submitted bool
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
+			return submitJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "reviewSubmissions",
+					"id": "existing-submission",
+					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"}
+				}],
+				"links": {}
+			}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/existing-submission":
+			detailReads++
+			return submitJSONResponse(http.StatusOK, `{
+				"data": {
+					"type": "reviewSubmissions",
+					"id": "existing-submission",
+					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"},
+					"relationships": {
+						"app": {"data": {"type": "apps", "id": "app-1"}}
+					}
+				}
+			}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/existing-submission/items":
+			itemReads++
+			return submitJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "reviewSubmissionItems",
+					"id": "target-item",
+					"relationships": {
+						"appStoreVersion": {
+							"data": {"type": "appStoreVersions", "id": "version-1"}
+						}
+					}
+				}],
+				"links": {}
+			}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/existing-submission":
+			submitted = true
+			return submitJSONResponse(http.StatusOK, `{
+				"data": {
+					"type": "reviewSubmissions",
+					"id": "existing-submission",
+					"attributes": {"state": "WAITING_FOR_REVIEW"}
+				}
+			}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	result, err := SubmitResolvedVersion(context.Background(), client, SubmitResolvedVersionOptions{
+		AppID:     "app-1",
+		VersionID: "version-1",
+		Platform:  "IOS",
+	})
+	if err != nil {
+		t.Fatalf("SubmitResolvedVersion() error: %v", err)
+	}
+	if result.SubmissionID != "existing-submission" || !submitted {
+		t.Fatalf("expected target-only submission to be reused and submitted, got %#v", result)
+	}
+	if detailReads != 1 {
+		t.Fatalf("expected one fresh detail recheck immediately before submit, got %d", detailReads)
+	}
+	if itemReads != 2 {
+		t.Fatalf("expected preparation plus fresh item membership checks, got %d", itemReads)
+	}
+}
+
+func TestPrepareReviewSubmissionForCreateNeverCancelsExistingSubmission(t *testing.T) {
+	var canceled bool
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
+			return submitJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "reviewSubmissions",
+					"id": "other-version-submission",
+					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"},
+					"relationships": {
+						"appStoreVersionForReview": {
+							"data": {"type": "appStoreVersions", "id": "version-2"}
+						}
+					}
+				}]
+			}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/other-version-submission/items":
+			return submitJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+		case req.Method == http.MethodPatch:
+			canceled = true
+			return submitJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"other-version-submission"}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+	}))
+
+	var messages []string
+	got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", func(message string) {
+		messages = append(messages, message)
+	})
+	if got.reuseSubmissionID != "" {
+		t.Fatalf("must not reuse a submission explicitly bound to another version: %#v", got)
+	}
+	if canceled {
+		t.Fatal("preparation must never implicitly cancel an existing submission")
+	}
+	if !strings.Contains(strings.Join(messages, "\n"), "asc submit cancel --id other-version-submission --confirm") {
+		t.Fatalf("expected explicit cancellation remediation, got %v", messages)
+	}
+}
+
+func TestReviewSubmissionInspectorCachesFailedInspection(t *testing.T) {
+	itemReads := 0
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/reviewSubmissions/submission-1/items" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
+		}
+		itemReads++
+		return submitJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","title":"Invalid request"}]}`)
+	}))
+	inspector := newReviewSubmissionInspector(client, "version-1")
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if _, err := inspector.summarize(context.Background(), "submission-1"); err == nil {
+			t.Fatal("expected failed item inspection")
+		}
+	}
+	if itemReads != 1 {
+		t.Fatalf("expected failed item inspection to be cached, got %d requests", itemReads)
+	}
+}

--- a/internal/cli/submit/submit_test.go
+++ b/internal/cli/submit/submit_test.go
@@ -2148,140 +2148,6 @@ func TestCollectSubmissionErrorSignalsTraversesJoinedErrorTree(t *testing.T) {
 	}
 }
 
-func TestAddVersionToSubmissionOrRecover_ExhaustsRetriesForRecentlyCanceledSubmission(t *testing.T) {
-	const staleSubmissionID = "stale-1"
-
-	attempts := 0
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method != http.MethodPost || req.URL.Path != "/v1/reviewSubmissionItems" {
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
-		}
-		attempts++
-		return submitJSONResponse(http.StatusConflict, submitAlreadyAddedConflictBody(staleSubmissionID))
-	}))
-
-	originalDelays := submitCreateRecentlyCanceledRetryDelays
-	submitCreateRecentlyCanceledRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
-	t.Cleanup(func() {
-		submitCreateRecentlyCanceledRetryDelays = originalDelays
-	})
-
-	resolvedID, err := addVersionToSubmissionOrRecover(
-		context.Background(),
-		client,
-		"new-sub-1",
-		"version-1",
-		map[string]struct{}{staleSubmissionID: {}},
-		nil,
-	)
-	if err == nil {
-		t.Fatal("expected retry exhaustion error")
-	}
-	if resolvedID != "" {
-		t.Fatalf("expected empty resolved submission ID on failure, got %q", resolvedID)
-	}
-	if !strings.Contains(err.Error(), "still attached to recently canceled review submission stale-1 after 2 retries") {
-		t.Fatalf("expected retry exhaustion message, got: %v", err)
-	}
-	if attempts != 3 {
-		t.Fatalf("expected 3 add-item attempts (initial + 2 retries), got %d", attempts)
-	}
-}
-
-func TestAddVersionToSubmissionOrRecover_RetriesStillInProgressConflictForRecentlyCanceledSubmission(t *testing.T) {
-	const staleSubmissionID = "stale-1"
-
-	attempts := 0
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method != http.MethodPost || req.URL.Path != "/v1/reviewSubmissionItems" {
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
-		}
-		attempts++
-		if attempts < 3 {
-			return submitJSONResponse(http.StatusConflict, submitStillInProgressConflictBody(staleSubmissionID))
-		}
-		return submitJSONResponse(http.StatusCreated, `{
-			"data": {
-				"type": "reviewSubmissionItems",
-				"id": "item-123",
-				"attributes": {
-					"state": "READY_FOR_REVIEW"
-				}
-			}
-		}`)
-	}))
-
-	originalDelays := submitCreateRecentlyCanceledRetryDelays
-	submitCreateRecentlyCanceledRetryDelays = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
-	t.Cleanup(func() {
-		submitCreateRecentlyCanceledRetryDelays = originalDelays
-	})
-
-	resolvedID, err := addVersionToSubmissionOrRecover(
-		context.Background(),
-		client,
-		"new-sub-1",
-		"version-1",
-		map[string]struct{}{staleSubmissionID: {}},
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("expected retry recovery, got %v", err)
-	}
-	if resolvedID != "new-sub-1" {
-		t.Fatalf("expected new submission ID after retry recovery, got %q", resolvedID)
-	}
-	if attempts != 3 {
-		t.Fatalf("expected 3 add-item attempts (2 conflicts + success), got %d", attempts)
-	}
-}
-
-func TestAddVersionToSubmissionOrRecover_ReturnsContextErrorWhileWaitingForDetach(t *testing.T) {
-	const staleSubmissionID = "stale-1"
-
-	attempts := 0
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method != http.MethodPost || req.URL.Path != "/v1/reviewSubmissionItems" {
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
-		}
-		attempts++
-		return submitJSONResponse(http.StatusConflict, submitAlreadyAddedConflictBody(staleSubmissionID))
-	}))
-
-	originalDelays := submitCreateRecentlyCanceledRetryDelays
-	submitCreateRecentlyCanceledRetryDelays = []time.Duration{100 * time.Millisecond}
-	t.Cleanup(func() {
-		submitCreateRecentlyCanceledRetryDelays = originalDelays
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-
-	resolvedID, err := addVersionToSubmissionOrRecover(
-		ctx,
-		client,
-		"new-sub-1",
-		"version-1",
-		map[string]struct{}{staleSubmissionID: {}},
-		nil,
-	)
-	if err == nil {
-		t.Fatal("expected context cancellation while waiting to retry")
-	}
-	if resolvedID != "" {
-		t.Fatalf("expected empty resolved submission ID on failure, got %q", resolvedID)
-	}
-	if !strings.Contains(err.Error(), "waiting for recently canceled review submission stale-1 to clear") {
-		t.Fatalf("expected wait/cancellation error message, got: %v", err)
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected wrapped context deadline exceeded error, got: %v", err)
-	}
-	if attempts != 1 {
-		t.Fatalf("expected one add-item attempt before context cancellation, got %d", attempts)
-	}
-}
-
 func TestCleanupEmptyReviewSubmissionWarnsOnUnexpectedCancelError(t *testing.T) {
 	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodPatch || req.URL.Path != "/v1/reviewSubmissions/empty-sub-1" {
@@ -2350,149 +2216,6 @@ func TestCleanupEmptyReviewSubmissionWarnsOnGenericConflict(t *testing.T) {
 	}
 }
 
-func TestPrepareReviewSubmissionForCreateWarnsOnGenericConflict(t *testing.T) {
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissions",
-					"id": "stale-sub-1",
-					"attributes": {
-						"state": "READY_FOR_REVIEW",
-						"platform": "IOS"
-					}
-				}]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1/items":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissionItems",
-					"id": "version-item",
-					"relationships": {
-						"appStoreVersion": {
-							"data": {"type": "appStoreVersions", "id": "version-1"}
-						}
-					}
-				}]
-			}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1":
-			return submitJSONResponse(http.StatusConflict, `{
-				"errors": [{
-					"status": "409",
-					"code": "CONFLICT",
-					"title": "Conflict",
-					"detail": "Another operation is already in progress"
-				}]
-			}`)
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
-		}
-	}))
-
-	stderr := captureSubmitStderr(t, func() {
-		got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", nil)
-		if got.reuseSubmissionID != "" {
-			t.Fatalf("expected no reusable submission, got %#v", got)
-		}
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("expected no canceled submissions, got %#v", got.canceledSubmissionIDs)
-		}
-	})
-	if !strings.Contains(stderr, "Warning: failed to cancel stale submission stale-sub-1:") {
-		t.Fatalf("expected stale submission warning for generic conflict, got %q", stderr)
-	}
-	if strings.Contains(stderr, "Skipped stale submission stale-sub-1") {
-		t.Fatalf("did not expect stale submission skip message, got %q", stderr)
-	}
-}
-
-func TestPrepareReviewSubmissionForCreateDoesNotReuseSubmissionThatBecameCanceling(t *testing.T) {
-	requests := make([]string, 0, 3)
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.RequestURI())
-
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissions",
-					"id": "stale-sub-1",
-					"attributes": {
-						"state": "READY_FOR_REVIEW",
-						"platform": "IOS"
-					}
-				}]
-			}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1":
-			return submitJSONResponse(http.StatusConflict, `{
-				"errors": [{
-					"status": "409",
-					"code": "CONFLICT",
-					"title": "Resource state is invalid.",
-					"detail": "Resource is not in cancellable state"
-				}]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": {
-					"type": "reviewSubmissions",
-					"id": "stale-sub-1",
-					"attributes": {
-						"state": "CANCELING",
-						"platform": "IOS"
-					},
-					"relationships": {
-						"appStoreVersionForReview": {
-							"data": {"type": "appStoreVersions", "id": "version-1"}
-						}
-					}
-				}
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1/items":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissionItems",
-					"id": "version-item",
-					"relationships": {
-						"appStoreVersion": {
-							"data": {"type": "appStoreVersions", "id": "version-1"}
-						}
-					}
-				}]
-			}`)
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
-		}
-	}))
-
-	stderr := captureSubmitStderr(t, func() {
-		got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", nil)
-		if got.reuseSubmissionID != "" {
-			t.Fatalf("expected no reusable submission after refreshed CANCELING state, got %#v", got)
-		}
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("expected no canceled submissions, got %#v", got.canceledSubmissionIDs)
-		}
-	})
-
-	wantRequests := []string{
-		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/stale-sub-1/items?limit=200",
-		"PATCH /v1/reviewSubmissions/stale-sub-1",
-		"GET /v1/reviewSubmissions/stale-sub-1",
-	}
-	if !reflect.DeepEqual(requests, wantRequests) {
-		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
-	}
-	if !strings.Contains(stderr, "Skipped stale submission stale-sub-1: already transitioned to a non-cancellable state") {
-		t.Fatalf("expected stale submission skip message, got %q", stderr)
-	}
-	if strings.Contains(stderr, "Reusing existing review submission stale-sub-1") {
-		t.Fatalf("did not expect reuse message, got %q", stderr)
-	}
-}
-
 // TestPrepareReviewSubmissionForCreateSkipsMixedTargetVersionSubmission proves
 // that a submission holding the selected version alongside other review items
 // (another version, an in-app purchase, an app event) is neither reused nor
@@ -2553,9 +2276,6 @@ func TestPrepareReviewSubmissionForCreateSkipsMixedTargetVersionSubmission(t *te
 		if got.reuseSubmissionHasVersion {
 			t.Fatalf("expected mixed-item submission not to be marked as reusable target version, got %#v", got)
 		}
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("expected no canceled submissions, got %#v", got.canceledSubmissionIDs)
-		}
 	})
 
 	wantRequests := []string{
@@ -2613,9 +2333,6 @@ func TestPrepareReviewSubmissionForCreateTreatsEmptyItemsAsMissingVersion(t *tes
 		if got.reuseSubmissionHasVersion {
 			t.Fatalf("expected empty-items submission to require re-attaching the version, got %#v", got)
 		}
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("did not expect canceled submissions when reusable empty submission exists, got %#v", got.canceledSubmissionIDs)
-		}
 	})
 
 	wantRequests := []string{
@@ -2627,103 +2344,6 @@ func TestPrepareReviewSubmissionForCreateTreatsEmptyItemsAsMissingVersion(t *tes
 	}
 	if !strings.Contains(stderr, "Reusing existing review submission empty-items-submission") {
 		t.Fatalf("expected reuse message for empty-items submission, got %q", stderr)
-	}
-}
-
-func TestPrepareReviewSubmissionForCreatePreservesCanceledIDsWhenReusingAfterConflict(t *testing.T) {
-	requests := make([]string, 0, 6)
-	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.RequestURI())
-
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/reviewSubmissions":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [
-					{
-						"type": "reviewSubmissions",
-						"id": "stale-sub-1",
-						"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"}
-					},
-					{
-						"type": "reviewSubmissions",
-						"id": "reusable-empty-sub",
-						"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"}
-					}
-				]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1/items":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": [{
-					"type": "reviewSubmissionItems",
-					"id": "version-item",
-					"relationships": {
-						"appStoreVersion": {
-							"data": {"type": "appStoreVersions", "id": "version-1"}
-						}
-					}
-				}]
-			}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/stale-sub-1":
-			return submitJSONResponse(http.StatusOK, `{"data":{"type":"reviewSubmissions","id":"stale-sub-1"}}`)
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/reviewSubmissions/reusable-empty-sub":
-			return submitJSONResponse(http.StatusConflict, `{
-				"errors": [{
-					"status": "409",
-					"code": "CONFLICT",
-					"title": "Resource state is invalid.",
-					"detail": "Resource is not in cancellable state"
-				}]
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/reusable-empty-sub":
-			return submitJSONResponse(http.StatusOK, `{
-				"data": {
-					"type": "reviewSubmissions",
-					"id": "reusable-empty-sub",
-					"attributes": {"state": "READY_FOR_REVIEW", "platform": "IOS"},
-					"relationships": {
-						"appStoreVersionForReview": {
-							"data": {"type": "appStoreVersions", "id": "version-1"}
-						}
-					}
-				}
-			}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/reviewSubmissions/reusable-empty-sub/items":
-			return submitJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.RequestURI())
-		}
-	}))
-
-	stderr := captureSubmitStderr(t, func() {
-		got := prepareReviewSubmissionForCreate(context.Background(), client, "app-1", "IOS", "version-1", nil)
-		if got.reuseSubmissionID != "reusable-empty-sub" {
-			t.Fatalf("expected reusable submission after cancel conflict, got %#v", got)
-		}
-		if got.reuseSubmissionHasVersion {
-			t.Fatalf("expected empty reusable submission to require re-adding the version, got %#v", got)
-		}
-		if _, ok := got.canceledSubmissionIDs["stale-sub-1"]; !ok {
-			t.Fatalf("expected earlier canceled submission ID to be preserved, got %#v", got.canceledSubmissionIDs)
-		}
-	})
-
-	wantRequests := []string{
-		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/stale-sub-1/items?limit=200",
-		"PATCH /v1/reviewSubmissions/stale-sub-1",
-		"GET /v1/reviewSubmissions/reusable-empty-sub/items?limit=200",
-		"PATCH /v1/reviewSubmissions/reusable-empty-sub",
-		"GET /v1/reviewSubmissions/reusable-empty-sub",
-		"GET /v1/reviewSubmissions/reusable-empty-sub/items?limit=200",
-	}
-	if !reflect.DeepEqual(requests, wantRequests) {
-		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
-	}
-	if !strings.Contains(stderr, "Canceled stale review submission stale-sub-1") {
-		t.Fatalf("expected stale submission cancellation message, got %q", stderr)
-	}
-	if !strings.Contains(stderr, "Reusing existing empty review submission reusable-empty-sub") {
-		t.Fatalf("expected empty reusable submission message, got %q", stderr)
 	}
 }
 
@@ -2781,9 +2401,6 @@ func TestPrepareReviewSubmissionForCreatePaginatesReadyForReviewLookups(t *testi
 		}
 		if !got.reuseSubmissionHasVersion {
 			t.Fatalf("expected reused paginated submission to already carry the target version, got %#v", got)
-		}
-		if got.canceledSubmissionIDs != nil {
-			t.Fatalf("did not expect canceled submissions when paginated reusable submission exists, got %#v", got.canceledSubmissionIDs)
 		}
 	})
 
@@ -3066,25 +2683,6 @@ func submitAlreadyAddedConflictBody(existingSubmissionID string) string {
 					"/v1/reviewSubmissionItems": [{
 						"code": "ENTITY_ERROR.RELATIONSHIP.INVALID",
 						"detail": "appStoreVersions with id version-1 was already added to another reviewSubmission with id %s"
-					}]
-				}
-			}
-		}]
-	}`, existingSubmissionID)
-}
-
-func submitStillInProgressConflictBody(existingSubmissionID string) string {
-	return fmt.Sprintf(`{
-		"errors": [{
-			"status": "409",
-			"code": "ENTITY_ERROR",
-			"title": "The request entity is not valid.",
-			"detail": "This resource cannot be reviewed, please check associated errors to see why.",
-			"meta": {
-				"associatedErrors": {
-					"/v1/reviewSubmissionItems": [{
-						"code": "ENTITY_ERROR.RELATIONSHIP.INVALID",
-						"detail": "appStoreVersions with id version-1 is already in another reviewSubmission with id %s still in progress"
 					}]
 				}
 			}

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -79,8 +79,9 @@ CSV format:
   email,first_name,last_name,groups
   - groups are semicolon-delimited when present (for fastlane compatibility)
   - a cell whose first character would start a spreadsheet formula (=, +, -, @)
-    is prefixed with a single quote so spreadsheet software treats it as text;
-    "beta-testers import" removes that prefix again
+    is prefixed with a single quote so spreadsheet software treats it as text
+  - when escaping is needed, an _asc_formula_escaping provenance column is
+    included so "beta-testers import" only removes prefixes added by this export
 
 Examples:
   asc testflight beta-testers export --app "APP_ID" --output "./testflight-testers.csv"
@@ -282,8 +283,9 @@ CSV formats accepted:
 
 Groups are semicolon-delimited in canonical import/export files.
 For compatibility, comma-delimited groups are also accepted when no semicolon is present.
-A leading single quote before =, +, -, or @ is removed, reversing the formula
-neutralization that "beta-testers export" applies.
+Exports that neutralize spreadsheet formulas include an _asc_formula_escaping
+provenance column. Only rows carrying the supported marker have the export-added
+single quote removed; user-authored CSV apostrophes are preserved.
 
 Examples:
   asc testflight beta-testers import --app "APP_ID" --input "./testflight-testers.csv" --dry-run
@@ -863,7 +865,7 @@ func validateBetaTestersCSVHeader(header []string) (map[string]int, error) {
 		}
 		canonical, ok := canonicalBetaTestersCSVColumn(col)
 		if !ok {
-			return nil, shared.UsageErrorf("unknown CSV column %q (allowed: email, first_name, last_name, groups)", col)
+			return nil, shared.UsageErrorf("unknown CSV column %q (allowed: email, first_name, last_name, groups, %s)", col, betaTestersFormulaEscapingColumn)
 		}
 		col = canonical
 		if _, exists := idx[col]; exists {
@@ -928,22 +930,32 @@ func canonicalBetaTestersCSVColumn(col string) (string, bool) {
 		return "last_name", true
 	case "groups":
 		return "groups", true
+	case betaTestersFormulaEscapingColumn:
+		return betaTestersFormulaEscapingColumn, true
 	default:
 		return "", false
 	}
 }
 
 func parseHeaderMappedBetaTesterCSVRow(record []string, headerIdx map[string]int) betaTestersCSVRow {
+	formulaEscaped := false
+	if idx, ok := headerIdx[betaTestersFormulaEscapingColumn]; ok && idx >= 0 && idx < len(record) {
+		formulaEscaped = strings.TrimSpace(record[idx]) == betaTestersFormulaEscapingVersion
+	}
 	get := func(col string) string {
 		i, ok := headerIdx[col]
 		if !ok || i < 0 || i >= len(record) {
 			return ""
 		}
-		return strings.TrimSpace(denormalizeSpreadsheetFormula(record[i]))
+		value := record[i]
+		if formulaEscaped {
+			value = denormalizeSpreadsheetFormula(value)
+		}
+		return strings.TrimSpace(value)
 	}
 	groups := make([]string, 0)
 	if idx, ok := headerIdx["groups"]; ok && idx >= 0 && idx < len(record) {
-		groups = splitBetaTesterCSVGroups(record[idx])
+		groups = splitBetaTesterCSVGroups(record[idx], formulaEscaped)
 	}
 	return betaTestersCSVRow{
 		email:     get("email"),
@@ -958,18 +970,21 @@ func parseLegacyBetaTesterCSVRow(record []string) (betaTestersCSVRow, error) {
 		return betaTestersCSVRow{}, shared.UsageError("legacy CSV rows must have 3 or 4 columns: first_name,last_name,email[,groups]")
 	}
 	row := betaTestersCSVRow{
-		firstName: strings.TrimSpace(denormalizeSpreadsheetFormula(record[0])),
-		lastName:  strings.TrimSpace(denormalizeSpreadsheetFormula(record[1])),
-		email:     strings.TrimSpace(denormalizeSpreadsheetFormula(record[2])),
+		firstName: strings.TrimSpace(record[0]),
+		lastName:  strings.TrimSpace(record[1]),
+		email:     strings.TrimSpace(record[2]),
 	}
 	if len(record) >= 4 {
-		row.groups = splitBetaTesterCSVGroups(record[3])
+		row.groups = splitBetaTesterCSVGroups(record[3], false)
 	}
 	return row, nil
 }
 
-func splitBetaTesterCSVGroups(value string) []string {
-	trimmed := strings.TrimSpace(denormalizeSpreadsheetFormula(value))
+func splitBetaTesterCSVGroups(value string, formulaEscaped bool) []string {
+	if formulaEscaped {
+		value = denormalizeSpreadsheetFormula(value)
+	}
+	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return nil
 	}
@@ -1008,9 +1023,14 @@ const spreadsheetFormulaMarkers = "=+-@"
 
 // spreadsheetTextPrefix neutralizes a formula-leading cell. Spreadsheet software
 // reads a leading apostrophe as "the rest of this cell is text" and does not
-// display it; `asc testflight beta-testers import` strips it again, so exported
-// files still round-trip.
+// display it. Exported rows carry a provenance marker so import can strip only
+// prefixes written by asc and leave user-authored apostrophes unchanged.
 const spreadsheetTextPrefix = "'"
+
+const (
+	betaTestersFormulaEscapingColumn  = "_asc_formula_escaping"
+	betaTestersFormulaEscapingVersion = "apostrophe-v1"
+)
 
 func neutralizeSpreadsheetFormulaRow(row []string) []string {
 	safe := make([]string, len(row))
@@ -1020,13 +1040,22 @@ func neutralizeSpreadsheetFormulaRow(row []string) []string {
 	return safe
 }
 
+func rowNeedsSpreadsheetFormulaEscaping(row []string) bool {
+	for _, cell := range row {
+		if neutralizeSpreadsheetFormula(cell) != cell {
+			return true
+		}
+	}
+	return false
+}
+
 // neutralizeSpreadsheetFormula prefixes externally derived cells whose first
 // effective character would start a spreadsheet formula. Leading whitespace and
 // control characters are skipped when looking for that character, because
 // spreadsheet software ignores them too. A cell that already begins with
-// literal apostrophes in front of a formula character gains one more, so import
-// can always remove exactly one and recover the original value. Safe cells are
-// returned unchanged.
+// literal apostrophes in front of a formula character gains one more; the
+// provenance-marked import path can then remove exactly one and recover the
+// original value. Safe cells are returned unchanged.
 func neutralizeSpreadsheetFormula(value string) string {
 	if !isSpreadsheetFormulaCell(strings.TrimLeft(value, spreadsheetTextPrefix)) {
 		return value
@@ -1034,10 +1063,9 @@ func neutralizeSpreadsheetFormula(value string) string {
 	return spreadsheetTextPrefix + value
 }
 
-// denormalizeSpreadsheetFormula reverses neutralizeSpreadsheetFormula so an
-// exported file can be imported again without the neutralization prefix leaking
-// into tester or group values. Exactly one prefix apostrophe is removed, which
-// also restores values whose originals begin with literal apostrophes.
+// denormalizeSpreadsheetFormula reverses neutralizeSpreadsheetFormula for rows
+// carrying the asc export provenance marker. Exactly one prefix apostrophe is
+// removed, which also restores values whose originals begin with apostrophes.
 func denormalizeSpreadsheetFormula(value string) string {
 	if !strings.HasPrefix(value, spreadsheetTextPrefix) {
 		return value
@@ -1099,11 +1127,27 @@ func writeCSVFileAtomicNoSymlink(outputPath string, header []string, rows [][]st
 	}
 
 	w := csv.NewWriter(tempFile)
-	if err := w.Write(header); err != nil {
+	formulaEscaping := false
+	for _, row := range rows {
+		if rowNeedsSpreadsheetFormulaEscaping(row) {
+			formulaEscaping = true
+			break
+		}
+	}
+
+	csvHeader := append([]string(nil), header...)
+	if formulaEscaping {
+		csvHeader = append(csvHeader, betaTestersFormulaEscapingColumn)
+	}
+	if err := w.Write(csvHeader); err != nil {
 		return err
 	}
 	for _, row := range rows {
-		if err := w.Write(neutralizeSpreadsheetFormulaRow(row)); err != nil {
+		csvRow := row
+		if formulaEscaping {
+			csvRow = append(neutralizeSpreadsheetFormulaRow(row), betaTestersFormulaEscapingVersion)
+		}
+		if err := w.Write(csvRow); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/testflight/beta_testers_csv_formula_test.go
+++ b/internal/cli/testflight/beta_testers_csv_formula_test.go
@@ -72,24 +72,53 @@ func TestWriteCSVFileNeutralizesFormulaLeadingCells(t *testing.T) {
 		t.Fatalf("expected %d records, got %d", len(rows)+1, len(records))
 	}
 
-	if strings.Join(records[0], ",") != strings.Join(header, ",") {
-		t.Fatalf("header = %q, want %q", records[0], header)
+	wantHeader := append(append([]string(nil), header...), "_asc_formula_escaping")
+	if strings.Join(records[0], ",") != strings.Join(wantHeader, ",") {
+		t.Fatalf("header = %q, want %q", records[0], wantHeader)
 	}
-	if strings.Join(records[1], ",") != strings.Join(rows[0], ",") {
-		t.Fatalf("safe row = %q, want it unchanged %q", records[1], rows[0])
+	wantSafeRow := append(append([]string(nil), rows[0]...), "apostrophe-v1")
+	if strings.Join(records[1], ",") != strings.Join(wantSafeRow, ",") {
+		t.Fatalf("safe row = %q, want values unchanged plus provenance %q", records[1], wantSafeRow)
 	}
 
 	for _, record := range records[1:] {
-		for _, cell := range record {
+		for _, cell := range record[:len(header)] {
 			if isSpreadsheetFormulaCell(cell) {
 				t.Fatalf("cell %q would be interpreted as a spreadsheet formula", cell)
 			}
 		}
 	}
 
-	want := []string{"'-tester@example.com", "'=1+1", "' @SUM(A1)", "'+Internal;-Beta"}
+	want := []string{"'-tester@example.com", "'=1+1", "' @SUM(A1)", "'+Internal;-Beta", "apostrophe-v1"}
 	if strings.Join(records[2], ",") != strings.Join(want, ",") {
 		t.Fatalf("neutralized row = %q, want %q", records[2], want)
+	}
+}
+
+func TestWriteCSVFileKeepsCanonicalSchemaWhenNoCellNeedsEscaping(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "testers.csv")
+	header := []string{"email", "first_name", "last_name", "groups"}
+	rows := [][]string{{"tester@example.com", "Ada", "Lovelace", "Beta"}}
+
+	if err := writeCSVFileAtomicNoSymlink(outputPath, header, rows); err != nil {
+		t.Fatalf("writeCSVFileAtomicNoSymlink() error: %v", err)
+	}
+
+	file, err := os.Open(outputPath)
+	if err != nil {
+		t.Fatalf("open csv: %v", err)
+	}
+	defer file.Close()
+
+	records, err := csv.NewReader(file).ReadAll()
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if strings.Join(records[0], ",") != strings.Join(header, ",") {
+		t.Fatalf("header = %q, want unchanged canonical header %q", records[0], header)
+	}
+	if strings.Join(records[1], ",") != strings.Join(rows[0], ",") {
+		t.Fatalf("row = %q, want unchanged canonical row %q", records[1], rows[0])
 	}
 }
 
@@ -130,5 +159,31 @@ func TestBetaTesterCSVRoundTripsNeutralizedCells(t *testing.T) {
 	}
 	if strings.Join(parsed[1].groups, ";") != "'=Internal" {
 		t.Fatalf("groups = %q, want %q", parsed[1].groups, []string{"'=Internal"})
+	}
+}
+
+func TestBetaTesterCSVImportPreservesUnmarkedLeadingApostrophes(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "third-party.csv")
+	content := "email,first_name,last_name,groups\n" +
+		"tester@example.com,'=Ada,''@Lovelace,'=Internal\n"
+	if err := os.WriteFile(inputPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	parsed, err := readBetaTestersCSV(inputPath)
+	if err != nil {
+		t.Fatalf("readBetaTestersCSV() error: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(parsed))
+	}
+	if parsed[0].firstName != "'=Ada" {
+		t.Fatalf("first name = %q, want literal user-authored apostrophe preserved", parsed[0].firstName)
+	}
+	if parsed[0].lastName != "''@Lovelace" {
+		t.Fatalf("last name = %q, want literal user-authored apostrophes preserved", parsed[0].lastName)
+	}
+	if strings.Join(parsed[0].groups, ";") != "'=Internal" {
+		t.Fatalf("groups = %q, want literal user-authored apostrophe preserved", parsed[0].groups)
 	}
 }

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -148,6 +148,7 @@ func VersionsViewCommand() *ffcli.Command {
 	includeBuild := fs.Bool("include-build", false, "Include attached build information")
 	includeSubmission := fs.Bool("include-submission", false, "Include submission information")
 	include := fs.String("include", "", "Include related resources: "+strings.Join(appStoreVersionIncludeList(), ", "))
+	includeSensitive := shared.BindIncludeSensitiveFlag(fs)
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -211,7 +212,15 @@ Examples:
 					}
 				}
 
-				return shared.PrintOutput(versionResp, *output.Output, *output.Pretty)
+				if *includeSensitive {
+					shared.WarnIncludeSensitive(os.Stderr, true)
+					return shared.PrintOutput(versionResp, *output.Output, *output.Pretty)
+				}
+				safe, err := asc.RedactAppStoreReviewDetailIncludesInSingleResponse(versionResp)
+				if err != nil {
+					return fmt.Errorf("versions view: %w", err)
+				}
+				return shared.PrintOutput(safe, *output.Output, *output.Pretty)
 			}
 
 			versionResp, err := client.GetAppStoreVersion(requestCtx, trimmedID)

--- a/internal/cli/web/web_containment_test.go
+++ b/internal/cli/web/web_containment_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -200,6 +201,40 @@ func TestWritePrivacyDeclarationFileWritesOrdinaryOutput(t *testing.T) {
 	}
 }
 
+func TestWritePrivacyDeclarationFilePreservesWhitespacePathBytes(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, " privacy.json ")
+	trimmedPath := filepath.Join(dir, "privacy.json")
+
+	if err := writePrivacyDeclarationFile(outPath, privacyDeclarationFile{}); err != nil {
+		t.Fatalf("writePrivacyDeclarationFile() error = %v", err)
+	}
+	if _, err := os.Lstat(outPath); err != nil {
+		t.Fatalf("Lstat(%q) error = %v", outPath, err)
+	}
+	if _, err := os.Lstat(trimmedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Lstat(%q) error = %v, want not exist", trimmedPath, err)
+	}
+}
+
+func TestParsePrivacyDeclarationFilePreservesWhitespacePathBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), " privacy.json ")
+	writeWebContainmentFile(t, path, `{
+		"schemaVersion": 1,
+		"dataUsages": [
+			{"dataProtections": ["DATA_NOT_COLLECTED"]}
+		]
+	}`)
+
+	declaration, err := parsePrivacyDeclarationFile(path)
+	if err != nil {
+		t.Fatalf("parsePrivacyDeclarationFile() error = %v", err)
+	}
+	if len(declaration.DataUsages) != 1 {
+		t.Fatalf("dataUsages count = %d, want 1", len(declaration.DataUsages))
+	}
+}
+
 func TestParsePrivacyDeclarationFileRefusesSymlinkedInput(t *testing.T) {
 	dir := t.TempDir()
 	externalPath := filepath.Join(t.TempDir(), "external.json")
@@ -214,6 +249,29 @@ func TestParsePrivacyDeclarationFileRefusesSymlinkedInput(t *testing.T) {
 		t.Fatal("parsePrivacyDeclarationFile() error = nil, want symlink rejection")
 	} else if !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("parsePrivacyDeclarationFile() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestDownloadRootPreservesWhitespacePathBytes(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), " downloads ")
+	trimmedDir := filepath.Join(filepath.Dir(outDir), "downloads")
+
+	root, prefix, err := newDownloadRoot(outDir)
+	if err != nil {
+		t.Fatalf("newDownloadRoot() error = %v", err)
+	}
+	name, err := resolveDownloadPath(root, prefix, "screenshot.png", false)
+	if err != nil {
+		t.Fatalf("resolveDownloadPath() error = %v", err)
+	}
+	if err := writeDownloadedAttachment(root, name, []byte("payload")); err != nil {
+		t.Fatalf("writeDownloadedAttachment() error = %v", err)
+	}
+	if got := readWebContainmentFile(t, filepath.Join(outDir, "screenshot.png")); got != "payload" {
+		t.Fatalf("content = %q, want payload", got)
+	}
+	if _, err := os.Lstat(trimmedDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Lstat(%q) error = %v, want not exist", trimmedDir, err)
 	}
 }
 

--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -724,7 +724,6 @@ func validateApplyPlanUsageIDs(plan privacyPlanOutput) error {
 }
 
 func parsePrivacyDeclarationFile(path string) (privacyDeclarationFile, error) {
-	path = strings.TrimSpace(path)
 	if path == "" {
 		return privacyDeclarationFile{}, fmt.Errorf("file path is required")
 	}
@@ -761,11 +760,10 @@ func parsePrivacyDeclarationFile(path string) (privacyDeclarationFile, error) {
 // parent directory of the operator-selected path, so the final component and any
 // component created below it cannot resolve through a symlink.
 func privacyDeclarationRoot(path string) (rootfs.Root, string, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	if path == "" {
 		return rootfs.Root{}, "", fmt.Errorf("file path is required")
 	}
-	absolute, err := filepath.Abs(trimmed)
+	absolute, err := filepath.Abs(path)
 	if err != nil {
 		return rootfs.Root{}, "", err
 	}
@@ -1303,11 +1301,13 @@ Examples:
 			}
 
 			declaration := declarationFromRemoteDataUsages(remoteUsages)
-			outPath := strings.TrimSpace(*out)
+			outPath := *out
 			if outPath != "" {
 				if err := writePrivacyDeclarationFile(outPath, declaration); err != nil {
 					return err
 				}
+			} else {
+				outPath = ""
 			}
 
 			payload := privacyPullOutput{
@@ -1360,7 +1360,7 @@ Examples:
 			if resolvedAppID == "" {
 				return shared.UsageError("--app is required (or set ASC_APP_ID)")
 			}
-			resolvedFilePath := strings.TrimSpace(*filePath)
+			resolvedFilePath := *filePath
 			if resolvedFilePath == "" {
 				return shared.UsageError("--file is required")
 			}
@@ -1440,7 +1440,7 @@ Examples:
 			if resolvedAppID == "" {
 				return shared.UsageError("--app is required (or set ASC_APP_ID)")
 			}
-			resolvedFilePath := strings.TrimSpace(*filePath)
+			resolvedFilePath := *filePath
 			if resolvedFilePath == "" {
 				return shared.UsageError("--file is required")
 			}

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -440,9 +440,8 @@ func sanitizePathPart(value string) string {
 }
 
 func resolveShowOutDir(appID, submissionID, out string) string {
-	trimmedOut := strings.TrimSpace(out)
-	if trimmedOut != "" {
-		return trimmedOut
+	if out != "" {
+		return out
 	}
 	return filepath.Join(".asc", "web-review", sanitizePathPart(appID), sanitizePathPart(submissionID))
 }
@@ -494,11 +493,10 @@ func normalizeAttachmentFilename(attachment webcore.ReviewAttachment) string {
 // the working directory is its own trusted root. The returned prefix is the
 // root-relative output directory.
 func newDownloadRoot(outDir string) (rootfs.Root, string, error) {
-	trimmed := strings.TrimSpace(outDir)
-	if trimmed == "" {
+	if outDir == "" {
 		return rootfs.Root{}, "", fmt.Errorf("output directory is required")
 	}
-	absolute, err := filepath.Abs(trimmed)
+	absolute, err := filepath.Abs(outDir)
 	if err != nil {
 		return rootfs.Root{}, "", fmt.Errorf("failed to resolve output directory %q: %w", outDir, err)
 	}

--- a/internal/cli/web/web_review_test.go
+++ b/internal/cli/web/web_review_test.go
@@ -69,6 +69,13 @@ func TestResolveShowOutDirSanitizesDotDotPathPart(t *testing.T) {
 	}
 }
 
+func TestResolveShowOutDirPreservesWhitespacePathBytes(t *testing.T) {
+	want := filepath.Join(t.TempDir(), " downloads ")
+	if got := resolveShowOutDir("app", "submission", want); got != want {
+		t.Fatalf("resolveShowOutDir() = %q, want %q", got, want)
+	}
+}
+
 func TestBuildReviewListTableRows(t *testing.T) {
 	submissions := []webcore.ReviewSubmission{
 		{

--- a/internal/cli/xcode/inject.go
+++ b/internal/cli/xcode/inject.go
@@ -633,7 +633,7 @@ func validateXcodeInjectDestination(path string, overwrite bool) error {
 // wrote it: resolved from the manifest directory as typed, so a relative
 // --manifest keeps relative result paths and an absolute one stays absolute.
 func xcodeInjectDisplayPath(displayBase, path string) string {
-	return filepath.Clean(filepath.Join(displayBase, strings.TrimSpace(path)))
+	return filepath.Clean(filepath.Join(displayBase, path))
 }
 
 // resolveXcodeInjectPath resolves a manifest-declared path from the manifest
@@ -641,18 +641,17 @@ func xcodeInjectDisplayPath(displayBase, path string) string {
 // paths, volume or UNC-style changes, and traversal that leaves the root are
 // refused because the manifest is repository-controlled.
 func resolveXcodeInjectPath(root rootfs.Root, baseDir string, path string) (string, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	if path == "" {
 		return "", newXcodeInjectUsageError("path is required")
 	}
-	if err := rootfs.ValidateRelativeAllowingTraversal(trimmed); err != nil {
+	if err := rootfs.ValidateRelativeAllowingTraversal(path); err != nil {
 		return "", fmt.Errorf(
 			"%w; manifest paths must be relative to the manifest directory and stay inside %s",
 			err,
 			root.Path(),
 		)
 	}
-	resolved, err := root.Resolve(filepath.Clean(filepath.Join(baseDir, trimmed)))
+	resolved, err := root.Resolve(filepath.Clean(filepath.Join(baseDir, path)))
 	if err != nil {
 		return "", fmt.Errorf("%w; manifest paths must stay inside %s", err, root.Path())
 	}

--- a/internal/cli/xcode/inject_containment_test.go
+++ b/internal/cli/xcode/inject_containment_test.go
@@ -217,3 +217,62 @@ func TestXcodeInjectRejectsSymlinkedCopySourceFile(t *testing.T) {
 		t.Fatal("copy produced an artifact from a symlinked source file")
 	}
 }
+
+func TestXcodeInjectPreservesWhitespaceInCopySourcePath(t *testing.T) {
+	dir := t.TempDir()
+	sourceName := " source.txt "
+	if err := os.WriteFile(filepath.Join(dir, sourceName), []byte("exact source\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "copy", "source": " source.txt ", "path": "copied.txt"}
+		]
+	}`)
+
+	result, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath})
+	if err != nil {
+		t.Fatalf("runXcodeInject() error = %v", err)
+	}
+	if want := filepath.Join(dir, sourceName); result.Outputs[0].Source != want {
+		t.Fatalf("reported source = %q, want exact path %q", result.Outputs[0].Source, want)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "copied.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if want := "exact source\n"; string(got) != want {
+		t.Fatalf("copied contents = %q, want %q", got, want)
+	}
+}
+
+func TestXcodeInjectPreservesWhitespaceInOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	outputName := " generated.txt "
+	manifestPath := filepath.Join(dir, "deployment.json")
+	writeXcodeInjectTestManifest(t, manifestPath, `{
+		"outputs": [
+			{"type": "text", "path": " generated.txt ", "contents": "exact output\n"}
+		]
+	}`)
+
+	result, err := runXcodeInject(xcodeInjectOptions{ManifestPath: manifestPath})
+	if err != nil {
+		t.Fatalf("runXcodeInject() error = %v", err)
+	}
+	if want := filepath.Join(dir, outputName); result.Outputs[0].Path != want {
+		t.Fatalf("reported output = %q, want exact path %q", result.Outputs[0].Path, want)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, outputName))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if want := "exact output\n"; string(got) != want {
+		t.Fatalf("output contents = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "generated.txt")); !os.IsNotExist(err) {
+		t.Fatalf("trimmed output path exists or returned unexpected error: %v", err)
+	}
+}

--- a/internal/cli/xcode/xcode_version.go
+++ b/internal/cli/xcode/xcode_version.go
@@ -110,14 +110,13 @@ Examples:
 }
 
 func selectedProjectInput(projectDir, project string) string {
-	if explicitProject := strings.TrimSpace(project); explicitProject != "" {
-		return explicitProject
+	if project != "" {
+		return project
 	}
-	dir := strings.TrimSpace(projectDir)
-	if dir == "" {
+	if projectDir == "" {
 		return "."
 	}
-	return dir
+	return projectDir
 }
 
 func xcodeVersionViewCommand() *ffcli.Command {

--- a/internal/cli/xcode/xcode_version_test.go
+++ b/internal/cli/xcode/xcode_version_test.go
@@ -81,6 +81,44 @@ func TestXcodeVersionViewCommandSupportsProjectFlag(t *testing.T) {
 	}
 }
 
+func TestSelectedProjectInputPreservesExactPathBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		projectDir string
+		project    string
+		want       string
+	}{
+		{
+			name:       "explicit project with trailing whitespace",
+			projectDir: "./ignored",
+			project:    "./MyApp/Foo.xcodeproj ",
+			want:       "./MyApp/Foo.xcodeproj ",
+		},
+		{
+			name:       "project directory with surrounding whitespace",
+			projectDir: " ./My App ",
+			want:       " ./My App ",
+		},
+		{
+			name:       "all-whitespace explicit project remains a path",
+			projectDir: "./ignored",
+			project:    " ",
+			want:       " ",
+		},
+		{
+			name: "empty values keep default",
+			want: ".",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := selectedProjectInput(test.projectDir, test.project); got != test.want {
+				t.Fatalf("selectedProjectInput(%q, %q) = %q, want %q", test.projectDir, test.project, got, test.want)
+			}
+		})
+	}
+}
+
 func TestXcodeVersionEditCommandOutputsResult(t *testing.T) {
 	originalRunSetVersion := runSetVersion
 	t.Cleanup(func() {

--- a/internal/infoplist/infoplist_test.go
+++ b/internal/infoplist/infoplist_test.go
@@ -2,6 +2,7 @@ package infoplist
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"strings"
@@ -62,6 +63,74 @@ func TestReadBoundedStopsShortOfEndlessStream(t *testing.T) {
 	if source.read > MaxBytes+1 {
 		t.Fatalf("expected at most %d bytes read, got %d", MaxBytes+1, source.read)
 	}
+}
+
+func TestValidateStructureAcceptsDeepButReasonableXML(t *testing.T) {
+	data := nestedXMLPlist(MaxDepth)
+	if err := ValidateStructure(data); err != nil {
+		t.Fatalf("ValidateStructure() rejected plist at depth limit: %v", err)
+	}
+}
+
+func TestValidateStructureRejectsXMLDepthAmplification(t *testing.T) {
+	data := nestedXMLPlist(MaxDepth + 1)
+	err := ValidateStructure(data)
+	if err == nil {
+		t.Fatal("expected excessive plist depth rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "nesting depth") {
+		t.Fatalf("expected nesting-depth error, got %v", err)
+	}
+}
+
+func TestValidateStructureRejectsXMLObjectAmplification(t *testing.T) {
+	var builder strings.Builder
+	builder.WriteString(`<?xml version="1.0"?><plist><array>`)
+	for range MaxObjects + 1 {
+		builder.WriteString(`<true/>`)
+	}
+	builder.WriteString(`</array></plist>`)
+
+	err := ValidateStructure([]byte(builder.String()))
+	if err == nil {
+		t.Fatal("expected excessive plist object-count rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "object count") {
+		t.Fatalf("expected object-count error, got %v", err)
+	}
+}
+
+func TestValidateStructureRejectsBinaryObjectAmplificationFromTrailer(t *testing.T) {
+	data := make([]byte, 40)
+	copy(data, "bplist00")
+	trailer := data[len(data)-32:]
+	trailer[6] = 1
+	trailer[7] = 1
+	binary.BigEndian.PutUint64(trailer[8:16], MaxObjects+1)
+	binary.BigEndian.PutUint64(trailer[16:24], 0)
+	binary.BigEndian.PutUint64(trailer[24:32], 9)
+
+	err := ValidateStructure(data)
+	if err == nil {
+		t.Fatal("expected excessive binary plist object-count rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "object count") {
+		t.Fatalf("expected object-count error, got %v", err)
+	}
+}
+
+func nestedXMLPlist(depth int) []byte {
+	var builder strings.Builder
+	builder.WriteString(`<?xml version="1.0"?><plist>`)
+	for range depth - 1 {
+		builder.WriteString(`<array>`)
+	}
+	builder.WriteString(`<string>value</string>`)
+	for range depth - 1 {
+		builder.WriteString(`</array>`)
+	}
+	builder.WriteString(`</plist>`)
+	return []byte(builder.String())
 }
 
 type countingReader struct {

--- a/internal/infoplist/structure.go
+++ b/internal/infoplist/structure.go
@@ -1,0 +1,321 @@
+package infoplist
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxDepth is the deepest container chain accepted in an app Info.plist.
+// Xcode-generated metadata is normally fewer than ten levels deep. A limit of
+// 128 keeps ample room for hand-authored URL schemes, scene manifests, and
+// extension dictionaries while preventing recursive plist decoders from being
+// driven into pathological stack growth.
+const MaxDepth = 128
+
+// MaxObjects bounds the number of scalar and container values a plist decoder
+// may materialize. Sixty-five thousand values are already far beyond a real
+// app manifest, but keep the 4 MiB byte allowance useful for legitimately wide
+// arrays and dictionaries.
+const MaxObjects = 65_536
+
+// ValidateStructure applies format-aware depth and object-count limits before
+// the third-party plist decoder materializes the document.
+func ValidateStructure(data []byte) error {
+	if len(data) > MaxBytes {
+		return fmt.Errorf("contents exceed the %d byte Info.plist limit", MaxBytes)
+	}
+	if bytes.HasPrefix(data, []byte("bplist")) {
+		return validateBinaryStructure(data)
+	}
+	trimmed := bytes.TrimSpace(data)
+	trimmed = bytes.TrimPrefix(trimmed, []byte{0xEF, 0xBB, 0xBF})
+	trimmed = bytes.TrimSpace(trimmed)
+	if len(trimmed) > 0 && trimmed[0] == '<' {
+		return validateXMLStructure(trimmed)
+	}
+	return validateOpenStepStructure(trimmed)
+}
+
+func validateXMLStructure(data []byte) error {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	depth := 0
+	objects := 0
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("inspect XML structure: %w", err)
+		}
+		switch value := token.(type) {
+		case xml.StartElement:
+			if !isPlistValueElement(value.Name.Local) {
+				continue
+			}
+			objects++
+			if objects > MaxObjects {
+				return fmt.Errorf("info.plist object count exceeds %d", MaxObjects)
+			}
+			depth++
+			if depth > MaxDepth {
+				return fmt.Errorf("info.plist nesting depth exceeds %d", MaxDepth)
+			}
+		case xml.EndElement:
+			if isPlistValueElement(value.Name.Local) {
+				depth--
+			}
+		}
+	}
+}
+
+func isPlistValueElement(name string) bool {
+	switch name {
+	case "dict", "array", "string", "integer", "real", "true", "false", "date", "data":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateOpenStepStructure(data []byte) error {
+	stack := make([]byte, 0, 16)
+	objects := 1
+	inString := false
+	escaped := false
+	lineComment := false
+	blockComment := false
+	inData := false
+
+	for i := 0; i < len(data); i++ {
+		current := data[i]
+		var next byte
+		if i+1 < len(data) {
+			next = data[i+1]
+		}
+		switch {
+		case lineComment:
+			if current == '\n' || current == '\r' {
+				lineComment = false
+			}
+			continue
+		case blockComment:
+			if current == '*' && next == '/' {
+				blockComment = false
+				i++
+			}
+			continue
+		case inString:
+			if escaped {
+				escaped = false
+			} else if current == '\\' {
+				escaped = true
+			} else if current == '"' {
+				inString = false
+			}
+			continue
+		case inData:
+			if current == '>' {
+				inData = false
+			}
+			continue
+		case current == '/' && next == '/':
+			lineComment = true
+			i++
+			continue
+		case current == '/' && next == '*':
+			blockComment = true
+			i++
+			continue
+		case current == '"':
+			inString = true
+			continue
+		case current == '<':
+			inData = true
+			continue
+		case current == '{' || current == '(':
+			stack = append(stack, current)
+			objects++
+			if len(stack) > MaxDepth {
+				return fmt.Errorf("info.plist nesting depth exceeds %d", MaxDepth)
+			}
+		case current == ',' || current == ';':
+			objects++
+		}
+		if objects > MaxObjects {
+			return fmt.Errorf("info.plist object count exceeds %d", MaxObjects)
+		}
+	}
+	return nil
+}
+
+type binaryPlistTrailer struct {
+	offsetSize  uint8
+	refSize     uint8
+	numObjects  uint64
+	topObject   uint64
+	offsetTable uint64
+	trailerAt   uint64
+}
+
+type binaryTraversalEntry struct {
+	object uint64
+	depth  int
+	exit   bool
+}
+
+func validateBinaryStructure(data []byte) error {
+	if len(data) < 40 {
+		return fmt.Errorf("inspect binary structure: document is too short")
+	}
+	trailerAt := uint64(len(data) - 32)
+	trailerBytes := data[trailerAt:]
+	trailer := binaryPlistTrailer{
+		offsetSize:  trailerBytes[6],
+		refSize:     trailerBytes[7],
+		numObjects:  binary.BigEndian.Uint64(trailerBytes[8:16]),
+		topObject:   binary.BigEndian.Uint64(trailerBytes[16:24]),
+		offsetTable: binary.BigEndian.Uint64(trailerBytes[24:32]),
+		trailerAt:   trailerAt,
+	}
+	if trailer.numObjects > MaxObjects {
+		return fmt.Errorf("info.plist object count exceeds %d", MaxObjects)
+	}
+	if trailer.numObjects == 0 || trailer.topObject >= trailer.numObjects {
+		return fmt.Errorf("inspect binary structure: invalid top object")
+	}
+	if trailer.offsetSize == 0 || trailer.offsetSize > 8 || trailer.refSize == 0 || trailer.refSize > 8 {
+		return fmt.Errorf("inspect binary structure: invalid offset or object-reference size")
+	}
+	if trailer.offsetTable < 8 || trailer.offsetTable >= trailer.trailerAt {
+		return fmt.Errorf("inspect binary structure: invalid offset table")
+	}
+	tableBytes := trailer.numObjects * uint64(trailer.offsetSize)
+	if trailer.numObjects != 0 && tableBytes/trailer.numObjects != uint64(trailer.offsetSize) {
+		return fmt.Errorf("inspect binary structure: offset table overflow")
+	}
+	if tableBytes > trailer.trailerAt-trailer.offsetTable {
+		return fmt.Errorf("inspect binary structure: truncated offset table")
+	}
+
+	offsets := make([]uint64, trailer.numObjects)
+	for object := uint64(0); object < trailer.numObjects; object++ {
+		offsetAt := trailer.offsetTable + object*uint64(trailer.offsetSize)
+		offset, ok := readBinaryUint(data, offsetAt, trailer.offsetSize)
+		if !ok || offset < 8 || offset >= trailer.offsetTable {
+			return fmt.Errorf("inspect binary structure: invalid object offset")
+		}
+		offsets[object] = offset
+	}
+
+	state := make([]uint8, trailer.numObjects)
+	stack := []binaryTraversalEntry{{object: trailer.topObject, depth: 1}}
+	for len(stack) > 0 {
+		entry := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if entry.exit {
+			state[entry.object] = 2
+			continue
+		}
+		switch state[entry.object] {
+		case 1:
+			return fmt.Errorf("inspect binary structure: self-referential container")
+		case 2:
+			continue
+		}
+		if entry.depth > MaxDepth {
+			return fmt.Errorf("info.plist nesting depth exceeds %d", MaxDepth)
+		}
+		state[entry.object] = 1
+		stack = append(stack, binaryTraversalEntry{object: entry.object, exit: true})
+
+		children, err := binaryContainerChildren(data, offsets[entry.object], trailer)
+		if err != nil {
+			return err
+		}
+		for i := len(children) - 1; i >= 0; i-- {
+			child := children[i]
+			if child >= trailer.numObjects {
+				return fmt.Errorf("inspect binary structure: object reference is out of range")
+			}
+			stack = append(stack, binaryTraversalEntry{object: child, depth: entry.depth + 1})
+		}
+	}
+	return nil
+}
+
+func binaryContainerChildren(data []byte, offset uint64, trailer binaryPlistTrailer) ([]uint64, error) {
+	if offset >= trailer.offsetTable {
+		return nil, fmt.Errorf("inspect binary structure: object begins beyond object table")
+	}
+	tag := data[offset]
+	kind := tag & 0xF0
+	if kind != 0xA0 && kind != 0xD0 {
+		return nil, nil
+	}
+	count, refsAt, err := binaryObjectCount(data, offset, trailer.offsetTable)
+	if err != nil {
+		return nil, err
+	}
+	if count > MaxObjects {
+		return nil, fmt.Errorf("info.plist object count exceeds %d", MaxObjects)
+	}
+	if kind == 0xD0 {
+		if count > MaxObjects/2 {
+			return nil, fmt.Errorf("info.plist object count exceeds %d", MaxObjects)
+		}
+		count *= 2
+	}
+	refBytes := count * uint64(trailer.refSize)
+	if count != 0 && refBytes/count != uint64(trailer.refSize) {
+		return nil, fmt.Errorf("inspect binary structure: container size overflow")
+	}
+	if refsAt > trailer.offsetTable || refBytes > trailer.offsetTable-refsAt {
+		return nil, fmt.Errorf("inspect binary structure: truncated container")
+	}
+	children := make([]uint64, count)
+	for index := uint64(0); index < count; index++ {
+		ref, ok := readBinaryUint(data, refsAt+index*uint64(trailer.refSize), trailer.refSize)
+		if !ok {
+			return nil, fmt.Errorf("inspect binary structure: truncated object reference")
+		}
+		children[index] = ref
+	}
+	return children, nil
+}
+
+func binaryObjectCount(data []byte, offset, tableAt uint64) (uint64, uint64, error) {
+	tag := data[offset]
+	if tag&0x0F != 0x0F {
+		return uint64(tag & 0x0F), offset + 1, nil
+	}
+	integerAt := offset + 1
+	if integerAt >= tableAt || data[integerAt]&0xF0 != 0x10 {
+		return 0, 0, fmt.Errorf("inspect binary structure: invalid extended object count")
+	}
+	exponent := data[integerAt] & 0x0F
+	if exponent > 3 {
+		return 0, 0, fmt.Errorf("inspect binary structure: object count is too wide")
+	}
+	size := uint8(1 << exponent)
+	count, ok := readBinaryUint(data, integerAt+1, size)
+	if !ok || integerAt+1+uint64(size) > tableAt {
+		return 0, 0, fmt.Errorf("inspect binary structure: truncated object count")
+	}
+	return count, integerAt + 1 + uint64(size), nil
+}
+
+func readBinaryUint(data []byte, offset uint64, size uint8) (uint64, bool) {
+	if size == 0 || size > 8 || offset > uint64(len(data)) || uint64(size) > uint64(len(data))-offset {
+		return 0, false
+	}
+	var value uint64
+	for _, current := range data[offset : offset+uint64(size)] {
+		value = value<<8 | uint64(current)
+	}
+	return value, true
+}

--- a/internal/rootfs/hardlinks_other.go
+++ b/internal/rootfs/hardlinks_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !freebsd && !netbsd && !openbsd && !dragonfly && !windows
+
+package rootfs
+
+import "os"
+
+func hasMultipleHardLinks(_ *os.File, _ os.FileInfo) (bool, error) {
+	return false, nil
+}

--- a/internal/rootfs/hardlinks_unix.go
+++ b/internal/rootfs/hardlinks_unix.go
@@ -1,0 +1,13 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package rootfs
+
+import (
+	"os"
+	"syscall"
+)
+
+func hasMultipleHardLinks(_ *os.File, info os.FileInfo) (bool, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Nlink > 1, nil
+}

--- a/internal/rootfs/hardlinks_windows.go
+++ b/internal/rootfs/hardlinks_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package rootfs
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func hasMultipleHardLinks(file *os.File, _ os.FileInfo) (bool, error) {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &info); err != nil {
+		return false, err
+	}
+	return info.NumberOfLinks > 1, nil
+}

--- a/internal/rootfs/metadata_other.go
+++ b/internal/rootfs/metadata_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package rootfs
+
+import "os"
+
+func copyReplacementMetadata(destination, _ *os.File, info os.FileInfo) error {
+	return destination.Chmod(info.Mode().Perm())
+}

--- a/internal/rootfs/metadata_unix.go
+++ b/internal/rootfs/metadata_unix.go
@@ -1,0 +1,72 @@
+//go:build darwin || linux
+
+package rootfs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func copyReplacementMetadata(destination, source *os.File, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("inspect replacement ownership: unsupported stat type %T", info.Sys())
+	}
+	if err := unix.Fchown(int(destination.Fd()), int(stat.Uid), int(stat.Gid)); err != nil {
+		return fmt.Errorf("preserve replacement ownership: %w", err)
+	}
+	if err := destination.Chmod(info.Mode().Perm()); err != nil {
+		return fmt.Errorf("preserve replacement permissions: %w", err)
+	}
+	// Apply ACL-bearing extended attributes after chmod so the mode update
+	// cannot rewrite the restored ACL mask.
+	if err := copyExtendedAttributes(destination, source); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyExtendedAttributes(destination, source *os.File) error {
+	size, err := unix.Flistxattr(int(source.Fd()), nil)
+	if err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+			return nil
+		}
+		return fmt.Errorf("list replacement extended attributes: %w", err)
+	}
+	if size == 0 {
+		return nil
+	}
+	names := make([]byte, size)
+	size, err = unix.Flistxattr(int(source.Fd()), names)
+	if err != nil {
+		return fmt.Errorf("list replacement extended attributes: %w", err)
+	}
+	for _, rawName := range bytes.Split(names[:size], []byte{0}) {
+		if len(rawName) == 0 {
+			continue
+		}
+		name := string(rawName)
+		valueSize, err := unix.Fgetxattr(int(source.Fd()), name, nil)
+		if err != nil {
+			return fmt.Errorf("read replacement extended attribute %q: %w", name, err)
+		}
+		value := make([]byte, valueSize)
+		if valueSize > 0 {
+			valueSize, err = unix.Fgetxattr(int(source.Fd()), name, value)
+			if err != nil {
+				return fmt.Errorf("read replacement extended attribute %q: %w", name, err)
+			}
+			value = value[:valueSize]
+		}
+		if err := unix.Fsetxattr(int(destination.Fd()), name, value, 0); err != nil {
+			return fmt.Errorf("preserve replacement extended attribute %q: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -372,11 +372,8 @@ func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64,
 // to perm for a new file. Use it where the pre-rooted in-place write preserved
 // an operator's chosen mode across rewrites.
 func (r Root) WriteFilePreservingMode(name string, data []byte, perm os.FileMode) error {
-	resolved, err := r.Resolve(name)
+	resolved, err := r.prepareWrite(name)
 	if err != nil {
-		return err
-	}
-	if err := r.ensureRootDir(0o755); err != nil {
 		return err
 	}
 	parent, base, err := r.openParentRooted(resolved)

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -46,6 +46,9 @@ type Root struct {
 	// internalSymlinks tolerates symlinked components below the root when they
 	// resolve back inside the root.
 	internalSymlinks bool
+	// afterValidationForTest makes path-swap regressions deterministic. It is
+	// intentionally unexported and unset outside package tests.
+	afterValidationForTest func()
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -219,10 +222,15 @@ func (r Root) OpenFile(name string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	parent, base, err := r.openParentRooted(resolved)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
 	if err := r.checkParentComponents(resolved); err != nil {
 		return nil, err
 	}
-	info, err := os.Lstat(resolved)
+	info, err := parent.Lstat(base)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +240,23 @@ func (r Root) OpenFile(name string) (*os.File, error) {
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("%q is not a regular file", resolved)
 	}
-	return secureopen.OpenExistingNoFollow(resolved)
+	if r.afterValidationForTest != nil {
+		r.afterValidationForTest()
+	}
+	file, err := secureopen.OpenExistingNoFollowInRoot(parent, base)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !openedInfo.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("%q is not a regular file", resolved)
+	}
+	return file, nil
 }
 
 // ReadFile reads a regular file beneath the root without following symlinks.
@@ -268,18 +292,18 @@ func (r Root) MkdirAll(name string, perm os.FileMode) error {
 	if err := r.ensureRootDir(perm); err != nil {
 		return err
 	}
-	components, err := r.componentsBelowRoot(resolved)
+	rooted, relative, err := r.openRooted(resolved, true)
 	if err != nil {
 		return err
 	}
-	current := r.path
-	for _, component := range components {
-		current = filepath.Join(current, component)
-		if err := r.mkdirNoFollow(current, perm); err != nil {
-			return err
-		}
+	defer rooted.Close()
+	if err := r.validateDirectoryComponents(resolved); err != nil {
+		return err
 	}
-	return nil
+	if err := rooted.MkdirAll(relative, perm); err != nil {
+		return err
+	}
+	return r.validateDirectoryComponents(resolved)
 }
 
 // WriteFile atomically creates or replaces a file beneath the root.
@@ -295,23 +319,29 @@ func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64,
 	if err != nil {
 		return 0, err
 	}
-
-	hadExisting, err := checkReplaceableFile(resolved)
+	parent, base, err := r.openParentRooted(resolved)
 	if err != nil {
 		return 0, err
 	}
+	defer parent.Close()
 
-	directory := filepath.Dir(resolved)
-	temporary, err := secureopen.CreateTempNoFollow(directory, temporaryFilePattern, perm)
+	hadExisting, err := checkReplaceableFileInRoot(parent, base, resolved)
 	if err != nil {
 		return 0, err
 	}
-	temporaryPath := temporary.Name()
+	if r.afterValidationForTest != nil {
+		r.afterValidationForTest()
+	}
+
+	temporary, temporaryName, err := secureopen.CreateTempNoFollowInRoot(parent, ".", temporaryFilePattern, perm)
+	if err != nil {
+		return 0, err
+	}
 	success := false
 	defer func() {
 		_ = temporary.Close()
 		if !success {
-			_ = os.Remove(temporaryPath)
+			_ = parent.Remove(temporaryName)
 		}
 	}()
 
@@ -330,7 +360,7 @@ func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64,
 		return 0, err
 	}
 
-	if err := replaceFile(temporaryPath, resolved, hadExisting); err != nil {
+	if err := replaceFileInRoot(parent, temporaryName, base, hadExisting); err != nil {
 		return 0, err
 	}
 	success = true
@@ -346,11 +376,22 @@ func (r Root) WriteFilePreservingMode(name string, data []byte, perm os.FileMode
 	if err != nil {
 		return err
 	}
-	if info, err := os.Lstat(resolved); err == nil {
+	if err := r.ensureRootDir(0o755); err != nil {
+		return err
+	}
+	parent, base, err := r.openParentRooted(resolved)
+	if err != nil {
+		return err
+	}
+	if info, err := parent.Lstat(base); err == nil {
 		if info.Mode().IsRegular() {
 			perm = info.Mode().Perm()
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
+		_ = parent.Close()
+		return err
+	}
+	if err := parent.Close(); err != nil {
 		return err
 	}
 	return r.WriteFile(name, data, perm)
@@ -363,8 +404,13 @@ func (r Root) CreateNewFile(name string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	parent, base, err := r.openParentRooted(resolved)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
 
-	info, err := os.Lstat(resolved)
+	info, err := parent.Lstat(base)
 	switch {
 	case err == nil:
 		if info.Mode()&os.ModeSymlink != 0 {
@@ -374,8 +420,11 @@ func (r Root) CreateNewFile(name string, data []byte, perm os.FileMode) error {
 	case !errors.Is(err, os.ErrNotExist):
 		return err
 	}
+	if r.afterValidationForTest != nil {
+		r.afterValidationForTest()
+	}
 
-	file, err := secureopen.OpenNewFileNoFollow(resolved, perm)
+	file, err := secureopen.OpenNewFileNoFollowInRoot(parent, base, perm)
 	if err != nil {
 		return err
 	}
@@ -393,8 +442,13 @@ func (r Root) AppendFile(name string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	parent, base, err := r.openParentRooted(resolved)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
 
-	if info, err := os.Lstat(resolved); err == nil {
+	if info, err := parent.Lstat(base); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return symlinkError(resolved)
 		}
@@ -404,10 +458,22 @@ func (r Root) AppendFile(name string, data []byte, perm os.FileMode) error {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
+	if r.afterValidationForTest != nil {
+		r.afterValidationForTest()
+	}
 
-	file, err := secureopen.OpenAppendNoFollow(resolved, perm)
+	file, err := secureopen.OpenAppendNoFollowInRoot(parent, base, perm)
 	if err != nil {
 		return err
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return err
+	}
+	if !openedInfo.Mode().IsRegular() {
+		_ = file.Close()
+		return fmt.Errorf("%q is not a regular file", resolved)
 	}
 	// The descriptor is known not to be a symlink, so tightening permissions
 	// here cannot affect an external file.
@@ -455,6 +521,109 @@ func (r Root) ensureRootDir(perm os.FileMode) error {
 		return err
 	}
 	return nil
+}
+
+func (r Root) openRooted(absolute string, resolveFinal bool) (*os.Root, string, error) {
+	rooted, err := os.OpenRoot(r.path)
+	if err != nil {
+		return nil, "", err
+	}
+	relative, err := r.rootedRelative(absolute, resolveFinal)
+	if err != nil {
+		_ = rooted.Close()
+		return nil, "", err
+	}
+	return rooted, relative, nil
+}
+
+func (r Root) openParentRooted(absolute string) (*os.Root, string, error) {
+	rooted, relative, err := r.openRooted(absolute, false)
+	if err != nil {
+		return nil, "", err
+	}
+	parent, err := rooted.OpenRoot(filepath.Dir(relative))
+	_ = rooted.Close()
+	if err != nil {
+		return nil, "", err
+	}
+	return parent, filepath.Base(relative), nil
+}
+
+// rootedRelative converts an already-contained absolute path into a name for
+// os.Root. Existing internal directory symlinks are resolved to their physical
+// path so AllowingInternalSymlinks remains compatible with absolute in-root
+// links, while the final file component remains unresolved for no-follow open.
+func (r Root) rootedRelative(absolute string, resolveFinal bool) (string, error) {
+	components, err := r.componentsBelowRoot(absolute)
+	if err != nil {
+		return "", err
+	}
+	physicalRoot, err := filepath.EvalSymlinks(r.path)
+	if err != nil {
+		return "", err
+	}
+	current := physicalRoot
+	resolveCount := len(components)
+	if !resolveFinal && resolveCount > 0 {
+		resolveCount--
+	}
+
+	for index := 0; index < resolveCount; index++ {
+		candidate := filepath.Join(current, components[index])
+		info, err := os.Lstat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			for _, remaining := range components[index:] {
+				current = filepath.Join(current, remaining)
+			}
+			return relativeWithinRoot(physicalRoot, current)
+		}
+		if err != nil {
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			if !r.internalSymlinks {
+				return "", symlinkError(candidate)
+			}
+			resolved, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return "", err
+			}
+			if _, err := relativeWithinRoot(physicalRoot, resolved); err != nil {
+				return "", symlinkError(candidate)
+			}
+			resolvedInfo, err := os.Stat(candidate)
+			if err != nil {
+				return "", err
+			}
+			if !resolvedInfo.IsDir() {
+				return "", fmt.Errorf("%q is not a directory", candidate)
+			}
+			current = resolved
+			continue
+		}
+		if !info.IsDir() {
+			return "", fmt.Errorf("%q is not a directory", candidate)
+		}
+		current = candidate
+	}
+	for _, remaining := range components[resolveCount:] {
+		current = filepath.Join(current, remaining)
+	}
+	return relativeWithinRoot(physicalRoot, current)
+}
+
+func relativeWithinRoot(root string, path string) (string, error) {
+	if !strings.EqualFold(filepath.VolumeName(path), filepath.VolumeName(root)) {
+		return "", fmt.Errorf("%w: %q changes volume from %q", ErrEscapesRoot, path, root)
+	}
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return "", fmt.Errorf("%w: %q is not below %q", ErrEscapesRoot, path, root)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q is not below %q", ErrEscapesRoot, path, root)
+	}
+	return relative, nil
 }
 
 func (r Root) componentsBelowRoot(absolute string) ([]string, error) {
@@ -534,16 +703,21 @@ func (r Root) checkParentComponents(absolute string) error {
 	return nil
 }
 
-func (r Root) mkdirNoFollow(path string, perm os.FileMode) error {
-	if err := r.validateExistingDir(path); err == nil {
-		return nil
-	} else if !errors.Is(err, os.ErrNotExist) {
+func (r Root) validateDirectoryComponents(absolute string) error {
+	components, err := r.componentsBelowRoot(absolute)
+	if err != nil {
 		return err
 	}
-	if err := os.Mkdir(path, perm); err != nil && !errors.Is(err, os.ErrExist) {
-		return err
+	current := r.path
+	for _, component := range components {
+		current = filepath.Join(current, component)
+		if err := r.validateExistingDir(current); errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else if err != nil {
+			return err
+		}
 	}
-	return r.validateExistingDir(path)
+	return nil
 }
 
 func (r Root) validateExistingDir(path string) error {
@@ -570,8 +744,8 @@ func (r Root) validateExistingDir(path string) error {
 	return nil
 }
 
-func checkReplaceableFile(path string) (bool, error) {
-	info, err := os.Lstat(path)
+func checkReplaceableFileInRoot(rooted *os.Root, name string, displayPath string) (bool, error) {
+	info, err := rooted.Lstat(name)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
@@ -579,43 +753,42 @@ func checkReplaceableFile(path string) (bool, error) {
 		return false, err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return false, symlinkError(path)
+		return false, symlinkError(displayPath)
 	}
 	if info.IsDir() {
-		return false, fmt.Errorf("%q is a directory", path)
+		return false, fmt.Errorf("%q is a directory", displayPath)
 	}
 	return true, nil
 }
 
-// replaceFile moves the staged temporary file onto path. Unix renames replace
+// replaceFileInRoot moves the staged temporary file onto path. Unix renames replace
 // the destination atomically; Windows renames fail when the destination exists,
 // so the original is moved aside first and restored if the final move fails.
-func replaceFile(temporaryPath, path string, hadExisting bool) error {
-	if err := os.Rename(temporaryPath, path); err == nil {
+func replaceFileInRoot(parent *os.Root, temporaryName string, name string, hadExisting bool) error {
+	if err := parent.Rename(temporaryName, name); err == nil {
 		return nil
 	} else if !hadExisting || runtime.GOOS != "windows" {
 		return err
 	}
 
-	backup, err := secureopen.CreateTempNoFollow(filepath.Dir(path), backupFilePattern, 0o600)
+	backup, backupName, err := secureopen.CreateTempNoFollowInRoot(parent, ".", backupFilePattern, 0o600)
 	if err != nil {
 		return err
 	}
-	backupPath := backup.Name()
 	if err := backup.Close(); err != nil {
 		return err
 	}
-	if err := os.Remove(backupPath); err != nil {
+	if err := parent.Remove(backupName); err != nil {
 		return err
 	}
-	if err := os.Rename(path, backupPath); err != nil {
+	if err := parent.Rename(name, backupName); err != nil {
 		return err
 	}
-	if err := os.Rename(temporaryPath, path); err != nil {
-		_ = os.Rename(backupPath, path)
+	if err := parent.Rename(temporaryName, name); err != nil {
+		_ = parent.Rename(backupName, name)
 		return err
 	}
-	_ = os.Remove(backupPath)
+	_ = parent.Remove(backupName)
 	return nil
 }
 

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -54,11 +54,10 @@ type Root struct {
 // New returns a Root anchored at path. The root itself is operator-selected and
 // may live outside the current repository; only paths below it are constrained.
 func New(path string) (Root, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	if path == "" {
 		return Root{}, fmt.Errorf("%w: trusted root path is empty", ErrEscapesRoot)
 	}
-	absolute, err := filepath.Abs(trimmed)
+	absolute, err := filepath.Abs(path)
 	if err != nil {
 		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
 	}
@@ -113,17 +112,16 @@ func (r Root) checkSymlinkComponent(path string) error {
 // can not smuggle a drive-relative, UNC-style, or backslash-traversing path
 // past validation on a different host platform.
 func ValidateRelative(name string) error {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
+	if name == "" {
 		return fmt.Errorf("%w: path is empty", ErrEscapesRoot)
 	}
-	if strings.ContainsRune(trimmed, 0) {
+	if strings.ContainsRune(name, 0) {
 		return fmt.Errorf("%w: %q contains a NUL byte", ErrEscapesRoot, name)
 	}
-	if isAbsoluteLike(trimmed) {
+	if isAbsoluteLike(name) {
 		return fmt.Errorf("%w: %q must be relative to the trusted root", ErrEscapesRoot, name)
 	}
-	for _, component := range strings.FieldsFunc(trimmed, isPathSeparator) {
+	for _, component := range strings.FieldsFunc(name, isPathSeparator) {
 		if component == ".." {
 			return fmt.Errorf("%w: %q traverses above the trusted root", ErrEscapesRoot, name)
 		}
@@ -136,14 +134,13 @@ func ValidateRelative(name string) error {
 // against a base directory below the root and then confirm containment of the
 // joined result with Resolve.
 func ValidateRelativeAllowingTraversal(name string) error {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
+	if name == "" {
 		return fmt.Errorf("%w: path is empty", ErrEscapesRoot)
 	}
-	if strings.ContainsRune(trimmed, 0) {
+	if strings.ContainsRune(name, 0) {
 		return fmt.Errorf("%w: %q contains a NUL byte", ErrEscapesRoot, name)
 	}
-	if isAbsoluteLike(trimmed) {
+	if isAbsoluteLike(name) {
 		return fmt.Errorf("%w: %q must be relative to the trusted root", ErrEscapesRoot, name)
 	}
 	return nil
@@ -152,33 +149,63 @@ func ValidateRelativeAllowingTraversal(name string) error {
 // Resolve validates name and returns its absolute path beneath the root. name
 // may be relative to the root or an absolute path that is already inside it.
 func (r Root) Resolve(name string) (string, error) {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
+	if name == "" {
 		return "", fmt.Errorf("%w: path is empty", ErrEscapesRoot)
 	}
-	if strings.ContainsRune(trimmed, 0) {
+	if strings.ContainsRune(name, 0) {
 		return "", fmt.Errorf("%w: %q contains a NUL byte", ErrEscapesRoot, name)
 	}
 
-	if isAbsoluteLike(trimmed) {
-		if !filepath.IsAbs(trimmed) {
+	if isAbsoluteLike(name) {
+		if !filepath.IsAbs(name) {
 			return "", fmt.Errorf("%w: %q is not an absolute path below %q", ErrEscapesRoot, name, r.path)
 		}
-		cleaned := filepath.Clean(trimmed)
+		cleaned := filepath.Clean(name)
 		if err := r.checkWithin(cleaned, name); err != nil {
 			return "", err
 		}
 		return cleaned, nil
 	}
 
-	if err := ValidateRelative(trimmed); err != nil {
+	if err := ValidateRelative(name); err != nil {
 		return "", err
 	}
-	joined := filepath.Join(r.path, trimmed)
+	joined := filepath.Join(r.path, name)
 	if err := r.checkWithin(joined, name); err != nil {
 		return "", err
 	}
 	return joined, nil
+}
+
+// ResolveContainedFinalSymlink resolves a final symlink only when its physical
+// target remains beneath this root. The returned name is relative to the root
+// and contains no symlink components, so callers can perform the actual I/O
+// through rooted no-follow operations without reopening the link.
+func (r Root) ResolveContainedFinalSymlink(name string) (string, error) {
+	absolute, err := r.Resolve(name)
+	if err != nil {
+		return "", err
+	}
+	if err := r.checkParentComponents(absolute); err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(absolute)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return "", fmt.Errorf("%w: %q is not a symlink", ErrSymlink, absolute)
+	}
+
+	physicalRoot, err := filepath.EvalSymlinks(r.path)
+	if err != nil {
+		return "", err
+	}
+	physicalTarget, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", err
+	}
+	return relativeWithinRoot(physicalRoot, physicalTarget)
 }
 
 // CheckContained verifies that name stays beneath the root and that neither its
@@ -315,6 +342,21 @@ func (r Root) WriteFile(name string, data []byte, perm os.FileMode) error {
 // WriteFrom atomically creates or replaces a file beneath the root with the
 // contents of reader and returns the number of bytes written.
 func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64, error) {
+	return r.writeFrom(name, reader, perm, true)
+}
+
+func (r Root) writeFrom(name string, reader io.Reader, perm os.FileMode, exactModeForNew bool) (int64, error) {
+	return r.writeFromPreservingMetadata(name, reader, perm, exactModeForNew, nil, nil)
+}
+
+func (r Root) writeFromPreservingMetadata(
+	name string,
+	reader io.Reader,
+	perm os.FileMode,
+	exactModeForNew bool,
+	metadataSource *os.File,
+	metadataInfo os.FileInfo,
+) (int64, error) {
 	resolved, err := r.prepareWrite(name)
 	if err != nil {
 		return 0, err
@@ -345,9 +387,18 @@ func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64,
 		}
 	}()
 
-	// Set the final mode explicitly so the process umask cannot widen it.
-	if err := temporary.Chmod(perm); err != nil {
-		return 0, err
+	// Preserve supported filesystem metadata from the already-open original.
+	// Otherwise keep the exact mode of an ordinary replacement. For a new file,
+	// retain the process umask unless the caller explicitly requested an exact
+	// mode.
+	if metadataSource != nil {
+		if err := copyReplacementMetadata(temporary, metadataSource, metadataInfo); err != nil {
+			return 0, err
+		}
+	} else if hadExisting || exactModeForNew {
+		if err := temporary.Chmod(perm); err != nil {
+			return 0, err
+		}
 	}
 	written, err := io.Copy(temporary, reader)
 	if err != nil {
@@ -367,10 +418,12 @@ func (r Root) WriteFrom(name string, reader io.Reader, perm os.FileMode) (int64,
 	return written, nil
 }
 
-// WriteFilePreservingMode atomically creates or replaces a file beneath the
-// root, reusing an existing regular destination's permissions and falling back
-// to perm for a new file. Use it where the pre-rooted in-place write preserved
-// an operator's chosen mode across rewrites.
+// WriteFilePreservingMode atomically creates or replaces a regular file beneath
+// the root. Existing files retain supported ownership, permission, ACL, and
+// extended-attribute metadata without mutating aliases outside the rooted path.
+// Where the platform exposes link counts, multiply linked files are refused
+// rather than silently changing hard-link semantics. New files use perm subject
+// to the process umask.
 func (r Root) WriteFilePreservingMode(name string, data []byte, perm os.FileMode) error {
 	resolved, err := r.prepareWrite(name)
 	if err != nil {
@@ -380,18 +433,85 @@ func (r Root) WriteFilePreservingMode(name string, data []byte, perm os.FileMode
 	if err != nil {
 		return err
 	}
-	if info, err := parent.Lstat(base); err == nil {
-		if info.Mode().IsRegular() {
-			perm = info.Mode().Perm()
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		_ = parent.Close()
+	defer parent.Close()
+
+	hadExisting, err := checkReplaceableFileInRoot(parent, base, resolved)
+	if err != nil {
 		return err
 	}
-	if err := parent.Close(); err != nil {
+	if !hadExisting {
+		_, err := r.writeFrom(name, bytes.NewReader(data), perm, false)
 		return err
 	}
-	return r.WriteFile(name, data, perm)
+
+	file, err := secureopen.OpenExistingWritableNoFollowInRoot(parent, base)
+	if err != nil {
+		return fmt.Errorf("open existing file %q for replacement: %w", resolved, err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if multiple, err := hasMultipleHardLinks(file, openedInfo); err != nil {
+		return fmt.Errorf("inspect existing file %q: %w", resolved, err)
+	} else if multiple {
+		return fmt.Errorf("refusing to rewrite multiply linked file %q", resolved)
+	}
+	_, err = r.writeFromPreservingMetadata(name, bytes.NewReader(data), perm, false, file, openedInfo)
+	return err
+}
+
+// CheckWriteFilePreservingMode performs the non-mutating checks required before
+// WriteFilePreservingMode replaces an existing file. Missing destinations are
+// accepted; callers can use this to preflight a multi-file plan before its first
+// write.
+func (r Root) CheckWriteFilePreservingMode(name string) error {
+	resolved, err := r.Resolve(name)
+	if err != nil {
+		return err
+	}
+	if resolved == r.path {
+		return fmt.Errorf("%w: %q is the trusted root itself", ErrEscapesRoot, name)
+	}
+	if err := r.checkParentComponents(resolved); err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(resolved)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return symlinkError(resolved)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%q is not a regular file", resolved)
+	}
+
+	parent, base, err := r.openParentRooted(resolved)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	file, err := secureopen.OpenExistingWritableNoFollowInRoot(parent, base)
+	if err != nil {
+		return fmt.Errorf("open existing file %q for replacement: %w", resolved, err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if multiple, err := hasMultipleHardLinks(file, openedInfo); err != nil {
+		return fmt.Errorf("inspect existing file %q: %w", resolved, err)
+	} else if multiple {
+		return fmt.Errorf("refusing to rewrite multiply linked file %q", resolved)
+	}
+	return nil
 }
 
 // CreateNewFile writes data to a new file beneath the root and fails when the
@@ -445,7 +565,9 @@ func (r Root) AppendFile(name string, data []byte, perm os.FileMode) error {
 	}
 	defer parent.Close()
 
+	hadExisting := false
 	if info, err := parent.Lstat(base); err == nil {
+		hadExisting = true
 		if info.Mode()&os.ModeSymlink != 0 {
 			return symlinkError(resolved)
 		}
@@ -459,7 +581,12 @@ func (r Root) AppendFile(name string, data []byte, perm os.FileMode) error {
 		r.afterValidationForTest()
 	}
 
-	file, err := secureopen.OpenAppendNoFollowInRoot(parent, base, perm)
+	var file *os.File
+	if hadExisting {
+		file, err = secureopen.OpenExistingAppendNoFollowInRoot(parent, base)
+	} else {
+		file, err = secureopen.OpenNewFileNoFollowInRoot(parent, base, perm)
+	}
 	if err != nil {
 		return err
 	}
@@ -472,11 +599,13 @@ func (r Root) AppendFile(name string, data []byte, perm os.FileMode) error {
 		_ = file.Close()
 		return fmt.Errorf("%q is not a regular file", resolved)
 	}
-	// The descriptor is known not to be a symlink, so tightening permissions
-	// here cannot affect an external file.
-	if err := file.Chmod(perm); err != nil {
-		_ = file.Close()
-		return err
+	if hadExisting {
+		// Security logs and similar callers use perm to tighten an existing
+		// file. New files retain the process umask from their exclusive create.
+		if err := file.Chmod(perm); err != nil {
+			_ = file.Close()
+			return err
+		}
 	}
 	if _, err := file.Write(data); err != nil {
 		_ = file.Close()
@@ -752,8 +881,8 @@ func checkReplaceableFileInRoot(rooted *os.Root, name string, displayPath string
 	if info.Mode()&os.ModeSymlink != 0 {
 		return false, symlinkError(displayPath)
 	}
-	if info.IsDir() {
-		return false, fmt.Errorf("%q is a directory", displayPath)
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("%q is not a regular file", displayPath)
 	}
 	return true, nil
 }
@@ -773,7 +902,7 @@ func replaceFileInRoot(parent *os.Root, temporaryName string, name string, hadEx
 		return err
 	}
 	if err := backup.Close(); err != nil {
-		return err
+		return errors.Join(err, parent.Remove(backupName))
 	}
 	if err := parent.Remove(backupName); err != nil {
 		return err
@@ -782,10 +911,18 @@ func replaceFileInRoot(parent *os.Root, temporaryName string, name string, hadEx
 		return err
 	}
 	if err := parent.Rename(temporaryName, name); err != nil {
-		_ = parent.Rename(backupName, name)
+		restoreErr := parent.Rename(backupName, name)
+		if restoreErr != nil {
+			return errors.Join(
+				err,
+				fmt.Errorf("restore original from backup %q: %w", backupName, restoreErr),
+			)
+		}
 		return err
 	}
-	_ = parent.Remove(backupName)
+	if err := parent.Remove(backupName); err != nil {
+		return fmt.Errorf("replacement succeeded but remove backup %q: %w", backupName, err)
+	}
 	return nil
 }
 

--- a/internal/rootfs/rootfs_metadata_unix_test.go
+++ b/internal/rootfs/rootfs_metadata_unix_test.go
@@ -1,0 +1,55 @@
+//go:build darwin || linux
+
+package rootfs
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWriteFilePreservingModePreservesExtendedAttributes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+	mustWrite(t, path, "original")
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	name := "user.asc-rootfs-test"
+	if runtime.GOOS == "darwin" {
+		name = "com.rork.asc-rootfs-test"
+	}
+	value := []byte("metadata")
+	if err := unix.Fsetxattr(int(file.Fd()), name, value, 0); err != nil {
+		_ = file.Close()
+		t.Skipf("extended attributes unavailable: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if err := root.WriteFilePreservingMode("existing.txt", []byte("replacement"), 0o644); err != nil {
+		t.Fatalf("WriteFilePreservingMode() error = %v", err)
+	}
+	replaced, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(replaced) error = %v", err)
+	}
+	defer replaced.Close()
+	size, err := unix.Fgetxattr(int(replaced.Fd()), name, nil)
+	if err != nil {
+		t.Fatalf("Fgetxattr(size) error = %v", err)
+	}
+	got := make([]byte, size)
+	if _, err := unix.Fgetxattr(int(replaced.Fd()), name, got); err != nil {
+		t.Fatalf("Fgetxattr() error = %v", err)
+	}
+	if string(got) != string(value) {
+		t.Fatalf("extended attribute = %q, want %q", got, value)
+	}
+}

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -156,6 +156,33 @@ func TestReadFileDoesNotEscapeWhenParentIsSwappedAfterValidation(t *testing.T) {
 	}
 }
 
+func TestReadFileRejectsFinalSymlinkSwappedAfterValidation(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	report := filepath.Join(dir, "report.txt")
+	mustWrite(t, report, "trusted")
+	mustWrite(t, filepath.Join(dir, "secret.txt"), "in-root-secret")
+
+	root := mustRoot(t, dir)
+	root.afterValidationForTest = func() {
+		if err := os.Remove(report); err != nil {
+			t.Fatalf("remove validated file: %v", err)
+		}
+		if err := os.Symlink("secret.txt", report); err != nil {
+			t.Fatalf("replace validated file with symlink: %v", err)
+		}
+	}
+
+	data, err := root.ReadFile("report.txt")
+	if err == nil {
+		t.Fatalf("ReadFile() returned %q through a swapped final symlink, want an error", data)
+	}
+	if string(data) == "in-root-secret" {
+		t.Fatal("ReadFile() disclosed the swapped symlink target")
+	}
+}
+
 func TestReadFileOptionalReportsMissingWithoutError(t *testing.T) {
 	root := mustRoot(t, t.TempDir())
 
@@ -533,6 +560,34 @@ func TestAppendFileDoesNotEscapeWhenParentIsSwappedAfterValidation(t *testing.T)
 	}
 	if got := mustRead(t, filepath.Join(dir, "nested-original", "snitch.log")); got != "trusted\nattacker\n" {
 		t.Fatalf("AppendFile() content in anchored parent = %q", got)
+	}
+}
+
+func TestAppendFileRejectsFinalSymlinkSwappedAfterValidation(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "snitch.log")
+	mustWrite(t, logPath, "trusted\n")
+	siblingPath := filepath.Join(dir, "sibling.log")
+	mustWrite(t, siblingPath, "sibling\n")
+
+	root := mustRoot(t, dir)
+	root.afterValidationForTest = func() {
+		if err := os.Remove(logPath); err != nil {
+			t.Fatalf("remove validated file: %v", err)
+		}
+		if err := os.Symlink("sibling.log", logPath); err != nil {
+			t.Fatalf("replace validated file with symlink: %v", err)
+		}
+	}
+
+	err := root.AppendFile("snitch.log", []byte("attacker\n"), 0o600)
+	if err == nil {
+		t.Fatal("AppendFile() succeeded through a swapped final symlink, want an error")
+	}
+	if got := mustRead(t, siblingPath); got != "sibling\n" {
+		t.Fatalf("AppendFile() modified the swapped symlink target: %q", got)
 	}
 }
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -16,7 +16,6 @@ func TestValidateRelativeRejectsEscapes(t *testing.T) {
 		path string
 	}{
 		{"empty", ""},
-		{"whitespace", "   "},
 		{"unix absolute", "/etc/passwd"},
 		{"windows absolute backslash", `\Windows\System32`},
 		{"windows drive absolute", `C:\Windows\System32`},
@@ -78,6 +77,43 @@ func TestResolveAcceptsAbsolutePathInsideRoot(t *testing.T) {
 	}
 }
 
+func TestRootPreservesWhitespaceInValidPathNames(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "trusted ")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if root.Path() != dir {
+		t.Fatalf("Path() = %q, want exact path %q", root.Path(), dir)
+	}
+	if err := root.WriteFile("report ", []byte("exact"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, "report ")); got != "exact" {
+		t.Fatalf("content = %q, want exact whitespace-bearing destination", got)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "report")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("trimmed sibling exists or returned unexpected error: %v", err)
+	}
+	if err := root.WriteFile("   ", []byte("all spaces"), 0o600); err != nil {
+		t.Fatalf("WriteFile(all-spaces) error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, "   ")); got != "all spaces" {
+		t.Fatalf("all-space filename content = %q", got)
+	}
+
+	allSpaceDir := filepath.Join(parent, "   ")
+	if err := os.Mkdir(allSpaceDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(all-space root) error = %v", err)
+	}
+	allSpaceRoot := mustRoot(t, allSpaceDir)
+	if allSpaceRoot.Path() != allSpaceDir {
+		t.Fatalf("all-space Path() = %q, want %q", allSpaceRoot.Path(), allSpaceDir)
+	}
+}
+
 func TestReadFileRefusesSymlinkedFinalComponent(t *testing.T) {
 	requireSymlinks(t)
 
@@ -94,6 +130,33 @@ func TestReadFileRefusesSymlinkedFinalComponent(t *testing.T) {
 	root := mustRoot(t, dir)
 	if _, err := root.ReadFile("description.txt"); !errors.Is(err, ErrSymlink) {
 		t.Fatalf("ReadFile() error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestResolveContainedFinalSymlinkAcceptsOnlyInRootTarget(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "actual.md"), "inside")
+	if err := os.Symlink("actual.md", filepath.Join(dir, "ASC.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	root := mustRoot(t, dir)
+	resolved, err := root.ResolveContainedFinalSymlink("ASC.md")
+	if err != nil {
+		t.Fatalf("ResolveContainedFinalSymlink() error = %v", err)
+	}
+	if resolved != "actual.md" {
+		t.Fatalf("ResolveContainedFinalSymlink() = %q, want actual.md", resolved)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	mustWrite(t, outside, "outside")
+	if err := os.Symlink(outside, filepath.Join(dir, "external.md")); err != nil {
+		t.Fatalf("Symlink(external) error = %v", err)
+	}
+	if _, err := root.ResolveContainedFinalSymlink("external.md"); !errors.Is(err, ErrEscapesRoot) {
+		t.Fatalf("external ResolveContainedFinalSymlink() error = %v, want ErrEscapesRoot", err)
 	}
 }
 
@@ -377,6 +440,70 @@ func TestWriteFilePreservingModeKeepsExistingModeAndDefaultsForNew(t *testing.T)
 	}
 	if runtime.GOOS != "windows" && freshInfo.Mode().Perm() != 0o640 {
 		t.Fatalf("new mode = %v, want default 0640", freshInfo.Mode().Perm())
+	}
+}
+
+func TestWriteFilePreservingModeRefusesReadOnlyExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not authoritative on Windows")
+	}
+
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	path := filepath.Join(dir, "read-only.txt")
+	mustWrite(t, path, "original")
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if err := root.WriteFilePreservingMode("read-only.txt", []byte("replacement"), 0o644); err == nil {
+		t.Fatal("WriteFilePreservingMode() error = nil, want read-only destination refusal")
+	}
+	if got := mustRead(t, path); got != "original" {
+		t.Fatalf("content = %q, want original", got)
+	}
+}
+
+func TestWriteFilePreservingModeRefusesMultiplyLinkedFile(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	path := filepath.Join(dir, "existing.txt")
+	linkPath := filepath.Join(dir, "linked.txt")
+	mustWrite(t, path, "original")
+	if err := os.Link(path, linkPath); err != nil {
+		t.Skipf("hard links unavailable: %v", err)
+	}
+	if err := root.WriteFilePreservingMode("existing.txt", []byte("replacement"), 0o644); err == nil {
+		t.Fatal("WriteFilePreservingMode() error = nil, want multiply-linked file refusal")
+	}
+	if got := mustRead(t, path); got != "original" {
+		t.Fatalf("destination content = %q, want original", got)
+	}
+	if got := mustRead(t, linkPath); got != "original" {
+		t.Fatalf("hard-link content = %q, want original", got)
+	}
+}
+
+func TestWriteFilePreservingModeDoesNotMutateHardLinkAddedAfterValidation(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	path := filepath.Join(dir, "existing.txt")
+	externalLink := filepath.Join(t.TempDir(), "external.txt")
+	mustWrite(t, path, "original")
+	root.afterValidationForTest = func() {
+		if err := os.Link(path, externalLink); err != nil {
+			t.Skipf("hard links unavailable: %v", err)
+		}
+	}
+
+	if err := root.WriteFilePreservingMode("existing.txt", []byte("replacement"), 0o644); err != nil {
+		t.Fatalf("WriteFilePreservingMode() error = %v", err)
+	}
+	if got := mustRead(t, path); got != "replacement" {
+		t.Fatalf("destination content = %q, want replacement", got)
+	}
+	if got := mustRead(t, externalLink); got != "original" {
+		t.Fatalf("late hard link content = %q, want original", got)
 	}
 }
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -128,6 +128,34 @@ func TestReadFileReadsOrdinaryFile(t *testing.T) {
 	}
 }
 
+func TestReadFileDoesNotEscapeWhenParentIsSwappedAfterValidation(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "nested")
+	mustWrite(t, filepath.Join(nested, "report.txt"), "trusted")
+	external := t.TempDir()
+	mustWrite(t, filepath.Join(external, "report.txt"), "external-secret")
+
+	root := mustRoot(t, dir)
+	root.afterValidationForTest = func() {
+		if err := os.Rename(nested, filepath.Join(dir, "nested-original")); err != nil {
+			t.Fatalf("swap validated parent: %v", err)
+		}
+		if err := os.Symlink(external, nested); err != nil {
+			t.Fatalf("replace validated parent with symlink: %v", err)
+		}
+	}
+
+	data, err := root.ReadFile(filepath.Join("nested", "report.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != "trusted" {
+		t.Fatalf("ReadFile() = %q, want the file anchored before the parent swap", data)
+	}
+}
+
 func TestReadFileOptionalReportsMissingWithoutError(t *testing.T) {
 	root := mustRoot(t, t.TempDir())
 
@@ -213,6 +241,38 @@ func TestWriteFileCreatesAndReplacesInRoot(t *testing.T) {
 	}
 	if leftovers := temporaryLeftovers(t, filepath.Join(dir, "nested", "deep")); len(leftovers) > 0 {
 		t.Fatalf("temporary files left behind: %v", leftovers)
+	}
+}
+
+func TestWriteFileDoesNotEscapeWhenParentIsSwappedAfterValidation(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	external := t.TempDir()
+
+	root := mustRoot(t, dir)
+	root.afterValidationForTest = func() {
+		if err := os.Rename(nested, filepath.Join(dir, "nested-original")); err != nil {
+			t.Fatalf("swap validated parent: %v", err)
+		}
+		if err := os.Symlink(external, nested); err != nil {
+			t.Fatalf("replace validated parent with symlink: %v", err)
+		}
+	}
+
+	err := root.WriteFile(filepath.Join("nested", "out.json"), []byte("attacker"), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(external, "out.json")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("WriteFile() created a file outside the trusted root: %v", statErr)
+	}
+	if got := mustRead(t, filepath.Join(dir, "nested-original", "out.json")); got != "attacker" {
+		t.Fatalf("WriteFile() content in anchored parent = %q", got)
 	}
 }
 
@@ -306,6 +366,38 @@ func TestCreateNewFileRefusesExistingFile(t *testing.T) {
 	}
 }
 
+func TestCreateNewFileDoesNotEscapeWhenParentIsSwappedAfterValidation(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	external := t.TempDir()
+
+	root := mustRoot(t, dir)
+	root.afterValidationForTest = func() {
+		if err := os.Rename(nested, filepath.Join(dir, "nested-original")); err != nil {
+			t.Fatalf("swap validated parent: %v", err)
+		}
+		if err := os.Symlink(external, nested); err != nil {
+			t.Fatalf("replace validated parent with symlink: %v", err)
+		}
+	}
+
+	err := root.CreateNewFile(filepath.Join("nested", "AuthKey.p8"), []byte("private"), 0o600)
+	if err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(external, "AuthKey.p8")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("CreateNewFile() created a file outside the trusted root: %v", statErr)
+	}
+	if got := mustRead(t, filepath.Join(dir, "nested-original", "AuthKey.p8")); got != "private" {
+		t.Fatalf("CreateNewFile() content in anchored parent = %q", got)
+	}
+}
+
 func TestMkdirAllRefusesSymlinkedComponent(t *testing.T) {
 	requireSymlinks(t)
 
@@ -396,6 +488,38 @@ func TestAppendFileAppendsInRoot(t *testing.T) {
 	}
 	if got := mustRead(t, filepath.Join(dir, "snitch.log")); got != "one\ntwo\n" {
 		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestAppendFileDoesNotEscapeWhenParentIsSwappedAfterValidation(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "nested")
+	mustWrite(t, filepath.Join(nested, "snitch.log"), "trusted\n")
+	external := t.TempDir()
+	externalLog := filepath.Join(external, "snitch.log")
+	mustWrite(t, externalLog, "external\n")
+
+	root := mustRoot(t, dir)
+	root.afterValidationForTest = func() {
+		if err := os.Rename(nested, filepath.Join(dir, "nested-original")); err != nil {
+			t.Fatalf("swap validated parent: %v", err)
+		}
+		if err := os.Symlink(external, nested); err != nil {
+			t.Fatalf("replace validated parent with symlink: %v", err)
+		}
+	}
+
+	err := root.AppendFile(filepath.Join("nested", "snitch.log"), []byte("attacker\n"), 0o600)
+	if err != nil {
+		t.Fatalf("AppendFile() error = %v", err)
+	}
+	if got := mustRead(t, externalLog); got != "external\n" {
+		t.Fatalf("AppendFile() modified a file outside the trusted root: %q", got)
+	}
+	if got := mustRead(t, filepath.Join(dir, "nested-original", "snitch.log")); got != "trusted\nattacker\n" {
+		t.Fatalf("AppendFile() content in anchored parent = %q", got)
 	}
 }
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -353,6 +353,19 @@ func TestWriteFilePreservingModeKeepsExistingModeAndDefaultsForNew(t *testing.T)
 	}
 }
 
+func TestWriteFilePreservingModeCreatesMissingIntermediateDirectories(t *testing.T) {
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	name := filepath.Join("nested", "deep", "fresh.txt")
+
+	if err := root.WriteFilePreservingMode(name, []byte("data"), 0o640); err != nil {
+		t.Fatalf("WriteFilePreservingMode() error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, name)); got != "data" {
+		t.Fatalf("content = %q, want %q", got, "data")
+	}
+}
+
 func TestCreateNewFileRefusesExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "AuthKey.p8"), "existing")

--- a/internal/rootfs/rootfs_umask_unix_test.go
+++ b/internal/rootfs/rootfs_umask_unix_test.go
@@ -1,0 +1,66 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package rootfs
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestWriteFilePreservingModeHonorsUmaskForNewFile(t *testing.T) {
+	oldUmask := syscall.Umask(0o077)
+	defer syscall.Umask(oldUmask)
+
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	if err := root.WriteFilePreservingMode("fresh.txt", []byte("data"), 0o644); err != nil {
+		t.Fatalf("WriteFilePreservingMode() error = %v", err)
+	}
+	info, err := os.Lstat(filepath.Join(dir, "fresh.txt"))
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("new mode = %v, want umask-restricted 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileRefusesToReplaceSpecialFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipe")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("Mkfifo() error = %v", err)
+	}
+
+	root := mustRoot(t, dir)
+	if err := root.WriteFile("pipe", []byte("replacement"), 0o600); err == nil {
+		t.Fatal("WriteFile() error = nil, want special-file refusal")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		t.Fatalf("destination mode = %v, want named pipe preserved", info.Mode())
+	}
+}
+
+func TestAppendFileHonorsUmaskForNewFile(t *testing.T) {
+	oldUmask := syscall.Umask(0o077)
+	defer syscall.Umask(oldUmask)
+
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	if err := root.AppendFile("fresh.log", []byte("entry\n"), 0o644); err != nil {
+		t.Fatalf("AppendFile() error = %v", err)
+	}
+	info, err := os.Lstat(filepath.Join(dir, "fresh.log"))
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("new mode = %v, want umask-restricted 0600", info.Mode().Perm())
+	}
+}

--- a/internal/secureopen/secure_open_best_effort.go
+++ b/internal/secureopen/secure_open_best_effort.go
@@ -89,3 +89,63 @@ func verifyOpenedPath(path string, file *os.File, before os.FileInfo) error {
 	}
 	return nil
 }
+
+func openExistingNoFollowInRootBestEffort(root *os.Root, name string, opener func() (*os.File, error)) (*os.File, error) {
+	before, err := rootLstatNoSymlink(root, name)
+	if err != nil {
+		return nil, err
+	}
+	file, err := opener()
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyRootOpenedPath(root, name, file, before); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func openNewFileNoFollowInRootBestEffort(root *os.Root, name string, opener func() (*os.File, error)) (*os.File, error) {
+	if _, err := rootLstatNoSymlink(root, name); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	file, err := opener()
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyRootOpenedPath(root, name, file, nil); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func rootLstatNoSymlink(root *os.Root, name string) (os.FileInfo, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to follow symlink %q", name)
+	}
+	return info, nil
+}
+
+func verifyRootOpenedPath(root *os.Root, name string, file *os.File, before os.FileInfo) error {
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	after, err := rootLstatNoSymlink(root, name)
+	if err != nil {
+		return err
+	}
+	if before != nil && !os.SameFile(before, after) {
+		return fmt.Errorf("file changed during open %q", name)
+	}
+	if !os.SameFile(after, openedInfo) {
+		return fmt.Errorf("file changed during open %q", name)
+	}
+	return nil
+}

--- a/internal/secureopen/secure_open_other.go
+++ b/internal/secureopen/secure_open_other.go
@@ -46,10 +46,26 @@ func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os
 	})
 }
 
+// OpenExistingAppendNoFollowInRoot opens an existing file for appending
+// relative to root using best-effort final-component checks.
+func OpenExistingAppendNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
+	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, os.O_WRONLY|os.O_APPEND, 0)
+	})
+}
+
 // OpenExistingNoFollowInRoot opens an existing file relative to root using
 // best-effort final-component checks. Root itself prevents parent traversal.
 func OpenExistingNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
 	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
 		return root.Open(name)
+	})
+}
+
+// OpenExistingWritableNoFollowInRoot opens an existing file for writing
+// relative to root using best-effort final-component checks.
+func OpenExistingWritableNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
+	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, os.O_WRONLY, 0)
 	})
 }

--- a/internal/secureopen/secure_open_other.go
+++ b/internal/secureopen/secure_open_other.go
@@ -2,7 +2,10 @@
 
 package secureopen
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // OpenNewFileNoFollow creates a new file without following symlinks.
 // Uses a best-effort pre/post open validation sequence because a portable
@@ -28,4 +31,82 @@ func OpenAppendNoFollow(path string, perm os.FileMode) (*os.File, error) {
 // The validation/open sequence reduces, but does not eliminate, TOCTOU risk.
 func OpenExistingNoFollow(path string) (*os.File, error) {
 	return openExistingNoFollowBestEffort(path, os.Open)
+}
+
+// OpenNewFileNoFollowInRoot creates a new file relative to root using
+// best-effort final-component checks. Root itself prevents parent traversal.
+func OpenNewFileNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
+	return openNewFileNoFollowInRootBestEffort(root, name, perm, func() (*os.File, error) {
+		return root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	})
+}
+
+// OpenAppendNoFollowInRoot opens a file for appending relative to root using
+// best-effort final-component checks. Root itself prevents parent traversal.
+func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
+	return openNewFileNoFollowInRootBestEffort(root, name, perm, func() (*os.File, error) {
+		return root.OpenFile(name, os.O_WRONLY|os.O_APPEND|os.O_CREATE, perm)
+	})
+}
+
+// OpenExistingNoFollowInRoot opens an existing file relative to root using
+// best-effort final-component checks. Root itself prevents parent traversal.
+func OpenExistingNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
+	before, err := rootLstatNoSymlink(root, name)
+	if err != nil {
+		return nil, err
+	}
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyRootOpenedPath(root, name, file, before); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func openNewFileNoFollowInRootBestEffort(root *os.Root, name string, perm os.FileMode, opener func() (*os.File, error)) (*os.File, error) {
+	if _, err := rootLstatNoSymlink(root, name); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	file, err := opener()
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyRootOpenedPath(root, name, file, nil); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func rootLstatNoSymlink(root *os.Root, name string) (os.FileInfo, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to follow symlink %q", name)
+	}
+	return info, nil
+}
+
+func verifyRootOpenedPath(root *os.Root, name string, file *os.File, before os.FileInfo) error {
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	after, err := rootLstatNoSymlink(root, name)
+	if err != nil {
+		return err
+	}
+	if before != nil && !os.SameFile(before, after) {
+		return fmt.Errorf("file changed during open %q", name)
+	}
+	if !os.SameFile(after, openedInfo) {
+		return fmt.Errorf("file changed during open %q", name)
+	}
+	return nil
 }

--- a/internal/secureopen/secure_open_other.go
+++ b/internal/secureopen/secure_open_other.go
@@ -2,10 +2,7 @@
 
 package secureopen
 
-import (
-	"fmt"
-	"os"
-)
+import "os"
 
 // OpenNewFileNoFollow creates a new file without following symlinks.
 // Uses a best-effort pre/post open validation sequence because a portable
@@ -36,7 +33,7 @@ func OpenExistingNoFollow(path string) (*os.File, error) {
 // OpenNewFileNoFollowInRoot creates a new file relative to root using
 // best-effort final-component checks. Root itself prevents parent traversal.
 func OpenNewFileNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
-	return openNewFileNoFollowInRootBestEffort(root, name, perm, func() (*os.File, error) {
+	return openNewFileNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
 		return root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
 	})
 }
@@ -44,7 +41,7 @@ func OpenNewFileNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*o
 // OpenAppendNoFollowInRoot opens a file for appending relative to root using
 // best-effort final-component checks. Root itself prevents parent traversal.
 func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
-	return openNewFileNoFollowInRootBestEffort(root, name, perm, func() (*os.File, error) {
+	return openNewFileNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
 		return root.OpenFile(name, os.O_WRONLY|os.O_APPEND|os.O_CREATE, perm)
 	})
 }
@@ -52,61 +49,7 @@ func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os
 // OpenExistingNoFollowInRoot opens an existing file relative to root using
 // best-effort final-component checks. Root itself prevents parent traversal.
 func OpenExistingNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
-	before, err := rootLstatNoSymlink(root, name)
-	if err != nil {
-		return nil, err
-	}
-	file, err := root.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	if err := verifyRootOpenedPath(root, name, file, before); err != nil {
-		_ = file.Close()
-		return nil, err
-	}
-	return file, nil
-}
-
-func openNewFileNoFollowInRootBestEffort(root *os.Root, name string, perm os.FileMode, opener func() (*os.File, error)) (*os.File, error) {
-	if _, err := rootLstatNoSymlink(root, name); err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-	file, err := opener()
-	if err != nil {
-		return nil, err
-	}
-	if err := verifyRootOpenedPath(root, name, file, nil); err != nil {
-		_ = file.Close()
-		return nil, err
-	}
-	return file, nil
-}
-
-func rootLstatNoSymlink(root *os.Root, name string) (os.FileInfo, error) {
-	info, err := root.Lstat(name)
-	if err != nil {
-		return nil, err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("refusing to follow symlink %q", name)
-	}
-	return info, nil
-}
-
-func verifyRootOpenedPath(root *os.Root, name string, file *os.File, before os.FileInfo) error {
-	openedInfo, err := file.Stat()
-	if err != nil {
-		return err
-	}
-	after, err := rootLstatNoSymlink(root, name)
-	if err != nil {
-		return err
-	}
-	if before != nil && !os.SameFile(before, after) {
-		return fmt.Errorf("file changed during open %q", name)
-	}
-	if !os.SameFile(after, openedInfo) {
-		return fmt.Errorf("file changed during open %q", name)
-	}
-	return nil
+	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.Open(name)
+	})
 }

--- a/internal/secureopen/secure_open_unix.go
+++ b/internal/secureopen/secure_open_unix.go
@@ -28,3 +28,24 @@ func OpenExistingNoFollow(path string) (*os.File, error) {
 	flags := os.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK
 	return os.OpenFile(path, flags, 0)
 }
+
+// OpenNewFileNoFollowInRoot creates a new file relative to root without
+// following the final component or permitting parent traversal outside root.
+func OpenNewFileNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
+	flags := os.O_WRONLY | os.O_CREATE | os.O_EXCL | unix.O_NOFOLLOW
+	return root.OpenFile(name, flags, perm)
+}
+
+// OpenAppendNoFollowInRoot opens a file for appending relative to root without
+// following the final component or permitting parent traversal outside root.
+func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
+	flags := os.O_WRONLY | os.O_APPEND | os.O_CREATE | unix.O_NOFOLLOW | unix.O_NONBLOCK
+	return root.OpenFile(name, flags, perm)
+}
+
+// OpenExistingNoFollowInRoot opens an existing file relative to root without
+// following the final component or permitting parent traversal outside root.
+func OpenExistingNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
+	flags := os.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK
+	return root.OpenFile(name, flags, 0)
+}

--- a/internal/secureopen/secure_open_unix.go
+++ b/internal/secureopen/secure_open_unix.go
@@ -33,19 +33,25 @@ func OpenExistingNoFollow(path string) (*os.File, error) {
 // following the final component or permitting parent traversal outside root.
 func OpenNewFileNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
 	flags := os.O_WRONLY | os.O_CREATE | os.O_EXCL | unix.O_NOFOLLOW
-	return root.OpenFile(name, flags, perm)
+	return openNewFileNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, flags, perm)
+	})
 }
 
 // OpenAppendNoFollowInRoot opens a file for appending relative to root without
 // following the final component or permitting parent traversal outside root.
 func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os.File, error) {
 	flags := os.O_WRONLY | os.O_APPEND | os.O_CREATE | unix.O_NOFOLLOW | unix.O_NONBLOCK
-	return root.OpenFile(name, flags, perm)
+	return openNewFileNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, flags, perm)
+	})
 }
 
 // OpenExistingNoFollowInRoot opens an existing file relative to root without
 // following the final component or permitting parent traversal outside root.
 func OpenExistingNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
 	flags := os.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK
-	return root.OpenFile(name, flags, 0)
+	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, flags, 0)
+	})
 }

--- a/internal/secureopen/secure_open_unix.go
+++ b/internal/secureopen/secure_open_unix.go
@@ -47,10 +47,29 @@ func OpenAppendNoFollowInRoot(root *os.Root, name string, perm os.FileMode) (*os
 	})
 }
 
+// OpenExistingAppendNoFollowInRoot opens an existing file for atomic appends
+// without following the final component.
+func OpenExistingAppendNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
+	flags := os.O_WRONLY | os.O_APPEND | unix.O_NOFOLLOW | unix.O_NONBLOCK
+	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, flags, 0)
+	})
+}
+
 // OpenExistingNoFollowInRoot opens an existing file relative to root without
 // following the final component or permitting parent traversal outside root.
 func OpenExistingNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
 	flags := os.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK
+	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
+		return root.OpenFile(name, flags, 0)
+	})
+}
+
+// OpenExistingWritableNoFollowInRoot opens an existing file for writing
+// relative to root without following its final component. Opening the existing
+// inode lets callers honor write ACLs and preserve filesystem metadata.
+func OpenExistingWritableNoFollowInRoot(root *os.Root, name string) (*os.File, error) {
+	flags := os.O_WRONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK
 	return openExistingNoFollowInRootBestEffort(root, name, func() (*os.File, error) {
 		return root.OpenFile(name, flags, 0)
 	})

--- a/internal/secureopen/temp.go
+++ b/internal/secureopen/temp.go
@@ -43,3 +43,35 @@ func CreateTempNoFollow(dir string, pattern string, perm os.FileMode) (*os.File,
 
 	return nil, fmt.Errorf("failed to create temporary file in %q", dir)
 }
+
+// CreateTempNoFollowInRoot creates a new temporary file beneath root and
+// returns both the file and its root-relative name. Parent resolution stays
+// anchored to root even if a directory is concurrently replaced by a symlink.
+func CreateTempNoFollowInRoot(root *os.Root, dir string, pattern string, perm os.FileMode) (*os.File, string, error) {
+	prefix := pattern
+	suffix := ""
+	if idx := strings.LastIndex(pattern, "*"); idx != -1 {
+		prefix = pattern[:idx]
+		suffix = pattern[idx+1:]
+	}
+
+	const maxAttempts = 10_000
+	var randBytes [12]byte
+	for range maxAttempts {
+		if _, err := rand.Read(randBytes[:]); err != nil {
+			return nil, "", err
+		}
+
+		name := filepath.Join(dir, prefix+hex.EncodeToString(randBytes[:])+suffix)
+		file, err := OpenNewFileNoFollowInRoot(root, name, perm)
+		if err == nil {
+			return file, name, nil
+		}
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return nil, "", err
+	}
+
+	return nil, "", fmt.Errorf("failed to create temporary file in %q beneath root %q", dir, root.Name())
+}

--- a/internal/urlsanitize/error.go
+++ b/internal/urlsanitize/error.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
+	"syscall"
 )
 
 // RedactedPlaceholder replaces a URL that cannot be reduced to a safe form.
@@ -62,6 +64,8 @@ func parseForError(rawURL string) (*url.URL, bool) {
 // ClassifyTransportFailure returns a short, credential-free description of a
 // transport failure so sanitized errors keep their diagnostic value.
 func ClassifyTransportFailure(err error) string {
+	var dnsError *net.DNSError
+	var netError *net.OpError
 	switch {
 	case err == nil:
 		return ""
@@ -69,6 +73,18 @@ func ClassifyTransportFailure(err error) string {
 		return "timeout"
 	case errors.Is(err, context.Canceled):
 		return "canceled"
+	case errors.As(err, &dnsError):
+		return "dns lookup"
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return "connection refused"
+	case errors.Is(err, syscall.ENETUNREACH), errors.Is(err, syscall.EHOSTUNREACH):
+		return "network unreachable"
+	case errors.As(err, &netError):
+		operation := strings.ToLower(netError.Op)
+		if strings.Contains(operation, "proxy") {
+			return "proxy connection"
+		}
+		return "network connection"
 	default:
 		return ""
 	}

--- a/internal/urlsanitize/error_test.go
+++ b/internal/urlsanitize/error_test.go
@@ -3,7 +3,9 @@ package urlsanitize
 import (
 	"context"
 	"errors"
+	"net"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -112,11 +114,17 @@ func TestNewTransportErrorClassifiesAndStaysInspectable(t *testing.T) {
 	}
 }
 
-func TestClassifyTransportFailureIgnoresUnknownCauses(t *testing.T) {
+func TestClassifyTransportFailureUsesSafeTypedCauses(t *testing.T) {
 	if got := ClassifyTransportFailure(nil); got != "" {
 		t.Fatalf("ClassifyTransportFailure(nil) = %q, want empty", got)
 	}
-	if got := ClassifyTransportFailure(errors.New("tls: handshake failure")); got != "" {
-		t.Fatalf("ClassifyTransportFailure(tls) = %q, want empty", got)
+	if got := ClassifyTransportFailure(&net.DNSError{Err: "no such host", Name: "secret.invalid"}); got != "dns lookup" {
+		t.Fatalf("ClassifyTransportFailure(dns) = %q, want dns lookup", got)
+	}
+	if got := ClassifyTransportFailure(syscall.ECONNREFUSED); got != "connection refused" {
+		t.Fatalf("ClassifyTransportFailure(refused) = %q, want connection refused", got)
+	}
+	if got := ClassifyTransportFailure(errors.New("arbitrary secret-bearing cause")); got != "" {
+		t.Fatalf("ClassifyTransportFailure(unknown) = %q, want empty", got)
 	}
 }

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -116,14 +116,13 @@ type BumpVersionResult struct {
 }
 
 func resolvedProjectDir(projectDir string) string {
-	trimmed := strings.TrimSpace(projectDir)
-	if trimmed == "" {
+	if projectDir == "" {
 		return "."
 	}
-	if strings.HasSuffix(trimmed, ".xcodeproj") {
-		return filepath.Dir(trimmed)
+	if strings.HasSuffix(projectDir, ".xcodeproj") {
+		return filepath.Dir(projectDir)
 	}
-	return trimmed
+	return projectDir
 }
 
 // GetVersion reads the current marketing version and build number.
@@ -591,22 +590,21 @@ func buildSettingsTargetNames(output string) []string {
 // findXcodeproj resolves an explicit .xcodeproj path or finds one in a project dir.
 // Returns an error if zero or multiple .xcodeproj directories are found.
 func findXcodeproj(projectDir string) (string, error) {
-	trimmedDir := strings.TrimSpace(projectDir)
-	if trimmedDir == "" {
-		trimmedDir = "."
+	if projectDir == "" {
+		projectDir = "."
 	}
-	if strings.HasSuffix(trimmedDir, ".xcodeproj") {
-		info, err := os.Stat(trimmedDir)
+	if strings.HasSuffix(projectDir, ".xcodeproj") {
+		info, err := os.Stat(projectDir)
 		if err != nil {
-			return "", fmt.Errorf("failed to read Xcode project %s: %w", trimmedDir, err)
+			return "", fmt.Errorf("failed to read Xcode project %s: %w", projectDir, err)
 		}
 		if !info.IsDir() {
-			return "", fmt.Errorf("%s is not an .xcodeproj directory", trimmedDir)
+			return "", fmt.Errorf("%s is not an .xcodeproj directory", projectDir)
 		}
-		return trimmedDir, nil
+		return projectDir, nil
 	}
 
-	entries, err := os.ReadDir(trimmedDir)
+	entries, err := os.ReadDir(projectDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read project directory: %w", err)
 	}
@@ -618,11 +616,11 @@ func findXcodeproj(projectDir string) (string, error) {
 	}
 	switch len(matches) {
 	case 0:
-		return "", fmt.Errorf("no .xcodeproj found in %s", trimmedDir)
+		return "", fmt.Errorf("no .xcodeproj found in %s", projectDir)
 	case 1:
-		return filepath.Join(trimmedDir, matches[0]), nil
+		return filepath.Join(projectDir, matches[0]), nil
 	default:
-		return "", fmt.Errorf("multiple .xcodeproj found in %s (%s); use --project to pick one", trimmedDir, strings.Join(matches, ", "))
+		return "", fmt.Errorf("multiple .xcodeproj found in %s (%s); use --project to pick one", projectDir, strings.Join(matches, ", "))
 	}
 }
 

--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -51,6 +52,8 @@ type preparedVersionWrite struct {
 	original []byte
 	updated  []byte
 	mode     os.FileMode
+	root     rootfs.Root
+	name     string
 }
 
 type xcconfigMutation struct {
@@ -880,6 +883,44 @@ func (project *structuredVersionProject) checkXCConfigWritable(path string, allo
 	return nil
 }
 
+func (project *structuredVersionProject) versionFileTarget(path string, allowExternal bool) (preparedVersionWrite, error) {
+	projectRoot, err := rootfs.New(project.rootDir)
+	if err != nil {
+		return preparedVersionWrite{}, err
+	}
+	projectRoot = projectRoot.AllowingInternalSymlinks()
+	if err := projectRoot.CheckContained(path); err == nil {
+		return preparedVersionWrite{path: path, root: projectRoot, name: path}, nil
+	} else if !allowExternal {
+		return preparedVersionWrite{}, err
+	}
+
+	// --allow-external-xcconfig deliberately authorizes the referenced parent
+	// directory as a separate trusted root. The final file must still be a
+	// regular, non-symlink entry below that root.
+	externalRoot, err := rootfs.New(filepath.Dir(path))
+	if err != nil {
+		return preparedVersionWrite{}, err
+	}
+	name := filepath.Base(path)
+	if err := externalRoot.CheckContained(name); err != nil {
+		return preparedVersionWrite{}, err
+	}
+	return preparedVersionWrite{path: path, root: externalRoot, name: name}, nil
+}
+
+func (project *structuredVersionProject) containedVersionFileTarget(path string) (preparedVersionWrite, error) {
+	projectRoot, err := rootfs.New(project.rootDir)
+	if err != nil {
+		return preparedVersionWrite{}, err
+	}
+	projectRoot = projectRoot.AllowingInternalSymlinks()
+	if err := projectRoot.CheckContained(path); err != nil {
+		return preparedVersionWrite{}, err
+	}
+	return preparedVersionWrite{path: path, root: projectRoot, name: path}, nil
+}
+
 func (project *structuredVersionProject) setVersion(opts SetVersionOptions) (*SetVersionResult, error) {
 	validation, err := project.validateSetVersion(opts)
 	if err != nil {
@@ -1002,7 +1043,11 @@ func (project *structuredVersionProject) setVersion(opts SetVersionOptions) (*Se
 		if err := project.checkXCConfigWritable(path, opts.AllowExternalXCConfig); err != nil {
 			return nil, err
 		}
-		write, fileChanges, changed, err := prepareXCConfigWrite(path, xcconfigMutations[path])
+		target, err := project.versionFileTarget(path, opts.AllowExternalXCConfig)
+		if err != nil {
+			return nil, fmt.Errorf("prepare xcconfig %s: %w", path, err)
+		}
+		write, fileChanges, changed, err := prepareXCConfigWrite(target, xcconfigMutations[path])
 		if err != nil {
 			return nil, err
 		}
@@ -1268,7 +1313,11 @@ func consumersSelected(paths []string, consumers map[string]map[string]bool, ide
 }
 
 func (project *structuredVersionProject) preparePBXProjWrite() (preparedVersionWrite, error) {
-	original, mode, err := readRegularVersionFile(project.pbxprojPath)
+	target, err := project.containedVersionFileTarget(project.pbxprojPath)
+	if err != nil {
+		return preparedVersionWrite{}, fmt.Errorf("prepare Xcode project file: %w", err)
+	}
+	original, mode, err := readRegularVersionFile(target)
 	if err != nil {
 		return preparedVersionWrite{}, err
 	}
@@ -1296,11 +1345,14 @@ func (project *structuredVersionProject) preparePBXProjWrite() (preparedVersionW
 	if _, err := xcodeproj.Open(stagedProjectPath); err != nil {
 		return preparedVersionWrite{}, fmt.Errorf("validate staged Xcode project: %w", err)
 	}
-	return preparedVersionWrite{path: project.pbxprojPath, original: original, updated: updated, mode: mode}, nil
+	target.original = original
+	target.updated = updated
+	target.mode = mode
+	return target, nil
 }
 
-func prepareXCConfigWrite(path string, mutations map[string]xcconfigMutation) (preparedVersionWrite, []VersionChange, bool, error) {
-	original, mode, err := readRegularVersionFile(path)
+func prepareXCConfigWrite(target preparedVersionWrite, mutations map[string]xcconfigMutation) (preparedVersionWrite, []VersionChange, bool, error) {
+	original, mode, err := readRegularVersionFile(target)
 	if err != nil {
 		return preparedVersionWrite{}, nil, false, err
 	}
@@ -1316,7 +1368,7 @@ func prepareXCConfigWrite(path string, mutations map[string]xcconfigMutation) (p
 		mutation := mutations[setting]
 		next, oldValues, settingChanged, err := editXCConfig(updated, setting, mutation.value)
 		if err != nil {
-			return preparedVersionWrite{}, nil, false, fmt.Errorf("edit %s: %w", path, err)
+			return preparedVersionWrite{}, nil, false, fmt.Errorf("edit %s: %w", target.path, err)
 		}
 		updated = next
 		if !settingChanged {
@@ -1334,36 +1386,41 @@ func prepareXCConfigWrite(path string, mutations map[string]xcconfigMutation) (p
 				NewValue:      mutation.value,
 				Target:        configuration.target,
 				Configuration: configuration.name,
-				Path:          path,
+				Path:          target.path,
 				Source:        "xcconfig",
 			})
 		}
 	}
 	if _, err := parseXCConfig(updated); err != nil {
-		return preparedVersionWrite{}, nil, false, fmt.Errorf("validate %s: %w", path, err)
+		return preparedVersionWrite{}, nil, false, fmt.Errorf("validate %s: %w", target.path, err)
 	}
-	return preparedVersionWrite{path: path, original: original, updated: updated, mode: mode}, changes, changed, nil
+	target.original = original
+	target.updated = updated
+	target.mode = mode
+	return target, changes, changed, nil
 }
 
-func readRegularVersionFile(path string) ([]byte, os.FileMode, error) {
-	info, err := os.Lstat(path)
+func readRegularVersionFile(target preparedVersionWrite) ([]byte, os.FileMode, error) {
+	file, err := target.root.OpenFile(target.name)
 	if err != nil {
 		return nil, 0, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, 0, fmt.Errorf("refusing to replace symlink: %s", path)
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, 0, err
 	}
 	if !info.Mode().IsRegular() {
-		return nil, 0, fmt.Errorf("not a regular file: %s", path)
+		return nil, 0, fmt.Errorf("not a regular file: %s", target.path)
 	}
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, 0, err
 	}
 	return data, info.Mode().Perm(), nil
 }
 
-var atomicWriteVersionFileFn = atomicWriteVersionFile
+var atomicWriteVersionFileFn = atomicWritePreparedVersionFile
 
 func commitVersionWrites(writes []preparedVersionWrite) error {
 	sort.Slice(writes, func(left, right int) bool { return writes[left].path < writes[right].path })
@@ -1372,10 +1429,10 @@ func commitVersionWrites(writes []preparedVersionWrite) error {
 		if string(write.original) == string(write.updated) {
 			continue
 		}
-		if err := atomicWriteVersionFileFn(write.path, write.updated, write.mode); err != nil {
+		if err := atomicWriteVersionFileFn(write, write.updated); err != nil {
 			var rollbackErrors []error
 			for index := len(committed) - 1; index >= 0; index-- {
-				if rollbackErr := atomicWriteVersionFileFn(committed[index].path, committed[index].original, committed[index].mode); rollbackErr != nil {
+				if rollbackErr := atomicWriteVersionFileFn(committed[index], committed[index].original); rollbackErr != nil {
 					rollbackErrors = append(rollbackErrors, fmt.Errorf("restore %s: %w", committed[index].path, rollbackErr))
 				}
 			}
@@ -1390,41 +1447,20 @@ func commitVersionWrites(writes []preparedVersionWrite) error {
 	return nil
 }
 
+func atomicWritePreparedVersionFile(write preparedVersionWrite, data []byte) error {
+	return write.root.WriteFile(write.name, data, write.mode)
+}
+
+// atomicWriteVersionFile is retained for other Xcode outputs that already
+// select an operator-trusted destination path. Version project writes use
+// atomicWritePreparedVersionFile so their project-root anchor survives from
+// preparation through commit.
 func atomicWriteVersionFile(path string, data []byte, mode os.FileMode) error {
-	directory := filepath.Dir(path)
-	temporary, err := os.CreateTemp(directory, ".asc-version-*")
+	root, err := rootfs.New(filepath.Dir(path))
 	if err != nil {
 		return err
 	}
-	temporaryPath := temporary.Name()
-	removeTemporary := true
-	defer func() {
-		_ = temporary.Close()
-		if removeTemporary {
-			_ = os.Remove(temporaryPath)
-		}
-	}()
-	if err := temporary.Chmod(mode); err != nil {
-		return err
-	}
-	if _, err := temporary.Write(data); err != nil {
-		return err
-	}
-	if err := temporary.Sync(); err != nil {
-		return err
-	}
-	if err := temporary.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(temporaryPath, path); err != nil {
-		return err
-	}
-	removeTemporary = false
-	if directoryHandle, err := os.Open(directory); err == nil {
-		_ = directoryHandle.Sync()
-		_ = directoryHandle.Close()
-	}
-	return nil
+	return root.WriteFile(filepath.Base(path), data, mode)
 }
 
 func sortVersionChanges(changes []VersionChange) {

--- a/internal/xcode/version_structured_test.go
+++ b/internal/xcode/version_structured_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 func TestStructuredVersion_TargetAndConfigurationScopedEditIsCrossPlatform(t *testing.T) {
@@ -70,6 +72,32 @@ func TestStructuredVersion_TargetAndConfigurationScopedEditIsCrossPlatform(t *te
 	}
 	if widget.Version != "1.2.3" || widget.BuildNumber != "42" {
 		t.Fatalf("Widget should remain unchanged, got %#v", widget)
+	}
+}
+
+func TestStructuredVersion_ProjectDirectoryWhitespaceIsPreservedDuringMutation(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	originalRoot := filepath.Dir(project)
+	whitespaceRoot := filepath.Join(filepath.Dir(originalRoot), " Project Root ")
+	if err := os.Rename(originalRoot, whitespaceRoot); err != nil {
+		t.Fatalf("Rename(project root) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(whitespaceRoot) })
+
+	projectPath := filepath.Join(whitespaceRoot, filepath.Base(project))
+	result, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir: whitespaceRoot,
+		Version:    "2.0.0",
+	})
+	if err != nil {
+		t.Fatalf("SetVersion() error = %v", err)
+	}
+	if result.ProjectDir != whitespaceRoot {
+		t.Fatalf("result project directory = %q, want %q", result.ProjectDir, whitespaceRoot)
+	}
+	updated := mustReadVersionTestFile(t, filepath.Join(projectPath, "project.pbxproj"))
+	if strings.Contains(updated, "MARKETING_VERSION = 1.2.3;") {
+		t.Fatalf("version was not updated in exact whitespace directory: %s", updated)
 	}
 }
 
@@ -1301,17 +1329,21 @@ func TestStructuredVersion_CommitFailureRollsBackEarlierFiles(t *testing.T) {
 
 	injectedErr := errors.New("injected write failure")
 	originalWriter := atomicWriteVersionFileFn
-	atomicWriteVersionFileFn = func(path string, data []byte, mode os.FileMode) error {
-		if path == secondPath {
+	atomicWriteVersionFileFn = func(write preparedVersionWrite, data []byte) error {
+		if write.path == secondPath {
 			return injectedErr
 		}
-		return atomicWriteVersionFile(path, data, mode)
+		return atomicWritePreparedVersionFile(write, data)
 	}
 	t.Cleanup(func() { atomicWriteVersionFileFn = originalWriter })
 
-	err := commitVersionWrites([]preparedVersionWrite{
-		{path: secondPath, original: []byte("old-b"), updated: []byte("new-b"), mode: 0o644},
-		{path: firstPath, original: []byte("old-a"), updated: []byte("new-a"), mode: 0o644},
+	fileRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = commitVersionWrites([]preparedVersionWrite{
+		{path: secondPath, root: fileRoot, name: secondPath, original: []byte("old-b"), updated: []byte("new-b"), mode: 0o644},
+		{path: firstPath, root: fileRoot, name: firstPath, original: []byte("old-a"), updated: []byte("new-a"), mode: 0o644},
 	})
 	if !errors.Is(err, injectedErr) {
 		t.Fatalf("expected injected failure, got %v", err)

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -253,6 +253,43 @@ func TestFindXcodeprojAcceptsExplicitProjectPath(t *testing.T) {
 	}
 }
 
+func TestFindXcodeprojDoesNotRetargetTrailingWhitespaceProjectPath(t *testing.T) {
+	tempDir := t.TempDir()
+	exactProject := filepath.Join(tempDir, "Foo.xcodeproj")
+	whitespaceProject := exactProject + " "
+	if err := os.MkdirAll(exactProject, 0o755); err != nil {
+		t.Fatalf("mkdir exact project: %v", err)
+	}
+	if err := os.MkdirAll(whitespaceProject, 0o755); err != nil {
+		t.Fatalf("mkdir whitespace project: %v", err)
+	}
+
+	got, err := findXcodeproj(whitespaceProject)
+	if err == nil {
+		t.Fatalf("findXcodeproj(%q) = %q, want no nested project error", whitespaceProject, got)
+	}
+	if got == exactProject {
+		t.Fatalf("trailing-whitespace path was retargeted to %q", exactProject)
+	}
+}
+
+func TestFindXcodeprojPreservesWhitespaceProjectDirectory(t *testing.T) {
+	parent := t.TempDir()
+	projectDir := filepath.Join(parent, " Project Root ")
+	projectPath := filepath.Join(projectDir, "Demo.xcodeproj")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir whitespace project directory: %v", err)
+	}
+
+	got, err := findXcodeproj(projectDir)
+	if err != nil {
+		t.Fatalf("findXcodeproj(%q) error = %v", projectDir, err)
+	}
+	if got != projectPath {
+		t.Fatalf("findXcodeproj(%q) = %q, want %q", projectDir, got, projectPath)
+	}
+}
+
 func TestFindXcodeprojMultipleProjectsSuggestsProjectFlag(t *testing.T) {
 	tempDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tempDir, "App.xcodeproj"), 0o755); err != nil {

--- a/internal/xcode/version_xcconfig_containment_test.go
+++ b/internal/xcode/version_xcconfig_containment_test.go
@@ -233,3 +233,102 @@ func TestSetVersionStillEditsXCConfigInsideProjectRoot(t *testing.T) {
 		t.Fatalf("in-root xcconfig content = %q, want update", after)
 	}
 }
+
+func TestSetVersionRefusesXCConfigParentSwapAfterValidation(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, true)
+	projectRoot := filepath.Dir(projectPath)
+	configsDir := filepath.Join(projectRoot, "Configs")
+	sharedPath := filepath.Join(configsDir, "Shared.xcconfig")
+	originalConfigsDir := filepath.Join(projectRoot, "Configs-original")
+	externalDir := t.TempDir()
+	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
+	externalBefore := mustReadVersionTestFile(t, sharedPath)
+	if err := os.WriteFile(externalPath, []byte(externalBefore), 0o640); err != nil {
+		t.Fatalf("WriteFile(external Shared.xcconfig) error = %v", err)
+	}
+
+	swapped := false
+	originalWriter := atomicWriteVersionFileFn
+	atomicWriteVersionFileFn = func(write preparedVersionWrite, data []byte) error {
+		if write.path == sharedPath && !swapped {
+			swapped = true
+			if err := os.Rename(configsDir, originalConfigsDir); err != nil {
+				return err
+			}
+			if err := os.Symlink(externalDir, configsDir); err != nil {
+				return err
+			}
+		}
+		return atomicWritePreparedVersionFile(write, data)
+	}
+	t.Cleanup(func() { atomicWriteVersionFileFn = originalWriter })
+
+	_, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:  projectPath,
+		Version:     "2.0.0",
+		BuildNumber: "99",
+	})
+	if err == nil {
+		t.Fatal("SetVersion() error = nil, want swapped xcconfig parent refusal")
+	}
+	if !swapped {
+		t.Fatal("test did not swap the xcconfig parent")
+	}
+	if after := mustReadVersionTestFile(t, externalPath); after != externalBefore {
+		t.Fatalf("external xcconfig changed through swapped parent: %q", after)
+	}
+	if after := mustReadVersionTestFile(t, filepath.Join(originalConfigsDir, "Shared.xcconfig")); after != externalBefore {
+		t.Fatalf("original in-root xcconfig changed after parent swap: %q", after)
+	}
+}
+
+func TestSetVersionRefusesXcodeprojParentSwapAfterValidation(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, false)
+	projectRoot := filepath.Dir(projectPath)
+	pbxprojPath := filepath.Join(projectPath, "project.pbxproj")
+	originalProjectPath := filepath.Join(projectRoot, "Demo-original.xcodeproj")
+	externalRoot := t.TempDir()
+	externalProjectPath := filepath.Join(externalRoot, "Demo.xcodeproj")
+	if err := os.MkdirAll(externalProjectPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalPBXProjPath := filepath.Join(externalProjectPath, "project.pbxproj")
+	externalBefore := mustReadVersionTestFile(t, pbxprojPath)
+	if err := os.WriteFile(externalPBXProjPath, []byte(externalBefore), 0o644); err != nil {
+		t.Fatalf("WriteFile(external project.pbxproj) error = %v", err)
+	}
+
+	swapped := false
+	originalWriter := atomicWriteVersionFileFn
+	atomicWriteVersionFileFn = func(write preparedVersionWrite, data []byte) error {
+		if write.path == pbxprojPath && !swapped {
+			swapped = true
+			if err := os.Rename(projectPath, originalProjectPath); err != nil {
+				return err
+			}
+			if err := os.Symlink(externalProjectPath, projectPath); err != nil {
+				return err
+			}
+		}
+		return atomicWritePreparedVersionFile(write, data)
+	}
+	t.Cleanup(func() { atomicWriteVersionFileFn = originalWriter })
+
+	_, err := SetVersion(context.Background(), SetVersionOptions{
+		ProjectDir:  projectPath,
+		Version:     "2.0.0",
+		BuildNumber: "99",
+	})
+	if err == nil {
+		t.Fatal("SetVersion() error = nil, want swapped .xcodeproj parent refusal")
+	}
+	if !swapped {
+		t.Fatal("test did not swap the .xcodeproj directory")
+	}
+	if after := mustReadVersionTestFile(t, externalPBXProjPath); after != externalBefore {
+		t.Fatalf("external project.pbxproj changed through swapped parent: %q", after)
+	}
+	if after := mustReadVersionTestFile(t, filepath.Join(originalProjectPath, "project.pbxproj")); after != externalBefore {
+		t.Fatalf("original project.pbxproj changed after parent swap: %q", after)
+	}
+}

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -279,12 +279,11 @@ func Export(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := moveExportedIPA(exportedIPAPath, opts.IPAPath, opts.Overwrite); err != nil {
-		return nil, err
-	}
-
-	info, err := readIPABundleInfo(opts.IPAPath)
+	info, err := readIPABundleInfo(exportedIPAPath)
 	if err != nil {
+		return nil, fmt.Errorf("inspect exported IPA before installation: %w", err)
+	}
+	if err := moveExportedIPA(exportedIPAPath, opts.IPAPath, opts.Overwrite); err != nil {
 		return nil, err
 	}
 
@@ -314,7 +313,11 @@ func Validate(ctx context.Context, opts ValidateOptions) (*ValidateResult, error
 	if err := validateExistingFile(opts.IPAPath, "--ipa"); err != nil {
 		return nil, err
 	}
-	if err := runAltoolValidate(ctx, buildValidateCommand(opts, inferValidatePlatform(opts.IPAPath)), opts.LogWriter); err != nil {
+	platform, err := inferValidatePlatform(opts.IPAPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := runAltoolValidate(ctx, buildValidateCommand(opts, platform), opts.LogWriter); err != nil {
 		return nil, err
 	}
 	return &ValidateResult{
@@ -657,15 +660,15 @@ func buildExportCommand(opts ExportOptions, exportDir string) []string {
 	return args
 }
 
-func inferValidatePlatform(ipaPath string) string {
+func inferValidatePlatform(ipaPath string) (string, error) {
 	info, err := readIPABundleInfo(ipaPath)
 	if err != nil {
-		return "ios"
+		return "", fmt.Errorf("inspect IPA metadata before validation: %w", err)
 	}
 	if platform := mapAppStorePlatformToAltoolType(info.Platform); platform != "" {
-		return platform
+		return platform, nil
 	}
-	return "ios"
+	return "ios", nil
 }
 
 func buildValidateCommand(opts ValidateOptions, platform string) []string {
@@ -1197,9 +1200,7 @@ func prepareIPAPath(ipaPath string, overwrite bool) error {
 	case err == nil && !overwrite:
 		return fmt.Errorf("--ipa-path already exists: %s (use --overwrite to replace it)", ipaPath)
 	case err == nil && overwrite:
-		if removeErr := os.Remove(ipaPath); removeErr != nil {
-			return fmt.Errorf("remove existing ipa path: %w", removeErr)
-		}
+		return nil
 	case err != nil && !errors.Is(err, os.ErrNotExist):
 		return fmt.Errorf("stat ipa path: %w", err)
 	}
@@ -1237,11 +1238,16 @@ func isDirectUploadMode(exportOptionsPlistPath string) bool {
 }
 
 func moveExportedIPA(sourcePath, destinationPath string, overwrite bool) error {
-	if overwrite {
-		if err := os.Remove(destinationPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove existing ipa path: %w", err)
+	if !overwrite {
+		if _, err := os.Lstat(destinationPath); err == nil {
+			return fmt.Errorf("--ipa-path already exists: %s (use --overwrite to replace it)", destinationPath)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("lstat ipa path: %w", err)
 		}
 	}
+	// Export runs only on macOS, where rename replaces an existing regular file
+	// atomically. Do not unlink the old artifact first: if the final move fails,
+	// the caller's prior IPA remains intact.
 	if err := os.Rename(sourcePath, destinationPath); err != nil {
 		return fmt.Errorf("move exported ipa: %w", err)
 	}
@@ -1314,6 +1320,9 @@ func readBundleInfoFromZip(file *zip.File) (bundleInfo, error) {
 	data, err := infoplist.ReadBounded(reader)
 	if err != nil {
 		return bundleInfo{}, fmt.Errorf("read Info.plist: %w", err)
+	}
+	if err := infoplist.ValidateStructure(data); err != nil {
+		return bundleInfo{}, fmt.Errorf("decode Info.plist: %w", err)
 	}
 	var payload map[string]any
 	if _, err := plist.Unmarshal(data, &payload); err != nil {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 )
 
 func TestArchiveUnsupportedPlatform(t *testing.T) {
@@ -417,6 +419,35 @@ func TestValidateRunsAltoolWithTVOSPlatform(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsOversizedInfoPlistBeforeAltool(t *testing.T) {
+	tempDir := t.TempDir()
+	ipaPath := writeIPAWithRawInfoPlist(t, buildSizedAppInfoPlist(t, infoplist.MaxBytes+1))
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		return "/usr/bin/" + file, nil
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Cleanup(restore)
+
+	_, err := Validate(context.Background(), ValidateOptions{IPAPath: ipaPath})
+	if err == nil {
+		t.Fatal("expected oversized Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Info.plist limit") {
+		t.Fatalf("expected Info.plist limit error, got %v", err)
+	}
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error: %v", readErr)
+	}
+	if strings.Contains(string(logData), "--validate-app") {
+		t.Fatalf("altool must not run after metadata rejection, got %q", string(logData))
+	}
+}
+
 func TestBuildStatusRunsAltoolWithLookupFlags(t *testing.T) {
 	tempDir := t.TempDir()
 	keyPath := filepath.Join(tempDir, "AuthKey_TEST12345.p8")
@@ -667,6 +698,75 @@ func TestExportWritesIPAAtExactPathAndReturnsMetadata(t *testing.T) {
 	}
 	if !strings.Contains(lines[1], "|-allowProvisioningUpdates") {
 		t.Fatalf("expected custom xcodebuild arg, got %q", lines[1])
+	}
+}
+
+func TestExportValidatesGeneratedIPABeforeReplacingDestination(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+	if err := os.MkdirAll(archivePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	exportOptionsPath := filepath.Join(tempDir, "ExportOptions.plist")
+	if err := os.WriteFile(exportOptionsPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Cleanup(restore)
+	t.Setenv("ASC_XCODE_HELPER_INVALID_IPA", "1")
+
+	ipaPath := filepath.Join(tempDir, "Demo.ipa")
+	if err := os.WriteFile(ipaPath, []byte("existing ipa"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	_, err := Export(context.Background(), ExportOptions{
+		ArchivePath:   archivePath,
+		ExportOptions: exportOptionsPath,
+		IPAPath:       ipaPath,
+		Overwrite:     true,
+	})
+	if err == nil {
+		t.Fatal("expected generated IPA metadata rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "inspect exported IPA before installation") {
+		t.Fatalf("expected pre-install metadata error, got %v", err)
+	}
+	data, readErr := os.ReadFile(ipaPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error: %v", readErr)
+	}
+	if string(data) != "existing ipa" {
+		t.Fatalf("expected existing IPA to survive failed export, got %q", data)
+	}
+}
+
+func TestMoveExportedIPAAtomicallyReplacesExistingDestination(t *testing.T) {
+	directory := t.TempDir()
+	source := filepath.Join(directory, "generated.ipa")
+	destination := filepath.Join(directory, "release.ipa")
+	if err := os.WriteFile(source, []byte("new ipa"), 0o644); err != nil {
+		t.Fatalf("WriteFile(source) error: %v", err)
+	}
+	if err := os.WriteFile(destination, []byte("old ipa"), 0o644); err != nil {
+		t.Fatalf("WriteFile(destination) error: %v", err)
+	}
+
+	if err := moveExportedIPA(source, destination, true); err != nil {
+		t.Fatalf("moveExportedIPA() error: %v", err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "new ipa" {
+		t.Fatalf("expected replacement IPA, got %q", data)
 	}
 }
 
@@ -1217,6 +1317,13 @@ func TestXcodeHelperProcess(t *testing.T) {
 			os.Exit(2)
 		}
 		if isDirectUploadMode(exportOptionsPath) {
+			os.Exit(0)
+		}
+		if os.Getenv("ASC_XCODE_HELPER_INVALID_IPA") == "1" {
+			if err := os.WriteFile(filepath.Join(exportPath, "Exported.ipa"), []byte("not an ipa"), 0o644); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
 			os.Exit(0)
 		}
 		if err := writeTestIPA(filepath.Join(exportPath, "Exported.ipa")); err != nil {


### PR DESCRIPTION
## Summary

This PR contains the fix-forward work from an adversarial release audit of merged security PRs #1826 through #1830. The original five PRs are not safe to release without these corrections.

### Blockers closed

- bound review-batch JSON and Info.plist parsing without accepting ambiguous duplicate keys, invalid Unicode, recursive amplification, or pagination loops
- redact review credentials and upload capabilities at every default output and error boundary; stop cross-origin redirects from carrying secrets
- normalize spaced boolean values so `--confirm false` cannot become true, and require fresh App Store submission validation instead of trusting unsigned checkpoints or canceling unrelated submissions
- replace the executable npm installer path with a pinned, manifest-verified, transactionally rolled-back installer with process locks and no-follow cleanup
- sanitize terminal, table, Markdown, CSV, and documentation workflow injection boundaries while preserving raw JSON
- harden rooted filesystem writes, metadata preservation, hardlinks, parent swaps, migration imports, docs initialization, Xcode project edits, and exact whitespace-bearing path support
- disable the automatic external skills updater that could mutate user state without an explicit command

## Compatibility

The fixes retain normal CLI flexibility:

- trusted external fastlane layouts remain available through explicit opt-in flags
- internal documented symlink layouts remain supported
- exact filenames, including leading, trailing, and all-space names, are preserved
- arbitrary user CSV apostrophes remain round-trippable; only ASC-exported formula escapes are marked and reversed
- raw JSON remains unsanitized while human-rendered terminal and Markdown output is safe

The merged security work includes breaking behavior, so the next release must be **4.0.0**, not another 3.x release.

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" make format`
- `make check-docs`
- `PATH="$(go env GOPATH)/bin:$PATH" make lint` — 0 issues
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`
- repository pre-commit hooks, including the uncached short suite
- focused race and cross-platform compile checks for rooted I/O, secure-open, installer, submission, migration, and Xcode boundaries
- `git diff --check`

No live App Store Connect mutations were performed. This PR must pass exact-head CI and review before merge; no release is authorized by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `asc install-skills` flow that uses `git` only (no Node/npx/npm execution), installs the pinned 23-skill pack, verifies contents, and rolls back safely on failure.
  - Added `--include-sensitive` opt-in for commands that may otherwise redact capability data.

- **Security Improvements**
  - Strengthened root-scoped file operations and symlink-safety to prevent escapes or unsafe replacements, even under post-validation filesystem swaps.
  - Hardened HTTP redirect handling so signed upload/download URLs are not followed.

- **Tests**
  - Expanded coverage for swapped symlink/rollback safety and installer locking/cleanup invariants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->