### PR TITLE
feat(analytics): filter view instances server-side

### DIFF
--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -533,6 +533,45 @@ func TestAnalyticsViewInvalidGranularityExitCode(t *testing.T) {
 	}
 }
 
+func TestAnalyticsViewInvalidProcessingDateExitCode(t *testing.T) {
+	binaryPath := buildASCBlackboxBinary(t)
+	for _, value := range []string{"2024-13-40", ""} {
+		t.Run(fmt.Sprintf("value=%q", value), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			runCmd := exec.Command(
+				binaryPath,
+				"analytics", "view",
+				"--request-id", "11111111-1111-1111-1111-111111111111",
+				"--processing-date", value,
+			)
+			runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			runCmd.Stdout = &stdout
+			runCmd.Stderr = &stderr
+			err := runCmd.Run()
+			if err == nil {
+				t.Fatal("expected invalid --processing-date to fail")
+			}
+
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
+			}
+			if exitErr.ExitCode() != ExitUsage {
+				t.Fatalf("exit code = %d, want %d; stderr=%q", exitErr.ExitCode(), ExitUsage, stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "--processing-date must be in YYYY-MM-DD format") {
+				t.Fatalf("unexpected stderr: %q", stderr.String())
+			}
+		})
+	}
+}
+
 func TestScreenshotsUploadResumeMissingValueExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryPath := buildASCBlackboxBinary(t)

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -484,6 +484,55 @@ func TestBuildsListMissingAppExitCode(t *testing.T) {
 	}
 }
 
+func TestAnalyticsViewInvalidGranularityExitCode(t *testing.T) {
+	binaryPath := buildASCBlackboxBinary(t)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "unsupported", value: "HOURLY"},
+		{name: "empty", value: ""},
+		{name: "empty entry", value: "DAILY,,WEEKLY"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			runCmd := exec.Command(
+				binaryPath,
+				"analytics", "view",
+				"--request-id", "11111111-1111-1111-1111-111111111111",
+				"--granularity", test.value,
+			)
+			runCmd.Env = isolatedCLITestEnv(filepath.Join(tmpDir, "config.json"))
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			runCmd.Stdout = &stdout
+			runCmd.Stderr = &stderr
+			err := runCmd.Run()
+			if err == nil {
+				t.Fatalf("expected non-zero exit for granularity %q", test.value)
+			}
+
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
+			}
+			if exitErr.ExitCode() != ExitUsage {
+				t.Fatalf("exit code = %d, want %d; stderr=%q", exitErr.ExitCode(), ExitUsage, stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "--granularity must be a comma-separated list of: DAILY, WEEKLY, MONTHLY") {
+				t.Fatalf("unexpected stderr: %q", stderr.String())
+			}
+		})
+	}
+}
+
 func TestScreenshotsUploadResumeMissingValueExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryPath := buildASCBlackboxBinary(t)

--- a/commands/analytics.mdx
+++ b/commands/analytics.mdx
@@ -149,11 +149,14 @@ asc analytics view --request-id "REQUEST_ID"
 **Optional Flags:**
 
 * `--instance-id` - Filter by specific report instance
-* `--date` - Filter instances by date (`YYYY-MM-DD`)
+* `--processing-date` - Filter instances by Apple's processing date (`YYYY-MM-DD`)
+* `--granularity` - Filter instances by `DAILY`, `WEEKLY`, or `MONTHLY` (comma-separated)
 * `--include-segments` - Include download URLs for report segments
 * `--limit` - Results per page (1-200)
-* `--paginate` - Fetch all reports (recommended with `--date`)
+* `--paginate` - Fetch all reports (recommended with `--processing-date`)
 * `--next` - Pagination URL
+
+`--date` remains available as a deprecated compatibility flag. It warns and preserves the previous local match against either `reportDate` or `processingDate`; new automation should use `--processing-date` for Apple's server-side filter.
 
 **Examples:**
 
@@ -166,10 +169,10 @@ asc analytics view \
   --request-id "REQUEST_ID" \
   --include-segments
 
-# Filter by date and paginate
+# Filter by processing date and paginate
 asc analytics view \
   --request-id "REQUEST_ID" \
-  --date "2024-01-20" \
+  --processing-date "2024-01-20" \
   --paginate
 
 # Get specific instance

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -10,7 +10,8 @@ Quirks and tips for specific App Store Connect API endpoints.
   - YEARLY: `YYYY`
 - Vendor number comes from Sales and Trends → Reports URL (`vendorNumber=...`)
 - Although OpenAPI marks `filter[version]` optional, the live Sales Reports endpoint requires it for subscription reports; Apple currently reports `1_4` as the latest `SUBSCRIPTION` version. Version values can advance independently of the API schema.
-- Use `--paginate` with `asc analytics view --date` to search every report page; the CLI forwards the date as `filter[processingDate]` when fetching instances
+- Use `--paginate` with `asc analytics view --processing-date` to search every report page; the CLI forwards the value as `filter[processingDate]` when fetching instances
+- `asc analytics view --date` is a deprecated compatibility flag. It preserves the previous local match against either `reportDate` or `processingDate` and warns callers to migrate to the explicit server-side `--processing-date` filter.
 - Use `--granularity "DAILY,WEEKLY,MONTHLY"` with `asc analytics view` to filter instances by one or more documented granularities
 - Long analytics runs may require raising `ASC_TIMEOUT`
 

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -10,7 +10,8 @@ Quirks and tips for specific App Store Connect API endpoints.
   - YEARLY: `YYYY`
 - Vendor number comes from Sales and Trends → Reports URL (`vendorNumber=...`)
 - Although OpenAPI marks `filter[version]` optional, the live Sales Reports endpoint requires it for subscription reports; Apple currently reports `1_4` as the latest `SUBSCRIPTION` version. Version values can advance independently of the API schema.
-- Use `--paginate` with `asc analytics get --date` to avoid missing instances on later pages
+- Use `--paginate` with `asc analytics view --date` to search every report page; the CLI forwards the date as `filter[processingDate]` when fetching instances
+- Use `--granularity "DAILY,WEEKLY,MONTHLY"` with `asc analytics view` to filter instances by one or more documented granularities
 - Long analytics runs may require raising `ASC_TIMEOUT`
 
 ## Finance Reports

--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -211,6 +211,8 @@ type analyticsReportsQuery struct {
 
 type analyticsReportInstancesQuery struct {
 	listQuery
+	granularities   []string
+	processingDates []string
 }
 
 type analyticsReportSegmentsQuery struct {
@@ -290,6 +292,20 @@ func WithAnalyticsReportInstancesNextURL(next string) AnalyticsReportInstancesOp
 	}
 }
 
