### PR TITLE
fix(pricing): fail closed on rejected availability bootstrap

### DIFF
--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -274,10 +274,11 @@ func capabilityRows() []Capability {
 		{
 			Area:         "app-management",
 			Capability:   "Initial app availability bootstrap",
-			Status:       statusCLISupported,
-			Commands:     []string{"asc pricing availability create"},
+			Status:       statusPartial,
+			Commands:     []string{"asc pricing availability create", "asc web apps availability create"},
 			APIResources: []string{"POST /v2/appAvailabilities", "territoryAvailabilities"},
-			Notes:        []string{"The CLI creates the initial appAvailabilityV2 record with inline territory availability resources."},
+			Notes:        []string{"The public command sends Apple's documented inline territory payload, but Apple can reject the bootstrap request. The web command requires an authenticated Apple web session."},
+			NextAction:   "If public bootstrap is rejected, run asc web auth login --apple-id EMAIL and use asc web apps availability create, or configure Pricing and Availability in App Store Connect.",
 		},
 		{
 			Area:       "app-management",
@@ -290,7 +291,7 @@ func capabilityRows() []Capability {
 				"appPriceSchedules",
 				"appPricePoints",
 			},
-			Notes: []string{"Availability records can be created and edited through the public App Store Connect API."},
+			Notes: []string{"Existing availability records can be viewed and edited through the public App Store Connect API; initial bootstrap can require an authenticated web session or App Store Connect."},
 		},
 		{
 			Area:       "metadata",

--- a/internal/cli/cmdtest/capabilities_command_test.go
+++ b/internal/cli/cmdtest/capabilities_command_test.go
@@ -58,6 +58,8 @@ func TestRun_CapabilitiesJSONReportsKnownGaps(t *testing.T) {
 
 	assertCapability(t, resp, "App Store release submission", "cli-supported", "asc publish appstore --submit")
 	assertCapability(t, resp, "App creation", "web-session", "asc web apps create")
+	assertCapability(t, resp, "Initial app availability bootstrap", "partial", "asc pricing availability create")
+	assertCapability(t, resp, "Initial app availability bootstrap", "partial", "asc web apps availability create")
 	assertCapability(t, resp, "Metadata and localization sync", "cli-supported", "asc metadata init")
 	assertCapability(t, resp, "Metadata and localization sync", "cli-supported", "asc metadata validate")
 	assertCapability(t, resp, "App privacy data-use declarations", "web-session", "asc web privacy")

--- a/internal/cli/cmdtest/pricing_availability_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_create_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -121,6 +122,87 @@ func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
 	}
 	if output.Data.ID != "app-1" || !output.Data.Attributes.AvailableInNewTerritories {
 		t.Fatalf("unexpected output: %#v", output.Data)
+	}
+}
+
+func TestPricingAvailabilityCreate_RelationshipRejectionExplainsFallback(t *testing.T) {
+	setupAuth(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v2/appAvailabilities" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"errors":[{"status":"409","code":"ENTITY_ERROR.RELATIONSHIP.INVALID","title":"The provided entity includes a relationship with an invalid value","detail":"The relationship 'territoryAvailabilities.territory' expects an included resource with type 'territories' and id 'TTO' but no matching resource was included."}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	restore := pricingcli.SetAvailabilityClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "create",
+			"--app", "app-1",
+			"--territory", "USA",
+			"--available", "true",
+			"--available-in-new-territories", "true",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected relationship rejection")
+	}
+	if got := cmd.ExitCodeFromError(runErr); got != cmd.ExitConflict {
+		t.Fatalf("expected exit code %d, got %d", cmd.ExitConflict, got)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	want := "pricing availability create: Apple rejected the initial availability request through the public API; availability was not configured. Authenticate a web session with \"asc web auth login --apple-id EMAIL\", then retry with \"asc web apps availability create\", or configure Pricing and Availability in App Store Connect: The provided entity includes a relationship with an invalid value: The relationship 'territoryAvailabilities.territory' expects an included resource with type 'territories' and id 'TTO' but no matching resource was included."
+	if runErr.Error() != want {
+		t.Fatalf("unexpected error:\n got: %q\nwant: %q", runErr.Error(), want)
+	}
+	var apiErr *asc.APIError
+	if !errors.As(runErr, &apiErr) {
+		t.Fatalf("expected original API error cause, got %T", runErr)
+	}
+	if apiErr.Code != "ENTITY_ERROR.RELATIONSHIP.INVALID" || apiErr.StatusCode != http.StatusConflict {
+		t.Fatalf("unexpected API error: %#v", apiErr)
 	}
 }
 

--- a/internal/cli/cmdtest/pricing_availability_set_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_set_create_test.go
@@ -35,7 +35,7 @@ func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T)
 				"--output", "json",
 			},
 			wantPrefix: `pricing availability edit: app availability not found for app "app-1"; this command only updates existing app availability`,
