### PR TITLE
fix(xcode): bound waits for inherited output pipes

### DIFF
--- a/internal/xcode/process.go
+++ b/internal/xcode/process.go
@@ -1,0 +1,29 @@
+package xcode
+
+import (
+	"errors"
+	"os/exec"
+	"time"
+)
+
+const xcodeCommandPipeWaitDelay = 250 * time.Millisecond
+
+// runXcodeCommand bounds the time spent waiting for descendants that inherited
+// the direct command's output descriptors after that command has exited.
+func runXcodeCommand(cmd *exec.Cmd) error {
+	cmd.WaitDelay = xcodeCommandPipeWaitDelay
+	return normalizeXcodeCommandWaitError(cmd, cmd.Run())
+}
+
+func outputXcodeCommand(cmd *exec.Cmd) ([]byte, error) {
+	cmd.WaitDelay = xcodeCommandPipeWaitDelay
+	output, err := cmd.Output()
+	return output, normalizeXcodeCommandWaitError(cmd, err)
+}
+
+func normalizeXcodeCommandWaitError(cmd *exec.Cmd, err error) error {
+	if errors.Is(err, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+		return nil
+	}
+	return err
+}

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -500,7 +500,7 @@ func runAgvtool(ctx context.Context, projectDir string, args ...string) (string,
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
+	if err := runXcodeCommand(cmd); err != nil {
 		stderrText := strings.TrimSpace(stderr.String())
 		if stderrText != "" {
 			return "", fmt.Errorf("%w: %s", err, stderrText)
@@ -530,7 +530,7 @@ func readBuildSettings(ctx context.Context, projectDir, target string) (map[stri
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
+	if err := runXcodeCommand(cmd); err != nil {
 		stderrText := strings.TrimSpace(stderr.String())
 		if stderrText != "" {
 			return nil, fmt.Errorf("%w: %s", err, stderrText)

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -609,7 +609,7 @@ func activeDeveloperDir(ctx context.Context) (string, error) {
 		ctx = context.Background()
 	}
 	cmd := exec.CommandContext(ctx, "xcode-select", "-p")
-	output, err := cmd.Output()
+	output, err := outputXcodeCommand(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -775,7 +775,7 @@ func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer
 	}
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
-	if err := cmd.Run(); err != nil {
+	if err := runXcodeCommand(cmd); err != nil {
 		detail := strings.TrimSpace(outputTail.String())
 		if detail == "" {
 			detail = strings.TrimSpace(mergeCapturedCommandOutput(stdout.String(), stderr.String()))
@@ -811,7 +811,7 @@ func readAltoolHelpOutput(ctx context.Context) (string, error) {
 	var stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	if err := runXcodeCommand(cmd); err != nil {
 		return "", err
 	}
 	return mergeCapturedCommandOutput(stdout.String(), stderr.String()), nil
@@ -1073,7 +1073,7 @@ func runCommandWithTail(ctx context.Context, name string, args []string, logWrit
 	}
 	cmd.Stdout = writer
 	cmd.Stderr = writer
-	if err := cmd.Run(); err != nil {
+	if err := runXcodeCommand(cmd); err != nil {
 		detail := strings.TrimSpace(outputTail.String())
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if detail != "" {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"howett.net/plist"
 
@@ -1175,6 +1178,54 @@ func TestRunXcodebuildWithLogWriterKeepsOnlyTailInErrorMessage(t *testing.T) {
 	}
 }
 
+func TestRunXcodebuildDoesNotWaitForDescendantHoldingOutputPipes(t *testing.T) {
+	tempDir := t.TempDir()
+	pidPath := filepath.Join(tempDir, "descendant.pid")
+
+	restore := overrideTestEnvironment(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
+	t.Setenv("ASC_XCODE_HELPER_DESCENDANT_PID", pidPath)
+	t.Cleanup(restore)
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidPath)
+		if err != nil {
+			return
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return
+		}
+		if process, err := os.FindProcess(pid); err == nil {
+			_ = process.Kill()
+		}
+	})
+
+	started := time.Now()
+	err := runXcodebuild(context.Background(), []string{"retain-output-after-exit"}, io.Discard)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("runXcodebuild() error = %v", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("runXcodebuild() waited %s for a descendant after the direct process exited", elapsed)
+	}
+}
+
+func TestRunXcodebuildPreservesContextCancellation(t *testing.T) {
+	tempDir := t.TempDir()
+	restore := overrideTestEnvironment(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
+	t.Cleanup(restore)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := runXcodebuild(ctx, []string{"wait-for-context-cancel"}, io.Discard)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runXcodebuild() error = %v, want context deadline exceeded", err)
+	}
+}
+
 func overrideTestEnvironment(t *testing.T) func() {
 	t.Helper()
 
@@ -1330,6 +1381,33 @@ func TestXcodeHelperProcess(t *testing.T) {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
 		}
+		os.Exit(0)
+	}
+
+	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "retain-output-after-exit" {
+		descendantArgs := []string{"-test.run=TestXcodeHelperProcess", "--", "xcodebuild", "hold-output-descriptors"}
+		descendant := exec.Command(os.Args[0], descendantArgs...)
+		descendant.Env = os.Environ()
+		descendant.Stdout = os.Stdout
+		descendant.Stderr = os.Stderr
+		if err := descendant.Start(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		if err := os.WriteFile(os.Getenv("ASC_XCODE_HELPER_DESCENDANT_PID"), []byte(strconv.Itoa(descendant.Process.Pid)), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	}
+
+	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "hold-output-descriptors" {
+		time.Sleep(2 * time.Second)
+		os.Exit(0)
+	}
+
+	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "wait-for-context-cancel" {
+		time.Sleep(2 * time.Second)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Summary

- apply a shared 250 ms `exec.Cmd.WaitDelay` policy to `internal/xcode` subprocess runners
- treat `exec.ErrWaitDelay` as success only when the direct process exited successfully
- preserve direct exit failures, context cancellation, streamed output, and bounded error tails

## Why

When a direct Xcode command exits but a descendant retains its output descriptors, Go can continue waiting for output-copy goroutines indefinitely. A completed `xcodebuild`, `xcrun`, `agvtool`, or `xcode-select` invocation should not leave the CLI hanging on inherited pipes.

## Validation

- RED regression reproduced a successful direct process waiting on a descendant
- focused `internal/xcode` and `internal/cli/xcode` tests
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

This does not impose a runtime timeout on a direct `xcodebuild` process that never exits; caller context deadlines remain responsible for that case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788337391&installation_model_id=10418&pr_number=1844&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1844&signature=d9a8ec0d2e68f62f2bccd5e13ef1aacc0534406056c6ebf9551affc2b5765181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Xcode command handling so processes no longer hang while waiting for descendant processes that retain output pipes.
  * Preserved context cancellation errors during Xcode command execution.
  * Continued reporting command failures accurately while treating successful command completion as success despite delayed descendant cleanup.

* **Tests**
  * Added coverage for descendant-process handling and context cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->