+// WithAnalyticsReportInstancesGranularities filters instances by one or more granularities.
+func WithAnalyticsReportInstancesGranularities(granularities []string) AnalyticsReportInstancesOption {
+	return func(q *analyticsReportInstancesQuery) {
+		q.granularities = normalizeUniqueList(normalizeUpperList(granularities))
+	}
+}
+
+// WithAnalyticsReportInstancesProcessingDates filters instances by one or more processing dates.
+func WithAnalyticsReportInstancesProcessingDates(dates []string) AnalyticsReportInstancesOption {
+	return func(q *analyticsReportInstancesQuery) {
+		q.processingDates = normalizeUniqueList(dates)
+	}
+}
+
 // WithAnalyticsReportSegmentsLimit sets the max number of segments to return.
 func WithAnalyticsReportSegmentsLimit(limit int) AnalyticsReportSegmentsOption {
 	return func(q *analyticsReportSegmentsQuery) {
@@ -351,6 +367,8 @@ func buildAnalyticsReportsQuery(query *analyticsReportsQuery) string {
 
 func buildAnalyticsReportInstancesQuery(query *analyticsReportInstancesQuery) string {
 	values := url.Values{}
+	addCSV(values, "filter[granularity]", query.granularities)
+	addCSV(values, "filter[processingDate]", query.processingDates)
 	addLimit(values, query.limit)
 	return values.Encode()
 }

--- a/internal/asc/analytics_instances_filters_test.go
+++ b/internal/asc/analytics_instances_filters_test.go
@@ -1,0 +1,53 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetAnalyticsReportInstancesUsesDocumentedFilters(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", req.Method)
+		}
+		if req.URL.Path != "/v1/analyticsReports/report-1/instances" {
+			t.Fatalf("path = %q, want analytics report instances path", req.URL.Path)
+		}
+		query := req.URL.Query()
+		if got := query.Get("filter[granularity]"); got != "DAILY,WEEKLY" {
+			t.Fatalf("filter[granularity] = %q, want %q", got, "DAILY,WEEKLY")
+		}
+		if got := query.Get("filter[processingDate]"); got != "2026-02-20,2026-02-27" {
+			t.Fatalf("filter[processingDate] = %q, want %q", got, "2026-02-20,2026-02-27")
+		}
+		if got := query.Get("limit"); got != "200" {
+			t.Fatalf("limit = %q, want %q", got, "200")
+		}
+		assertAuthorized(t, req)
+	}, jsonResponse(http.StatusOK, `{
+		"data":[{
+			"type":"analyticsReportInstances",
+			"id":"instance-1",
+			"attributes":{"granularity":"WEEKLY","processingDate":"2026-02-27"}
+		}],
+		"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReports/report-1/instances"}
+	}`))
+
+	response, err := client.GetAnalyticsReportInstances(
+		context.Background(),
+		"report-1",
+		WithAnalyticsReportInstancesGranularities([]string{"daily", " WEEKLY ", "DAILY"}),
+		WithAnalyticsReportInstancesProcessingDates([]string{"2026-02-20", " 2026-02-27 ", "2026-02-20", ""}),
+		WithAnalyticsReportInstancesLimit(200),
+	)
+	if err != nil {
+		t.Fatalf("GetAnalyticsReportInstances() error = %v", err)
+	}
+	if len(response.Data) != 1 || response.Data[0].ID != "instance-1" {
+		t.Fatalf("unexpected response %+v", response.Data)
+	}
+	if got := response.Data[0].Attributes.Granularity; got != "WEEKLY" {
+		t.Fatalf("decoded granularity = %q, want WEEKLY", got)
+	}
+}

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -169,14 +169,27 @@ func normalizeAnalyticsDateFilter(value string) (string, error) {
 	return parsed.Format("2006-01-02"), nil
 }
 
