### PR TITLE
feat(certificates): support pass type ID certificates

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -7415,6 +7415,9 @@ func TestCreateCertificate_SendsRequest(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body error: %v", err)
 		}
+		if strings.Contains(string(body), `"relationships"`) {
+			t.Fatalf("expected relationships member to be omitted, got %s", body)
+		}
 		var payload CertificateCreateRequest
 		if err := json.Unmarshal(body, &payload); err != nil {
 			t.Fatalf("decode body error: %v", err)
@@ -7428,10 +7431,52 @@ func TestCreateCertificate_SendsRequest(t *testing.T) {
 		if payload.Data.Attributes.CSRContent != "CSR_CONTENT" {
 			t.Fatalf("expected csr content, got %q", payload.Data.Attributes.CSRContent)
 		}
+		if payload.Data.Relationships != nil {
+			t.Fatalf("expected relationships to be omitted, got %#v", payload.Data.Relationships)
+		}
 		assertAuthorized(t, req)
 	}, response)
 
 	if _, err := client.CreateCertificate(context.Background(), "CSR_CONTENT", "IOS_DISTRIBUTION"); err != nil {
+		t.Fatalf("CreateCertificate() error: %v", err)
+	}
+}
+
+func TestCreateCertificate_WithPassTypeIDRelationship(t *testing.T) {
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"certificates","id":"c1","attributes":{"name":"Pass Cert","certificateType":"PASS_TYPE_ID"}}}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/certificates" {
+			t.Fatalf("expected path /v1/certificates, got %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body error: %v", err)
+		}
+		var payload CertificateCreateRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode body error: %v", err)
+		}
+		if payload.Data.Relationships == nil || payload.Data.Relationships.PassTypeID == nil {
+			t.Fatal("expected passTypeId relationship")
+		}
+		if got := payload.Data.Relationships.PassTypeID.Data.Type; got != ResourceTypePassTypeIds {
+			t.Fatalf("expected relationship type passTypeIds, got %q", got)
+		}
+		if got := payload.Data.Relationships.PassTypeID.Data.ID; got != "pass-123" {
+			t.Fatalf("expected relationship ID pass-123, got %q", got)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.CreateCertificate(
+		context.Background(),
+		"CSR_CONTENT",
+		"PASS_TYPE_ID",
+		WithCertificatePassTypeID(" pass-123 "),
+	); err != nil {
 		t.Fatalf("CreateCertificate() error: %v", err)
 	}
 }

--- a/internal/asc/client_signing.go
+++ b/internal/asc/client_signing.go
@@ -383,8 +383,27 @@ func (c *Client) GetCertificate(ctx context.Context, id string, opts ...Certific
 	return &response, nil
 }
 
+type certificateCreateOptions struct {
+	passTypeID string
+}
+
+// CertificateCreateOption configures certificate creation.
+type CertificateCreateOption func(*certificateCreateOptions)
+
+// WithCertificatePassTypeID associates a pass type ID with a pass certificate.
+func WithCertificatePassTypeID(passTypeID string) CertificateCreateOption {
+	return func(options *certificateCreateOptions) {
+		options.passTypeID = strings.TrimSpace(passTypeID)
+	}
+}
+
 // CreateCertificate creates a new certificate.
