### PR TITLE
fix(analytics): accept current sales report versions

### DIFF
--- a/commands/analytics.mdx
+++ b/commands/analytics.mdx
@@ -44,7 +44,7 @@ asc analytics sales \
 
 **Optional Flags:**
 
-* `--version` - Report format version: `1_0` (default), `1_1`, `1_3`
+* `--version` - Report format version (for example, `1_0` or `1_4`). Defaults to `1_4` for `SUBSCRIPTION` reports and `1_0` for other report types
 * `--output` - Custom output path (default: `sales_report_{date}_{type}.tsv.gz`)
 * `--decompress` - Decompress to `.tsv` format
 

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -9,6 +9,7 @@ Quirks and tips for specific App Store Connect API endpoints.
   - MONTHLY: `YYYY-MM`
   - YEARLY: `YYYY`
 - Vendor number comes from Sales and Trends → Reports URL (`vendorNumber=...`)
+- Although OpenAPI marks `filter[version]` optional, the live Sales Reports endpoint requires it for subscription reports; Apple currently reports `1_4` as the latest `SUBSCRIPTION` version. Version values can advance independently of the API schema.
 - Use `--paginate` with `asc analytics get --date` to avoid missing instances on later pages
 - Long analytics runs may require raising `ASC_TIMEOUT`
 

--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -45,6 +45,7 @@ const (
 	SalesReportVersion1_0 SalesReportVersion = "1_0"
 	SalesReportVersion1_1 SalesReportVersion = "1_1"
 	SalesReportVersion1_3 SalesReportVersion = "1_3"
+	SalesReportVersion1_4 SalesReportVersion = "1_4"
 )
 
 // AnalyticsAccessType represents analytics report access types.