-func matchAnalyticsInstanceDate(attrs asc.AnalyticsReportInstanceAttributes, date string) bool {
-	if strings.TrimSpace(date) == "" {
-		return true
+func normalizeAnalyticsGranularities(value string) ([]string, error) {
+	parts := strings.Split(value, ",")
+	seen := make(map[string]struct{}, len(parts))
+	granularities := make([]string, 0, len(parts))
+	for _, part := range parts {
+		granularity := strings.ToUpper(strings.TrimSpace(part))
+		if granularity == "" {
+			return nil, fmt.Errorf("--granularity must be a comma-separated list of: DAILY, WEEKLY, MONTHLY")
+		}
+		switch granularity {
+		case "DAILY", "WEEKLY", "MONTHLY":
+		default:
+			return nil, fmt.Errorf("--granularity must be a comma-separated list of: DAILY, WEEKLY, MONTHLY")
+		}
+		if _, exists := seen[granularity]; exists {
+			continue
+		}
+		seen[granularity] = struct{}{}
+		granularities = append(granularities, granularity)
 	}
-	if strings.HasPrefix(attrs.ReportDate, date) {
-		return true
-	}
-	return strings.HasPrefix(attrs.ProcessingDate, date)
+	return granularities, nil
 }
 
 func fetchAnalyticsReports(ctx context.Context, client *asc.Client, requestID string, limit int, next string, paginate bool) ([]asc.Resource[asc.AnalyticsReportAttributes], asc.Links, error) {
@@ -226,7 +239,7 @@ func fetchAnalyticsReports(ctx context.Context, client *asc.Client, requestID st
 	return all, links, nil
 }
 
-func fetchAnalyticsReportInstances(ctx context.Context, client *asc.Client, reportID string) ([]asc.Resource[asc.AnalyticsReportInstanceAttributes], error) {
+func fetchAnalyticsReportInstances(ctx context.Context, client *asc.Client, reportID string, opts ...asc.AnalyticsReportInstancesOption) ([]asc.Resource[asc.AnalyticsReportInstanceAttributes], error) {
 	var (
 		all  []asc.Resource[asc.AnalyticsReportInstanceAttributes]
 		next string
@@ -242,7 +255,10 @@ func fetchAnalyticsReportInstances(ctx context.Context, client *asc.Client, repo
 			seen[next] = true
 			resp, err = client.GetAnalyticsReportInstances(ctx, reportID, asc.WithAnalyticsReportInstancesNextURL(next))
 		} else {
-			resp, err = client.GetAnalyticsReportInstances(ctx, reportID, asc.WithAnalyticsReportInstancesLimit(analyticsMaxLimit))
+			firstPageOpts := make([]asc.AnalyticsReportInstancesOption, 0, len(opts)+1)
+			firstPageOpts = append(firstPageOpts, asc.WithAnalyticsReportInstancesLimit(analyticsMaxLimit))
+			firstPageOpts = append(firstPageOpts, opts...)
+			resp, err = client.GetAnalyticsReportInstances(ctx, reportID, firstPageOpts...)
 		}
 		if err != nil {
 			return nil, err

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -157,6 +157,18 @@ func normalizeReportDate(value string, frequency asc.SalesReportFrequency) (stri
 	}
 }
 
+func normalizeAnalyticsProcessingDateFilter(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("--processing-date must be in YYYY-MM-DD format")
+	}
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return "", fmt.Errorf("--processing-date must be in YYYY-MM-DD format")
+	}
+	return parsed.Format("2006-01-02"), nil
+}
+
 func normalizeAnalyticsDateFilter(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -167,6 +179,16 @@ func normalizeAnalyticsDateFilter(value string) (string, error) {
 		return "", fmt.Errorf("--date must be in YYYY-MM-DD format")
 	}
 	return parsed.Format("2006-01-02"), nil
+}
+
+func matchAnalyticsInstanceDate(attrs asc.AnalyticsReportInstanceAttributes, date string) bool {
+	if strings.TrimSpace(date) == "" {
+		return true
+	}
+	if strings.HasPrefix(attrs.ReportDate, date) {
+		return true
+	}
+	return strings.HasPrefix(attrs.ProcessingDate, date)
 }
 
 func normalizeAnalyticsGranularities(value string) ([]string, error) {

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -363,7 +363,7 @@ func AnalyticsGetCommand() *ffcli.Command {
 	includeSegments := fs.Bool("include-segments", false, "Include report segments with download URLs")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
-	paginate := fs.Bool("paginate", false, "Paginate all reports (recommended with --date)")
+	paginate := fs.Bool("paginate", false, "Paginate all reports (recommended with --processing-date)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -372,15 +372,17 @@ func AnalyticsGetCommand() *ffcli.Command {
 		ShortHelp:  "View analytics reports for a request.",
 		LongHelp: `View analytics reports for a request.
 
-The --date and --granularity filters are sent to App Store Connect when
-fetching report instances. Granularity accepts DAILY, WEEKLY, and MONTHLY.
+The --processing-date and --granularity filters are sent to App Store Connect
+when fetching report instances. Granularity accepts DAILY, WEEKLY, and MONTHLY.
+The deprecated --date compatibility flag retains its previous local matching
+against either reportDate or processingDate.
 
 Examples:
   asc analytics view --request-id "REQUEST_ID"
   asc analytics view --request-id "REQUEST_ID" --include-segments
   asc analytics view --request-id "REQUEST_ID" --instance-id "INSTANCE_ID"
-  asc analytics view --request-id "REQUEST_ID" --date "2024-01-20" --paginate
-  asc analytics view --request-id "REQUEST_ID" --date "2024-01-20" --granularity "DAILY,WEEKLY" --paginate`,
+  asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-20" --paginate
+  asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-20" --granularity "DAILY,WEEKLY" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -356,7 +356,8 @@ func AnalyticsGetCommand() *ffcli.Command {
 
 	requestID := fs.String("request-id", "", "Analytics report request ID")
 	instanceID := fs.String("instance-id", "", "Filter by specific instance ID")
-	date := fs.String("date", "", "Filter instances by date (YYYY-MM-DD)")
+	date := fs.String("date", "", "Filter instances by processing date (YYYY-MM-DD)")
+	granularity := fs.String("granularity", "", "Filter instances by granularity (comma-separated: DAILY, WEEKLY, MONTHLY)")
 	includeSegments := fs.Bool("include-segments", false, "Include report segments with download URLs")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -369,11 +370,15 @@ func AnalyticsGetCommand() *ffcli.Command {
 		ShortHelp:  "View analytics reports for a request.",
 		LongHelp: `View analytics reports for a request.
 
+The --date and --granularity filters are sent to App Store Connect when
+fetching report instances. Granularity accepts DAILY, WEEKLY, and MONTHLY.
+
 Examples:
   asc analytics view --request-id "REQUEST_ID"
   asc analytics view --request-id "REQUEST_ID" --include-segments
   asc analytics view --request-id "REQUEST_ID" --instance-id "INSTANCE_ID"
-  asc analytics view --request-id "REQUEST_ID" --date "2024-01-20" --paginate`,
+  asc analytics view --request-id "REQUEST_ID" --date "2024-01-20" --paginate
+  asc analytics view --request-id "REQUEST_ID" --date "2024-01-20" --granularity "DAILY,WEEKLY" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -403,6 +408,20 @@ Examples:
 				return fmt.Errorf("analytics view: %w", err)
 			}
 
+			granularityProvided := false
+			fs.Visit(func(item *flag.Flag) {
+				if item.Name == "granularity" {
+					granularityProvided = true
+				}
+			})
+			var granularities []string
+			if granularityProvided {
+				granularities, err = normalizeAnalyticsGranularities(*granularity)
+				if err != nil {
+					return shared.UsageErrorf("analytics view: %v", err)
+				}
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("analytics view: %w", err)
@@ -421,10 +440,17 @@ Examples:
 				RequestID: strings.TrimSpace(*requestID),
 				Links:     links,
 			}
+			instanceOpts := make([]asc.AnalyticsReportInstancesOption, 0, 2)
+			if dateFilter != "" {
+				instanceOpts = append(instanceOpts, asc.WithAnalyticsReportInstancesProcessingDates([]string{dateFilter}))
+			}
+			if len(granularities) > 0 {
+				instanceOpts = append(instanceOpts, asc.WithAnalyticsReportInstancesGranularities(granularities))
+			}
 
 			foundInstance := false
 			for _, report := range reports {
-				instances, err := fetchAnalyticsReportInstances(requestCtx, client, report.ID)
+				instances, err := fetchAnalyticsReportInstances(requestCtx, client, report.ID, instanceOpts...)
 				if err != nil {
 					return fmt.Errorf("analytics view: failed to fetch instances: %w", err)
 				}
@@ -439,9 +465,6 @@ Examples:
 
 				for _, instance := range instances {
 					if strings.TrimSpace(*instanceID) != "" && instance.ID != strings.TrimSpace(*instanceID) {
-						continue
-					}
-					if !matchAnalyticsInstanceDate(instance.Attributes, dateFilter) {
 						continue
 					}
 

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -356,7 +356,9 @@ func AnalyticsGetCommand() *ffcli.Command {
 
 	requestID := fs.String("request-id", "", "Analytics report request ID")
 	instanceID := fs.String("instance-id", "", "Filter by specific instance ID")
-	date := fs.String("date", "", "Filter instances by processing date (YYYY-MM-DD)")
+	processingDate := fs.String("processing-date", "", "Filter instances by processing date (YYYY-MM-DD)")
+	legacyDate := fs.String("date", "", "DEPRECATED: filter instances by report or processing date (YYYY-MM-DD); use --processing-date")
+	shared.HideFlagFromHelp(fs.Lookup("date"))
 	granularity := fs.String("granularity", "", "Filter instances by granularity (comma-separated: DAILY, WEEKLY, MONTHLY)")
 	includeSegments := fs.Bool("include-segments", false, "Include report segments with download URLs")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
@@ -382,6 +384,23 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			var processingDateProvided, legacyDateProvided, granularityProvided bool
+			fs.Visit(func(item *flag.Flag) {
+				switch item.Name {
+				case "processing-date":
+					processingDateProvided = true
+				case "date":
+					legacyDateProvided = true
+				case "granularity":
+					granularityProvided = true
+				}
+			})
+			if legacyDateProvided {
+				fmt.Fprintln(os.Stderr, "Warning: `--date` is deprecated. Use `--processing-date`.")
+				if processingDateProvided {
+					return shared.UsageError("--date conflicts with --processing-date; use only --processing-date")
+				}
+			}
 			if strings.TrimSpace(*requestID) == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --request-id is required")
 				return shared.MissingRequiredUsageError()
@@ -403,23 +422,30 @@ Examples:
 				return fmt.Errorf("analytics view: %w", err)
 			}
 
-			dateFilter, err := normalizeAnalyticsDateFilter(*date)
-			if err != nil {
-				return fmt.Errorf("analytics view: %w", err)
+			var processingDateFilter string
+			if processingDateProvided {
+				normalized, normalizeErr := normalizeAnalyticsProcessingDateFilter(*processingDate)
+				if normalizeErr != nil {
+					return shared.UsageErrorf("analytics view: %v", normalizeErr)
+				}
+				processingDateFilter = normalized
+			}
+			var legacyDateFilter string
+			if legacyDateProvided {
+				normalized, normalizeErr := normalizeAnalyticsDateFilter(*legacyDate)
+				if normalizeErr != nil {
+					return shared.UsageErrorf("analytics view: %v", normalizeErr)
+				}
+				legacyDateFilter = normalized
 			}
 
-			granularityProvided := false
-			fs.Visit(func(item *flag.Flag) {
-				if item.Name == "granularity" {
-					granularityProvided = true
-				}
-			})
 			var granularities []string
 			if granularityProvided {
-				granularities, err = normalizeAnalyticsGranularities(*granularity)
-				if err != nil {
-					return shared.UsageErrorf("analytics view: %v", err)
+				normalized, normalizeErr := normalizeAnalyticsGranularities(*granularity)
+				if normalizeErr != nil {
+					return shared.UsageErrorf("analytics view: %v", normalizeErr)
 				}
+				granularities = normalized
 			}
 
 			client, err := shared.GetASCClient()
@@ -441,8 +467,8 @@ Examples:
 				Links:     links,
 			}
 			instanceOpts := make([]asc.AnalyticsReportInstancesOption, 0, 2)
-			if dateFilter != "" {
-				instanceOpts = append(instanceOpts, asc.WithAnalyticsReportInstancesProcessingDates([]string{dateFilter}))
+			if processingDateFilter != "" {
+				instanceOpts = append(instanceOpts, asc.WithAnalyticsReportInstancesProcessingDates([]string{processingDateFilter}))
 			}
 			if len(granularities) > 0 {
 				instanceOpts = append(instanceOpts, asc.WithAnalyticsReportInstancesGranularities(granularities))
@@ -465,6 +491,9 @@ Examples:
 
 				for _, instance := range instances {
 					if strings.TrimSpace(*instanceID) != "" && instance.ID != strings.TrimSpace(*instanceID) {
+						continue
+					}
+					if legacyDateFilter != "" && !matchAnalyticsInstanceDate(instance.Attributes, legacyDateFilter) {
 						continue
 					}
 
@@ -504,7 +533,7 @@ Examples:
 					continue
 				}
 
-				if dateFilter != "" && len(reportResult.Instances) == 0 {
+				if (processingDateFilter != "" || legacyDateFilter != "") && len(reportResult.Instances) == 0 {
 					continue
 				}
 				result.Data = append(result.Data, reportResult)
@@ -513,11 +542,17 @@ Examples:
 			if strings.TrimSpace(*instanceID) != "" && !foundInstance {
 				return fmt.Errorf("analytics view: instance %q not found for request %q", strings.TrimSpace(*instanceID), strings.TrimSpace(*requestID))
 			}
-			if dateFilter != "" && len(result.Data) == 0 {
+			dateFilterValue := processingDateFilter
+			dateFilterLabel := "processing date"
+			if legacyDateFilter != "" {
+				dateFilterValue = legacyDateFilter
+				dateFilterLabel = "date"
+			}
+			if dateFilterValue != "" && len(result.Data) == 0 {
 				if strings.TrimSpace(*next) == "" && !*paginate {
-					return fmt.Errorf("analytics view: no instances found for date %q in the first page of reports (use --paginate or --next)", dateFilter)
+					return fmt.Errorf("analytics view: no instances found for %s %q in the first page of reports (use --paginate or --next)", dateFilterLabel, dateFilterValue)
 				}
-				return fmt.Errorf("analytics view: no instances found for date %q", dateFilter)
+				return fmt.Errorf("analytics view: no instances found for %s %q", dateFilterLabel, dateFilterValue)
 			}
 
 			return shared.PrintOutput(result, *output.Output, *output.Pretty)

--- a/internal/cli/analytics/analytics_test.go
+++ b/internal/cli/analytics/analytics_test.go
@@ -9,7 +9,30 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+func TestAnalyticsViewProcessingDateFlagLifecycle(t *testing.T) {
+	cmd := AnalyticsGetCommand()
+	if cmd.FlagSet.Lookup("processing-date") == nil {
+		t.Fatal("canonical --processing-date flag is not registered")
+	}
+	if cmd.FlagSet.Lookup("date") == nil {
+		t.Fatal("deprecated --date compatibility flag is not registered")
+	}
+
+	visible := make(map[string]bool)
+	for _, item := range shared.VisibleHelpFlags(cmd.FlagSet) {
+		visible[item.Name] = true
+	}
+	if !visible["processing-date"] {
+		t.Fatal("canonical --processing-date flag is hidden from help")
+	}
+	if visible["date"] {
+		t.Fatal("deprecated --date flag should be hidden from canonical help")
+	}
+}
 
 func parseAnalyticsArgs(args []string) []string {
 	if len(args) > 0 && args[0] == "analytics" {

--- a/internal/cli/analytics/analytics_test.go
+++ b/internal/cli/analytics/analytics_test.go
@@ -32,6 +32,20 @@ func TestAnalyticsViewProcessingDateFlagLifecycle(t *testing.T) {
 	if visible["date"] {
 		t.Fatal("deprecated --date flag should be hidden from canonical help")
 	}
+
+	usage := cmd.UsageFunc(cmd)
+	for _, want := range []string{
+		"The --processing-date and --granularity filters are sent to App Store Connect",
+		"The deprecated --date compatibility flag retains its previous local matching",
+		`--processing-date "2024-01-20"`,
+	} {
+		if !strings.Contains(usage, want) {
+			t.Fatalf("analytics view help does not contain %q:\n%s", want, usage)
+		}
+	}
+	if strings.Contains(usage, `--date "2024-01-20"`) {
+		t.Fatalf("analytics view help still teaches deprecated --date:\n%s", usage)
+	}
 }
 
 func parseAnalyticsArgs(args []string) []string {

--- a/internal/cli/cmdtest/analytics_view_filters_test.go
+++ b/internal/cli/cmdtest/analytics_view_filters_test.go
@@ -1,0 +1,412 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const analyticsViewRequestID = "11111111-1111-1111-1111-111111111111"
+
+func TestAnalyticsViewDateOutputCharacterization(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports" {
+				t.Fatalf("unexpected reports request: %s %s", req.Method, req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{
+					"type":"analyticsReports",
+					"id":"report-1",
+					"attributes":{"name":"App Sessions","reportType":"STANDARD","category":"APP_USAGE","granularity":"DAILY"}
+				}],
+				"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports"}
+			}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/analyticsReports/report-1/instances" {
+				t.Fatalf("unexpected instances request: %s %s", req.Method, req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{
+					"type":"analyticsReportInstances",
+					"id":"instance-1",
+					"attributes":{"reportDate":"2024-01-19","processingDate":"2024-01-20T00:00:00Z","granularity":"DAILY","version":"1.0"}
+				}],
+				"links":{}
+			}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr := runAnalyticsViewForOutput(
+		t,
+		"--request-id", analyticsViewRequestID,
+		"--date", "2024-01-20",
+		"--output", "json",
+	)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	assertAnalyticsViewJSONEqual(t, stdout, `{
+		"requestId":"11111111-1111-1111-1111-111111111111",
+		"data":[{
+			"id":"report-1",
+			"reportType":"STANDARD",
+			"name":"App Sessions",
+			"category":"APP_USAGE",
+			"granularity":"DAILY",
+			"instances":[{
+				"id":"instance-1",
+				"reportDate":"2024-01-19",
+				"processingDate":"2024-01-20T00:00:00Z",
+				"granularity":"DAILY",
+				"version":"1.0"
+			}]
+		}],
+		"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports"}
+	}`)
+	if requestCount != 2 {
+		t.Fatalf("expected 2 requests, got %d", requestCount)
+	}
+}
+
+func TestAnalyticsViewDateForwardsProcessingDate(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReports","id":"report-1","attributes":{"name":"App Sessions","granularity":"DAILY"}}],
+				"links":{}
+			}`), nil
+		case 2:
+			if got := req.URL.Query().Get("filter[processingDate]"); got != "2024-01-20" {
+				t.Fatalf("filter[processingDate] = %q, want %q", got, "2024-01-20")
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReportInstances","id":"instance-1","attributes":{"processingDate":"2024-01-20","granularity":"DAILY"}}],
+				"links":{}
+			}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	_, stderr := runAnalyticsViewForOutput(
+		t,
+		"--request-id", analyticsViewRequestID,
+		"--date", "2024-01-20",
+		"--output", "json",
+	)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
+func TestAnalyticsViewGranularityOnlyPreservesReportMetadata(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReports","id":"report-1","attributes":{"name":"Sales","reportType":"STANDARD","category":"COMMERCE","granularity":"MONTHLY"}}],
+				"links":{}
+			}`), nil
+		case 2:
+			query := req.URL.Query()
+			if got := query.Get("filter[granularity]"); got != "MONTHLY" {
+				t.Fatalf("filter[granularity] = %q, want MONTHLY", got)
+			}
+			if query.Has("filter[processingDate]") {
+				t.Fatalf("unexpected processing-date filter: %s", req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{"data":[],"links":{}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr := runAnalyticsViewForOutput(
+		t,
+		"--request-id", analyticsViewRequestID,
+		"--granularity", "monthly",
+		"--output", "json",
+	)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	assertAnalyticsViewJSONEqual(t, stdout, `{
+		"requestId":"11111111-1111-1111-1111-111111111111",
+		"data":[{
+			"id":"report-1",
+			"reportType":"STANDARD",
+			"name":"Sales",
+			"category":"COMMERCE",
+			"granularity":"MONTHLY"
+		}],
+		"links":{}
+	}`)
+	if requestCount != 2 {
+		t.Fatalf("expected 2 requests, got %d", requestCount)
+	}
+}
+
+func TestAnalyticsViewFiltersPaginateAndPreserveOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const (
+		reportsNextURL   = "https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports?cursor=reports-next"
+		instancesNextURL = "https://api.appstoreconnect.apple.com/v1/analyticsReports/report-1/instances?cursor=instances-next"
+	)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.URL.Path != "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports" || req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("unexpected first reports request: %s", req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReports","id":"report-1","attributes":{"name":"App Sessions","reportType":"STANDARD","category":"APP_USAGE","granularity":"DAILY"}}],
+				"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports","next":"` + reportsNextURL + `"}
+			}`), nil
+		case 2:
+			if req.URL.String() != reportsNextURL {
+				t.Fatalf("reports next URL = %q, want %q", req.URL.String(), reportsNextURL)
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReports","id":"report-2","attributes":{"name":"Store Discovery","reportType":"STANDARD","category":"APP_STORE_ENGAGEMENT","granularity":"WEEKLY"}}],
+				"links":{}
+			}`), nil
+		case 3:
+			assertAnalyticsInstanceFilters(t, req, "/v1/analyticsReports/report-1/instances")
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReportInstances","id":"instance-1","attributes":{"reportDate":"2024-01-19","processingDate":"2024-01-20","granularity":"DAILY","version":"1.0"}}],
+				"links":{"next":"` + instancesNextURL + `"}
+			}`), nil
+		case 4:
+			if req.URL.String() != instancesNextURL {
+				t.Fatalf("instances next URL = %q, want %q", req.URL.String(), instancesNextURL)
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReportInstances","id":"instance-2","attributes":{"reportDate":"2024-01-19","processingDate":"2024-01-20","granularity":"WEEKLY","version":"1.0"}}],
+				"links":{}
+			}`), nil
+		case 5:
+			assertAnalyticsInstanceFilters(t, req, "/v1/analyticsReports/report-2/instances")
+			return analyticsViewJSONResponse(`{"data":[],"links":{}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr := runAnalyticsViewForOutput(
+		t,
+		"--request-id", analyticsViewRequestID,
+		"--date", "2024-01-20",
+		"--granularity", "daily, weekly, monthly",
+		"--paginate",
+		"--output", "json",
+	)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	assertAnalyticsViewJSONEqual(t, stdout, `{
+		"requestId":"11111111-1111-1111-1111-111111111111",
+		"data":[{
+			"id":"report-1",
+			"reportType":"STANDARD",
+			"name":"App Sessions",
+			"category":"APP_USAGE",
+			"granularity":"DAILY",
+			"instances":[
+				{"id":"instance-1","reportDate":"2024-01-19","processingDate":"2024-01-20","granularity":"DAILY","version":"1.0"},
+				{"id":"instance-2","reportDate":"2024-01-19","processingDate":"2024-01-20","granularity":"WEEKLY","version":"1.0"}
+			]
+		}],
+		"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports"}
+	}`)
+	if requestCount != 5 {
+		t.Fatalf("expected 5 requests, got %d", requestCount)
+	}
+}
+
+func TestAnalyticsViewNoFiltersPreservesInstanceAndSegmentBehavior(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const instanceID = "22222222-2222-2222-2222-222222222222"
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.URL.Path != "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports" || req.URL.RawQuery != "limit=200" {
+				t.Fatalf("unexpected reports request: %s", req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReports","id":"report-1","attributes":{"name":"App Sessions","granularity":"DAILY"}}],
+				"links":{}
+			}`), nil
+		case 2:
+			if req.URL.Path != "/v1/analyticsReports/report-1/instances" || req.URL.RawQuery != "limit=200" {
+				t.Fatalf("unexpected unfiltered instances request: %s", req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[
+					{"type":"analyticsReportInstances","id":"ignored-instance","attributes":{"processingDate":"2024-01-19"}},
+					{"type":"analyticsReportInstances","id":"` + instanceID + `","attributes":{"reportDate":"2024-01-19","processingDate":"2024-01-20","granularity":"DAILY","version":"1.0"}}
+				],
+				"links":{}
+			}`), nil
+		case 3:
+			if req.URL.Path != "/v1/analyticsReportInstances/"+instanceID+"/segments" || req.URL.RawQuery != "limit=200" {
+				t.Fatalf("unexpected segments request: %s", req.URL.String())
+			}
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReportSegments","id":"segment-1","attributes":{"url":"https://example.com/report.gz","checksum":"abc123","sizeInBytes":42,"urlExpirationDate":"2024-01-21T00:00:00Z"}}],
+				"links":{}
+			}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr := runAnalyticsViewForOutput(
+		t,
+		"--request-id", analyticsViewRequestID,
+		"--instance-id", instanceID,
+		"--include-segments",
+		"--output", "json",
+	)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	assertAnalyticsViewJSONEqual(t, stdout, `{
+		"requestId":"11111111-1111-1111-1111-111111111111",
+		"data":[{
+			"id":"report-1",
+			"name":"App Sessions",
+			"granularity":"DAILY",
+			"instances":[{
+				"id":"22222222-2222-2222-2222-222222222222",
+				"reportDate":"2024-01-19",
+				"processingDate":"2024-01-20",
+				"granularity":"DAILY",
+				"version":"1.0",
+				"segments":[{
+					"id":"segment-1",
+					"downloadUrl":"https://example.com/report.gz",
+					"checksum":"abc123",
+					"sizeInBytes":42,
+					"urlExpirationDate":"2024-01-21T00:00:00Z"
+				}]
+			}]
+		}],
+		"links":{}
+	}`)
+	if requestCount != 3 {
+		t.Fatalf("expected 3 requests, got %d", requestCount)
+	}
+}
+
+func assertAnalyticsInstanceFilters(t *testing.T, req *http.Request, wantPath string) {
+	t.Helper()
+	if req.Method != http.MethodGet || req.URL.Path != wantPath {
+		t.Fatalf("unexpected instances request: %s %s", req.Method, req.URL.String())
+	}
+	query := req.URL.Query()
+	if got := query.Get("filter[processingDate]"); got != "2024-01-20" {
+		t.Fatalf("filter[processingDate] = %q, want %q", got, "2024-01-20")
+	}
+	if got := query.Get("filter[granularity]"); got != "DAILY,WEEKLY,MONTHLY" {
+		t.Fatalf("filter[granularity] = %q, want %q", got, "DAILY,WEEKLY,MONTHLY")
+	}
+	if got := query.Get("limit"); got != "200" {
+		t.Fatalf("limit = %q, want %q", got, "200")
+	}
+}
+
+func runAnalyticsViewForOutput(t *testing.T, args ...string) (string, string) {
+	t.Helper()
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	fullArgs := append([]string{"analytics", "view"}, args...)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(fullArgs); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	return stdout, stderr
+}
+
+func assertAnalyticsViewJSONEqual(t *testing.T, gotJSON, wantJSON string) {
+	t.Helper()
+	var got any
+	if err := json.Unmarshal([]byte(gotJSON), &got); err != nil {
+		t.Fatalf("failed to parse command output: %v\noutput=%s", err, gotJSON)
+	}
+	var want any
+	if err := json.Unmarshal([]byte(wantJSON), &want); err != nil {
+		t.Fatalf("failed to parse expected output: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected JSON output\ngot:  %s\nwant: %s", gotJSON, wantJSON)
+	}
+}
+
+func analyticsViewJSONResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}

--- a/internal/cli/cmdtest/analytics_view_filters_test.go
+++ b/internal/cli/cmdtest/analytics_view_filters_test.go
@@ -3,6 +3,8 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -13,7 +15,7 @@ import (
 
 const analyticsViewRequestID = "11111111-1111-1111-1111-111111111111"
 
-func TestAnalyticsViewDateOutputCharacterization(t *testing.T) {
+func TestAnalyticsViewDeprecatedDatePreservesReportDateMatching(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -40,11 +42,14 @@ func TestAnalyticsViewDateOutputCharacterization(t *testing.T) {
 			if req.Method != http.MethodGet || req.URL.Path != "/v1/analyticsReports/report-1/instances" {
 				t.Fatalf("unexpected instances request: %s %s", req.Method, req.URL.String())
 			}
+			if req.URL.Query().Has("filter[processingDate]") {
+				t.Fatalf("deprecated --date must not become a processing-date API filter: %s", req.URL.String())
+			}
 			return analyticsViewJSONResponse(`{
 				"data":[{
 					"type":"analyticsReportInstances",
 					"id":"instance-1",
-					"attributes":{"reportDate":"2024-01-19","processingDate":"2024-01-20T00:00:00Z","granularity":"DAILY","version":"1.0"}
+					"attributes":{"reportDate":"2024-01-20","processingDate":"2024-01-21","granularity":"DAILY","version":"1.0"}
 				}],
 				"links":{}
 			}`), nil
@@ -60,8 +65,9 @@ func TestAnalyticsViewDateOutputCharacterization(t *testing.T) {
 		"--date", "2024-01-20",
 		"--output", "json",
 	)
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	const warning = "Warning: `--date` is deprecated. Use `--processing-date`.\n"
+	if stderr != warning {
+		t.Fatalf("stderr = %q, want %q", stderr, warning)
 	}
 	assertAnalyticsViewJSONEqual(t, stdout, `{
 		"requestId":"11111111-1111-1111-1111-111111111111",
@@ -73,8 +79,8 @@ func TestAnalyticsViewDateOutputCharacterization(t *testing.T) {
 			"granularity":"DAILY",
 			"instances":[{
 				"id":"instance-1",
-				"reportDate":"2024-01-19",
-				"processingDate":"2024-01-20T00:00:00Z",
+				"reportDate":"2024-01-20",
+				"processingDate":"2024-01-21",
 				"granularity":"DAILY",
 				"version":"1.0"
 			}]
@@ -86,7 +92,7 @@ func TestAnalyticsViewDateOutputCharacterization(t *testing.T) {
 	}
 }
 
-func TestAnalyticsViewDateForwardsProcessingDate(t *testing.T) {
+func TestAnalyticsViewProcessingDateForwardsFilter(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -119,7 +125,7 @@ func TestAnalyticsViewDateForwardsProcessingDate(t *testing.T) {
 	_, stderr := runAnalyticsViewForOutput(
 		t,
 		"--request-id", analyticsViewRequestID,
-		"--date", "2024-01-20",
+		"--processing-date", "2024-01-20",
 		"--output", "json",
 	)
 	if stderr != "" {
@@ -241,7 +247,7 @@ func TestAnalyticsViewFiltersPaginateAndPreserveOutput(t *testing.T) {
 	stdout, stderr := runAnalyticsViewForOutput(
 		t,
 		"--request-id", analyticsViewRequestID,
-		"--date", "2024-01-20",
+		"--processing-date", "2024-01-20",
 		"--granularity", "daily, weekly, monthly",
 		"--paginate",
 		"--output", "json",
@@ -266,6 +272,32 @@ func TestAnalyticsViewFiltersPaginateAndPreserveOutput(t *testing.T) {
 	}`)
 	if requestCount != 5 {
 		t.Fatalf("expected 5 requests, got %d", requestCount)
+	}
+}
+
+func TestAnalyticsViewDeprecatedDateConflictsWithProcessingDate(t *testing.T) {
+	stdout, stderr, err := runCommand(t, []string{
+		"analytics", "view",
+		"--request-id", analyticsViewRequestID,
+		"--processing-date", "2024-01-20",
+		"--date", "2024-01-21",
+	})
+	if err == nil {
+		t.Fatal("expected conflicting date flags to fail")
+	}
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("error = %v, want usage error", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	const warning = "Warning: `--date` is deprecated. Use `--processing-date`."
+	if !strings.Contains(stderr, warning) {
+		t.Fatalf("stderr = %q, want warning %q", stderr, warning)
+	}
+	const conflict = "Error: --date conflicts with --processing-date; use only --processing-date"
+	if !strings.Contains(stderr, conflict) {
+		t.Fatalf("stderr = %q, want conflict %q", stderr, conflict)
 	}
 }
 

--- a/resources/api-notes.mdx
+++ b/resources/api-notes.mdx
@@ -36,10 +36,10 @@ export ASC_VENDOR_NUMBER="12345678"
 
 ### Pagination Quirks
 
-Use `--paginate` with `asc analytics view --request-id ... --date ...` to avoid missing instances on later pages. Without pagination, you may only receive partial data.
+Use `--paginate` with `asc analytics view --request-id ... --processing-date ...` to avoid missing instances on later pages. Without pagination, you may only receive partial data. The deprecated `--date` compatibility flag keeps the older local match against either `reportDate` or `processingDate`.
 
 ```bash  theme={null}
-asc analytics view --request-id "REQUEST_ID" --date "2024-01-01" --paginate
+asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-01" --paginate
 ```
 
 ### Long-Running Operations
@@ -48,7 +48,7 @@ Long analytics runs may require raising `ASC_TIMEOUT`:
 
 ```bash  theme={null}
 export ASC_TIMEOUT=5m
-asc analytics view --request-id "REQUEST_ID" --date "2024-01-01" --paginate
+asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-01" --paginate
 ```
 
 ## Finance Reports

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -123,7 +123,7 @@
 
   ```bash  theme={null}
   asc testflight feedback list --app "123456789" --paginate
-  asc analytics view --request-id "REQUEST_ID" --date "2024-01-01" --paginate
+  asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-01" --paginate
   ```
 
   Without `--paginate`, only the first page (default limit) is returned. This is especially important for:

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -88,7 +88,7 @@ For analytics operations with large datasets:
 
 ```bash  theme={null}
 export ASC_TIMEOUT=5m
-asc analytics view --request-id "REQUEST_ID" --date "2024-01-01" --paginate
+asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-01" --paginate
 ```
 
 ## Permission Errors
@@ -140,7 +140,7 @@ If the build shows `PROCESSING` for more than 30 minutes, check App Store Connec
 **Solution**: Always use `--paginate` for complete results:
 
 ```bash  theme={null}
-asc analytics view --request-id "REQUEST_ID" --date "2024-01-01" --paginate
+asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-01" --paginate
 asc testflight feedback list --app "123456789" --paginate
 ```
 


### PR DESCRIPTION
## Summary

- make `asc analytics view --processing-date` send Apple's documented
  `filter[processingDate]` on each report's initial instances request
- add `--granularity` as a case-insensitive, comma-separated filter for the
  documented `DAILY`, `WEEKLY`, and `MONTHLY` values
- follow Apple-provided instance `links.next` URLs exactly while preserving
  report pagination and the existing output contract
- retain the previous local `reportDate`/`processingDate` matcher only for the
  deprecated `--date` compatibility path
- document the command behavior and cover the client, command, pagination,
  compatibility, validation, and exit-code paths

## Context

This is the user-visible follow-up to #1836. That draft exposed filter helpers
under `internal/asc`, but no CLI command called them, so the change was not
independently useful and the companion skills repository could not consume it.

This PR keeps the helpers and their first caller together. The result is a
complete command path that can be reviewed end to end and is useful on its own:
users can ask Apple for only the report instances they need instead of fetching
every instance and filtering locally.

## User-visible behavior

The existing command now performs server-side processing-date filtering:

```bash
asc analytics view \
  --request-id "REQUEST_ID" \
  --processing-date "2024-01-20" \
  --paginate
```

It can also select one or more granularities:

```bash
asc analytics view \
  --request-id "REQUEST_ID" \
  --processing-date "2024-01-20" \
  --granularity "DAILY,WEEKLY" \
  --paginate
```

For each report, the first instances request includes `limit=200` plus the
selected filters. Later pages use the exact `links.next` URL returned by Apple;
the CLI does not reconstruct that URL or reapply first-page options.

`--granularity` accepts surrounding whitespace and lowercase input, normalizes
values to uppercase, removes duplicates, and rejects unsupported or empty
entries before authentication or network access. Invalid values are usage
errors: the diagnostic is written to stderr, stdout stays empty, and the
process exits with code 2.

## Compatibility

- deprecated `--date` remains accepted, warns on stderr, and preserves its
  previous local match against either `reportDate` or `processingDate`
- `--date` and `--processing-date` conflict instead of silently changing meaning
- no-filter instance requests remain `?limit=200`
- `--next`, report pagination, and instance pagination retain their existing
  behavior
- `--instance-id` remains a local selection over returned instances
- `--include-segments` and segment pagination are unchanged
- existing JSON fields, table rendering, links, and not-found diagnostics are
  preserved
- granularity-only filtering does not introduce a new not-found error or drop
  report metadata when Apple returns no matching instances

## Maintainer-feedback mapping

| Feedback from #1836 | This PR |
| --- | --- |
| Keep the helper with its first caller | The client options and `analytics view` wiring are in the same commit and PR |
| Send `filter[processingDate]` from an explicit CLI flag | `--processing-date` adds the normalized filter to each report's initial instances request |
| Do not fetch every instance for the new server-side path | `--processing-date` filters at the API boundary; only deprecated `--date` retains local matching for compatibility |
| Cover request wiring and pagination at command level | Tests cover report pagination, instance pagination, first-page filters, and exact next-URL traversal |
| Preserve existing output | Tests parse JSON and compare the complete existing result structure |
| Model the documented multi-value granularity contract | `--granularity` supports comma-separated `DAILY`, `WEEKLY`, and `MONTHLY`, case-insensitively |
| Keep the dossier as a downstream consumer | No dossier, presentation, aggregation, or skills code is included here |

## API contract

The repository's OpenAPI snapshot documents both parameters on:

```text
GET /v1/analyticsReports/{id}/instances
```

Both `filter[granularity]` and `filter[processingDate]` are array query
parameters with `style: form` and `explode: false`, so the client models them as
lists and encodes them as comma-separated query values.

## Verification

Focused coverage includes:

- client HTTP method, path, authentication header, limit, multi-value filters,
  and representative response decoding
- command-level processing-date wiring and rendered-help migration guidance
- deprecated `--date` warning, conflict handling, and original report-date or processing-date matching
- all three documented granularity values and case normalization
- report pagination plus instance pagination with exact `links.next` traversal
- parsed JSON equality for the existing output contract
- no-filter, `--instance-id`, and `--include-segments` compatibility
- granularity-only empty-result metadata preservation
- invalid, empty, and empty-entry granularity values exiting 2 before auth

Repository gates run successfully:

```text
make format
make generate-command-docs  # generated no diff
make check-docs
make lint                   # 0 issues
ASC_BYPASS_KEYCHAIN=1 make test
make build
```

The built binary's help and invalid-value stdout/stderr/exit behavior were also
smoke-tested. A read-only App Store Connect call authenticated successfully and
Apple returned HTTP 200 for an instances request containing both
`filter[processingDate]=2024-01-20` and `filter[granularity]=WEEKLY`. That report
had no matching instance, so legacy matching semantics remain verified
independently through deterministic command-level regression coverage.

## Downstream vision (separate scope)

This command remains generic and deterministic. Once its JSON contract is
stable, an optional skill in the companion skills repository can consume it as
one evidence source for an app-acquisition or investor dossier:

```text
Apple analytics -> stable asc JSON -> evidence/provenance layer -> optional dossier or presentation
```

That downstream work is intentionally not part of this repository or this PR.
It would not import a Go `internal` package, and it would remain a separate
review with its own evidence, privacy, and non-fabrication safeguards.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788176796&installation_model_id=10418&pr_number=1840&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1840&signature=f4cad5eea5ab3340dff2a77161b741787d860ae28fefbadf30aa6c94994b3889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--granularity` filtering to `analytics view` for DAILY, WEEKLY, and MONTHLY values.
  - Added server-side processing-date filtering for analytics reports.
  - Analytics results now paginate while preserving report metadata and output.

- **Bug Fixes**
  - Improved validation and diagnostics for invalid filter values.
  - Added compatibility handling and conflict warnings for deprecated `--date` usage.

- **Documentation**
  - Updated analytics and sales report guidance for date filtering, pagination, and granularity options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->