### PR TITLE
fix(builds): reconcile ambiguous upload commits

### DIFF
--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -847,7 +847,7 @@ func (c *Client) UpdateBuildUploadFile(ctx context.Context, id string, req Build
 
 	var response BuildUploadFileResponse
 	if err := json.Unmarshal(data, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
+		return nil, newBuildUploadFileCommitResponseDecodingError(err)
 	}
 
 	return &response, nil

--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -842,12 +842,15 @@ func (c *Client) UpdateBuildUploadFile(ctx context.Context, id string, req Build
 
 	data, err := c.do(ctx, "PATCH", fmt.Sprintf("/v1/buildUploadFiles/%s", id), body)
 	if err != nil {
+		if isResponseBodyReadError(err) {
+			return nil, newBuildUploadFileCommitResponseError(err)
+		}
 		return nil, err
 	}
 
 	var response BuildUploadFileResponse
 	if err := json.Unmarshal(data, &response); err != nil {
-		return nil, newBuildUploadFileCommitResponseDecodingError(err)
+		return nil, newBuildUploadFileCommitResponseError(fmt.Errorf("failed to parse response: %w", err))
 	}
 
 	return &response, nil

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -256,7 +256,7 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		readErr := fmt.Errorf("failed to read response body: %w", err)
+		readErr := &responseBodyReadError{err: err}
 		if isTransientTransportError(err) {
 			return nil, &RetryableError{Err: readErr}
 		}

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -16,6 +16,29 @@ var (
 	ErrRepeatedPaginationURL = errors.New("detected repeated pagination URL")
 )
 
+type buildUploadFileCommitResponseDecodingError struct {
+	err error
+}
+
+func (e *buildUploadFileCommitResponseDecodingError) Error() string {
+	return fmt.Sprintf("failed to parse response: %v", e.err)
+}
+
+func (e *buildUploadFileCommitResponseDecodingError) Unwrap() error {
+	return e.err
+}
+
+func newBuildUploadFileCommitResponseDecodingError(err error) error {
+	return &buildUploadFileCommitResponseDecodingError{err: err}
+}
+
+// IsBuildUploadFileCommitResponseDecodingError reports whether a successful
+// build-upload-file commit response could not be decoded.
+func IsBuildUploadFileCommitResponseDecodingError(err error) bool {
+	var decodeErr *buildUploadFileCommitResponseDecodingError
+	return errors.As(err, &decodeErr)
+}
+
 // APIError represents a parsed App Store Connect error response.
 type APIError struct {
 	Code             string

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -16,27 +16,44 @@ var (
 	ErrRepeatedPaginationURL = errors.New("detected repeated pagination URL")
 )
 
-type buildUploadFileCommitResponseDecodingError struct {
+type responseBodyReadError struct {
 	err error
 }
 
-func (e *buildUploadFileCommitResponseDecodingError) Error() string {
-	return fmt.Sprintf("failed to parse response: %v", e.err)
+func (e *responseBodyReadError) Error() string {
+	return fmt.Sprintf("failed to read response body: %v", e.err)
 }
 
-func (e *buildUploadFileCommitResponseDecodingError) Unwrap() error {
+func (e *responseBodyReadError) Unwrap() error {
 	return e.err
 }
 
-func newBuildUploadFileCommitResponseDecodingError(err error) error {
-	return &buildUploadFileCommitResponseDecodingError{err: err}
+func isResponseBodyReadError(err error) bool {
+	var readErr *responseBodyReadError
+	return errors.As(err, &readErr)
 }
 
-// IsBuildUploadFileCommitResponseDecodingError reports whether a successful
-// build-upload-file commit response could not be decoded.
-func IsBuildUploadFileCommitResponseDecodingError(err error) bool {
-	var decodeErr *buildUploadFileCommitResponseDecodingError
-	return errors.As(err, &decodeErr)
+type buildUploadFileCommitResponseError struct {
+	err error
+}
+
+func (e *buildUploadFileCommitResponseError) Error() string {
+	return e.err.Error()
+}
+
+func (e *buildUploadFileCommitResponseError) Unwrap() error {
+	return e.err
+}
+
+func newBuildUploadFileCommitResponseError(err error) error {
+	return &buildUploadFileCommitResponseError{err: err}
+}
+
+// IsBuildUploadFileCommitResponseError reports whether a successful
+// build-upload-file commit response could not be read or decoded.
+func IsBuildUploadFileCommitResponseError(err error) bool {
+	var responseErr *buildUploadFileCommitResponseError
+	return errors.As(err, &responseErr)
 }
 
 // APIError represents a parsed App Store Connect error response.

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -291,7 +291,7 @@ Examples:
 				}
 
 				commitCtx, commitCancel := shared.ContextWithUploadTimeout(ctx)
-				commitResp, err := shared.CommitBuildUploadFile(commitCtx, client, fileResp.Data.ID, verifiedChecksums)
+				commitResp, err := shared.CommitBuildUploadFile(commitCtx, client, uploadResp.Data.ID, fileResp.Data.ID, verifiedChecksums)
 				commitCancel()
 				if err != nil {
 					return fmt.Errorf("builds upload: %w", err)

--- a/internal/cli/cmdtest/builds_upload_reconciliation_test.go
+++ b/internal/cli/cmdtest/builds_upload_reconciliation_test.go
@@ -1,0 +1,138 @@
+package cmdtest
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func writeBuildUploadReconciliationIPA(t *testing.T, path string) int64 {
+	t.Helper()
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create IPA fixture: %v", err)
+	}
+	archive := zip.NewWriter(file)
+	plist, err := archive.Create("Payload/Demo.app/Info.plist")
+	if err != nil {
+		_ = file.Close()
+		t.Fatalf("create Info.plist entry: %v", err)
+	}
+	const infoPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.demo</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>42</string>
+</dict>
+</plist>`
+	if _, err := io.WriteString(plist, infoPlist); err != nil {
+		_ = archive.Close()
+		_ = file.Close()
+		t.Fatalf("write Info.plist entry: %v", err)
+	}
+	if err := archive.Close(); err != nil {
+		_ = file.Close()
+		t.Fatalf("close IPA archive: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close IPA fixture: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat IPA fixture: %v", err)
+	}
+	return info.Size()
+}
+
+func TestBuildsUploadRecoversAmbiguousCommitFromBuildUploadState(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	ipaPath := filepath.Join(t.TempDir(), "app.ipa")
+	ipaSize := writeBuildUploadReconciliationIPA(t, ipaPath)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	reconciliationChecks := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			body := fmt.Sprintf(`{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":%d,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":%d,"offset":0,"requestHeaders":[{"name":"Content-Type","value":"application/octet-stream"}]}]}}}`, ipaSize, ipaSize)
+			return jsonResponse(http.StatusOK, body)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read uploaded IPA: %v", err)
+			}
+			if int64(len(body)) != ipaSize {
+				t.Fatalf("expected %d uploaded bytes, got %d", ipaSize, len(body))
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
+			return jsonResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable"}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-1":
+			reconciliationChecks++
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"state":{"state":"PROCESSING"}}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "upload",
+			"--app", "123456789",
+			"--ipa", ipaPath,
+			"--version", "1.0.0",
+			"--build-number", "42",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("builds upload error: %v", runErr)
+	}
+	if reconciliationChecks != 1 {
+		t.Fatalf("expected one reconciliation lookup, got %d", reconciliationChecks)
+	}
+	if !strings.Contains(stderr, "Upload committed in App Store Connect.") {
+		t.Fatalf("expected commit progress on stderr, got %q", stderr)
+	}
+	var output asc.BuildUploadResult
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\nstdout=%s", err, stdout)
+	}
+	if output.UploadID != "upload-1" || output.Uploaded == nil || !*output.Uploaded {
+		t.Fatalf("expected reconciled upload output, got %#v", output)
+	}
+}

--- a/internal/cli/cmdtest/builds_upload_reconciliation_test.go
+++ b/internal/cli/cmdtest/builds_upload_reconciliation_test.go
@@ -84,10 +84,13 @@ func TestBuildsUploadRecoversAmbiguousCommitFromBuildUploadState(t *testing.T) {
 		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
-				t.Fatalf("read uploaded IPA: %v", err)
+				t.Errorf("read uploaded IPA: %v", err)
+				return nil, fmt.Errorf("read uploaded IPA: %w", err)
 			}
 			if int64(len(body)) != ipaSize {
-				t.Fatalf("expected %d uploaded bytes, got %d", ipaSize, len(body))
+				err := fmt.Errorf("expected %d uploaded bytes, got %d", ipaSize, len(body))
+				t.Error(err)
+				return nil, err
 			}
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
@@ -96,8 +99,9 @@ func TestBuildsUploadRecoversAmbiguousCommitFromBuildUploadState(t *testing.T) {
 			reconciliationChecks++
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"state":{"state":"PROCESSING"}}}}`)
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Error(err)
+			return nil, err
 		}
 	})
 

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -876,7 +876,7 @@ func uploadBuildAndWaitForID(ctx context.Context, client *asc.Client, appID, ipa
 	}
 
 	commitCtx, commitCancel := contextWithPublishUploadTimeout(ctx, uploadTimeout, overrideUploadTimeout)
