### PR TITLE
fix(telemetry): drop permanently rejected events

### DIFF
--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -164,8 +164,10 @@ Collectors should accept `POST /asc/v1/events`, validate the event schema, add
 server-side receive metadata, and insert accepted events into analytics storage.
 They should return a 2xx response only after that insert commits; temporary
 storage failures should return a retryable non-2xx response so the CLI keeps the
-event in its bounded local spool. Collector credentials must never be shipped
-in the CLI.
+event in its bounded local spool. The CLI retries network errors, HTTP 408, HTTP
+429, and 5xx responses. It acknowledges and removes events rejected with any
+other 4xx response because replay cannot repair an unsupported schema or
+semantic shape. Collector credentials must never be shipped in the CLI.
 
 Recommended ClickHouse table:
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -19,6 +20,19 @@ const (
 	endpointEnvVar  = "ASC_TELEMETRY_ENDPOINT"
 	maxSendDuration = 3 * time.Second
 )
+
+type permanentDeliveryError struct {
+	statusCode int
+}
+
+func (err *permanentDeliveryError) Error() string {
+	return fmt.Sprintf("unexpected telemetry status %d", err.statusCode)
+}
+
+func isPermanentDeliveryError(err error) bool {
+	var permanentError *permanentDeliveryError
+	return errors.As(err, &permanentError)
+}
 
 func Emit(commandName, version string, duration time.Duration, exitCode int) {
 	EmitWithContext(commandName, version, duration, exitCode, EventContext{InvocationShape: InvocationShapeLeaf})
@@ -129,6 +143,11 @@ func sendHTTPEventToEndpoint(ev Event, endpointURL string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 &&
+			resp.StatusCode != http.StatusRequestTimeout &&
+			resp.StatusCode != http.StatusTooManyRequests {
+			return &permanentDeliveryError{statusCode: resp.StatusCode}
+		}
 		return fmt.Errorf("unexpected telemetry status %d", resp.StatusCode)
 	}
 	return nil

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -256,6 +256,41 @@ func TestSendHTTPEventAllowsSlowCollectorResponse(t *testing.T) {
 	}
 }
 
+func TestSendHTTPEventClassifiesPermanentCollectorRejections(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		wantPermanent bool
+	}{
+		{name: "bad request", statusCode: http.StatusBadRequest, wantPermanent: true},
+		{name: "unprocessable event", statusCode: http.StatusUnprocessableEntity, wantPermanent: true},
+		{name: "request timeout", statusCode: http.StatusRequestTimeout, wantPermanent: false},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, wantPermanent: false},
+		{name: "server error", statusCode: http.StatusInternalServerError, wantPermanent: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.statusCode)
+			}))
+			t.Cleanup(server.Close)
+
+			originalClient := http.DefaultClient
+			http.DefaultClient = server.Client()
+			t.Cleanup(func() { http.DefaultClient = originalClient })
+
+			err := sendHTTPEventToEndpoint(Event{}, server.URL)
+			if err == nil {
+				t.Fatalf("sendHTTPEvent() error = nil for status %d", test.statusCode)
+			}
+			if got := isPermanentDeliveryError(err); got != test.wantPermanent {
+				t.Fatalf("isPermanentDeliveryError(%v) = %t, want %t", err, got, test.wantPermanent)
+			}
+		})
+	}
+}
+
 func TestSendHTTPEventRejectsPlaintextRedirect(t *testing.T) {
 	plaintextHit := false
 	plaintextServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {

--- a/internal/telemetry/worker.go
+++ b/internal/telemetry/worker.go
@@ -90,6 +90,11 @@ func flushSpoolWhileEnabled(
 				return nil
 			}
 			if err := deliver(record.Event, record.Endpoint); err != nil {
+				if isPermanentDeliveryError(err) {
+					delivered[record.Event.EventID] = struct{}{}
+					debugf("telemetry event permanently rejected: %v", err)
+					continue
+				}
 				hadFailure = true
 				debugf("telemetry send failed: %v", err)
 				continue

--- a/internal/telemetry/worker_test.go
+++ b/internal/telemetry/worker_test.go
@@ -51,6 +51,48 @@ func TestFlushSpoolRetainsOnlyFailedEvents(t *testing.T) {
 	assertSpoolEventIDs(t, store, "event-02")
 }
 
+func TestFlushSpoolDoesNotRetryPermanentCollectorRejections(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), spoolFileName))
+	for _, id := range []string{"permanent", "retryable", "accepted"} {
+		if err := store.append(testSpoolRecord(id)); err != nil {
+			t.Fatalf("append %s: %v", id, err)
+		}
+	}
+
+	var firstAttempt []string
+	err := flushSpool(store, func(event Event, _ string) error {
+		firstAttempt = append(firstAttempt, event.EventID)
+		switch event.EventID {
+		case "permanent":
+			return &permanentDeliveryError{statusCode: 400}
+		case "retryable":
+			return errors.New("endpoint unavailable")
+		default:
+			return nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("first flushSpool() error = %v", err)
+	}
+	if len(firstAttempt) != 3 {
+		t.Fatalf("first-attempt events = %v, want all three records", firstAttempt)
+	}
+	assertSpoolEventIDs(t, store, "retryable")
+
+	var secondAttempt []string
+	err = flushSpool(store, func(event Event, _ string) error {
+		secondAttempt = append(secondAttempt, event.EventID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("second flushSpool() error = %v", err)
+	}
+	if len(secondAttempt) != 1 || secondAttempt[0] != "retryable" {
+		t.Fatalf("second-attempt events = %v, want only retryable record", secondAttempt)
+	}
+	assertSpoolEventIDs(t, store)
+}
+
 func TestMaintenanceWorkerDeduplicatesActiveFlushes(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)


### PR DESCRIPTION
## Summary

Treat collector rejections that replay cannot repair as permanent. Telemetry events rejected with a 4xx response are acknowledged and removed from the bounded local spool, except HTTP 408 and HTTP 429, which remain retryable alongside network errors and 5xx responses.

This prevents an unsupported schema version or semantic event shape from poisoning later telemetry flushes while preserving retries for transient failures. The collector contract documentation now states the same boundary.

## Rollout relationship

Companion Rork collector hardening: https://github.com/rorkai/rorkai/pull/4914

The two PRs can merge independently, but this CLI behavior should land before any future schema or semantic event expansion. For a future root command, apply the Rork constraint migration, deploy the Rork API normalization, and only then release that CLI command.

Neither PR releases or deploys anything.

## Testing

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Focused client and worker tests cover permanent 400/422 responses, retryable 408/429/500 responses, and spool removal without retry poison.