--- a/internal/cli/analytics/analytics_compare.go
+++ b/internal/cli/analytics/analytics_compare.go
@@ -212,7 +212,7 @@ func fetchAndAggregate(ctx context.Context, client *asc.Client, vendor string, s
 			ReportSubType: subType,
 			Frequency:     freq,
 			ReportDate:    date,
-			Version:       asc.SalesReportVersion1_0,
+			Version:       defaultSalesReportVersion(salesType),
 		})
 		if err != nil {
 			if asc.IsNotFound(err) {

--- a/internal/cli/analytics/analytics_compare_test.go
+++ b/internal/cli/analytics/analytics_compare_test.go
@@ -472,6 +472,40 @@ func TestFetchAndAggregate_SingleReportKeepsAvailableColumns(t *testing.T) {
 	}
 }
 
+func TestFetchAndAggregate_UsesSubscriptionVersion1_4(t *testing.T) {
+	client := newCompareTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Query().Get("filter[version]"); got != "1_4" {
+			t.Fatalf("filter[version] = %q, want 1_4", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(bytes.NewReader(gzipCompareText(t, compareSalesReportTSV(
+				"123",
+				"APP",
+			)))),
+			Request: req,
+		}, nil
+	})
+
+	_, found, err := fetchAndAggregate(
+		context.Background(),
+		client,
+		"V",
+		insights.SalesScope{AppID: "123", AppSKU: "APP"},
+		[]string{"2026-01-01"},
+		asc.SalesReportTypeSubscription,
+		asc.SalesReportSubTypeSummary,
+		asc.SalesReportFrequencyDaily,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if found != 1 {
+		t.Fatalf("expected 1 found report, got %d", found)
+	}
+}
+
 func TestFetchAndAggregate_ReturnsParseError(t *testing.T) {
 	client := newCompareTestClient(t, func(req *http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -66,15 +66,19 @@ func normalizeSalesReportFrequency(value string) (asc.SalesReportFrequency, erro
 func normalizeSalesReportVersion(value string, reportType asc.SalesReportType) (asc.SalesReportVersion, error) {
 	normalized := strings.TrimSpace(value)
 	if normalized == "" {
-		if reportType == asc.SalesReportTypeSubscription {
-			return asc.SalesReportVersion1_4, nil
-		}
-		return asc.SalesReportVersion1_0, nil
+		return defaultSalesReportVersion(reportType), nil
 	}
 	if !salesReportVersionPattern.MatchString(normalized) {
 		return "", fmt.Errorf("--version must use major_minor format (for example, 1_4)")
 	}
 	return asc.SalesReportVersion(normalized), nil
+}
+
+func defaultSalesReportVersion(reportType asc.SalesReportType) asc.SalesReportVersion {
+	if reportType == asc.SalesReportTypeSubscription {
+		return asc.SalesReportVersion1_4
+	}
+	return asc.SalesReportVersion1_0
 }
 
 func normalizeAnalyticsAccessType(value string) (asc.AnalyticsAccessType, error) {

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -12,7 +12,10 @@ import (
 
 const analyticsMaxLimit = 200
 
-var uuidPattern = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
+var (
+	uuidPattern               = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
+	salesReportVersionPattern = regexp.MustCompile(`^[0-9]+_[0-9]+$`)
+)
 
 func normalizeSalesReportType(value string) (asc.SalesReportType, error) {
 	normalized := strings.ToUpper(strings.TrimSpace(value))
@@ -60,21 +63,18 @@ func normalizeSalesReportFrequency(value string) (asc.SalesReportFrequency, erro
 	}
 }
 
-func normalizeSalesReportVersion(value string) (asc.SalesReportVersion, error) {
+func normalizeSalesReportVersion(value string, reportType asc.SalesReportType) (asc.SalesReportVersion, error) {
 	normalized := strings.TrimSpace(value)
 	if normalized == "" {
+		if reportType == asc.SalesReportTypeSubscription {
+			return asc.SalesReportVersion1_4, nil
+		}
 		return asc.SalesReportVersion1_0, nil
 	}
-	switch normalized {
-	case string(asc.SalesReportVersion1_0):
-		return asc.SalesReportVersion1_0, nil
-	case string(asc.SalesReportVersion1_1):
-		return asc.SalesReportVersion1_1, nil
-	case string(asc.SalesReportVersion1_3):
-		return asc.SalesReportVersion1_3, nil
-	default:
-		return "", fmt.Errorf("--version must be 1_0, 1_1, or 1_3")
+	if !salesReportVersionPattern.MatchString(normalized) {
+		return "", fmt.Errorf("--version must use major_minor format (for example, 1_4)")
 	}
+	return asc.SalesReportVersion(normalized), nil
 }
 
 func normalizeAnalyticsAccessType(value string) (asc.AnalyticsAccessType, error) {

--- a/internal/cli/analytics/analytics_helpers_test.go
+++ b/internal/cli/analytics/analytics_helpers_test.go
@@ -91,20 +91,50 @@ func TestNormalizeReportDate_WeeklyRejectsNonBoundaryDate(t *testing.T) {
 	}
 }
 
-func TestNormalizeSalesReportVersionSupports1_3(t *testing.T) {
-	version, err := normalizeSalesReportVersion("1_3")
+func TestNormalizeSalesReportVersionSupportsCurrentVersion(t *testing.T) {
+	version, err := normalizeSalesReportVersion("1_4", asc.SalesReportTypeSales)
 	if err != nil {
-		t.Fatalf("expected version 1_3 to parse, got %v", err)
+		t.Fatalf("expected version 1_4 to parse, got %v", err)
 	}
-	if version != asc.SalesReportVersion1_3 {
-		t.Fatalf("expected version 1_3, got %q", version)
+	if version != asc.SalesReportVersion1_4 {
+		t.Fatalf("expected version 1_4, got %q", version)
+	}
+}
+
+func TestNormalizeSalesReportVersionDefaultsSubscriptionTo1_4(t *testing.T) {
+	version, err := normalizeSalesReportVersion("  ", asc.SalesReportTypeSubscription)
+	if err != nil {
+		t.Fatalf("expected empty version to use the default, got %v", err)
+	}
+	if version != asc.SalesReportVersion1_4 {
+		t.Fatalf("expected subscription default version 1_4, got %q", version)
+	}
+}
+
+func TestNormalizeSalesReportVersionPreservesOtherDefaults(t *testing.T) {
+	version, err := normalizeSalesReportVersion("  ", asc.SalesReportTypeSales)
+	if err != nil {
+		t.Fatalf("expected empty version to use the default, got %v", err)
+	}
+	if version != asc.SalesReportVersion1_0 {
+		t.Fatalf("expected sales default version 1_0, got %q", version)
 	}
 }
 
 func TestNormalizeSalesReportVersionRejectsInvalidValue(t *testing.T) {
-	_, err := normalizeSalesReportVersion("2_0")
+	_, err := normalizeSalesReportVersion("1.4", asc.SalesReportTypeSubscription)
 	if err == nil {
 		t.Fatal("expected invalid version error")
+	}
+}
+
+func TestNormalizeSalesReportVersionAllowsFutureVersion(t *testing.T) {
+	version, err := normalizeSalesReportVersion(" 1_5 ", asc.SalesReportTypeSubscription)
+	if err != nil {
+		t.Fatalf("expected future version to parse, got %v", err)
+	}
+	if version != asc.SalesReportVersion("1_5") {
+		t.Fatalf("expected version 1_5, got %q", version)
 	}
 }
 

--- a/internal/cli/analytics/analytics_sales.go
+++ b/internal/cli/analytics/analytics_sales.go
@@ -22,7 +22,7 @@ func AnalyticsSalesCommand() *ffcli.Command {
 	reportSubType := fs.String("subtype", "", "Report subtype: SUMMARY, DETAILED")
 	frequency := fs.String("frequency", "", "Frequency: DAILY, WEEKLY, MONTHLY, YEARLY")
 	date := fs.String("date", "", "Report date: daily YYYY-MM-DD, weekly Monday(start) or Sunday(end) YYYY-MM-DD, monthly YYYY-MM, yearly YYYY")
-	version := fs.String("version", "1_0", "Report format version: 1_0 (default), 1_1, 1_3")
+	version := fs.String("version", "", "Report format version in major_minor format (defaults to 1_4 for SUBSCRIPTION and 1_0 otherwise)")
 	output := fs.String("output", "", "Output file path (default: sales_report_{date}_{type}.tsv.gz)")
 	decompress := fs.Bool("decompress", false, "Decompress gzip output to .tsv")
 	outputFlags := shared.BindMetadataOutputFlags(fs)
@@ -80,7 +80,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("analytics sales: %w", err)
 			}
-			reportVersion, err := normalizeSalesReportVersion(*version)
+			reportVersion, err := normalizeSalesReportVersion(*version, salesType)
 			if err != nil {
 				return fmt.Errorf("analytics sales: %w", err)
 			}

--- a/internal/cli/cmdtest/analytics_sales_version_test.go
+++ b/internal/cli/cmdtest/analytics_sales_version_test.go
@@ -1,0 +1,103 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/salesReports" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		query := req.URL.Query()
+		if got := query.Get("filter[reportType]"); got != "SUBSCRIPTION" {
+			t.Fatalf("filter[reportType] = %q, want SUBSCRIPTION", got)
+		}
+		if got := query.Get("filter[reportSubType]"); got != "SUMMARY" {
+			t.Fatalf("filter[reportSubType] = %q, want SUMMARY", got)
+		}
+		if got := query.Get("filter[frequency]"); got != "DAILY" {
+			t.Fatalf("filter[frequency] = %q, want DAILY", got)
+		}
+		if got := query.Get("filter[reportDate]"); got != "2026-07-30" {
+			t.Fatalf("filter[reportDate] = %q, want 2026-07-30", got)
+		}
+		if got := query.Get("filter[version]"); got != "1_4" {
+			t.Fatalf("filter[version] = %q, want 1_4", got)
+		}
+		if req.Header.Get("Authorization") == "" {
+			t.Fatal("expected Authorization header")
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(strings.NewReader("report-data")),
+			ContentLength: int64(len("report-data")),
+			Header:        http.Header{"Content-Type": []string{"application/a-gzip"}},
+		}, nil
+	})
+
+	outputPath := filepath.Join(t.TempDir(), "subscription.tsv.gz")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"analytics", "sales",
+			"--vendor", "12345678",
+			"--type", "SUBSCRIPTION",
+			"--subtype", "SUMMARY",
+			"--frequency", "DAILY",
+			"--date", "2026-07-30",
+			"--output", outputPath,
+			"--output-format", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if got := string(data); got != "report-data" {
+		t.Fatalf("report contents = %q, want report-data", got)
+	}
+
+	var result struct {
+		Version  string `json:"version"`
+		FilePath string `json:"filePath"`
+		FileSize int64  `json:"fileSize"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON output: %v\nstdout=%s", err, stdout)
+	}
+	if result.Version != "1_4" || result.FilePath != outputPath || result.FileSize != int64(len("report-data")) {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}

--- a/internal/cli/cmdtest/analytics_sales_version_test.go
+++ b/internal/cli/cmdtest/analytics_sales_version_test.go
@@ -5,21 +5,22 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/salesReports" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -43,13 +44,35 @@ func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
 		if req.Header.Get("Authorization") == "" {
 			t.Fatal("expected Authorization header")
 		}
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          io.NopCloser(strings.NewReader("report-data")),
-			ContentLength: int64(len("report-data")),
-			Header:        http.Header{"Content-Type": []string{"application/a-gzip"}},
-		}, nil
+		w.Header().Set("Content-Type", "application/a-gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "report-data")
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
 	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create analytics sales test client: %v", err)
+	}
+	restoreClient := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restoreClient)
 
 	outputPath := filepath.Join(t.TempDir(), "subscription.tsv.gz")
 	root := RootCommand("1.2.3")

--- a/internal/cli/cmdtest/analytics_sales_version_test.go
+++ b/internal/cli/cmdtest/analytics_sales_version_test.go
@@ -1,6 +1,8 @@
 package cmdtest
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -18,6 +20,15 @@ import (
 func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var reportPayload bytes.Buffer
+	gzipWriter := gzip.NewWriter(&reportPayload)
+	if _, err := gzipWriter.Write([]byte("report-data")); err != nil {
+		t.Fatalf("create report payload: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close report payload: %v", err)
+	}
 
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -46,7 +57,7 @@ func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/a-gzip")
 		w.WriteHeader(http.StatusOK)
-		_, _ = io.WriteString(w, "report-data")
+		_, _ = w.Write(reportPayload.Bytes())
 	}))
 	t.Cleanup(server.Close)
 
@@ -108,7 +119,21 @@ func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read report: %v", err)
 	}
-	if got := string(data); got != "report-data" {
+	if !bytes.Equal(data, reportPayload.Bytes()) {
+		t.Fatal("downloaded report does not match the gzip response payload")
+	}
+	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("open downloaded report: %v", err)
+	}
+	uncompressed, err := io.ReadAll(gzipReader)
+	if err != nil {
+		t.Fatalf("read downloaded report: %v", err)
+	}
+	if err := gzipReader.Close(); err != nil {
+		t.Fatalf("close downloaded report: %v", err)
+	}
+	if got := string(uncompressed); got != "report-data" {
 		t.Fatalf("report contents = %q, want report-data", got)
 	}
 
@@ -120,7 +145,7 @@ func TestAnalyticsSalesDefaultsSubscriptionsToVersion1_4(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("parse JSON output: %v\nstdout=%s", err, stdout)
 	}
-	if result.Version != "1_4" || result.FilePath != outputPath || result.FileSize != int64(len("report-data")) {
+	if result.Version != "1_4" || result.FilePath != outputPath || result.FileSize != int64(reportPayload.Len()) {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 }


### PR DESCRIPTION
## What changed

- default `SUBSCRIPTION` sales reports to Apple's required `1_4` format version while preserving `1_0` for other report types
- accept well-formed `major_minor` versions instead of capping the CLI at a stale hard-coded list
- add the `SalesReportVersion1_4` typed constant and document the live API version requirement
- cover the complete command path, query parameters, authentication header, report artifact, and JSON result

## Why

Apple now rejects subscription report version `1_0` and reports `1_4` as the latest supported version. The CLI also rejected an explicit `--version 1_4` before making the request, leaving the advertised subscription report workflow unusable.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- live read-only `SUBSCRIPTION` / `SUMMARY` / `DAILY` download without `--version`: succeeded and reported `version: 1_4`
- malformed `--version 1.4`: rejected locally without creating an artifact

Fixes #1841

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788193856&installation_model_id=10418&pr_number=1842&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1842&signature=ce7fc79a54f4c0381d93bb9e29cfccb2f61ec802e90e658548ed9e8f3628e5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for subscription Sales Reports version `1_4`.
  - Subscription reports now default to `1_4`, while other Sales Reports default to `1_0`.
  - Future report versions using the `major_minor` format are accepted.

- **Documentation**
  - Documented subscription report version requirements and current version behavior.
  - Updated Sales Report version guidance with type-specific defaults.

- **Bug Fixes**
  - Improved validation and handling of Sales Report version values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->