### PR TITLE
Remember Apple Account passwords for web auth

### DIFF
--- a/internal/cli/web/web_apps_create_shared.go
+++ b/internal/cli/web/web_apps_create_shared.go
@@ -238,6 +238,10 @@ func persistFreshAppCreateSession(session *webcore.AuthSession) error {
 	return nil
 }
 
+func persistAutoReauthAppCreateSession(session *webcore.AuthSession) {
+	_ = persistFreshAppCreateSession(session)
+}
+
 func rollbackCreatedBundleID(ctx context.Context, bundleID string) error {
 	bundleID = strings.TrimSpace(bundleID)
 	if bundleID == "" {
@@ -259,6 +263,7 @@ func resolveAppCreateSession(ctx context.Context, appleID, password, twoFactorCo
 		promptAppleID:        promptAppsCreateSessionAppleID,
 		resolvePassword:      resolveAppCreatePassword,
 		persistFresh:         persistFreshAppCreateSession,
+		persistAutoReauth:    persistAutoReauthAppCreateSession,
 		twoFactorCodeCommand: command,
 	})
 	if err != nil {

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -559,11 +559,6 @@ func loginWithOptionalTwoFactor(ctx context.Context, appleID, password, twoFacto
 	return loginWithOptionalTwoFactorUsing(ctx, "Signing in to Apple web session", appleID, password, twoFactorCode, webLoginFn, nil, twoFactorCodeCommand...)
 }
 
-func loginWithOptionalTwoFactorClient(ctx context.Context, client *http.Client, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
-	session, _, err := loginWithOptionalTwoFactorClientTracked(ctx, client, appleID, password, twoFactorCode, twoFactorCodeCommand...)
-	return session, err
-}
-
 func loginWithOptionalTwoFactorClientTracked(ctx context.Context, client *http.Client, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, bool, error) {
 	twoFactorStarted := false
 	session, err := loginWithOptionalTwoFactorUsing(ctx, "Refreshing expired web session", appleID, password, twoFactorCode, func(ctx context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
@@ -700,12 +695,15 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 			return nil, "", false, nil
 		}
 
-		session, loginErr := loginWithOptionalTwoFactorClient(ctx, expiredCachedSession.Client, reauthAppleID, silentPassword.value, twoFactorCode, command)
+		session, twoFactorStarted, loginErr := loginWithOptionalTwoFactorClientTracked(ctx, expiredCachedSession.Client, reauthAppleID, silentPassword.value, twoFactorCode, command)
 		if loginErr == nil {
 			if opts.persistAutoReauth != nil {
 				opts.persistAutoReauth(session)
 			}
 			return session, "auto-reauth", true, nil
+		}
+		if twoFactorStarted {
+			return nil, "", false, fmt.Errorf("web auth auto-reauth failed: %w", loginErr)
 		}
 		if errors.Is(loginErr, webcore.ErrInvalidAppleAccountCredentials) {
 			if silentPassword.source != webPasswordSourceStored {
@@ -717,8 +715,8 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 			return nil, "", false, nil
 		}
 
-		// A cached jar can become unusable independently of the credentials.
-		// Preserve the same password source for one fresh-client fallback.
+		// Before 2FA begins, a cached jar can become unusable independently of
+		// the credentials. Preserve the password source for one fresh fallback.
 		fallbackPassword = silentPassword
 		expiredCachedSession = nil
 		printExpiredNotice()

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -23,6 +24,7 @@ import (
 
 const (
 	webPasswordEnv             = "ASC_WEB_PASSWORD"
+	webDontStorePasswordEnv    = "ASC_WEB_DONT_STORE_PASSWORD"
 	webTwoFactorCodeCommandEnv = "ASC_WEB_2FA_CODE_COMMAND"
 	webTwoFactorCommandTimeout = 60 * time.Second
 	passwordReadPollInterval   = 100 * time.Millisecond
@@ -35,8 +37,6 @@ func webPasswordEnvDisplay() string {
 func webPasswordEnvAssignmentExample() string {
 	return webPasswordEnvDisplay() + "=\"...\""
 }
-
-var errAutoReauthRequiresAppleID = errors.New("cached web session is missing stored apple id metadata")
 
 var (
 	openTTYFn                                = openTTY
@@ -56,12 +56,20 @@ var (
 	loadCachedSessionFn                      = webcore.LoadCachedSession
 	loadLastCachedSessionFn                  = webcore.LoadLastCachedSession
 	webLoginWithClientFn                     = webcore.LoginWithClient
+	loadStoredWebPasswordFn                  = webcore.LoadPassword
+	storeStoredWebPasswordFn                 = webcore.StorePassword
+	storedWebPasswordExistsFn                = webcore.PasswordStored
+	deleteStoredWebPasswordFn                = webcore.DeletePassword
+	deleteAllStoredWebPasswordsFn            = webcore.DeleteAllPasswords
+	deleteWebSessionFn                       = webcore.DeleteSession
+	deleteAllWebSessionsFn                   = webcore.DeleteAllSessions
 	selectWebProviderFn                      = webcore.SelectProvider
 	resolveSessionFn               any       = resolveSession
 	resolveSessionWithoutPersistFn any       = resolveSessionWithoutPersist
 	twoFactorStatusWriter          io.Writer = os.Stderr
 	sessionExpiredWriter           io.Writer = os.Stderr
 	sessionCacheWarningWriter      io.Writer = os.Stderr
+	passwordStoreWarningWriter     io.Writer = os.Stderr
 )
 
 func callSessionResolverHook(ctx context.Context, hook any, hookName, appleID, password, twoFactorCode, twoFactorCodeCommand string) (*webcore.AuthSession, string, error) {
@@ -84,12 +92,43 @@ func webPasswordProvided(password string) bool {
 	return strings.TrimSpace(password) != ""
 }
 
+func webPasswordStorageDisabled() bool {
+	if webEnvTruthy(os.Getenv(webDontStorePasswordEnv)) {
+		return true
+	}
+	return webEnvTruthy(os.Getenv("ASC_BYPASS_KEYCHAIN"))
+}
+
+func webEnvTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+type webPasswordSource string
+
+const (
+	webPasswordSourceProvided webPasswordSource = "provided"
+	webPasswordSourceEnv      webPasswordSource = "environment"
+	webPasswordSourceStored   webPasswordSource = "stored"
+	webPasswordSourcePrompted webPasswordSource = "prompted"
+)
+
+type resolvedWebPassword struct {
+	value  string
+	source webPasswordSource
+}
+
 func openTTY() (*os.File, error) {
 	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
 }
 
 type webAuthStatus struct {
 	Authenticated    bool   `json:"authenticated"`
+	PasswordStored   bool   `json:"passwordStored"`
 	Source           string `json:"source,omitempty"`
 	AppleID          string `json:"appleId,omitempty"`
 	TeamID           string `json:"teamId,omitempty"`
@@ -336,9 +375,58 @@ func printCacheLookupWarning(writer io.Writer, err error) {
 	_, _ = fmt.Fprintf(writer, "Warning: %v; continuing with fresh login.\n", err)
 }
 
-func loginWithOptionalTwoFactor(ctx context.Context, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
-	session, err := withWebSpinnerValue("Signing in to Apple web session", func() (*webcore.AuthSession, error) {
-		return webLoginFn(ctx, webcore.LoginCredentials{
+func printPasswordStoreWarning(writer io.Writer, action string, err error) {
+	if writer == nil || err == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(writer, "Warning: could not %s saved Apple Account password: %v.\n", action, err)
+}
+
+func resolveNonInteractiveWebPassword(appleID, provided string, skipStored bool) resolvedWebPassword {
+	if webPasswordProvided(provided) {
+		return resolvedWebPassword{value: provided, source: webPasswordSourceProvided}
+	}
+	if password := readPasswordFromEnv(); webPasswordProvided(password) {
+		return resolvedWebPassword{value: password, source: webPasswordSourceEnv}
+	}
+	if skipStored || webPasswordStorageDisabled() || strings.TrimSpace(appleID) == "" {
+		return resolvedWebPassword{}
+	}
+	password, ok, err := loadStoredWebPasswordFn(appleID)
+	if err != nil {
+		printPasswordStoreWarning(passwordStoreWarningWriter, "load", err)
+		return resolvedWebPassword{}
+	}
+	if !ok || !webPasswordProvided(password) {
+		return resolvedWebPassword{}
+	}
+	return resolvedWebPassword{value: password, source: webPasswordSourceStored}
+}
+
+func persistPromptedWebPassword(appleID string, password resolvedWebPassword) {
+	if password.source != webPasswordSourcePrompted || webPasswordStorageDisabled() {
+		return
+	}
+	if err := storeStoredWebPasswordFn(appleID, password.value); err != nil {
+		printPasswordStoreWarning(passwordStoreWarningWriter, "save", err)
+	}
+}
+
+func storedWebPasswordStatus(appleID string) bool {
+	if webPasswordStorageDisabled() || strings.TrimSpace(appleID) == "" {
+		return false
+	}
+	stored, err := storedWebPasswordExistsFn(appleID)
+	if err != nil {
+		printPasswordStoreWarning(passwordStoreWarningWriter, "check", err)
+		return false
+	}
+	return stored
+}
+
+func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, appleID, password, twoFactorCode string, loginFn func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error), twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
+	session, err := withWebSpinnerValue(progressMessage, func() (*webcore.AuthSession, error) {
+		return loginFn(ctx, webcore.LoginCredentials{
 			Username: appleID,
 			Password: password,
 		})
@@ -426,52 +514,14 @@ func loginWithOptionalTwoFactor(ctx context.Context, appleID, password, twoFacto
 	return nil, err
 }
 
-func tryAutoReauthWebSession(ctx context.Context, appleID, password string) (*webcore.AuthSession, string, bool, error) {
-	if !webPasswordProvided(password) {
-		return nil, "", false, nil
-	}
+func loginWithOptionalTwoFactor(ctx context.Context, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
+	return loginWithOptionalTwoFactorUsing(ctx, "Signing in to Apple web session", appleID, password, twoFactorCode, webLoginFn, twoFactorCodeCommand...)
+}
 
-	var (
-		cached *webcore.AuthSession
-		ok     bool
-		err    error
-	)
-	if strings.TrimSpace(appleID) != "" {
-		cached, ok, err = loadCachedSessionFn(appleID)
-	} else {
-		cached, ok, err = loadLastCachedSessionFn()
-	}
-	if err != nil || !ok || cached == nil {
-		return nil, "", false, err
-	}
-	if cached.Client == nil {
-		return nil, "", false, nil
-	}
-
-	reauthAppleID := strings.TrimSpace(appleID)
-	if reauthAppleID == "" {
-		reauthAppleID = strings.TrimSpace(cached.UserEmail)
-	}
-	if reauthAppleID == "" {
-		return nil, "", false, errAutoReauthRequiresAppleID
-	}
-
-	session, err := withWebSpinnerValue("Refreshing expired web session", func() (*webcore.AuthSession, error) {
-		return webLoginWithClientFn(ctx, cached.Client, webcore.LoginCredentials{
-			Username: reauthAppleID,
-			Password: password,
-		})
-	})
-	if err != nil {
-		if errors.Is(err, webcore.ErrInvalidAppleAccountCredentials) {
-			return nil, "", false, err
-		}
-		// Fall back to the pre-existing fresh-login path when the cached-jar
-		// attempt cannot be completed. The cache format is intentionally
-		// best-effort and may not preserve enough cookie metadata for relogin.
-		return nil, "", false, nil
-	}
-	return session, "auto-reauth", true, nil
+func loginWithOptionalTwoFactorClient(ctx context.Context, client *http.Client, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
+	return loginWithOptionalTwoFactorUsing(ctx, "Refreshing expired web session", appleID, password, twoFactorCode, func(ctx context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		return webLoginWithClientFn(ctx, client, credentials)
+	}, twoFactorCodeCommand...)
 }
 
 func tryResumeWebSession(ctx context.Context, appleID string) (*webcore.AuthSession, bool, error) {
@@ -538,40 +588,99 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		command = strings.TrimSpace(os.Getenv(webTwoFactorCodeCommandEnv))
 	}
 	expiredNoticePrinted := false
-
-	tryHandleExpiredSession := func(targetAppleID string) (*webcore.AuthSession, string, bool, error) {
-		silentPassword := password
-		if !webPasswordProvided(silentPassword) {
-			silentPassword = readPasswordFromEnv()
+	printExpiredNotice := func() {
+		if expiredNoticePrinted {
+			return
 		}
-		if session, source, ok, err := tryAutoReauthWebSession(ctx, targetAppleID, silentPassword); err != nil {
-			if errors.Is(err, errAutoReauthRequiresAppleID) {
-				return nil, "", false, shared.UsageError("last cached web session predates stored Apple ID metadata; re-run once with --apple-id to refresh the cache")
-			}
-			return nil, "", false, fmt.Errorf("web auth auto-reauth failed: %w", err)
-		} else if ok {
+		printExpiredSessionNotice(sessionExpiredWriter)
+		expiredNoticePrinted = true
+	}
+
+	var (
+		expiredCachedSession *webcore.AuthSession
+		fallbackPassword     resolvedWebPassword
+		skipStoredPassword   bool
+	)
+
+	tryKnownSession := func(targetAppleID string) (*webcore.AuthSession, string, bool, error) {
+		resumed, ok, cacheExpired, err := resolveKnownWebSession(ctx, targetAppleID)
+		if err != nil {
+			printCacheLookupWarning(sessionCacheWarningWriter, err)
+			return nil, "", false, nil
+		}
+		if ok {
+			return resumed, "cache", true, nil
+		}
+		if !cacheExpired {
+			return nil, "", false, nil
+		}
+
+		var cachedOK bool
+		if strings.TrimSpace(targetAppleID) != "" {
+			expiredCachedSession, cachedOK, err = loadCachedSessionFn(targetAppleID)
+		} else {
+			expiredCachedSession, cachedOK, err = loadLastCachedSessionFn()
+		}
+		if err != nil {
+			printCacheLookupWarning(sessionCacheWarningWriter, fmt.Errorf("loading expired cached web session failed: %w", err))
+			expiredCachedSession = nil
+			printExpiredNotice()
+			return nil, "", false, nil
+		}
+		if !cachedOK || expiredCachedSession == nil || expiredCachedSession.Client == nil {
+			expiredCachedSession = nil
+			printExpiredNotice()
+			return nil, "", false, nil
+		}
+
+		reauthAppleID := strings.TrimSpace(targetAppleID)
+		if reauthAppleID == "" {
+			reauthAppleID = strings.TrimSpace(expiredCachedSession.UserEmail)
+		}
+		if reauthAppleID == "" {
+			return nil, "", false, shared.UsageError("last cached web session predates stored Apple ID metadata; re-run once with --apple-id to refresh the cache")
+		}
+		if appleID == "" {
+			appleID = reauthAppleID
+		}
+
+		silentPassword := resolveNonInteractiveWebPassword(reauthAppleID, password, skipStoredPassword)
+		if !webPasswordProvided(silentPassword.value) {
+			printExpiredNotice()
+			return nil, "", false, nil
+		}
+
+		session, loginErr := loginWithOptionalTwoFactorClient(ctx, expiredCachedSession.Client, reauthAppleID, silentPassword.value, twoFactorCode, command)
+		if loginErr == nil {
 			if opts.persistAutoReauth != nil {
 				opts.persistAutoReauth(session)
 			}
-			return session, source, true, nil
+			return session, "auto-reauth", true, nil
 		}
-		if !expiredNoticePrinted {
-			printExpiredSessionNotice(sessionExpiredWriter)
-			expiredNoticePrinted = true
+		if errors.Is(loginErr, webcore.ErrInvalidAppleAccountCredentials) {
+			if silentPassword.source != webPasswordSourceStored {
+				return nil, "", false, fmt.Errorf("web auth auto-reauth failed: %w", loginErr)
+			}
+			if passwordStoreWarningWriter != nil {
+				_, _ = fmt.Fprintln(passwordStoreWarningWriter, "Saved Apple Account password was rejected; enter the current password to replace it.")
+			}
+			skipStoredPassword = true
+			printExpiredNotice()
+			return nil, "", false, nil
 		}
+
+		// A cached jar can become unusable independently of the credentials.
+		// Preserve the same password source for one fresh-client fallback.
+		fallbackPassword = silentPassword
+		expiredCachedSession = nil
+		printExpiredNotice()
 		return nil, "", false, nil
 	}
 
-	if resumed, ok, cacheExpired, err := resolveKnownWebSession(ctx, appleID); err != nil {
-		printCacheLookupWarning(sessionCacheWarningWriter, err)
+	if session, source, ok, err := tryKnownSession(appleID); err != nil {
+		return nil, "", err
 	} else if ok {
-		return resumed, "cache", nil
-	} else if cacheExpired {
-		if session, source, ok, err := tryHandleExpiredSession(appleID); err != nil {
-			return nil, "", err
-		} else if ok {
-			return session, source, nil
-		}
+		return session, source, nil
 	}
 
 	if appleID == "" {
@@ -582,34 +691,46 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 			return nil, "", err
 		}
 		appleID = strings.TrimSpace(appleID)
-		if resumed, ok, cacheExpired, err := resolveKnownWebSession(ctx, appleID); err != nil {
-			printCacheLookupWarning(sessionCacheWarningWriter, err)
+		if session, source, ok, err := tryKnownSession(appleID); err != nil {
+			return nil, "", err
 		} else if ok {
-			return resumed, "cache", nil
-		} else if cacheExpired {
-			if session, source, ok, err := tryHandleExpiredSession(appleID); err != nil {
-				return nil, "", err
-			} else if ok {
-				return session, source, nil
-			}
+			return session, source, nil
 		}
 	}
 
 	if opts.resolvePassword == nil {
 		return nil, "", fmt.Errorf("password resolver is required")
 	}
-	resolvedPassword, err := opts.resolvePassword(ctx, password)
-	if err != nil {
-		return nil, "", err
+	resolvedPassword := fallbackPassword
+	if !webPasswordProvided(resolvedPassword.value) {
+		resolvedPassword = resolveNonInteractiveWebPassword(appleID, password, skipStoredPassword)
 	}
-	if !webPasswordProvided(resolvedPassword) {
+	if !webPasswordProvided(resolvedPassword.value) {
+		promptedPassword, err := opts.resolvePassword(ctx, "")
+		if err != nil {
+			return nil, "", err
+		}
+		if webPasswordProvided(promptedPassword) {
+			resolvedPassword = resolvedWebPassword{value: promptedPassword, source: webPasswordSourcePrompted}
+		}
+	}
+	if !webPasswordProvided(resolvedPassword.value) {
 		return nil, "", shared.UsageError(fmt.Sprintf("password is required: run in a terminal for an interactive prompt or set %s", webPasswordEnvDisplay()))
 	}
 
-	session, err := loginWithOptionalTwoFactor(ctx, appleID, resolvedPassword, twoFactorCode, command)
+	var (
+		session *webcore.AuthSession
+		err     error
+	)
+	if expiredCachedSession != nil && expiredCachedSession.Client != nil {
+		session, err = loginWithOptionalTwoFactorClient(ctx, expiredCachedSession.Client, appleID, resolvedPassword.value, twoFactorCode, command)
+	} else {
+		session, err = loginWithOptionalTwoFactor(ctx, appleID, resolvedPassword.value, twoFactorCode, command)
+	}
 	if err != nil {
 		return nil, "", fmt.Errorf("web auth login failed: %w", err)
 	}
+	persistPromptedWebPassword(appleID, resolvedPassword)
 	if opts.persistFresh != nil {
 		if err := opts.persistFresh(session); err != nil {
 			return nil, "", err
@@ -732,8 +853,9 @@ func WebAuthLoginCommand() *ffcli.Command {
 Authenticate using Apple web-session behavior for "asc web" workflows.
 
 Password input options:
-  - secure interactive prompt (default and recommended for local use)
+  - secure interactive prompt (default; saved in the native credential store after successful login)
   - %s environment variable
+  - %s=1 disables saved-password reads and writes
 
 Two-factor input options:
   - secure interactive prompt (default for manual use)
@@ -753,6 +875,7 @@ Examples:
   %s asc web auth login --apple-id "user@example.com"
   %s='osascript /path/to/get-apple-2fa-code.scpt' asc web auth login --apple-id "user@example.com"`,
 			webPasswordEnvDisplay(),
+			webDontStorePasswordEnv,
 			webTwoFactorCodeCommandEnv,
 			webPasswordEnvAssignmentExample(),
 			webTwoFactorCodeCommandEnv,
@@ -778,6 +901,7 @@ Examples:
 
 			status := webAuthStatus{
 				Authenticated:    true,
+				PasswordStored:   storedWebPasswordStatus(session.UserEmail),
 				Source:           source,
 				AppleID:          session.UserEmail,
 				TeamID:           session.TeamID,
@@ -825,16 +949,31 @@ If --apple-id is not provided, this checks the last cached session.
 			}
 			if err != nil {
 				if errors.Is(err, webcore.ErrCachedSessionExpired) {
-					return shared.PrintOutput(webAuthStatus{Authenticated: false}, *output.Output, *output.Pretty)
+					statusAppleID := trimmedAppleID
+					if statusAppleID == "" {
+						if cached, cachedOK, cacheErr := loadLastCachedSessionFn(); cacheErr == nil && cachedOK && cached != nil {
+							statusAppleID = strings.TrimSpace(cached.UserEmail)
+						}
+					}
+					return shared.PrintOutput(webAuthStatus{
+						Authenticated:  false,
+						PasswordStored: storedWebPasswordStatus(statusAppleID),
+						AppleID:        statusAppleID,
+					}, *output.Output, *output.Pretty)
 				}
 				return fmt.Errorf("web auth status failed: %w", err)
 			}
 
 			if !ok || session == nil {
-				return shared.PrintOutput(webAuthStatus{Authenticated: false}, *output.Output, *output.Pretty)
+				return shared.PrintOutput(webAuthStatus{
+					Authenticated:  false,
+					PasswordStored: storedWebPasswordStatus(trimmedAppleID),
+					AppleID:        trimmedAppleID,
+				}, *output.Output, *output.Pretty)
 			}
 			return shared.PrintOutput(webAuthStatus{
 				Authenticated:    true,
+				PasswordStored:   storedWebPasswordStatus(session.UserEmail),
 				Source:           "cache",
 				AppleID:          session.UserEmail,
 				TeamID:           session.TeamID,
@@ -851,14 +990,17 @@ func WebAuthLogoutCommand() *ffcli.Command {
 
 	appleID := fs.String("apple-id", "", "Apple Account email to remove from cache")
 	all := fs.Bool("all", false, "Remove all cached web sessions")
+	forgetPassword := fs.Bool("forget-password", false, "Also remove the saved Apple Account password")
+	confirm := fs.Bool("confirm", false, "Confirm removal of saved password credentials")
 
 	return &ffcli.Command{
 		Name:       "logout",
-		ShortUsage: "asc web auth logout [--apple-id EMAIL | --all]",
+		ShortUsage: "asc web auth logout [--apple-id EMAIL | --all] [--forget-password --confirm]",
 		ShortHelp:  "Clear web-session cache.",
 		LongHelp: `WEB SESSION WORKFLOWS
 
 Remove cached web-session credentials for "asc web" commands.
+Pass --forget-password --confirm to also remove the native credential-store password.
 
 `,
 		FlagSet:   fs,
@@ -868,9 +1010,22 @@ Remove cached web-session credentials for "asc web" commands.
 			if *all && trimmedAppleID != "" {
 				return shared.UsageError("--all and --apple-id are mutually exclusive")
 			}
+			if *confirm && !*forgetPassword {
+				return shared.UsageError("--confirm requires --forget-password")
+			}
+			if *forgetPassword && !*confirm {
+				return shared.UsageError("--forget-password requires --confirm")
+			}
 			if *all {
-				if err := webcore.DeleteAllSessions(); err != nil {
+				if err := deleteAllWebSessionsFn(); err != nil {
 					return fmt.Errorf("web auth logout failed: %w", err)
+				}
+				if *forgetPassword {
+					if err := deleteAllStoredWebPasswordsFn(); err != nil {
+						return fmt.Errorf("web auth logout removed sessions but failed to forget saved passwords: %w", err)
+					}
+					_, _ = fmt.Fprintln(os.Stdout, "Removed all cached web sessions and stored passwords.")
+					return nil
 				}
 				_, _ = fmt.Fprintln(os.Stdout, "Removed all cached web sessions.")
 				return nil
@@ -878,8 +1033,15 @@ Remove cached web-session credentials for "asc web" commands.
 			if trimmedAppleID == "" {
 				return shared.UsageError("provide --apple-id or --all")
 			}
-			if err := webcore.DeleteSession(trimmedAppleID); err != nil {
+			if err := deleteWebSessionFn(trimmedAppleID); err != nil {
 				return fmt.Errorf("web auth logout failed: %w", err)
+			}
+			if *forgetPassword {
+				if err := deleteStoredWebPasswordFn(trimmedAppleID); err != nil {
+					return fmt.Errorf("web auth logout removed the session but failed to forget saved password: %w", err)
+				}
+				_, _ = fmt.Fprintf(os.Stdout, "Removed cached web session and stored password for %s.\n", trimmedAppleID)
+				return nil
 			}
 			_, _ = fmt.Fprintf(os.Stdout, "Removed cached web session for %s.\n", trimmedAppleID)
 			return nil

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -96,7 +96,7 @@ func webPasswordStorageDisabled() bool {
 	if webEnvTruthy(os.Getenv(webDontStorePasswordEnv)) {
 		return true
 	}
-	return webEnvTruthy(os.Getenv("ASC_BYPASS_KEYCHAIN"))
+	return webcore.PasswordStoreBypassed()
 }
 
 func webEnvTruthy(value string) bool {
@@ -412,6 +412,12 @@ func persistPromptedWebPassword(appleID string, password resolvedWebPassword) {
 	}
 }
 
+func printStoredPasswordRejected() {
+	if passwordStoreWarningWriter != nil {
+		_, _ = fmt.Fprintln(passwordStoreWarningWriter, "Saved Apple Account password was rejected; enter the current password to replace it.")
+	}
+}
+
 func storedWebPasswordStatus(appleID string) bool {
 	if webPasswordStorageDisabled() || strings.TrimSpace(appleID) == "" {
 		return false
@@ -581,7 +587,7 @@ func resolveKnownWebSession(ctx context.Context, appleID string) (*webcore.AuthS
 func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode string, opts webSessionResolveOptions) (*webcore.AuthSession, string, error) {
 	shared.ApplyRootLoggingOverrides()
 
-	appleID = strings.TrimSpace(appleID)
+	resolvedAppleID := strings.TrimSpace(appleID)
 	twoFactorCode = strings.TrimSpace(twoFactorCode)
 	command := strings.TrimSpace(opts.twoFactorCodeCommand)
 	if command == "" {
@@ -640,8 +646,8 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		if reauthAppleID == "" {
 			return nil, "", false, shared.UsageError("last cached web session predates stored Apple ID metadata; re-run once with --apple-id to refresh the cache")
 		}
-		if appleID == "" {
-			appleID = reauthAppleID
+		if resolvedAppleID == "" {
+			resolvedAppleID = reauthAppleID
 		}
 
 		silentPassword := resolveNonInteractiveWebPassword(reauthAppleID, password, skipStoredPassword)
@@ -661,9 +667,7 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 			if silentPassword.source != webPasswordSourceStored {
 				return nil, "", false, fmt.Errorf("web auth auto-reauth failed: %w", loginErr)
 			}
-			if passwordStoreWarningWriter != nil {
-				_, _ = fmt.Fprintln(passwordStoreWarningWriter, "Saved Apple Account password was rejected; enter the current password to replace it.")
-			}
+			printStoredPasswordRejected()
 			skipStoredPassword = true
 			printExpiredNotice()
 			return nil, "", false, nil
@@ -677,21 +681,21 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		return nil, "", false, nil
 	}
 
-	if session, source, ok, err := tryKnownSession(appleID); err != nil {
+	if session, source, ok, err := tryKnownSession(resolvedAppleID); err != nil {
 		return nil, "", err
 	} else if ok {
 		return session, source, nil
 	}
 
-	if appleID == "" {
+	if resolvedAppleID == "" {
 		if opts.promptAppleID == nil {
 			return nil, "", shared.UsageError("--apple-id is required when no cached web session is available")
 		}
-		if err := opts.promptAppleID(&appleID); err != nil {
+		if err := opts.promptAppleID(&resolvedAppleID); err != nil {
 			return nil, "", err
 		}
-		appleID = strings.TrimSpace(appleID)
-		if session, source, ok, err := tryKnownSession(appleID); err != nil {
+		resolvedAppleID = strings.TrimSpace(resolvedAppleID)
+		if session, source, ok, err := tryKnownSession(resolvedAppleID); err != nil {
 			return nil, "", err
 		} else if ok {
 			return session, source, nil
@@ -703,7 +707,7 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 	}
 	resolvedPassword := fallbackPassword
 	if !webPasswordProvided(resolvedPassword.value) {
-		resolvedPassword = resolveNonInteractiveWebPassword(appleID, password, skipStoredPassword)
+		resolvedPassword = resolveNonInteractiveWebPassword(resolvedAppleID, password, skipStoredPassword)
 	}
 	if !webPasswordProvided(resolvedPassword.value) {
 		promptedPassword, err := opts.resolvePassword(ctx, "")
@@ -718,19 +722,29 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		return nil, "", shared.UsageError(fmt.Sprintf("password is required: run in a terminal for an interactive prompt or set %s", webPasswordEnvDisplay()))
 	}
 
-	var (
-		session *webcore.AuthSession
-		err     error
-	)
-	if expiredCachedSession != nil && expiredCachedSession.Client != nil {
-		session, err = loginWithOptionalTwoFactorClient(ctx, expiredCachedSession.Client, appleID, resolvedPassword.value, twoFactorCode, command)
-	} else {
-		session, err = loginWithOptionalTwoFactor(ctx, appleID, resolvedPassword.value, twoFactorCode, command)
+	login := func(candidate resolvedWebPassword) (*webcore.AuthSession, error) {
+		if expiredCachedSession != nil && expiredCachedSession.Client != nil {
+			return loginWithOptionalTwoFactorClient(ctx, expiredCachedSession.Client, resolvedAppleID, candidate.value, twoFactorCode, command)
+		}
+		return loginWithOptionalTwoFactor(ctx, resolvedAppleID, candidate.value, twoFactorCode, command)
+	}
+
+	session, err := login(resolvedPassword)
+	if errors.Is(err, webcore.ErrInvalidAppleAccountCredentials) && resolvedPassword.source == webPasswordSourceStored {
+		printStoredPasswordRejected()
+		promptedPassword, promptErr := opts.resolvePassword(ctx, "")
+		if promptErr != nil {
+			return nil, "", promptErr
+		}
+		if webPasswordProvided(promptedPassword) {
+			resolvedPassword = resolvedWebPassword{value: promptedPassword, source: webPasswordSourcePrompted}
+			session, err = login(resolvedPassword)
+		}
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("web auth login failed: %w", err)
 	}
-	persistPromptedWebPassword(appleID, resolvedPassword)
+	persistPromptedWebPassword(resolvedAppleID, resolvedPassword)
 	if opts.persistFresh != nil {
 		if err := opts.persistFresh(session); err != nil {
 			return nil, "", err
@@ -990,8 +1004,8 @@ func WebAuthLogoutCommand() *ffcli.Command {
 
 	appleID := fs.String("apple-id", "", "Apple Account email to remove from cache")
 	all := fs.Bool("all", false, "Remove all cached web sessions")
-	forgetPassword := fs.Bool("forget-password", false, "Also remove the saved Apple Account password")
-	confirm := fs.Bool("confirm", false, "Confirm removal of saved password credentials")
+	forgetPassword := fs.Bool("forget-password", false, "[experimental] Also remove the saved Apple Account password")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm removal of saved password credentials")
 
 	return &ffcli.Command{
 		Name:       "logout",
@@ -1017,13 +1031,18 @@ Pass --forget-password --confirm to also remove the native credential-store pass
 				return shared.UsageError("--forget-password requires --confirm")
 			}
 			if *all {
+				if *forgetPassword {
+					if err := deleteAllStoredWebPasswordsFn(); err != nil {
+						return fmt.Errorf("web auth logout failed to forget saved passwords: %w", err)
+					}
+				}
 				if err := deleteAllWebSessionsFn(); err != nil {
+					if *forgetPassword {
+						return fmt.Errorf("web auth logout forgot saved passwords but failed to remove sessions: %w", err)
+					}
 					return fmt.Errorf("web auth logout failed: %w", err)
 				}
 				if *forgetPassword {
-					if err := deleteAllStoredWebPasswordsFn(); err != nil {
-						return fmt.Errorf("web auth logout removed sessions but failed to forget saved passwords: %w", err)
-					}
 					_, _ = fmt.Fprintln(os.Stdout, "Removed all cached web sessions and stored passwords.")
 					return nil
 				}
@@ -1033,13 +1052,18 @@ Pass --forget-password --confirm to also remove the native credential-store pass
 			if trimmedAppleID == "" {
 				return shared.UsageError("provide --apple-id or --all")
 			}
+			if *forgetPassword {
+				if err := deleteStoredWebPasswordFn(trimmedAppleID); err != nil {
+					return fmt.Errorf("web auth logout failed to forget saved password: %w", err)
+				}
+			}
 			if err := deleteWebSessionFn(trimmedAppleID); err != nil {
+				if *forgetPassword {
+					return fmt.Errorf("web auth logout forgot saved password but failed to remove session: %w", err)
+				}
 				return fmt.Errorf("web auth logout failed: %w", err)
 			}
 			if *forgetPassword {
-				if err := deleteStoredWebPasswordFn(trimmedAppleID); err != nil {
-					return fmt.Errorf("web auth logout removed the session but failed to forget saved password: %w", err)
-				}
 				_, _ = fmt.Fprintf(os.Stdout, "Removed cached web session and stored password for %s.\n", trimmedAppleID)
 				return nil
 			}

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -462,7 +462,7 @@ func storedWebPasswordStatus(appleID string) bool {
 	return stored
 }
 
-func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, appleID, password, twoFactorCode string, loginFn func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error), twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
+func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, appleID, password, twoFactorCode string, loginFn func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error), twoFactorStarted func(), twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
 	session, err := withWebSpinnerValue(progressMessage, func() (*webcore.AuthSession, error) {
 		return loginFn(ctx, webcore.LoginCredentials{
 			Username: appleID,
@@ -475,6 +475,9 @@ func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, apple
 
 	var tfaErr *webcore.TwoFactorRequiredError
 	if session != nil && errors.As(err, &tfaErr) {
+		if twoFactorStarted != nil {
+			twoFactorStarted()
+		}
 		challenge, prepErr := prepareTwoFactorChallengeFn(ctx, session)
 		if prepErr != nil {
 			return nil, fmt.Errorf("2fa challenge setup failed: %w", prepErr)
@@ -553,13 +556,22 @@ func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, apple
 }
 
 func loginWithOptionalTwoFactor(ctx context.Context, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
-	return loginWithOptionalTwoFactorUsing(ctx, "Signing in to Apple web session", appleID, password, twoFactorCode, webLoginFn, twoFactorCodeCommand...)
+	return loginWithOptionalTwoFactorUsing(ctx, "Signing in to Apple web session", appleID, password, twoFactorCode, webLoginFn, nil, twoFactorCodeCommand...)
 }
 
 func loginWithOptionalTwoFactorClient(ctx context.Context, client *http.Client, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
-	return loginWithOptionalTwoFactorUsing(ctx, "Refreshing expired web session", appleID, password, twoFactorCode, func(ctx context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+	session, _, err := loginWithOptionalTwoFactorClientTracked(ctx, client, appleID, password, twoFactorCode, twoFactorCodeCommand...)
+	return session, err
+}
+
+func loginWithOptionalTwoFactorClientTracked(ctx context.Context, client *http.Client, appleID, password, twoFactorCode string, twoFactorCodeCommand ...string) (*webcore.AuthSession, bool, error) {
+	twoFactorStarted := false
+	session, err := loginWithOptionalTwoFactorUsing(ctx, "Refreshing expired web session", appleID, password, twoFactorCode, func(ctx context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
 		return webLoginWithClientFn(ctx, client, credentials)
+	}, func() {
+		twoFactorStarted = true
 	}, twoFactorCodeCommand...)
+	return session, twoFactorStarted, err
 }
 
 func tryResumeWebSession(ctx context.Context, appleID string) (*webcore.AuthSession, bool, error) {
@@ -754,22 +766,24 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		return nil, "", shared.UsageError(fmt.Sprintf("password is required: run in a terminal for an interactive prompt or set %s", webPasswordEnvDisplay()))
 	}
 
-	login := func(candidate resolvedWebPassword) (*webcore.AuthSession, error) {
+	login := func(candidate resolvedWebPassword) (*webcore.AuthSession, bool, error) {
 		if expiredCachedSession != nil && expiredCachedSession.Client != nil {
-			return loginWithOptionalTwoFactorClient(ctx, expiredCachedSession.Client, resolvedAppleID, candidate.value, twoFactorCode, command)
+			return loginWithOptionalTwoFactorClientTracked(ctx, expiredCachedSession.Client, resolvedAppleID, candidate.value, twoFactorCode, command)
 		}
-		return loginWithOptionalTwoFactor(ctx, resolvedAppleID, candidate.value, twoFactorCode, command)
+		session, err := loginWithOptionalTwoFactor(ctx, resolvedAppleID, candidate.value, twoFactorCode, command)
+		return session, false, err
 	}
 	loginWithPromptedFreshFallback := func(candidate resolvedWebPassword) (*webcore.AuthSession, error) {
-		session, err := login(candidate)
-		if err == nil || candidate.source != webPasswordSourcePrompted || expiredCachedSession == nil || errors.Is(err, webcore.ErrInvalidAppleAccountCredentials) {
+		session, twoFactorStarted, err := login(candidate)
+		if err == nil || candidate.source != webPasswordSourcePrompted || expiredCachedSession == nil || twoFactorStarted || errors.Is(err, webcore.ErrInvalidAppleAccountCredentials) {
 			return session, err
 		}
 		// Match the non-interactive reauth path: a non-credential failure can
 		// mean that the cached cookie jar itself is unusable. Retry once with a
 		// fresh client while preserving the already-resolved password.
 		expiredCachedSession = nil
-		return login(candidate)
+		session, _, err = login(candidate)
+		return session, err
 	}
 
 	session, err := loginWithPromptedFreshFallback(resolvedPassword)

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -70,6 +71,8 @@ var (
 	sessionExpiredWriter           io.Writer = os.Stderr
 	sessionCacheWarningWriter      io.Writer = os.Stderr
 	passwordStoreWarningWriter     io.Writer = os.Stderr
+	invalidWebPasswordOptOutMu     sync.Mutex
+	invalidWebPasswordOptOutValues = map[string]struct{}{}
 )
 
 func callSessionResolverHook(ctx context.Context, hook any, hookName, appleID, password, twoFactorCode, twoFactorCodeCommand string) (*webcore.AuthSession, string, error) {
@@ -93,19 +96,48 @@ func webPasswordProvided(password string) bool {
 }
 
 func webPasswordStorageDisabled() bool {
-	if webEnvTruthy(os.Getenv(webDontStorePasswordEnv)) {
+	if webPasswordStorageOptedOut() {
 		return true
 	}
 	return webcore.PasswordStoreBypassed()
 }
 
-func webEnvTruthy(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
+func webPasswordStorageOptedOut() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(webDontStorePasswordEnv)))
+	switch value {
 	case "1", "true", "yes", "on":
 		return true
-	default:
+	case "", "0", "false", "no", "off":
 		return false
+	default:
+		warnInvalidWebPasswordOptOutOnce(value)
+		return true
 	}
+}
+
+func warnInvalidWebPasswordOptOutOnce(value string) {
+	invalidWebPasswordOptOutMu.Lock()
+	if _, warned := invalidWebPasswordOptOutValues[value]; warned {
+		invalidWebPasswordOptOutMu.Unlock()
+		return
+	}
+	invalidWebPasswordOptOutValues[value] = struct{}{}
+	invalidWebPasswordOptOutMu.Unlock()
+
+	if passwordStoreWarningWriter != nil {
+		_, _ = fmt.Fprintf(
+			passwordStoreWarningWriter,
+			"Warning: invalid %s value %q (expected true/false, 1/0, yes/no, or on/off); password storage disabled.\n",
+			webDontStorePasswordEnv,
+			value,
+		)
+	}
+}
+
+func resetInvalidWebPasswordOptOutWarnings() {
+	invalidWebPasswordOptOutMu.Lock()
+	defer invalidWebPasswordOptOutMu.Unlock()
+	invalidWebPasswordOptOutValues = map[string]struct{}{}
 }
 
 type webPasswordSource string
@@ -728,8 +760,19 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		}
 		return loginWithOptionalTwoFactor(ctx, resolvedAppleID, candidate.value, twoFactorCode, command)
 	}
+	loginWithPromptedFreshFallback := func(candidate resolvedWebPassword) (*webcore.AuthSession, error) {
+		session, err := login(candidate)
+		if err == nil || candidate.source != webPasswordSourcePrompted || expiredCachedSession == nil || errors.Is(err, webcore.ErrInvalidAppleAccountCredentials) {
+			return session, err
+		}
+		// Match the non-interactive reauth path: a non-credential failure can
+		// mean that the cached cookie jar itself is unusable. Retry once with a
+		// fresh client while preserving the already-resolved password.
+		expiredCachedSession = nil
+		return login(candidate)
+	}
 
-	session, err := login(resolvedPassword)
+	session, err := loginWithPromptedFreshFallback(resolvedPassword)
 	if errors.Is(err, webcore.ErrInvalidAppleAccountCredentials) && resolvedPassword.source == webPasswordSourceStored {
 		printStoredPasswordRejected()
 		promptedPassword, promptErr := opts.resolvePassword(ctx, "")
@@ -738,7 +781,7 @@ func resolveWebSession(ctx context.Context, appleID, password, twoFactorCode str
 		}
 		if webPasswordProvided(promptedPassword) {
 			resolvedPassword = resolvedWebPassword{value: promptedPassword, source: webPasswordSourcePrompted}
-			session, err = login(resolvedPassword)
+			session, err = loginWithPromptedFreshFallback(resolvedPassword)
 		}
 	}
 	if err != nil {

--- a/internal/cli/web/web_auth_password_store_test.go
+++ b/internal/cli/web/web_auth_password_store_test.go
@@ -1,0 +1,409 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"net/http"
+	"strings"
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func preserveWebPasswordHooks(t *testing.T) {
+	t.Helper()
+
+	originalLoad := loadStoredWebPasswordFn
+	originalStore := storeStoredWebPasswordFn
+	originalExists := storedWebPasswordExistsFn
+	originalDelete := deleteStoredWebPasswordFn
+	originalDeleteAll := deleteAllStoredWebPasswordsFn
+	originalDeleteSession := deleteWebSessionFn
+	originalDeleteAllSessions := deleteAllWebSessionsFn
+	originalWarningWriter := passwordStoreWarningWriter
+	t.Cleanup(func() {
+		loadStoredWebPasswordFn = originalLoad
+		storeStoredWebPasswordFn = originalStore
+		storedWebPasswordExistsFn = originalExists
+		deleteStoredWebPasswordFn = originalDelete
+		deleteAllStoredWebPasswordsFn = originalDeleteAll
+		deleteWebSessionFn = originalDeleteSession
+		deleteAllWebSessionsFn = originalDeleteAllSessions
+		passwordStoreWarningWriter = originalWarningWriter
+	})
+}
+
+func preserveWebLoginHooks(t *testing.T) {
+	t.Helper()
+
+	originalTryResume := tryResumeSessionFn
+	originalTryResumeLast := tryResumeLastFn
+	originalLoadCached := loadCachedSessionFn
+	originalLoadLastCached := loadLastCachedSessionFn
+	originalPromptPassword := promptPasswordFn
+	originalPromptTwoFactor := promptTwoFactorCodeFn
+	originalWebLogin := webLoginFn
+	originalWebLoginWithClient := webLoginWithClientFn
+	originalPrepare := prepareTwoFactorChallengeFn
+	originalEnsure := ensureTwoFactorCodeRequestedFn
+	originalSubmit := submitTwoFactorCodeFn
+	originalPersist := persistWebSessionFn
+	originalExpiredWriter := sessionExpiredWriter
+	t.Cleanup(func() {
+		tryResumeSessionFn = originalTryResume
+		tryResumeLastFn = originalTryResumeLast
+		loadCachedSessionFn = originalLoadCached
+		loadLastCachedSessionFn = originalLoadLastCached
+		promptPasswordFn = originalPromptPassword
+		promptTwoFactorCodeFn = originalPromptTwoFactor
+		webLoginFn = originalWebLogin
+		webLoginWithClientFn = originalWebLoginWithClient
+		prepareTwoFactorChallengeFn = originalPrepare
+		ensureTwoFactorCodeRequestedFn = originalEnsure
+		submitTwoFactorCodeFn = originalSubmit
+		persistWebSessionFn = originalPersist
+		sessionExpiredWriter = originalExpiredWriter
+	})
+}
+
+func configureFreshPasswordLoginTest(t *testing.T) *webcore.AuthSession {
+	t.Helper()
+
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, nil
+	}
+	loadStoredWebPasswordFn = func(string) (string, bool, error) {
+		return "", false, nil
+	}
+	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+	expected := &webcore.AuthSession{UserEmail: "user@example.com"}
+	webLoginFn = func(_ context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if credentials.Username != "user@example.com" || credentials.Password != "prompted-secret" {
+			t.Fatalf("Login credentials = %+v, want prompted credentials", credentials)
+		}
+		return expected, nil
+	}
+	return expected
+}
+
+func TestResolveSessionStoresPromptedPasswordAfterSuccessfulLogin(t *testing.T) {
+	expected := configureFreshPasswordLoginTest(t)
+
+	loginSucceeded := false
+	originalLogin := webLoginFn
+	webLoginFn = func(ctx context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		session, err := originalLogin(ctx, credentials)
+		loginSucceeded = err == nil
+		return session, err
+	}
+	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+	var storedAppleID, storedPassword string
+	storeStoredWebPasswordFn = func(appleID, password string) error {
+		if !loginSucceeded {
+			t.Fatal("password was stored before login succeeded")
+		}
+		storedAppleID, storedPassword = appleID, password
+		return nil
+	}
+
+	session, source, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if session != expected || source != "fresh" {
+		t.Fatalf("resolveSession() = (%+v, %q), want (%+v, fresh)", session, source, expected)
+	}
+	if storedAppleID != "user@example.com" || storedPassword != "prompted-secret" {
+		t.Fatalf("stored credentials = (%q, %q), want prompted credentials", storedAppleID, storedPassword)
+	}
+}
+
+func TestResolveSessionDoesNotStoreEnvironmentPassword(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "env-secret")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) { return nil, false, nil }
+	loadStoredWebPasswordFn = func(string) (string, bool, error) {
+		t.Fatal("stored password should not be loaded when the environment password is set")
+		return "", false, nil
+	}
+	promptPasswordFn = func(context.Context) (string, error) {
+		t.Fatal("password should not be prompted when the environment password is set")
+		return "", nil
+	}
+	storeStoredWebPasswordFn = func(string, string) error {
+		t.Fatal("environment password should not be stored")
+		return nil
+	}
+	webLoginFn = func(_ context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if credentials.Password != "env-secret" {
+			t.Fatalf("password = %q, want env-secret", credentials.Password)
+		}
+		return &webcore.AuthSession{UserEmail: credentials.Username}, nil
+	}
+	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+
+	if _, _, err := resolveSession(context.Background(), "user@example.com", "", ""); err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+}
+
+func TestResolveSessionOptOutSkipsStoredPasswordReadAndWrite(t *testing.T) {
+	configureFreshPasswordLoginTest(t)
+	t.Setenv(webDontStorePasswordEnv, "1")
+
+	loadStoredWebPasswordFn = func(string) (string, bool, error) {
+		t.Fatal("stored password should not be loaded when storage is disabled")
+		return "", false, nil
+	}
+	storeStoredWebPasswordFn = func(string, string) error {
+		t.Fatal("prompted password should not be stored when storage is disabled")
+		return nil
+	}
+	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+
+	if _, _, err := resolveSession(context.Background(), "user@example.com", "", ""); err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+}
+
+func TestResolveSessionUsesStoredPasswordAndCachedCookiesForTwoFactorReauth(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	cachedClient := &http.Client{}
+	expected := &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	loadCachedSessionFn = func(string) (*webcore.AuthSession, bool, error) {
+		return &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}, true, nil
+	}
+	loadStoredWebPasswordFn = func(appleID string) (string, bool, error) {
+		if appleID != "user@example.com" {
+			t.Fatalf("stored password lookup Apple ID = %q", appleID)
+		}
+		return "stored-secret", true, nil
+	}
+	promptPasswordFn = func(context.Context) (string, error) {
+		t.Fatal("stored password should avoid the password prompt")
+		return "", nil
+	}
+	webLoginFn = func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		t.Fatal("reauthentication should reuse the cached client")
+		return nil, nil
+	}
+	webLoginWithClientFn = func(_ context.Context, client *http.Client, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if client != cachedClient || credentials.Password != "stored-secret" {
+			t.Fatalf("cached login = (%p, %+v), want cached client and stored password", client, credentials)
+		}
+		return expected, &webcore.TwoFactorRequiredError{}
+	}
+	prepareTwoFactorChallengeFn = func(context.Context, *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
+		return &webcore.TwoFactorChallenge{Method: "trusted-device"}, nil
+	}
+	ensureTwoFactorCodeRequestedFn = func(context.Context, *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
+		t.Fatal("trusted-device challenge should not request phone delivery")
+		return nil, nil
+	}
+	promptTwoFactorCodeFn = func() (string, error) { return "123456", nil }
+	submitTwoFactorCodeFn = func(_ context.Context, session *webcore.AuthSession, code string) error {
+		if session != expected || code != "123456" {
+			t.Fatalf("2FA submission = (%+v, %q), want expected session and code", session, code)
+		}
+		return nil
+	}
+	persistWebSessionFn = func(session *webcore.AuthSession) error {
+		if session != expected {
+			t.Fatalf("persisted session = %+v, want expected", session)
+		}
+		return nil
+	}
+	storeStoredWebPasswordFn = func(string, string) error {
+		t.Fatal("an existing stored password should not be written again")
+		return nil
+	}
+
+	session, source, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if session != expected || source != "auto-reauth" {
+		t.Fatalf("resolveSession() = (%+v, %q), want (%+v, auto-reauth)", session, source, expected)
+	}
+}
+
+func TestResolveSessionReplacesRejectedStoredPasswordOnlyAfterSuccessfulLogin(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	cachedClient := &http.Client{}
+	expected := &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	loadCachedSessionFn = func(string) (*webcore.AuthSession, bool, error) {
+		return &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}, true, nil
+	}
+	loadStoredWebPasswordFn = func(string) (string, bool, error) { return "old-secret", true, nil }
+	promptPasswordFn = func(context.Context) (string, error) { return "new-secret", nil }
+
+	loginAttempts := 0
+	webLoginWithClientFn = func(_ context.Context, client *http.Client, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		loginAttempts++
+		if client != cachedClient {
+			t.Fatal("expected cached client to be retained across password replacement")
+		}
+		switch loginAttempts {
+		case 1:
+			if credentials.Password != "old-secret" {
+				t.Fatalf("first password = %q, want old-secret", credentials.Password)
+			}
+			return nil, webcore.ErrInvalidAppleAccountCredentials
+		case 2:
+			if credentials.Password != "new-secret" {
+				t.Fatalf("second password = %q, want new-secret", credentials.Password)
+			}
+			return expected, nil
+		default:
+			t.Fatalf("unexpected login attempt %d", loginAttempts)
+			return nil, nil
+		}
+	}
+	webLoginFn = func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		t.Fatal("password replacement should retain cached cookies")
+		return nil, nil
+	}
+	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+	stored := ""
+	storeStoredWebPasswordFn = func(_ string, password string) error {
+		if loginAttempts != 2 {
+			t.Fatal("replacement password was stored before its login succeeded")
+		}
+		stored = password
+		return nil
+	}
+
+	session, source, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if session != expected || source != "fresh" || stored != "new-secret" {
+		t.Fatalf("result = (%+v, %q, stored %q), want expected fresh session with replacement", session, source, stored)
+	}
+}
+
+func TestResolveSessionWarnsButSucceedsWhenPromptedPasswordCannotBeStored(t *testing.T) {
+	configureFreshPasswordLoginTest(t)
+	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+	storeStoredWebPasswordFn = func(string, string) error { return errors.New("keychain locked") }
+	var warning bytes.Buffer
+	passwordStoreWarningWriter = &warning
+
+	if _, _, err := resolveSession(context.Background(), "user@example.com", "", ""); err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if got := warning.String(); !strings.Contains(got, "could not save") || !strings.Contains(got, "keychain locked") {
+		t.Fatalf("warning = %q, want non-fatal password-store warning", got)
+	}
+}
+
+func TestWebAuthStatusReportsStoredPasswordForExpiredSession(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	storedWebPasswordExistsFn = func(appleID string) (bool, error) {
+		return appleID == "user@example.com", nil
+	}
+
+	cmd := WebAuthStatusCommand()
+	if err := cmd.FlagSet.Parse([]string{"--apple-id", "user@example.com", "--output", "json"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var runErr error
+	stdout, _ := captureWebCommandOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+	if runErr != nil {
+		t.Fatalf("status Exec() error = %v", runErr)
+	}
+	if !strings.Contains(stdout, `"authenticated":false`) || !strings.Contains(stdout, `"passwordStored":true`) {
+		t.Fatalf("status output = %q, want unauthenticated with stored password", stdout)
+	}
+}
+
+func TestWebAuthLogoutForgetPasswordRequiresConfirmation(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	deleteWebSessionFn = func(string) error {
+		t.Fatal("session should not be deleted without --confirm")
+		return nil
+	}
+	deleteStoredWebPasswordFn = func(string) error {
+		t.Fatal("password should not be deleted without --confirm")
+		return nil
+	}
+
+	cmd := WebAuthLogoutCommand()
+	if err := cmd.FlagSet.Parse([]string{"--apple-id", "user@example.com", "--forget-password"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var runErr error
+	_, stderr := captureWebCommandOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "--confirm") {
+		t.Fatalf("Exec() = %v, stderr %q; want --confirm usage error", runErr, stderr)
+	}
+}
+
+func TestWebAuthLogoutCanForgetPasswordWithSession(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	var deletedSession, deletedPassword string
+	deleteWebSessionFn = func(appleID string) error {
+		deletedSession = appleID
+		return nil
+	}
+	deleteStoredWebPasswordFn = func(appleID string) error {
+		deletedPassword = appleID
+		return nil
+	}
+
+	cmd := WebAuthLogoutCommand()
+	if err := cmd.FlagSet.Parse([]string{"--apple-id", "user@example.com", "--forget-password", "--confirm"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var runErr error
+	stdout, _ := captureWebCommandOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+	if runErr != nil {
+		t.Fatalf("logout Exec() error = %v", runErr)
+	}
+	if deletedSession != "user@example.com" || deletedPassword != "user@example.com" {
+		t.Fatalf("deleted = (%q, %q), want both account entries", deletedSession, deletedPassword)
+	}
+	if !strings.Contains(stdout, "stored password") {
+		t.Fatalf("logout output = %q, want stored-password confirmation", stdout)
+	}
+}

--- a/internal/cli/web/web_auth_password_store_test.go
+++ b/internal/cli/web/web_auth_password_store_test.go
@@ -182,6 +182,32 @@ func TestResolveSessionOptOutSkipsStoredPasswordReadAndWrite(t *testing.T) {
 	}
 }
 
+func TestResolveSessionInvalidOptOutFailsClosedWithWarning(t *testing.T) {
+	configureFreshPasswordLoginTest(t)
+	t.Setenv(webDontStorePasswordEnv, "treu")
+
+	loadStoredWebPasswordFn = func(string) (string, bool, error) {
+		t.Error("stored password should not be loaded for an invalid opt-out value")
+		return "", false, nil
+	}
+	storeStoredWebPasswordFn = func(string, string) error {
+		t.Error("prompted password should not be stored for an invalid opt-out value")
+		return nil
+	}
+	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+	var warning bytes.Buffer
+	passwordStoreWarningWriter = &warning
+	resetInvalidWebPasswordOptOutWarnings()
+	t.Cleanup(resetInvalidWebPasswordOptOutWarnings)
+
+	if _, _, err := resolveSession(context.Background(), "user@example.com", "", ""); err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if got := warning.String(); !strings.Contains(got, `invalid ASC_WEB_DONT_STORE_PASSWORD value "treu"`) || !strings.Contains(got, "password storage disabled") {
+		t.Fatalf("warning = %q, want invalid opt-out warning with fail-closed behavior", got)
+	}
+}
+
 func TestResolveSessionUsesStoredPasswordAndCachedCookiesForTwoFactorReauth(t *testing.T) {
 	preserveWebPasswordHooks(t)
 	preserveWebLoginHooks(t)
@@ -248,6 +274,49 @@ func TestResolveSessionUsesStoredPasswordAndCachedCookiesForTwoFactorReauth(t *t
 	}
 	if session != expected || source != "auto-reauth" {
 		t.Fatalf("resolveSession() = (%+v, %q), want (%+v, auto-reauth)", session, source, expected)
+	}
+}
+
+func TestResolveSessionPromptedPasswordFallsBackFromExpiredCookiesToFreshClient(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	cachedClient := &http.Client{}
+	expected := &webcore.AuthSession{UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	loadCachedSessionFn = func(string) (*webcore.AuthSession, bool, error) {
+		return &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}, true, nil
+	}
+	loadStoredWebPasswordFn = func(string) (string, bool, error) { return "", false, nil }
+	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+	webLoginWithClientFn = func(_ context.Context, client *http.Client, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if client != cachedClient || credentials.Password != "prompted-secret" {
+			t.Fatalf("cached login = (%p, %+v), want cached client and prompted password", client, credentials)
+		}
+		return nil, errors.New("cached cookie jar rejected")
+	}
+	freshAttempts := 0
+	webLoginFn = func(_ context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		freshAttempts++
+		if credentials.Password != "prompted-secret" {
+			t.Fatalf("fresh password = %q, want prompted-secret", credentials.Password)
+		}
+		return expected, nil
+	}
+	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+	storeStoredWebPasswordFn = func(string, string) error { return nil }
+
+	session, source, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if session != expected || source != "fresh" || freshAttempts != 1 {
+		t.Fatalf("result = (%+v, %q, fresh attempts %d), want fresh fallback", session, source, freshAttempts)
 	}
 }
 

--- a/internal/cli/web/web_auth_password_store_test.go
+++ b/internal/cli/web/web_auth_password_store_test.go
@@ -277,6 +277,59 @@ func TestResolveSessionUsesStoredPasswordAndCachedCookiesForTwoFactorReauth(t *t
 	}
 }
 
+func TestResolveAppCreateSessionPersistsStoredPasswordAutoReauth(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	cachedClient := &http.Client{}
+	expected := &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	loadCachedSessionFn = func(string) (*webcore.AuthSession, bool, error) {
+		return &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}, true, nil
+	}
+	loadStoredWebPasswordFn = func(appleID string) (string, bool, error) {
+		if appleID != "user@example.com" {
+			t.Fatalf("stored password lookup Apple ID = %q", appleID)
+		}
+		return "stored-secret", true, nil
+	}
+	webLoginWithClientFn = func(_ context.Context, client *http.Client, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if client != cachedClient || credentials.Password != "stored-secret" {
+			t.Fatalf("cached login = (%p, %+v), want cached client and stored password", client, credentials)
+		}
+		return expected, nil
+	}
+	promptPasswordFn = func(context.Context) (string, error) {
+		t.Fatal("stored password should avoid the password prompt")
+		return "", nil
+	}
+	webLoginFn = func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		t.Fatal("auto-reauthentication should reuse the cached client")
+		return nil, nil
+	}
+	var persisted *webcore.AuthSession
+	persistWebSessionFn = func(session *webcore.AuthSession) error {
+		persisted = session
+		return nil
+	}
+
+	session, source, err := resolveAppCreateSession(context.Background(), "user@example.com", "", "")
+	if err != nil {
+		t.Fatalf("resolveAppCreateSession() error = %v", err)
+	}
+	if session != expected || source != "auto-reauth" {
+		t.Fatalf("resolveAppCreateSession() = (%+v, %q), want (%+v, auto-reauth)", session, source, expected)
+	}
+	if persisted != expected {
+		t.Fatalf("persisted session = %+v, want refreshed app-create session %+v", persisted, expected)
+	}
+}
+
 func TestResolveSessionPromptedPasswordFallsBackFromExpiredCookiesToFreshClient(t *testing.T) {
 	preserveWebPasswordHooks(t)
 	preserveWebLoginHooks(t)

--- a/internal/cli/web/web_auth_password_store_test.go
+++ b/internal/cli/web/web_auth_password_store_test.go
@@ -407,6 +407,38 @@ func TestResolveSessionPromptedPasswordDoesNotRetryFreshAfterTwoFactorStarts(t *
 	}
 }
 
+func TestResolveSessionAutoReauthDoesNotRetryFreshAfterTwoFactorStarts(t *testing.T) {
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "env-secret")
+
+	cachedClient := &http.Client{}
+	twoFactorSession := &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	loadCachedSessionFn = func(string) (*webcore.AuthSession, bool, error) {
+		return &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}, true, nil
+	}
+	webLoginWithClientFn = func(_ context.Context, client *http.Client, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		if client != cachedClient || credentials.Password != "env-secret" {
+			t.Fatalf("cached login = (%p, %+v), want cached client and environment password", client, credentials)
+		}
+		return twoFactorSession, &webcore.TwoFactorRequiredError{}
+	}
+	prepareTwoFactorChallengeFn = func(context.Context, *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
+		return nil, errors.New("challenge setup failed")
+	}
+	webLoginFn = func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		t.Fatal("automatic 2FA flow errors must not trigger a fresh login retry")
+		return nil, nil
+	}
+
+	_, _, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err == nil || !strings.Contains(err.Error(), "2fa challenge setup failed") {
+		t.Fatalf("resolveSession() error = %v, want original automatic 2FA setup failure", err)
+	}
+}
+
 func TestResolveSessionReplacesRejectedStoredPasswordOnlyAfterSuccessfulLogin(t *testing.T) {
 	preserveWebPasswordHooks(t)
 	preserveWebLoginHooks(t)

--- a/internal/cli/web/web_auth_password_store_test.go
+++ b/internal/cli/web/web_auth_password_store_test.go
@@ -160,21 +160,25 @@ func TestResolveSessionDoesNotStoreEnvironmentPassword(t *testing.T) {
 }
 
 func TestResolveSessionOptOutSkipsStoredPasswordReadAndWrite(t *testing.T) {
-	configureFreshPasswordLoginTest(t)
-	t.Setenv(webDontStorePasswordEnv, "1")
+	for _, optOutEnv := range []string{webDontStorePasswordEnv, "ASC_BYPASS_KEYCHAIN"} {
+		t.Run(optOutEnv, func(t *testing.T) {
+			configureFreshPasswordLoginTest(t)
+			t.Setenv(optOutEnv, "1")
 
-	loadStoredWebPasswordFn = func(string) (string, bool, error) {
-		t.Fatal("stored password should not be loaded when storage is disabled")
-		return "", false, nil
-	}
-	storeStoredWebPasswordFn = func(string, string) error {
-		t.Fatal("prompted password should not be stored when storage is disabled")
-		return nil
-	}
-	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+			loadStoredWebPasswordFn = func(string) (string, bool, error) {
+				t.Error("stored password should not be loaded when storage is disabled")
+				return "", false, nil
+			}
+			storeStoredWebPasswordFn = func(string, string) error {
+				t.Error("prompted password should not be stored when storage is disabled")
+				return nil
+			}
+			promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
 
-	if _, _, err := resolveSession(context.Background(), "user@example.com", "", ""); err != nil {
-		t.Fatalf("resolveSession() error = %v", err)
+			if _, _, err := resolveSession(context.Background(), "user@example.com", "", ""); err != nil {
+				t.Fatalf("resolveSession() error = %v", err)
+			}
+		})
 	}
 }
 
@@ -292,6 +296,8 @@ func TestResolveSessionReplacesRejectedStoredPasswordOnlyAfterSuccessfulLogin(t 
 		return nil, nil
 	}
 	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+	var warning bytes.Buffer
+	passwordStoreWarningWriter = &warning
 	stored := ""
 	storeStoredWebPasswordFn = func(_ string, password string) error {
 		if loginAttempts != 2 {
@@ -307,6 +313,66 @@ func TestResolveSessionReplacesRejectedStoredPasswordOnlyAfterSuccessfulLogin(t 
 	}
 	if session != expected || source != "fresh" || stored != "new-secret" {
 		t.Fatalf("result = (%+v, %q, stored %q), want expected fresh session with replacement", session, source, stored)
+	}
+	if got := warning.String(); !strings.Contains(got, "Saved Apple Account password was rejected; enter the current password to replace it.") {
+		t.Fatalf("warning = %q, want stored-password rejection notice", got)
+	}
+}
+
+func TestResolveSessionReplacesRejectedStoredPasswordWithoutCachedSession(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	expected := &webcore.AuthSession{UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, nil
+	}
+	loadStoredWebPasswordFn = func(string) (string, bool, error) { return "old-secret", true, nil }
+	promptPasswordFn = func(context.Context) (string, error) { return "new-secret", nil }
+	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+
+	loginAttempts := 0
+	webLoginFn = func(_ context.Context, credentials webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		loginAttempts++
+		switch loginAttempts {
+		case 1:
+			if credentials.Password != "old-secret" {
+				t.Fatalf("first password = %q, want old-secret", credentials.Password)
+			}
+			return nil, webcore.ErrInvalidAppleAccountCredentials
+		case 2:
+			if credentials.Password != "new-secret" {
+				t.Fatalf("second password = %q, want new-secret", credentials.Password)
+			}
+			return expected, nil
+		default:
+			t.Fatalf("unexpected login attempt %d", loginAttempts)
+			return nil, nil
+		}
+	}
+	var warning bytes.Buffer
+	passwordStoreWarningWriter = &warning
+	stored := ""
+	storeStoredWebPasswordFn = func(_ string, password string) error {
+		if loginAttempts != 2 {
+			t.Fatal("replacement password was stored before its login succeeded")
+		}
+		stored = password
+		return nil
+	}
+
+	session, source, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err != nil {
+		t.Fatalf("resolveSession() error = %v", err)
+	}
+	if session != expected || source != "fresh" || stored != "new-secret" {
+		t.Fatalf("result = (%+v, %q, stored %q), want expected fresh session with replacement", session, source, stored)
+	}
+	if got := warning.String(); !strings.Contains(got, "Saved Apple Account password was rejected; enter the current password to replace it.") {
+		t.Fatalf("warning = %q, want stored-password rejection notice", got)
 	}
 }
 
@@ -405,5 +471,91 @@ func TestWebAuthLogoutCanForgetPasswordWithSession(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "stored password") {
 		t.Fatalf("logout output = %q, want stored-password confirmation", stdout)
+	}
+}
+
+func TestWebAuthLogoutForgetPasswordFailsBeforeDeletingSession(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	deleteStoredWebPasswordFn = func(string) error { return webcore.ErrPasswordStoreUnavailable }
+	deleteWebSessionFn = func(string) error {
+		t.Fatal("session should not be deleted when the saved password cannot be removed")
+		return nil
+	}
+
+	cmd := WebAuthLogoutCommand()
+	if err := cmd.FlagSet.Parse([]string{"--apple-id", "user@example.com", "--forget-password", "--confirm"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, webcore.ErrPasswordStoreUnavailable) || !strings.Contains(err.Error(), "failed to forget saved password") {
+		t.Fatalf("Exec() error = %v, want password-store failure before session deletion", err)
+	}
+}
+
+func TestWebAuthLogoutAllForgetPasswordRequiresConfirmationWithoutDeletingAnything(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	deleteAllStoredWebPasswordsFn = func() error {
+		t.Fatal("passwords should not be deleted without --confirm")
+		return nil
+	}
+	deleteAllWebSessionsFn = func() error {
+		t.Fatal("sessions should not be deleted without --confirm")
+		return nil
+	}
+
+	cmd := WebAuthLogoutCommand()
+	if err := cmd.FlagSet.Parse([]string{"--all", "--forget-password"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var runErr error
+	_, stderr := captureWebCommandOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "--confirm") {
+		t.Fatalf("Exec() = %v, stderr %q; want --confirm usage error", runErr, stderr)
+	}
+}
+
+func TestWebAuthLogoutAllCanForgetPasswordsWithSessions(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	var calls []string
+	deleteAllStoredWebPasswordsFn = func() error {
+		calls = append(calls, "passwords")
+		return nil
+	}
+	deleteAllWebSessionsFn = func() error {
+		calls = append(calls, "sessions")
+		return nil
+	}
+
+	cmd := WebAuthLogoutCommand()
+	if err := cmd.FlagSet.Parse([]string{"--all", "--forget-password", "--confirm"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var runErr error
+	stdout, _ := captureWebCommandOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), nil)
+	})
+	if runErr != nil {
+		t.Fatalf("logout Exec() error = %v", runErr)
+	}
+	if got := strings.Join(calls, ","); got != "passwords,sessions" {
+		t.Fatalf("deletion order = %q, want passwords,sessions", got)
+	}
+	if !strings.Contains(stdout, "stored passwords") {
+		t.Fatalf("logout output = %q, want stored-password confirmation", stdout)
+	}
+}
+
+func TestWebAuthLogoutPasswordFlagsAreExperimental(t *testing.T) {
+	cmd := WebAuthLogoutCommand()
+	for _, name := range []string{"forget-password", "confirm"} {
+		flag := cmd.FlagSet.Lookup(name)
+		if flag == nil {
+			t.Fatalf("--%s flag not found", name)
+		}
+		if !strings.HasPrefix(flag.Usage, "[experimental]") {
+			t.Fatalf("--%s usage = %q, want [experimental] prefix", name, flag.Usage)
+		}
 	}
 }

--- a/internal/cli/web/web_auth_password_store_test.go
+++ b/internal/cli/web/web_auth_password_store_test.go
@@ -320,6 +320,40 @@ func TestResolveSessionPromptedPasswordFallsBackFromExpiredCookiesToFreshClient(
 	}
 }
 
+func TestResolveSessionPromptedPasswordDoesNotRetryFreshAfterTwoFactorStarts(t *testing.T) {
+	preserveWebPasswordHooks(t)
+	preserveWebLoginHooks(t)
+	t.Setenv(webPasswordEnv, "")
+	t.Setenv(webDontStorePasswordEnv, "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+
+	cachedClient := &http.Client{}
+	twoFactorSession := &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}
+	tryResumeSessionFn = func(context.Context, string) (*webcore.AuthSession, bool, error) {
+		return nil, false, webcore.ErrCachedSessionExpired
+	}
+	loadCachedSessionFn = func(string) (*webcore.AuthSession, bool, error) {
+		return &webcore.AuthSession{Client: cachedClient, UserEmail: "user@example.com"}, true, nil
+	}
+	loadStoredWebPasswordFn = func(string) (string, bool, error) { return "", false, nil }
+	promptPasswordFn = func(context.Context) (string, error) { return "prompted-secret", nil }
+	webLoginWithClientFn = func(context.Context, *http.Client, webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		return twoFactorSession, &webcore.TwoFactorRequiredError{}
+	}
+	prepareTwoFactorChallengeFn = func(context.Context, *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
+		return nil, errors.New("challenge setup failed")
+	}
+	webLoginFn = func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		t.Fatal("2FA flow errors must not trigger a fresh login retry")
+		return nil, nil
+	}
+
+	_, _, err := resolveSession(context.Background(), "user@example.com", "", "")
+	if err == nil || !strings.Contains(err.Error(), "2fa challenge setup failed") {
+		t.Fatalf("resolveSession() error = %v, want original 2FA setup failure", err)
+	}
+}
+
 func TestResolveSessionReplacesRejectedStoredPasswordOnlyAfterSuccessfulLogin(t *testing.T) {
 	preserveWebPasswordHooks(t)
 	preserveWebLoginHooks(t)

--- a/internal/web/password_store.go
+++ b/internal/web/password_store.go
@@ -35,7 +35,9 @@ var passwordKeyringOpen = func() (keyring.Keyring, error) {
 	})
 }
 
-func passwordStoreBypassed() bool {
+// PasswordStoreBypassed reports whether native credential-store access is
+// intentionally disabled for this process.
+func PasswordStoreBypassed() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(keychainBypassEnv))) {
 	case "1", "true", "yes", "on":
 		return true
@@ -63,7 +65,7 @@ func passwordItemKey(appleID string) (string, error) {
 // LoadPassword loads a password for one Apple Account from the native
 // credential store. It never falls back to a file-backed store.
 func LoadPassword(appleID string) (string, bool, error) {
-	if passwordStoreBypassed() {
+	if PasswordStoreBypassed() {
 		return "", false, nil
 	}
 	key, err := passwordItemKey(appleID)
@@ -89,15 +91,40 @@ func LoadPassword(appleID string) (string, bool, error) {
 
 // PasswordStored reports whether a password exists for one Apple Account.
 func PasswordStored(appleID string) (bool, error) {
-	_, ok, err := LoadPassword(appleID)
-	return ok, err
+	if PasswordStoreBypassed() {
+		return false, nil
+	}
+	key, err := passwordItemKey(appleID)
+	if err != nil {
+		return false, err
+	}
+	kr, err := passwordKeyringOpen()
+	if err != nil {
+		return false, fmt.Errorf("open native password store: %w", err)
+	}
+	if _, err := kr.GetMetadata(key); errors.Is(err, keyring.ErrKeyNotFound) {
+		return false, nil
+	} else if errors.Is(err, keyring.ErrMetadataNeedsCredentials) || errors.Is(err, keyring.ErrMetadataNotSupported) {
+		// Some native backends cannot query existence without retrieving the
+		// credential. Preserve status behavior there while keeping macOS
+		// Keychain's metadata-only path secret-free.
+		if _, err := kr.Get(key); errors.Is(err, keyring.ErrKeyNotFound) {
+			return false, nil
+		} else if err != nil {
+			return false, fmt.Errorf("check native password store: %w", err)
+		}
+		return true, nil
+	} else if err != nil {
+		return false, fmt.Errorf("check native password store: %w", err)
+	}
+	return true, nil
 }
 
 // StorePassword saves a password for one Apple Account in the native
 // credential store. The caller is responsible for only storing passwords that
 // have already authenticated successfully.
 func StorePassword(appleID, password string) error {
-	if passwordStoreBypassed() {
+	if PasswordStoreBypassed() {
 		return ErrPasswordStoreUnavailable
 	}
 	normalized, err := normalizedPasswordAppleID(appleID)
@@ -128,7 +155,7 @@ func StorePassword(appleID, password string) error {
 
 // DeletePassword removes the password for one Apple Account.
 func DeletePassword(appleID string) error {
-	if passwordStoreBypassed() {
+	if PasswordStoreBypassed() {
 		return ErrPasswordStoreUnavailable
 	}
 	key, err := passwordItemKey(appleID)
@@ -147,7 +174,7 @@ func DeletePassword(appleID string) error {
 
 // DeleteAllPasswords removes every password saved by asc web auth.
 func DeleteAllPasswords() error {
-	if passwordStoreBypassed() {
+	if PasswordStoreBypassed() {
 		return ErrPasswordStoreUnavailable
 	}
 	kr, err := passwordKeyringOpen()

--- a/internal/web/password_store.go
+++ b/internal/web/password_store.go
@@ -3,16 +3,16 @@ package web
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/99designs/keyring"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
 )
 
 const (
 	webPasswordKeyringService = "asc-web-password"
 	webPasswordKeyPrefix      = "asc:web-password:"
-	keychainBypassEnv         = "ASC_BYPASS_KEYCHAIN"
 )
 
 // ErrPasswordStoreUnavailable indicates that native credential storage is
@@ -38,12 +38,7 @@ var passwordKeyringOpen = func() (keyring.Keyring, error) {
 // PasswordStoreBypassed reports whether native credential-store access is
 // intentionally disabled for this process.
 func PasswordStoreBypassed() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(keychainBypassEnv))) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
-	}
+	return auth.ShouldBypassKeychain()
 }
 
 func normalizedPasswordAppleID(appleID string) (string, error) {

--- a/internal/web/password_store.go
+++ b/internal/web/password_store.go
@@ -1,8 +1,6 @@
 package web
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -54,13 +52,12 @@ func normalizedPasswordAppleID(appleID string) (string, error) {
 	return normalized, nil
 }
 
-func passwordKey(appleID string) (string, error) {
+func passwordItemKey(appleID string) (string, error) {
 	normalized, err := normalizedPasswordAppleID(appleID)
 	if err != nil {
 		return "", err
 	}
-	digest := sha256.Sum256([]byte(normalized))
-	return webPasswordKeyPrefix + hex.EncodeToString(digest[:]), nil
+	return webPasswordKeyPrefix + normalized, nil
 }
 
 // LoadPassword loads a password for one Apple Account from the native
@@ -69,7 +66,7 @@ func LoadPassword(appleID string) (string, bool, error) {
 	if passwordStoreBypassed() {
 		return "", false, nil
 	}
-	key, err := passwordKey(appleID)
+	key, err := passwordItemKey(appleID)
 	if err != nil {
 		return "", false, err
 	}
@@ -110,7 +107,7 @@ func StorePassword(appleID, password string) error {
 	if strings.TrimSpace(password) == "" {
 		return fmt.Errorf("password is required")
 	}
-	key, err := passwordKey(normalized)
+	key, err := passwordItemKey(normalized)
 	if err != nil {
 		return err
 	}
@@ -134,7 +131,7 @@ func DeletePassword(appleID string) error {
 	if passwordStoreBypassed() {
 		return ErrPasswordStoreUnavailable
 	}
-	key, err := passwordKey(appleID)
+	key, err := passwordItemKey(appleID)
 	if err != nil {
 		return err
 	}

--- a/internal/web/password_store.go
+++ b/internal/web/password_store.go
@@ -1,0 +1,173 @@
+package web
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/99designs/keyring"
+)
+
+const (
+	webPasswordKeyringService = "asc-web-password"
+	webPasswordKeyPrefix      = "asc:web-password:"
+	keychainBypassEnv         = "ASC_BYPASS_KEYCHAIN"
+)
+
+// ErrPasswordStoreUnavailable indicates that native credential storage is
+// unavailable or intentionally bypassed. Web login can continue without it.
+var ErrPasswordStoreUnavailable = errors.New("native password store unavailable")
+
+var passwordKeyringOpen = func() (keyring.Keyring, error) {
+	return keyring.Open(keyring.Config{
+		ServiceName:                    webPasswordKeyringService,
+		KeychainTrustApplication:       true,
+		KeychainSynchronizable:         false,
+		KeychainAccessibleWhenUnlocked: true,
+		AllowedBackends: []keyring.BackendType{
+			keyring.KeychainBackend,
+			keyring.WinCredBackend,
+			keyring.SecretServiceBackend,
+			keyring.KWalletBackend,
+			keyring.KeyCtlBackend,
+		},
+	})
+}
+
+func passwordStoreBypassed() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(keychainBypassEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizedPasswordAppleID(appleID string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(appleID))
+	if normalized == "" {
+		return "", fmt.Errorf("apple id is required")
+	}
+	return normalized, nil
+}
+
+func passwordKey(appleID string) (string, error) {
+	normalized, err := normalizedPasswordAppleID(appleID)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256([]byte(normalized))
+	return webPasswordKeyPrefix + hex.EncodeToString(digest[:]), nil
+}
+
+// LoadPassword loads a password for one Apple Account from the native
+// credential store. It never falls back to a file-backed store.
+func LoadPassword(appleID string) (string, bool, error) {
+	if passwordStoreBypassed() {
+		return "", false, nil
+	}
+	key, err := passwordKey(appleID)
+	if err != nil {
+		return "", false, err
+	}
+	kr, err := passwordKeyringOpen()
+	if err != nil {
+		return "", false, fmt.Errorf("open native password store: %w", err)
+	}
+	item, err := kr.Get(key)
+	if errors.Is(err, keyring.ErrKeyNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read native password store: %w", err)
+	}
+	if len(item.Data) == 0 {
+		return "", false, nil
+	}
+	return string(item.Data), true, nil
+}
+
+// PasswordStored reports whether a password exists for one Apple Account.
+func PasswordStored(appleID string) (bool, error) {
+	_, ok, err := LoadPassword(appleID)
+	return ok, err
+}
+
+// StorePassword saves a password for one Apple Account in the native
+// credential store. The caller is responsible for only storing passwords that
+// have already authenticated successfully.
+func StorePassword(appleID, password string) error {
+	if passwordStoreBypassed() {
+		return ErrPasswordStoreUnavailable
+	}
+	normalized, err := normalizedPasswordAppleID(appleID)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(password) == "" {
+		return fmt.Errorf("password is required")
+	}
+	key, err := passwordKey(normalized)
+	if err != nil {
+		return err
+	}
+	kr, err := passwordKeyringOpen()
+	if err != nil {
+		return fmt.Errorf("open native password store: %w", err)
+	}
+	if err := kr.Set(keyring.Item{
+		Key:         key,
+		Data:        []byte(password),
+		Label:       "ASC Apple Account Password (" + normalized + ")",
+		Description: "Password saved by asc web auth",
+	}); err != nil {
+		return fmt.Errorf("store native password: %w", err)
+	}
+	return nil
+}
+
+// DeletePassword removes the password for one Apple Account.
+func DeletePassword(appleID string) error {
+	if passwordStoreBypassed() {
+		return ErrPasswordStoreUnavailable
+	}
+	key, err := passwordKey(appleID)
+	if err != nil {
+		return err
+	}
+	kr, err := passwordKeyringOpen()
+	if err != nil {
+		return fmt.Errorf("open native password store: %w", err)
+	}
+	if err := kr.Remove(key); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+		return fmt.Errorf("delete native password: %w", err)
+	}
+	return nil
+}
+
+// DeleteAllPasswords removes every password saved by asc web auth.
+func DeleteAllPasswords() error {
+	if passwordStoreBypassed() {
+		return ErrPasswordStoreUnavailable
+	}
+	kr, err := passwordKeyringOpen()
+	if err != nil {
+		return fmt.Errorf("open native password store: %w", err)
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		return fmt.Errorf("list native passwords: %w", err)
+	}
+	for _, key := range keys {
+		if !strings.HasPrefix(key, webPasswordKeyPrefix) {
+			continue
+		}
+		if err := kr.Remove(key); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+			return fmt.Errorf("delete native password: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/web/password_store_test.go
+++ b/internal/web/password_store_test.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/99designs/keyring"
@@ -45,11 +44,8 @@ func TestStoredWebPasswordRoundTripNormalizesAppleID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Keys() error = %v", err)
 	}
-	if len(keys) != 1 || !strings.HasPrefix(keys[0], webPasswordKeyPrefix) {
-		t.Fatalf("stored keys = %v, want one %q-prefixed key", keys, webPasswordKeyPrefix)
-	}
-	if strings.Contains(keys[0], "user@example.com") {
-		t.Fatalf("stored key %q unexpectedly exposes the Apple ID", keys[0])
+	if len(keys) != 1 || keys[0] != webPasswordKeyPrefix+"user@example.com" {
+		t.Fatalf("stored keys = %v, want normalized account key", keys)
 	}
 }
 

--- a/internal/web/password_store_test.go
+++ b/internal/web/password_store_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/99designs/keyring"
 )
 
+type passwordMetadataKeyring struct {
+	keyring.Keyring
+	getCalls      int
+	metadataCalls int
+	metadataKey   string
+}
+
+func (kr *passwordMetadataKeyring) Get(key string) (keyring.Item, error) {
+	kr.getCalls++
+	return kr.Keyring.Get(key)
+}
+
+func (kr *passwordMetadataKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	kr.metadataCalls++
+	kr.metadataKey = key
+	return keyring.Metadata{}, nil
+}
+
 func useTestPasswordKeyring(t *testing.T) keyring.Keyring {
 	t.Helper()
 
@@ -77,7 +95,7 @@ func TestStoredWebPasswordsAreIsolatedAndDeletable(t *testing.T) {
 	}
 }
 
-func TestStoredWebPasswordExistsDoesNotReturnSecret(t *testing.T) {
+func TestStoredWebPasswordExistsReportsPresence(t *testing.T) {
 	useTestPasswordKeyring(t)
 
 	if err := StorePassword("user@example.com", "secret"); err != nil {
@@ -89,6 +107,28 @@ func TestStoredWebPasswordExistsDoesNotReturnSecret(t *testing.T) {
 	}
 	if !exists {
 		t.Fatal("PasswordStored() = false, want true")
+	}
+}
+
+func TestStoredWebPasswordExistsUsesMetadataWithoutLoadingSecret(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	kr := &passwordMetadataKeyring{}
+	originalOpen := passwordKeyringOpen
+	passwordKeyringOpen = func() (keyring.Keyring, error) { return kr, nil }
+	t.Cleanup(func() { passwordKeyringOpen = originalOpen })
+
+	exists, err := PasswordStored(" User@Example.COM ")
+	if err != nil {
+		t.Fatalf("PasswordStored() error = %v", err)
+	}
+	if !exists {
+		t.Fatal("PasswordStored() = false, want true")
+	}
+	if kr.getCalls != 0 || kr.metadataCalls != 1 {
+		t.Fatalf("keyring calls = (Get %d, GetMetadata %d), want (0, 1)", kr.getCalls, kr.metadataCalls)
+	}
+	if kr.metadataKey != webPasswordKeyPrefix+"user@example.com" {
+		t.Fatalf("metadata key = %q, want normalized account key", kr.metadataKey)
 	}
 }
 
@@ -108,5 +148,11 @@ func TestStoredWebPasswordHonorsKeychainBypass(t *testing.T) {
 	}
 	if err := StorePassword("user@example.com", "secret"); !errors.Is(err, ErrPasswordStoreUnavailable) {
 		t.Fatalf("StorePassword() error = %v, want ErrPasswordStoreUnavailable", err)
+	}
+	if err := DeletePassword("user@example.com"); !errors.Is(err, ErrPasswordStoreUnavailable) {
+		t.Fatalf("DeletePassword() error = %v, want ErrPasswordStoreUnavailable", err)
+	}
+	if err := DeleteAllPasswords(); !errors.Is(err, ErrPasswordStoreUnavailable) {
+		t.Fatalf("DeleteAllPasswords() error = %v, want ErrPasswordStoreUnavailable", err)
 	}
 }

--- a/internal/web/password_store_test.go
+++ b/internal/web/password_store_test.go
@@ -1,0 +1,116 @@
+package web
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/99designs/keyring"
+)
+
+func useTestPasswordKeyring(t *testing.T) keyring.Keyring {
+	t.Helper()
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "")
+	kr := keyring.NewArrayKeyring(nil)
+	originalOpen := passwordKeyringOpen
+	passwordKeyringOpen = func() (keyring.Keyring, error) {
+		return kr, nil
+	}
+	t.Cleanup(func() {
+		passwordKeyringOpen = originalOpen
+	})
+	return kr
+}
+
+func TestStoredWebPasswordRoundTripNormalizesAppleID(t *testing.T) {
+	kr := useTestPasswordKeyring(t)
+
+	if err := StorePassword(" User@Example.COM ", " secret "); err != nil {
+		t.Fatalf("StorePassword() error = %v", err)
+	}
+
+	password, ok, err := LoadPassword("user@example.com")
+	if err != nil {
+		t.Fatalf("LoadPassword() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("LoadPassword() ok = false, want true")
+	}
+	if password != " secret " {
+		t.Fatalf("LoadPassword() password = %q, want %q", password, " secret ")
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatalf("Keys() error = %v", err)
+	}
+	if len(keys) != 1 || !strings.HasPrefix(keys[0], webPasswordKeyPrefix) {
+		t.Fatalf("stored keys = %v, want one %q-prefixed key", keys, webPasswordKeyPrefix)
+	}
+	if strings.Contains(keys[0], "user@example.com") {
+		t.Fatalf("stored key %q unexpectedly exposes the Apple ID", keys[0])
+	}
+}
+
+func TestStoredWebPasswordsAreIsolatedAndDeletable(t *testing.T) {
+	useTestPasswordKeyring(t)
+
+	if err := StorePassword("one@example.com", "one-secret"); err != nil {
+		t.Fatalf("StorePassword(one) error = %v", err)
+	}
+	if err := StorePassword("two@example.com", "two-secret"); err != nil {
+		t.Fatalf("StorePassword(two) error = %v", err)
+	}
+	if err := DeletePassword("one@example.com"); err != nil {
+		t.Fatalf("DeletePassword() error = %v", err)
+	}
+
+	if _, ok, err := LoadPassword("one@example.com"); err != nil || ok {
+		t.Fatalf("LoadPassword(one) = (_, %v, %v), want (_, false, nil)", ok, err)
+	}
+	if password, ok, err := LoadPassword("two@example.com"); err != nil || !ok || password != "two-secret" {
+		t.Fatalf("LoadPassword(two) = (%q, %v, %v), want (%q, true, nil)", password, ok, err, "two-secret")
+	}
+
+	if err := DeleteAllPasswords(); err != nil {
+		t.Fatalf("DeleteAllPasswords() error = %v", err)
+	}
+	if _, ok, err := LoadPassword("two@example.com"); err != nil || ok {
+		t.Fatalf("LoadPassword(two) after delete all = (_, %v, %v), want (_, false, nil)", ok, err)
+	}
+}
+
+func TestStoredWebPasswordExistsDoesNotReturnSecret(t *testing.T) {
+	useTestPasswordKeyring(t)
+
+	if err := StorePassword("user@example.com", "secret"); err != nil {
+		t.Fatalf("StorePassword() error = %v", err)
+	}
+	exists, err := PasswordStored("user@example.com")
+	if err != nil {
+		t.Fatalf("PasswordStored() error = %v", err)
+	}
+	if !exists {
+		t.Fatal("PasswordStored() = false, want true")
+	}
+}
+
+func TestStoredWebPasswordHonorsKeychainBypass(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	originalOpen := passwordKeyringOpen
+	passwordKeyringOpen = func() (keyring.Keyring, error) {
+		t.Fatal("password keyring should not be opened while keychain is bypassed")
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		passwordKeyringOpen = originalOpen
+	})
+
+	if _, ok, err := LoadPassword("user@example.com"); err != nil || ok {
+		t.Fatalf("LoadPassword() = (_, %v, %v), want (_, false, nil)", ok, err)
+	}
+	if err := StorePassword("user@example.com", "secret"); !errors.Is(err, ErrPasswordStoreUnavailable) {
+		t.Fatalf("StorePassword() error = %v, want ErrPasswordStoreUnavailable", err)
+	}
+}


### PR DESCRIPTION
## Summary

- save interactively entered Apple Account passwords in the native OS credential store by default, with no file fallback
- reuse saved passwords together with the cached trusted-cookie jar when a web session expires, including the existing 2FA and `/2sv/trust` flow
- expose `passwordStored` in `asc web auth status`, add `ASC_WEB_DONT_STORE_PASSWORD=1`, and let logout remove passwords with `--forget-password --confirm`

## Behavior

Password resolution is now: explicit compatibility input, `ASC_WEB_PASSWORD`, native credential store, then secure prompt. Only a successfully authenticated prompted password is saved; environment-provided passwords remain ephemeral. Credential-store read/write failures warn and allow login to continue.

A rejected saved password is left intact until a newly prompted password authenticates successfully, at which point it is replaced. Accounts are stored independently using normalized Apple IDs as native credential-store account keys. `ASC_BYPASS_KEYCHAIN=1` and `ASC_WEB_DONT_STORE_PASSWORD=1` both disable password-store reads and writes.

Session-only logout remains unchanged. Password removal is explicit and supports both one account and `--all`.

## Verification

- `go build -o /tmp/asc .`
- focused RED/GREEN tests for password storage and web-session resolution
- `make format`
- `make check-docs`
- `make lint` (0 issues)
- `ASC_BYPASS_KEYCHAIN=1 make test`
- manual `/tmp/asc web auth login --help`, `status --output json`, and destructive-confirmation checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web authentication securely saves passwords in the system keychain.
  * Saved passwords can be reused for login and two-factor reauthentication.
  * Authentication status reports whether a password is stored, including expired sessions.
  * Logout can remove saved passwords for one account or all accounts, with confirmation.
  * App creation preserves sessions after automatic reauthentication.
  * An environment option disables password storage.

* **Bug Fixes**
  * Failed or rejected passwords are not saved.
  * Password-storage failures no longer block successful login; users receive a warning.

* **Documentation**
  * Updated help text explains password storage and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->