-	_, err = shared.CommitBuildUploadFile(commitCtx, client, fileResp.Data.ID, nil)
+	_, err = shared.CommitBuildUploadFile(commitCtx, client, uploadResp.Data.ID, fileResp.Data.ID, nil)
 	commitCancel()
 	if err != nil {
 		return nil, err
@@ -937,10 +937,7 @@ func resolvePublishTimeout(timeout time.Duration) time.Duration {
 
 func contextWithPublishUploadTimeout(ctx context.Context, timeout time.Duration, override bool) (context.Context, context.CancelFunc) {
 	if override {
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		return context.WithTimeout(ctx, timeout)
+		return shared.ContextWithTimeoutDuration(ctx, timeout)
 	}
 	return shared.ContextWithUploadTimeout(ctx)
 }

--- a/internal/cli/publish/upload_reconciliation_test.go
+++ b/internal/cli/publish/upload_reconciliation_test.go
@@ -1,0 +1,78 @@
+package publish
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestUploadBuildAndWaitForIDRecoversAmbiguousCommit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Demo.ipa")
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write IPA: %v", err)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat IPA: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	reconciliationChecks := 0
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.2.3","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"Demo.ipa","fileSize":4,"uti":"com.apple.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":4,"offset":0}]}}}`)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(""))}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
+			return publishCommandJSONResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable"}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-1":
+			reconciliationChecks++
+			if reconciliationChecks == 1 {
+				return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"state":{"state":"PROCESSING"}}}}`)
+			}
+			return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"state":{"state":"COMPLETE"}},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1":
+			return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"PROCESSING"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	client := newPublishCommandTestClient(t)
+
+	var result *publishUploadResult
+	var uploadErr error
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		result, uploadErr = uploadBuildAndWaitForID(ctx, client, "app-1", path, fileInfo, "1.2.3", "42", asc.PlatformIOS, time.Millisecond, time.Second, true)
+		return uploadErr
+	})
+
+	if uploadErr != nil {
+		t.Fatalf("uploadBuildAndWaitForID() error: %v", uploadErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout from upload helper, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Upload committed in App Store Connect.") {
+		t.Fatalf("expected commit progress on stderr, got %q", stderr)
+	}
+	if reconciliationChecks != 2 {
+		t.Fatalf("expected reconciliation and build-wait lookups, got %d", reconciliationChecks)
+	}
+	if result == nil || result.Build == nil || result.Build.Data.ID != "build-1" {
+		t.Fatalf("expected recovered build result, got %#v", result)
+	}
+}

