### PR TITLE
fix(builds): validate IPA app identity before upload

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -23,7 +23,7 @@ const (
 func BuildsUploadCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("upload", flag.ExitOnError)
 
-	appID := fs.String("app", "", "App Store Connect app ID (required, or ASC_APP_ID env)")
+	appID := fs.String("app", "", "App Store Connect app ID; IPA uploads also accept an exact bundle ID or exact name (required, or ASC_APP_ID env)")
 	ipaPath := fs.String("ipa", "", "Path to .ipa file (for iOS, tvOS, visionOS apps)")
 	pkgPath := fs.String("pkg", "", "Path to .pkg file (for macOS apps)")
 	version := fs.String("version", "", "CFBundleShortVersionString (e.g., 1.0.0, auto-extracted from IPA if not provided)")
@@ -190,24 +190,32 @@ Examples:
 
 			versionValue := strings.TrimSpace(*version)
 			buildNumberValue := strings.TrimSpace(*buildNumber)
-			if versionValue == "" || buildNumberValue == "" {
-				// Auto-extraction only works for IPA files
-				if hasIPA {
-					versionValue, buildNumberValue, err = shared.ResolveBundleInfoForIPA(filePath, versionValue, buildNumberValue)
-					if err != nil {
-						return fmt.Errorf("builds upload: %w", err)
-					}
-				} else {
-					// PKG files require explicit version and build number
-					missingFlags := make([]string, 0, 2)
-					if versionValue == "" {
-						missingFlags = append(missingFlags, "--version")
-					}
-					if buildNumberValue == "" {
-						missingFlags = append(missingFlags, "--build-number")
-					}
-					return fmt.Errorf("builds upload: %s required for PKG uploads", strings.Join(missingFlags, " and "))
+			var ipaBundleID string
+			if hasIPA {
+				ipaInfo, extractErr := shared.ExtractBundleInfoFromIPA(filePath)
+				if extractErr != nil {
+					return fmt.Errorf("builds upload: inspect IPA metadata: %w", extractErr)
 				}
+				ipaBundleID = strings.TrimSpace(ipaInfo.BundleID)
+				if ipaBundleID == "" {
+					return fmt.Errorf("builds upload: IPA top-level app Info.plist is missing CFBundleIdentifier")
+				}
+				if versionValue == "" {
+					versionValue = ipaInfo.Version
+				}
+				if buildNumberValue == "" {
+					buildNumberValue = ipaInfo.BuildNumber
+				}
+			} else if versionValue == "" || buildNumberValue == "" {
+				// PKG files require explicit version and build number
+				missingFlags := make([]string, 0, 2)
+				if versionValue == "" {
+					missingFlags = append(missingFlags, "--version")
+				}
+				if buildNumberValue == "" {
+					missingFlags = append(missingFlags, "--build-number")
+				}
+				return fmt.Errorf("builds upload: %s required for PKG uploads", strings.Join(missingFlags, " and "))
 			}
 			if versionValue == "" || buildNumberValue == "" {
 				missingFields := make([]string, 0, 2)
@@ -234,6 +242,31 @@ Examples:
 			}
 			requestCtx, cancel := shared.ContextWithTimeoutDuration(ctx, timeoutValue)
 			defer cancel()
+
+			if hasIPA {
+				resolvedAppID, err = shared.ResolveAppIDWithExactLookup(requestCtx, client, resolvedAppID)
+				if err != nil {
+					return fmt.Errorf("builds upload: %w", err)
+				}
+				appResp, err := client.GetApp(requestCtx, resolvedAppID)
+				if err != nil {
+					return fmt.Errorf("builds upload: fetch selected app %q: %w", resolvedAppID, err)
+				}
+				if appResp == nil {
+					return fmt.Errorf("builds upload: fetch selected app %q: empty response", resolvedAppID)
+				}
+				appBundleID := strings.TrimSpace(appResp.Data.Attributes.BundleID)
+				if appBundleID == "" {
+					return fmt.Errorf("builds upload: selected app %q has no bundle ID", resolvedAppID)
+				}
+				if !strings.EqualFold(ipaBundleID, appBundleID) {
+					appName := strings.TrimSpace(appResp.Data.Attributes.Name)
+					if appName == "" {
+						appName = resolvedAppID
+					}
+					return fmt.Errorf("builds upload: IPA bundle ID %q does not match selected app %q bundle ID %q", ipaBundleID, appName, appBundleID)
+				}
+			}
 
 			uploadResp, fileResp, err := shared.PrepareBuildUpload(requestCtx, client, resolvedAppID, fileInfo, versionValue, buildNumberValue, platformValue, fileUTI)
 			if err != nil {

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -76,6 +76,19 @@ func TestBuildsUploadCommandHasExplicitSensitiveOutputOptIn(t *testing.T) {
 	}
 }
 
+func TestBuildsUploadCommandAppHelpDescribesExactIPAIdentityLookup(t *testing.T) {
+	cmd := BuildsUploadCommand()
+	appFlag := cmd.FlagSet.Lookup("app")
+	if appFlag == nil {
+		t.Fatal("expected --app flag to be registered")
+	}
+	for _, want := range []string{"IPA uploads", "exact bundle ID", "exact name"} {
+		if !strings.Contains(appFlag.Usage, want) {
+			t.Fatalf("expected --app usage to include %q, got %q", want, appFlag.Usage)
+		}
+	}
+}
+
 func TestBuildsListCommand_ProcessingStateFlagDescription(t *testing.T) {
 	cmd := BuildsListCommand()
 

--- a/internal/cli/cmdtest/builds_upload_concurrency_test.go
+++ b/internal/cli/cmdtest/builds_upload_concurrency_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -15,10 +14,7 @@ func TestBuildsUploadDryRunRejectsExplicitConcurrency(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -60,10 +56,7 @@ func TestBuildsUploadDryRunSucceedsWithDefaultConcurrency(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -73,6 +66,8 @@ func TestBuildsUploadDryRunSucceedsWithDefaultConcurrency(t *testing.T) {
 	var uploadRequests int32
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
@@ -127,10 +122,7 @@ func TestBuildsUploadDryRunRequiresExplicitOptInForUploadCapabilities(t *testing
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -138,6 +130,8 @@ func TestBuildsUploadDryRunRequiresExplicitOptInForUploadCapabilities(t *testing
 	})
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":

--- a/internal/cli/cmdtest/builds_upload_identity_test.go
+++ b/internal/cli/cmdtest/builds_upload_identity_test.go
@@ -1,0 +1,253 @@
+package cmdtest
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"howett.net/plist"
+)
+
+func TestBuildsUploadResolvesExactBundleIDAndChecksIPAIdentityBeforeReservation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var reservations int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps" && req.URL.Query().Get("filter[bundleId]") == "com.example.demo":
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			atomic.AddInt32(&reservations, 1)
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read reservation request: %v", err)
+			}
+			if !strings.Contains(string(body), `"id":"123456789"`) {
+				t.Fatalf("expected resolved app ID in reservation body: %s", body)
+			}
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":1,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[]}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "upload",
+		"--app", "com.example.demo",
+		"--ipa", ipaPath,
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, _ = captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if got := atomic.LoadInt32(&reservations); got != 1 {
+		t.Fatalf("expected one upload reservation, got %d", got)
+	}
+}
+
+func TestBuildsUploadRejectsMissingOrAmbiguousExactAppBeforeReservation(t *testing.T) {
+	tests := []struct {
+		name     string
+		appInput string
+		appList  string
+		wantErr  string
+	}{
+		{
+			name:     "missing",
+			appInput: "Missing App",
+			appList:  `{"data":[]}`,
+			wantErr:  `app "Missing App" not found (expected app ID, exact bundle ID, or exact app name)`,
+		},
+		{
+			name:     "ambiguous exact name",
+			appInput: "Duplicate App",
+			appList: `{"data":[
+				{"type":"apps","id":"111","attributes":{"name":"Duplicate App","bundleId":"com.example.one"}},
+				{"type":"apps","id":"222","attributes":{"name":"Duplicate App","bundleId":"com.example.two"}}
+			]}`,
+			wantErr: `multiple apps found for name "Duplicate App" (111, 222); use --app with App Store Connect app ID`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			ipaPath := writeBuildUploadIPA(t, "com.example.demo")
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+			var reservations int32
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+					if req.URL.Query().Get("filter[bundleId]") != "" {
+						return jsonResponse(http.StatusOK, `{"data":[]}`)
+					}
+					return jsonResponse(http.StatusOK, test.appList)
+				case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+					atomic.AddInt32(&reservations, 1)
+					return nil, http.ErrUseLastResponse
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			if err := root.Parse([]string{
+				"builds", "upload",
+				"--app", test.appInput,
+				"--ipa", ipaPath,
+				"--dry-run",
+			}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			err := root.Run(context.Background())
+			if err == nil {
+				t.Fatal("expected app lookup failure, got nil")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("unexpected lookup error: %v", err)
+			}
+			if got := atomic.LoadInt32(&reservations); got != 0 {
+				t.Fatalf("expected no upload reservation, got %d", got)
+			}
+		})
+	}
+}
+
+func TestBuildsUploadRejectsBundleMismatchBeforeReservation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	ipaPath := writeBuildUploadIPA(t, "com.example.ipa")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var reservations int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Selected App","bundleId":"com.example.selected"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			atomic.AddInt32(&reservations, 1)
+			return nil, http.ErrUseLastResponse
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "upload",
+		"--app", "123456789",
+		"--ipa", ipaPath,
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected bundle mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), `IPA bundle ID "com.example.ipa" does not match selected app "Selected App" bundle ID "com.example.selected"`) {
+		t.Fatalf("unexpected mismatch error: %v", err)
+	}
+	if got := atomic.LoadInt32(&reservations); got != 0 {
+		t.Fatalf("expected no upload reservation, got %d", got)
+	}
+}
+
+func TestBuildsUploadRequiresTopLevelIPABundleIDBeforeAppLookup(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	ipaPath := writeBuildUploadIPA(t, "")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "upload",
+		"--app", "123456789",
+		"--ipa", ipaPath,
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected missing CFBundleIdentifier failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "IPA top-level app Info.plist is missing CFBundleIdentifier") {
+		t.Fatalf("unexpected missing bundle ID error: %v", err)
+	}
+}
+
+func writeBuildUploadIPA(t *testing.T, bundleID string) string {
+	t.Helper()
+
+	plistData, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier":         bundleID,
+		"CFBundleShortVersionString": "1.0.0",
+		"CFBundleVersion":            "42",
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("marshal Info.plist: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "app.ipa")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create IPA: %v", err)
+	}
+	zipWriter := zip.NewWriter(file)
+	entry, err := zipWriter.Create("Payload/Demo.app/Info.plist")
+	if err != nil {
+		t.Fatalf("create Info.plist entry: %v", err)
+	}
+	if _, err := entry.Write(plistData); err != nil {
+		t.Fatalf("write Info.plist entry: %v", err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("close IPA: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close IPA file: %v", err)
+	}
+	return path
+}