-			wantHint:   `use "asc pricing availability create" first`,
+			wantHint:   `use "asc pricing availability create" first. If Apple rejects public-API bootstrap`,
 		},
 		{
 			name: "app-setup availability edit",
@@ -48,7 +48,7 @@ func TestAvailabilitySet_MissingAvailabilityReturnsUpdateOnlyError(t *testing.T)
 				"--output", "json",
 			},
 			wantPrefix: `app-setup availability edit: app availability not found for app "app-1"; this command only updates existing app availability`,
-			wantHint:   `use "asc pricing availability create" first`,
+			wantHint:   `use "asc pricing availability create" first. If Apple rejects public-API bootstrap`,
 		},
 	}
 

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -749,7 +749,10 @@ func PricingAvailabilityCreateCommand() *ffcli.Command {
 		LongHelp: `Initialize app availability for territories.
 
 Creates the initial app availability record and its territory availability
-entries through the public App Store Connect API. Once created, use
+entries through the public App Store Connect API. Apple can reject this
+bootstrap request even when it matches the published schema. If that happens,
+the command fails without treating availability as configured and explains the
+authenticated web-session or App Store Connect fallback. Once created, use
 "asc pricing availability edit" to update the record.
 
 Examples:
@@ -813,12 +816,30 @@ Examples:
 				TerritoryAvailabilities:   territoryAvailabilities,
 			})
 			if err != nil {
+				if isAvailabilityBootstrapRelationshipRejection(err) {
+					return fmt.Errorf(
+						"pricing availability create: Apple rejected the initial availability request through the public API; availability was not configured. Authenticate a web session with \"asc web auth login --apple-id EMAIL\", then retry with \"asc web apps availability create\", or configure Pricing and Availability in App Store Connect: %w",
+						err,
+					)
+				}
 				return fmt.Errorf("pricing availability create: %w", err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func isAvailabilityBootstrapRelationshipRejection(err error) bool {
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != "ENTITY_ERROR.RELATIONSHIP.INVALID" {
+		return false
+	}
+
+	detail := apiErr.Detail
+	return strings.Contains(detail, "territoryAvailabilities.territory") &&
+		strings.Contains(detail, "expects an included resource with type 'territories'") &&
+		strings.Contains(detail, "no matching resource was included")
 }
 
 // PricingAvailabilitySetCommand returns the availability edit subcommand.
@@ -836,7 +857,11 @@ Examples:
 
 Note:
   This command only updates an existing app availability. If the app has no
-  availability record yet, use "asc pricing availability create" first.`,
+  availability record yet, use "asc pricing availability create" first. If
+  Apple rejects public-API bootstrap, authenticate with
+  "asc web auth login --apple-id EMAIL" and use
+  "asc web apps availability create", or configure Pricing and Availability in
+  App Store Connect.`,
 		ErrorPrefix:                      "pricing availability edit",
 		IncludeAvailableInNewTerritories: true,
 	})

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -99,7 +99,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				if isAppAvailabilityMissing(err) {
 					return NewErrorWithCause(
 						fmt.Errorf(
-							"%s: app availability not found for app %q; this command only updates existing app availability, so use \"asc pricing availability create\" first: %w",
+							"%s: app availability not found for app %q; this command only updates existing app availability, so use \"asc pricing availability create\" first. If Apple rejects public-API bootstrap, authenticate with \"asc web auth login --apple-id EMAIL\" and use \"asc web apps availability create\", or configure Pricing and Availability in App Store Connect: %w",
 							config.ErrorPrefix,
 							resolvedAppID,
 							asc.ErrNotFound,


### PR DESCRIPTION
## Summary

- keep the current inline-only `POST /v2/appAvailabilities` payload
- recognize the captured `ENTITY_ERROR.RELATIONSHIP.INVALID` response and preserve its conflict exit and API cause
- say that availability was not configured, then point to authenticated web-session and App Store Connect fallbacks
- report initial availability bootstrap as partial instead of universally CLI-supported

## Evidence

A redacted production trace sent the same schema-valid public request more than once and received the same relationship error with changing territory IDs. The relevant implementation is unchanged between ASC 3.3.0 and 3.5.0, and the bundled OpenAPI 4.4.1 schema accepts the current inline payload. The regression fixture contains no app, account, or customer identifiers.

This PR does not add bare territory resources, remove the command, or change a downstream version pin.

## Verification

- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make lint`
- `make check-docs`
- built the CLI and checked create help plus the app-management capability report

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788502469&installation_model_id=10418&pr_number=1863&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1863&signature=72fc077dc05ed0d7fb93297ad815a134919c8393114511a322f15883dd2da512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing and app availability creation errors when Apple rejects initial relationship setup.
  * Added clearer guidance for recovering through web authentication or App Store Connect.
  * Preserved underlying API error details and metadata for rejected requests.

* **Documentation**
  * Clarified that initial availability bootstrap has partial CLI support.
  * Updated command help and capability reporting to explain available fallback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->