--- a/internal/cli/publish/upload_reconciliation_test.go
+++ b/internal/cli/publish/upload_reconciliation_test.go
@@ -2,6 +2,7 @@ package publish
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -25,7 +26,7 @@ func TestUploadBuildAndWaitForIDRecoversAmbiguousCommit(t *testing.T) {
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	reconciliationChecks := 0
+	buildUploadLookups := 0
 	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
@@ -37,16 +38,17 @@ func TestUploadBuildAndWaitForIDRecoversAmbiguousCommit(t *testing.T) {
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
 			return publishCommandJSONResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable"}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-1":
-			reconciliationChecks++
-			if reconciliationChecks == 1 {
+			buildUploadLookups++
+			if buildUploadLookups == 1 {
 				return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"state":{"state":"PROCESSING"}}}}`)
 			}
 			return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"state":{"state":"COMPLETE"}},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}}}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1":
 			return publishCommandJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"PROCESSING"}}}`)
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Error(err)
+			return nil, err
 		}
 	})
 	client := newPublishCommandTestClient(t)
@@ -69,8 +71,8 @@ func TestUploadBuildAndWaitForIDRecoversAmbiguousCommit(t *testing.T) {
 	if !strings.Contains(stderr, "Upload committed in App Store Connect.") {
 		t.Fatalf("expected commit progress on stderr, got %q", stderr)
 	}
-	if reconciliationChecks != 2 {
-		t.Fatalf("expected reconciliation and build-wait lookups, got %d", reconciliationChecks)
+	if buildUploadLookups != 2 {
+		t.Fatalf("expected reconciliation and build-wait lookups, got %d", buildUploadLookups)
 	}
 	if result == nil || result.Build == nil || result.Build.Data.ID != "build-1" {
 		t.Fatalf("expected recovered build result, got %#v", result)

--- a/internal/cli/shared/build_uploads.go
+++ b/internal/cli/shared/build_uploads.go
@@ -121,6 +121,9 @@ func isAmbiguousBuildUploadCommitError(err error) bool {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return false
 	}
+	if asc.IsBuildUploadFileCommitResponseDecodingError(err) {
+		return true
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}

--- a/internal/cli/shared/build_uploads.go
+++ b/internal/cli/shared/build_uploads.go
@@ -121,7 +121,7 @@ func isAmbiguousBuildUploadCommitError(err error) bool {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return false
 	}
-	if asc.IsBuildUploadFileCommitResponseDecodingError(err) {
+	if asc.IsBuildUploadFileCommitResponseError(err) {
 		return true
 	}
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/cli/shared/build_uploads.go
+++ b/internal/cli/shared/build_uploads.go
@@ -62,7 +62,8 @@ func PrepareBuildUpload(ctx context.Context, client *asc.Client, appID string, f
 // CommitBuildUploadFile marks a reserved upload file as uploaded and optionally
 // persists source-file checksums. When the mutation result is ambiguous, it
 // reads the parent build upload once and accepts success only when App Store
-// Connect reports that processing has started or completed.
+// Connect reports that processing has started or completed. A reconciled
+// success returns a nil response because no authoritative file payload exists.
 func CommitBuildUploadFile(ctx context.Context, client *asc.Client, uploadID, fileID string, checksums *asc.Checksums) (*asc.BuildUploadFileResponse, error) {
 	uploaded := true
 	req := asc.BuildUploadFileUpdateRequest{
@@ -90,9 +91,10 @@ func CommitBuildUploadFile(ctx context.Context, client *asc.Client, uploadID, fi
 		return nil, buildUploadCommitError(uploadID, err, "build upload ID is unavailable for reconciliation")
 	}
 
-	// The mutation context may already have reached its deadline. Return to its
-	// parent operation before creating a fresh, bounded readback context.
-	reconcileBase := ContextWithoutTimeout(ctx)
+	// The mutation context may already have reached its deadline. Remove only
+	// that request deadline so an outer operation deadline still bounds the
+	// reconciliation readback.
+	reconcileBase := contextWithoutCurrentTimeout(ctx)
 	if parentErr := reconcileBase.Err(); parentErr != nil {
 		return nil, buildUploadCommitError(uploadID, err, fmt.Sprintf("reconciliation skipped because the parent operation ended: %v", parentErr))
 	}

--- a/internal/cli/shared/build_uploads.go
+++ b/internal/cli/shared/build_uploads.go
@@ -2,8 +2,10 @@ package shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
@@ -58,8 +60,10 @@ func PrepareBuildUpload(ctx context.Context, client *asc.Client, appID string, f
 }
 
 // CommitBuildUploadFile marks a reserved upload file as uploaded and optionally
-// persists source-file checksums.
-func CommitBuildUploadFile(ctx context.Context, client *asc.Client, fileID string, checksums *asc.Checksums) (*asc.BuildUploadFileResponse, error) {
+// persists source-file checksums. When the mutation result is ambiguous, it
+// reads the parent build upload once and accepts success only when App Store
+// Connect reports that processing has started or completed.
+func CommitBuildUploadFile(ctx context.Context, client *asc.Client, uploadID, fileID string, checksums *asc.Checksums) (*asc.BuildUploadFileResponse, error) {
 	uploaded := true
 	req := asc.BuildUploadFileUpdateRequest{
 		Data: asc.BuildUploadFileUpdateData{
@@ -73,8 +77,82 @@ func CommitBuildUploadFile(ctx context.Context, client *asc.Client, fileID strin
 	}
 
 	resp, err := client.UpdateBuildUploadFile(ctx, fileID, req)
-	if err != nil {
-		return nil, fmt.Errorf("commit upload file: %w", err)
+	if err == nil {
+		return resp, nil
 	}
-	return resp, nil
+
+	if !isAmbiguousBuildUploadCommitError(err) {
+		return nil, buildUploadCommitError(uploadID, err, "")
+	}
+
+	uploadID = strings.TrimSpace(uploadID)
+	if uploadID == "" {
+		return nil, buildUploadCommitError(uploadID, err, "build upload ID is unavailable for reconciliation")
+	}
+
+	// The mutation context may already have reached its deadline. Return to its
+	// parent operation before creating a fresh, bounded readback context.
+	reconcileBase := ContextWithoutTimeout(ctx)
+	if parentErr := reconcileBase.Err(); parentErr != nil {
+		return nil, buildUploadCommitError(uploadID, err, fmt.Sprintf("reconciliation skipped because the parent operation ended: %v", parentErr))
+	}
+	reconcileCtx, cancel := ContextWithTimeout(reconcileBase)
+	defer cancel()
+
+	uploadResp, lookupErr := client.GetBuildUpload(reconcileCtx, uploadID)
+	if lookupErr != nil {
+		return nil, buildUploadCommitError(uploadID, err, fmt.Sprintf("reconciliation lookup failed: %v", lookupErr))
+	}
+
+	state := buildUploadState(uploadResp)
+	switch state {
+	case "PROCESSING", "COMPLETE":
+		return nil, nil
+	case "":
+		return nil, buildUploadCommitError(uploadID, err, "reconciliation returned no authoritative upload state")
+	default:
+		return nil, buildUploadCommitError(uploadID, err, fmt.Sprintf("reconciliation returned upload state %q", state))
+	}
+}
+
+func isAmbiguousBuildUploadCommitError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if !asc.IsRetryable(err) {
+		return false
+	}
+
+	var statusErr interface{ HTTPStatusCode() int }
+	if !errors.As(err, &statusErr) {
+		return true
+	}
+	status := statusErr.HTTPStatusCode()
+	return status == 0 || status == 408 || status >= 500
+}
+
+func buildUploadState(resp *asc.BuildUploadResponse) string {
+	if resp == nil || resp.Data.Attributes.State == nil || resp.Data.Attributes.State.State == nil {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(asc.SanitizeTerminalText(*resp.Data.Attributes.State.State)))
+}
+
+func buildUploadCommitError(uploadID string, mutationErr error, reconciliation string) error {
+	uploadID = strings.TrimSpace(uploadID)
+	if uploadID == "" {
+		if reconciliation == "" {
+			return fmt.Errorf("commit upload file: %w", mutationErr)
+		}
+		return fmt.Errorf("commit upload file: %w; %s", mutationErr, reconciliation)
+	}
+
+	message := fmt.Sprintf("commit upload file for build upload %q", uploadID)
+	if reconciliation != "" {
+		message += "; " + reconciliation
+	}
+	return fmt.Errorf("%s; inspect with asc builds uploads view --id %q: %w", message, uploadID, mutationErr)
 }

--- a/internal/cli/shared/build_uploads_test.go
+++ b/internal/cli/shared/build_uploads_test.go
@@ -173,20 +173,16 @@ func TestCommitBuildUploadFileReconcilesAmbiguousServerFailure(t *testing.T) {
 }
 
 func TestCommitBuildUploadFileReconcilesAfterMutationDeadline(t *testing.T) {
-	requestCount := 0
+	patchCount := 0
+	getCount := 0
 	client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
-		requestCount++
-		switch requestCount {
-		case 1:
-			if req.Method != http.MethodPatch {
-				t.Fatalf("expected PATCH, got %s", req.Method)
-			}
+		switch {
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-456":
+			patchCount++
 			<-req.Context().Done()
 			return nil, req.Context().Err()
-		case 2:
-			if req.Method != http.MethodGet || req.URL.Path != "/v1/buildUploads/upload-123" {
-				t.Fatalf("unexpected reconciliation request: %s %s", req.Method, req.URL.String())
-			}
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-123":
+			getCount++
 			if err := req.Context().Err(); err != nil {
 				t.Fatalf("expected fresh reconciliation context, got %v", err)
 			}
@@ -195,8 +191,9 @@ func TestCommitBuildUploadFileReconcilesAfterMutationDeadline(t *testing.T) {
 			}
 			return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`)
 		default:
-			t.Fatalf("unexpected request count %d", requestCount)
-			return nil, nil
+			err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Error(err)
+			return nil, err
 		}
 	})
 
@@ -208,6 +205,51 @@ func TestCommitBuildUploadFileReconcilesAfterMutationDeadline(t *testing.T) {
 	}
 	if resp != nil {
 		t.Fatalf("expected no synthetic file response after reconciliation, got %#v", resp)
+	}
+	if patchCount > 1 {
+		t.Fatalf("expected at most one commit request, got %d", patchCount)
+	}
+	if getCount != 1 {
+		t.Fatalf("expected one reconciliation lookup, got %d", getCount)
+	}
+}
+
+func TestCommitBuildUploadFileDoesNotReconcilePastParentDeadline(t *testing.T) {
+	patchCount := 0
+	getCount := 0
+	var parentCtx context.Context
+	client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-456":
+			patchCount++
+			<-req.Context().Done()
+			<-parentCtx.Done()
+			return nil, req.Context().Err()
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-123":
+			getCount++
+			return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`)
+		default:
+			err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Error(err)
+			return nil, err
+		}
+	})
+
+	var parentCancel context.CancelFunc
+	parentCtx, parentCancel = ContextWithTimeoutDuration(context.Background(), 5*time.Millisecond)
+	defer parentCancel()
+	commitCtx, commitCancel := ContextWithTimeoutDuration(parentCtx, time.Second)
+	defer commitCancel()
+
+	_, err := CommitBuildUploadFile(commitCtx, client, "upload-123", "file-456", nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected parent deadline error, got %v", err)
+	}
+	if patchCount != 1 {
+		t.Fatalf("expected one commit request, got %d", patchCount)
+	}
+	if getCount != 0 {
+		t.Fatalf("expected no reconciliation after parent deadline, got %d lookups", getCount)
 	}
 }
 

--- a/internal/cli/shared/build_uploads_test.go
+++ b/internal/cli/shared/build_uploads_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
@@ -123,7 +125,7 @@ func TestCommitBuildUploadFileMarksUploadComplete(t *testing.T) {
 		return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-456","attributes":{"uploaded":true}}}`)
 	})
 
-	resp, err := CommitBuildUploadFile(context.Background(), client, "file-456", &asc.Checksums{
+	resp, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", &asc.Checksums{
 		File: &asc.Checksum{
 			Hash:      "abc123",
 			Algorithm: asc.ChecksumAlgorithmSHA256,
@@ -134,5 +136,179 @@ func TestCommitBuildUploadFileMarksUploadComplete(t *testing.T) {
 	}
 	if resp == nil || resp.Data.Attributes.Uploaded == nil || !*resp.Data.Attributes.Uploaded {
 		t.Fatalf("expected uploaded response, got %#v", resp)
+	}
+}
+
+func TestCommitBuildUploadFileReconcilesAmbiguousServerFailure(t *testing.T) {
+	requestCount := 0
+	client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/buildUploadFiles/file-456" {
+				t.Fatalf("unexpected commit request: %s %s", req.Method, req.URL.String())
+			}
+			return buildUploadsJSONStatusResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable"}]}`)
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/buildUploads/upload-123" {
+				t.Fatalf("unexpected reconciliation request: %s %s", req.Method, req.URL.String())
+			}
+			return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"PROCESSING"}}}}`)
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	resp, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
+	if err != nil {
+		t.Fatalf("CommitBuildUploadFile() error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected no synthetic file response after reconciliation, got %#v", resp)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected commit and reconciliation requests, got %d", requestCount)
+	}
+}
+
+func TestCommitBuildUploadFileReconcilesAfterMutationDeadline(t *testing.T) {
+	requestCount := 0
+	client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", req.Method)
+			}
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/buildUploads/upload-123" {
+				t.Fatalf("unexpected reconciliation request: %s %s", req.Method, req.URL.String())
+			}
+			if err := req.Context().Err(); err != nil {
+				t.Fatalf("expected fresh reconciliation context, got %v", err)
+			}
+			if _, ok := req.Context().Deadline(); !ok {
+				t.Fatal("expected reconciliation lookup to have a bounded deadline")
+			}
+			return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`)
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	commitCtx, cancel := ContextWithTimeoutDuration(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	resp, err := CommitBuildUploadFile(commitCtx, client, "upload-123", "file-456", nil)
+	if err != nil {
+		t.Fatalf("CommitBuildUploadFile() error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected no synthetic file response after reconciliation, got %#v", resp)
+	}
+}
+
+func TestCommitBuildUploadFileDoesNotReconcileDefinitiveClientErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnprocessableEntity, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			requestCount := 0
+			client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+				requestCount++
+				if req.Method != http.MethodPatch {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+				return buildUploadsJSONStatusResponse(status, fmt.Sprintf(`{"errors":[{"status":"%d","code":"CLIENT_ERROR","title":"Client error"}]}`, status))
+			})
+
+			_, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
+			if err == nil {
+				t.Fatal("expected commit error, got nil")
+			}
+			if requestCount != 1 {
+				t.Fatalf("expected no reconciliation lookup, got %d requests", requestCount)
+			}
+			if !strings.Contains(err.Error(), `build upload "upload-123"`) || !strings.Contains(err.Error(), `asc builds uploads view --id "upload-123"`) {
+				t.Fatalf("expected upload ID and remediation, got %v", err)
+			}
+			var apiErr *asc.APIError
+			if !errors.As(err, &apiErr) || apiErr.StatusCode != status {
+				t.Fatalf("expected original status %d to remain inspectable, got %v", status, err)
+			}
+		})
+	}
+}
+
+func TestCommitBuildUploadFileRejectsUnprovenReconciliationStates(t *testing.T) {
+	tests := []struct {
+		name      string
+		stateJSON string
+		want      string
+	}{
+		{name: "awaiting upload", stateJSON: `"AWAITING_UPLOAD"`, want: "AWAITING_UPLOAD"},
+		{name: "failed", stateJSON: `"FAILED"`, want: "FAILED"},
+		{name: "unknown", stateJSON: `"FUTURE_STATE"`, want: "FUTURE_STATE"},
+		{name: "missing", stateJSON: `null`, want: "no authoritative upload state"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+				requestCount++
+				switch requestCount {
+				case 1:
+					return buildUploadsJSONStatusResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable"}]}`)
+				case 2:
+					body := fmt.Sprintf(`{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":%s}}}}`, tt.stateJSON)
+					return buildUploadsJSONStatusResponse(http.StatusOK, body)
+				default:
+					t.Fatalf("unexpected request count %d", requestCount)
+					return nil, nil
+				}
+			})
+
+			_, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
+			if err == nil {
+				t.Fatal("expected original commit error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q in error, got %v", tt.want, err)
+			}
+			var retryableErr *asc.RetryableError
+			if !errors.As(err, &retryableErr) {
+				t.Fatalf("expected original retryable commit error to remain inspectable, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCommitBuildUploadFilePreservesMutationErrorWhenReadbackFails(t *testing.T) {
+	requestCount := 0
+	client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return buildUploadsJSONStatusResponse(http.StatusServiceUnavailable, `{"errors":[{"status":"503","code":"SERVICE_UNAVAILABLE","title":"Service unavailable"}]}`)
+		case 2:
+			return buildUploadsJSONStatusResponse(http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden"}]}`)
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	_, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
+	if err == nil {
+		t.Fatal("expected commit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "reconciliation lookup failed") || !strings.Contains(err.Error(), "Forbidden") {
+		t.Fatalf("expected reconciliation diagnostics, got %v", err)
+	}
+	var retryableErr *asc.RetryableError
+	if !errors.As(err, &retryableErr) {
+		t.Fatalf("expected original mutation error to remain inspectable, got %v", err)
 	}
 }

--- a/internal/cli/shared/build_uploads_test.go
+++ b/internal/cli/shared/build_uploads_test.go
@@ -172,6 +172,48 @@ func TestCommitBuildUploadFileReconcilesAmbiguousServerFailure(t *testing.T) {
 	}
 }
 
+func TestCommitBuildUploadFileReconcilesSuccessfulResponseDecodeFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: ""},
+		{name: "malformed", body: "{"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchCount := 0
+			getCount := 0
+			client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-456":
+					patchCount++
+					return buildUploadsJSONStatusResponse(http.StatusOK, tt.body)
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-123":
+					getCount++
+					return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`)
+				default:
+					err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+					t.Error(err)
+					return nil, err
+				}
+			})
+
+			resp, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
+			if err != nil {
+				t.Fatalf("CommitBuildUploadFile() error: %v", err)
+			}
+			if resp != nil {
+				t.Fatalf("expected no synthetic file response after reconciliation, got %#v", resp)
+			}
+			if patchCount != 1 || getCount != 1 {
+				t.Fatalf("expected one commit and one reconciliation request, got patch=%d get=%d", patchCount, getCount)
+			}
+		})
+	}
+}
+
 func TestCommitBuildUploadFileReconcilesAfterMutationDeadline(t *testing.T) {
 	patchCount := 0
 	getCount := 0
@@ -245,8 +287,8 @@ func TestCommitBuildUploadFileDoesNotReconcilePastParentDeadline(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected parent deadline error, got %v", err)
 	}
-	if patchCount != 1 {
-		t.Fatalf("expected one commit request, got %d", patchCount)
+	if patchCount > 1 {
+		t.Fatalf("expected at most one commit request, got %d", patchCount)
 	}
 	if getCount != 0 {
 		t.Fatalf("expected no reconciliation after parent deadline, got %d lookups", getCount)

--- a/internal/cli/shared/build_uploads_test.go
+++ b/internal/cli/shared/build_uploads_test.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -28,6 +32,36 @@ func newBuildUploadsTestClient(t *testing.T, transport buildUploadsRoundTripFunc
 	writeECDSAPEM(t, keyPath)
 
 	httpClient := &http.Client{Transport: transport}
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, httpClient)
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
+	}
+	return client
+}
+
+func newBuildUploadsServerTestClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse() error: %v", err)
+	}
+
+	httpClient := server.Client()
+	serverTransport := httpClient.Transport
+	httpClient.Transport = buildUploadsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		routedReq := req.Clone(req.Context())
+		routedURL := *req.URL
+		routedURL.Scheme = serverURL.Scheme
+		routedURL.Host = serverURL.Host
+		routedReq.URL = &routedURL
+		routedReq.Host = serverURL.Host
+		return serverTransport.RoundTrip(routedReq)
+	})
+
+	keyPath := filepath.Join(t.TempDir(), "key.p8")
+	writeECDSAPEM(t, keyPath)
+
 	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, httpClient)
 	if err != nil {
 		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
@@ -183,22 +217,29 @@ func TestCommitBuildUploadFileReconcilesSuccessfulResponseDecodeFailure(t *testi
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			patchCount := 0
-			getCount := 0
-			client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+			var patchCount atomic.Int32
+			var getCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
 				switch {
 				case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-456":
-					patchCount++
-					return buildUploadsJSONStatusResponse(http.StatusOK, tt.body)
+					patchCount.Add(1)
+					w.WriteHeader(http.StatusOK)
+					if _, err := io.WriteString(w, tt.body); err != nil {
+						t.Errorf("WriteString() error: %v", err)
+					}
 				case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-123":
-					getCount++
-					return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`)
+					getCount.Add(1)
+					if _, err := io.WriteString(w, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`); err != nil {
+						t.Errorf("WriteString() error: %v", err)
+					}
 				default:
-					err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-					t.Error(err)
-					return nil, err
+					t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
 				}
-			})
+			}))
+			defer server.Close()
+			client := newBuildUploadsServerTestClient(t, server)
 
 			resp, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
 			if err != nil {
@@ -207,10 +248,44 @@ func TestCommitBuildUploadFileReconcilesSuccessfulResponseDecodeFailure(t *testi
 			if resp != nil {
 				t.Fatalf("expected no synthetic file response after reconciliation, got %#v", resp)
 			}
-			if patchCount != 1 || getCount != 1 {
-				t.Fatalf("expected one commit and one reconciliation request, got patch=%d get=%d", patchCount, getCount)
+			if patchCount.Load() != 1 || getCount.Load() != 1 {
+				t.Fatalf("expected one commit and one reconciliation request, got patch=%d get=%d", patchCount.Load(), getCount.Load())
 			}
 		})
+	}
+}
+
+func TestCommitBuildUploadFileReconcilesSuccessfulResponseReadFailure(t *testing.T) {
+	patchCount := 0
+	getCount := 0
+	client := newBuildUploadsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-456":
+			patchCount++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(iotest.ErrReader(errors.New("response body read failed"))),
+			}, nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-123":
+			getCount++
+			return buildUploadsJSONStatusResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-123","attributes":{"state":{"state":"COMPLETE"}}}}`)
+		default:
+			err := fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Error(err)
+			return nil, err
+		}
+	})
+
+	resp, err := CommitBuildUploadFile(context.Background(), client, "upload-123", "file-456", nil)
+	if err != nil {
+		t.Fatalf("CommitBuildUploadFile() error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected no synthetic file response after reconciliation, got %#v", resp)
+	}
+	if patchCount != 1 || getCount != 1 {
+		t.Fatalf("expected one commit and one reconciliation request, got patch=%d get=%d", patchCount, getCount)
 	}
 }
 

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -1451,6 +1451,9 @@ func contextWithoutTimeout(ctx context.Context) context.Context {
 	return ctx
 }
 