--- a/internal/cli/cmdtest/builds_upload_wait_test.go
+++ b/internal/cli/cmdtest/builds_upload_wait_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,10 +21,7 @@ func TestBuildsUploadWaitFailsFastWhenBuildUploadFails(t *testing.T) {
 	})
 	t.Cleanup(restoreDiagnostics)
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -35,6 +31,8 @@ func TestBuildsUploadWaitFailsFastWhenBuildUploadFails(t *testing.T) {
 	buildUploadChecks := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
@@ -115,10 +113,7 @@ func TestBuildsUploadFailsFastWhenPostCommitVerificationSeesFailure(t *testing.T
 	})
 	t.Cleanup(restoreDiagnostics)
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -128,6 +123,8 @@ func TestBuildsUploadFailsFastWhenPostCommitVerificationSeesFailure(t *testing.T
 	buildUploadChecks := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
@@ -195,10 +192,7 @@ func TestBuildsUploadWithoutWaitSkipsPostCommitVerificationByDefault(t *testing.
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -207,6 +201,8 @@ func TestBuildsUploadWithoutWaitSkipsPostCommitVerificationByDefault(t *testing.
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
@@ -258,10 +254,7 @@ func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) 
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	t.Setenv("ASC_TIMEOUT", "1ms")
 
-	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
-	if err := os.WriteFile(ipaPath, []byte("test"), 0o600); err != nil {
-		t.Fatalf("write ipa fixture: %v", err)
-	}
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
@@ -271,6 +264,8 @@ func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) 
 	buildUploadChecks := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":

--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -14,6 +14,7 @@ import (
 )
 
 type IPABundleInfo struct {
+	BundleID    string
 	Version     string
 	BuildNumber string
 }
@@ -34,7 +35,8 @@ func ValidateIPAPath(ipaPath string) (os.FileInfo, error) {
 	return fileInfo, nil
 }
 
-// ExtractBundleInfoFromIPA reads CFBundleVersion info from an IPA.
+// ExtractBundleInfoFromIPA reads the top-level app's bundle identifier and
+// version metadata from an IPA.
 func ExtractBundleInfoFromIPA(ipaPath string) (IPABundleInfo, error) {
 	reader, err := zip.OpenReader(ipaPath)
 	if err != nil {
@@ -94,6 +96,7 @@ func readBundleInfoFromInfoPlist(file *zip.File) (IPABundleInfo, error) {
 	}
 
 	return IPABundleInfo{
+		BundleID:    coercePlistValueToString(info["CFBundleIdentifier"]),
 		Version:     coercePlistValueToString(info["CFBundleShortVersionString"]),
 		BuildNumber: coercePlistValueToString(info["CFBundleVersion"]),
 	}, nil

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -30,11 +30,21 @@ func TestExtractBundleInfoFromIPA(t *testing.T) {
 	if info.BuildNumber != "45" {
 		t.Fatalf("expected build number 45, got %q", info.BuildNumber)
 	}
+	if info.BundleID != "com.example.demo" {
+		t.Fatalf("expected bundle ID com.example.demo, got %q", info.BundleID)
+	}
 }
 
 func TestExtractBundleInfoFromIPA_PrefersTopLevelApp(t *testing.T) {
 	plistData := buildInfoPlist(t, "2.0.0", "200")
-	extensionPlist := buildInfoPlist(t, "9.9.9", "999")
+	extensionPlist, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier":         "com.example.demo.widget",
+		"CFBundleShortVersionString": "9.9.9",
+		"CFBundleVersion":            "999",
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("marshal extension plist: %v", err)
+	}
 	ipaPath := writeTestIPA(t, map[string][]byte{
 		"Payload/Demo.app/Info.plist":                              plistData,
 		"Payload/Demo.app/PlugIns/Widget.appex/Info.plist":         extensionPlist,
@@ -53,6 +63,9 @@ func TestExtractBundleInfoFromIPA_PrefersTopLevelApp(t *testing.T) {
 	}
 	if info.BuildNumber != "200" {
 		t.Fatalf("expected build number 200, got %q", info.BuildNumber)
+	}
+	if info.BundleID != "com.example.demo" {
+		t.Fatalf("expected top-level bundle ID com.example.demo, got %q", info.BundleID)
 	}
 }
 
@@ -306,6 +319,7 @@ func buildInfoPlistWithValues(t *testing.T, versionValue any, buildValue any, fo
 	t.Helper()
 
 	payload := map[string]any{
+		"CFBundleIdentifier":         "com.example.demo",
 		"CFBundleShortVersionString": versionValue,
 		"CFBundleVersion":            buildValue,
 	}


### PR DESCRIPTION
## Summary

- extract the top-level app bundle identifier from IPA metadata
- allow IPA uploads to resolve `--app` by numeric ID, exact bundle ID, or exact app name
- compare the IPA bundle identifier with the selected App Store Connect app before reserving an upload
- keep PKG behavior and existing flag, environment, and config precedence unchanged

## Why

The upload command previously passed the selected app value directly into the upload reservation without proving that it identified the app contained in the IPA. A typo or mismatched app could reach a mutating endpoint before the discrepancy was detected.

## Validation

- exact, missing, and ambiguous app lookup coverage
- top-level IPA selection and bundle-mismatch tests
- tests proving every preflight failure occurs before `POST /v1/buildUploads`
- built-binary upload help check
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

The command does not infer a missing `--app` from the IPA, and no live upload was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788337396&installation_model_id=10418&pr_number=1846&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1846&signature=7a54f166a937806a1b186b6e8e92770b99973ea992c4f38475d6f63c171f4687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build uploads can now identify apps by exact bundle ID or exact app name.
  * IPA uploads automatically read the bundle ID, version, and build number from the package.
  * IPA uploads validate that the package’s bundle ID matches the selected app before uploading.

* **Bug Fixes**
  * Invalid, missing, or ambiguous app matches are rejected before an upload is reserved.
  * PKG uploads continue to require an explicitly provided version and build number.

* **Documentation**
  * Updated command help to describe IPA app identification options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->