### PR TITLE
fix(security): propagate gosec failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,8 @@ dev: format lint test build
 .PHONY: security
 security:
 	@echo "$(BLUE)Checking for security vulnerabilities...$(NC)"
-	@which gosec > /dev/null 2>&1 && \
-		gosec ./... || \
-		echo "$(YELLOW)Install gosec for security checks$(NC)"
+	@if command -v gosec > /dev/null 2>&1; then \
+		gosec ./...; \
+	else \
+		echo "$(YELLOW)Install gosec for security checks$(NC)"; \
+	fi

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
-"""Protect CI runner, build, and artifact ownership contracts."""
+"""Protect CI runner, build, artifact, and security-check contracts."""
 
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import tempfile
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -9,6 +13,7 @@ PR_WORKFLOW = ROOT / ".github/workflows/pr-checks.yml"
 MAIN_WORKFLOW = ROOT / ".github/workflows/main-branch.yml"
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
 WEBSITE_WORKFLOW = ROOT / ".github/workflows/website-checks.yml"
+MAKEFILE = ROOT / "Makefile"
 
 
 def job_block(workflow: str, job: str) -> str:
@@ -87,6 +92,62 @@ def assert_optimized_workflow(path: Path, test_job: str) -> None:
     assert "needs.ordinary-build.result" in build
 
 
+def run_security_target(path: str) -> subprocess.CompletedProcess[str]:
+    make = shutil.which("make")
+    if make is None:
+        raise AssertionError("make is required to test Makefile contracts")
+
+    env = os.environ.copy()
+    env["PATH"] = path
+    return subprocess.run(
+        [
+            make,
+            "--no-print-directory",
+            "-f",
+            str(MAKEFILE),
+            "VERSION=test",
+            "COMMIT=test",
+            "DATE=test",
+            "GOBIN=/tmp/asc-test-bin",
+            "GO_TOOLCHAIN_VERSION=test",
+            "security",
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def assert_security_target_contract() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_go = Path(tmpdir) / "go"
+        fake_go.write_text("#!/bin/sh\nexit 0\n")
+        fake_go.chmod(0o755)
+
+        missing = run_security_target(tmpdir)
+        assert missing.returncode == 0, missing.stderr
+        assert "Install gosec for security checks" in missing.stdout
+
+        fake_gosec = Path(tmpdir) / "gosec"
+        fake_gosec.write_text("#!/bin/sh\necho scanner-result >&2\nexit 23\n")
+        fake_gosec.chmod(0o755)
+
+        finding = run_security_target(tmpdir)
+        assert finding.returncode != 0, (
+            "make security must fail when gosec fails; "
+            f"stdout:\n{finding.stdout}\nstderr:\n{finding.stderr}"
+        )
+        assert "scanner-result" in finding.stderr
+        assert "Install gosec for security checks" not in finding.stdout
+
+        fake_gosec.write_text("#!/bin/sh\nexit 0\n")
+        success = run_security_target(tmpdir)
+        assert success.returncode == 0, success.stderr
+        assert "Install gosec for security checks" not in success.stdout
+
+
 def main() -> None:
     assert_optimized_workflow(PR_WORKFLOW, "unit-test-shards")
     assert_optimized_workflow(MAIN_WORKFLOW, "test-shards")
@@ -111,6 +172,8 @@ def main() -> None:
 
     release = RELEASE_WORKFLOW.read_text()
     assert "actions/upload-artifact" in release, "release workflow must retain official artifact publication"
+
+    assert_security_target_contract()
 
     print("CI workflow contracts passed")
 


### PR DESCRIPTION
## Summary

- separate missing-tool handling from scanner execution in `make security`
- preserve the installation diagnostic when `gosec` is unavailable
- propagate nonzero `gosec` results instead of converting findings into success
- add executable Makefile contract tests for missing, successful, and failing scanners

## Why

The existing `command && scanner || installation hint` expression treated scanner findings as though the tool were missing and returned success. That made the security target unreliable for automation.

## Validation

- RED contract reproduced a fake scanner failure returning success
- GREEN contract verifies missing, successful, and failing scanner behavior
- `python3 scripts/test_ci_workflows.py`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`

The repository's current real `gosec` run reports existing findings, so `make security` now correctly fails until those findings are triaged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788337404&installation_model_id=10418&pr_number=1849&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1849&signature=49dbb900e358088a0adaf951d03313c4ba434de0ecc4b3c9519900b339de0ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security checks so missing security tooling displays installation guidance instead of causing an unexpected failure.
  * Preserved clear failure reporting when security checks encounter errors.

* **Tests**
  * Added automated coverage for missing, failing, and successful security-check scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->