+// contextWithoutCurrentTimeout removes only the innermost timeout applied by
+// withTimeoutContext. Unlike contextWithoutTimeout, it preserves outer parent
+// deadlines so they continue to bound subsequent work.
 func contextWithoutCurrentTimeout(ctx context.Context) context.Context {
 	if ctx == nil {
 		return context.Background()

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -1451,6 +1451,16 @@ func contextWithoutTimeout(ctx context.Context) context.Context {
 	return ctx
 }
 
+func contextWithoutCurrentTimeout(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	if base, ok := ctx.Value(timeoutParentContextKey{}).(context.Context); ok && base != nil {
+		return base
+	}
+	return ctx
+}
+
 func contextWithTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	return withTimeoutContext(ctx, asc.ResolveTimeout())
 }


### PR DESCRIPTION
## Summary

- pass the parent build-upload ID into upload-file finalization
- reconcile ambiguous deadline, transport, HTTP 408, and retryable 5xx failures with one bounded `GET /v1/buildUploads/{id}`
- accept recovery only when App Store Connect reports `PROCESSING` or `COMPLETE`
- retain the original mutation error and provide an inspection command when server state cannot prove success

## Why

The final `uploaded=true` PATCH may be applied by App Store Connect even when the client loses the response. Returning failure immediately can incorrectly report a failed upload after processing has already started.

## Validation

- RED/GREEN shared-helper reconciliation tests
- black-box `builds upload` coverage with a valid IPA fixture
- publish-path upload reconciliation coverage
- definitive client-error, failed-state, unknown-state, cancellation, and lookup-failure tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

The mutation is never replayed, and no live App Store Connect upload was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788337399&installation_model_id=10418&pr_number=1847&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1847&signature=c7a8e4221666400ed988590294f786cca02f6c240a5e667e6af4629f9a9c0a03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build upload reliability when commit responses are ambiguous or temporarily unavailable.
  * Automatically reconciles upload status after retryable failures and recognizes processing or completed uploads.
  * Provides clearer diagnostics for canceled, failed, or unresolved upload operations.
  * Handles malformed or unreadable commit responses more consistently while preserving useful error details.
* **Tests**
  * Added coverage for successful reconciliation, timeout handling, server errors, and failed status lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->