### PR TITLE
feat(analytics): add report instance filters

### DIFF
--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -210,6 +210,8 @@ type analyticsReportsQuery struct {
 
 type analyticsReportInstancesQuery struct {
 	listQuery
+	granularity    string
+	processingDate []string
 }
 
 type analyticsReportSegmentsQuery struct {
@@ -289,6 +291,33 @@ func WithAnalyticsReportInstancesNextURL(next string) AnalyticsReportInstancesOp
 	}
 }
 
+// WithAnalyticsReportInstancesGranularity filters instances by granularity.
+func WithAnalyticsReportInstancesGranularity(granularity string) AnalyticsReportInstancesOption {
+	return func(q *analyticsReportInstancesQuery) {
+		q.granularity = strings.TrimSpace(granularity)
+	}
+}
+
+// WithAnalyticsReportInstancesProcessingDates filters instances by processing date.
+func WithAnalyticsReportInstancesProcessingDates(dates ...string) AnalyticsReportInstancesOption {
+	return func(q *analyticsReportInstancesQuery) {
+		seen := make(map[string]struct{}, len(dates))
+		normalized := make([]string, 0, len(dates))
+		for _, date := range dates {
+			value := strings.TrimSpace(date)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			normalized = append(normalized, value)
+		}
+		q.processingDate = normalized
+	}
+}
+
 // WithAnalyticsReportSegmentsLimit sets the max number of segments to return.
 func WithAnalyticsReportSegmentsLimit(limit int) AnalyticsReportSegmentsOption {
 	return func(q *analyticsReportSegmentsQuery) {
@@ -350,6 +379,12 @@ func buildAnalyticsReportsQuery(query *analyticsReportsQuery) string {
 
 func buildAnalyticsReportInstancesQuery(query *analyticsReportInstancesQuery) string {
 	values := url.Values{}
+	if strings.TrimSpace(query.granularity) != "" {
+		values.Set("filter[granularity]", strings.TrimSpace(query.granularity))
+	}
+	if len(query.processingDate) > 0 {
+		values.Set("filter[processingDate]", strings.Join(query.processingDate, ","))
+	}
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/analytics_instances_filters_test.go
+++ b/internal/asc/analytics_instances_filters_test.go
@@ -1,0 +1,50 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetAnalyticsReportInstances_UsesDocumentedFilters(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/analyticsReports/report-1/instances" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if got := query.Get("filter[granularity]"); got != "WEEKLY" {
+			t.Fatalf("expected weekly granularity filter, got %q", got)
+		}
+		if got := query.Get("filter[processingDate]"); got != "2026-02-20,2026-02-27" {
+			t.Fatalf("unexpected processing-date filter %q", got)
+		}
+		if got := query.Get("limit"); got != "200" {
+			t.Fatalf("expected limit 200, got %q", got)
+		}
+		assertAuthorized(t, req)
+	}, jsonResponse(http.StatusOK, `{
+		"data":[{
+			"type":"analyticsReportInstances",
+			"id":"instance-1",
+			"attributes":{"granularity":"WEEKLY","processingDate":"2026-02-27"}
+		}],
+		"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReports/report-1/instances"}
+	}`))
+
+	response, err := client.GetAnalyticsReportInstances(
+		context.Background(),
+		"report-1",
+		WithAnalyticsReportInstancesGranularity("WEEKLY"),
+		WithAnalyticsReportInstancesProcessingDates("2026-02-20", "2026-02-27"),
+		WithAnalyticsReportInstancesLimit(200),
+	)
+	if err != nil {
+		t.Fatalf("GetAnalyticsReportInstances() error = %v", err)
+	}
+	if len(response.Data) != 1 || response.Data[0].ID != "instance-1" {
+		t.Fatalf("unexpected response %+v", response.Data)
+	}
+}


### PR DESCRIPTION
## Summary

- expose `WithAnalyticsReportInstancesGranularity` for the documented
  `filter[granularity]` query parameter
- expose `WithAnalyticsReportInstancesProcessingDates` for the documented
  `filter[processingDate]` query parameter
- normalize whitespace, ignore empty dates, remove duplicates, and preserve
  caller order
- add a focused request-level test covering the encoded filters, pagination
  limit, authentication header, and response decoding

## Why

`GetAnalyticsReportInstances` currently exposes pagination but not Apple's
instance filters. Callers that need a particular weekly or daily report must
therefore fetch and scan every available instance or rebuild request URLs
outside the client.

This adds the missing, reusable client primitive without changing existing
behavior. It also keeps filtering on Apple's API rather than duplicating it in
each downstream workflow.

## Scope

This PR is intentionally narrow. It does not add CLI flags, create analytics
report requests, download report segments, aggregate metrics, or change output
formats.

## End goal: evidence-backed investor presentations

The intended end state is an optional `asc-app-dossier` skill in the
[companion skills repository](https://github.com/rorkai/app-store-connect-cli-skills).
An app owner could ask it to prepare an acquisition, fundraising, or
investor-update presentation from their App Store evidence.

```text
Apple Analytics Reports
  -> deterministic asc metrics with provenance and privacy caveats
  -> optional asc-app-dossier skill
  -> evidence ledger + written memo + presentation-ready slide deck
```

The presentation would separate every material claim into `verified`,
`derived`, `owner-provided`, `assumption`, or `unavailable`. It would not invent
traction, conversion, retention, revenue, profit, market size, valuation, or
transfer readiness when the evidence does not support those claims.

The core CLI would remain generic and deterministic; presentation generation
would stay in the optional skill rather than becoming CLI behavior.

## Proposed cross-repository sequence

1. **This PR:** expose the documented filters needed to select exact weekly
   report instances.
2. **Separate CLI PR:** download, integrity-check, and parse all compressed
   segments, then emit additive weekly metrics with provenance and explicit
   `unavailable` states.
3. **Separate skills PR:** add `asc-app-dossier`, consuming that stable JSON to
   create an evidence ledger, investor/acquisition memo, chart plan, and
   presentation-ready slide deck.

I would appreciate maintainer feedback on this boundary and sequence before
submitting the larger follow-ups. Each step remains independently useful and
reviewable.

## Validation

Validated locally with the repository's required Go 1.26 toolchain:

- `go test ./internal/asc`
- focused race tests
- `make format`
- `make lint`
- `make check-docs`
- `git diff --check main...HEAD`