-func (c *Client) CreateCertificate(ctx context.Context, csrContent string, certType string) (*CertificateResponse, error) {
+func (c *Client) CreateCertificate(ctx context.Context, csrContent string, certType string, opts ...CertificateCreateOption) (*CertificateResponse, error) {
+	options := &certificateCreateOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	request := CertificateCreateRequest{
 		Data: CertificateCreateData{
 			Type: ResourceTypeCertificates,
@@ -393,6 +412,16 @@ func (c *Client) CreateCertificate(ctx context.Context, csrContent string, certT
 				CSRContent:      strings.TrimSpace(csrContent),
 			},
 		},
+	}
+	if options.passTypeID != "" {
+		request.Data.Relationships = &CertificateCreateRelationships{
+			PassTypeID: &Relationship{
+				Data: ResourceData{
+					Type: ResourceTypePassTypeIds,
+					ID:   options.passTypeID,
+				},
+			},
+		}
 	}
 
 	body, err := BuildRequestBody(request)

--- a/internal/asc/signing.go
+++ b/internal/asc/signing.go
@@ -135,10 +135,16 @@ type CertificateCreateAttributes struct {
 	CSRContent      string `json:"csrContent"`
 }
 
+// CertificateCreateRelationships describes relationships for certificate creation.
+type CertificateCreateRelationships struct {
+	PassTypeID *Relationship `json:"passTypeId,omitempty"`
+}
+
 // CertificateCreateData is the data portion of a certificate create request.
 type CertificateCreateData struct {
-	Type       ResourceType                `json:"type"`
-	Attributes CertificateCreateAttributes `json:"attributes"`
+	Type          ResourceType                    `json:"type"`
+	Attributes    CertificateCreateAttributes     `json:"attributes"`
+	Relationships *CertificateCreateRelationships `json:"relationships,omitempty"`
 }
 
 // CertificateCreateRequest is a request to create a certificate.

--- a/internal/cli/certificates/certificates.go
+++ b/internal/cli/certificates/certificates.go
@@ -33,6 +33,7 @@ Examples:
   asc certificates list --certificate-type IOS_DISTRIBUTION
   asc certificates view --id "CERT_ID" --include passTypeId
   asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"
+  asc certificates create --certificate-type PASS_TYPE_ID --pass-type-id "PASS_TYPE_ID" --csr "./pass.csr"
   asc certificates update --id "CERT_ID" --activated true
   asc certificates update --id "CERT_ID" --activated false
   asc certificates revoke --id "CERT_ID" --confirm
@@ -189,6 +190,7 @@ func CertificatesCreateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("create", flag.ExitOnError)
 
 	certificateType := fs.String("certificate-type", "", "Certificate type (e.g., IOS_DISTRIBUTION)")
+	passTypeID := fs.String("pass-type-id", "", "Pass Type ID resource ID (required for PASS_TYPE_ID and PASS_TYPE_ID_WITH_NFC)")
 	csrPath := fs.String("csr", "", "CSR file path")
 	generateCSR := fs.Bool("generate-csr", false, "Generate a private key and CSR before creating the certificate")
 	keyOut := fs.String("key-out", "", "Private key output path for --generate-csr (PEM)")
@@ -205,12 +207,13 @@ func CertificatesCreateCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "create",
-		ShortUsage: "asc certificates create --certificate-type TYPE (--csr ./cert.csr | --generate-csr --key-out ./cert.key --csr-out ./cert.csr)",
+		ShortUsage: "asc certificates create --certificate-type TYPE [--pass-type-id ID] (--csr ./cert.csr | --generate-csr --key-out ./cert.key --csr-out ./cert.csr)",
 		ShortHelp:  "Create a signing certificate.",
 		LongHelp: `Create a signing certificate.
 
 Examples:
   asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"
+  asc certificates create --certificate-type PASS_TYPE_ID --pass-type-id "PASS_TYPE_ID" --csr "./pass.csr"
   asc certificates create --certificate-type IOS_DISTRIBUTION --generate-csr --key-out "./signing/dist.key" --csr-out "./signing/dist.csr"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -219,6 +222,15 @@ Examples:
 			if certificateValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --certificate-type is required")
 				return shared.MissingRequiredUsageError()
+			}
+			passTypeIDValue := strings.TrimSpace(*passTypeID)
+			isPassTypeCertificate := certificateValue == "PASS_TYPE_ID" || certificateValue == "PASS_TYPE_ID_WITH_NFC"
+			if isPassTypeCertificate && passTypeIDValue == "" {
+				fmt.Fprintf(os.Stderr, "Error: --pass-type-id is required with --certificate-type %s\n", certificateValue)
+				return shared.MissingRequiredUsageError("--pass-type-id")
+			}
+			if !isPassTypeCertificate && passTypeIDValue != "" {
+				return shared.UsageError("--pass-type-id can only be used with --certificate-type PASS_TYPE_ID or PASS_TYPE_ID_WITH_NFC")
 			}
 			csrValue := strings.TrimSpace(*csrPath)
 
@@ -281,7 +293,12 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.CreateCertificate(requestCtx, csrContent, certificateValue)
+			createOpts := []asc.CertificateCreateOption{}
+			if passTypeIDValue != "" {
+				createOpts = append(createOpts, asc.WithCertificatePassTypeID(passTypeIDValue))
+			}
+
+			resp, err := client.CreateCertificate(requestCtx, csrContent, certificateValue, createOpts...)
 			if err != nil {
 				return fmt.Errorf("certificates create: failed to create: %w", err)
 			}

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -12,7 +12,9 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,19 +142,36 @@ func TestCertificatesCreateCommand_PassTypeIDRelationship(t *testing.T) {
 	}
 
 	var got asc.CertificateCreateRequest
-	client := newCertificatesTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/certificates" {
-			t.Fatalf("expected POST /v1/certificates, got %s %s", req.Method, req.URL.Path)
+			t.Errorf("expected POST /v1/certificates, got %s %s", req.Method, req.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
 		}
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			t.Fatalf("read request body: %v", err)
+		if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
 		}
-		if err := json.Unmarshal(body, &got); err != nil {
-			t.Fatalf("decode request body: %v", err)
-		}
-		return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"certificates","id":"cert-1","attributes":{"name":"Pass Cert","certificateType":"PASS_TYPE_ID"}}}`), nil
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"certificates","id":"cert-1","attributes":{"name":"Pass Cert","certificateType":"PASS_TYPE_ID"}}}`)
 	}))
+	t.Cleanup(server.Close)
+
+	transport, ok := server.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("server transport type = %T, want *http.Transport", server.Client().Transport)
+	}
+	transport = transport.Clone()
+	transport.Proxy = nil
+	transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.ServerName = "example.com"
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	client := newCertificatesTestClient(t, transport)
 
 	originalGetClient := getCertificatesASCClient
 	getCertificatesASCClient = func() (*asc.Client, error) { return client, nil }

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -64,6 +64,124 @@ func TestCertificatesCreateCommand_CSRAndGenerateCSRAreMutuallyExclusive(t *test
 	}
 }
 
+func TestCertificatesCreateCommand_PassTypeCertificateRequiresPassTypeIDBeforeCSRGeneration(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "pass.key")
+	csrOut := filepath.Join(dir, "pass.csr")
+
+	originalGetClient := getCertificatesASCClient
+	getCertificatesASCClient = func() (*asc.Client, error) {
+		t.Fatal("ASC client should not be resolved when --pass-type-id is missing")
+		return nil, nil
+	}
+	t.Cleanup(func() { getCertificatesASCClient = originalGetClient })
+
+	cmd := CertificatesCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--certificate-type", "PASS_TYPE_ID",
+		"--generate-csr",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), []string{})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp when --pass-type-id is missing, got %v", err)
+	}
+	if _, err := os.Stat(keyOut); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private key should not be generated, stat error: %v", err)
+	}
+	if _, err := os.Stat(csrOut); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("CSR should not be generated, stat error: %v", err)
+	}
+}
+
+func TestCertificatesCreateCommand_PassTypeIDRejectsIncompatibleTypeBeforeCSRGeneration(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "distribution.key")
+	csrOut := filepath.Join(dir, "distribution.csr")
+
+	originalGetClient := getCertificatesASCClient
+	getCertificatesASCClient = func() (*asc.Client, error) {
+		t.Fatal("ASC client should not be resolved for an incompatible --pass-type-id")
+		return nil, nil
+	}
+	t.Cleanup(func() { getCertificatesASCClient = originalGetClient })
+
+	cmd := CertificatesCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--certificate-type", "IOS_DISTRIBUTION",
+		"--pass-type-id", "pass-123",
+		"--generate-csr",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), []string{})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp for an incompatible --pass-type-id, got %v", err)
+	}
+	if _, err := os.Stat(keyOut); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private key should not be generated, stat error: %v", err)
+	}
+	if _, err := os.Stat(csrOut); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("CSR should not be generated, stat error: %v", err)
+	}
+}
+
+func TestCertificatesCreateCommand_PassTypeIDRelationship(t *testing.T) {
+	csrPath := filepath.Join(t.TempDir(), "pass.csr")
+	if err := os.WriteFile(csrPath, []byte("CSR_CONTENT"), 0o600); err != nil {
+		t.Fatalf("write CSR: %v", err)
+	}
+
+	var got asc.CertificateCreateRequest
+	client := newCertificatesTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/certificates" {
+			t.Fatalf("expected POST /v1/certificates, got %s %s", req.Method, req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"certificates","id":"cert-1","attributes":{"name":"Pass Cert","certificateType":"PASS_TYPE_ID"}}}`), nil
+	}))
+
+	originalGetClient := getCertificatesASCClient
+	getCertificatesASCClient = func() (*asc.Client, error) { return client, nil }
+	t.Cleanup(func() { getCertificatesASCClient = originalGetClient })
+
+	cmd := CertificatesCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--certificate-type", "pass_type_id",
+		"--pass-type-id", "  pass-123  ",
+		"--csr", csrPath,
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); err != nil {
+		t.Fatalf("exec error: %v", err)
+	}
+	if got.Data.Relationships == nil || got.Data.Relationships.PassTypeID == nil {
+		t.Fatal("expected passTypeId relationship")
+	}
+	if got.Data.Relationships.PassTypeID.Data.Type != asc.ResourceTypePassTypeIds {
+		t.Fatalf("expected passTypeIds relationship type, got %q", got.Data.Relationships.PassTypeID.Data.Type)
+	}
+	if got.Data.Relationships.PassTypeID.Data.ID != "pass-123" {
+		t.Fatalf("expected trimmed pass type ID, got %q", got.Data.Relationships.PassTypeID.Data.ID)
+	}
+}
+
 func TestCertificatesCreateCommand_GenerateCSRCreatesFilesAndPostsCSR(t *testing.T) {
 	dir := t.TempDir()
 	keyOut := filepath.Join(dir, "dist.key")

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -2081,6 +2081,21 @@ func TestCertificatesCreateGenerateCSRFlagValidation(t *testing.T) {
 			args:    []string{"certificates", "create", "--certificate-type", "IOS_DISTRIBUTION", "--key-out", "./dist.key", "--csr", "./dist.csr"},
 			wantErr: "--key-out, --csr-out, CSR subject flags, --key-type, --key-size, and --force require --generate-csr",
 		},
+		{
+			name:    "pass type certificate requires pass type id before reading csr",
+			args:    []string{"certificates", "create", "--csr", "./missing.csr", "--certificate-type", "PASS_TYPE_ID"},
+			wantErr: "--pass-type-id is required with --certificate-type PASS_TYPE_ID",
+		},
+		{
+			name:    "pass type certificate with nfc requires pass type id",
+			args:    []string{"certificates", "create", "--certificate-type", "PASS_TYPE_ID_WITH_NFC", "--csr", "./missing.csr"},
+			wantErr: "--pass-type-id is required with --certificate-type PASS_TYPE_ID_WITH_NFC",
+		},
+		{
+			name:    "pass type id rejects incompatible certificate type",
+			args:    []string{"certificates", "create", "--pass-type-id", "create", "--certificate-type", "IOS_DISTRIBUTION", "--csr", "./missing.csr"},
+			wantErr: "--pass-type-id can only be used with --certificate-type PASS_TYPE_ID or PASS_TYPE_ID_WITH_NFC",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- add `--pass-type-id` to `asc certificates create`
- support `PASS_TYPE_ID` and `PASS_TYPE_ID_WITH_NFC` certificate creation
- send the OpenAPI-defined `relationships.passTypeId` linkage
- reject missing or incompatible relationships before CSR generation, file writes, client resolution, or HTTP requests

## Why

ASC already manages Pass Type IDs but certificate creation could not associate a pass certificate with its required Pass Type ID resource.

## Example

```bash
asc certificates create \
  --certificate-type PASS_TYPE_ID \
  --pass-type-id PASS_TYPE_RESOURCE_ID \
  --csr ./pass.csr
```

## Validation

- CLI tests for both pass certificate types and incompatible usage
- exact `POST /v1/certificates` request-body coverage
- compatibility test proving ordinary certificate payloads omit relationships
- built-binary help and exit-code checks
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

The request shape was verified against the repository OpenAPI snapshot. No live certificate was created.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788337402&installation_model_id=10418&pr_number=1848&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1848&signature=00837c8d93a1440857e3f2d1795ccd0500c2de37c804dd8515ac6aec0e172c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--pass-type-id` support when creating compatible certificate types.
  * Pass type IDs are trimmed and included in certificate creation requests.
  * Updated command help text and examples.

* **Bug Fixes**
  * Added validation requiring pass type IDs for applicable certificate types.
  * Rejects pass type IDs for incompatible certificate types before processing CSR files.
  * Preserves existing certificate creation behavior when no pass type ID is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->